### PR TITLE
Create DistributionBasePlugin

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -164,6 +164,31 @@ try (GroupTestEventReporter outer = root.reportTestGroup("OuterNestingSuite")) {
 
 Nested events are reflected in the HTML test reports, providing clear traceability.
 
+#### Distribution base plugin introduced
+
+This release introduces a new `distribution-base` plugin.
+This plugin is identical to the existing [Distribution Plugin](userguide/distribution_plugin.html), except it does not add any distributions by default.
+The existing `distribution` plugin is now a simple wrapper over the `distribution-base` plugin, except it additionally adds a `main` distribution by default.
+
+The `distribution-base` plugin is useful when you want to create plugins that do not have a `main` distribution, while retaining the other features of the Distribution Plugin.
+
+```kotlin
+plugins {
+    id("distribution-base")
+}
+
+distributions {
+    create("custom") {
+        distributionBaseName = "customName"
+        contents {
+            from("src/customLocation")
+        }
+    }
+}
+
+assert(distributions.findByName("main") == null)
+```
+
 <a name="error-warning"></a>
 ### Error and warning reporting improvements
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -166,11 +166,10 @@ Nested events are reflected in the HTML test reports, providing clear traceabili
 
 #### Distribution base plugin introduced
 
-This release introduces a new `distribution-base` plugin.
-This plugin is identical to the existing [Distribution Plugin](userguide/distribution_plugin.html), except it does not add any distributions by default.
-The existing `distribution` plugin is now a simple wrapper over the `distribution-base` plugin, except it additionally adds a `main` distribution by default.
+Gradle now includes a `distribution-base` plugin, which mirrors the functionality of the [Distribution Plugin](userguide/distribution_plugin.html) but does not add a default distribution.
+The existing `distribution` plugin now acts as a wrapper for the `distribution-base` plugin, adding a default `main` distribution.
 
-The `distribution-base` plugin is useful when you want to create plugins that do not have a `main` distribution, while retaining the other features of the Distribution Plugin.
+The `distribution-base` plugin is particularly useful for plugin developers who want the capabilities of the Distribution Plugin without a `main` distribution.
 
 ```kotlin
 plugins {

--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/distribution_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/distribution_plugin.adoc
@@ -20,12 +20,14 @@ Distribution archives typically contain the executable application and other sup
 
 [[sec:distribution_base]]
 == Base Plugin
+
 The distribution plugin is split into the `distribution` and `distribution-base` plugins.
 
 The `distribution-base` plugin adds an extension named `distributions` of type link:{groovyDslPath}/org.gradle.api.distribution.DistributionContainer.html[DistributionContainer] to the project.
 
 The `distribution` plugin applies the `distribution-base` plugin and creates a single distribution in the distributions container extension named `main`.
-If your build only produces one distribution you only need to configure this distribution (or use the defaults).
+
+If your build produces only one distribution, you only need to configure the distribution or rely on the defaults.
 
 [[sec:distribution_usage]]
 == Usage

--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/distribution_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/distribution_plugin.adoc
@@ -15,8 +15,17 @@
 [[distribution_plugin]]
 = The Distribution Plugin
 
-The Distribution Plugin facilitates building archives that serve as distributions of the project. Distribution archives typically contain the executable application and other supporting files, such as documentation.
+The Distribution Plugin facilitates building archives that serve as distributions of the project.
+Distribution archives typically contain the executable application and other supporting files, such as documentation.
 
+[[sec:distribution_base]]
+== Base Plugin
+The distribution plugin is split into the `distribution` and `distribution-base` plugins.
+
+The `distribution-base` plugin adds an extension named `distributions` of type link:{groovyDslPath}/org.gradle.api.distribution.DistributionContainer.html[DistributionContainer] to the project.
+
+The `distribution` plugin applies the `distribution-base` plugin and creates a single distribution in the distributions container extension named `main`.
+If your build only produces one distribution you only need to configure this distribution (or use the defaults).
 
 [[sec:distribution_usage]]
 == Usage
@@ -28,8 +37,6 @@ To use the Distribution Plugin, include the following in your build script:
 include::sample[dir="snippets/base/distribution/kotlin",files="build.gradle.kts[tags=use-plugin]"]
 include::sample[dir="snippets/base/distribution/groovy",files="build.gradle[tags=use-plugin]"]
 ====
-
-The plugin adds an extension named `distributions` of type link:{groovyDslPath}/org.gradle.api.distribution.DistributionContainer.html[DistributionContainer] to the project. It also creates a single distribution in the distributions container extension named `main`. If your build only produces one distribution you only need to configure this distribution (or use the defaults).
 
 You can run `gradle distZip` to package the main distribution as a ZIP, or `gradle distTar` to create a TAR file. To build both types of archives just run `gradle assembleDist`.
 The files will be created at `__layout.buildDirectory.dir__("distributions/__${project.name}__-__${project.version}__.__«ext»__")`.

--- a/platforms/software/plugins-distribution/src/integTest/groovy/org/gradle/api/distribution/plugins/DistributionBasePluginTest.groovy
+++ b/platforms/software/plugins-distribution/src/integTest/groovy/org/gradle/api/distribution/plugins/DistributionBasePluginTest.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.distribution.plugins
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.distribution.DistributionContainer
+import org.gradle.api.tasks.Sync
+import org.gradle.api.tasks.TaskDependencyMatchers
+import org.gradle.api.tasks.bundling.Tar
+import org.gradle.api.tasks.bundling.Zip
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+
+/**
+ * Tests {@link DistributionBasePlugin}.
+ */
+class DistributionBasePluginTest extends AbstractProjectBuilderSpec {
+
+    def "provides default values for additional distributions"() {
+        when:
+        project.pluginManager.apply(DistributionBasePlugin)
+
+        then:
+        def distributions = project.extensions.getByType(DistributionContainer.class)
+        def dist = distributions.create('custom')
+        dist.name == 'custom'
+        dist.distributionBaseName.get() == 'test-project-custom'
+    }
+
+    def "adds distZip task for custom distribution"() {
+        when:
+        project.pluginManager.apply(DistributionBasePlugin)
+        project.distributions.create('custom')
+
+        then:
+        def task = project.tasks.customDistZip
+        task instanceof Zip
+        task.archiveFile.get().asFile == project.file("build/distributions/test-project-custom.zip")
+    }
+
+    def "adds distTar task for custom distribution"() {
+        when:
+        project.pluginManager.apply(DistributionBasePlugin)
+        project.distributions.create('custom')
+
+        then:
+        def task = project.tasks.customDistTar
+        task instanceof Tar
+        task.archiveFile.get().asFile == project.file("build/distributions/test-project-custom.tar")
+    }
+
+    def "adds assembleDist task for custom distribution"() {
+        when:
+        project.pluginManager.apply(DistributionBasePlugin)
+        project.distributions.create('custom')
+
+        then:
+        def task = project.tasks.assembleCustomDist
+        task instanceof DefaultTask
+        task TaskDependencyMatchers.dependsOn ("customDistZip","customDistTar")
+    }
+
+    def "adds installDist task for custom distribution"() {
+        when:
+        project.pluginManager.apply(DistributionBasePlugin)
+        project.distributions.create('custom')
+
+        then:
+        def task = project.installCustomDist
+        task instanceof Sync
+        task.destinationDir == project.file("build/install/test-project-custom")
+    }
+
+}

--- a/platforms/software/plugins-distribution/src/integTest/groovy/org/gradle/api/plugins/DistributionBasePluginIntegrationTest.groovy
+++ b/platforms/software/plugins-distribution/src/integTest/groovy/org/gradle/api/plugins/DistributionBasePluginIntegrationTest.groovy
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
+import org.gradle.test.fixtures.dsl.GradleDsl
+
+/**
+ * Tests {@link org.gradle.api.distribution.plugins.DistributionBasePlugin}
+ */
+@TestReproducibleArchives
+class DistributionBasePluginIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'TestProject'
+        """
+
+        file("someFile").createFile()
+    }
+
+    def "can apply base distribution plugin to empty project"() {
+        buildFile << """
+            plugins {
+                id("distribution-base")
+            }
+
+            assert distributions.isEmpty()
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "can create a custom distribution in #dsl"() {
+        def file = dsl == GradleDsl.GROOVY ? buildFile : buildKotlinFile
+        file << """
+            plugins {
+                id("distribution-base")
+            }
+
+            distributions {
+                create("custom") {
+                    distributionBaseName = "customName"
+                    contents {
+                        from("src/customLocation")
+                    }
+                }
+            }
+
+            assert(distributions.findByName("main") == null)
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        dsl << [GradleDsl.GROOVY, GradleDsl.KOTLIN]
+    }
+
+    def createTaskForCustomDistribution() {
+        buildFile << """
+            plugins {
+                id("distribution-base")
+            }
+
+            distributions {
+                custom {
+                    contents {
+                        from { "someFile" }
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds('customDistZip')
+
+        then:
+        file('build/distributions/TestProject-custom.zip').usingNativeTools().unzipTo(file("unzip"))
+        file("unzip/TestProject-custom/someFile").assertIsFile()
+    }
+
+    def createTaskForCustomDistributionWithCustomName() {
+        given:
+        buildFile << """
+            plugins {
+                id("distribution-base")
+            }
+
+            distributions {
+                custom {
+                    distributionBaseName = 'customName'
+                    contents {
+                        from { "someFile" }
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds('customDistZip')
+
+        then:
+        file('build/distributions/customName.zip').usingNativeTools().unzipTo(file("unzip"))
+        file("unzip/customName/someFile").assertIsFile()
+    }
+
+    def createTaskForCustomDistributionWithEmptyCustomName() {
+        given:
+        buildFile << """
+            plugins {
+                id("distribution-base")
+            }
+
+            distributions {
+                custom{
+                    distributionBaseName = ''
+                    contents {
+                        from { "someFile" }
+                    }
+                }
+            }
+        """
+
+        when:
+        runAndFail('customDistZip')
+
+        then:
+        failure.assertHasCause "Distribution 'custom' must not have an empty distributionBaseName."
+    }
+
+    def createCreateArchiveForCustomDistribution(){
+        given:
+        createDir('src/custom/dist') {
+            file 'file1.txt'
+            dir2 {
+                file 'file2.txt'
+            }
+        }
+
+        buildFile << """
+            plugins {
+                id("distribution-base")
+            }
+
+            distributions{
+                custom
+            }
+        """
+
+        when:
+        run('customDistZip')
+
+        then:
+        file('build/distributions/TestProject-custom.zip').exists()
+    }
+
+    def includeFileFromSrcMainCustom() {
+        given:
+        createDir('src/custom/dist'){
+            file 'file1.txt'
+            dir {
+                file 'file2.txt'
+            }
+        }
+
+        buildFile << """
+            plugins {
+                id("distribution-base")
+            }
+
+            version = 1.2
+
+            distributions{
+                custom
+            }
+        """
+
+        when:
+        run('customDistZip')
+
+        then:
+        file('build/distributions/TestProject-custom-1.2.zip').usingNativeTools().unzipTo(file("unzip"))
+        file("unzip").assertHasDescendants('TestProject-custom-1.2/file1.txt', 'TestProject-custom-1.2/dir/file2.txt')
+    }
+
+    def includeFileFromDistContent() {
+        given:
+        createDir('src/custom/dist'){
+            file 'file1.txt'
+            dir {
+                file 'file2.txt'
+            }
+        }
+
+        createDir("docs"){
+            file 'file3.txt'
+            dir2 {
+                file 'file4.txt'
+            }
+        }
+
+        buildFile << """
+            plugins {
+                id("distribution-base")
+            }
+
+            version = 1.2
+
+            distributions{
+                custom {
+                    contents {
+                        from ( 'docs' ){
+                            into 'docs'
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        run('customDistZip')
+
+        then:
+        file('build/distributions/TestProject-custom-1.2.zip').usingNativeTools().unzipTo(file("unzip"))
+        file("unzip").assertHasDescendants(
+            'TestProject-custom-1.2/file1.txt',
+            'TestProject-custom-1.2/dir/file2.txt',
+            'TestProject-custom-1.2/docs/file3.txt',
+            'TestProject-custom-1.2/docs/dir2/file4.txt')
+    }
+
+    def installFromDistContent() {
+        given:
+        createDir('src/custom/dist'){
+            file 'file1.txt'
+            dir {
+                file 'file2.txt'
+            }
+        }
+        createDir("docs"){
+            file 'file3.txt'
+            dir2 {
+                file 'file4.txt'
+            }
+        }
+        and:
+        buildFile << """
+            plugins {
+                id("distribution-base")
+            }
+
+            version = 1.2
+
+            distributions{
+                custom {
+                    contents {
+                        from ( 'docs' ){
+                            into 'docs'
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        run('installCustomDist')
+
+        then:
+        file('build/install/TestProject-custom').exists()
+        file('build/install/TestProject-custom').assertHasDescendants(
+            'file1.txt',
+            'dir/file2.txt',
+            'docs/file3.txt',
+            'docs/dir2/file4.txt')
+    }
+
+    def installDistCanBeRerun() {
+        buildFile << """
+            plugins {
+                id("distribution-base")
+            }
+
+            distributions {
+                custom {
+                    contents {
+                        from { "someFile" }
+                    }
+                }
+            }
+
+        """
+
+        expect:
+        succeeds('installCustomDist')
+
+        when:
+        // update the file so that when it re-runs it is not UP-TO-DATE
+        file("someFile") << "updated"
+        succeeds('installCustomDist')
+
+        then:
+        file('build/install/TestProject-custom/someFile').assertIsCopyOf(file("someFile"))
+    }
+
+    def createTarTaskForCustomDistribution() {
+        buildFile << """
+            apply plugin:'distribution'
+
+            distributions {
+                custom {
+                    contents {
+                        from { "someFile" }
+                    }
+                }
+            }
+
+        """
+
+        when:
+        succeeds('customDistTar')
+
+        then:
+        file('build/distributions/TestProject-custom.tar').usingNativeTools().untarTo(file("untar"))
+        file("untar/TestProject-custom/someFile").assertIsFile()
+    }
+
+}

--- a/platforms/software/plugins-distribution/src/integTest/groovy/org/gradle/api/plugins/DistributionPluginIntegrationTest.groovy
+++ b/platforms/software/plugins-distribution/src/integTest/groovy/org/gradle/api/plugins/DistributionPluginIntegrationTest.groovy
@@ -16,51 +16,38 @@
 
 package org.gradle.api.plugins
 
-
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.test.fixtures.archive.TarTestFixture
 import org.gradle.test.fixtures.maven.MavenPom
 
+/**
+ * Tests {@link org.gradle.api.distribution.plugins.DistributionPlugin}.
+ */
 @TestReproducibleArchives
 class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
+
     @Override
     String getMainTask() {
         return "distZip"
     }
 
     def setup() {
-        file("settings.gradle").text = "rootProject.name='TestProject'"
+        settingsFile << """
+            rootProject.name = 'TestProject'
+        """
+
         file("someFile").createFile()
-        using m2
-    }
-
-    def createTaskForCustomDistribution() {
-        when:
-        buildFile << """
-            apply plugin:'distribution'
-
-            distributions {
-                custom{
-                    contents {
-                        from { "someFile" }
-                    }
-                }
-            }
-
-            """
-        then:
-        succeeds('customDistZip')
-        and:
-        file('build/distributions/TestProject-custom.zip').usingNativeTools().unzipTo(file("unzip"))
-        file("unzip/TestProject-custom/someFile").assertIsFile()
     }
 
     def "can publish distribution"() {
         when:
         buildFile << """
-            apply plugin:'distribution'
-            apply plugin:'maven-publish'
+            plugins {
+                id("distribution")
+                id("maven-publish")
+            }
+
             group = "org.acme"
             version = "1.0"
 
@@ -85,10 +72,10 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
                 @Inject
                 SoftwareComponentFactory getSoftwareComponentFactory()
             }
+
             def factory = objects.newInstance(MyServices).softwareComponentFactory
             def distributionComponent = factory.adhoc("distribution")
             distributionComponent.addVariantsFromConfiguration(configurations.distribution) {}
-
 
             publishing {
                 repositories {
@@ -100,8 +87,8 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
                     }
                 }
             }
+        """
 
-            """
         then:
         succeeds("publishMavenPublicationToMavenRepository")
         file("repo/org/acme/TestProject/1.0/TestProject-1.0.zip").assertIsFile()
@@ -114,47 +101,6 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
         pom.packaging == "zip"
     }
 
-    def createTaskForCustomDistributionWithCustomName() {
-        when:
-        buildFile << """
-            apply plugin:'distribution'
-
-            distributions {
-                custom{
-                    distributionBaseName = 'customName'
-                    contents {
-                        from { "someFile" }
-                    }
-                }
-            }
-            """
-        then:
-        succeeds('customDistZip')
-        and:
-        file('build/distributions/customName.zip').usingNativeTools().unzipTo(file("unzip"))
-        file("unzip/customName/someFile").assertIsFile()
-    }
-
-    def createTaskForCustomDistributionWithEmptyCustomName() {
-        when:
-        buildFile << """
-            apply plugin:'distribution'
-            distributions {
-                custom{
-                    distributionBaseName = ''
-                    contents {
-                        from { "someFile" }
-                    }
-                }
-            }
-
-
-            """
-        then:
-        runAndFail('customDistZip')
-        failure.assertHasCause "Distribution 'custom' must not have an empty distributionBaseName."
-    }
-
     def createDistributionWithoutVersion() {
         given:
         createDir('src/main/dist') {
@@ -163,19 +109,23 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
                 file 'file2.txt'
             }
         }
+
         and:
         buildFile << """
-            apply plugin: 'distribution'
-
+            plugins {
+                id("distribution")
+            }
 
             distributions {
-                main{
+                main {
                     distributionBaseName = 'myDistribution'
                 }
             }
-            """
+        """
+
         when:
         run('distZip')
+
         then:
         file('build/distributions/myDistribution.zip').exists()
     }
@@ -188,19 +138,23 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
                 file 'file2.txt'
             }
         }
+
         and:
         buildFile << """
-            apply plugin:'distribution'
-
+            plugins {
+                id("distribution")
+            }
 
             distributions {
-                main{
+                main {
                     distributionBaseName = 'myDistribution'
                 }
             }
-            """
+        """
+
         when:
         run('assemble')
+
         then:
         file('build/distributions/myDistribution.zip').exists()
         file('build/distributions/myDistribution.tar').exists()
@@ -214,22 +168,27 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
                 file 'file2.txt'
             }
         }
+
         and:
         buildFile << """
-            apply plugin:'distribution'
+            plugins {
+                id("distribution")
+            }
 
             version = '1.2'
             distributions {
-                main{
+                main {
                     distributionBaseName = 'myDistribution'
                 }
             }
             distZip{
 
             }
-            """
+        """
+
         when:
         run('distZip')
+
         then:
         file('build/distributions/myDistribution-1.2.zip').exists()
     }
@@ -242,13 +201,17 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
                 file 'file2.txt'
             }
         }
+
         and:
         buildFile << """
-            apply plugin:'distribution'
+            plugins {
+                id("distribution")
+            }
+        """
 
-            """
         when:
         run('distZip')
+
         then:
         file('build/distributions/TestProject.zip').exists()
     }
@@ -261,211 +224,40 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
                 file 'file2.txt'
             }
         }
+
         and:
         buildFile << """
-            apply plugin:'distribution'
+            plugins {
+                id("distribution")
+            }
 
             version = 1.2
-            """
+        """
+
         when:
         run('distZip')
+
         then:
         file('build/distributions/TestProject-1.2.zip').exists()
-    }
-
-    def createCreateArchiveForCustomDistribution(){
-        given:
-        createDir('src/custom/dist') {
-            file 'file1.txt'
-            dir2 {
-                file 'file2.txt'
-            }
-        }
-        and:
-        buildFile << """
-            apply plugin:'distribution'
-
-            distributions{
-                custom
-            }
-            """
-        when:
-        run('customDistZip')
-        then:
-        file('build/distributions/TestProject-custom.zip').exists()
-    }
-
-
-    def includeFileFromSrcMainCustom() {
-        given:
-        createDir('src/custom/dist'){
-            file 'file1.txt'
-            dir {
-                file 'file2.txt'
-            }
-        }
-        and:
-        buildFile << """
-            apply plugin:'distribution'
-
-            version = 1.2
-
-            distributions{
-                custom
-            }
-            """
-        when:
-        run('customDistZip')
-        then:
-        file('build/distributions/TestProject-custom-1.2.zip').usingNativeTools().unzipTo(file("unzip"))
-        file("unzip").assertHasDescendants(
-                'TestProject-custom-1.2/file1.txt',
-                'TestProject-custom-1.2/dir/file2.txt')
-    }
-
-    def includeFileFromDistContent() {
-        given:
-        createDir('src/custom/dist'){
-            file 'file1.txt'
-            dir {
-                file 'file2.txt'
-            }
-        }
-        createDir("docs"){
-            file 'file3.txt'
-            dir2 {
-                file 'file4.txt'
-            }
-        }
-        and:
-        buildFile << """
-            apply plugin:'distribution'
-
-            version = 1.2
-
-            distributions{
-                custom {
-                    contents {
-                        from ( 'docs' ){
-                            into 'docs'
-                        }
-
-
-                    }
-                }
-            }
-            """
-        when:
-        run('customDistZip')
-        then:
-        file('build/distributions/TestProject-custom-1.2.zip').usingNativeTools().unzipTo(file("unzip"))
-        file("unzip").assertHasDescendants(
-                'TestProject-custom-1.2/file1.txt',
-                'TestProject-custom-1.2/dir/file2.txt',
-                'TestProject-custom-1.2/docs/file3.txt',
-                'TestProject-custom-1.2/docs/dir2/file4.txt')
-    }
-
-    def installFromDistContent() {
-        given:
-        createDir('src/custom/dist'){
-            file 'file1.txt'
-            dir {
-                file 'file2.txt'
-            }
-        }
-        createDir("docs"){
-            file 'file3.txt'
-            dir2 {
-                file 'file4.txt'
-            }
-        }
-        and:
-        buildFile << """
-            apply plugin:'distribution'
-
-            version = 1.2
-
-            distributions{
-                custom {
-                    contents {
-                        from ( 'docs' ){
-                            into 'docs'
-                        }
-                    }
-                }
-            }
-            """
-        when:
-        run('installCustomDist')
-
-        then:
-        file('build/install/TestProject-custom').exists()
-        file('build/install/TestProject-custom').assertHasDescendants(
-                'file1.txt',
-                'dir/file2.txt',
-                'docs/file3.txt',
-                'docs/dir2/file4.txt')
-    }
-
-    def installDistCanBeRerun() {
-        when:
-        buildFile << """
-            apply plugin:'distribution'
-
-            distributions {
-                custom{
-                    contents {
-                        from { "someFile" }
-                    }
-                }
-            }
-
-            """
-        succeeds('installCustomDist')
-        // update the file so that when it re-runs it is not UP-TO-DATE
-        file("someFile") << "updated"
-        then:
-        succeeds('installCustomDist')
-        and:
-        file('build/install/TestProject-custom/someFile').assertIsCopyOf(file("someFile"))
-    }
-
-    def createTarTaskForCustomDistribution() {
-        when:
-        buildFile << """
-            apply plugin:'distribution'
-
-            distributions {
-                custom{
-                    contents {
-                        from { "someFile" }
-                    }
-                }
-            }
-
-            """
-        then:
-        succeeds('customDistTar')
-        and:
-        file('build/distributions/TestProject-custom.tar').usingNativeTools().untarTo(file("untar"))
-        file("untar/TestProject-custom/someFile").assertIsFile()
     }
 
     def "can create distribution with .tar in project name"() {
         when:
         buildFile << """
-            apply plugin: 'application'
-            apply plugin: 'java'
+            plugins {
+                id("application")
+            }
 
             application {
                 mainClass = "Main"
             }
         """
+
         file("src/main/java/Main.java") << "public class Main {}"
         settingsFile << """
             rootProject.name = 'projectWithtarInName'
         """
+
         then:
         succeeds("distTar")
         new TarTestFixture(file("build/distributions/projectWithtarInName.tar")).assertContainsFile("projectWithtarInName/lib/projectWithtarInName.jar")
@@ -495,6 +287,7 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
                 }
             }
         """
+
         file("someFile") << "some text"
 
         then:

--- a/platforms/software/plugins-distribution/src/main/java/org/gradle/api/distribution/plugins/DistributionBasePlugin.java
+++ b/platforms/software/plugins-distribution/src/main/java/org/gradle/api/distribution/plugins/DistributionBasePlugin.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.distribution.plugins;
+
+import org.apache.commons.lang.StringUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.distribution.Distribution;
+import org.gradle.api.distribution.DistributionContainer;
+import org.gradle.api.distribution.internal.DefaultDistributionContainer;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
+import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Sync;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.gradle.api.tasks.bundling.Tar;
+import org.gradle.api.tasks.bundling.Zip;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.util.internal.TextUtil;
+
+import javax.inject.Inject;
+import java.util.concurrent.Callable;
+
+/**
+ * A plugin that configures rules allowing projects to be packaged as a distribution.
+ * <p>
+ * As a base plugin, this plugin adds no distributions by default.
+ * The {@link DistributionPlugin} adds a {@code main} distribution as a convention.
+ *
+ * @see <a href="https://docs.gradle.org/current/userguide/distribution_plugin.html">Distribution plugin reference</a>
+ *
+ * @since 8.13
+ */
+public abstract class DistributionBasePlugin implements Plugin<Project> {
+
+    private static final String DISTRIBUTION_GROUP = "distribution";
+    private static final String TASK_DIST_ZIP_NAME = "distZip";
+    private static final String TASK_DIST_TAR_NAME = "distTar";
+    private static final String TASK_ASSEMBLE_NAME = "assembleDist";
+
+    private final Instantiator instantiator;
+    private final FileOperations fileOperations;
+    private final CollectionCallbackActionDecorator callbackActionDecorator;
+
+    @Inject
+    public DistributionBasePlugin(Instantiator instantiator, FileOperations fileOperations, CollectionCallbackActionDecorator callbackActionDecorator) {
+        this.instantiator = instantiator;
+        this.fileOperations = fileOperations;
+        this.callbackActionDecorator = callbackActionDecorator;
+    }
+
+    @Override
+    public void apply(final Project project) {
+        project.getPluginManager().apply(BasePlugin.class);
+        DefaultArtifactPublicationSet defaultArtifactPublicationSet = project.getExtensions().getByType(DefaultArtifactPublicationSet.class);
+
+        DistributionContainer distributions = project.getExtensions().create(DistributionContainer.class, "distributions", DefaultDistributionContainer.class, Distribution.class, instantiator, project.getObjects(), fileOperations, callbackActionDecorator);
+        distributions.all(dist -> configureDistribution((ProjectInternal) project, dist, defaultArtifactPublicationSet));
+
+        // TODO: Maintain old behavior of checking for empty-string distribution base names.
+        // It would be nice if we could do this as validation on the property itself.
+        project.afterEvaluate(p -> {
+            distributions.forEach(distribution -> {
+                if (distribution.getDistributionBaseName().get().equals("")) {
+                    throw new GradleException(String.format("Distribution '%s' must not have an empty distributionBaseName.", distribution.getName()));
+                }
+            });
+        });
+    }
+
+    /**
+     * Configures conventions and associated domain objects for a single distribution.
+     */
+    private static void configureDistribution(
+        ProjectInternal project,
+        Distribution dist,
+        DefaultArtifactPublicationSet defaultArtifactPublicationSet
+    ) {
+        dist.getContents().from("src/" + dist.getName() + "/dist");
+
+        String zipTaskName;
+        String tarTaskName;
+        String installTaskName;
+        String assembleTaskName;
+
+        if (dist.getName().equals(DistributionPlugin.MAIN_DISTRIBUTION_NAME)) {
+            zipTaskName = TASK_DIST_ZIP_NAME;
+            tarTaskName = TASK_DIST_TAR_NAME;
+            installTaskName = DistributionPlugin.TASK_INSTALL_NAME;
+            assembleTaskName = TASK_ASSEMBLE_NAME;
+            dist.getDistributionBaseName().convention(project.getName());
+        } else {
+            zipTaskName = dist.getName() + "DistZip";
+            tarTaskName = dist.getName() + "DistTar";
+            installTaskName = "install" + StringUtils.capitalize(dist.getName()) + "Dist";
+            assembleTaskName = "assemble" + StringUtils.capitalize(dist.getName()) + "Dist";
+            dist.getDistributionBaseName().convention(String.format("%s-%s", project.getName(), dist.getName()));
+        }
+
+        TaskProvider<Zip> zipTask = addArchiveTask(project, zipTaskName, Zip.class, dist);
+        TaskProvider<Tar> tarTask = addArchiveTask(project, tarTaskName, Tar.class, dist);
+        addInstallTask(project, installTaskName, dist);
+        addAssembleTask(project, dist, assembleTaskName, zipTask, tarTask);
+
+        // Build zips and tars by default when running the build-wide assemble task.
+        defaultArtifactPublicationSet.addCandidate(new LazyPublishArtifact(zipTask, project.getFileResolver(), project.getTaskDependencyFactory()));
+        defaultArtifactPublicationSet.addCandidate(new LazyPublishArtifact(tarTask, project.getFileResolver(), project.getTaskDependencyFactory()));
+    }
+
+    /**
+     * Adds a task that archives the contents of the distribution into an archive file.
+     */
+    private static <T extends AbstractArchiveTask> TaskProvider<T> addArchiveTask(
+        Project project,
+        String taskName,
+        Class<T> type,
+        Distribution distribution
+    ) {
+        return project.getTasks().register(taskName, type, task -> {
+            task.setDescription("Bundles the project as a distribution.");
+            task.setGroup(DISTRIBUTION_GROUP);
+            task.getArchiveBaseName().convention(distribution.getDistributionBaseName());
+            task.getArchiveClassifier().convention(distribution.getDistributionClassifier());
+
+            CopySpec childSpec = project.copySpec();
+            childSpec.with(distribution.getContents());
+            childSpec.into((Callable<String>) () ->
+                TextUtil.minus(task.getArchiveFileName().get(), "." + task.getArchiveExtension().get())
+            );
+            task.with(childSpec);
+        });
+    }
+
+    /**
+     * Adds a task that syncs the contents of the distribution into a directory within the build dir.
+     */
+    private static void addInstallTask(Project project, String taskName, Distribution distribution) {
+        project.getTasks().register(taskName, Sync.class, installTask -> {
+            installTask.setDescription("Installs the project as a distribution as-is.");
+            installTask.setGroup(DISTRIBUTION_GROUP);
+            installTask.with(distribution.getContents());
+            Provider<String> installDirectoryName = project.provider(() -> {
+                String baseName = distribution.getDistributionBaseName().get();
+                String classifier = distribution.getDistributionClassifier().getOrNull();
+                return "install/" + baseName + (classifier != null ? "-" + classifier : "");
+            });
+            installTask.into(project.getLayout().getBuildDirectory().dir(installDirectoryName));
+        });
+    }
+
+    /**
+     * Adds a task that builds all archives for distribution.
+     */
+    private static void addAssembleTask(
+        ProjectInternal project,
+        Distribution dist,
+        String assembleTaskName,
+        TaskProvider<Zip> zipTask,
+        TaskProvider<Tar> tarTask
+    ) {
+        project.getTasks().register(assembleTaskName, DefaultTask.class, assembleTask -> {
+            assembleTask.setDescription("Assembles the " + dist.getName() + " distributions");
+            assembleTask.setGroup(DISTRIBUTION_GROUP);
+            assembleTask.dependsOn(zipTask);
+            assembleTask.dependsOn(tarTask);
+        });
+    }
+}

--- a/platforms/software/plugins-distribution/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
+++ b/platforms/software/plugins-distribution/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
@@ -16,142 +16,33 @@
 
 package org.gradle.api.distribution.plugins;
 
-import org.apache.commons.lang.StringUtils;
-import org.gradle.api.DefaultTask;
-import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.distribution.Distribution;
 import org.gradle.api.distribution.DistributionContainer;
-import org.gradle.api.distribution.internal.DefaultDistributionContainer;
-import org.gradle.api.file.CopySpec;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
-import org.gradle.api.internal.file.FileOperations;
-import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
-import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Sync;
-import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.tasks.bundling.AbstractArchiveTask;
-import org.gradle.api.tasks.bundling.Tar;
-import org.gradle.api.tasks.bundling.Zip;
-import org.gradle.internal.reflect.Instantiator;
-import org.gradle.util.internal.TextUtil;
-
-import javax.inject.Inject;
-import java.util.concurrent.Callable;
 
 /**
- * <p>A {@link Plugin} to package project as a distribution.</p>
+ * <p>Applies the {@link DistributionBasePlugin} and adds a conventional {@link #MAIN_DISTRIBUTION_NAME main} distribution.</p>
  *
  * @see <a href="https://docs.gradle.org/current/userguide/distribution_plugin.html">Distribution plugin reference</a>
  */
 public abstract class DistributionPlugin implements Plugin<Project> {
+
     /**
      * Name of the main distribution
      */
     public static final String MAIN_DISTRIBUTION_NAME = "main";
+
+    /**
+     * The name of the install task for the main distribution.
+     */
     public static final String TASK_INSTALL_NAME = "installDist";
-
-    private static final String DISTRIBUTION_GROUP = "distribution";
-    private static final String TASK_DIST_ZIP_NAME = "distZip";
-    private static final String TASK_DIST_TAR_NAME = "distTar";
-    private static final String TASK_ASSEMBLE_NAME = "assembleDist";
-
-    private final Instantiator instantiator;
-    private final FileOperations fileOperations;
-    private final CollectionCallbackActionDecorator callbackActionDecorator;
-
-    @Inject
-    public DistributionPlugin(Instantiator instantiator, FileOperations fileOperations, CollectionCallbackActionDecorator callbackActionDecorator) {
-        this.instantiator = instantiator;
-        this.fileOperations = fileOperations;
-        this.callbackActionDecorator = callbackActionDecorator;
-    }
 
     @Override
     public void apply(final Project project) {
-        project.getPluginManager().apply(BasePlugin.class);
-        DistributionContainer distributions = project.getExtensions().create(DistributionContainer.class, "distributions", DefaultDistributionContainer.class, Distribution.class, instantiator, project.getObjects(), fileOperations, callbackActionDecorator);
+        project.getPluginManager().apply(DistributionBasePlugin.class);
 
-        // TODO - refactor this action out so it can be unit tested
-        distributions.all(dist -> {
-            dist.getContents().from("src/" + dist.getName() + "/dist");
-            final String zipTaskName;
-            final String tarTaskName;
-            final String installTaskName;
-            final String assembleTaskName;
-            if (dist.getName().equals(MAIN_DISTRIBUTION_NAME)) {
-                zipTaskName = TASK_DIST_ZIP_NAME;
-                tarTaskName = TASK_DIST_TAR_NAME;
-                installTaskName = TASK_INSTALL_NAME;
-                assembleTaskName = TASK_ASSEMBLE_NAME;
-                dist.getDistributionBaseName().convention(project.getName());
-            } else {
-                zipTaskName = dist.getName() + "DistZip";
-                tarTaskName = dist.getName() + "DistTar";
-                installTaskName = "install" + StringUtils.capitalize(dist.getName()) + "Dist";
-                assembleTaskName = "assemble" + StringUtils.capitalize(dist.getName()) + "Dist";
-                dist.getDistributionBaseName().convention(String.format("%s-%s", project.getName(), dist.getName()));
-            }
-
-            addArchiveTask(project, zipTaskName, Zip.class, dist);
-            addArchiveTask(project, tarTaskName, Tar.class, dist);
-            addInstallTask(project, installTaskName, dist);
-            addAssembleTask(project, assembleTaskName, dist, zipTaskName, tarTaskName);
-        });
+        DistributionContainer distributions = project.getExtensions().getByType(DistributionContainer.class);
         distributions.create(MAIN_DISTRIBUTION_NAME);
-
-        // TODO: Maintain old behavior of checking for empty-string distribution base names.
-        // It would be nice if we could do this as validation on the property itself.
-        project.afterEvaluate(p -> {
-            distributions.forEach(distribution -> {
-                if (distribution.getDistributionBaseName().get().equals("")) {
-                    throw new GradleException(String.format("Distribution '%s' must not have an empty distributionBaseName.", distribution.getName()));
-                }
-            });
-        });
     }
 
-    private <T extends AbstractArchiveTask> void addArchiveTask(final Project project, String taskName, Class<T> type, final Distribution distribution) {
-        final TaskProvider<T> archiveTask = project.getTasks().register(taskName, type, task -> {
-            task.setDescription("Bundles the project as a distribution.");
-            task.setGroup(DISTRIBUTION_GROUP);
-            task.getArchiveBaseName().convention(distribution.getDistributionBaseName());
-            task.getArchiveClassifier().convention(distribution.getDistributionClassifier());
-
-            final CopySpec childSpec = project.copySpec();
-            childSpec.with(distribution.getContents());
-            childSpec.into((Callable<String>)() -> TextUtil.minus(task.getArchiveFileName().get(), "." + task.getArchiveExtension().get()));
-            task.with(childSpec);
-        });
-
-        PublishArtifact archiveArtifact = new LazyPublishArtifact(archiveTask, ((ProjectInternal) project).getFileResolver(), ((ProjectInternal) project).getTaskDependencyFactory());
-        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(archiveArtifact);
-    }
-
-    private void addInstallTask(final Project project, final String taskName, final Distribution distribution) {
-        project.getTasks().register(taskName, Sync.class, installTask -> {
-            installTask.setDescription("Installs the project as a distribution as-is.");
-            installTask.setGroup(DISTRIBUTION_GROUP);
-            installTask.with(distribution.getContents());
-            final Provider<String> installDirectoryName = project.provider(() -> {
-                String baseName = distribution.getDistributionBaseName().get();
-                String classifier = distribution.getDistributionClassifier().getOrNull();
-                return "install/" + baseName + (classifier != null ? "-" + classifier : "");
-            });
-            installTask.into(project.getLayout().getBuildDirectory().dir(installDirectoryName));
-        });
-    }
-
-    private void addAssembleTask(Project project, final String taskName, final Distribution distribution, final String... tasks) {
-        project.getTasks().register(taskName, DefaultTask.class, assembleTask -> {
-            assembleTask.setDescription("Assembles the " + distribution.getName() + " distributions");
-            assembleTask.setGroup(DISTRIBUTION_GROUP);
-            assembleTask.dependsOn((Object[])tasks);
-        });
-    }
 }

--- a/platforms/software/plugins-distribution/src/main/resources/META-INF/gradle-plugins/org.gradle.distribution-base.properties
+++ b/platforms/software/plugins-distribution/src/main/resources/META-INF/gradle-plugins/org.gradle.distribution-base.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2012 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=org.gradle.api.distribution.plugins.DistributionBasePlugin

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,6 +1,20 @@
 {
     "acceptedApiChanges": [
         {
+            "type": "org.gradle.api.distribution.plugins.DistributionBasePlugin",
+            "member": "Class org.gradle.api.distribution.plugins.DistributionBasePlugin",
+            "acceptation": "No need to incubate",
+            "changes": [
+                "Interface has been added"
+            ]
+        },
+        {
+            "type": "org.gradle.api.distribution.plugins.DistributionPlugin",
+            "member": "Constructor org.gradle.api.distribution.plugins.DistributionPlugin()",
+            "acceptation": "No need to incubate",
+            "changes": []
+        },
+        {
             "type": "org.gradle.api.plugins.SoftwareReportingTasksPlugin",
             "member": "Class org.gradle.api.plugins.SoftwareReportingTasksPlugin",
             "acceptation": "Splitting diagnostics into base- and software-",
@@ -36,6 +50,14 @@
             "acceptation": "Protected methods intended to be overriden by Gradle, not API",
             "changes": [
                 "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.BuiltinPluginIdExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.BuiltinPluginIdExtensionsKt.getDistribution-base(org.gradle.plugin.use.PluginDependenciesSpec)",
+            "acceptation": "Generated extension",
+            "changes": [
+                "Method added to public class"
             ]
         },
         {


### PR DESCRIPTION
This is essentially the distribution plugin, except it does not create a main distribution by default. Most logic from distribution was moved to distribution-base The distribution plugin applies distribution-base

DistributionBasePlugin is introduced as non-incubating. Release notes entry has been added.
Userguide has been updated to mention the base plugin.

The existing integ tests have been split between those that operate on the main distribution and those that operate on custom distributions.

Fixes [#32065](https://github.com/gradle/gradle/issues/32065)

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
