### PR TITLE
Test if Kotlin extension functions work with the published API

### DIFF
--- a/testing/public-api-tests/src/integTest/groovy/org/gradle/api/PublicApiIntegrationTest.groovy
+++ b/testing/public-api-tests/src/integTest/groovy/org/gradle/api/PublicApiIntegrationTest.groovy
@@ -138,10 +138,11 @@ class PublicApiIntegrationTest extends AbstractIntegrationSpec implements JavaTo
 
             import org.gradle.api.Plugin
             import org.gradle.api.Project
+            import org.gradle.kotlin.dsl.*
 
             class PublishedApiTestPlugin : Plugin<Project> {
                 override fun apply(project: Project) {
-                    project.tasks.register("myTask", CustomTask::class.java) { task ->
+                    val myTask = project.tasks.registering(CustomTask::class) { task ->
                         task.mapValues.set(mapOf("alma" to 1, "bela" to 2))
                         println("Hello from plugin")
                     }


### PR DESCRIPTION
This is to make sure that code compiled against the published API can use Kotlin extension functions like `tasks.registering()`.

Fixes #32203.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
