### PR TITLE
Simplify display name of parallel project configuration operation

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
@@ -167,7 +167,7 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                return BuildOperationDescriptor.displayName("Traverse project " + project.getName());
+                return BuildOperationDescriptor.displayName("Parallelize configuration");
             }
         };
     }


### PR DESCRIPTION
The project name is unnecessary since there's always a nested "Configure project ..." operation.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
