### PR TITLE
Use distict artifact set identifier for composite builds

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/composite/internal/CompositeProjectComponentArtifactMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/composite/internal/CompositeProjectComponentArtifactMetadata.java
@@ -17,22 +17,34 @@
 package org.gradle.composite.internal;
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.io.File;
 
+/**
+ * Represents an artifact that has its owning component ID overridden.
+ * <p>
+ * This is used when an artifact is referenced from another build, and its owning component id is overridden to its foreign counterpart.
+ * This will go away in Gradle 9.0, when we no longer need to override the owning component id with a foreign identifier.
+ * <p>
+ * This should be better named as {@code OverriddenComponentIdArtifactMetadata} or similar, but Kotlin currently references this internal class.
+ *
+ * @see <a href="https://github.com/JetBrains/kotlin/blame/83a7ecda3eccd378a3882b81d8e83ecc12b3b786/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/resolver/KotlinCompilationNpmResolver.kt#L245">Link</a>
+ */
 public class CompositeProjectComponentArtifactMetadata implements LocalComponentArtifactMetadata, ComponentArtifactIdentifier {
-    private final ProjectComponentIdentifier componentIdentifier;
-    private final LocalComponentArtifactMetadata delegate;
-    private final File file;
 
-    public CompositeProjectComponentArtifactMetadata(ProjectComponentIdentifier componentIdentifier, LocalComponentArtifactMetadata delegate, File file) {
-        this.componentIdentifier = componentIdentifier;
+    private final ComponentIdentifier overrideComponentId;
+    private final LocalComponentArtifactMetadata delegate;
+
+    public CompositeProjectComponentArtifactMetadata(
+        ComponentIdentifier overrideComponentId,
+        LocalComponentArtifactMetadata delegate
+    ) {
+        this.overrideComponentId = overrideComponentId;
         this.delegate = delegate;
-        this.file = file;
     }
 
     @Override
@@ -45,8 +57,8 @@ public class CompositeProjectComponentArtifactMetadata implements LocalComponent
     }
 
     @Override
-    public ProjectComponentIdentifier getComponentId() {
-        return componentIdentifier;
+    public ComponentIdentifier getComponentId() {
+        return overrideComponentId;
     }
 
     @Override
@@ -60,8 +72,8 @@ public class CompositeProjectComponentArtifactMetadata implements LocalComponent
     }
 
     @Override
-    public ProjectComponentIdentifier getComponentIdentifier() {
-        return componentIdentifier;
+    public ComponentIdentifier getComponentIdentifier() {
+        return overrideComponentId;
     }
 
     @Override
@@ -76,7 +88,7 @@ public class CompositeProjectComponentArtifactMetadata implements LocalComponent
 
     @Override
     public File getFile() {
-        return file;
+        return delegate.getFile();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/composite/internal/CompositeProjectComponentArtifactMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/composite/internal/CompositeProjectComponentArtifactMetadata.java
@@ -33,7 +33,10 @@ import java.io.File;
  * This should be better named as {@code OverriddenComponentIdArtifactMetadata} or similar, but Kotlin currently references this internal class.
  *
  * @see <a href="https://github.com/JetBrains/kotlin/blame/83a7ecda3eccd378a3882b81d8e83ecc12b3b786/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/npm/resolver/KotlinCompilationNpmResolver.kt#L245">Link</a>
+ *
+ * @deprecated This class will be removed in Gradle 9.0.
  */
+@Deprecated
 public class CompositeProjectComponentArtifactMetadata implements LocalComponentArtifactMetadata, ComponentArtifactIdentifier {
 
     private final ComponentIdentifier overrideComponentId;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalVariantGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalVariantGraphResolveState.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.composite.internal.CompositeProjectComponentArtifactMetadata;
 import org.gradle.internal.Describables;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -80,10 +79,11 @@ public class DefaultLocalVariantGraphResolveState implements LocalVariantGraphRe
         ImmutableSet.Builder<LocalVariantMetadata> copiedArtifactSets = ImmutableSet.builderWithExpectedSize(artifactSets.size());
 
         for (LocalVariantMetadata oldArtifactSet : artifactSets) {
+            @SuppressWarnings("deprecation")
             CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> newArtifacts =
                 calculatedValueContainerFactory.create(Describables.of(oldArtifactSet.asDescribable(), "artifacts"), c ->
                     oldArtifactSet.getArtifacts().stream()
-                        .map(originalArtifact -> new CompositeProjectComponentArtifactMetadata(overrideComponentId, originalArtifact))
+                        .map(originalArtifact -> new org.gradle.composite.internal.CompositeProjectComponentArtifactMetadata(overrideComponentId, originalArtifact))
                         .collect(ImmutableList.toImmutableList())
                 );
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalVariantGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalVariantGraphResolveState.java
@@ -18,9 +18,9 @@ package org.gradle.internal.component.local.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.composite.internal.CompositeProjectComponentArtifactMetadata;
 import org.gradle.internal.Describables;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -34,6 +34,7 @@ import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.model.CalculatedValue;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
 
@@ -74,8 +75,7 @@ public class DefaultLocalVariantGraphResolveState implements LocalVariantGraphRe
     }
 
     @Override
-    public LocalVariantGraphResolveState copyWithTransformedArtifacts(Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> artifactTransformer) {
-
+    public LocalVariantGraphResolveState copyWithComponentId(ComponentIdentifier overrideComponentId) {
         Set<LocalVariantMetadata> artifactSets = artifactState.getArtifactVariants();
         ImmutableSet.Builder<LocalVariantMetadata> copiedArtifactSets = ImmutableSet.builderWithExpectedSize(artifactSets.size());
 
@@ -83,13 +83,13 @@ public class DefaultLocalVariantGraphResolveState implements LocalVariantGraphRe
             CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> newArtifacts =
                 calculatedValueContainerFactory.create(Describables.of(oldArtifactSet.asDescribable(), "artifacts"), c ->
                     oldArtifactSet.getArtifacts().stream()
-                        .map(artifactTransformer::transform)
+                        .map(originalArtifact -> new CompositeProjectComponentArtifactMetadata(overrideComponentId, originalArtifact))
                         .collect(ImmutableList.toImmutableList())
                 );
 
             copiedArtifactSets.add(new LocalVariantMetadata(
                 oldArtifactSet.getName(),
-                oldArtifactSet.getIdentifier(),
+                OverrideComponentIdArtifactSetIdentifier.of(overrideComponentId, oldArtifactSet.getIdentifier()),
                 oldArtifactSet.asDescribable(),
                 oldArtifactSet.getAttributes(),
                 oldArtifactSet.getCapabilities(),
@@ -218,5 +218,62 @@ public class DefaultLocalVariantGraphResolveState implements LocalVariantGraphRe
         public Set<LocalVariantMetadata> getArtifactVariants() {
             return artifactSets;
         }
+    }
+
+    /**
+     * Identifies an artifact set where the owning component identifier has been overridden.
+     * <p>
+     * When overriding the owning component identifier of an artifact, their identity changes. As such,
+     * the identity of the artifact set must also change. This identifier tracks the identity of an
+     * artifact set where the owning component identifier has been overridden, so that caches
+     * properly track the artifacts within this artifact set have an overridden component ID.
+     *
+     * @see org.gradle.internal.resolve.resolver.ResolvedVariantCache
+     */
+    private static class OverrideComponentIdArtifactSetIdentifier implements VariantResolveMetadata.Identifier {
+
+        private final ComponentIdentifier overrideComponentId;
+        private final VariantResolveMetadata.Identifier delegate;
+
+        public OverrideComponentIdArtifactSetIdentifier(
+            ComponentIdentifier overrideComponentId,
+            VariantResolveMetadata.Identifier delegate
+        ) {
+            this.overrideComponentId = overrideComponentId;
+            this.delegate = delegate;
+        }
+
+        @Nullable
+        public static OverrideComponentIdArtifactSetIdentifier of(
+            ComponentIdentifier overrideComponentId,
+            @Nullable VariantResolveMetadata.Identifier delegate
+        ) {
+            if (delegate == null) {
+                return null;
+            }
+
+            return new OverrideComponentIdArtifactSetIdentifier(overrideComponentId, delegate);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            OverrideComponentIdArtifactSetIdentifier that = (OverrideComponentIdArtifactSetIdentifier) o;
+            return overrideComponentId.equals(that.overrideComponentId) && delegate.equals(that.delegate);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = overrideComponentId.hashCode();
+            result = 31 * result + delegate.hashCode();
+            return result;
+        }
+
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveState.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.component.local.model;
 
-import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
@@ -56,9 +55,9 @@ public interface LocalComponentGraphResolveState extends ComponentGraphResolveSt
     LocalComponentGraphResolveMetadata getMetadata();
 
     /**
-     * Copies this state, but with the new component ID and the artifacts transformed by the given transformer.
+     * Copies this state, but with the new component ID.
      */
-    LocalComponentGraphResolveState copy(ComponentIdentifier newComponentId, Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> transformer);
+    LocalComponentGraphResolveState copyWithComponentId(ComponentIdentifier newComponentId);
 
     /**
      * We currently allow a configuration that has been partially observed for resolution to be modified

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantGraphResolveState.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.component.local.model;
 
-import org.gradle.api.Transformer;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.internal.component.model.VariantGraphResolveState;
 
 import java.util.Set;
@@ -37,12 +37,12 @@ public interface LocalVariantGraphResolveState extends VariantGraphResolveState 
     Set<LocalFileDependencyMetadata> getFiles();
 
     /**
-     * Returns a copy of this variant, except with all artifacts transformed by the given transformer.
+     * Returns a copy of this variant, except with the given component identifier.
      *
-     * @param artifactTransformer A transformer applied to all artifacts and sub-variant artifacts.
+     * @param overrideComponentId The new owning component identifier.
      *
-     * @return A copy of this variant, with the given transformer applied to all artifacts.
+     * @return A copy of this variant, with the given owning component identifier.
      */
-    LocalVariantGraphResolveState copyWithTransformedArtifacts(Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> artifactTransformer);
+    LocalVariantGraphResolveState copyWithComponentId(ComponentIdentifier overrideComponentId);
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantMetadata.java
@@ -24,6 +24,8 @@ import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.model.CalculatedValue;
 
+import javax.annotation.Nullable;
+
 /**
  * Implementation of {@link VariantResolveMetadata} which allows variant artifacts to be calculated lazily
  * while holding a project lock.
@@ -31,7 +33,7 @@ import org.gradle.internal.model.CalculatedValue;
 public final class LocalVariantMetadata extends DefaultVariantMetadata {
     private final CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts;
 
-    public LocalVariantMetadata(String name, Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, ImmutableCapabilities capabilities, CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts) {
+    public LocalVariantMetadata(String name, @Nullable Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, ImmutableCapabilities capabilities, CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts) {
         super(name, identifier, displayName, attributes, ImmutableList.of(), capabilities);
         this.artifacts = artifacts;
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildsValueSnapshotterSerializerRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildsValueSnapshotterSerializerRegistry.java
@@ -21,6 +21,7 @@ import org.gradle.internal.snapshot.impl.ValueSnapshotterSerializerRegistry;
 
 public class CompositeBuildsValueSnapshotterSerializerRegistry extends DefaultSerializerRegistry implements ValueSnapshotterSerializerRegistry {
 
+    @SuppressWarnings("deprecation")
     public CompositeBuildsValueSnapshotterSerializerRegistry() {
         super();
         register(CompositeProjectComponentArtifactMetadata.class, new CompositeProjectComponentArtifactMetadataSerializer());

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeProjectComponentArtifactMetadataSerializer.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeProjectComponentArtifactMetadataSerializer.java
@@ -24,6 +24,7 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
+@SuppressWarnings("deprecation")
 public class CompositeProjectComponentArtifactMetadataSerializer implements Serializer<CompositeProjectComponentArtifactMetadata> {
 
     private final ComponentIdentifierSerializer componentIdentifierSerializer = new ComponentIdentifierSerializer();

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeProjectComponentArtifactMetadataSerializer.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeProjectComponentArtifactMetadataSerializer.java
@@ -24,8 +24,6 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
-import java.io.File;
-
 public class CompositeProjectComponentArtifactMetadataSerializer implements Serializer<CompositeProjectComponentArtifactMetadata> {
 
     private final ComponentIdentifierSerializer componentIdentifierSerializer = new ComponentIdentifierSerializer();
@@ -35,14 +33,12 @@ public class CompositeProjectComponentArtifactMetadataSerializer implements Seri
     public CompositeProjectComponentArtifactMetadata read(Decoder decoder) throws Exception {
         ProjectComponentIdentifier componentIdentifier = (ProjectComponentIdentifier) componentIdentifierSerializer.read(decoder);
         PublishArtifactLocalArtifactMetadata delegate = publishArtifactLocalArtifactMetadataSerializer.read(decoder);
-        File file = new File(decoder.readString());
-        return new CompositeProjectComponentArtifactMetadata(componentIdentifier, delegate, file);
+        return new CompositeProjectComponentArtifactMetadata(componentIdentifier, delegate);
     }
 
     @Override
     public void write(Encoder encoder, CompositeProjectComponentArtifactMetadata value) throws Exception {
         componentIdentifierSerializer.write(encoder, value.getComponentIdentifier());
         publishArtifactLocalArtifactMetadataSerializer.write(encoder, (PublishArtifactLocalArtifactMetadata) value.getDelegate());
-        encoder.writeString(value.getFile().getCanonicalPath());
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildTreeLocalComponentProvider.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildTreeLocalComponentProvider.java
@@ -29,12 +29,11 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
-import org.gradle.internal.model.InMemoryLoadingCache;
 import org.gradle.internal.model.InMemoryCacheFactory;
+import org.gradle.internal.model.InMemoryLoadingCache;
 import org.gradle.util.Path;
 
 import javax.inject.Inject;
-import java.io.File;
 
 /**
  * Default implementation of {@link BuildTreeLocalComponentProvider}.
@@ -106,12 +105,7 @@ public class DefaultBuildTreeLocalComponentProvider implements BuildTreeLocalCom
         // Get the local component, then transform it to have a foreign identifier
         LocalComponentGraphResolveState originalComponent = originalComponents.get(projectIdentifier);
         ProjectComponentIdentifier foreignIdentifier = buildState.idToReferenceProjectFromAnotherBuild(projectIdentifier);
-        return originalComponent.copy(foreignIdentifier, originalArtifact -> {
-            // Currently need to resolve the file, so that the artifact can be used in both a script classpath and
-            // the main build. This accesses project state. Instead, the file should be resolved as required.
-            File file = projectState.fromMutableState(p -> originalArtifact.getFile());
-            return new CompositeProjectComponentArtifactMetadata(foreignIdentifier, originalArtifact, file);
-        });
+        return originalComponent.copyWithComponentId(foreignIdentifier);
     }
 
     @Override


### PR DESCRIPTION
In a prior PR, #31260, we modified the caching of variant artifact sets to cache in more scenarios. This improved caching exposed a bug elsewhere that caused artifacts from an included build to be reported as coming from the current build, or sometimes the reverse where an artifact from the current build was reported as coming from an included build.

The root problem is that we continued to use the same artifact set identifier, which is used as a cache key, when the artifacts of that artifact set were different. This caused us to use cache values that did not correspond to what we were actually caching. In effect, one key (identifier) mapped to multiple values. This commit ensures the key properly describes the artifacts it identifies.

Fixes #32045 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
