### PR TITLE
Only allow plugin lookups on a `ClassLoaderScope` after it's been locked

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -301,6 +301,10 @@ class CrossProjectConfigurationReportingGradle private constructor(
     override fun getConfigurationTargetIdentifier(): ConfigurationTargetIdentifier =
         delegate.configurationTargetIdentifier
 
+    override fun executeRootProjectActions() {
+        delegate.executeRootProjectActions()
+    }
+
     override fun isRootBuild(): Boolean =
         delegate.isRootBuild
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt
@@ -270,6 +270,10 @@ class CrossProjectConfigurationReportingGradle private constructor(
     override fun projectsLoaded(action: Action<in Gradle>) =
         delegate.projectsLoaded(action)
 
+    override fun baseProjectClassLoaderLocked(action: Action<in GradleInternal>) {
+        delegate.baseProjectClassLoaderLocked(action)
+    }
+
     @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
     override fun buildFinished(closure: Closure<*>) =
         // already reported as configuration cache problem, no need to override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
@@ -233,7 +233,7 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
     }
 
     @Nullable
-    private static <T> Class<? extends T> loadFactory(ClassLoaderScope classLoaderScope, String className) {
+    private <T> Class<? extends T> loadFactory(String className) {
         Class<? extends T> clazz;
         try {
             clazz = Cast.uncheckedCast(classLoaderScope.getExportClassLoader().loadClass(className));
@@ -307,7 +307,7 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
         Class<? extends ExternalModuleDependencyFactory> factory;
         synchronized (this) {
             factory = factories.computeIfAbsent(accessorsClassnameSuffix, n ->
-                loadFactory(classLoaderScope, ACCESSORS_PACKAGE + "." + ACCESSORS_CLASSNAME_PREFIX + accessorsClassnameSuffix)
+                loadFactory(ACCESSORS_PACKAGE + "." + ACCESSORS_CLASSNAME_PREFIX + accessorsClassnameSuffix)
             );
         }
         return factory;
@@ -316,7 +316,7 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
     private void createProjectsExtension(ExtensionContainer container, DependencyResolutionManagementInternal drm, ProjectFinder projectFinder) {
         if (generatedProjectFactory == null) {
             synchronized (this) {
-                generatedProjectFactory = loadFactory(classLoaderScope, ROOT_PROJECT_ACCESSOR_FQCN);
+                generatedProjectFactory = loadFactory(ROOT_PROJECT_ACCESSOR_FQCN);
             }
         }
         if (generatedProjectFactory != null) {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -28,7 +28,6 @@ import org.gradle.launcher.exec.RunBuildBuildOperationType
 import org.gradle.operations.lifecycle.RunRequestedWorkBuildOperationType
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
-import spock.lang.Ignore
 
 import java.util.regex.Pattern
 
@@ -150,7 +149,6 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         "rootProject.name='someLib'" | "configured root project name"
     }
 
-    @Ignore('wip')
     @Requires(value = IntegTestPreconditions.NotConfigCached, reason = "Also covered by tests in configuration cache project")
     def "generates configure, task graph and run tasks operations when all builds have buildSrc with #display"() {
         given:

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.launcher.exec.RunBuildBuildOperationType
 import org.gradle.operations.lifecycle.RunRequestedWorkBuildOperationType
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
+import spock.lang.Ignore
 
 import java.util.regex.Pattern
 
@@ -127,7 +128,7 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         runTasksOps[0].displayName == "Run tasks (:buildB:buildSrc)"
         runTasksOps[0].parentId == buildSrcOps[0].id
         // Build operations are run in parallel, so can appear in either order
-        [runTasksOps[1].displayName, runTasksOps[2].displayName].sort()  == ["Run tasks", "Run tasks (:buildB)"]
+        [runTasksOps[1].displayName, runTasksOps[2].displayName].sort() == ["Run tasks", "Run tasks (:buildB)"]
         runTasksOps[1].parentId == runMainTasks.id
         runTasksOps[2].parentId == runMainTasks.id
 
@@ -149,6 +150,7 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         "rootProject.name='someLib'" | "configured root project name"
     }
 
+    @Ignore('wip')
     @Requires(value = IntegTestPreconditions.NotConfigCached, reason = "Also covered by tests in configuration cache project")
     def "generates configure, task graph and run tasks operations when all builds have buildSrc with #display"() {
         given:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptClassloaderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptClassloaderIntegrationTest.groovy
@@ -17,9 +17,12 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 
 class BuildScriptClassloaderIntegrationTest extends AbstractIntegrationSpec{
 
+    @Requires(IntegTestPreconditions.NotConfigCached)
     def 'cannot eagerly access buildscript classloader of the project'() {
         buildFile("a/build.gradle", "")
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptClassloaderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptClassloaderIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 
-class BuildScriptClassloaderIntegrationTest extends AbstractIntegrationSpec{
+class BuildScriptClassloaderIntegrationTest extends AbstractIntegrationSpec {
 
     @Requires(IntegTestPreconditions.NotConfigCached)
     def 'cannot eagerly access buildscript classloader of the project'() {
@@ -41,4 +41,5 @@ class BuildScriptClassloaderIntegrationTest extends AbstractIntegrationSpec{
 
         then:
         failureCauseContains("Attempt to define scope class loader before scope is locked, scope identifier is ClassLoaderScopeIdentifier{coreAndPlugins:settings[:]:buildSrc[:]:root-project[:]:project-a}")
-    }}
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleCallbacksIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleCallbacksIntegrationTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.invocation
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class GradleCallbacksIntegrationTest extends AbstractIntegrationSpec {
+
+    def 'plugins cannot be applied from gradle.projectsLoaded'() {
+        file("buildSrc/src/main/kotlin/foo.gradle") << """
+            println("Foo applied")
+        """
+        file("buildSrc/build.gradle.kts") << """
+            plugins {
+                `groovy-gradle-plugin`
+            }
+            repositories {
+               mavenCentral()
+            }
+        """
+
+        settingsFile """
+            gradle.projectsLoaded {
+                plugins.apply("foo")
+            }
+        """
+
+        when:
+        fails "help"
+
+        then:
+        failureDescriptionContains("Plugin with id 'foo' not found")
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleCallbacksIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleCallbacksIntegrationTest.groovy
@@ -35,7 +35,7 @@ class GradleCallbacksIntegrationTest extends AbstractIntegrationSpec {
 
         settingsFile """
             gradle.projectsLoaded {
-                plugins.apply("foo")
+                gradle.rootProject.plugins.apply("foo")
             }
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIsolationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIsolationIntegrationTest.groovy
@@ -142,7 +142,7 @@ class GradleLifecycleIsolationIntegrationTest extends AbstractIntegrationSpec {
         fails("help")
 
         then:
-        failure.assertHasCause("Failed to isolate 'GradleLifecycle' action: cannot serialize Gradle script object references as these are not supported with the configuration cache.")
+        failure.assertHasDescription("Failed to isolate 'GradleLifecycle' action: cannot serialize Gradle script object references as these are not supported with the configuration cache.")
 
 //        outputContains("project name = root")
 //        outputContains("project name = a")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleUnsupportedTypesIntegrationTest.groovy
@@ -65,7 +65,7 @@ class GradleLifecycleUnsupportedTypesIntegrationTest extends AbstractIntegration
         fails "help"
 
         then:
-        failureCauseContains("cannot serialize object of type '$concreteTypeName'")
+        failureDescriptionContains("cannot serialize object of type '$concreteTypeName'")
 
         where:
         concreteType                      | baseType         | reference

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleRootProjectIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleRootProjectIntegrationTest.groovy
@@ -31,16 +31,16 @@ class GradleRootProjectIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        buildFile("build-logic/build.gradle.kts", """
+        file("build-logic/build.gradle.kts") << """
             plugins {
                 `kotlin-dsl`
             }
             repositories {
                mavenCentral()
             }
-        """)
+        """
 
-        settingsFile << """
+        settingsFile """
             pluginManagement {
                 includeBuild("build-logic")
             }
@@ -60,14 +60,14 @@ class GradleRootProjectIntegrationTest extends AbstractIntegrationSpec {
         file("buildSrc/src/main/kotlin/foo.gradle.kts") << """
             println("Foo applied")
         """
-        buildFile("buildSrc/build.gradle.kts", """
+        file("buildSrc/build.gradle.kts") << """
             plugins {
                 `kotlin-dsl`
             }
             repositories {
                mavenCentral()
             }
-        """)
+        """
 
         settingsFile """
             gradle.rootProject {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleRootProjectIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleRootProjectIntegrationTest.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.invocation
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class GradleRootProjectIntegrationTest extends AbstractIntegrationSpec {
+
+    def 'settings plugin from included build can apply plugin by id to the root project'() {
+        file("build-logic/src/main/kotlin/foo.gradle.kts") << """
+            println("Foo applied")
+        """
+
+        file("build-logic/src/main/kotlin/bar.settings.gradle.kts") << """
+            gradle.rootProject {
+                plugins.apply("foo")
+            }
+        """
+
+        buildFile("build-logic/build.gradle.kts", """
+            plugins {
+                `kotlin-dsl`
+            }
+            repositories {
+               mavenCentral()
+            }
+        """)
+
+        settingsFile << """
+            pluginManagement {
+                includeBuild("build-logic")
+            }
+            plugins {
+                id("bar")
+            }
+        """
+
+        when:
+        run "help"
+
+        then:
+        outputContains "Foo applied"
+    }
+
+    def "plugin from buildSrc can be applied by id to the root project"() {
+        file("buildSrc/src/main/kotlin/foo.gradle.kts") << """
+            println("Foo applied")
+        """
+        buildFile("buildSrc/build.gradle.kts", """
+            plugins {
+                `kotlin-dsl`
+            }
+            repositories {
+               mavenCentral()
+            }
+        """)
+
+        settingsFile """
+            gradle.rootProject {
+                plugins.apply("foo")
+            }
+        """
+
+        when:
+        run "help"
+
+        then:
+        outputContains "Foo applied"
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal;
 
 import org.gradle.BuildListener;
 import org.gradle.api.Action;
+import org.gradle.api.IsolatedAction;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.plugins.PluginAwareInternal;
@@ -159,6 +160,14 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
      */
     ClassLoaderScope baseProjectClassLoaderScope();
 
+    /**
+     * Add a callback to be called after base project classloader locked, effectively at the very end of the root project actions execution.
+     * Relative to other callbacks it happens later than {@link Gradle#projectsLoaded(Action)} and
+     * right after {@link org.gradle.api.invocation.GradleLifecycle#beforeProject(IsolatedAction)}.
+     * <p>
+     * Adding a callback is NOT thread-safe.
+     * @see #executeRootProjectActions()
+     */
     void baseProjectClassLoaderLocked(Action<? super GradleInternal> action);
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -55,6 +55,8 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
     @Nullable
     GradleInternal getParent();
 
+    void executeRootProjectActions();
+
     GradleInternal getRoot();
 
     boolean isRootBuild();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal;
 
 import org.gradle.BuildListener;
+import org.gradle.api.Action;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.plugins.PluginAwareInternal;
@@ -55,6 +56,11 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
     @Nullable
     GradleInternal getParent();
 
+    /**
+     * Executes previously registered actions against root project.
+     * Must be called only after base classloader scope has been locked
+     * @throws IllegalStateException when base project classloader scope is not locked
+     * */
     void executeRootProjectActions();
 
     GradleInternal getRoot();
@@ -152,6 +158,8 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
      * @throws IllegalStateException if called before {@link #setBaseProjectClassLoaderScope(ClassLoaderScope)}
      */
     ClassLoaderScope baseProjectClassLoaderScope();
+
+    void baseProjectClassLoaderLocked(Action<? super GradleInternal> action);
 
     /**
      * @throws IllegalStateException if called more than once

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -58,7 +58,7 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
 
     /**
      * Executes previously registered actions against root project.
-     * Must be called only after base classloader scope has been locked
+     * Must be called only after base classloader scope has been locked.
      * @throws IllegalStateException when base project classloader scope is not locked
      * */
     void executeRootProjectActions();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
@@ -156,28 +156,17 @@ public class DefaultPluginRegistry implements PluginRegistry {
     @Nullable
     @Override
     public PluginImplementation<?> lookup(PluginId pluginId) {
-        PluginImplementation<?> lookup;
         if (parent != null) {
-            lookup = parent.lookup(pluginId);
+            PluginImplementation<?> lookup = parent.lookup(pluginId);
             if (lookup != null) {
                 return lookup;
             }
         }
 
-        return lookup(pluginId, classLoaderForPluginLookup());
-    }
-
-    private ClassLoader classLoaderForPluginLookup() {
         // Only allow lookups in the current scope after it's been locked
         return classLoaderScope.isLocked()
-            ? classLoaderScope.getLocalClassLoader()
-            : findLockedAncestorExportClassLoader(classLoaderScope.getParent());
-    }
-
-    private static ClassLoader findLockedAncestorExportClassLoader(ClassLoaderScope scope) {
-        return scope.isLocked()
-            ? scope.getExportClassLoader()
-            : findLockedAncestorExportClassLoader(scope.getParent());
+            ? lookup(pluginId, classLoaderScope.getLocalClassLoader())
+            : null;
     }
 
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
@@ -164,7 +164,14 @@ public class DefaultPluginRegistry implements PluginRegistry {
             }
         }
 
-        return lookup(pluginId, classLoaderScope.getLocalClassLoader());
+        return lookup(pluginId, classLoaderForPluginLookup());
+    }
+
+    private ClassLoader classLoaderForPluginLookup() {
+        // Only allow lookups in the current scope after it's been locked
+        return classLoaderScope.isLocked()
+            ? classLoaderScope.getLocalClassLoader()
+            : classLoaderScope.getParent().getExportClassLoader();
     }
 
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
@@ -171,7 +171,13 @@ public class DefaultPluginRegistry implements PluginRegistry {
         // Only allow lookups in the current scope after it's been locked
         return classLoaderScope.isLocked()
             ? classLoaderScope.getLocalClassLoader()
-            : classLoaderScope.getParent().getExportClassLoader();
+            : findLockedAncestorExportClassLoader(classLoaderScope.getParent());
+    }
+
+    private static ClassLoader findLockedAncestorExportClassLoader(ClassLoaderScope scope) {
+        return scope.isLocked()
+            ? scope.getExportClassLoader()
+            : findLockedAncestorExportClassLoader(scope.getParent());
     }
 
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
@@ -54,14 +54,17 @@ public class BuildTreePreparingProjectsPreparer implements ProjectsPreparer {
         gradle.setBaseProjectClassLoaderScope(buildSrcClassLoaderScope);
         generateDependenciesAccessorsAndAssignPluginVersions(gradle.getServices(), settings, buildSrcClassLoaderScope);
 
-        // Build buildSrc and export classpath to root project
-        buildBuildSrcAndLockClassloader(gradle, buildSrcClassLoaderScope);
-
         // attaches root project
         buildLoader.load(gradle.getSettings(), gradle);
 
         // Makes included build substitutions available for this build
         coordinator.registerSubstitutionsAvailableFor(gradle.getOwner());
+
+        // Build buildSrc and export classpath to root project
+        buildBuildSrcAndLockClassloader(gradle, buildSrcClassLoaderScope);
+
+        // Executes previously registered actions only after base project classloader has been locked
+        gradle.executeRootProjectActions();
 
         delegate.prepareProjects(gradle);
 

--- a/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
@@ -53,14 +53,15 @@ public class BuildTreePreparingProjectsPreparer implements ProjectsPreparer {
         ClassLoaderScope buildSrcClassLoaderScope = settingsClassLoaderScope.createChild("buildSrc[" + gradle.getIdentityPath() + "]", null);
         gradle.setBaseProjectClassLoaderScope(buildSrcClassLoaderScope);
         generateDependenciesAccessorsAndAssignPluginVersions(gradle.getServices(), settings, buildSrcClassLoaderScope);
+
+        // Build buildSrc and export classpath to root project
+        buildBuildSrcAndLockClassloader(gradle, buildSrcClassLoaderScope);
+
         // attaches root project
         buildLoader.load(gradle.getSettings(), gradle);
 
         // Makes included build substitutions available for this build
         coordinator.registerSubstitutionsAvailableFor(gradle.getOwner());
-
-        // Build buildSrc and export classpath to root project
-        buildBuildSrcAndLockClassloader(gradle, buildSrcClassLoaderScope);
 
         delegate.prepareProjects(gradle);
 

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationBridge.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationBridge.java
@@ -18,6 +18,7 @@ package org.gradle.internal.operations.notify;
 
 import org.gradle.BuildListener;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.InternalAction;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.internal.InternalBuildAdapter;
@@ -97,7 +98,7 @@ public class BuildOperationNotificationBridge implements BuildOperationNotificat
         @Override
         public void beforeSettings(Settings settings) {
             if (settings.getGradle().getParent() == null) {
-                settings.getGradle().projectsLoaded((InternalAction<Gradle>) project -> {
+                ((GradleInternal)settings.getGradle()).baseProjectClassLoaderLocked((InternalAction<Gradle>) project -> {
                     State s = state;
                     if (s != null && s.notificationListener == null) {
                         valve.stop();

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
@@ -372,6 +372,7 @@ class DefaultPluginContainerTest extends Specification {
     def scope(ClassLoader classLoader) {
         return Stub(ClassLoaderScope) {
             getLocalClassLoader() >> classLoader
+            isLocked() >> true
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
@@ -81,6 +81,8 @@ class DefaultPluginManagerTest extends Specification {
         """)
 
         classLoader.addURL(testDirectoryProvider.testDirectory.toURI().toURL())
+
+        _ * classLoaderScope.isLocked() >> true
     }
 
     def "empty manager ops"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginRegistryTest.groovy
@@ -38,6 +38,10 @@ class DefaultPluginRegistryTest extends Specification {
     def pluginInspector = new PluginInspector(new ModelRuleSourceDetector())
     private DefaultPluginRegistry pluginRegistry = new DefaultPluginRegistry(pluginInspector, classLoaderScope)
 
+    def setup() {
+        _ * classLoaderScope.isLocked() >> true
+    }
+
     def "can locate imperative plugin implementation given an id"() {
         def url = writePluginProperties(TestPlugin1)
 
@@ -298,6 +302,7 @@ class DefaultPluginRegistryTest extends Specification {
         given:
         PluginRegistry child = pluginRegistry.createChild(lookupScope)
         _ * lookupScope.localClassLoader >> childClassLoader
+        _ * lookupScope.isLocked() >> true
         _ * childClassLoader.getResource("META-INF/gradle-plugins/somePlugin.properties") >> url
         _ * childClassLoader.loadClass(TestPlugin1.name) >> TestPlugin1
 

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -409,7 +409,8 @@ class DefaultGradleSpec extends Specification {
         gradle.executeRootProjectActions()
 
         then:
-        thrown(IllegalStateException)
+        def e = thrown(IllegalStateException)
+        e.message == "Root project actions may be executed only after base project classloader scope has been locked"
 
         when:
         baseProjectClassLoaderScope.isLocked() >> true
@@ -447,7 +448,8 @@ class DefaultGradleSpec extends Specification {
         gradle.executeRootProjectActions()
 
         then:
-        thrown(IllegalStateException)
+        def e = thrown(IllegalStateException)
+        e.message == "Root project actions may be executed only after base project classloader scope has been locked"
 
         when:
         baseProjectClassLoaderScope.isLocked() >> true


### PR DESCRIPTION
In order to avoid producing `ClassLoader` structures that CC cannot handle.

Fixes #32039 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
