### PR TITLE
Let IP scheduler only wait for projects that have children to be configured

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsParallelConfigurationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsParallelConfigurationIntegrationTest.groovy
@@ -52,6 +52,9 @@ class IsolatedProjectsParallelConfigurationIntegrationTest extends AbstractIsola
         given:
         withTwoWaitingProjects()
 
+        and: 'two workers should be enough for two waiting projects'
+        executer.withArguments("--max-workers=2")
+
         server.expect("configure-root")
         server.expectConcurrent("configure-a", "configure-b")
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsParallelConfigurationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsParallelConfigurationIntegrationTest.groovy
@@ -52,7 +52,7 @@ class IsolatedProjectsParallelConfigurationIntegrationTest extends AbstractIsola
         given:
         withTwoWaitingProjects()
 
-        and: 'two workers should be enough for two waiting projects'
+        and: 'two workers ought to be enough for two waiting projects'
         executer.withArguments("--max-workers=2")
 
         server.expect("configure-root")

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
@@ -131,7 +131,7 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
             final LinkedBlockingQueue<ProjectState> readyQueue = new LinkedBlockingQueue<>();
             queue.add(traverseProject(root, readyQueue));
 
-            int pending = 1;
+            int pending = root.hasChildren() ? 1 : 0;
             while (pending > 0) {
                 ProjectState next;
                 try {
@@ -142,7 +142,10 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
                 }
                 for (final ProjectState child : next.getUnorderedChildProjects()) {
                     queue.add(traverseProject(child, readyQueue));
-                    ++pending;
+                    if (child.hasChildren()) {
+                        // Only wait for projects that have children to be configured
+                        ++pending;
+                    }
                 }
             }
         });
@@ -155,7 +158,10 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
                 try {
                     project.ensureSelfConfigured();
                 } finally {
-                    readyQueue.add(project);
+                    if (project.hasChildren()) {
+                        // Only enqueue projects that have children to be configured
+                        readyQueue.add(project);
+                    }
                 }
             }
 


### PR DESCRIPTION
In order to avoid wasting a worker.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
