### PR TITLE
Avoid calling `ClassLoaderScope#onReuse` in the same session

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderCachingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderCachingIntegrationTest.groovy
@@ -20,10 +20,10 @@ import org.gradle.integtests.fixtures.longlived.PersistentBuildProcessIntegratio
 
 class ConfigurationCacheClassLoaderCachingIntegrationTest extends PersistentBuildProcessIntegrationTest {
 
-    def "reuses cached ClassLoaders"() {
+    File staticDataLib
 
-        given: 'a Task that holds some static data'
-        File staticDataLib = file("lib/StaticData.jar").tap {
+    def setup() {
+        staticDataLib = file("lib/StaticData.jar").tap {
             parentFile.mkdirs()
         }
         jarWithClasses(
@@ -50,32 +50,40 @@ class ConfigurationCacheClassLoaderCachingIntegrationTest extends PersistentBuil
                 }
             """
         )
+    }
 
-        and: "multiple sub-projects"
-        settingsFile << """
-            include 'foo:foo'
-            include 'bar:bar'
-        """
+    def "reuses cached ClassLoaders"() {
+
+        given: "multiple sub-projects"
+        kotlinFile "settings.$scriptExtension", '''
+            include("foo:foo")
+            include("bar:bar")
+        '''
+        kotlinFile "build.$scriptExtension", '''
+            tasks.register("unused") {}
+        '''
 
         // Make the classpath of :foo differ from :bar's
         // thus causing :foo:foo and :bar:bar to have separate ClassLoaders.
-        File someLib = file('lib/someLib.jar')
-        jarWithClasses(someLib, SomeClass: 'class SomeClass {}')
-
-        file("foo/build.gradle") << """
-            buildscript { dependencies { classpath(files('${someLib.toURI()}')) } }
-        """
+        buildscriptWithCustomClasspath "foo/build.$scriptExtension"
 
         // Load the StaticData class in the different sub-sub-projects
         // for a more interesting ClassLoader hierarchy.
         for (projectDir in ['foo/foo', 'bar/bar']) {
-            file("$projectDir/build.gradle") << """
-                buildscript { dependencies { classpath(files('${staticDataLib.toURI()}')) } }
+            file("$projectDir/build.$scriptExtension") << """
+                buildscript {
+                    dependencies {
+                        classpath(files("${staticDataLib.toURI()}"))
+                    }
+                }
 
-                task ok(type: StaticData) {
+                tasks.register("ok", $classRef) {
                 }
             """
         }
+
+        and: 'non-strict classloaders are allowed'
+        executer.withStackTraceChecksDisabled()
 
         when:
         configurationCacheRun ":foo:foo:ok", ":bar:bar:ok"
@@ -90,6 +98,95 @@ class ConfigurationCacheClassLoaderCachingIntegrationTest extends PersistentBuil
         then:
         outputContains("foo.value = 2")
         outputContains("bar.value = 2")
+
+        when: 'one of the scripts change'
+        file("foo/foo/build.$scriptExtension") << """
+            tasks.register("unused") {}
+        """
+
+        and:
+        configurationCacheRun ":foo:foo:ok", ":bar:bar:ok"
+
+        then: 'classloaders are still reused since the classpath remains the same'
+        outputContains("foo.value = 3")
+        outputContains("bar.value = 3")
+
+        and: 'configuration cache is retrieved successfully after reuse'
+        configurationCacheRun ":foo:foo:ok", ":bar:bar:ok"
+
+        then:
+        outputContains("foo.value = 4")
+        outputContains("bar.value = 4")
+
+        where:
+        scriptExtension | classRef
+        'gradle'        | 'StaticData'
+        'gradle.kts'    | 'StaticData::class'
+    }
+
+    def "reuses strict ClassLoaders but discards scripts with non-strict ones"() {
+        given:
+        settingsFile '''
+            rootProject.name = "test"
+            include("foo:foo")
+            include("bar:bar")
+        '''
+
+        // Make the classpath of :foo differ from :bar's
+        // thus causing :foo:foo and :bar:bar to have separate ClassLoaders.
+        buildscriptWithCustomClasspath 'foo/build.gradle.kts'
+
+        for (projectDir in ['foo/foo', 'bar/bar']) {
+            kotlinFile "$projectDir/build.gradle.kts", """
+                buildscript {
+                    // make bar/bar classLoader non-strict by accessing classLoader
+                    // this should cause the compiled script class to be discarded
+                    ${projectDir.endsWith('bar') ? 'require(classLoader != null)' : ''}
+                    dependencies {
+                        classpath(files("${staticDataLib.toURI()}"))
+                    }
+                }
+
+                class StaticScriptData {
+                    companion object {
+                        var script = 1
+                    }
+                }
+
+                tasks.register("ok", StaticData::class) {
+                    val id = "\${project.name}.script"
+                    doLast { println("\$id = \${StaticScriptData.script++}") }
+                }
+            """
+        }
+        and: 'non-strict classloaders must be allowed'
+        executer.withEagerClassLoaderCreationCheckDisabled()
+
+        when:
+        run "ok"
+
+        then:
+        outputContains("foo.value = 1")
+        outputContains("foo.script = 1")
+        outputContains("bar.value = 1")
+        outputContains("bar.script = 1")
+
+        when:
+        configurationCacheRun "ok"
+
+        then: 'strict foo/foo is fully reused but non-strict script bar/bar is discarded'
+        outputContains("foo.value = 2")
+        outputContains("foo.script = 2")
+        outputContains("bar.value = 2")
+        outputContains("bar.script = 1")
+    }
+
+    private void buildscriptWithCustomClasspath(String scriptFileName) {
+        File someLib = file('lib/someLib.jar')
+        jarWithClasses(someLib, SomeClass: 'class SomeClass {}')
+        file(scriptFileName) << """
+            buildscript { dependencies { classpath(files("${someLib.toURI()}")) } }
+        """
     }
 
     private void configurationCacheRun(String... args) {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderCachingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderCachingIntegrationTest.groovy
@@ -82,9 +82,6 @@ class ConfigurationCacheClassLoaderCachingIntegrationTest extends PersistentBuil
             """
         }
 
-        and: 'non-strict classloaders are allowed'
-        executer.withStackTraceChecksDisabled()
-
         when:
         configurationCacheRun ":foo:foo:ok", ":bar:bar:ok"
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheKotlinScriptReuseIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheKotlinScriptReuseIntegrationTest.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import spock.lang.Issue
+
+class ConfigurationCacheKotlinScriptReuseIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    @Issue('https://github.com/gradle/gradle/issues/32039')
+    def 'compiled Kotlin script with non-strict ClassLoaderScope parent can be reused in same build in the presence of version catalog'() {
+        given: 'a version catalog'
+        file('gradle/libs.versions.toml').text = '''
+            [versions]
+            # Deleting this line fixes the issue
+            test = "1"
+
+            [libraries]
+        '''.stripIndent()
+
+        and: 'two projects with the exact same script'
+        settingsFile '''
+            include("foo")
+            include("bar")
+            gradle.rootProject {
+                // induces non-strict ClassLoaderScope in the hierarchy
+                // since this callback runs too early
+                buildscript.classLoader
+            }
+        '''
+
+        for (projectDir in ['foo', 'bar']) {
+            kotlinFile "$projectDir/build.gradle.kts", '''
+                class StaticScriptData {
+                    companion object {
+                        val count = java.util.concurrent.atomic.AtomicInteger(1)
+                    }
+                }
+                tasks.register("ok") {
+                    doLast {
+                        println("count = " + StaticScriptData.count.getAndIncrement())
+                    }
+                }
+            '''
+        }
+
+        when:
+        executer.withEagerClassLoaderCreationCheckDisabled()
+
+        and:
+        configurationCacheRun 'ok'
+
+        then:
+        outputContains 'count = 1'
+        outputContains 'count = 2'
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheKotlinScriptReuseIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheKotlinScriptReuseIntegrationTest.groovy
@@ -16,10 +16,13 @@
 
 package org.gradle.internal.cc.impl
 
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 import spock.lang.Issue
 
 class ConfigurationCacheKotlinScriptReuseIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
+    @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = 'non-strict ClassLoader scope')
     @Issue('https://github.com/gradle/gradle/issues/32039')
     def 'compiled Kotlin script with non-strict ClassLoaderScope parent can be reused in same build in the presence of version catalog'() {
         given: 'a version catalog'

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassloadingCache.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassloadingCache.kt
@@ -33,10 +33,10 @@ class KotlinScriptClassloadingCache @Inject constructor(
 ) {
 
     private
-    val cache: CrossBuildInMemoryCache<ProgramId, CompiledScript> = cacheFactory.newCache()
+    val cache: CrossBuildInMemoryCache<ProgramId, CompiledScript> = cacheFactory.newCache { reused -> reused.onReuse() }
 
     fun get(key: ProgramId): CompiledScript? =
-        cache.getIfPresent(key)?.also { it.onReuse() }
+        cache.getIfPresent(key)
 
     fun put(key: ProgramId, loadedScriptClass: CompiledScript) {
         cache.put(key, loadedScriptClass)

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
@@ -45,6 +45,11 @@ public interface CrossBuildInMemoryCacheFactory {
      */
     <K, V> CrossBuildInMemoryCache<K, V> newCache();
 
+    /**
+     * See {@link #newCache()}.
+     *
+     * @param onReuse callback triggered when a cached value is reused in a new session after being retained.
+     */
     <K, V> CrossBuildInMemoryCache<K, V> newCache(Consumer<V> onReuse);
 
     /**

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
@@ -20,6 +20,7 @@ import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
@@ -43,6 +44,8 @@ public interface CrossBuildInMemoryCacheFactory {
      * <p>Note: this should be used to create _only_ global scoped instances.
      */
     <K, V> CrossBuildInMemoryCache<K, V> newCache();
+
+    <K, V> CrossBuildInMemoryCache<K, V> newCache(Consumer<V> onReuse);
 
     /**
      * Creates a new cache instance. Keys and values are always referenced using strong references.

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
@@ -48,7 +48,7 @@ public interface CrossBuildInMemoryCacheFactory {
     /**
      * See {@link #newCache()}.
      *
-     * @param onReuse callback triggered when a cached value is reused in a new session after being retained.
+     * @param onReuse callback triggered when a cached value is reused in a new session after being retained. The callback will be invoked under the cache lock so make it swift.
      */
     <K, V> CrossBuildInMemoryCache<K, V> newCache(Consumer<V> onReuse);
 

--- a/platforms/core-execution/persistent-cache/src/testFixtures/groovy/org/gradle/cache/internal/TestCrossBuildInMemoryCacheFactory.groovy
+++ b/platforms/core-execution/persistent-cache/src/testFixtures/groovy/org/gradle/cache/internal/TestCrossBuildInMemoryCacheFactory.groovy
@@ -19,6 +19,7 @@ package org.gradle.cache.internal
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantLock
+import java.util.function.Consumer
 import java.util.function.Function
 import java.util.function.Predicate
 
@@ -31,6 +32,11 @@ class TestCrossBuildInMemoryCacheFactory implements CrossBuildInMemoryCacheFacto
 
     @Override
     <K, V> CrossBuildInMemoryCache<K, V> newCache() {
+        return new TestCache<K, V>()
+    }
+
+    @Override
+    <K, V> CrossBuildInMemoryCache<K, V> newCache(Consumer<V> onReuse) {
         return new TestCache<K, V>()
     }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/ProblemLocationAnalyzer.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/ProblemLocationAnalyzer.java
@@ -23,10 +23,11 @@ import org.gradle.problems.Location;
 
 import javax.annotation.Nullable;
 
-@ServiceScope(Scope.BuildTree.class)
+@ServiceScope(Scope.BuildSession.class)
 public interface ProblemLocationAnalyzer {
     /**
      * Calculates the location for a problem with the given stack.
+     *
      * @return A display name for the location or null for an unknown location.
      */
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ClassLoaderScope.java
@@ -116,8 +116,8 @@ public interface ClassLoaderScope {
     boolean isLocked();
 
     /**
-     * Notifies this scope that it is about to be reused in a new build invocation, so that the scope can recreate or otherwise prepare its classloaders for this, as certain state may have
-     * been discarded to reduce memory pressure.
+     * Notifies this scope that it is about to be reused in a new build invocation, so that the scope can recreate or
+     * otherwise prepare its classloaders for this, as certain state may have been discarded to reduce memory pressure.
      */
     void onReuse();
 

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -57,6 +58,24 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
         listenerManager.addListener(cache);
         return cache;
     }
+
+    @Override
+    public <K, V> CrossBuildInMemoryCache<K, V> newCache(Consumer<V> onReuse) {
+        DefaultCrossBuildInMemoryCache<K, V> cache = new DefaultCrossBuildInMemoryCache<K, V>(new HashMap<>()) {
+            @Nullable
+            @Override
+            protected V maybeGetRetainedValue(K key) {
+                V v = super.maybeGetRetainedValue(key);
+                if (v != null) {
+                    onReuse.accept(v);
+                }
+                return v;
+            }
+        };
+        listenerManager.addListener(cache);
+        return cache;
+    }
+
 
     @Override
     public <K, V> CrossBuildInMemoryCache<K, V> newCacheRetainingDataFromPreviousBuild(Predicate<V> retentionFilter) {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -67,6 +67,7 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
             protected V maybeGetRetainedValue(K key) {
                 V v = super.maybeGetRetainedValue(key);
                 if (v != null) {
+                    // This callback better be swift as it runs under the cache lock.
                     onReuse.accept(v);
                 }
                 return v;

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -66,7 +66,6 @@ import org.gradle.internal.instrumentation.reporting.MethodInterceptionReportCol
 import org.gradle.internal.instrumentation.reporting.PropertyUpgradeReportConfig;
 import org.gradle.internal.model.BuildTreeObjectFactory;
 import org.gradle.internal.problems.DefaultProblemDiagnosticsFactory;
-import org.gradle.internal.problems.DefaultProblemLocationAnalyzer;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import org.gradle.internal.service.PrivateService;
 import org.gradle.internal.service.Provides;
@@ -106,7 +105,6 @@ public class BuildTreeScopeServices implements ServiceRegistrationProvider {
         registration.add(DeprecationsReporter.class);
         registration.add(TaskPathProjectEvaluator.class);
         registration.add(DefaultFeatureFlags.class);
-        registration.add(DefaultProblemLocationAnalyzer.class);
         registration.add(DefaultProblemDiagnosticsFactory.class);
         registration.add(DefaultExceptionAnalyser.class);
         registration.add(ConfigurationCacheableIdFactory.class);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreBuildSessionServices.java
@@ -55,6 +55,8 @@ import org.gradle.internal.model.InMemoryCacheFactory;
 import org.gradle.internal.model.StateTransitionControllerFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.problems.DefaultProblemLocationAnalyzer;
+import org.gradle.internal.problems.ProblemLocationAnalyzer;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.scopeids.PersistentScopeIdLoader;
 import org.gradle.internal.scopeids.ScopeIdsServices;
@@ -75,6 +77,7 @@ import java.io.File;
 public class CoreBuildSessionServices implements ServiceRegistrationProvider {
     void configure(ServiceRegistration registration) {
         registration.add(CalculatedValueContainerFactory.class);
+        registration.add(ProblemLocationAnalyzer.class, DefaultProblemLocationAnalyzer.class);
         registration.add(InMemoryCacheFactory.class);
         registration.add(StateTransitionControllerFactory.class);
         registration.add(BuildLayoutValidator.class);

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1226,9 +1226,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
             properties.put("user.variant", locale.getVariant());
         }
 
-        if (eagerClassLoaderCreationChecksOn) {
-            properties.put(DefaultClassLoaderScope.STRICT_MODE_PROPERTY, "true");
-        }
+        properties.put(DefaultClassLoaderScope.STRICT_MODE_PROPERTY, Boolean.toString(eagerClassLoaderCreationChecksOn));
 
         if (interactive) {
             properties.put(TestOverrideConsoleDetector.INTERACTIVE_TOGGLE, "true");


### PR DESCRIPTION
As to avoid triggering CC assertion on non-strict ClassLoader setups.

Fixes [#32039](https://github.com/gradle/gradle/issues/32039)

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
