### PR TITLE
Daemon toolchain add expected patterns for KnownJvmVendors

### DIFF
--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVendor.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVendor.java
@@ -22,19 +22,19 @@ public interface JvmVendor {
 
     enum KnownJvmVendor {
         ADOPTIUM("adoptium", "temurin|adoptium|eclipse foundation", "Eclipse Temurin"),
-        ADOPTOPENJDK("adoptopenjdk", "AdoptOpenJDK"),
-        AMAZON("amazon", "Amazon Corretto"),
+        ADOPTOPENJDK("adoptopenjdk", "aoj|adoptopenjdk", "AdoptOpenJDK"),
+        AMAZON("amazon", "amazon|corretto", "Amazon Corretto"),
         APPLE("apple", "Apple"),
-        AZUL("azul systems", "Azul Zulu"),
-        BELLSOFT("bellsoft", "BellSoft Liberica"),
-        GRAAL_VM("graalvm community", "GraalVM Community"),
-        HEWLETT_PACKARD("hewlett-packard", "HP-UX"),
-        IBM("ibm", "ibm|international business machines corporation", "IBM"),
-        JETBRAINS("jetbrains", "JetBrains"),
+        AZUL("azul systems", "azul|zulu", "Azul Zulu"),
+        BELLSOFT("bellsoft", "bellsoft|liberica", "BellSoft Liberica"),
+        GRAAL_VM("graalvm community", "graalvm|graal vm", "GraalVM Community"),
+        HEWLETT_PACKARD("hewlett-packard", "hp|hewlett", "HP-UX"),
+        IBM("ibm", "ibm|semeru|international business machines corporation", "IBM"),
+        JETBRAINS("jetbrains", "jbr|jetbrains", "JetBrains"),
         MICROSOFT("microsoft", "Microsoft"),
         ORACLE("oracle", "Oracle"),
-        SAP("sap se", "SAP SapMachine"),
-        TENCENT("tencent", "Tencent"),
+        SAP("sap se", "sap", "SAP SapMachine"),
+        TENCENT("tencent", "tencent|kona", "Tencent"),
         UNKNOWN("gradle", "Unknown Vendor");
 
         private final String indicatorString;

--- a/platforms/jvm/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/KnownJvmVendorSpec.groovy
+++ b/platforms/jvm/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/KnownJvmVendorSpec.groovy
@@ -35,4 +35,92 @@ class KnownJvmVendorSpec extends Specification {
         where:
         vendorString << ['Adoptium', 'Temurin', 'Eclipse Foundation', 'Eclipse Temurin']
     }
+
+    def 'AdoptOpenJDK matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.ADOPTOPENJDK == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['AdoptOpenJDK', 'AOJ']
+    }
+
+    def 'Amazon matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.AMAZON == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['Amazon', 'Corretto', 'Amazon Corretto']
+    }
+
+    def 'Azul matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.AZUL == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['Azul', 'Zulu', 'Azul Systems', 'Azul Zulu']
+    }
+
+    def 'BellSoft matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.BELLSOFT == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['BellSoft', 'Liberica', 'BellSoft Liberica']
+    }
+
+    def 'GraalVM matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.GRAAL_VM == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['GraalVM', 'GraalVM Community', 'Graal VM']
+    }
+
+    def 'Hewlett matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.HEWLETT_PACKARD == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['HP', 'Hewlett', 'Hewlett Packard']
+    }
+
+    def 'IBM matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.IBM == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['IBM', 'Semeru', 'IBM Semeru', 'International Business Machines Corporation']
+    }
+
+    def 'Jetbrains matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.JETBRAINS == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['JBR', 'JetBrains', 'JetBrains Runtime']
+    }
+
+    def 'Oracle matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.ORACLE == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['Oracle', 'Oracle OpenJDK']
+    }
+
+    def 'SAP matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.SAP == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['SAP', 'SAP SE', 'SAP Machine']
+    }
+
+    def 'Tencent matches multiple vendor strings'() {
+        expect:
+        JvmVendor.KnownJvmVendor.TENCENT == JvmVendor.KnownJvmVendor.parse(vendorString)
+
+        where:
+        vendorString << ['Tencent', 'Kona', 'Tencent Kona']
+    }
 }


### PR DESCRIPTION
### Context
The `updateDaemonJvm` task allows to specify any string vendor, however, the applied foojay-plugin is only able to resolve the known ones generating the download URLs. This implies that for `tencent` vendor defined on `KnownJvmVendor` the `kona` must be specified for `updateDaemonJvm` task in order to obtain the `foojay-plugin` URLs, otherwise those aren't going to be resolved.
```java
enum KnownJvmVendor {
       ....
        TENCENT("tencent", "Tencent"), 
}
```

- Tested on snapshot `gradle-8.13-20250128002155+0000-bin`


<img width="1001" alt="Screenshot 2025-01-28 at 13 49 38" src="https://github.com/user-attachments/assets/b71003b6-6e41-487b-9e14-e86dac588c77" />

In addition, IDE uses the `JvmVendor.rawVendor` when invoking the `updateDaemonJvm` being unable to populate those download URLs resulting on non-desired configuration since `auto-provisioning` will not be able to download the toolchain if cannot be found locally.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.
