### PR TITLE
Enable logging for receiving WorkerReadyMessage when using TD

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,5 +29,7 @@ defaultPerformanceBaselines=8.13-commit-a6bf0de82e44
 systemProp.dependency.analysis.test.analysis=false
 # Disable automatic recursive application of the plugin to subprojects
 dependency.analysis.autoapply=false
-# If enabled, the build scans is tagged with TD_REMOTE_EXECUTOR_ENQUEUED_IN_WRONG_STATE if a remote executor is trying to be enqueued in a wrong state
+# If enabled, the build scans is tagged with TD_REMOTE_EXECUTOR_ENQUEUED_IN_WRONG_STATE if a remote executor is trying to be enqueued in a wrong state.
 systemProp.develocity.internal.testacceleration.enableCustomValues=true
+# If enabled, the build logs whenever a WorkerReadyMessage is received. This should help analyzing the problem of remote executors being in wrong state.
+systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true


### PR DESCRIPTION
The Develocity Gradle plugin was recently updated to 3.19.1. This version supports an internal property to enable logging in the build when it receives a `WorkerReadyMessage` from the TD agent.

The testing team currently assumes that for some unknown reason, builds can receive a `WorkerReadyMessage` for the same assigned TD agent multiple times. This additional logging is used to support or reject our assumption when the problem occurs next time.
