### PR TITLE
Avoid IP violations in 'idea' plugin when Scala plugin not applied

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIdeaPluginIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsIdeaPluginIntegrationTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.isolated
+
+import org.gradle.util.internal.ToBeImplemented
+
+class IsolatedProjectsIdeaPluginIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
+
+    def "can apply idea plugin"() {
+        settingsFile << """
+            include("sub")
+        """
+        buildFile """
+            plugins { id("idea") }
+        """
+        buildFile "sub/build.gradle", """
+            plugins { id("idea") }
+        """
+
+        when:
+        isolatedProjectsRun("help")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":", ":sub")
+        }
+
+        when:
+        isolatedProjectsRun("help")
+
+        then:
+        fixture.assertStateLoaded()
+    }
+
+    @ToBeImplemented
+    def "can apply idea plugin and scala plugin"() {
+        settingsFile << """
+            include("sub")
+        """
+        buildFile """
+            plugins { id("idea") }
+        """
+        buildFile "sub/build.gradle", """
+            plugins {
+                id("idea")
+                id("scala")
+            }
+        """
+
+        when:
+        withIsolatedProjects()
+        fails("help")
+
+        then:
+        failureHasCause("Applying 'idea' plugin to Scala projects is not supported with Isolated Projects. Disable Isolated Projects to use this integration.")
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiIdeaProjectIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiIdeaProjectIntegrationTest.groovy
@@ -499,15 +499,10 @@ class IsolatedProjectsToolingApiIdeaProjectIntegrationTest extends AbstractIsola
         fetchModelFails(IdeaProject)
 
         then:
-        fixture.assertModelStoredAndDiscarded {
-            modelsCreated(":", models(IdeaProject, pluginApplyingModel, IsolatedGradleProjectInternal, IsolatedIdeaModuleInternal))
-            modelsCreated(":lib1", models(pluginApplyingModel, IsolatedGradleProjectInternal, IsolatedIdeaModuleInternal))
-            // TODO:isolated there should be no violation
-            problem("Plugin class 'org.gradle.plugins.ide.idea.IdeaPlugin': Project ':lib1' cannot access 'Project.tasks' functionality on another project ':'")
-        }
-
+        failureHasCause("Applying 'idea' plugin to Scala projects is not supported with Isolated Projects. Disable Isolated Projects to use this integration.")
+        // TODO:isolated assert model stored successfully
         // TODO:isolated check the model matches the vintage model
-//        checkIdeaProject(ideaModel, originalIdeaModel)
+        // checkIdeaProject(ideaModel, originalIdeaModel)
     }
 
     private static void checkIdeaProject(IdeaProject actual, IdeaProject expected) {

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -510,17 +510,25 @@ public abstract class IdeaPlugin extends IdePlugin {
             }
         });
         if (isRoot()) {
-            new IdeaScalaConfigurer(project, isolatedProjects).configure();
+            new IdeaScalaConfigurer(project, scalaProjects -> {
+                if (!scalaProjects.isEmpty() && isolatedProjects) {
+                    failOnIncompatibleWithIsolatedProjects();
+                }
+            }).configure();
         }
     }
 
     private void ideaModuleDependsOnRoot(boolean isolatedProjects) {
         if (isolatedProjects) {
-            throw new GradleException(IdeaScalaConfigurer.INCOMPATIBLE_WITH_ISOLATED_PROJECTS_MESSAGE);
+            failOnIncompatibleWithIsolatedProjects();
         }
 
         // see IdeaScalaConfigurer which requires the ipr to be generated first
         project.getTasks().named(IDEA_MODULE_TASK_NAME, dependsOn(project.getRootProject().getTasks().named(IDEA_PROJECT_TASK_NAME)));
+    }
+
+    private static void failOnIncompatibleWithIsolatedProjects() {
+        throw new GradleException("Applying 'idea' plugin to Scala projects is not supported with Isolated Projects. Disable Isolated Projects to use this integration.");
     }
 
     private void linkCompositeBuildDependencies(final ProjectInternal project) {

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -21,12 +21,14 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
+import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.configuration.BuildFeatures;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
@@ -500,18 +502,23 @@ public abstract class IdeaPlugin extends IdePlugin {
     }
 
     private void configureForScalaPlugin() {
+        boolean isolatedProjects = getBuildFeatures().getIsolatedProjects().getActive().get();
         project.getPlugins().withType(ScalaBasePlugin.class, new Action<ScalaBasePlugin>() {
             @Override
             public void execute(ScalaBasePlugin scalaBasePlugin) {
-                ideaModuleDependsOnRoot();
+                ideaModuleDependsOnRoot(isolatedProjects);
             }
         });
         if (isRoot()) {
-            new IdeaScalaConfigurer(project).configure();
+            new IdeaScalaConfigurer(project, isolatedProjects).configure();
         }
     }
 
-    private void ideaModuleDependsOnRoot() {
+    private void ideaModuleDependsOnRoot(boolean isolatedProjects) {
+        if (isolatedProjects) {
+            throw new GradleException(IdeaScalaConfigurer.INCOMPATIBLE_WITH_ISOLATED_PROJECTS_MESSAGE);
+        }
+
         // see IdeaScalaConfigurer which requires the ipr to be generated first
         project.getTasks().named(IDEA_MODULE_TASK_NAME, dependsOn(project.getRootProject().getTasks().named(IDEA_PROJECT_TASK_NAME)));
     }
@@ -546,4 +553,7 @@ public abstract class IdeaPlugin extends IdePlugin {
             reference.visitDependencies(context);
         }
     }
+
+    @Inject
+    protected abstract BuildFeatures getBuildFeatures();
 }

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaIsolatedProjectsWorkarounds.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaIsolatedProjectsWorkarounds.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.idea.internal;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
+
+/**
+ * Utilities that are introduced to aid with Isolated Projects adoption in the implementation.
+ * <p>
+ * This class is intended to be temporary and should be removed as soon as proper building blocks
+ * are available to solve the use cases without the workarounds.
+ */
+class IdeaIsolatedProjectsWorkarounds {
+
+    /**
+     * Checks whether the project has the plugin applied, configuring the project if necessary.
+     * <p>
+     * The check is done bypassing the Isolated Projects validations.
+     */
+    public static boolean hasPlugin(Project project, Class<? extends Plugin<?>> pluginClass) {
+        ProjectState projectState = ((ProjectInternal) project).getOwner();
+        // This is a precaution that will be a no-op most of the time
+        projectState.ensureConfigured();
+        return projectState.getMutableModel().getPluginManager().getPluginContainer()
+            .hasPlugin(pluginClass);
+    }
+
+}

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaIsolatedProjectsWorkarounds.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaIsolatedProjectsWorkarounds.java
@@ -19,7 +19,6 @@ package org.gradle.plugins.ide.idea.internal;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.project.ProjectState;
 
 /**
  * Utilities that are introduced to aid with Isolated Projects adoption in the implementation.
@@ -35,10 +34,7 @@ class IdeaIsolatedProjectsWorkarounds {
      * The check is done bypassing the Isolated Projects validations.
      */
     public static boolean hasPlugin(Project project, Class<? extends Plugin<?>> pluginClass) {
-        ProjectState projectState = ((ProjectInternal) project).getOwner();
-        // This is a precaution that will be a no-op most of the time
-        projectState.ensureConfigured();
-        return projectState.getMutableModel().getPluginManager().getPluginContainer()
+        return ((ProjectInternal) project).getOwner().getMutableModel().getPluginManager().getPluginContainer()
             .hasPlugin(pluginClass);
     }
 

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaIsolatedProjectsWorkarounds.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaIsolatedProjectsWorkarounds.java
@@ -16,6 +16,7 @@
 
 package org.gradle.plugins.ide.idea.internal;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -26,6 +27,7 @@ import org.gradle.api.internal.project.ProjectInternal;
  * This class is intended to be temporary and should be removed as soon as proper building blocks
  * are available to solve the use cases without the workarounds.
  */
+@NonNullApi
 class IdeaIsolatedProjectsWorkarounds {
 
     /**

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaIsolatedProjectsWorkarounds.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/internal/IdeaIsolatedProjectsWorkarounds.java
@@ -29,7 +29,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 class IdeaIsolatedProjectsWorkarounds {
 
     /**
-     * Checks whether the project has the plugin applied, configuring the project if necessary.
+     * Checks whether the project has the plugin applied.
      * <p>
      * The check is done bypassing the Isolated Projects validations.
      */


### PR DESCRIPTION
Fixes #29515

The `idea` plugin still detects whether Scala plugin is applied via an unsafe internal API. This is done to be able to fail the build to explicitly warn users about Isolated Projects not being supported in this setup. This is a temporary solution that is relatively safe, given the specific implementation state.

In the light of IP, instead of fixing the plugin as is, it might be better to redesign them and split the Scala integration into a separate plugin. In any case, the current implementation relies on too many assumptions about the sequential execution and is not following best practices in plugin authoring.