### PR TITLE
Avoid IP unsafe constructs in dependency management integ tests

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
@@ -81,7 +81,6 @@ class ArtifactDependenciesIntegrationTest extends AbstractDependencyResolutionTe
 
     void dependencyReportWithConflicts() {
         given:
-        createDirs("subproject")
         resolve.prepare {
             config("evictedTransitive")
             config("evictedDirect")
@@ -174,32 +173,34 @@ class ArtifactDependenciesIntegrationTest extends AbstractDependencyResolutionTe
 
     void resolutionFailsWhenProjectHasNoRepositoriesEvenWhenArtifactIsCachedLocally() {
         expect:
-        createDirs("a", "b")
         file('settings.gradle') << 'include "a", "b"'
-        file('build.gradle') << """
-subprojects {
-    configurations {
-        compile
-    }
-    task listDeps {
-        def files = configurations.compile
-        doLast { files.files }
-    }
-}
-project(':a') {
-    repositories {
-        maven { url = '${repo.uri}' }
-    }
-    dependencies {
-        compile 'org.gradle.test:external1:1.0'
-    }
-}
-project(':b') {
-    dependencies {
-        compile 'org.gradle.test:external1:1.0'
-    }
-}
-"""
+        file("a/build.gradle") << """
+            configurations {
+                compile
+            }
+            task listDeps {
+                def files = configurations.compile
+                doLast { files.files }
+            }
+            repositories {
+                maven { url = '${repo.uri}' }
+            }
+            dependencies {
+                compile 'org.gradle.test:external1:1.0'
+            }
+        """
+        file("b/build.gradle") << """
+            configurations {
+                compile
+            }
+            task listDeps {
+                def files = configurations.compile
+                doLast { files.files }
+            }
+            dependencies {
+                compile 'org.gradle.test:external1:1.0'
+            }
+        """
         repo.module('org.gradle.test', 'external1', '1.0').publish()
 
         succeeds('a:listDeps')
@@ -262,35 +263,38 @@ Searched in the following locations:
         repo1.module('org.gradle.test', 'external1', '1.0').publish()
         def repo2 = maven('repo2')
 
-        createDirs("a", "b")
         file('settings.gradle') << 'include "a", "b"'
-        file('build.gradle') << """
-subprojects {
-    configurations {
-        compile
-    }
-    task listDeps {
-        def files = configurations.compile
-        doLast { files.each { } }
-    }
-}
-project(':a') {
-    repositories {
-        maven { url = '${repo1.uri}' }
-    }
-    dependencies {
-        compile 'org.gradle.test:external1:1.0'
-    }
-}
-project(':b') {
-    repositories {
-        maven { url = '${repo2.uri}' }
-    }
-    dependencies {
-        compile 'org.gradle.test:external1:1.0'
-    }
-}
-"""
+        file("a/build.gradle") << """
+            configurations {
+                compile
+            }
+            task listDeps {
+                def files = configurations.compile
+                doLast { files.each { } }
+            }
+            repositories {
+                maven { url = '${repo1.uri}' }
+            }
+            dependencies {
+                compile 'org.gradle.test:external1:1.0'
+            }
+        """
+        file("b/build.gradle") << """
+            configurations {
+                compile
+            }
+            task listDeps {
+                def files = configurations.compile
+                doLast { files.each { } }
+            }
+            repositories {
+                maven { url = '${repo2.uri}' }
+            }
+            dependencies {
+                compile 'org.gradle.test:external1:1.0'
+            }
+
+        """
 
         succeeds('a:listDeps')
         fails('b:listDeps')
@@ -401,43 +405,44 @@ tasks.register("test", CheckArtifacts) {
         lib.artifact(classifier: 'classifier2')
         lib.publish()
 
-        createDirs("a", "b", "c")
         file('settings.gradle') << """
             rootProject.name = "test"
-            include "a", "b", "c"
+            include "a", "b"
         """
-        file('build.gradle') << """
-subprojects {
-    repositories {
-        maven { url = '${repo.uri}' }
-    }
-    configurations {
-        compile
-    }
-}
-project(':a') {
-    dependencies {
-        compile 'org.gradle.test:external1:1.0:classifier1'
-    }
-    task test(dependsOn: configurations.compile) {
-        doLast {
-            assert configurations.compile.collect { it.name } == ['external1-1.0-classifier1.jar']
-            assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { "\${it.name}-\${it.classifier}" } == ['external1-classifier1']
-        }
-    }
-}
-project(':b') {
-    dependencies {
-        compile 'org.gradle.test:external1:1.0:classifier2'
-    }
-    task test(dependsOn: configurations.compile) {
-        doLast {
-            assert configurations.compile.collect { it.name } == ['external1-1.0-classifier2.jar']
-            assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { "\${it.name}-\${it.classifier}" } == ['external1-classifier2']
-        }
-    }
-}
-"""
+        file("a/build.gradle") << """
+            repositories {
+                maven { url = '${repo.uri}' }
+            }
+            configurations {
+                compile
+            }
+            dependencies {
+                compile 'org.gradle.test:external1:1.0:classifier1'
+            }
+            task test(dependsOn: configurations.compile) {
+                doLast {
+                    assert configurations.compile.collect { it.name } == ['external1-1.0-classifier1.jar']
+                    assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { "\${it.name}-\${it.classifier}" } == ['external1-classifier1']
+                }
+            }
+        """
+        file("b/build.gradle") << """
+            repositories {
+                maven { url = '${repo.uri}' }
+            }
+            configurations {
+                compile
+            }
+            dependencies {
+                compile 'org.gradle.test:external1:1.0:classifier2'
+            }
+            task test(dependsOn: configurations.compile) {
+                doLast {
+                    assert configurations.compile.collect { it.name } == ['external1-1.0-classifier2.jar']
+                    assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { "\${it.name}-\${it.classifier}" } == ['external1-classifier2']
+                }
+            }
+        """
         resolve.prepare("compile")
 
         when:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -24,56 +24,30 @@ import org.gradle.integtests.fixtures.resolve.ResolveFailureTestFixture
 @FluidDependenciesResolveTest
 class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def setup() {
-        createDirs("lib", "ui", "app")
         settingsFile << """
             rootProject.name = 'root'
-            include 'lib'
-            include 'ui'
-            include 'app'
+            dependencyResolutionManagement {
+                repositories {
+                    ivy { url = '${ivyHttpRepo.uri}' }
+                }
+            }
         """
+    }
 
-        buildFile << """
-def artifactType = Attribute.of('artifactType', String)
-def usage = Attribute.of('usage', String)
-def buildType = Attribute.of('buildType', String)
-def flavor = Attribute.of('flavor', String)
-
-allprojects {
-    repositories {
-        ivy { url = '${ivyHttpRepo.uri}' }
-    }
-    dependencies {
-        attributesSchema {
-           attribute(usage)
-           attribute(buildType)
-           attribute(flavor)
-        }
-    }
-    configurations {
-        compile {
-            attributes { attribute(usage, 'api') }
-        }
-    }
-    task utilJar {
-        outputs.file("\${project.name}-util.jar")
-    }
-    task jar {
-        outputs.file("\${project.name}.jar")
-    }
-    task utilClasses {
-        outputs.file("\${project.name}-util.classes")
-    }
-    task classes {
-        outputs.file("\${project.name}.classes")
-    }
-    task dir {
-        outputs.file("\${project.name}")
-    }
-    task utilDir {
-        outputs.file("\${project.name}-util")
-    }
-}
-"""
+    def getHeader() {
+        """
+            def usage = Attribute.of('usage', String)
+            dependencies {
+                attributesSchema {
+                    attribute(usage)
+                }
+            }
+            configurations {
+                compile {
+                    attributes { attribute(usage, 'api') }
+                }
+            }
+        """
     }
 
     def "selects artifacts and files whose format matches the requested"() {
@@ -85,79 +59,114 @@ allprojects {
                     .artifact(name: 'some-classes', type: 'classes')
                     .publish()
 
-        buildFile << """
-            project(':lib') {
-                dependencies {
-                    compile utilJar.outputs.files
-                    compile utilClasses.outputs.files
-                    compile utilDir.outputs.files
-                    compile 'org:test:1.0'
-                    compile 'org:test2:1.0'
-                }
-                configurations {
-                    compile {
-                        outgoing {
-                            variants {
-                                jarFormat {
-                                    artifact file: file('lib.jar'), builtBy: tasks.jar
-                                }
-                                classesFormat {
-                                    artifact file: file('lib.classes'), builtBy: tasks.classes
-                                }
-                                dirFormat {
-                                    artifact file: file('lib'), builtBy: tasks.dir
-                                }
+        settingsFile << """
+            include 'lib'
+            include 'ui'
+            include 'app'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            task utilJar {
+                outputs.file("\${project.name}-util.jar")
+            }
+            task jar {
+                outputs.file("\${project.name}.jar")
+            }
+            task utilClasses {
+                outputs.file("\${project.name}-util.classes")
+            }
+            task classes {
+                outputs.file("\${project.name}.classes")
+            }
+            task dir {
+                outputs.file("\${project.name}")
+            }
+            task utilDir {
+                outputs.file("\${project.name}-util")
+            }
+            dependencies {
+                compile utilJar.outputs.files
+                compile utilClasses.outputs.files
+                compile utilDir.outputs.files
+                compile 'org:test:1.0'
+                compile 'org:test2:1.0'
+            }
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            jarFormat {
+                                artifact file: file('lib.jar'), builtBy: tasks.jar
+                            }
+                            classesFormat {
+                                artifact file: file('lib.classes'), builtBy: tasks.classes
+                            }
+                            dirFormat {
+                                artifact file: file('lib'), builtBy: tasks.dir
                             }
                         }
                     }
                 }
             }
-            project(':ui') {
-                artifacts {
-                    compile file: file('ui.jar'), builtBy: jar
+        """
+
+        file("ui/build.gradle") << """
+            $header
+            task jar {
+                outputs.file("\${project.name}.jar")
+            }
+            artifacts {
+                compile file: file('ui.jar'), builtBy: jar
+            }
+        """
+
+        file("app/build.gradle") << """
+            $header
+            def otherAttributeRequired = Attribute.of('otherAttributeRequired', String)
+            def otherAttributeOptional = Attribute.of('otherAttributeOptional', String)
+            dependencies {
+                attributesSchema {
+                    attribute(otherAttributeRequired)
+                    attribute(otherAttributeRequired)
                 }
             }
 
-            project(':app') {
-                def otherAttributeRequired = Attribute.of('otherAttributeRequired', String)
-                def otherAttributeOptional = Attribute.of('otherAttributeOptional', String)
+            dependencies {
+                compile project(':lib'), project(':ui')
 
-                dependencies {
-                    compile project(':lib'), project(':ui')
+                attributesSchema {
+                    attribute(otherAttributeOptional)
+                }
+            }
 
-                    attributesSchema {
-                        attribute(otherAttributeOptional)
+            task resolve {
+                // Get a view specifying the default type
+                def defaultView = configurations.compile.incoming.artifactView {
+                    attributes {
+                        it.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'jar')
                     }
                 }
+                def defaultFiles = defaultView.files
+                def defaultArtifacts = defaultView.artifacts
 
-                task resolve {
-                    // Get a view specifying the default type
-                    def defaultView = configurations.compile.incoming.artifactView {
-                        attributes {
-                            it.attribute(artifactType, 'jar')
-                        }
+                // Get a view with additional optional attribute
+                def optionalAttributeView = configurations.compile.incoming.artifactView {
+                    attributes {
+                        it.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'jar')
+                        it.attribute(otherAttributeOptional, 'anything')
                     }
-                    def defaultFiles = defaultView.files
-                    def defaultArtifacts = defaultView.artifacts
+                }
+                def optionalFiles = optionalAttributeView.files
+                def optionalArtifacts = optionalAttributeView.artifacts
 
-                    // Get a view with additional optional attribute
-                    def optionalAttributeView = configurations.compile.incoming.artifactView {
-                        attributes {
-                            it.attribute(artifactType, 'jar')
-                            it.attribute(otherAttributeOptional, 'anything')
-                        }
-                    }
-                    def optionalFiles = optionalAttributeView.files
-                    def optionalArtifacts = optionalAttributeView.artifacts
+                inputs.files defaultFiles
+                doLast {
+                    assert defaultFiles.collect { it.name } == ['lib.jar', 'lib-util.jar', 'ui.jar', 'some-jar-1.0.jar']
+                    assert defaultArtifacts.collect { it.id.displayName }  == ['lib.jar (project :lib)', 'lib-util.jar', 'ui.jar (project :ui)', 'some-jar-1.0.jar (org:test:1.0)']
 
-                    inputs.files defaultFiles
-                    doLast {
-                        assert defaultFiles.collect { it.name } == ['lib.jar', 'lib-util.jar', 'ui.jar', 'some-jar-1.0.jar']
-                        assert defaultArtifacts.collect { it.id.displayName }  == ['lib.jar (project :lib)', 'lib-util.jar', 'ui.jar (project :ui)', 'some-jar-1.0.jar (org:test:1.0)']
-
-                        assert optionalFiles.collect { it.name } == ['lib.jar', 'lib-util.jar', 'ui.jar', 'some-jar-1.0.jar']
-                        assert optionalArtifacts.collect { it.id.displayName }  == ['lib.jar (project :lib)', 'lib-util.jar', 'ui.jar (project :ui)', 'some-jar-1.0.jar (org:test:1.0)']
-                    }
+                    assert optionalFiles.collect { it.name } == ['lib.jar', 'lib-util.jar', 'ui.jar', 'some-jar-1.0.jar']
+                    assert optionalArtifacts.collect { it.id.displayName }  == ['lib.jar (project :lib)', 'lib-util.jar', 'ui.jar (project :ui)', 'some-jar-1.0.jar (org:test:1.0)']
                 }
             }
         """
@@ -182,59 +191,88 @@ allprojects {
                     .artifact(name: 'some-classes', type: 'classes')
                     .publish()
 
-        buildFile << """
-            project(':lib') {
-                dependencies {
-                    compile utilJar.outputs.files
-                    compile utilClasses.outputs.files
-                    compile utilDir.outputs.files
-                    compile 'org:test:1.0'
-                    compile 'org:test2:1.0'
-                }
-                configurations {
-                    compile {
-                        outgoing {
-                            variants {
-                                jarFormat {
-                                    artifact file: file('lib.jar'), builtBy: tasks.jar
-                                }
-                                classesFormat {
-                                    artifact file: file('lib.classes'), builtBy: tasks.classes
-                                }
-                                dirFormat {
-                                    artifact file: file('lib'), builtBy: tasks.dir
-                                }
+        settingsFile << """
+            include 'lib'
+            include 'ui'
+            include 'app'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            task utilJar {
+                outputs.file("\${project.name}-util.jar")
+            }
+            task jar {
+                outputs.file("\${project.name}.jar")
+            }
+            task utilClasses {
+                outputs.file("\${project.name}-util.classes")
+            }
+            task classes {
+                outputs.file("\${project.name}.classes")
+            }
+            task dir {
+                outputs.file("\${project.name}")
+            }
+            task utilDir {
+                outputs.file("\${project.name}-util")
+            }
+            dependencies {
+                compile utilJar.outputs.files
+                compile utilClasses.outputs.files
+                compile utilDir.outputs.files
+                compile 'org:test:1.0'
+                compile 'org:test2:1.0'
+            }
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            jarFormat {
+                                artifact file: file('lib.jar'), builtBy: tasks.jar
+                            }
+                            classesFormat {
+                                artifact file: file('lib.classes'), builtBy: tasks.classes
+                            }
+                            dirFormat {
+                                artifact file: file('lib'), builtBy: tasks.dir
                             }
                         }
                     }
                 }
             }
-            project(':ui') {
-                artifacts {
-                    compile file: file('ui.classes'), builtBy: classes
+        """
+
+        file("ui/build.gradle") << """
+            $header
+            task classes {
+                outputs.file("\${project.name}.classes")
+            }
+            artifacts {
+                compile file: file('ui.classes'), builtBy: classes
+            }
+        """
+
+        file("app/build.gradle") << """
+            $header
+            configurations {
+                compile {
+                    attributes { attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'jar') }
                 }
             }
 
-            project(':app') {
-                configurations {
-                    compile {
-                        attributes { attribute(artifactType, 'jar') }
-                    }
-                }
+            dependencies {
+                compile project(':lib'), project(':ui')
+            }
 
-                dependencies {
-                    compile project(':lib'), project(':ui')
+            task resolve {
+                def view = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'classes') }
                 }
-
-                task resolve {
-                    def view = configurations.compile.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'classes') }
-                    }
-                    inputs.files view.files
-                    doLast {
-                        assert view.files.collect { it.name } == ['lib.classes', 'lib-util.classes', 'ui.classes', 'some-classes-1.0.classes']
-                        assert view.artifacts.collect { it.id.displayName } == ['lib.classes (project :lib)', 'lib-util.classes', 'ui.classes (project :ui)', 'some-classes-1.0.classes (org:test2:1.0)']
-                    }
+                inputs.files view.files
+                doLast {
+                    assert view.files.collect { it.name } == ['lib.classes', 'lib-util.classes', 'ui.classes', 'some-classes-1.0.classes']
+                    assert view.artifacts.collect { it.id.displayName } == ['lib.classes (project :lib)', 'lib-util.classes', 'ui.classes (project :ui)', 'some-classes-1.0.classes (org:test2:1.0)']
                 }
             }
         """
@@ -251,71 +289,96 @@ allprojects {
 
     def "applies consumers compatibility and disambiguation rules when selecting variant"() {
         buildFile << """
-class BuildTypeCompatibilityRule implements AttributeCompatibilityRule<String> {
-    void execute(CompatibilityCheckDetails<String> details) {
-        if (details.consumerValue == "debug" && details.producerValue == "profile") {
-            details.compatible()
-        }
-    }
-}
-class FlavorSelectionRule implements AttributeDisambiguationRule<String> {
-    void execute(MultipleCandidatesDetails<String> details) {
-        if (details.candidateValues.contains('tasty')) {
-            details.closestMatch('tasty')
-        }
-    }
-}
+            $header
+            def buildType = Attribute.of('buildType', String)
+            def flavor = Attribute.of('flavor', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                    attribute(flavor)
+                }
+            }
 
-dependencies.attributesSchema {
-    attribute(buildType) {
-        compatibilityRules.add(BuildTypeCompatibilityRule)
-    }
-    attribute(flavor) {
-        disambiguationRules.add(FlavorSelectionRule)
-    }
-}
-
-dependencies {
-    compile project(':lib')
-}
-
-project(':lib') {
-    configurations {
-        compile {
-            outgoing {
-                variants {
-                    var1 {
-                        artifact file('a1.jar')
-                        attributes.attribute(buildType, 'profile')
-                        attributes.attribute(flavor, 'bland')
-                    }
-                    var2 {
-                        artifact file('a2.jar')
-                        attributes.attribute(buildType, 'profile')
-                        attributes.attribute(flavor, 'tasty')
-                    }
-                    var3 {
-                        artifact file('a3.jar')
-                        attributes.attribute(buildType, 'profile')
-                        attributes.attribute(flavor, 'bland')
+            class BuildTypeCompatibilityRule implements AttributeCompatibilityRule<String> {
+                void execute(CompatibilityCheckDetails<String> details) {
+                    if (details.consumerValue == "debug" && details.producerValue == "profile") {
+                        details.compatible()
                     }
                 }
             }
-        }
-    }
-}
+            class FlavorSelectionRule implements AttributeDisambiguationRule<String> {
+                void execute(MultipleCandidatesDetails<String> details) {
+                    if (details.candidateValues.contains('tasty')) {
+                        details.closestMatch('tasty')
+                    }
+                }
+            }
 
-task show {
-    inputs.files configurations.compile
-    def artifacts = configurations.compile.incoming.artifactView {
-        attributes { it.attribute(buildType, 'debug') }
-    }.artifacts
-    doLast {
-        println "files: " + artifacts.collect { it.file.name }
-        println "variants: " + artifacts.collect { it.variant.attributes }
-    }
-}
-"""
+            dependencies.attributesSchema {
+                attribute(buildType) {
+                    compatibilityRules.add(BuildTypeCompatibilityRule)
+                }
+                attribute(flavor) {
+                    disambiguationRules.add(FlavorSelectionRule)
+                }
+            }
+
+            dependencies {
+                compile project(':lib')
+            }
+
+            task show {
+                inputs.files configurations.compile
+                def artifacts = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(buildType, 'debug') }
+                }.artifacts
+                doLast {
+                    println "files: " + artifacts.collect { it.file.name }
+                    println "variants: " + artifacts.collect { it.variant.attributes }
+                }
+            }
+        """
+
+        settingsFile << """
+            include 'lib'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            def buildType = Attribute.of('buildType', String)
+            def flavor = Attribute.of('flavor', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                    attribute(flavor)
+                }
+            }
+
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            var1 {
+                                artifact file('a1.jar')
+                                attributes.attribute(buildType, 'profile')
+                                attributes.attribute(flavor, 'bland')
+                            }
+                            var2 {
+                                artifact file('a2.jar')
+                                attributes.attribute(buildType, 'profile')
+                                attributes.attribute(flavor, 'tasty')
+                            }
+                            var3 {
+                                artifact file('a3.jar')
+                                attributes.attribute(buildType, 'profile')
+                                attributes.attribute(flavor, 'bland')
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
         when:
         run 'show'
 
@@ -326,67 +389,92 @@ task show {
 
     def "applies producer's disambiguation rules when selecting variant"() {
         buildFile << """
-class FlavorCompatibilityRule implements AttributeCompatibilityRule<String> {
-    void execute(CompatibilityCheckDetails<String> details) {
-        details.compatible()
-    }
-}
-class FlavorSelectionRule implements AttributeDisambiguationRule<String> {
-    void execute(MultipleCandidatesDetails<String> details) {
-        if (details.candidateValues.contains('tasty')) {
-            details.closestMatch('tasty')
-        }
-    }
-}
+            $header
+            def buildType = Attribute.of('buildType', String)
+            def flavor = Attribute.of('flavor', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                    attribute(flavor)
+                }
+            }
 
-dependencies {
-    compile project(':lib')
-}
+            dependencies {
+                compile project(':lib')
+            }
 
-project(':lib') {
-    dependencies.attributesSchema {
-        attribute(flavor) {
-            compatibilityRules.add(FlavorCompatibilityRule)
-            disambiguationRules.add(FlavorSelectionRule)
-        }
-    }
+            task show {
+                def artifacts = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(buildType, 'debug'); it.attribute(flavor, 'anything') }
+                }.artifacts
+                inputs.files artifacts.artifactFiles
+                doLast {
+                    println "files: " + artifacts.collect { it.file.name }
+                    println "variants: " + artifacts.collect { it.variant.attributes }
+                }
+            }
+        """
 
-    configurations {
-        compile {
-            outgoing {
-                variants {
-                    var1 {
-                        artifact file('a1.jar')
-                        attributes.attribute(buildType, 'release')
-                        attributes.attribute(flavor, 'bland')
-                    }
-                    var2 {
-                        artifact file('a2.jar')
-                        attributes.attribute(buildType, 'debug')
-                        attributes.attribute(flavor, 'bland')
-                    }
-                    var3 {
-                        artifact file('a3.jar')
-                        attributes.attribute(buildType, 'debug')
-                        attributes.attribute(flavor, 'tasty')
+        settingsFile << """
+            include 'lib'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            def buildType = Attribute.of('buildType', String)
+            def flavor = Attribute.of('flavor', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                    attribute(flavor)
+                }
+            }
+
+            class FlavorCompatibilityRule implements AttributeCompatibilityRule<String> {
+                void execute(CompatibilityCheckDetails<String> details) {
+                    details.compatible()
+                }
+            }
+            class FlavorSelectionRule implements AttributeDisambiguationRule<String> {
+                void execute(MultipleCandidatesDetails<String> details) {
+                    if (details.candidateValues.contains('tasty')) {
+                        details.closestMatch('tasty')
                     }
                 }
             }
-        }
-    }
-}
 
-task show {
-    def artifacts = configurations.compile.incoming.artifactView {
-        attributes { it.attribute(buildType, 'debug'); it.attribute(flavor, 'anything') }
-    }.artifacts
-    inputs.files artifacts.artifactFiles
-    doLast {
-        println "files: " + artifacts.collect { it.file.name }
-        println "variants: " + artifacts.collect { it.variant.attributes }
-    }
-}
-"""
+            dependencies.attributesSchema {
+                attribute(flavor) {
+                    compatibilityRules.add(FlavorCompatibilityRule)
+                    disambiguationRules.add(FlavorSelectionRule)
+                }
+            }
+
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            var1 {
+                                artifact file('a1.jar')
+                                attributes.attribute(buildType, 'release')
+                                attributes.attribute(flavor, 'bland')
+                            }
+                            var2 {
+                                artifact file('a2.jar')
+                                attributes.attribute(buildType, 'debug')
+                                attributes.attribute(flavor, 'bland')
+                            }
+                            var3 {
+                                artifact file('a3.jar')
+                                attributes.attribute(buildType, 'debug')
+                                attributes.attribute(flavor, 'tasty')
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
         when:
         run 'show'
 
@@ -397,63 +485,84 @@ task show {
 
     def "applies producer's compatibility disambiguation rules for additional producer attributes when selecting variant"() {
         buildFile << """
-class ExtraSelectionRule implements AttributeDisambiguationRule<String> {
-    void execute(MultipleCandidatesDetails<String> details) {
-        if (details.candidateValues.contains('good')) {
-            details.closestMatch('good')
-        }
-    }
-}
+            $header
+            def buildType = Attribute.of('buildType', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                }
+            }
 
-def extra = Attribute.of('extra', String)
+            dependencies {
+                compile project(':lib')
+            }
 
-dependencies {
-    compile project(':lib')
-}
+            task show {
+                inputs.files configurations.compile
+                def artifacts = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(buildType, 'debug') }
+                }.artifacts
+                doLast {
+                    println "files: " + artifacts.collect { it.file.name }
+                    println "variants: " + artifacts.collect { it.variant.attributes }
+                }
+            }
+        """
 
-project(':lib') {
-    dependencies.attributesSchema {
-        attribute(extra) {
-            disambiguationRules.add(ExtraSelectionRule)
-        }
-    }
+        settingsFile << """
+            include 'lib'
+        """
 
-    configurations {
-        compile {
-            outgoing {
-                variants {
-                    var1 {
-                        artifact file('a1.jar')
-                        attributes.attribute(buildType, 'release')
-                        attributes.attribute(extra, 'ok')
-                    }
-                    var2 {
-                        artifact file('a2.jar')
-                        attributes.attribute(buildType, 'debug')
-                        attributes.attribute(extra, 'ok')
-                    }
-                    var3 {
-                        artifact file('a3.jar')
-                        attributes.attribute(buildType, 'debug')
-                        attributes.attribute(extra, 'good')
+        file("lib/build.gradle") << """
+            $header
+            def buildType = Attribute.of('buildType', String)
+            def extra = Attribute.of('extra', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                    attribute(extra)
+                }
+            }
+
+            class ExtraSelectionRule implements AttributeDisambiguationRule<String> {
+                void execute(MultipleCandidatesDetails<String> details) {
+                    if (details.candidateValues.contains('good')) {
+                        details.closestMatch('good')
                     }
                 }
             }
-        }
-    }
-}
 
-task show {
-    inputs.files configurations.compile
-    def artifacts = configurations.compile.incoming.artifactView {
-        attributes { it.attribute(buildType, 'debug') }
-    }.artifacts
-    doLast {
-        println "files: " + artifacts.collect { it.file.name }
-        println "variants: " + artifacts.collect { it.variant.attributes }
-    }
-}
-"""
+            dependencies.attributesSchema {
+                attribute(extra) {
+                    disambiguationRules.add(ExtraSelectionRule)
+                }
+            }
+
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            var1 {
+                                artifact file('a1.jar')
+                                attributes.attribute(buildType, 'release')
+                                attributes.attribute(extra, 'ok')
+                            }
+                            var2 {
+                                artifact file('a2.jar')
+                                attributes.attribute(buildType, 'debug')
+                                attributes.attribute(extra, 'ok')
+                            }
+                            var3 {
+                                artifact file('a3.jar')
+                                attributes.attribute(buildType, 'debug')
+                                attributes.attribute(extra, 'good')
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
         when:
         run 'show'
 
@@ -464,57 +573,80 @@ task show {
 
     def "can select the implicit variant of a configuration"() {
         buildFile << """
-
-dependencies {
-    compile project(':lib')
-    compile project(':ui')
-}
-
-project(':lib') {
-    configurations {
-        legacy
-        compile.extendsFrom legacy
-    }
-    artifacts {
-        legacy file('a1.jar')
-    }
-    configurations.compile.outgoing {
-        artifact file('a2.jar')
-        attributes.attribute(buildType, 'debug')
-        variants {
-            var1 {
-                artifact file('ignore-me.jar')
-                attributes.attribute(buildType, 'release')
+            $header
+            def buildType = Attribute.of('buildType', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                }
             }
-            var2 {
-                artifact file('ignore-me.jar')
-                attributes.attribute(buildType, 'profile')
-            }
-        }
-    }
-}
-project(':ui') {
-    configurations {
-        legacy
-        compile.extendsFrom legacy
-    }
-    artifacts {
-        legacy file('b1.jar')
-        compile file('b2.jar')
-    }
-}
 
-task show {
-    def artifacts = configurations.compile.incoming.artifactView {
-        attributes { it.attribute(buildType, 'debug') }
-    }.artifacts
-    inputs.files artifacts.artifactFiles
-    doLast {
-        println "files: " + artifacts.collect { it.file.name }
-        println "variants: " + artifacts.collect { it.variant.attributes }
-    }
-}
-"""
+            dependencies {
+                compile project(':lib')
+                compile project(':ui')
+            }
+
+            task show {
+                def artifacts = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(buildType, 'debug') }
+                }.artifacts
+                inputs.files artifacts.artifactFiles
+                doLast {
+                    println "files: " + artifacts.collect { it.file.name }
+                    println "variants: " + artifacts.collect { it.variant.attributes }
+                }
+            }
+        """
+
+        settingsFile << """
+            include 'lib'
+            include 'ui'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            def buildType = Attribute.of('buildType', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                }
+            }
+
+            configurations {
+                legacy
+                compile.extendsFrom legacy
+            }
+            artifacts {
+                legacy file('a1.jar')
+            }
+            configurations.compile.outgoing {
+                artifact file('a2.jar')
+                attributes.attribute(buildType, 'debug')
+                variants {
+                    var1 {
+                        artifact file('ignore-me.jar')
+                        attributes.attribute(buildType, 'release')
+                    }
+                    var2 {
+                        artifact file('ignore-me.jar')
+                        attributes.attribute(buildType, 'profile')
+                    }
+                }
+            }
+        """
+
+        file("ui/build.gradle") << """
+            $header
+            configurations {
+                legacy
+                compile.extendsFrom legacy
+            }
+            artifacts {
+                legacy file('b1.jar')
+                compile file('b2.jar')
+            }
+        """
+
         when:
         run 'show'
 
@@ -527,65 +659,83 @@ task show {
         def m1 = ivyHttpRepo.module("org", "test", "1.0").publish()
 
         buildFile << """
-import org.gradle.api.artifacts.transform.TransformParameters
+            import org.gradle.api.artifacts.transform.TransformParameters
 
-abstract class VariantArtifactTransform implements TransformAction<TransformParameters.None> {
-    @InputArtifact
-    abstract Provider<FileSystemLocation> getInputArtifact()
+            $header
 
-    void transform(TransformOutputs outputs) {
-        def output = outputs.file("transformed-" + inputArtifact.get().asFile.name)
-        output << "transformed"
-    }
-}
+            abstract class VariantArtifactTransform implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
 
-dependencies {
-    compile files('test-lib.jar')
-    compile project(':lib')
-    compile project(':ui')
-    compile 'org:test:1.0'
-    registerTransform(VariantArtifactTransform) {
-        from.attribute(usage, "api")
-        to.attribute(usage, "transformed")
-    }
-}
+                void transform(TransformOutputs outputs) {
+                    def output = outputs.file("transformed-" + inputArtifact.get().asFile.name)
+                    output << "transformed"
+                }
+            }
 
-project(':lib') {
-    configurations {
-        compile {
-            attributes.attribute(buildType, 'debug')
-            outgoing {
-                variants {
-                    var1 {
-                        artifact file('a1.jar')
-                        attributes.attribute(flavor, 'one')
+            dependencies {
+                compile files('test-lib.jar')
+                compile project(':lib')
+                compile project(':ui')
+                compile 'org:test:1.0'
+                registerTransform(VariantArtifactTransform) {
+                    from.attribute(usage, "api")
+                    to.attribute(usage, "transformed")
+                }
+            }
+
+            task show {
+                def artifacts = configurations.compile.incoming.artifactView {
+                    attributes {
+                        attribute(usage, 'transformed')
+                    }
+                }.artifacts
+                inputs.files artifacts.artifactFiles
+                doLast {
+                    println "files: " + artifacts.collect { it.file.name }
+                    println "components: " + artifacts.collect { it.id.componentIdentifier.displayName }
+                    println "variants: " + artifacts.collect { it.variant.attributes }
+                }
+            }
+        """
+
+        settingsFile << """
+            include 'lib'
+            include 'ui'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            def buildType = Attribute.of('buildType', String)
+            def flavor = Attribute.of('flavor', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                    attribute(flavor)
+                }
+            }
+
+            configurations {
+                compile {
+                    attributes.attribute(buildType, 'debug')
+                    outgoing {
+                        variants {
+                            var1 {
+                                artifact file('a1.jar')
+                                attributes.attribute(flavor, 'one')
+                            }
+                        }
                     }
                 }
             }
-        }
-    }
-}
+        """
 
-project(':ui') {
-    artifacts {
-        compile file('b2.jar')
-    }
-}
-
-task show {
-    def artifacts = configurations.compile.incoming.artifactView {
-        attributes {
-            attribute(usage, 'transformed')
-        }
-    }.artifacts
-    inputs.files artifacts.artifactFiles
-    doLast {
-        println "files: " + artifacts.collect { it.file.name }
-        println "components: " + artifacts.collect { it.id.componentIdentifier.displayName }
-        println "variants: " + artifacts.collect { it.variant.attributes }
-    }
-}
-"""
+        file("ui/build.gradle") << """
+            $header
+            artifacts {
+                compile file('b2.jar')
+            }
+        """
 
         when:
         m1.ivy.expectGet()
@@ -607,59 +757,88 @@ task show {
                     .artifact(name: 'some-classes', type: 'classes')
                     .publish()
 
-        buildFile << """
-            project(':lib') {
-                dependencies {
-                    compile utilJar.outputs.files
-                    compile utilClasses.outputs.files
-                    compile utilDir.outputs.files
-                    compile 'org:test:1.0'
-                    compile 'org:test2:1.0'
-                }
-                configurations {
-                    compile {
-                        outgoing {
-                            variants {
-                                jarFormat {
-                                    artifact file: file('lib.jar'), builtBy: tasks.jar
-                                }
-                                classesFormat {
-                                    artifact file: file('lib.classes'), builtBy: tasks.classes
-                                }
-                                dirFormat {
-                                    artifact file: file('lib'), builtBy: tasks.dir
-                                }
+        settingsFile << """
+            include 'lib'
+            include 'ui'
+            include 'app'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            task utilJar {
+                outputs.file("\${project.name}-util.jar")
+            }
+            task jar {
+                outputs.file("\${project.name}.jar")
+            }
+            task utilClasses {
+                outputs.file("\${project.name}-util.classes")
+            }
+            task classes {
+                outputs.file("\${project.name}.classes")
+            }
+            task dir {
+                outputs.file("\${project.name}")
+            }
+            task utilDir {
+                outputs.file("\${project.name}-util")
+            }
+            dependencies {
+                compile utilJar.outputs.files
+                compile utilClasses.outputs.files
+                compile utilDir.outputs.files
+                compile 'org:test:1.0'
+                compile 'org:test2:1.0'
+            }
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            jarFormat {
+                                artifact file: file('lib.jar'), builtBy: tasks.jar
+                            }
+                            classesFormat {
+                                artifact file: file('lib.classes'), builtBy: tasks.classes
+                            }
+                            dirFormat {
+                                artifact file: file('lib'), builtBy: tasks.dir
                             }
                         }
                     }
                 }
             }
-            project(':ui') {
-                artifacts {
-                    compile file: file('ui.classes'), builtBy: classes
+        """
+
+        file("ui/build.gradle") << """
+            $header
+            task classes {
+                outputs.file("\${project.name}.classes")
+            }
+            artifacts {
+                compile file: file('ui.classes'), builtBy: classes
+            }
+        """
+
+        file("app/build.gradle") << """
+            $header
+            configurations {
+                compile {
+                    attributes { attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'jar') }
                 }
             }
 
-            project(':app') {
-                configurations {
-                    compile {
-                        attributes { attribute(artifactType, 'jar') }
-                    }
-                }
+            dependencies {
+                compile project(':lib'), project(':ui')
+            }
 
-                dependencies {
-                    compile project(':lib'), project(':ui')
-                }
-
-                task resolve {
-                    def files = configurations.compile.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'classes') }
-                    }.files
-                    files.each { println it.name }
-                    inputs.files files
-                    doLast {
-                        assert files.collect { it.name } == ['lib.classes', 'lib-util.classes', 'ui.classes', 'some-classes-1.0.classes']
-                    }
+            task resolve {
+                def files = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'classes') }
+                }.files
+                files.each { println it.name }
+                inputs.files files
+                doLast {
+                    assert files.collect { it.name } == ['lib.classes', 'lib-util.classes', 'ui.classes', 'some-classes-1.0.classes']
                 }
             }
         """
@@ -676,44 +855,57 @@ task show {
 
     def "can create a view for configuration that has no attributes"() {
         given:
-        buildFile << """
-            project(':lib') {
-                configurations {
-                    compile {
-                        outgoing {
-                            variants {
-                                jarFormat {
-                                    artifact file: file('lib.jar'), builtBy: tasks.jar
-                                }
-                                classesFormat {
-                                    artifact file: file('lib.classes'), builtBy: tasks.classes
-                                }
-                                dirFormat {
-                                    artifact file: file('lib'), builtBy: tasks.dir
-                                }
+        settingsFile << """
+            include 'lib'
+            include 'app'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            task jar {
+                outputs.file("\${project.name}.jar")
+            }
+            task classes {
+                outputs.file("\${project.name}.classes")
+            }
+            task dir {
+                outputs.file("\${project.name}")
+            }
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            jarFormat {
+                                artifact file: file('lib.jar'), builtBy: tasks.jar
+                            }
+                            classesFormat {
+                                artifact file: file('lib.classes'), builtBy: tasks.classes
+                            }
+                            dirFormat {
+                                artifact file: file('lib'), builtBy: tasks.dir
                             }
                         }
                     }
                 }
             }
+        """
 
-            project(':app') {
-                configurations {
-                    noAttributes
-                }
+        file("app/build.gradle") << """
+            configurations {
+                noAttributes
+            }
 
-                dependencies {
-                    noAttributes project(path: ':lib', configuration: 'compile')
-                }
+            dependencies {
+                noAttributes project(path: ':lib', configuration: 'compile')
+            }
 
-                task resolve {
-                    def files = configurations.noAttributes.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'classes') }
-                    }.files
-                    inputs.files files
-                    doLast {
-                        assert files.collect { it.name } == ['lib.classes']
-                    }
+            task resolve {
+                def files = configurations.noAttributes.incoming.artifactView {
+                    attributes { it.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'classes') }
+                }.files
+                inputs.files files
+                doLast {
+                    assert files.collect { it.name } == ['lib.classes']
                 }
             }
         """
@@ -725,43 +917,55 @@ task show {
 
     def "fails when multiple variants match"() {
         given:
-        buildFile << """
-            project(':lib') {
-                configurations {
-                    compile {
-                        attributes.attribute(buildType, 'n/a')
-                        outgoing {
-                            variants {
-                                debug {
-                                    attributes.attribute(buildType, 'debug')
-                                    artifact file: file('lib-debug.jar')
-                                }
-                                release {
-                                    attributes.attribute(buildType, 'release')
-                                    artifact file: file('lib-release.jar')
-                                }
+        settingsFile << """
+            include 'lib'
+            include 'app'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            def buildType = Attribute.of('buildType', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                }
+            }
+
+            configurations {
+                compile {
+                    attributes.attribute(buildType, 'n/a')
+                    outgoing {
+                        variants {
+                            debug {
+                                attributes.attribute(buildType, 'debug')
+                                artifact file: file('lib-debug.jar')
+                            }
+                            release {
+                                attributes.attribute(buildType, 'release')
+                                artifact file: file('lib-release.jar')
                             }
                         }
                     }
                 }
-                artifacts {
-                    compile file('implicit.jar')
-                }
+            }
+            artifacts {
+                compile file('implicit.jar')
+            }
+        """
+
+        file("app/build.gradle") << """
+            $header
+            dependencies {
+                compile project(':lib')
             }
 
-            project(':app') {
-                dependencies {
-                    compile project(':lib')
-                }
-
-                task resolveView {
-                    def files = configurations.compile.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'jar') }
-                    }.files
-                    inputs.files files
-                    doLast {
-                        files.collect { it.name }
-                    }
+            task resolveView {
+                def files = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'jar') }
+                }.files
+                inputs.files files
+                doLast {
+                    files.collect { it.name }
                 }
             }
         """
@@ -784,42 +988,54 @@ task show {
 
     def "returns empty result when no variants match and view attributes specified"() {
         given:
-        buildFile << """
-            project(':lib') {
-                configurations {
-                    compile {
-                        outgoing {
-                            variants {
-                                debug {
-                                    attributes.attribute(buildType, 'debug')
-                                    artifact file: file('lib-debug.jar')
-                                }
-                                release {
-                                    attributes.attribute(buildType, 'release')
-                                    artifact file: file('lib-release.jar')
-                                }
+        settingsFile << """
+            include 'lib'
+            include 'app'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            def buildType = Attribute.of('buildType', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                }
+            }
+
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            debug {
+                                attributes.attribute(buildType, 'debug')
+                                artifact file: file('lib-debug.jar')
+                            }
+                            release {
+                                attributes.attribute(buildType, 'release')
+                                artifact file: file('lib-release.jar')
                             }
                         }
                     }
                 }
-                artifacts {
-                    compile file('implicit.jar')
-                }
+            }
+            artifacts {
+                compile file('implicit.jar')
+            }
+        """
+
+        file("app/build.gradle") << """
+            $header
+            dependencies {
+                compile project(':lib')
             }
 
-            project(':app') {
-                dependencies {
-                    compile project(':lib')
-                }
-
-                task resolveView {
-                    def files = configurations.compile.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'dll') }
-                    }.files
-                    inputs.files files
-                    doLast {
-                        assert files.empty
-                    }
+            task resolveView {
+                def files = configurations.compile.incoming.artifactView {
+                    attributes { it.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'dll') }
+                }.files
+                inputs.files files
+                doLast {
+                    assert files.empty
                 }
             }
         """
@@ -834,43 +1050,55 @@ task show {
         ivyHttpRepo.module("test","test", "1.2").publish().allowAll()
 
         given:
-        buildFile << """
-            project(':lib') {
-                configurations {
-                    compile {
-                        outgoing {
-                            variants {
-                                debug {
-                                    attributes.attribute(buildType, 'debug')
-                                    artifact file: file('lib-debug.jar')
-                                }
-                                release {
-                                    attributes.attribute(buildType, 'release')
-                                    artifact file: file('lib-release.jar')
-                                }
+        settingsFile << """
+            include 'lib'
+            include 'app'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            def buildType = Attribute.of('buildType', String)
+            dependencies {
+                attributesSchema {
+                    attribute(buildType)
+                }
+            }
+
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            debug {
+                                attributes.attribute(buildType, 'debug')
+                                artifact file: file('lib-debug.jar')
+                            }
+                            release {
+                                attributes.attribute(buildType, 'release')
+                                artifact file: file('lib-release.jar')
                             }
                         }
                     }
                 }
-                artifacts {
-                    compile file('implicit.jar')
-                }
+            }
+            artifacts {
+                compile file('implicit.jar')
+            }
+        """
+
+        file("app/build.gradle") << """
+            $header
+            configurations.compile.attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, 'dll')
+
+            dependencies {
+                compile project(':lib')
+                compile 'test:test:1.2'
+                compile files('thing.jar')
             }
 
-            project(':app') {
-                configurations.compile.attributes.attribute(artifactType, 'dll')
-
-                dependencies {
-                    compile project(':lib')
-                    compile 'test:test:1.2'
-                    compile files('thing.jar')
-                }
-
-                task resolveView {
-                    def files = configurations.compile.incoming.artifactView { }.files
-                    doLast {
-                        assert files.empty
-                    }
+            task resolveView {
+                def files = configurations.compile.incoming.artifactView { }.files
+                doLast {
+                    assert files.empty
                 }
             }
         """
@@ -906,72 +1134,88 @@ task show {
     def "reports failure to match attributes during selection"() {
         def resolve = new ResolveFailureTestFixture(buildFile)
 
-        buildFile << """
-            project(':lib') {
-                def attr = Attribute.of('attr', Boolean)
-                dependencies {
-                    attributesSchema {
-                        attribute(attr)
-                    }
+        settingsFile << """
+            include 'lib'
+            include 'ui'
+            include 'app'
+        """
+
+        file("lib/build.gradle") << """
+            $header
+            def attr = Attribute.of('attr', Boolean)
+            dependencies {
+                attributesSchema {
+                    attribute(attr)
                 }
-                configurations {
-                    compile {
-                        outgoing {
-                            variants {
-                                broken1 {
-                                    attributes.attribute(attr, true)
-                                }
-                                broken2 {
-                                    attributes.attribute(attr, false)
-                                }
+            }
+
+            dependencies {
+                attributesSchema {
+                    attribute(attr)
+                }
+            }
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            broken1 {
+                                attributes.attribute(attr, true)
+                            }
+                            broken2 {
+                                attributes.attribute(attr, false)
                             }
                         }
                     }
                 }
             }
+        """
 
-            project(':ui') {
-                def attr = Attribute.of('attr', Number)
-                dependencies {
-                    attributesSchema {
-                        attribute(attr)
-                    }
+        file("ui/build.gradle") << """
+            $header
+            def attr = Attribute.of('attr', Number)
+            dependencies {
+                attributesSchema {
+                    attribute(attr)
                 }
-                configurations {
-                    compile {
-                        outgoing {
-                            variants {
-                                broken1 {
-                                    attributes.attribute(attr, 12)
-                                }
-                                broken2 {
-                                    attributes.attribute(attr, 10)
-                                }
+            }
+
+            configurations {
+                compile {
+                    outgoing {
+                        variants {
+                            broken1 {
+                                attributes.attribute(attr, 12)
+                            }
+                            broken2 {
+                                attributes.attribute(attr, 10)
                             }
                         }
                     }
                 }
             }
+        """
 
-            project(':app') {
-                def attr = Attribute.of('attr', String)
-                dependencies {
-                    attributesSchema {
-                        attribute(attr)
-                    }
-
-                    compile project(':lib'), project(':ui')
+        file("app/build.gradle") << """
+            $header
+            def attr = Attribute.of('attr', String)
+            dependencies {
+                attributesSchema {
+                    attribute(attr)
                 }
+            }
 
-                task resolve {
-                    def files = configurations.compile.incoming.artifactView {
-                        attributes {
-                            it.attribute(attr, 'jar')
-                        }
-                    }.files
-                    doLast {
-                        files.each { println it }
+            dependencies {
+                compile project(':lib'), project(':ui')
+            }
+
+            task resolve {
+                def files = configurations.compile.incoming.artifactView {
+                    attributes {
+                        it.attribute(attr, 'jar')
                     }
+                }.files
+                doLast {
+                    files.each { println it }
                 }
             }
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BeforeResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BeforeResolveIntegrationTest.groovy
@@ -276,14 +276,14 @@ task resolveDependencies {
         mavenRepo.module('org.test', 'module1', '1.0').publish()
         mavenRepo.module('org.test', 'module2', '1.0').publish()
         settingsFile << """
-           include ":lib"
-        """
-        buildFile << """
-            allprojects {
-                repositories {
-                    maven { url = '${mavenRepo.uri}' }
-                }
+            include ":lib"
+
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
             }
+        """
+
+        buildFile << """
             configurations {
                 foo
                 bar {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CacheResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CacheResolveIntegrationTest.groovy
@@ -76,33 +76,34 @@ task deleteCacheFiles(type: Delete) {
         def module2 = repo2.module('org.gradle', 'testproject', '1.0').publishWithChangedContent()
 
         and:
-        createDirs("a", "b")
         settingsFile << "include 'a','b'"
-        buildFile << """
-subprojects {
-    configurations {
-        test
-    }
-    dependencies {
-        test "org.gradle:testproject:1.0"
-    }
-    task retrieve(type: Sync) {
-        into 'build'
-        from configurations.test
-    }
-}
-project('a') {
-    repositories {
-        ivy { url = "${repo1.uri}" }
-    }
-}
-project('b') {
-    repositories {
-        ivy { url = "${repo2.uri}" }
-    }
-    retrieve.dependsOn(':a:retrieve')
-}
-"""
+        def header = """
+            configurations {
+                test
+            }
+            dependencies {
+                test "org.gradle:testproject:1.0"
+            }
+            task retrieve(type: Sync) {
+                into 'build'
+                from configurations.test
+            }
+        """
+
+        file("a/build.gradle") << """
+            $header
+            repositories {
+                ivy { url = "${repo1.uri}" }
+            }
+        """
+
+        file("b/build.gradle") << """
+            $header
+            repositories {
+                ivy { url = "${repo2.uri}" }
+            }
+            retrieve.dependsOn(':a:retrieve')
+        """
 
         when:
         module1.ivy.expectGet()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConcurrentDerivationStrategyIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConcurrentDerivationStrategyIntegTest.groovy
@@ -32,15 +32,15 @@ class ConcurrentDerivationStrategyIntegTest extends AbstractIntegrationSpec {
         settingsFile << """
             include 'app'
             include 'lib'
+            dependencyResolutionManagement {
+                ${mavenCentralRepository()}
+            }
         """
 
-        buildFile << """
-            subprojects {
-                ${mavenCentralRepository()}
-                dependencies {
-                    components {
-                        $rules
-                    }
+        def common = """
+            dependencies {
+                components {
+                    $rules
                 }
             }
 
@@ -61,6 +61,8 @@ class ConcurrentDerivationStrategyIntegTest extends AbstractIntegrationSpec {
         """
 
         file('app/build.gradle') << """
+            $common
+
             configurations {
                foo
             }
@@ -90,6 +92,8 @@ class ConcurrentDerivationStrategyIntegTest extends AbstractIntegrationSpec {
             plugins {
                id 'java-library'
             }
+
+            $common
 
             dependencies {
                api 'org.apache.commons:commons-lang3:3.3.1'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyManagementResultsAsInputsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyManagementResultsAsInputsIntegrationTest.groovy
@@ -83,12 +83,14 @@ class DependencyManagementResultsAsInputsIntegrationTest extends AbstractHttpDep
             .allowAll()
         mavenHttpRepo.module("org.external", "external-tool").publish().allowAll()
         file('lib/file-lib.jar') << 'content'
-        buildFile << """
-            project(':project-lib') {
-                apply plugin: 'java-library'
-                ${variantDeclaration('projectLibAttrValue')}
-                ${unselectedVariantDeclaration('projectUnselectedLibAttrValue')}
+        file("project-lib/build.gradle") << """
+            plugins {
+                id("java-library")
             }
+            ${variantDeclaration('projectLibAttrValue')}
+            ${unselectedVariantDeclaration('projectUnselectedLibAttrValue')}
+        """
+        buildFile << """
             apply plugin: 'java-library'
             repositories { maven { url = "${mavenHttpRepo.uri}" } }
             dependencies {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -64,7 +64,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
                 failOnVersionConflict()
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -111,7 +111,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     }
                 }
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -161,7 +161,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     }
                 }
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -211,7 +211,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     }
                 }
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -250,7 +250,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     }
                 }
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -291,7 +291,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     substitute module("org.utils:api") using module("org.utils:api:1.6")
                 }
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -333,7 +333,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     assert deps[0].selected.selectionReason.selectedByRule
                 }
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -347,21 +347,20 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     }
 
     void "can substitute modules with project dependency using #name"() {
-        createDirs("api", "impl")
         settingsFile << 'include "api", "impl"'
-        buildFile << """
+        buildFile << common
+        file("api/build.gradle") << common
+        file("impl/build.gradle") << """
             $common
 
-            project(":impl") {
-                dependencies {
-                    conf group: "org.utils", name: "api", version: "1.5", configuration: "conf"
-                }
-
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute module("$selector") using project(":api")
-                }
+            dependencies {
+                conf group: "org.utils", name: "api", version: "1.5", configuration: "conf"
             }
-"""
+
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute module("$selector") using project(":api")
+            }
+        """
 
         when:
         run ":impl:checkDeps"
@@ -386,46 +385,47 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     }
 
     void "can access built artifacts from substituted project dependency"() {
-        createDirs("api", "impl")
         settingsFile << 'include "api", "impl"'
 
-        buildFile << """
+        buildFile << common
+
+        file("api/build.gradle") << """
             $common
 
-            project(":api") {
-                task build {
-                    def outFile = file("artifact.txt")
-                    outputs.file(outFile)
-                    doLast {
-                        outFile << "Lajos"
-                    }
-                }
-
-                artifacts {
-                    conf (file("artifact.txt")) {
-                        builtBy build
-                    }
+            task build {
+                def outFile = file("artifact.txt")
+                outputs.file(outFile)
+                doLast {
+                    outFile << "Lajos"
                 }
             }
 
-            project(":impl") {
-                dependencies {
-                    conf group: "org.utils", name: "api", version: "1.5"
-                }
-
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute module("org.utils:api") using project(":api")
-                }
-
-                task check(dependsOn: configurations.conf) {
-                    def files = configurations.conf
-                    doLast {
-                        assert files*.name.sort() == ["api.jar", "artifact.txt"]
-                        assert files[1].text == "Lajos"
-                    }
+            artifacts {
+                conf (file("artifact.txt")) {
+                    builtBy build
                 }
             }
-"""
+        """
+
+        file("impl/build.gradle") << """
+            $common
+
+            dependencies {
+                conf group: "org.utils", name: "api", version: "1.5"
+            }
+
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute module("org.utils:api") using project(":api")
+            }
+
+            task check(dependsOn: configurations.conf) {
+                def files = configurations.conf
+                doLast {
+                    assert files*.name.sort() == ["api.jar", "artifact.txt"]
+                    assert files[1].text == "Lajos"
+                }
+            }
+        """
 
         when:
         succeeds ":impl:check"
@@ -437,25 +437,27 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     void "can replace project dependency #projectGroup:api:#projectVersion with external dependency org.utils:api:1.5"() {
         mavenRepo.module("org.utils", "api", '1.5').publish()
 
-        createDirs("api", "impl")
         settingsFile << 'include "api", "impl"'
 
-        buildFile << """
-            $common
-            project(":api") {
-                group = "$projectGroup"
-                version = "$projectVersion"
-            }
-            project(":impl") {
-                dependencies {
-                    conf project(path: ":api")
-                }
+        buildFile << common
 
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute project(":api") using module("org.utils:api:1.5")
-                }
+        file("api/build.gradle") << """
+            $common
+            group = "$projectGroup"
+            version = "$projectVersion"
+        """
+
+        file("impl/build.gradle") << """
+            $common
+
+            dependencies {
+                conf project(path: ":api")
             }
-"""
+
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute project(":api") using module("org.utils:api:1.5")
+            }
+        """
 
         when:
         run ":impl:checkDeps"
@@ -481,24 +483,24 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
 
     void "can replace transitive external dependency with project dependency"() {
         mavenRepo.module("org.utils", "impl", '1.5').dependsOn('org.utils', 'api', '1.5').publish()
-        createDirs("api", "test")
         settingsFile << 'include "api", "test"'
 
-        buildFile << """
+        buildFile << common
+        file("api/build.gradle") << common
+
+        file("test/build.gradle") << """
             $common
 
-            project(":test") {
-                dependencies {
-                    conf group: "org.utils", name: "impl", version: "1.5"
-                }
-
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute module("org.utils:api") using project(":api")
-                }
-
-                task("buildConf", dependsOn: configurations.conf)
+            dependencies {
+                conf group: "org.utils", name: "impl", version: "1.5"
             }
-"""
+
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute module("org.utils:api") using project(":api")
+            }
+
+            task("buildConf", dependsOn: configurations.conf)
+        """
 
         when:
         run ":test:checkDeps"
@@ -520,36 +522,36 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     }
 
     void "can replace client module dependency with project dependency"() {
-        createDirs("api", "impl")
         settingsFile << 'include "api", "impl"'
 
-        buildFile << """
+        buildFile << common
+        file("api/build.gradle") << common
+
+        file("impl/build.gradle") << """
             $common
 
-            project(":impl") {
-                dependencies {
-                    conf module(group: "org.utils", name: "api", version: "1.5")
-                }
+            dependencies {
+                conf module(group: "org.utils", name: "api", version: "1.5")
+            }
 
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute module("org.utils:api") using project(":api")
-                }
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute module("org.utils:api") using project(":api")
+            }
 
-                task check {
-                    doLast {
-                        def deps = configurations.conf.incoming.resolutionResult.allDependencies as List
-                        assert deps.size() == 1
-                        assert deps[0] instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult
+            task check {
+                doLast {
+                    def deps = configurations.conf.incoming.resolutionResult.allDependencies as List
+                    assert deps.size() == 1
+                    assert deps[0] instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult
 
-                        assert deps[0].requested.matchesStrictly(moduleId("org.utils", "api", "1.5"))
-                        assert deps[0].selected.componentId == projectId(":api")
+                    assert deps[0].requested.matchesStrictly(moduleId("org.utils", "api", "1.5"))
+                    assert deps[0].selected.componentId == projectId(":api")
 
-                        assert !deps[0].selected.selectionReason.forced
-                        assert deps[0].selected.selectionReason.selectedByRule
-                    }
+                    assert !deps[0].selected.selectionReason.forced
+                    assert deps[0].selected.selectionReason.selectedByRule
                 }
             }
-"""
+        """
 
 
         when:
@@ -568,25 +570,25 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     }
 
     void "can replace client module's transitive dependency with project dependency"() {
-        createDirs("api", "impl")
         settingsFile << 'include "api", "impl"'
         mavenRepo.module("org.utils", "bela", '1.5').publish()
 
-        buildFile << """
+        buildFile << common
+        file("api/build.gradle") << common
+
+        file("impl/build.gradle") << """
             $common
 
-            project(":impl") {
-                dependencies {
-                    conf module(group: "org.utils", name: "bela", version: "1.5") {
-                        dependencies group: "org.utils", name: "api", version: "1.5"
-                    }
-                }
-
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute module("org.utils:api") using project(":api")
+            dependencies {
+                conf module(group: "org.utils", name: "bela", version: "1.5") {
+                    dependencies group: "org.utils", name: "api", version: "1.5"
                 }
             }
-"""
+
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute module("org.utils:api") using project(":api")
+            }
+        """
 
         when:
         executer.expectDocumentedDeprecationWarning("Declaring client module dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use component metadata rules instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#declaring_client_module_dependencies")
@@ -609,27 +611,27 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     void "can replace external dependency declared in extended configuration with project dependency"() {
         mavenRepo.module("org.utils", "api", '1.5').publish()
 
-        createDirs("api", "impl")
         settingsFile << 'include "api", "impl"'
 
-        buildFile << """
+        buildFile << common
+        file("api/build.gradle") << common
+
+        file("impl/build.gradle") << """
             $common
 
-            project(":impl") {
-                configurations {
-                    subConf
-                    conf.extendsFrom subConf
-                }
-
-                dependencies {
-                    subConf group: "org.utils", name: "api", version: "1.5"
-                }
-
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute module("org.utils:api") using project(":api")
-                }
+            configurations {
+                subConf
+                conf.extendsFrom subConf
             }
-"""
+
+            dependencies {
+                subConf group: "org.utils", name: "api", version: "1.5"
+            }
+
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute module("org.utils:api") using project(":api")
+            }
+        """
 
         when:
         run ":impl:checkDeps"
@@ -646,26 +648,26 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     }
 
     void "can replace forced external dependency with project dependency"() {
-        createDirs("api", "impl")
         settingsFile << 'include "api", "impl"'
 
-        buildFile << """
+        buildFile << common
+        file("api/build.gradle") << common
+
+        file("impl/build.gradle") << """
             $common
 
-            project(":impl") {
-                dependencies {
-                    conf group: "org.utils", name: "api", version: "1.5"
-                }
+            dependencies {
+                conf group: "org.utils", name: "api", version: "1.5"
+            }
 
-                configurations.conf.resolutionStrategy {
-                    force("org.utils:api:1.3")
+            configurations.conf.resolutionStrategy {
+                force("org.utils:api:1.3")
 
-                    dependencySubstitution {
-                        substitute module("org.utils:api") using project(":api")
-                    }
+                dependencySubstitution {
+                    substitute module("org.utils:api") using project(":api")
                 }
             }
-"""
+        """
 
         when:
         run ":impl:checkDeps"
@@ -683,53 +685,52 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     }
 
     void "get useful error message when replacing an external dependency with a project that does not exist"() {
-        createDirs("api", "impl")
         settingsFile << 'include "api", "impl"'
 
-        buildFile << """
+        buildFile << common
+        file("api/build.gradle") << common
+
+        file("impl/build.gradle") << """
             $common
 
-            project(":impl") {
-                dependencies {
-                    conf group: "org.utils", name: "api", version: "1.5"
-                }
+            dependencies {
+                conf group: "org.utils", name: "api", version: "1.5"
+            }
 
-                configurations.conf.resolutionStrategy {
-                    force("org.utils:api:1.3")
+            configurations.conf.resolutionStrategy {
+                force("org.utils:api:1.3")
 
-                    dependencySubstitution {
-                        substitute module("org.utils:api") using project(":doesnotexist")
-                    }
+                dependencySubstitution {
+                    substitute module("org.utils:api") using project(":doesnotexist")
                 }
             }
-"""
-
+        """
 
         when:
         fails ":impl:checkDeps"
 
         then:
-        failure.assertHasDescription("A problem occurred evaluating root project 'depsub'.")
+        failure.assertHasDescription("A problem occurred evaluating project ':impl'.")
         failure.assertHasCause("Project with path ':doesnotexist' not found in build ':'.")
     }
 
     void "replacing external module dependency with project dependency keeps the original configuration"() {
-        createDirs("api", "impl")
         settingsFile << 'include "api", "impl"'
 
-        buildFile << """
+        buildFile << common
+        file("api/build.gradle") << common
+
+        file("impl/build.gradle") << """
             $common
 
-            project(":impl") {
-                dependencies {
-                    conf group: "org.utils", name: "api", version: "1.5", configuration: "conf"
-                }
-
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute module("org.utils:api:1.5") using project(":api")
-                }
+            dependencies {
+                conf group: "org.utils", name: "api", version: "1.5", configuration: "conf"
             }
-"""
+
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute module("org.utils:api:1.5") using project(":api")
+            }
+        """
 
         when:
         run ":impl:checkDeps"
@@ -747,22 +748,22 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
 
     void "replacing external module dependency with project dependency keeps the original transitivity"() {
         mavenRepo.module("org.utils", "impl", '1.5').dependsOn('org.utils', 'api', '1.5').publish()
-        createDirs("impl", "test")
         settingsFile << 'include "impl", "test"'
 
-        buildFile << """
+        buildFile << common
+        file("impl/build.gradle") << common
+
+        file("test/build.gradle") << """
             $common
 
-            project(":test") {
-                dependencies {
-                    conf (group: "org.utils", name: "impl", version: "1.5") { transitive = false }
-                }
-
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute module("org.utils:impl") using project(":impl")
-                }
+            dependencies {
+                conf (group: "org.utils", name: "impl", version: "1.5") { transitive = false }
             }
-"""
+
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute module("org.utils:impl") using project(":impl")
+            }
+        """
 
         when:
         run ":test:checkDeps"
@@ -781,50 +782,50 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     void "external dependency substituted for a project dependency participates in conflict resolution"() {
         mavenRepo.module("org.utils", "api", '2.0').publish()
 
-        createDirs("api", "impl")
         settingsFile << 'include "api", "impl"'
 
-        buildFile << """
+        buildFile << common
+        file("api/build.gradle") << common
+
+        file("impl/build.gradle") << """
             $common
 
-            project(":impl") {
-                dependencies {
-                    conf project(":api")
-                    conf "org.utils:api:2.0"
-                }
+            dependencies {
+                conf project(":api")
+                conf "org.utils:api:2.0"
+            }
 
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute project(":api") using module("org.utils:api:1.6")
-                }
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute project(":api") using module("org.utils:api:1.6")
+            }
 
-                task check {
-                    doLast {
-                        def deps = configurations.conf.incoming.resolutionResult.allDependencies as List
-                        assert deps.size() == 2
-                        assert deps.find {
-                            it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                            it.requested.matchesStrictly(projectId(":api")) &&
-                            it.selected.componentId == moduleId("org.utils", "api", "2.0") &&
-                            !it.selected.selectionReason.forced &&
-                            !it.selected.selectionReason.selectedByRule &&
-                            it.selected.selectionReason.conflictResolution
-                        }
-                        assert deps.find {
-                            it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                            it.requested.matchesStrictly(moduleId("org.utils", "api", "2.0")) &&
-                            it.selected.componentId == moduleId("org.utils", "api", "2.0") &&
-                            !it.selected.selectionReason.forced &&
-                            !it.selected.selectionReason.selectedByRule &&
-                            it.selected.selectionReason.conflictResolution
-                        }
-
-                        def resolvedDeps = configurations.conf.resolvedConfiguration.firstLevelModuleDependencies
-                        resolvedDeps.size() == 1
-                        resolvedDeps[0].module.id == moduleId("org.utils", "api", "2.0")
+            task check {
+                doLast {
+                    def deps = configurations.conf.incoming.resolutionResult.allDependencies as List
+                    assert deps.size() == 2
+                    assert deps.find {
+                        it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
+                        it.requested.matchesStrictly(projectId(":api")) &&
+                        it.selected.componentId == moduleId("org.utils", "api", "2.0") &&
+                        !it.selected.selectionReason.forced &&
+                        !it.selected.selectionReason.selectedByRule &&
+                        it.selected.selectionReason.conflictResolution
                     }
+                    assert deps.find {
+                        it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
+                        it.requested.matchesStrictly(moduleId("org.utils", "api", "2.0")) &&
+                        it.selected.componentId == moduleId("org.utils", "api", "2.0") &&
+                        !it.selected.selectionReason.forced &&
+                        !it.selected.selectionReason.selectedByRule &&
+                        it.selected.selectionReason.conflictResolution
+                    }
+
+                    def resolvedDeps = configurations.conf.resolvedConfiguration.firstLevelModuleDependencies
+                    resolvedDeps.size() == 1
+                    resolvedDeps[0].module.id == moduleId("org.utils", "api", "2.0")
                 }
             }
-"""
+        """
 
         when:
         run ":impl:checkDeps"
@@ -841,39 +842,42 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     void "project dependency substituted for an external dependency participates in conflict resolution"() {
         mavenRepo.module("org.utils", "dep1", '2.0').publish()
         mavenRepo.module("org.utils", "dep2", '2.0').publish()
-        createDirs("impl", "dep1", "dep2")
         settingsFile << 'include "impl", "dep1", "dep2"'
 
-        buildFile << """
+        buildFile << common
+
+        file("dep1/build.gradle") << """
             $common
 
-            project(":dep1") {
-                group = "org.utils"
-                version = '1.6'
+            group = "org.utils"
+            version = '1.6'
+        """
+
+        file("dep2/build.gradle") << """
+            $common
+
+            group = "org.utils"
+            version = '3.0'
+
+            jar.archiveVersion = '3.0'
+        """
+
+        file("impl/build.gradle") << """
+            $common
+
+            dependencies {
+                conf "org.utils:dep1:1.5"
+                conf "org.utils:dep1:2.0"
+
+                conf "org.utils:dep2:1.5"
+                conf "org.utils:dep2:2.0"
             }
 
-            project(":dep2") {
-                group = "org.utils"
-                version = '3.0'
-
-                jar.archiveVersion = '3.0'
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute module("org.utils:dep1:1.5") using project(":dep1")
+                substitute module("org.utils:dep2:1.5") using project(":dep2")
             }
-
-            project(":impl") {
-                dependencies {
-                    conf "org.utils:dep1:1.5"
-                    conf "org.utils:dep1:2.0"
-
-                    conf "org.utils:dep2:1.5"
-                    conf "org.utils:dep2:2.0"
-                }
-
-                configurations.conf.resolutionStrategy.dependencySubstitution {
-                    substitute module("org.utils:dep1:1.5") using project(":dep1")
-                    substitute module("org.utils:dep2:1.5") using project(":dep2")
-                }
-            }
-"""
+        """
 
         when:
         run ":impl:checkDeps"
@@ -914,7 +918,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
             configurations.conf.resolutionStrategy.dependencySubstitution {
                 substitute module('org.utils:a:1.2') using module('org.utils:a:1.4')
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -945,7 +949,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
             configurations.conf.resolutionStrategy.dependencySubstitution {
                 substitute module('org.utils:a:1.2') using module('org.utils:a:1.2.1')
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -979,7 +983,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     it.useTarget group: it.requested.group, name: it.requested.module, version: '1.3'
                 }
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -1008,7 +1012,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     it.useTarget group: it.requested.group, name: it.requested.module, version: '1.3'
                 }
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -1050,7 +1054,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     assert deps[0].requested.version == '1.3'
                 }
             }
-"""
+        """
 
         when:
         succeeds "check"
@@ -1106,7 +1110,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     assert requested == [ 'api:1.3', 'api:1.5', 'bar:2.0', 'foo:2.0', 'impl:1.3']
                 }
             }
-"""
+        """
 
         expect:
         succeeds "check"
@@ -1136,7 +1140,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                     }
                 }
             }
-"""
+        """
 
         when:
         fails "checkDeps"
@@ -1187,7 +1191,7 @@ Required by:
             configurations.conf.resolutionStrategy.dependencySubstitution {
                 substitute module(":foo:bar:baz:") using module("")
             }
-"""
+        """
 
         when:
         fails "checkDeps"
@@ -1213,7 +1217,7 @@ Required by:
                     it.useTarget moduleSelector
                 }
             }
-"""
+        """
 
         when:
         fails "checkDeps"
@@ -1237,7 +1241,7 @@ Required by:
             configurations.conf.resolutionStrategy.dependencySubstitution {
                 substitute module('org.utils:a:1.2') using module('org.utils:b:2.1')
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -1271,7 +1275,7 @@ Required by:
                     it.useTarget('org:' + it.requested.module + ':' + it.requested.version)
                 }
             }
-"""
+        """
 
         when:
         run "checkDeps"
@@ -1309,8 +1313,7 @@ Required by:
             configurations.conf.resolutionStrategy.dependencySubstitution {
                 substitute module('foo:bar:baz') using module('org:b:1.0')
             }
-"""
-
+        """
 
         when:
         run "checkDeps"
@@ -1341,7 +1344,7 @@ Required by:
             configurations.conf.resolutionStrategy.dependencySubstitution.all {
                 it.useTarget "foobar"
             }
-"""
+        """
 
         when:
         fails "checkDeps"
@@ -1366,8 +1369,7 @@ Required by:
             configurations.conf.resolutionStrategy.dependencySubstitution {
                 substitute module('org:a:1.0') using module('org:c:1.1')
             }
-"""
-
+        """
 
         when:
         run "checkDeps"
@@ -1390,26 +1392,24 @@ Required by:
 
     String getCommon() {
         """
-        allprojects {
-            configurations {
-                conf
-            }
-            configurations.create("default").extendsFrom(configurations.conf)
-
-            repositories {
-                maven { url = "${mavenRepo.uri}" }
-            }
-
-            task jar(type: Jar) {
-                archiveBaseName = project.name
-                // TODO LJA: No idea why I have to do this
-                if (project.version != 'unspecified') {
-                    archiveFileName = "\${project.name}-\${project.version}.jar"
-                }
-                destinationDirectory = buildDir
-            }
-            artifacts { conf jar }
+        configurations {
+            conf
         }
+        configurations.create("default").extendsFrom(configurations.conf)
+
+        repositories {
+            maven { url = "${mavenRepo.uri}" }
+        }
+
+        task jar(type: Jar) {
+            archiveBaseName = project.name
+            // TODO LJA: No idea why I have to do this
+            if (project.version != 'unspecified') {
+                archiveFileName = "\${project.name}-\${project.version}.jar"
+            }
+            destinationDirectory = buildDir
+        }
+        artifacts { conf jar }
 
         def moduleId(String group, String name, String version) {
             return org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier.newId(group, name, version)
@@ -1439,8 +1439,7 @@ Required by:
             configurations.conf.resolutionStrategy.dependencySubstitution {
                 substitute module('foo:bar:baz') because('we need integration tests') using module('org:b:1.0')
             }
-"""
-
+        """
 
         when:
         run "checkDeps"
@@ -1462,31 +1461,31 @@ Required by:
 
     @Issue("gradle/gradle#5692")
     def 'substitution with project does not trigger failOnVersionConflict'() {
-        createDirs("sub")
         settingsFile << 'include "sub"'
         buildFile << """
-subprojects {
-    it.version = '0.0.1'
-    group = 'org.test'
-}
+            $common
 
-$common
+            dependencies {
+                conf 'foo:bar:1'
+                conf project(':sub')
+            }
 
-dependencies {
-    conf 'foo:bar:1'
-    conf project(':sub')
-}
+            configurations.all {
+                resolutionStrategy {
+                    dependencySubstitution { DependencySubstitutions subs ->
+                        subs.substitute(subs.module('foo:bar:1')).using(subs.project(':sub'))
+                    }
+                    failOnVersionConflict()
+                }
+            }
+        """
 
-configurations.all {
-  resolutionStrategy {
-      dependencySubstitution { DependencySubstitutions subs ->
-          subs.substitute(subs.module('foo:bar:1')).using(subs.project(':sub'))
-      }
-      failOnVersionConflict()
-  }
-}
+        file("sub/build.gradle") << """
+            version = '0.0.1'
+            group = 'org.test'
 
-"""
+            $common
+        """
 
         when:
         succeeds ':checkDeps'
@@ -1659,7 +1658,6 @@ configurations.all {
             .dependencyConstraint(fooModule)
             .publish()
 
-        createDirs("lib")
         settingsFile << """
             include 'lib'
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FilteredConfigurationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FilteredConfigurationIntegrationTest.groovy
@@ -27,56 +27,64 @@ class FilteredConfigurationIntegrationTest extends AbstractDependencyResolutionT
         mavenRepo.module("group", "test1", "1.0").publish()
         mavenRepo.module("group", "test2", "1.0").publish()
 
-        createDirs("child1", "child2")
         settingsFile << """
-rootProject.name = "main"
-include "child1", "child2"
-"""
+            rootProject.name = "main"
+            include "child1", "child2"
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
+
         buildFile << """
-allprojects {
-    repositories {
-        maven { url = '${mavenRepo.uri}' }
-    }
-    configurations {
-        compile
-        create('default') { extendsFrom compile }
-    }
-}
-artifacts {
-    compile file("main.jar")
-}
-dependencies {
-    compile files("lib.jar")
-    compile "group:test1:1.0"
-    compile project(':child1')
-    compile project(':child2')
-}
-project(':child1') {
-    artifacts {
-        compile file("child1.jar")
-    }
-    dependencies {
-        compile files("child1-lib.jar")
-        compile "group:test2:1.0"
-    }
-}
-project(':child2') {
-    artifacts {
-        compile file("child2.jar")
-    }
-}
+            configurations {
+                compile
+                create('default') { extendsFrom compile }
+            }
+            artifacts {
+                compile file("main.jar")
+            }
+            dependencies {
+                compile files("lib.jar")
+                compile "group:test1:1.0"
+                compile project(':child1')
+                compile project(':child2')
+            }
 
-task verify {
-    doLast {
-        println "file-dependencies: " + configurations.compile.files { it instanceof FileCollectionDependency }.collect { it.name }
-        println "external-dependencies: " + configurations.compile.files { it instanceof ExternalDependency }.collect { it.name }
-        println "child1-dependencies: " + configurations.compile.files { it instanceof ProjectDependency && it.path == ':child1' }.collect { it.name }
+            task verify {
+                doLast {
+                    println "file-dependencies: " + configurations.compile.files { it instanceof FileCollectionDependency }.collect { it.name }
+                    println "external-dependencies: " + configurations.compile.files { it instanceof ExternalDependency }.collect { it.name }
+                    println "child1-dependencies: " + configurations.compile.files { it instanceof ProjectDependency && it.path == ':child1' }.collect { it.name }
 
-        assert configurations.compile.resolvedConfiguration.files == configurations.compile.files
-        assert configurations.compile.resolvedConfiguration.lenientConfiguration.files == configurations.compile.files
-    }
-}
-"""
+                    assert configurations.compile.resolvedConfiguration.files == configurations.compile.files
+                    assert configurations.compile.resolvedConfiguration.lenientConfiguration.files == configurations.compile.files
+                }
+            }
+        """
+
+        file("child1/build.gradle") << """
+            configurations {
+                compile
+                create('default') { extendsFrom compile }
+            }
+            artifacts {
+                compile file("child1.jar")
+            }
+            dependencies {
+                compile files("child1-lib.jar")
+                compile "group:test2:1.0"
+            }
+        """
+
+        file("child2/build.gradle") << """
+            configurations {
+                compile
+                create('default') { extendsFrom compile }
+            }
+            artifacts {
+                compile file("child2.jar")
+            }
+        """
 
         when:
         executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
@@ -84,7 +92,7 @@ task verify {
         executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
         executer.expectDocumentedDeprecationWarning("The ResolvedConfiguration.getFiles() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration#getFiles instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_legacy_configuration_get_files")
         executer.expectDocumentedDeprecationWarning("The LenientConfiguration.getFiles() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use a lenient ArtifactView instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_legacy_configuration_get_files")
-        run "verify"
+        succeeds("verify")
 
         then:
         outputContains("file-dependencies: [lib.jar]")
@@ -97,57 +105,59 @@ task verify {
         mavenRepo.module("group", "test1", "1.0").publish()
         mavenRepo.module("group", "test2", "1.0").publish()
 
-        createDirs("child1", "child2")
         settingsFile << """
-rootProject.name = "main"
-include "child1", "child2"
-"""
+            rootProject.name = "main"
+            include "child1"
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
         buildFile << """
-allprojects {
-    repositories {
-        maven { url = '${mavenRepo.uri}' }
-    }
-    configurations {
-        compile
-        create('default') { extendsFrom compile }
-    }
-}
-dependencies {
-    compile files("lib.jar")
-    compile "group:test1:1.0"
-    compile project(':child1')
-}
-artifacts {
-    compile file("main.jar")
-}
-project(':child1') {
-    artifacts {
-        compile file("child1.jar")
-    }
-    dependencies {
-        compile files("child1-lib.jar")
-        compile "group:test2:1.0"
-        compile project(":")
-    }
-}
+            configurations {
+                compile
+                create('default') { extendsFrom compile }
+            }
+            dependencies {
+                compile files("lib.jar")
+                compile "group:test1:1.0"
+                compile project(':child1')
+            }
+            artifacts {
+                compile file("main.jar")
+            }
 
-task verify {
-    doLast {
-        println "external-dependencies: " + configurations.compile.files { it instanceof ExternalDependency }.collect { it.name }
-        println "child1-dependencies: " + configurations.compile.files { it instanceof ProjectDependency && it.path == ':child1' }.collect { it.name }
+            task verify {
+                doLast {
+                    println "external-dependencies: " + configurations.compile.files { it instanceof ExternalDependency }.collect { it.name }
+                    println "child1-dependencies: " + configurations.compile.files { it instanceof ProjectDependency && it.path == ':child1' }.collect { it.name }
 
-        assert configurations.compile.resolvedConfiguration.files == configurations.compile.files
-        assert configurations.compile.resolvedConfiguration.lenientConfiguration.files == configurations.compile.files
-    }
-}
-"""
+                    assert configurations.compile.resolvedConfiguration.files == configurations.compile.files
+                    assert configurations.compile.resolvedConfiguration.lenientConfiguration.files == configurations.compile.files
+                }
+            }
+        """
+
+        file("child1/build.gradle") << """
+            configurations {
+                compile
+                create('default') { extendsFrom compile }
+            }
+            artifacts {
+                compile file("child1.jar")
+            }
+            dependencies {
+                compile files("child1-lib.jar")
+                compile "group:test2:1.0"
+                compile project(":")
+            }
+        """
 
         when:
         executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
         executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
         executer.expectDocumentedDeprecationWarning("The ResolvedConfiguration.getFiles() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration#getFiles instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_legacy_configuration_get_files")
         executer.expectDocumentedDeprecationWarning("The LenientConfiguration.getFiles() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use a lenient ArtifactView instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_legacy_configuration_get_files")
-        run "verify"
+        succeeds("verify")
 
         then:
         outputContains("external-dependencies: [test1-1.0.jar]")
@@ -156,48 +166,56 @@ task verify {
 
     // Note: this captures existing behaviour (all files are built) rather than desired behaviour (only those files reachable from selected deps are built)
     def "can use filtered configuration as task input"() {
-        createDirs("child1", "child2")
         settingsFile << """
-rootProject.name = "main"
-include "child1", "child2"
-"""
+            rootProject.name = "main"
+            include "child1"
+        """
         buildFile << """
-allprojects {
-    configurations {
-        compile
-        create('default') { extendsFrom compile }
-    }
-    task jar {
-        outputs.file file("\${project.name}.jar")
-    }
-    task lib {
-        outputs.file file("\${project.name}-lib.jar")
-    }
-}
-artifacts {
-    compile file: jar.outputs.files.singleFile, builtBy: jar
-}
-dependencies {
-    compile lib.outputs.files
-    compile project(':child1')
-}
-project(':child1') {
-    artifacts {
-        compile file: jar.outputs.files.singleFile, builtBy: jar
-    }
-    dependencies {
-        compile lib.outputs.files
-    }
-}
+            configurations {
+                compile
+                create('default') { extendsFrom compile }
+            }
+            task jar {
+                outputs.file file("\${project.name}.jar")
+            }
+            task lib {
+                outputs.file file("\${project.name}-lib.jar")
+            }
+            artifacts {
+                compile file: jar.outputs.files.singleFile, builtBy: jar
+            }
+            dependencies {
+                compile lib.outputs.files
+                compile project(':child1')
+            }
 
-task verify {
-    inputs.files configurations.compile.fileCollection { it instanceof ProjectDependency }
-}
-"""
+            task verify {
+                inputs.files configurations.compile.fileCollection { it instanceof ProjectDependency }
+            }
+        """
+
+        file("child1/build.gradle") << """
+            configurations {
+                compile
+                create('default') { extendsFrom compile }
+            }
+            task jar {
+                outputs.file file("\${project.name}.jar")
+            }
+            task lib {
+                outputs.file file("\${project.name}-lib.jar")
+            }
+            artifacts {
+                compile file: jar.outputs.files.singleFile, builtBy: jar
+            }
+            dependencies {
+                compile lib.outputs.files
+            }
+        """
 
         when:
         executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
-        run "verify"
+        succeeds("verify")
 
         then:
         // Should not be including ':lib' as it's not required

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
@@ -21,36 +21,34 @@ import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 class ForcedModulesIntegrationTest extends AbstractIntegrationSpec {
     private ResolveTestFixture resolve = new ResolveTestFixture(buildFile)
 
-    def setup() {
-        resolve.addDefaultVariantDerivationStrategy()
-    }
-
     void "can force the version of a particular module"() {
         mavenRepo.module("org", "foo", '1.3.3').publish()
         mavenRepo.module("org", "foo", '1.4.4').publish()
 
         buildFile << """
-apply plugin: 'java'
-repositories { maven { url = "${mavenRepo.uri}" } }
+            plugins {
+                id("java-library")
+            }
+            ${mavenTestRepository()}
 
-dependencies {
-    implementation 'org:foo:1.3.3'
-}
+            dependencies {
+                implementation 'org:foo:1.3.3'
+            }
 
-configurations.all {
-    resolutionStrategy.force 'org:foo:1.4.4'
-}
+            configurations.all {
+                resolutionStrategy.force 'org:foo:1.4.4'
+            }
 
-task checkDeps {
-    def compileClasspath = configurations.compileClasspath
-    doLast {
-        assert compileClasspath*.name == ['foo-1.4.4.jar']
-    }
-}
-"""
+            task checkDeps {
+                def compileClasspath = configurations.compileClasspath
+                doLast {
+                    assert compileClasspath*.name == ['foo-1.4.4.jar']
+                }
+            }
+        """
 
         expect:
-        run("checkDeps")
+        succeeds("checkDeps")
     }
 
     void "can force the version of a transitive dependency module"() {
@@ -60,75 +58,86 @@ task checkDeps {
         mavenRepo.module("org", "bar", '1.0').publish()
 
         buildFile << """
-apply plugin: 'java'
-repositories { maven { url = "${mavenRepo.uri}" } }
+            plugins {
+                id("java-library")
+            }
+            ${mavenTestRepository()}
 
-dependencies {
-    implementation 'org:foo:1.3.3'
-}
+            dependencies {
+                implementation 'org:foo:1.3.3'
+            }
 
-configurations.all {
-    resolutionStrategy.force 'org:bar:1.0'
-}
+            configurations.all {
+                resolutionStrategy.force 'org:bar:1.0'
+            }
 
-task checkDeps {
-    def compileClasspath = configurations.compileClasspath
-    doLast {
-        assert compileClasspath*.name == ['foo-1.3.3.jar', 'bar-1.0.jar']
-    }
-}
-"""
+            task checkDeps {
+                def compileClasspath = configurations.compileClasspath
+                doLast {
+                    assert compileClasspath*.name == ['foo-1.3.3.jar', 'bar-1.0.jar']
+                }
+            }
+        """
 
         expect:
-        run("checkDeps")
+        succeeds("checkDeps")
     }
 
     void "can force already resolved version of a module and avoid conflict"() {
         mavenRepo.module("org", "foo", '1.3.3').publish()
         mavenRepo.module("org", "foo", '1.4.4').publish()
 
-        createDirs("api", "impl", "tool")
-        settingsFile << "include 'api', 'impl', 'tool'"
+        settingsFile << """
+            include 'api'
+            include 'impl'
+            include 'tool'
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
 
-        buildFile << """
-allprojects {
-	apply plugin: 'java'
-	repositories { maven { url = "${mavenRepo.uri}" } }
-}
+        file("api/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+            configurations.all {
+                resolutionStrategy {
+                    force 'org:foo:1.3.3'
+                    failOnVersionConflict()
+                }
+            }
+            dependencies {
+                implementation (group: 'org', name: 'foo', version:'1.4.4')
+            }
+        """
 
-project(':api') {
-	dependencies {
-		implementation (group: 'org', name: 'foo', version:'1.4.4')
-	}
-}
+        file("impl/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+            dependencies {
+                implementation (group: 'org', name: 'foo', version:'1.3.3')
+            }
+        """
 
-project(':impl') {
-	dependencies {
-		implementation (group: 'org', name: 'foo', version:'1.3.3')
-	}
-}
-
-project(':tool') {
-
-	dependencies {
-		implementation project(':api')
-		implementation project(':impl')
-	}
-}
-
-allprojects {
-    configurations.all {
-	    resolutionStrategy {
-	        force 'org:foo:1.3.3'
-	        failOnVersionConflict()
-	    }
-	}
-}
-
-"""
+        file("tool/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+            configurations.all {
+                resolutionStrategy {
+                    force 'org:foo:1.3.3'
+                    failOnVersionConflict()
+                }
+            }
+            dependencies {
+                implementation project(':api')
+                implementation project(':impl')
+            }
+        """
 
         expect:
-        run("api:dependencies", "tool:dependencies")
+        succeeds("api:dependencies", "tool:dependencies")
     }
 
     void "can force arbitrary version of a module and avoid conflict"() {
@@ -137,51 +146,67 @@ allprojects {
         mavenRepo.module("org", "foo", '1.4.4').publish()
         mavenRepo.module("org", "foo", '1.5.5').publish()
 
-        createDirs("api", "impl", "tool")
-        settingsFile << "include 'api', 'impl', 'tool'"
+        settingsFile << """
+            include 'api'
+            include 'impl'
+            include 'tool'
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
 
-        buildFile << """
-allprojects {
-	apply plugin: 'java'
-	repositories { maven { url = "${mavenRepo.uri}" } }
-	group = 'org.foo.unittests'
-	version = '1.0'
-}
+        file("api/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
 
-project(':api') {
-	dependencies {
-		implementation (group: 'org', name: 'foo', version:'1.4.4')
-	}
-}
+            group = 'org.foo.unittests'
+            version = '1.0'
 
-project(':impl') {
-	dependencies {
-		implementation (group: 'org', name: 'foo', version:'1.3.3')
-	}
-}
+            dependencies {
+                implementation (group: 'org', name: 'foo', version:'1.4.4')
+            }
+        """
 
-project(':tool') {
-	dependencies {
-		implementation project(':api')
-		implementation project(':impl')
-	}
-}
+        file('impl/build.gradle') << """
+            plugins {
+                id("java-library")
+            }
 
-allprojects {
-    configurations.all {
-        resolutionStrategy {
-            failOnVersionConflict()
-            force 'org:foo:1.5.5'
-        }
-    }
-}
+            group = 'org.foo.unittests'
+            version = '1.0'
 
-"""
+            dependencies {
+                implementation (group: 'org', name: 'foo', version:'1.3.3')
+            }
+        """
+
+        file("tool/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+
+            group = 'org.foo.unittests'
+            version = '1.0'
+
+            dependencies {
+                implementation project(':api')
+                implementation project(':impl')
+            }
+
+            configurations.all {
+                resolutionStrategy {
+                    failOnVersionConflict()
+                    force 'org:foo:1.5.5'
+                }
+            }
+        """
+
         resolve.expectDefaultConfiguration("runtimeElements")
         resolve.prepare("runtimeClasspath")
 
         expect:
-        run(":tool:checkDeps")
+        succeeds(":tool:checkDeps")
         resolve.expectGraph {
             root(":tool", "org.foo.unittests:tool:1.0") {
                 project(":api", "org.foo.unittests:api:1.0") {
@@ -200,49 +225,60 @@ allprojects {
         mavenRepo.module("org", "foo", '1.3.3').publish()
         mavenRepo.module("org", "foo", '1.4.4').publish()
 
-        createDirs("api", "impl", "tool")
-        settingsFile << "include 'api', 'impl', 'tool'"
+        settingsFile << """
+            include 'api'
+            include 'impl'
+            include 'tool'
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
 
-        buildFile << """
-allprojects {
-	apply plugin: 'java'
-	repositories { maven { url = "${mavenRepo.uri}" } }
-}
+        file("api/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
 
-project(':api') {
-	dependencies {
-		implementation (group: 'org', name: 'foo', version:'1.3.3')
-	}
-}
+            dependencies {
+                implementation (group: 'org', name: 'foo', version:'1.3.3')
+            }
+        """
 
-project(':impl') {
-	dependencies {
-		implementation (group: 'org', name: 'foo', version:'1.4.4')
-	}
-}
+        file("impl/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
 
-project(':tool') {
-	dependencies {
-		implementation project(':api')
-		implementation project(':impl')
-	}
-	configurations.all {
-	    resolutionStrategy {
-	        failOnVersionConflict()
-	        force 'org:foo:1.3.3'
-	    }
-	}
-    task checkDeps {
-        def runtimeClasspath = configurations.runtimeClasspath
-        doLast {
-            assert runtimeClasspath*.name == ['api.jar', 'impl.jar', 'foo-1.3.3.jar']
-        }
-    }
-}
-"""
+            dependencies {
+                implementation (group: 'org', name: 'foo', version:'1.4.4')
+            }
+        """
+
+        file("tool/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+
+            dependencies {
+                implementation project(':api')
+                implementation project(':impl')
+            }
+            configurations.all {
+                resolutionStrategy {
+                    failOnVersionConflict()
+                    force 'org:foo:1.3.3'
+                }
+            }
+            task checkDeps {
+                def runtimeClasspath = configurations.runtimeClasspath
+                doLast {
+                    assert runtimeClasspath*.name == ['api.jar', 'impl.jar', 'foo-1.3.3.jar']
+                }
+            }
+        """
 
         expect:
-        run("tool:checkDeps")
+        succeeds("tool:checkDeps")
     }
 
     void "forcing transitive dependency does not add extra dependency"() {
@@ -250,57 +286,61 @@ project(':tool') {
         mavenRepo.module("hello", "world", '1.4.4').publish()
 
         buildFile << """
-apply plugin: 'java'
-repositories { maven { url = "${mavenRepo.uri}" } }
+            plugins {
+                id("java-library")
+            }
+            ${mavenTestRepository()}
 
-dependencies {
-    implementation 'org:foo:1.3.3'
-}
+            dependencies {
+                implementation 'org:foo:1.3.3'
+            }
 
-configurations.all {
-    resolutionStrategy.force 'hello:world:1.4.4'
-}
+            configurations.all {
+                resolutionStrategy.force 'hello:world:1.4.4'
+            }
 
-task checkDeps {
-    def compileClasspath = configurations.compileClasspath
-    doLast {
-        assert compileClasspath*.name == ['foo-1.3.3.jar']
-    }
-}
-"""
+            task checkDeps {
+                def compileClasspath = configurations.compileClasspath
+                doLast {
+                    assert compileClasspath*.name == ['foo-1.3.3.jar']
+                }
+            }
+        """
 
         expect:
-        run("checkDeps")
+        succeeds("checkDeps")
     }
 
     void "when forcing the same module last declaration wins"() {
         mavenRepo.module("org", "foo", '1.9').publish()
 
         buildFile << """
-apply plugin: 'java'
-repositories { maven { url = "${mavenRepo.uri}" } }
+            plugins {
+                id("java-library")
+            }
+            ${mavenTestRepository()}
 
-dependencies {
-    implementation 'org:foo:1.0'
-}
+            dependencies {
+                implementation 'org:foo:1.0'
+            }
 
-configurations.all {
-    resolutionStrategy {
-        force 'org:foo:1.5'
-        force 'org:foo:2.0'
-        force 'org:foo:1.9'
-    }
-}
+            configurations.all {
+                resolutionStrategy {
+                    force 'org:foo:1.5'
+                    force 'org:foo:2.0'
+                    force 'org:foo:1.9'
+                }
+            }
 
-task checkDeps {
-    def compileClasspath = configurations.compileClasspath
-    doLast {
-        assert compileClasspath*.name == ['foo-1.9.jar']
-    }
-}
-"""
+            task checkDeps {
+                def compileClasspath = configurations.compileClasspath
+                doLast {
+                    assert compileClasspath*.name == ['foo-1.9.jar']
+                }
+            }
+        """
 
         expect:
-        run("checkDeps")
+        succeeds("checkDeps")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LazyDownloadsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LazyDownloadsIntegrationTest.groovy
@@ -23,29 +23,35 @@ class LazyDownloadsIntegrationTest extends AbstractHttpDependencyResolutionTest 
     def module2 = mavenHttpRepo.module("test", "test2", "1.0").publish()
 
     def setup() {
-        createDirs("child")
-        settingsFile << "include 'child'"
-        buildFile << """
-            allprojects {
+        settingsFile << """
+            include 'child'
+            dependencyResolutionManagement {
                 repositories {
                     maven { url = '$mavenHttpRepo.uri' }
                 }
-                configurations {
-                    compile
-                    create('default').extendsFrom compile
-                }
+            }
+        """
+        buildFile << """
+            configurations {
+                compile
+                create('default').extendsFrom compile
             }
 
             dependencies {
                 compile project(':child')
             }
-            project(':child') {
-                dependencies {
-                    compile 'test:test:1.0'
-                    compile 'test:test2:1.0'
-                }
+        """
+
+        file("child/build.gradle") << """
+            configurations {
+                compile
+                create('default').extendsFrom compile
             }
-"""
+            dependencies {
+                compile 'test:test:1.0'
+                compile 'test:test2:1.0'
+            }
+        """
     }
 
     def "downloads only the metadata when dependency graph is queried"() {
@@ -57,7 +63,7 @@ class LazyDownloadsIntegrationTest extends AbstractHttpDependencyResolutionTest 
                     root.get()
                 }
             }
-"""
+        """
 
         when:
         module.pom.expectGet()
@@ -96,7 +102,7 @@ class LazyDownloadsIntegrationTest extends AbstractHttpDependencyResolutionTest 
                     compile.files*.name
                 }
             }
-"""
+        """
 
         when:
         module.pom.expectGetUnauthorized()
@@ -118,7 +124,7 @@ class LazyDownloadsIntegrationTest extends AbstractHttpDependencyResolutionTest 
                     result*.id
                 }
             }
-"""
+        """
 
         when:
         module.pom.expectGetUnauthorized()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
@@ -24,14 +24,12 @@ class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             def usage = Attribute.of('usage', String)
             def format = Attribute.of('format', String)
-            allprojects {
-                dependencies {
-                    attributesSchema {
-                        attribute(usage)
-                    }
+            dependencies {
+                attributesSchema {
+                    attribute(usage)
                 }
-                configurations { compile { attributes.attribute(usage, 'for-compile') } }
             }
+            configurations { compile { attributes.attribute(usage, 'for-compile') } }
         """
     }
 
@@ -39,42 +37,41 @@ class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
     def "cannot mutate outgoing variants after configuration is resolved"() {
         given:
         buildFile << """
-
-        configurations {
-            compile {
-                attributes.attribute(usage, 'for compile')
-                outgoing {
-                    artifact file('lib1.jar')
-                    variants {
-                        classes {
-                            attributes.attribute(format, 'classes-dir')
-                            artifact file('classes')
-                        }
-                        jar {
-                            attributes.attribute(format, 'classes-jar')
-                            artifact file('lib.jar')
-                        }
-                        sources {
-                            attributes.attribute(format, 'source-jar')
-                            artifact file('source.zip')
+            configurations {
+                compile {
+                    attributes.attribute(usage, 'for compile')
+                    outgoing {
+                        artifact file('lib1.jar')
+                        variants {
+                            classes {
+                                attributes.attribute(format, 'classes-dir')
+                                artifact file('classes')
+                            }
+                            jar {
+                                attributes.attribute(format, 'classes-jar')
+                                artifact file('lib.jar')
+                            }
+                            sources {
+                                attributes.attribute(format, 'source-jar')
+                                artifact file('source.zip')
+                            }
                         }
                     }
                 }
             }
-        }
-        task mutateBeforeResolve {
-            doLast {
-                def classes = configurations.compile.outgoing.variants['classes']
-                classes.attributes.attribute(format, 'classes2')
+            task mutateBeforeResolve {
+                doLast {
+                    def classes = configurations.compile.outgoing.variants['classes']
+                    classes.attributes.attribute(format, 'classes2')
+                }
             }
-        }
-        task mutateAfterResolve {
-            doLast {
-                configurations.compile.resolve()
-                def classes = configurations.compile.outgoing.variants['classes']
-                classes.attributes.attribute(format, 'classes-dir')
+            task mutateAfterResolve {
+                doLast {
+                    configurations.compile.resolve()
+                    def classes = configurations.compile.outgoing.variants['classes']
+                    classes.attributes.attribute(format, 'classes-dir')
+                }
             }
-        }
         """
 
         when:
@@ -94,42 +91,41 @@ class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
     def "cannot add outgoing variants after configuration is resolved"() {
         given:
         buildFile << """
-
-        configurations {
-            compile {
-                attributes.attribute(usage, 'for compile')
-                outgoing {
-                    artifact file('lib1.jar')
-                    variants {
-                        classes {
-                            attributes.attribute(format, 'classes-dir')
-                            artifact file('classes')
+            configurations {
+                compile {
+                    attributes.attribute(usage, 'for compile')
+                    outgoing {
+                        artifact file('lib1.jar')
+                        variants {
+                            classes {
+                                attributes.attribute(format, 'classes-dir')
+                                artifact file('classes')
+                            }
                         }
                     }
                 }
             }
-        }
-        task mutateBeforeResolve {
-            doLast {
-                configurations.compile.outgoing.variants {
-                    jar {
-                        attributes.attribute(format, 'classes-jar')
-                        artifact file('lib.jar')
+            task mutateBeforeResolve {
+                doLast {
+                    configurations.compile.outgoing.variants {
+                        jar {
+                            attributes.attribute(format, 'classes-jar')
+                            artifact file('lib.jar')
+                        }
                     }
                 }
             }
-        }
-        task mutateAfterResolve {
-            doLast {
-                configurations.compile.resolve()
-                configurations.compile.outgoing.variants {
-                    sources {
-                        attributes.attribute(format, 'source-jar')
-                        artifact file('source.zip')
+            task mutateAfterResolve {
+                doLast {
+                    configurations.compile.resolve()
+                    configurations.compile.outgoing.variants {
+                        sources {
+                            attributes.attribute(format, 'source-jar')
+                            artifact file('source.zip')
+                        }
                     }
                 }
             }
-        }
         """
 
         when:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesIntegrationTest.groovy
@@ -28,7 +28,6 @@ class ProjectDependenciesIntegrationTest extends AbstractDependencyResolutionTes
 
     @Issue("GRADLE-2477") //this is a feature on its own but also covers one of the reported issues
     def "resolving project dependency triggers configuration of the target project"() {
-        createDirs("impl")
         settingsFile << "include 'impl'"
         buildFile << """
             apply plugin: 'java'
@@ -59,10 +58,9 @@ class ProjectDependenciesIntegrationTest extends AbstractDependencyResolutionTes
 
     @ToBeFixedForConfigurationCache(because = "task uses dependencies API")
     def "configuring project dependencies by map is validated"() {
-        createDirs("impl")
         settingsFile << "include 'impl'"
         buildFile << """
-            allprojects { configurations.create('conf') }
+            configurations.create('conf')
             task extraKey {
                 doLast {
                     dependencies.project(path: ":impl", configuration: ":conf", foo: "bar")
@@ -78,6 +76,9 @@ class ProjectDependenciesIntegrationTest extends AbstractDependencyResolutionTes
                     dependencies.project(path: ":impl")
                 }
             }
+        """
+        file("impl/build.gradle") << """
+            configurations.create('conf')
         """
 
         when:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.integtests.resolve
 
-import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
@@ -41,41 +40,43 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
         mavenRepo.module("org.other", "externalB", "2.1").publish()
 
         and:
-        createDirs("a", "b")
-        file('settings.gradle') << "include 'a', 'b'"
+        settingsFile << """
+            include 'a'
+            include 'b'
+            dependencyResolutionManagement {
+                repositories { maven { url = '$mavenRepo.uri' } }
+            }
+        """
 
         and:
-        buildFile << """
-allprojects {
-    repositories { maven { url = '$mavenRepo.uri' } }
-}
-project(":a") {
-    configurations {
-        api
-        'default' { extendsFrom api }
-    }
-    dependencies {
-        api "org.other:externalA:1.2"
-        'default' "org.other:externalB:2.1"
-    }
-    task jar(type: Jar) {
-        archiveBaseName = 'a'
-        destinationDirectory = buildDir
-    }
-    artifacts { api jar }
-}
-project(":b") {
-    group = 'org.gradle'
-    version = '1.0'
+        file("a/build.gradle") << """
+            configurations {
+                api
+                'default' { extendsFrom api }
+            }
+            dependencies {
+                api "org.other:externalA:1.2"
+                'default' "org.other:externalB:2.1"
+            }
+            task jar(type: Jar) {
+                archiveBaseName = 'a'
+                destinationDirectory = buildDir
+            }
+            artifacts { api jar }
+        """
 
-    configurations {
-        compile
-    }
-    dependencies {
-        compile project(':a')
-    }
-}
-"""
+        file("b/build.gradle") << """
+            group = 'org.gradle'
+            version = '1.0'
+
+            configurations {
+                compile
+            }
+            dependencies {
+                compile project(':a')
+            }
+        """
+
         resolve.prepare()
 
         expect:
@@ -96,41 +97,43 @@ project(":b") {
         mavenRepo.module("org.other", "externalA", "1.2").publish()
 
         and:
-        createDirs("a", "b")
-        file('settings.gradle') << """
-            include 'a', 'b'
+        settingsFile << """
+            include 'a'
+            include 'b'
+            dependencyResolutionManagement {
+                repositories { maven { url = '$mavenRepo.uri' } }
+            }
         """
 
-        and:
-        buildFile << """
-allprojects {
-    repositories { maven { url = '$mavenRepo.uri' } }
-}
-project(":a") {
-    apply plugin: 'base'
-    configurations {
-        api
-        runtime { extendsFrom api }
-    }
-    dependencies {
-        api("org.other:externalA:1.2") {
-            because 'also check dependency reasons'
-        }
-    }
-    task jar(type: Jar) { archiveBaseName = 'a' }
-    artifacts { api jar }
-}
-project(":b") {
-    configurations {
-        compile
-    }
-    dependencies {
-        compile(project(path: ':a', configuration: 'runtime')) {
-            because 'can provide a dependency reason for project dependencies too'
-        }
-    }
-}
-"""
+        file("a/build.gradle") << """
+            plugins {
+                id("base")
+            }
+            configurations {
+                api
+                runtime { extendsFrom api }
+            }
+            dependencies {
+                api("org.other:externalA:1.2") {
+                    because 'also check dependency reasons'
+                }
+            }
+            task jar(type: Jar) { archiveBaseName = 'a' }
+            artifacts { api jar }
+        """
+
+        file("b/build.gradle") << """
+            configurations {
+                compile
+            }
+            dependencies {
+                compile(project(path: ':a', configuration: 'runtime')) {
+                    because 'can provide a dependency reason for project dependencies too'
+                }
+            }
+        """
+
+
         resolve.prepare()
 
         when:
@@ -157,40 +160,40 @@ project(":b") {
     @Issue("GRADLE-2899")
     def "multiple project configurations can refer to different configurations of target project"() {
         given:
-        createDirs("a", "b")
         file('settings.gradle') << "include 'a', 'b'"
 
         and:
-        buildFile << """
-project(':a') {
-    apply plugin: 'base'
-    configurations {
-        configA1
-        configA2
-    }
-    task A1jar(type: Jar) {
-        archiveBaseName = 'A1'
-    }
-    task A2jar(type: Jar) {
-        archiveBaseName = 'A2'
-    }
-    artifacts {
-        configA1 A1jar
-        configA2 A2jar
-    }
-}
+        file("a/build.gradle") << """
+            plugins {
+                id("base")
+            }
+            configurations {
+                configA1
+                configA2
+            }
+            task A1jar(type: Jar) {
+                archiveBaseName = 'A1'
+            }
+            task A2jar(type: Jar) {
+                archiveBaseName = 'A2'
+            }
+            artifacts {
+                configA1 A1jar
+                configA2 A2jar
+            }
+        """
 
-project(':b') {
-    configurations {
-        configB1
-        configB2
-    }
-    dependencies {
-        configB1 project(path:':a', configuration:'configA1')
-        configB2 project(path:':a', configuration:'configA2')
-    }
-}
-"""
+        file("b/build.gradle") << """
+            configurations {
+                configB1
+                configB2
+            }
+            dependencies {
+                configB1 project(path:':a', configuration:'configA1')
+                configB2 project(path:':a', configuration:'configA2')
+            }
+        """
+
         resolve.prepare {
             config("configB1")
             config("configB2")
@@ -227,33 +230,39 @@ project(':b') {
 
     def "resolved project artifacts reflect project properties changed after task graph is resolved"() {
         given:
-        createDirs("a", "b")
         file('settings.gradle') << "include 'a', 'b'"
 
         and:
         file('a/build.gradle') << '''
-            apply plugin: 'base'
+            plugins {
+                id("base")
+            }
             configurations { compile }
             dependencies { compile project(path: ':b', configuration: 'compile') }
             task aJar(type: Jar) { }
             gradle.taskGraph.whenReady { project.version = 'late' }
             artifacts { compile aJar }
-'''
+        '''
+
         file('b/build.gradle') << '''
-            apply plugin: 'base'
+            plugins {
+                id("base")
+            }
             version = 'early'
             configurations { compile }
             task bJar(type: Jar) { }
             gradle.taskGraph.whenReady { project.version = 'transitive-late' }
             artifacts { compile bJar }
-'''
+        '''
+
         file('build.gradle') << '''
             configurations {
                 compile
                 testCompile { extendsFrom compile }
             }
             dependencies { compile project(path: ':a', configuration: 'compile') }
-'''
+        '''
+
         resolve.prepare("testCompile")
 
         when:
@@ -277,12 +286,13 @@ project(':b') {
     @UnsupportedWithConfigurationCache(because = "configure task changes jar task")
     def "resolved project artifact can be changed by configuration task"() {
         given:
-        createDirs("a")
         file('settings.gradle') << "include 'a'"
 
         and:
         file('a/build.gradle') << '''
-            apply plugin: 'base'
+            plugins {
+                id("base")
+            }
             configurations { compile }
             task configureJar {
                 doLast {
@@ -294,7 +304,8 @@ project(':b') {
                 dependsOn configureJar
             }
             artifacts { compile aJar }
-'''
+        '''
+
         file('build.gradle') << '''
             configurations {
                 compile
@@ -307,7 +318,7 @@ project(':b') {
                     assert configurations.testCompile.collect { it.name } == ['a-modified.txt']
                 }
             }
-'''
+        '''
 
         expect:
         succeeds ":test"
@@ -319,32 +330,38 @@ project(':b') {
         mavenRepo.module("group", "externalA", "1.5").publish()
 
         and:
-        createDirs("a", "b")
-        file('settings.gradle') << "include 'a', 'b'"
+        settingsFile << """
+            include 'a'
+            include 'b'
+            dependencyResolutionManagement {
+                repositories { maven { url = '$mavenRepo.uri' } }
+            }
+        """
 
-        and:
-        buildFile << """
-allprojects {
-    apply plugin: 'base'
-    repositories { maven { url = '${mavenRepo.uri}' } }
-}
+        file("a/build.gradle") << """
+            plugins {
+                id("base")
+            }
 
-project(":a") {
-    configurations {
-        deps
-        'default' { extendsFrom deps }
-    }
-    dependencies { deps 'group:externalA:1.5' }
-    task xJar(type: Jar) { archiveBaseName='x' }
-    task yJar(type: Jar) { archiveBaseName='y' }
-    artifacts { 'default' xJar, yJar }
-}
+            configurations {
+                deps
+                'default' { extendsFrom deps }
+            }
+            dependencies { deps 'group:externalA:1.5' }
+            task xJar(type: Jar) { archiveBaseName='x' }
+            task yJar(type: Jar) { archiveBaseName='y' }
+            artifacts { 'default' xJar, yJar }
+        """
 
-project(":b") {
-    configurations { compile }
-    dependencies { compile(project(':a')) { artifact { name = 'y'; type = 'jar' } } }
-}
-"""
+        file("b/build.gradle") << """
+            plugins {
+                id("base")
+            }
+
+            configurations { compile }
+            dependencies { compile(project(':a')) { artifact { name = 'y'; type = 'jar' } } }
+        """
+
         resolve.prepare("compile")
 
         when:
@@ -364,30 +381,29 @@ project(":b") {
 
     def "reports project dependency that refers to an unknown artifact"() {
         given:
-        createDirs("a", "b")
         file('settings.gradle') << """
-include 'a', 'b'
-"""
+            include 'a'
+            include 'b'
+        """
 
         and:
-        buildFile << """
-allprojects { group = 'test' }
-project(":a") {
-    configurations { 'default' {} }
-}
+        file("a/build.gradle") << """
+            group = 'test'
+            configurations { 'default' {} }
+        """
 
-project(":b") {
-    configurations { compile }
-    dependencies { compile(project(':a')) { artifact { name = 'b'; type = 'jar' } } }
-    task test {
-        inputs.files configurations.compile
-        outputs.upToDateWhen { false }
-        doFirst {
-            configurations.compile.files.collect { it.name }
-        }
-    }
-}
-"""
+        file("b/build.gradle") << """
+            group = 'test'
+            configurations { compile }
+            dependencies { compile(project(':a')) { artifact { name = 'b'; type = 'jar' } } }
+            task test {
+                inputs.files configurations.compile
+                outputs.upToDateWhen { false }
+                doFirst {
+                    configurations.compile.files.collect { it.name }
+                }
+            }
+        """
 
         expect:
         fails ':b:test'
@@ -402,27 +418,35 @@ project(":b") {
         mavenRepo.module("group", "externalA", "1.5").publish()
 
         and:
-        createDirs("a", "b")
-        file('settings.gradle') << "include 'a', 'b'"
+        settingsFile << """
+            include 'a'
+            include 'b'
+            dependencyResolutionManagement {
+                repositories { maven { url = '$mavenRepo.uri' } }
+            }
+        """
 
-        and:
-        buildFile << """
-allprojects {
-    apply plugin: 'java'
-    repositories { maven { url = '${mavenRepo.uri}' } }
-}
-project(':a') {
-    dependencies {
-        implementation 'group:externalA:1.5'
-        implementation files('libs/externalB.jar')
-    }
-}
-project(':b') {
-    dependencies {
-        implementation project(':a'), { transitive = false }
-    }
-}
-"""
+        file("a/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+
+            dependencies {
+                implementation 'group:externalA:1.5'
+                implementation files('libs/externalB.jar')
+            }
+        """
+
+        file("b/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+
+            dependencies {
+                implementation project(':a'), { transitive = false }
+            }
+        """
+
         resolve.prepare("runtimeClasspath")
 
         when:
@@ -441,46 +465,46 @@ project(':b') {
 
     def "can have cycle in project dependencies"() {
         given:
-        createDirs("a", "b", "c")
         file('settings.gradle') << "include 'a', 'b', 'c'"
 
         and:
-        buildFile << """
+        def common = """
+            plugins {
+                id("base")
+            }
+            configurations {
+                first
+                other
+                'default' {
+                    extendsFrom first
+                }
+            }
+            task jar(type: Jar)
+            artifacts {
+                'default' jar
+            }
+        """
 
-subprojects {
-    apply plugin: 'base'
-    configurations {
-        first
-        other
-        'default' {
-            extendsFrom first
-        }
-    }
-    task jar(type: Jar)
-    artifacts {
-        'default' jar
-    }
-}
+        file("a/build.gradle") << """
+            $common
+            dependencies {
+                first project(':b')
+                other project(':b')
+            }
+        """
+        file("b/build.gradle") << """
+            $common
+            dependencies {
+                first project(':c')
+            }
+        """
+        file("c/build.gradle") << """
+            $common
+            dependencies {
+                first project(':a')
+            }
+        """
 
-project('a') {
-    dependencies {
-        first project(':b')
-        other project(':b')
-    }
-}
-
-project('b') {
-    dependencies {
-        first project(':c')
-    }
-}
-
-project('c') {
-    dependencies {
-        first project(':a')
-    }
-}
-"""
         when:
         resolve.prepare("first")
         run ":a:checkDeps"
@@ -498,51 +522,72 @@ project('c') {
         }
     }
 
-    @NotYetImplemented
     @Issue('GRADLE-3280')
     def "can resolve recursive copy of configuration with cyclic project dependencies"() {
         given:
-        createDirs("a", "b", "c")
         settingsFile << "include 'a', 'b', 'c'"
-        buildFile '''
-            subprojects {
-                apply plugin: 'base'
-                task jar(type: Jar)
-                artifacts {
-                    'default' jar
-                }
+        def common = """
+            plugins {
+                id("base")
             }
-            project('a') {
-                dependencies {
-                    'default' project(':b')
-                }
-                task assertCanResolve {
-                    doLast {
-                        assert !project.configurations.default.resolvedConfiguration.hasError()
+            task jar(type: Jar)
+            configurations {
+                dependencyScope('implementation')
+                resolvable("res") {
+                    extendsFrom(implementation)
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
                     }
                 }
-                task assertCanResolveRecursiveCopy {
-                    doLast {
-                        assert !project.configurations.default.copyRecursive().resolvedConfiguration.hasError()
+                consumable("cons") {
+                    extendsFrom(implementation)
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
                     }
+                    outgoing.artifact(jar)
                 }
             }
-            project('b') {
-                dependencies {
-                    'default' project(':c')
+        """
+
+        file("a/build.gradle") << """
+            $common
+            dependencies {
+                implementation(project(":b"))
+            }
+            task assertCanResolve {
+                def files = project.configurations.res.incoming.files
+                doLast {
+                    println(files*.name)
                 }
             }
-            project('c') {
-                dependencies {
-                    'default' project(':a')
+            task assertCanResolveRecursiveCopy {
+                def files = project.configurations.res.copyRecursive().incoming.files
+                doLast {
+                    println(files*.name)
                 }
             }
-        '''.stripIndent()
+        """
+
+        file("b/build.gradle") << """
+            $common
+            dependencies {
+                implementation(project(':c'))
+            }
+        """
+
+        file("c/build.gradle") << """
+            $common
+            dependencies {
+                implementation(project(':a'))
+            }
+        """
 
         expect:
         succeeds ':a:assertCanResolve'
 
         and:
+        executer.expectDocumentedDeprecationWarning("The resCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
+        executer.expectDocumentedDeprecationWarning("While resolving configuration 'resCopy', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
         succeeds ':a:assertCanResolveRecursiveCopy'
     }
 
@@ -550,7 +595,6 @@ project('c') {
     // project dependencies that are “built” by built in plugins like the Java plugin's created jars
     def "can use zip files as project dependencies"() {
         given:
-        createDirs("a", "b")
         file("settings.gradle") << "include 'a'; include 'b'"
         file("a/some.txt") << "foo"
         file("a/build.gradle") << """
@@ -590,38 +634,44 @@ project('c') {
 
     @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "resolving configuration with project dependency marks dependency's configuration as observed"() {
-        createDirs("api", "impl")
-        settingsFile << "include 'api'; include 'impl'"
+        settingsFile << """
+            include 'api'
+            include 'impl'
+        """
 
-        buildFile << """
-            allprojects {
-                configurations {
-                    conf
-                }
-                configurations.create("default").extendsFrom(configurations.conf)
+        file("api/build.gradle") << """
+            configurations {
+                conf
+            }
+            configurations.create("default").extendsFrom(configurations.conf)
+        """
+
+        file("impl/build.gradle") << """
+            configurations {
+                conf
+            }
+            configurations.create("default").extendsFrom(configurations.conf)
+
+            dependencies {
+                conf project(":api")
             }
 
-            project(":impl") {
-                dependencies {
-                    conf project(":api")
-                }
+            task check {
+                doLast {
+                    assert configurations.conf.state == Configuration.State.UNRESOLVED
+                    assert project(":api").configurations.conf.state == Configuration.State.UNRESOLVED
 
-                task check {
-                    doLast {
-                        assert configurations.conf.state == Configuration.State.UNRESOLVED
-                        assert project(":api").configurations.conf.state == Configuration.State.UNRESOLVED
+                    configurations.conf.resolve()
 
-                        configurations.conf.resolve()
+                    assert configurations.conf.state == Configuration.State.RESOLVED
+                    assert project(":api").configurations.conf.state == Configuration.State.UNRESOLVED
 
-                        assert configurations.conf.state == Configuration.State.RESOLVED
-                        assert project(":api").configurations.conf.state == Configuration.State.UNRESOLVED
-
-                        // Attempt to change the configuration, to demonstrate that is has been observed
-                        project(":api").configurations.conf.dependencies.add(null)
-                    }
+                    // Attempt to change the configuration, to demonstrate that is has been observed
+                    project(":api").configurations.conf.dependencies.add(null)
                 }
             }
-"""
+
+        """
 
         when:
         expectTaskGetProjectDeprecations(3)
@@ -634,43 +684,43 @@ project('c') {
     @Issue(["GRADLE-3330", "GRADLE-3362"])
     def "project dependency can resolve multiple artifacts from target project that are differentiated by archiveFileName only"() {
         given:
-        createDirs("a", "b")
         file('settings.gradle') << "include 'a', 'b'"
 
         and:
-        buildFile << """
-project(':a') {
-    apply plugin: 'base'
-    configurations {
-        configOne
-        configTwo
-    }
-    task A1jar(type: Jar) {
-        archiveFileName = 'A1.jar'
-    }
-    task A2jar(type: Jar) {
-        archiveFileName = 'A2.jar'
-    }
-    task A3jar(type: Jar) {
-        archiveFileName = 'A3.jar'
-    }
-    artifacts {
-        configOne A1jar
-        configTwo A2jar
-        configTwo A3jar
-    }
-}
+        file("a/build.gradle") << """
+            plugins {
+                id("base")
+            }
+            configurations {
+                configOne
+                configTwo
+            }
+            task A1jar(type: Jar) {
+                archiveFileName = 'A1.jar'
+            }
+            task A2jar(type: Jar) {
+                archiveFileName = 'A2.jar'
+            }
+            task A3jar(type: Jar) {
+                archiveFileName = 'A3.jar'
+            }
+            artifacts {
+                configOne A1jar
+                configTwo A2jar
+                configTwo A3jar
+            }
+        """
 
-project(':b') {
-    configurations {
-        configB
-    }
-    dependencies {
-        configB project(path:':a', configuration:'configOne')
-        configB project(path:':a', configuration:'configTwo')
-    }
-}
-"""
+        file("b/build.gradle") << """
+            configurations {
+                configB
+            }
+            dependencies {
+                configB project(path:':a', configuration:'configOne')
+                configB project(path:':a', configuration:'configTwo')
+            }
+        """
+
         resolve.prepare("configB")
 
         when:
@@ -734,10 +784,8 @@ project(':b') {
                 configurations.a.files
                 []
             })
-
         """
 
-        createDirs("other")
         settingsFile << "include 'other'"
         file("other/build.gradle") << """
             configurations {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishAndResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishAndResolveIntegrationTest.groovy
@@ -23,15 +23,9 @@ import org.gradle.util.internal.TextUtil
 
 class PublishAndResolveIntegrationTest extends AbstractDependencyResolutionTest {
     def setup() {
-        settingsFile << "rootProject.name = 'root'"
-        buildFile << """
-            allprojects {
-                apply plugin: 'java'
-                apply plugin: 'ivy-publish'
-
-                group = 'org.gradle.test'
-                version = '1.9'
-
+        settingsFile << """
+            rootProject.name = 'root'
+            dependencyResolutionManagement {
                 repositories {
                     ivy {
                         url = "${ivyRepo.uri}"
@@ -45,6 +39,14 @@ class PublishAndResolveIntegrationTest extends AbstractDependencyResolutionTest 
     def "can resolve static dependency published by a dependent task in the same project"() {
         given:
         buildFile << """
+            plugins {
+                id("java-library")
+                id("ivy-publish")
+            }
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
             ${taskWhichPublishes('api', '1.1')}
             ${taskWhichResolves('api', '1.1')}
         """
@@ -56,17 +58,33 @@ class PublishAndResolveIntegrationTest extends AbstractDependencyResolutionTest 
 
     @ToBeFixedForConfigurationCache
     def "can resolve static dependency published by a dependent task in another project in the same build"() {
-        createDirs("child")
         settingsFile << """
             include ':child'
         """
 
         given:
         buildFile << """
-            ${taskWhichPublishes('api', '1.1')}
-            project(':child') {
-                ${taskWhichResolves('api', '1.1')}
+            plugins {
+                id("java-library")
+                id("ivy-publish")
             }
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            ${taskWhichPublishes('api', '1.1')}
+        """
+
+        file('child/build.gradle') << """
+            plugins {
+                id("java-library")
+                id("ivy-publish")
+            }
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            ${taskWhichResolves('api', '1.1')}
         """
 
         expect:
@@ -80,6 +98,14 @@ class PublishAndResolveIntegrationTest extends AbstractDependencyResolutionTest 
 
         given:
         buildFile << """
+            plugins {
+                id("java-library")
+                id("ivy-publish")
+            }
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
             ${taskWhichPublishes('api', '1.1')}
             ${taskWhichResolves('api', '1.+')}
         """
@@ -96,6 +122,14 @@ class PublishAndResolveIntegrationTest extends AbstractDependencyResolutionTest 
 
         given:
         buildFile << """
+            plugins {
+                id("java-library")
+                id("ivy-publish")
+            }
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
             task customPublish(type: Copy) {
                 from "${safePath(tmpRepo.moduleDir('org.gradle.test', 'api'), '1.1')}"
                 into "${safePath(ivyRepo.moduleDir('org.gradle.test', 'api'), '1.1')}"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
@@ -183,20 +183,25 @@ class ResolveConfigurationRepositoriesBuildOperationIntegrationTest extends Abst
 
     def "repositories shared across projects are stable"() {
         setup:
-        createDirs("child")
         settingsFile << """
             include 'child'
-        """
-        buildFile << """
-            allprojects {
-                apply plugin: 'java'
-                ${mavenCentralRepoBlock()}
-                task resolve {
-                    def files = configurations.compileClasspath
-                    doLast { files.files }
-                }
+            dependencyResolutionManagement {
+                ${mavenCentralRepository()}
             }
         """
+
+        def common = """
+            plugins {
+                id("java-library")
+            }
+            task resolve {
+                def files = configurations.compileClasspath
+                doLast { files.files }
+            }
+        """
+
+        buildFile << common
+        file("child/build.gradle") << common
 
         when:
         succeeds 'resolve'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFileOrderingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFileOrderingIntegrationTest.groovy
@@ -22,23 +22,24 @@ import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 class ResolvedFileOrderingIntegrationTest extends AbstractDependencyResolutionTest {
     def setup() {
         settingsFile << """
-rootProject.name = 'test'
-"""
-        buildFile << """
-allprojects {
-    dependencies {
-        attributesSchema {
-           attribute(Attribute.of('usage', String))
-        }
+            rootProject.name = 'test'
+        """
     }
-    configurations {
-        compile
-        "default" {
-            extendsFrom compile
-        }
-    }
-}
-"""
+
+    String getHeader() {
+        """
+            dependencies {
+                attributesSchema {
+                   attribute(Attribute.of('usage', String))
+                }
+            }
+            configurations {
+                compile
+                "default" {
+                    extendsFrom compile
+                }
+            }
+        """
     }
 
     @ToBeFixedForConfigurationCache(because = "task uses Configuration API")
@@ -51,108 +52,119 @@ allprojects {
         mavenRepo.module("org", "test2", "1.0").publish()
         mavenRepo.module("org", "test3", "1.0").publish()
 
-        createDirs("a", "b", "c")
         settingsFile << """
-include 'a', 'b', 'c'
-"""
+            include 'a'
+            include 'b'
+            include 'c'
+            dependencyResolutionManagement {
+                repositories { maven { url = '$mavenRepo.uri' } }
+            }
+        """
         buildFile << """
-allprojects {
-    repositories { maven { url = '$mavenRepo.uri' } }
-}
-dependencies {
-    compile files('test-lib.jar')
-    compile project(':a')
-    compile 'org:test:1.0'
-    compile('org:test:1.0') {
-        artifact {
-            name = 'test'
-            classifier = 'from-main'
-            type = 'jar'
-        }
-    }
-    artifacts {
-        compile file('test.jar')
-    }
-}
-project(':a') {
-    dependencies {
-        compile files('a-lib.jar')
-        compile project(':b')
-        compile project(':c')
-        compile 'org:test:1.0'
-        compile('org:test:1.0') {
-            artifact {
-                name = 'test'
-                classifier = 'from-a'
-                type = 'jar'
+            $header
+            dependencies {
+                compile files('test-lib.jar')
+                compile project(':a')
+                compile 'org:test:1.0'
+                compile('org:test:1.0') {
+                    artifact {
+                        name = 'test'
+                        classifier = 'from-main'
+                        type = 'jar'
+                    }
+                }
+                artifacts {
+                    compile file('test.jar')
+                }
             }
-        }
-        compile('org:test:1.0') {
-            artifact {
-                name = 'test'
-                classifier = 'from-a'
-                type = 'jar'
-            }
-        }
-    }
-    artifacts {
-        compile file('a.jar')
-        compile file('a.jar')
-    }
-}
-project(':b') {
-    dependencies {
-        compile files('b-lib.jar')
-        compile files('b-lib.jar')
-        compile 'org:test2:1.0'
-        compile project(':c')
-    }
-    artifacts {
-        compile file('b.jar')
-    }
-}
-project(':c') {
-    dependencies {
-        compile files('c-lib.jar')
-        compile 'org:test3:1.0'
-        compile('org:test:1.0') {
-            artifact {
-                name = 'test'
-                classifier = 'from-c'
-                type = 'jar'
-            }
-            artifact {
-                // this is the default artifact
-                name = 'test'
-                type = 'jar'
-            }
-        }
-    }
-    artifacts {
-        compile file('c.jar')
-    }
-}
 
-task show {
-    doLast {
-        println "artifacts 1: " + configurations.compile.incoming.artifacts.collect { it.file.name }
-        println "artifacts 2: " + configurations.compile.incoming.artifactView { }.artifacts.collect { it.file.name }
-        println "artifacts 3: " + configurations.compile.incoming.artifactView { lenient = true }.artifacts.collect { it.file.name }
+            task show {
+                doLast {
+                    println "artifacts 1: " + configurations.compile.incoming.artifacts.collect { it.file.name }
+                    println "artifacts 2: " + configurations.compile.incoming.artifactView { }.artifacts.collect { it.file.name }
+                    println "artifacts 3: " + configurations.compile.incoming.artifactView { lenient = true }.artifacts.collect { it.file.name }
 
-        println "files 1: " + configurations.compile.incoming.files.collect { it.name }
-        println "files 2: " + configurations.compile.files.collect { it.name }
-        println "files 3: " + configurations.compile.resolve().collect { it.name }
-        println "files 4: " + configurations.compile.incoming.artifactView { }.files.collect { it.name }
-        println "files 5: " + configurations.compile.incoming.artifactView { lenient = true }.files.collect { it.name }
+                    println "files 1: " + configurations.compile.incoming.files.collect { it.name }
+                    println "files 2: " + configurations.compile.files.collect { it.name }
+                    println "files 3: " + configurations.compile.resolve().collect { it.name }
+                    println "files 4: " + configurations.compile.incoming.artifactView { }.files.collect { it.name }
+                    println "files 5: " + configurations.compile.incoming.artifactView { lenient = true }.files.collect { it.name }
 
-        println "files 6: " + configurations.compile.files { true }.collect { it.name }
-        println "files 7: " + configurations.compile.fileCollection { true }.collect { it.name }
-        println "files 8: " + configurations.compile.fileCollection { true }.files.collect { it.name }
-        println "files 9: " + configurations.compile.incoming.artifactView { }.files.collect { it.name }
-        println "files 10: " + configurations.compile.incoming.artifactView { lenient = true }.files.collect { it.name }
-    }
-}
-"""
+                    println "files 6: " + configurations.compile.files { true }.collect { it.name }
+                    println "files 7: " + configurations.compile.fileCollection { true }.collect { it.name }
+                    println "files 8: " + configurations.compile.fileCollection { true }.files.collect { it.name }
+                    println "files 9: " + configurations.compile.incoming.artifactView { }.files.collect { it.name }
+                    println "files 10: " + configurations.compile.incoming.artifactView { lenient = true }.files.collect { it.name }
+                }
+            }
+        """
+
+        file("a/build.gradle") << """
+            $header
+
+            dependencies {
+                compile files('a-lib.jar')
+                compile project(':b')
+                compile project(':c')
+                compile 'org:test:1.0'
+                compile('org:test:1.0') {
+                    artifact {
+                        name = 'test'
+                        classifier = 'from-a'
+                        type = 'jar'
+                    }
+                }
+                compile('org:test:1.0') {
+                    artifact {
+                        name = 'test'
+                        classifier = 'from-a'
+                        type = 'jar'
+                    }
+                }
+            }
+            artifacts {
+                compile file('a.jar')
+                compile file('a.jar')
+            }
+        """
+
+        file("b/build.gradle") << """
+            $header
+
+            dependencies {
+                compile files('b-lib.jar')
+                compile files('b-lib.jar')
+                compile 'org:test2:1.0'
+                compile project(':c')
+            }
+            artifacts {
+                compile file('b.jar')
+            }
+        """
+
+        file("c/build.gradle") << """
+            $header
+
+            dependencies {
+                compile files('c-lib.jar')
+                compile 'org:test3:1.0'
+                compile('org:test:1.0') {
+                    artifact {
+                        name = 'test'
+                        classifier = 'from-c'
+                        type = 'jar'
+                    }
+                    artifact {
+                        // this is the default artifact
+                        name = 'test'
+                        type = 'jar'
+                    }
+                }
+            }
+            artifacts {
+                compile file('c.jar')
+            }
+        """
 
         when:
         executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/SelfResolvingDependencyIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/SelfResolvingDependencyIntegrationTest.groovy
@@ -23,37 +23,37 @@ class SelfResolvingDependencyIntegrationTest extends AbstractDependencyResolutio
     @ToBeFixedForConfigurationCache(because = "Task uses the Configuration API")
     def "can query file dependency for its files"() {
         buildFile << """
-allprojects {
-    configurations {
-        compile
-    }
-}
-artifacts {
-    compile file("main.jar") // include to ensure artifacts are not included in the result
-}
-dependencies {
-    compile files("lib.jar")
-    compile "group:test1:1.0" // unknown module, include to ensure that other dependencies are not resolved
-}
+            configurations {
+                compile
+            }
 
-task verify {
-    doLast {
-        def dep = configurations.compile.dependencies.find { it instanceof FileCollectionDependency }
-        println "files: " + dep.files.files.collect { it.name }
-        println "resolve: " + dep.resolve().collect { it.name }
-        println "resolve-not-transitive: " + dep.resolve(false).collect { it.name }
-        println "resolve-transitive: " + dep.resolve(true).collect { it.name }
-        dep.getBuildDependencies()
-    }
-}
-"""
+            artifacts {
+                compile file("main.jar") // include to ensure artifacts are not included in the result
+            }
+
+            dependencies {
+                compile files("lib.jar")
+                compile "group:test1:1.0" // unknown module, include to ensure that other dependencies are not resolved
+            }
+
+            task verify {
+                doLast {
+                    def dep = configurations.compile.dependencies.find { it instanceof FileCollectionDependency }
+                    println "files: " + dep.files.files.collect { it.name }
+                    println "resolve: " + dep.resolve().collect { it.name }
+                    println "resolve-not-transitive: " + dep.resolve(false).collect { it.name }
+                    println "resolve-transitive: " + dep.resolve(true).collect { it.name }
+                    dep.getBuildDependencies()
+                }
+            }
+        """
 
         when:
         executer.expectDocumentedDeprecationWarning("Directly resolving a file collection dependency's files has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration and resolve the configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
         executer.expectDocumentedDeprecationWarning("Directly resolving a file collection dependency's files has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration and resolve the configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
         executer.expectDocumentedDeprecationWarning("Directly resolving a file collection dependency's files has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration and resolve the configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
         executer.expectDocumentedDeprecationWarning("Accessing the build dependencies of a file collection dependency has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration use the configuration to track task dependencies. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
-        run "verify"
+        succeeds("verify")
 
         then:
         outputContains("files: [lib.jar]")
@@ -68,74 +68,89 @@ task verify {
         mavenRepo.module("group", "test1", "1.0").publish()
         mavenRepo.module("group", "test2", "1.0").publish()
 
-        createDirs("child1", "child2", "child3")
         settingsFile << """
-rootProject.name = "main"
-include "child1", "child2", "child3"
-"""
-        buildFile << """
-allprojects {
-    repositories {
-        maven { url = '${mavenRepo.uri}' }
-    }
-    configurations {
-        compile
-        create('default') { extendsFrom compile }
-    }
-}
-artifacts {
-    compile file("main.jar")
-}
-dependencies {
-    compile files("lib.jar")
-    compile "group:test1:1.0"
-    compile project(':child1')
-    compile project(':child2')
-}
-project(':child1') {
-    artifacts {
-        compile file("child1.jar")
-    }
-    dependencies {
-        compile files("child1-lib.jar")
-        compile "group:test2:1.0"
-        compile project(':child3')
-    }
-}
-project(':child2') {
-    artifacts {
-        compile file("child2.jar")
-    }
-    dependencies {
-        compile files("child2-lib.jar")
-    }
-}
-project(':child3') {
-    artifacts {
-        compile file("child3.jar")
-    }
-    dependencies {
-        compile files("child3-lib.jar")
-    }
-}
+            rootProject.name = "main"
+            include "child1"
+            include "child2"
+            include "child3"
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
 
-task verify {
-    doLast {
-        def dep = configurations.compile.dependencies.find { it instanceof ProjectDependency }
-        println "files: " + dep.resolve().collect { it.name }
-        println "files-not-transitive: " + dep.resolve(false).collect { it.name }
-        println "files-transitive: " + dep.resolve(true).collect { it.name }
-        dep.getBuildDependencies()
-    }
-}
-"""
+        def common = """
+            configurations {
+                compile
+                create('default') { extendsFrom compile }
+            }
+        """
+
+        buildFile << """
+            $common
+
+            artifacts {
+                compile file("main.jar")
+            }
+
+            dependencies {
+                compile files("lib.jar")
+                compile "group:test1:1.0"
+                compile project(':child1')
+                compile project(':child2')
+            }
+
+            task verify {
+                doLast {
+                    def dep = configurations.compile.dependencies.find { it instanceof ProjectDependency }
+                    println "files: " + dep.resolve().collect { it.name }
+                    println "files-not-transitive: " + dep.resolve(false).collect { it.name }
+                    println "files-transitive: " + dep.resolve(true).collect { it.name }
+                    dep.getBuildDependencies()
+                }
+            }
+        """
+
+        file("child1/build.gradle") << """
+            $common
+
+            artifacts {
+                compile file("child1.jar")
+            }
+            dependencies {
+                compile files("child1-lib.jar")
+                compile "group:test2:1.0"
+                compile project(':child3')
+            }
+        """
+
+        file("child2/build.gradle") << """
+            $common
+
+            artifacts {
+                compile file("child2.jar")
+            }
+            dependencies {
+                compile files("child2-lib.jar")
+            }
+        """
+
+        file("child3/build.gradle") << """
+            $common
+
+            artifacts {
+                compile file("child3.jar")
+            }
+            dependencies {
+                compile files("child3-lib.jar")
+            }
+        """
 
         when:
         executer.expectDocumentedDeprecationWarning("Directly resolving the files of project dependency ':child1' has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration and resolve the configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
         executer.expectDocumentedDeprecationWarning("Directly resolving the files of project dependency ':child1' has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration and resolve the configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
         executer.expectDocumentedDeprecationWarning("Directly resolving the files of project dependency ':child1' has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration and resolve the configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
         executer.expectDocumentedDeprecationWarning("Accessing the build dependencies of project dependency ':child1' has been deprecated. This will fail with an error in Gradle 9.0. Add the dependency to a resolvable configuration and use the configuration to track task dependencies. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency")
-        run "verify"
+        succeeds("verify")
 
         then:
         outputContains("files: [child1-lib.jar, child3-lib.jar]")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsDependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsDependencySubstitutionRulesIntegrationTest.groovy
@@ -46,7 +46,6 @@ class VariantsDependencySubstitutionRulesIntegrationTest extends AbstractIntegra
             }
         """
 
-        createDirs("platform")
         settingsFile << """
             include 'platform'
         """
@@ -196,10 +195,10 @@ class VariantsDependencySubstitutionRulesIntegrationTest extends AbstractIntegra
             }
         """
 
-        createDirs("other")
         settingsFile << """
             include 'other'
         """
+        file("other/build.gradle") << ""
 
         when:
         fails ':checkDeps'
@@ -285,7 +284,6 @@ class VariantsDependencySubstitutionRulesIntegrationTest extends AbstractIntegra
             }
         """
 
-        createDirs("other")
         settingsFile << """
             include 'other'
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactCollectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactCollectionIntegrationTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 class ArtifactCollectionIntegrationTest extends AbstractHttpDependencyResolutionTest {
 
     def setup() {
-        createDirs("project-lib")
         settingsFile << """
             rootProject.name = 'root'
             include 'project-lib'
@@ -36,9 +35,6 @@ class ArtifactCollectionIntegrationTest extends AbstractHttpDependencyResolution
         file('lib/file-lib.jar') << 'content'
 
         buildFile << """
-            project(':project-lib') {
-                apply plugin: 'java'
-            }
             configurations {
                 compile
             }
@@ -62,7 +58,13 @@ class ArtifactCollectionIntegrationTest extends AbstractHttpDependencyResolution
 
                 @OutputFile File outputFile
             }
-"""
+        """
+
+        file("project-lib/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+        """
     }
 
     def "artifact collection has resolved artifact files and metadata"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactCollectionResultProviderIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactCollectionResultProviderIntegrationTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 class ArtifactCollectionResultProviderIntegrationTest extends AbstractHttpDependencyResolutionTest {
 
     def setup() {
-        createDirs("project-lib")
         settingsFile << """
             rootProject.name = 'root'
             include 'project-lib'
@@ -32,9 +31,6 @@ class ArtifactCollectionResultProviderIntegrationTest extends AbstractHttpDepend
         mavenRepo.module("org.external", "external-lib").publish()
         file('lib/file-lib.jar') << 'content'
         buildFile << """
-            project(':project-lib') {
-                apply plugin: 'java'
-            }
             configurations {
                 compile
             }
@@ -63,6 +59,12 @@ class ArtifactCollectionResultProviderIntegrationTest extends AbstractHttpDepend
                     println(artifactFiles.files)
                     println(resolvedArtifacts.get())
                 }
+            }
+        """
+
+        file("project-lib/build.gradle") << """
+            plugins {
+                id("java-library")
             }
         """
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
@@ -125,42 +125,43 @@ project.status = 'foo'
 
     @Issue("gradle/gradle#812")
     def "can use defaultDependencies in a multi-project build"() {
-        buildFile << """
-subprojects {
-    apply plugin: 'java'
-
-    repositories {
-        maven { url = '${mavenRepo.uri}' }
-    }
-}
-
-project(":producer") {
-    configurations {
-        implementation {
-            defaultDependencies {
-                add(project.dependencies.create("org:default-dependency:1.0"))
-            }
-        }
-    }
-    dependencies {
-        if (System.getProperty('explicitDeps')) {
-            implementation "org:explicit-dependency:1.0"
-        }
-    }
-}
-
-project(":consumer") {
-    dependencies {
-        implementation project(":producer")
-    }
-}
-"""
-        resolve.prepare("runtimeClasspath")
-        resolve.expectDefaultConfiguration("runtimeElements")
-        createDirs("consumer", "producer")
         settingsFile << """
-include 'consumer', 'producer'
-"""
+            include 'consumer'
+            include 'producer'
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
+        file("producer/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+
+            configurations {
+                implementation {
+                    defaultDependencies {
+                        add(project.dependencies.create("org:default-dependency:1.0"))
+                    }
+                }
+            }
+            dependencies {
+                if (System.getProperty('explicitDeps')) {
+                    implementation "org:explicit-dependency:1.0"
+                }
+            }
+        """
+
+        file("consumer/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+
+            dependencies {
+                implementation project(":producer")
+            }
+        """
+
+        resolve.prepare("runtimeClasspath")
 
         when:
         executer.withArgument("-DexplicitDeps=yes")
@@ -225,7 +226,6 @@ include 'consumer', 'producer'
     }
 """
         resolve.prepare("runtimeClasspath")
-        resolve.expectDefaultConfiguration("runtimeElements")
 
         when:
         run ":checkDeps"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
@@ -137,10 +137,9 @@ This method is only meant to be called on configurations which allow the (non-de
 
     def "cannot add a dependency on a configuration role #role"() {
         given:
-        createDirs("a", "b")
         file('settings.gradle') << 'include "a", "b"'
-        buildFile << """
-        project(':a') {
+
+        file("a/build.gradle") << """
             configurations {
                 compile
             }
@@ -152,15 +151,14 @@ This method is only meant to be called on configurations which allow the (non-de
                 def files = configurations.compile
                 doLast { files.files }
             }
-        }
-        project(':b') {
+        """
+
+        file("b/build.gradle") << """
             configurations {
                 internal {
                     $code
                 }
             }
-        }
-
         """
 
         when:
@@ -177,10 +175,9 @@ This method is only meant to be called on configurations which allow the (non-de
 
     def "cannot depend on default configuration if it's not consumable (#role)"() {
         given:
-        createDirs("a", "b")
         file('settings.gradle') << 'include "a", "b"'
-        buildFile << """
-        project(':a') {
+
+        file("a/build.gradle") << """
             configurations {
                 compile
             }
@@ -192,15 +189,14 @@ This method is only meant to be called on configurations which allow the (non-de
                 def files = configurations.compile
                 doLast { files.files }
             }
-        }
-        project(':b') {
+        """
+
+        file("b/build.gradle") << """
             configurations {
                 'default' {
                     $code
                 }
             }
-        }
-
         """
 
         when:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/InvalidConfigurationResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/InvalidConfigurationResolutionIntegrationTest.groovy
@@ -35,27 +35,26 @@ class InvalidConfigurationResolutionIntegrationTest extends AbstractIntegrationS
             repositories {
                 maven { url = "${mavenRepo.uri}" }
             }
-            allprojects {
-                configurations {
-                    implementation
-                    compile.canBeDeclared = false
-                    compile.canBeConsumed = false
-                    compile.canBeResolved = false
-                    compileOnly.canBeResolved = false
-                    apiElements {
-                        assert canBeConsumed
-                        canBeResolved = false
-                        extendsFrom compile
-                        extendsFrom compileOnly
-                        extendsFrom implementation
-                    }
-                    compileClasspath {
-                        canBeConsumed = false
-                        assert canBeResolved
-                        extendsFrom compile
-                        extendsFrom compileOnly
-                        extendsFrom implementation
-                    }
+
+            configurations {
+                implementation
+                compile.canBeDeclared = false
+                compile.canBeConsumed = false
+                compile.canBeResolved = false
+                compileOnly.canBeResolved = false
+                apiElements {
+                    assert canBeConsumed
+                    canBeResolved = false
+                    extendsFrom compile
+                    extendsFrom compileOnly
+                    extendsFrom implementation
+                }
+                compileClasspath {
+                    canBeConsumed = false
+                    assert canBeResolved
+                    extendsFrom compile
+                    extendsFrom compileOnly
+                    extendsFrom implementation
                 }
             }
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedConfigurationApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedConfigurationApiIntegrationTest.groovy
@@ -24,18 +24,8 @@ import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 class ResolvedConfigurationApiIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def setup() {
         settingsFile << """
-rootProject.name = 'test'
-"""
-        buildFile << """
-allprojects {
-    configurations {
-        compile
-        "default" {
-            extendsFrom compile
-        }
-    }
-}
-"""
+            rootProject.name = 'test'
+        """
     }
 
     @ToBeFixedForConfigurationCache(because = "task exercises the ResolvedConfiguration API")
@@ -47,24 +37,30 @@ allprojects {
         m1.publish()
 
         buildFile << """
-allprojects {
-    repositories { ivy { url = '$ivyHttpRepo.uri' } }
-}
-dependencies {
-    compile 'org:test:1.0'
-}
+            repositories { ivy { url = '$ivyHttpRepo.uri' } }
 
-task show {
-    inputs.files configurations.compile
-    doLast {
-        println "files: " + configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.file.name }
-        println "display-names: " + configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.toString() }
-        println "ids: " + configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.id.toString() }
-        println "names: " + configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { "\$it.name:\$it.extension:\$it.type" }
-        println "classifiers: " + configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.classifier }
-    }
-}
-"""
+            configurations {
+                compile
+                "default" {
+                    extendsFrom compile
+                }
+            }
+
+            dependencies {
+                compile 'org:test:1.0'
+            }
+
+            task show {
+                inputs.files configurations.compile
+                doLast {
+                    println "files: " + configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.file.name }
+                    println "display-names: " + configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.toString() }
+                    println "ids: " + configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.id.toString() }
+                    println "names: " + configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { "\$it.name:\$it.extension:\$it.type" }
+                    println "classifiers: " + configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.classifier }
+                }
+            }
+        """
 
         when:
         m1.ivy.expectGet()
@@ -86,6 +82,14 @@ task show {
     def "reports multiple failures to resolve components"() {
         buildFile << """
             repositories { maven { url = '${mavenHttpRepo.uri}' } }
+
+            configurations {
+                compile
+                "default" {
+                    extendsFrom compile
+                }
+            }
+
             dependencies {
                 compile 'test:test1:1.2'
                 compile 'test:test2:1.2'
@@ -97,7 +101,7 @@ task show {
                     configurations.compile.resolvedConfiguration.resolvedArtifacts
                 }
             }
-"""
+        """
 
         when:
         def m1 = mavenHttpRepo.module("test", "test1", "1.2")
@@ -120,6 +124,14 @@ task show {
     def "reports failure to resolve artifact"() {
         buildFile << """
             repositories { maven { url = '${mavenHttpRepo.uri}' } }
+
+            configurations {
+                compile
+                "default" {
+                    extendsFrom compile
+                }
+            }
+
             dependencies {
                 compile 'test:test1:1.2'
                 compile 'test:test2:1.2'
@@ -131,7 +143,7 @@ task show {
                     configurations.compile.resolvedConfiguration.resolvedArtifacts.each { it.file }
                 }
             }
-"""
+        """
 
         when:
         def m1 = mavenHttpRepo.module("test", "test1", "1.2").publish()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/UnsupportedConfigurationMutationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/UnsupportedConfigurationMutationTest.groovy
@@ -129,69 +129,74 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow changing dependencies of a configuration that has been resolved for task dependencies"() {
         mavenRepo.module("org.utils", "extra", '1.5').publish()
 
-        createDirs("api", "impl")
-        settingsFile << "include 'api', 'impl'"
-        buildFile << """
-            allprojects {
-                repositories {
-                    maven { url = "${mavenRepo.uri}" }
-                }
-                configurations {
-                    compile
-                    testCompile { extendsFrom compile }
-                    'default' { extendsFrom compile }
-                }
-                configurations.all {
-                    resolutionStrategy.assumeFluidDependencies()
-                }
+        settingsFile << """
+            include 'api'
+            include 'impl'
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
             }
+        """
 
-            project(":api") {
-                task addDependency {
-                    doLast {
-                        dependencies {
-                            compile "org.utils:extra:1.5"
-                        }
-                    }
-                }
+        def common = """
+            configurations {
+                compile
+                testCompile { extendsFrom compile }
+                'default' { extendsFrom compile }
             }
+            configurations.all {
+                resolutionStrategy.assumeFluidDependencies()
+            }
+        """
 
-            project(":impl") {
-                dependencies {
-                    compile project(":api")
-                }
+        file("api/build.gradle") << """
+            $common
 
-                task addDependency {
-                    doLast {
-                        dependencies {
-                            compile "org.utils:extra:1.5"
-                        }
-                    }
-                }
-
-                task modifyConfigDuringTaskExecution(dependsOn: [':impl:addDependency', configurations.compile]) {
-                    doLast {
-                        def files = configurations.compile.files
-                        assert files*.name.sort() == ["api.jar", "extra-1.5.jar"]
-                        assert files*.exists() == [ true, true ]
-                    }
-                }
-                task modifyParentConfigDuringTaskExecution(dependsOn: [':impl:addDependency', configurations.testCompile]) {
-                    doLast {
-                        def files = configurations.testCompile.files
-                        assert files*.name.sort() == ["api.jar", "extra-1.5.jar"]
-                        assert files*.exists() == [ true, true ]
-                    }
-                }
-                task modifyDependentConfigDuringTaskExecution(dependsOn: [':api:addDependency', configurations.compile]) {
-                    doLast {
-                        def files = configurations.compile.files
-                        assert files*.name.sort() == ["api.jar"] // Late dependency is not honoured
-                        assert files*.exists() == [ true ]
+            task addDependency {
+                doLast {
+                    dependencies {
+                        compile "org.utils:extra:1.5"
                     }
                 }
             }
-"""
+        """
+
+        file("impl/build.gradle") << """
+            $common
+
+            dependencies {
+                compile project(":api")
+            }
+
+            task addDependency {
+                doLast {
+                    dependencies {
+                        compile "org.utils:extra:1.5"
+                    }
+                }
+            }
+
+            task modifyConfigDuringTaskExecution(dependsOn: [':impl:addDependency', configurations.compile]) {
+                doLast {
+                    def files = configurations.compile.files
+                    assert files*.name.sort() == ["api.jar", "extra-1.5.jar"]
+                    assert files*.exists() == [ true, true ]
+                }
+            }
+            task modifyParentConfigDuringTaskExecution(dependsOn: [':impl:addDependency', configurations.testCompile]) {
+                doLast {
+                    def files = configurations.testCompile.files
+                    assert files*.name.sort() == ["api.jar", "extra-1.5.jar"]
+                    assert files*.exists() == [ true, true ]
+                }
+            }
+            task modifyDependentConfigDuringTaskExecution(dependsOn: [':api:addDependency', configurations.compile]) {
+                doLast {
+                    def files = configurations.compile.files
+                    assert files*.name.sort() == ["api.jar"] // Late dependency is not honoured
+                    assert files*.exists() == [ true ]
+                }
+            }
+        """
 
         when:
         fails("impl:modifyConfigDuringTaskExecution")
@@ -216,46 +221,51 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow changing artifacts of a configuration that has been resolved for task dependencies"() {
         mavenRepo.module("org.utils", "extra", '1.5').publish()
 
-        createDirs("api", "impl")
-        settingsFile << "include 'api', 'impl'"
-        buildFile << """
-            allprojects {
-                repositories {
-                    maven { url = "${mavenRepo.uri}" }
+        settingsFile << """
+            include 'api'
+            include 'impl'
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
+
+        def common = """
+            configurations {
+                compile
+                testCompile { extendsFrom compile }
+                'default' { extendsFrom compile }
+            }
+            configurations.all {
+                resolutionStrategy.assumeFluidDependencies()
+            }
+        """
+
+        file("api/build.gradle") << """
+            $common
+
+            task addArtifact {
+                doLast {
+                    artifacts { compile file("some.jar") }
                 }
-                configurations {
-                    compile
-                    testCompile { extendsFrom compile }
-                    'default' { extendsFrom compile }
-                }
-                configurations.all {
-                    resolutionStrategy.assumeFluidDependencies()
+            }
+        """
+
+        file("impl/build.gradle") << """
+            $common
+
+            dependencies {
+                compile project(":api")
+            }
+            task addArtifact {
+                doLast {
+                    artifacts { compile file("some.jar") }
                 }
             }
 
-            project(":api") {
-                task addArtifact {
-                    doLast {
-                        artifacts { compile file("some.jar") }
-                    }
-                }
-            }
-
-            project(":impl") {
-                dependencies {
-                    compile project(":api")
-                }
-                task addArtifact {
-                    doLast {
-                        artifacts { compile file("some.jar") }
-                    }
-                }
-
-                task addArtifactToConfigDuringTaskExecution(dependsOn: [':impl:addArtifact', configurations.compile])
-                task addArtifactToParentConfigDuringTaskExecution(dependsOn: [':impl:addArtifact', configurations.testCompile])
-                task addArtifactToDependentConfigDuringTaskExecution(dependsOn: [':api:addArtifact', configurations.compile])
-            }
-"""
+            task addArtifactToConfigDuringTaskExecution(dependsOn: [':impl:addArtifact', configurations.compile])
+            task addArtifactToParentConfigDuringTaskExecution(dependsOn: [':impl:addArtifact', configurations.testCompile])
+            task addArtifactToDependentConfigDuringTaskExecution(dependsOn: [':api:addArtifact', configurations.compile])
+        """
 
         when:
         fails("impl:addArtifactToConfigDuringTaskExecution")
@@ -405,31 +415,40 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     }
 
     def "does not allow changing a dependency project's dependencies after included in resolution"() {
-        createDirs("api", "impl")
-        settingsFile << "include 'api', 'impl'"
-        buildFile << """
-            allprojects {
+        settingsFile << """
+            include 'api'
+            gradle.lifecycle.beforeProject {
                 configurations {
-                    compile
-                    'default' { extendsFrom compile }
+                    create("compile")
+                    create("default") {
+                        extendsFrom compile
+                    }
                 }
             }
+        """
+
+        buildFile << """
             dependencies {
-                compile project(":impl")
-            }
-            project(":impl") {
-                dependencies {
-                    compile project(":api")
-                }
+                compile project(":api")
             }
             configurations.compile.resolve()
-            project(":api") {
+        """
+
+        file("api/build.gradle") << """
+            tasks.register("jar", Jar) {
+                archiveFileName = "jar.jar"
+                destinationDirectory = buildDir
                 dependencies {
                     compile files("some.jar")
                 }
             }
-"""
 
+            configurations {
+                compile {
+                    outgoing.artifact(tasks.named("jar"))
+                }
+            }
+        """
 
         when: fails()
         then: failure.assertHasCause("Cannot change dependencies of dependency configuration ':api:compile' after it has been included in dependency resolution.")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ArtifactResolutionQueryIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifactreuse/ArtifactResolutionQueryIntegrationTest.groovy
@@ -41,43 +41,48 @@ class ArtifactResolutionQueryIntegrationTest extends AbstractHttpDependencyResol
         def handler = blockingServer.expectConcurrentAndBlock(blockingServer.get(module.pom.path).sendFile(module.pom.file), blockingServer.get('/sync'))
         blockingServer.expect(blockingServer.get(module.artifact.path).sendFile(module.artifact.file))
 
-        createDirs("query", "resolve")
         settingsFile << 'include "query", "resolve"'
-        buildFile << """
-import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier as DMI
+        def common = """
+            import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+            import org.gradle.api.internal.artifacts.DefaultModuleIdentifier as DMI
 
-allprojects {
-    apply plugin: 'java'
-    repositories {
-       maven { url = '${blockingServer.uri}/repo' }
-    }
+            plugins {
+                id("java-library")
+            }
 
-    dependencies {
-        implementation 'group:artifact:1.0'
-    }
-}
+            repositories {
+               maven { url = '${blockingServer.uri}/repo' }
+            }
 
-project('query') {
-    task query {
-        doLast {
-            '${blockingServer.uri}/sync'.toURL().text
-            dependencies.createArtifactResolutionQuery()
-                        .forComponents(new DefaultModuleComponentIdentifier(DMI.newId('group','artifact'),'1.0'))
-                        .withArtifacts(JvmLibrary)
-                        .execute()
-        }
-    }
-}
+            dependencies {
+                implementation 'group:artifact:1.0'
+            }
+        """
 
-project('resolve') {
-    task resolve {
-        doLast {
-            configurations.compileClasspath.files.collect { it.file }
-        }
-    }
-}
-"""
+        file("query/build.gradle") << """
+            $common
+
+            task query {
+                doLast {
+                    '${blockingServer.uri}/sync'.toURL().text
+                    dependencies.createArtifactResolutionQuery()
+                                .forComponents(new DefaultModuleComponentIdentifier(DMI.newId('group','artifact'),'1.0'))
+                                .withArtifacts(JvmLibrary)
+                                .execute()
+                }
+            }
+        """
+
+        file("resolve/build.gradle") << """
+            $common
+
+            task resolve {
+                doLast {
+                    configurations.compileClasspath.files.collect { it.file }
+                }
+            }
+        """
+
         executer.requireOwnGradleUserHomeDir().requireIsolatedDaemons()
 
         expect:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -22,19 +22,13 @@ import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
 class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDependencyResolutionTest {
 
-    ResolveTestFixture resolve
+    ResolveTestFixture resolve = new ResolveTestFixture(buildFile, "compileClasspath")
 
     def setup() {
-        buildFile << """
-            allprojects {
-                apply plugin: 'java-library'
-            }
-        """
         settingsFile << """
             rootProject.name = 'test'
         """
-        resolve = new ResolveTestFixture(buildFile, "compileClasspath")
-        resolve.prepare()
+        resolve
     }
 
     def "can select both main variant and test fixtures with project dependencies"() {
@@ -42,6 +36,9 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         settingsFile << "include 'lib'"
 
         file("lib/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
             configurations {
                 testFixtures {
                     canBeResolved = false
@@ -62,6 +59,9 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         """
 
         buildFile << """
+            plugins {
+                id("java-library")
+            }
             dependencies {
                 implementation project(':lib')
                 implementation (project(':lib')) {
@@ -74,6 +74,8 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                 }
             }
         """
+
+        resolve.prepare()
 
         when:
         succeeds ':checkDeps'
@@ -98,6 +100,9 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         settingsFile << "include 'lib'"
 
         file("lib/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
             configurations {
                 testFixtures {
                     canBeResolved = false
@@ -120,10 +125,15 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         """
 
         buildFile << """
+            plugins {
+                id("java-library")
+            }
             dependencies {
                 implementation project(':lib')
             }
         """
+
+        resolve.prepare()
 
         when:
         succeeds ':checkDeps'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StringConfigurationAttributesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StringConfigurationAttributesResolveIntegrationTest.groovy
@@ -27,14 +27,12 @@ class StringConfigurationAttributesResolveIntegrationTest extends AbstractConfig
             def buildType = Attribute.of('buildType', String)
             def extra = Attribute.of('extra', String)
 
-            allprojects {
-               dependencies {
-                   attributesSchema {
-                      attribute(flavor)
-                      attribute(buildType)
-                      attribute(extra)
-                   }
-               }
+            dependencies {
+                attributesSchema {
+                   attribute(flavor)
+                   attribute(buildType)
+                   attribute(extra)
+                }
             }
         '''
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
@@ -552,10 +552,9 @@ Required by:
         def repo2 = mavenHttpRepo("repo2")
         def repo2Module = repo2.module("group", "projectA", "1.0")
 
-        createDirs("subproject")
-        settingsFile << "include 'subproject'"
-        buildFile << """
-            allprojects{
+        settingsFile << """
+            include 'subproject'
+            dependencyResolutionManagement {
                 repositories {
                     maven {
                         name = 'repo1'
@@ -567,6 +566,8 @@ Required by:
                     }
                 }
             }
+        """
+        buildFile << """
             configurations {
                 config1
             }
@@ -581,23 +582,24 @@ Required by:
                    }
                }
             }
+        """
 
-            project(":subproject"){
-                configurations{
-                    config2
-                }
-                dependencies{
-                    config2 'group:projectA:1.0'
-                }
-                task resolveConfig2 {
-                    doLast {
-                        configurations.config2.incoming.resolutionResult.allDependencies{
-                            assert it instanceof UnresolvedDependencyResult
-                        }
+        file("subproject/build.gradle") << """
+            configurations{
+                config2
+            }
+            dependencies{
+                config2 'group:projectA:1.0'
+            }
+            task resolveConfig2 {
+                doLast {
+                    configurations.config2.incoming.resolutionResult.allDependencies{
+                        assert it instanceof UnresolvedDependencyResult
                     }
                 }
             }
         """
+
         when:
         repo1Module.pom.expectGetMissing()
         repo2Module.pom.expectGetMissing()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachingDependencyMetadataInMemoryIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachingDependencyMetadataInMemoryIntegrationTest.groovy
@@ -70,21 +70,25 @@ class CachingDependencyMetadataInMemoryIntegrationTest extends AbstractHttpDepen
         given:
         def lib = ivyHttpRepo.module("org", "lib").publish()
 
-        createDirs("impl")
         file("settings.gradle") << "include 'impl'"
 
-        file("build.gradle") << """
-            allprojects {
-                configurations { conf }
-                repositories { ivy { url = "${ivyHttpRepo.uri}" } }
-                dependencies { conf 'org:lib:1.0' }
-                task resolveConf {
-                    def files = configurations.conf
-                    doLast { println path + " " + files*.name }
-                }
+        def common = """
+            configurations { conf }
+            repositories { ivy { url = "${ivyHttpRepo.uri}" } }
+            dependencies { conf 'org:lib:1.0' }
+            task resolveConf {
+                def files = configurations.conf
+                doLast { println path + " " + files*.name }
             }
+        """
+
+        file("build.gradle") << """
+            $common
+
             resolveConf.dependsOn(':impl:resolveConf')
         """
+
+        file("impl/build.gradle") << common
 
         when:
         lib.ivy.expectGet()
@@ -102,29 +106,34 @@ class CachingDependencyMetadataInMemoryIntegrationTest extends AbstractHttpDepen
         def ivyRepo2 = new IvyFileRepository(file("ivy-repo2"))
         ivyRepo2.module("org", "lib", "2.0").publish() //different version of lib
 
-        createDirs("impl")
         file("settings.gradle") << "include 'impl'"
 
-        file("build.gradle") << """
-            allprojects {
-                configurations {
-                    conf {
-                        incoming.afterResolve { deps ->
-                            println "\${project.path} " + deps.files*.name
-                        }
+        def common = """
+            configurations {
+                conf {
+                    incoming.afterResolve { deps ->
+                        println "\${project.path} " + deps.files*.name
                     }
                 }
-                dependencies { conf 'org:lib:1.0' }
-                task resolveConf {
-                    def files = configurations.conf
-                    doLast { files.files }
-                }
             }
+            dependencies { conf 'org:lib:1.0' }
+            task resolveConf {
+                def files = configurations.conf
+                doLast { files.files }
+            }
+        """
+
+        buildFile << """
+            $common
+
             repositories { ivy { url = "${ivyRepo.uri}" } }
-            project(":impl") {
-                repositories { ivy { url = "${ivyRepo2.uri}" } }
-                tasks.resolveConf.dependsOn(":resolveConf")
-            }
+        """
+
+        file('impl/build.gradle') << """
+            $common
+
+            repositories { ivy { url = "${ivyRepo2.uri}" } }
+            tasks.resolveConf.dependsOn(":resolveConf")
         """
 
         when:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
@@ -153,7 +153,6 @@ Required by:
 
     @ToBeFixedForConfigurationCache
     void "reports and recovers from multiple missing transitive modules"() {
-        createDirs("child1")
         settingsFile << "include 'child1'"
 
         given:
@@ -168,29 +167,39 @@ Required by:
             .dependsOn(moduleB)
             .publish()
 
+        settingsFile << """
+            dependencyResolutionManagement {
+                repositories {
+                    ivy { url = "${repo.uri}"}
+                }
+            }
+        """
+
         buildFile << """
-allprojects {
-    repositories {
-        ivy { url = "${repo.uri}"}
-    }
-    configurations {
-        compile
-        'default' {
-            extendsFrom(compile)
-        }
-    }
-}
-dependencies {
-    compile 'group:projectC:0.99'
-    compile project(':child1')
-}
-project(':child1') {
-    dependencies {
-        compile 'group:projectD:1.0GA'
-    }
-}
-task showMissing { doLast { println configurations.compile.files } }
-"""
+            configurations {
+                compile
+                'default' {
+                    extendsFrom(compile)
+                }
+            }
+            dependencies {
+                compile 'group:projectC:0.99'
+                compile project(':child1')
+            }
+            task showMissing { doLast { println configurations.compile.files } }
+        """
+
+        file("child1/build.gradle") << """
+            configurations {
+                compile
+                'default' {
+                    extendsFrom(compile)
+                }
+            }
+            dependencies {
+                compile 'group:projectD:1.0GA'
+            }
+        """
 
         when:
         moduleA.ivy.expectGetMissing()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
@@ -23,40 +23,44 @@ class MultiProjectDependencyLockingIntegrationTest  extends AbstractDependencyRe
     def firstLockFileFixture = new LockfileFixture(testDirectory: testDirectory.file('first'))
 
     def setup() {
-        createDirs("first", "second")
         settingsFile << """
-rootProject.name = 'multiDepLock'
-include 'first', 'second'
-"""
+            rootProject.name = 'multiDepLock'
+            include 'first', 'second'
+        """
     }
 
     def 'does not apply lock defined in a dependent project'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
-        buildFile << """
-allprojects {
-    apply plugin: 'java-library'
-    repositories {
-        maven { url = "${mavenRepo.uri}" }
-    }
-}
+        settingsFile << """
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
 
-project(':first') {
-    configurations.all {
-        resolutionStrategy.activateDependencyLocking()
-    }
-    dependencies {
-        api 'org:foo:[1.0,2.0)'
-    }
-}
+        file("first/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+            configurations.all {
+                resolutionStrategy.activateDependencyLocking()
+            }
+            dependencies {
+                api 'org:foo:[1.0,2.0)'
+            }
 
-project(':second') {
-    dependencies {
-        implementation project(':first')
-    }
-}
-"""
+        """
+
+        file("second/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+            dependencies {
+                implementation project(':first')
+            }
+        """
+
         firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'], false)
 
         when:
@@ -76,29 +80,34 @@ project(':second') {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
-        buildFile << """
-allprojects {
-    apply plugin: 'java-library'
-    repositories {
-        maven { url = "${mavenRepo.uri}" }
-    }
-}
+        settingsFile << """
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
 
-project(':first') {
-    configurations.all {
-        resolutionStrategy.activateDependencyLocking()
-    }
-    dependencies {
-        implementation project(':second')
-    }
-}
+        file("first/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+            configurations.all {
+                resolutionStrategy.activateDependencyLocking()
+            }
+            dependencies {
+                implementation project(':second')
+            }
 
-project(':second') {
-    dependencies {
-        api 'org:foo:[1.0,2.0)'
-    }
-}
-"""
+        """
+
+        file("second/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+            dependencies {
+                api 'org:foo:[1.0,2.0)'
+            }
+        """
+
         firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'], false)
 
         when:
@@ -118,29 +127,34 @@ project(':second') {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
-        buildFile << """
-allprojects {
-    apply plugin: 'java-library'
-    repositories {
-        maven { url = "${mavenRepo.uri}" }
-    }
-}
+        settingsFile << """
+            dependencyResolutionManagement {
+                ${mavenTestRepository()}
+            }
+        """
 
-project(':first') {
-    configurations.all {
-        resolutionStrategy.activateDependencyLocking()
-    }
-    dependencies {
-        implementation project(':second')
-    }
-}
+        file("first/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+            configurations.all {
+                resolutionStrategy.activateDependencyLocking()
+            }
+            dependencies {
+                implementation project(':second')
+            }
+        """
 
-project(':second') {
-    dependencies {
-        api 'org:foo:[1.0,2.0)'
-    }
-}
-"""
+        file("second/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+            dependencies {
+                api 'org:foo:[1.0,2.0)'
+            }
+        """
+
+
         when:
         succeeds ':first:dependencies', '--configuration', 'compileClasspath', '--write-locks'
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/EnforcedPlatformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/EnforcedPlatformIntegrationTest.groovy
@@ -75,14 +75,15 @@ class EnforcedPlatformIntegrationTest extends AbstractHttpDependencyResolutionTe
         settingsFile << """
             include 'platform'
             include 'lib'
+            dependencyResolutionManagement {
+                ${mavenCentralRepository()}
+            }
         """
 
         buildFile << """
-            allprojects {
-                ${mavenCentralRepository()}
+            plugins {
+                id("java-library")
             }
-
-            apply plugin: 'java-library'
 
             dependencies {
                 implementation enforcedPlatform(project(":platform"))

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/PlatformResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/PlatformResolveIntegrationTest.groovy
@@ -144,7 +144,6 @@ class PlatformResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
             .allowAll()
             .publish()
 
-        createDirs("sub")
         settingsFile << """
             include 'sub'
         """
@@ -161,17 +160,22 @@ class PlatformResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                 api platform("org:platform") // no version, will select the "platform" component
                 api project(":sub")
             }
-            project(":sub") {
-                apply plugin: 'java-library'
-                group = "org.test"
-                version = "1.9"
-                dependencies {
-                    constraints {
-                       api "org:platform:1.0"
-                    }
+        """
+
+        file("sub/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+
+            group = "org.test"
+            version = "1.9"
+            dependencies {
+                constraints {
+                   api "org:platform:1.0"
                 }
             }
         """
+
         checkConfiguration("compileClasspath")
 
         run ":checkDeps"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnDynamicVersionsResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnDynamicVersionsResolveIntegrationTest.groovy
@@ -35,20 +35,19 @@ class FailOnDynamicVersionsResolveIntegrationTest extends AbstractModuleDependen
     }
 
     def "does not fail with a project and direct dependency with non dynamic version"() {
-        createDirs("other")
         settingsFile << """
             include("other")
-"""
+        """
         buildFile << """
             dependencies {
                 conf(project(':other'))
                 conf 'org:test:1.0'
             }
+        """
 
-            project(':other') {
-                configurations.create('default')
-            }
-"""
+        file("other/build.gradle") << """
+            configurations.create('default')
+        """
         repository {
             'org:test:1.0'()
         }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
@@ -544,58 +544,59 @@ dependencies {
             'org.test:projectB:1.0'()
         }
 
-        createDirs("sub")
         settingsFile << """
-rootProject.name = 'root'
-include 'sub'
-"""
+            rootProject.name = 'root'
+            include 'sub'
+        """
+
         buildFile << """
-class AddDependencyRule implements ComponentMetadataRule {
-    public void execute(ComponentMetadataContext context) {
-        context.details.allVariants {
-            withDependencies {
-                add('org.test:projectB:1.0')
+            task res {
+                def conf = configurations.conf
+                doLast {
+                    // Should get the unmodified component metadata for 'projectA'
+                    println conf.collect { it.name }
+                    assert conf.collect { it.name } == ['projectA-1.0.jar']
+                }
             }
-        }
-    }
-}
+        """
 
-project (':sub') {
-    $repositoryDeclaration
+        file("sub/build.gradle") << """
+            $repositoryDeclaration
 
-    configurations {
-        conf
-        other
-    }
-    dependencies {
-        conf 'org.test:projectA:1.0'
-        other 'org.test:projectA:1.0'
+            configurations {
+                conf
+                other
+            }
 
-        // Component metadata rule that applies only to the 'sub' project
-        components {
-            withModule('org.test:projectA', AddDependencyRule)
-        }
-    }
-    task res {
-        def conf = configurations.conf
-        def other = configurations.other
-        doLast {
-            // If we resolve twice the modified component metadata for 'projectA' must not be cached in-memory
-            println conf.collect { it.name }
-            println other.collect { it.name }
-        }
-    }
-}
+            class AddDependencyRule implements ComponentMetadataRule {
+                public void execute(ComponentMetadataContext context) {
+                    context.details.allVariants {
+                        withDependencies {
+                            add('org.test:projectB:1.0')
+                        }
+                    }
+                }
+            }
 
-task res {
-    def conf = configurations.conf
-    doLast {
-        // Should get the unmodified component metadata for 'projectA'
-        println conf.collect { it.name }
-        assert conf.collect { it.name } == ['projectA-1.0.jar']
-    }
-}
-"""
+            dependencies {
+                conf 'org.test:projectA:1.0'
+                other 'org.test:projectA:1.0'
+
+                // Component metadata rule that applies only to the 'sub' project
+                components {
+                    withModule('org.test:projectA', AddDependencyRule)
+                }
+            }
+            task res {
+                def conf = configurations.conf
+                def other = configurations.other
+                doLast {
+                    // If we resolve twice the modified component metadata for 'projectA' must not be cached in-memory
+                    println conf.collect { it.name }
+                    println other.collect { it.name }
+                }
+            }
+        """
 
         when:
         repositoryInteractions {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest.groovy
@@ -34,7 +34,6 @@ class DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest e
         mavenRepo.module("org.test", "m2", "1.0").dependsOn("org.test", "m3", "1.0").withModuleMetadata().publish()
         mavenRepo.module("org.test", "m3", '1.0').withModuleMetadata().publish()
 
-        createDirs("m1", "m2", "m3")
         settingsFile << """
             dependencyResolutionManagement {
                 repositories.maven { url = "${mavenRepo.uri}" }
@@ -43,45 +42,53 @@ class DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest e
             include 'm1', 'm2', 'm3'
         """
 
-        buildFile << """
-            allprojects {
-                group = 'org.test'
-                version = '0.9'
-                def conf = configurations.create('conf') {
+        def common = """
+            group = 'org.test'
+            version = '0.9'
+            configurations {
+                conf {
                     canBeConsumed = false
                     canBeResolved = false
                 }
-                configurations.create('runtime') {
+                runtime {
                     extendsFrom(conf)
                     assert canBeConsumed
                     canBeResolved = false
                     attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
                 }
             }
-            project(':m1') {
-                configurations.create('localPath') {
-                    extendsFrom(configurations.conf)
-                    canBeConsumed = false
-                    assert canBeResolved
-                    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                }
-                configurations.create('publishedPath') {
-                    extendsFrom(configurations.conf)
-                    canBeConsumed = false
-                    assert canBeResolved
-                    resolutionStrategy.useGlobalDependencySubstitutionRules.set(false)
-                    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                }
-                dependencies {
-                    conf 'org.test:m2:1.0'
-                }
+        """
+
+        file("m1/build.gradle") << """
+            $common
+
+            configurations.create('localPath') {
+                extendsFrom(configurations.conf)
+                canBeConsumed = false
+                assert canBeResolved
+                attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
             }
-            project(':m2') {
-                dependencies {
-                    conf 'org.test:m3:1.0'
-                }
+            configurations.create('publishedPath') {
+                extendsFrom(configurations.conf)
+                canBeConsumed = false
+                assert canBeResolved
+                resolutionStrategy.useGlobalDependencySubstitutionRules.set(false)
+                attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+            }
+            dependencies {
+                conf 'org.test:m2:1.0'
             }
         """
+
+        file("m2/build.gradle") << """
+            $common
+
+            dependencies {
+                conf 'org.test:m3:1.0'
+            }
+        """
+
+        file("m3/build.gradle") << common
     }
 
     def resolveLocalPath() {
@@ -139,10 +146,8 @@ class DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest e
 
     def "global dependency substitution can be re-enabled"() {
         given:
-        buildFile << """
-            project(':m1') {
-                configurations.publishedPath.resolutionStrategy.useGlobalDependencySubstitutionRules.set(true)
-            }
+        file("m1/build.gradle") << """
+            configurations.publishedPath.resolutionStrategy.useGlobalDependencySubstitutionRules.set(true)
         """
 
         when:
@@ -156,11 +161,9 @@ class DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest e
 
     def "global dependency substitution can be disabled for all configurations"() {
         given:
-        buildFile << """
-            project(':m1') {
-                configurations.all {
-                    resolutionStrategy.useGlobalDependencySubstitutionRules.set(false)
-                }
+        file("m1/build.gradle") << """
+            configurations.all {
+                resolutionStrategy.useGlobalDependencySubstitutionRules.set(false)
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesPreferProjectModulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesPreferProjectModulesIntegrationTest.groovy
@@ -34,47 +34,49 @@ class DependencyResolveRulesPreferProjectModulesIntegrationTest extends Abstract
     }
 
     def "preferProjectModules() only influence dependency declarations in the subproject it is used in"() {
-        createDirs("ModuleC", "Subproject_with_preferProjectModules", "Subproject_without_preferProjectModules")
-        settingsFile << 'include "ModuleC", "Subproject_with_preferProjectModules", "Subproject_without_preferProjectModules"'
+        settingsFile << """
+            include "ModuleC"
+            include "Subproject_with_preferProjectModules"
+            include "Subproject_without_preferProjectModules"
+        """
 
-        buildFile << """
-            project(":ModuleC") {
-                group = "myorg"
-                version = "1.0"
+        file("ModuleC/build.gradle") << """
+            group = "myorg"
+            version = "1.0"
 
-                configurations { conf }
-                configurations.create("default").extendsFrom(configurations.conf)
+            configurations { conf }
+            configurations.create("default").extendsFrom(configurations.conf)
+        """
+
+        file("Subproject_with_preferProjectModules/build.gradle") << """
+            repositories { maven { url = "${mavenRepo.uri}" } }
+
+            configurations { conf }
+            configurations.create("default").extendsFrom(configurations.conf)
+
+            configurations.conf.resolutionStrategy {
+                preferProjectModules()
             }
 
-            project(":Subproject_with_preferProjectModules") {
-                repositories { maven { url = "${mavenRepo.uri}" } }
-
-                configurations { conf }
-                configurations.create("default").extendsFrom(configurations.conf)
-
-                configurations.conf.resolutionStrategy {
-                    preferProjectModules()
-                }
-
-                dependencies {
-                    conf "myorg:ModuleB:1.0"
-                    conf project(":ModuleC")
-                }
+            dependencies {
+                conf "myorg:ModuleB:1.0"
+                conf project(":ModuleC")
             }
+        """
 
-            project(":Subproject_without_preferProjectModules") {
-                repositories { maven { url = "${mavenRepo.uri}" } }
+        file("Subproject_without_preferProjectModules/build.gradle") << """
+            repositories { maven { url = "${mavenRepo.uri}" } }
 
-                configurations { conf }
-                configurations.create("default").extendsFrom(configurations.conf)
+            configurations { conf }
+            configurations.create("default").extendsFrom(configurations.conf)
 
-                dependencies {
-                    conf project(":Subproject_with_preferProjectModules")
-                    conf "myorg:ModuleB:1.0"
-                    conf project(":ModuleC")
-                }
+            dependencies {
+                conf project(":Subproject_with_preferProjectModules")
+                conf "myorg:ModuleB:1.0"
+                conf project(":ModuleC")
             }
-"""
+        """
+
         when:
         succeeds('Subproject_with_preferProjectModules:checkDeps')
 
@@ -117,43 +119,43 @@ class DependencyResolveRulesPreferProjectModulesIntegrationTest extends Abstract
     }
 
     def "preferProjectModules() does not propagate to extending configurations"() {
-        createDirs("ModuleC", "ProjectA")
-        settingsFile << 'include "ModuleC", "ProjectA"'
+        settingsFile << """
+            include "ModuleC"
+            include "ProjectA"
+        """
 
-        buildFile << """
-            project(":ModuleC") {
-                group = "myorg"
-                version = "1.0"
+        file("ModuleC/build.gradle") << """
+            group = "myorg"
+            version = "1.0"
 
-                configurations {
-                    baseConf
-                    conf.extendsFrom(baseConf)
-                }
-                configurations.create("default").extendsFrom(configurations.baseConf)
+            configurations {
+                baseConf
+                conf.extendsFrom(baseConf)
+            }
+            configurations.create("default").extendsFrom(configurations.baseConf)
+        """
+
+        file("ProjectA/build.gradle") << """
+            repositories { maven { url = "${mavenRepo.uri}" } }
+
+            configurations {
+                baseConf
+                conf.extendsFrom(baseConf)
+            }
+            configurations.create("default").extendsFrom(configurations.baseConf)
+
+            configurations.baseConf.resolutionStrategy {
+                preferProjectModules()
             }
 
-            project(":ProjectA") {
-                repositories { maven { url = "${mavenRepo.uri}" } }
+            dependencies {
+                conf "myorg:ModuleB:1.0"
+                conf project(":ModuleC")
 
-                configurations {
-                    baseConf
-                    conf.extendsFrom(baseConf)
-                }
-                configurations.create("default").extendsFrom(configurations.baseConf)
-
-                configurations.baseConf.resolutionStrategy {
-                    preferProjectModules()
-                }
-
-                dependencies {
-                    conf "myorg:ModuleB:1.0"
-                    conf project(":ModuleC")
-
-                    baseConf "myorg:ModuleB:1.0"
-                    baseConf project(":ModuleC")
-                }
+                baseConf "myorg:ModuleB:1.0"
+                baseConf project(":ModuleC")
             }
-"""
+        """
 
         when:
         succeeds('ProjectA:checkDeps')

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsFeatureInteractionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsFeatureInteractionIntegrationTest.groovy
@@ -203,18 +203,11 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
             'org:bar:2.0'()
         }
 
-        createDirs("foo")
-        settingsFile << "\ninclude 'foo'"
+        settingsFile << """
+            include 'foo'
+        """
+
         buildFile << """
-            project(':foo') {
-                configurations.create('conf')
-                artifacts { add('conf', file('foo.jar')) }
-                dependencies {
-                    conf('org:bar') {
-                        version { strictly '2.0' }
-                    }
-                }
-            }
             dependencies {
                 constraints {
                     conf('org:bar') {
@@ -222,6 +215,16 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
                     }
                 }
                 conf(project(path: ':foo', configuration: 'conf'))
+            }
+        """
+
+        file("foo/build.gradle") << """
+            configurations.create('conf')
+            artifacts { add('conf', file('foo.jar')) }
+            dependencies {
+                conf('org:bar') {
+                    version { strictly '2.0' }
+                }
             }
         """
 
@@ -244,17 +247,12 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
             'org:bar:2.0'()
         }
 
-        createDirs("foo")
-        settingsFile << "\ninclude 'foo'"
+        settingsFile << """
+            include 'foo'
+        """
+
         buildFile << """
             configurations.conf.resolutionStrategy.force('org:bar:2.0')
-            project(':foo') {
-                configurations.create('conf')
-                artifacts { add('conf', file('foo.jar')) }
-                dependencies {
-                    conf('org:bar:2.0')
-                }
-            }
             dependencies {
                 constraints {
                     conf('org:bar') {
@@ -262,6 +260,14 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
                     }
                 }
                 conf(project(path: ':foo', configuration: 'conf'))
+            }
+        """
+
+        file("foo/build.gradle") << """
+            configurations.create('conf')
+            artifacts { add('conf', file('foo.jar')) }
+            dependencies {
+                conf('org:bar:2.0')
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
@@ -473,14 +473,11 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
             }
         }
 
-        createDirs("foo")
-        settingsFile << "\ninclude 'foo'"
+        settingsFile << """
+            include 'foo'
+        """
+
         buildFile << """
-            project(':foo') {
-                configurations.create('default')
-                group = 'org'
-                version = '1.0'
-            }
             dependencies {
                 constraints {
                     conf('org:foo') {
@@ -490,6 +487,12 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
                 conf('org:bar:1.0')
                 conf(project(':foo'))
             }
+        """
+
+        file("foo/build.gradle") << """
+            configurations.create('default')
+            group = 'org'
+            version = '1.0'
         """
 
         when:
@@ -519,14 +522,11 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
     def "incompatible strict constraint and local project fail to resolve"() {
         given:
 
-        createDirs("foo")
-        settingsFile << "\ninclude 'foo'"
+        settingsFile << """
+            include 'foo'
+        """
+
         buildFile << """
-            project(':foo') {
-                configurations.create('default')
-                group = 'org'
-                version = '1.2'
-            }
             dependencies {
                 constraints {
                     conf('org:foo') {
@@ -535,6 +535,12 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
                 }
                 conf(project(':foo'))
             }
+        """
+
+        file("foo/build.gradle") << """
+            configurations.create('default')
+            group = 'org'
+            version = '1.2'
         """
 
         when:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -405,31 +405,36 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
 
     void "(5) if two libraries are combined without agreeing on an override, the original platform constraint is brought back [#platformType]"() {
         updatedRepository(platformType)
-        createDirs("recklessLibrary", "secondLibrary")
-        settingsFile << "\ninclude 'recklessLibrary', 'secondLibrary'"
+        settingsFile << """
+            include 'recklessLibrary'
+            include 'secondLibrary'
+        """
+
         buildFile << """
-            project(':recklessLibrary') {
-                configurations { conf }
-                dependencies {
-                    ${platformDependency(platformType, 'org:platform:1.+')}
-                    conf('org:bar')
-                    constraints {
-                        conf('org:foo') {
-                            version { strictly '3.2' } // ignoring platform's reject
-                        }
-                    }
-                }
-            }
-            project(':secondLibrary') {
-                configurations { conf }
-                dependencies {
-                    ${platformDependency(platformType, 'org:platform:1.+')}
-                    conf('org:bar')
-                }
-            }
             dependencies {
                 conf(project(path: ':recklessLibrary', configuration: 'conf'))
                 conf(project(path: ':secondLibrary', configuration: 'conf'))
+            }
+        """
+
+        file("recklessLibrary/build.gradle") << """
+            configurations { conf }
+            dependencies {
+                ${platformDependency(platformType, 'org:platform:1.+')}
+                conf('org:bar')
+                constraints {
+                    conf('org:foo') {
+                        version { strictly '3.2' } // ignoring platform's reject
+                    }
+                }
+            }
+        """
+
+        file("secondLibrary/build.gradle") << """
+            configurations { conf }
+            dependencies {
+                ${platformDependency(platformType, 'org:platform:1.+')}
+                conf('org:bar')
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/AbstractRichVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/AbstractRichVersionConstraintsIntegrationTest.groovy
@@ -550,8 +550,6 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
                 }
             }
         """
-        createDirs("other")
-        settingsFile << "\ninclude 'other'"
 
         when:
         repositoryInteractions {
@@ -591,8 +589,6 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
                 conf('org:bar:1')
             }
         """
-        createDirs("other")
-        settingsFile << "\ninclude 'other'"
 
         when:
         repositoryInteractions {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/AbstractVersionRangeResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/AbstractVersionRangeResolveIntegrationTest.groovy
@@ -72,9 +72,7 @@ embedded mode
         }
 
         buildFile.text = baseBuild + """
-            allprojects {
-                configurations { conf }
-            }
+            configurations { conf }
 
             configurations {
                 ${singleProjectConfs.join('\n')}
@@ -102,18 +100,18 @@ embedded mode
         for (int i = 1; i <= versions.size(); i++) {
             VersionRangeResolveTestScenarios.RenderableVersion version = versions.get(i - 1);
             def nextProjectDependency = i < versions.size() ? "conf project(path: ':p${i + 1}', configuration: 'conf')" : ""
-            buildFile << """
-                project('p${i}') {
-                    dependencies {
-                        conf ${version.render()}
-                        ${nextProjectDependency}
-                    }
+            file("p${i}/build.gradle") << """
+                configurations {
+                    conf
                 }
-"""
-            createDirs("p${i}")
+                dependencies {
+                    conf ${version.render()}
+                    ${nextProjectDependency}
+                }
+                """
             settingsFile << """
                 include ':p${i}'
-"""
+            """
         }
 
         boolean expectFailureSingle = expectedSingle == VersionRangeResolveTestScenarios.REJECTED || expectedSingle == VersionRangeResolveTestScenarios.FAILED

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
@@ -138,7 +138,6 @@ class VersionConflictResolutionIntegrationTest extends AbstractIntegrationSpec {
         mavenRepo.module("org", "foo", '1.3.3').publish()
         mavenRepo.module("org", "foo", '1.4.4').publish()
 
-        createDirs("api", "impl", "tool")
         settingsFile << """
             include 'api', 'impl', 'tool'
             dependencyResolutionManagement {
@@ -2187,7 +2186,6 @@ parentFirst
         mavenRepo.module('org', 'lib', '1.0').publish()
         mavenRepo.module('org', 'other', '1.0').publish()
 
-        createDirs("sub")
         settingsFile << """
             include 'sub'
         """

--- a/platforms/software/dependency-management/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/dependencyReportWithConflicts/build.gradle
+++ b/platforms/software/dependency-management/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/dependencyReportWithConflicts/build.gradle
@@ -1,17 +1,14 @@
-allprojects {
-    configurations {
-        evictedTransitive
-        evictedDirect
-        multiProject
-        create('default')
-    }
-    dependencies {
-        repositories {
-            ivy {
-                artifactPattern(projectDir.absolutePath + '/[module]-[revision].jar')
-                ivyPattern(projectDir.absolutePath + '/[module]-[revision]-ivy.xml')
-            }
-        }
+
+configurations {
+    evictedTransitive
+    evictedDirect
+    multiProject
+}
+
+repositories {
+    ivy {
+        artifactPattern(projectDir.absolutePath + '/[module]-[revision].jar')
+        ivyPattern(projectDir.absolutePath + '/[module]-[revision]-ivy.xml')
     }
 }
 
@@ -27,12 +24,6 @@ dependencies {
     // subproject depends on projectA-2.0, which should evict projectA-1.2
     multiProject 'test:projectA:1.2'
     multiProject project(':subproject')
-}
-
-project(':subproject') {
-    dependencies {
-        add('default', 'test:projectA:2.0')
-    }
 }
 
 file("projectA-1.2.jar").text = ''

--- a/platforms/software/dependency-management/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/dependencyReportWithConflicts/subproject/build.gradle
+++ b/platforms/software/dependency-management/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/dependencyReportWithConflicts/subproject/build.gradle
@@ -1,0 +1,7 @@
+configurations {
+    create('default')
+}
+
+dependencies {
+    add('default', 'test:projectA:2.0')
+}


### PR DESCRIPTION
Avoid allprojects/subprojects/project in many DM integ tests. This gets us closer to enabling IP tests for DM

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
