### PR TITLE
Never load native libraries from system temp dir

### DIFF
--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherRegistryFactory.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherRegistryFactory.java
@@ -43,6 +43,10 @@ public abstract class AbstractFileWatcherRegistryFactory<T extends AbstractNativ
         this.immutableLocationsFilter = immutableLocationsFilter;
     }
 
+    public interface FileEventFunctionsLookup {
+        <T extends AbstractNativeFileEventFunctions<?>> T getFileEventFunctions(Class<T> type);
+    }
+
     @Override
     public FileWatcherRegistry createFileWatcherRegistry(FileWatcherRegistry.ChangeHandler handler) {
         BlockingQueue<FileWatchEvent> fileEvents = new ArrayBlockingQueue<>(FILE_EVENT_QUEUE_SIZE);

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DarwinFileWatcherRegistryFactory.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.watch.registry.impl;
 
 import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
-import org.gradle.fileevents.FileEvents;
 import org.gradle.fileevents.FileWatchEvent;
 import org.gradle.fileevents.internal.OsxFileEventFunctions;
 import org.gradle.fileevents.internal.OsxFileEventFunctions.OsxFileWatcher;
@@ -34,8 +33,8 @@ import java.util.function.Predicate;
 
 public class DarwinFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory<OsxFileEventFunctions, OsxFileWatcher> {
 
-    public DarwinFileWatcherRegistryFactory(Predicate<String> immutableLocationsFilter) throws NativeIntegrationUnavailableException {
-        super(FileEvents.get(OsxFileEventFunctions.class), immutableLocationsFilter);
+    public DarwinFileWatcherRegistryFactory(FileEventFunctionsLookup fileEvents, Predicate<String> immutableLocationsFilter) throws NativeIntegrationUnavailableException {
+        super(fileEvents.getFileEventFunctions(OsxFileEventFunctions.class), immutableLocationsFilter);
     }
 
     @Override

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/LinuxFileWatcherRegistryFactory.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/LinuxFileWatcherRegistryFactory.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.watch.registry.impl;
 
 import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
-import org.gradle.fileevents.FileEvents;
 import org.gradle.fileevents.FileWatchEvent;
 import org.gradle.fileevents.internal.LinuxFileEventFunctions;
 import org.gradle.fileevents.internal.LinuxFileEventFunctions.LinuxFileWatcher;
@@ -34,8 +33,8 @@ import java.util.stream.Collectors;
 
 public class LinuxFileWatcherRegistryFactory extends AbstractFileWatcherRegistryFactory<LinuxFileEventFunctions, LinuxFileWatcher> {
 
-    public LinuxFileWatcherRegistryFactory(Predicate<String> immutableLocationsFilter) throws NativeIntegrationUnavailableException {
-        super(FileEvents.get(LinuxFileEventFunctions.class), immutableLocationsFilter);
+    public LinuxFileWatcherRegistryFactory(FileEventFunctionsLookup fileEvents, Predicate<String> immutableLocationsFilter) throws NativeIntegrationUnavailableException {
+        super(fileEvents.getFileEventFunctions(LinuxFileEventFunctions.class), immutableLocationsFilter);
     }
 
     @Override

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WindowsFileWatcherRegistryFactory.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.watch.registry.impl;
 
 import net.rubygrapefruit.platform.NativeIntegrationUnavailableException;
-import org.gradle.fileevents.FileEvents;
 import org.gradle.fileevents.FileWatchEvent;
 import org.gradle.fileevents.internal.WindowsFileEventFunctions;
 import org.gradle.fileevents.internal.WindowsFileEventFunctions.WindowsFileWatcher;
@@ -36,9 +35,10 @@ public class WindowsFileWatcherRegistryFactory extends AbstractFileWatcherRegist
     private static final int BUFFER_SIZE = 64 * 1024;
 
     public WindowsFileWatcherRegistryFactory(
+        FileEventFunctionsLookup fileEvents,
         Predicate<String> immutableLocationsFilter
     ) throws NativeIntegrationUnavailableException {
-        super(FileEvents.get(WindowsFileEventFunctions.class), immutableLocationsFilter);
+        super(fileEvents.getFileEventFunctions(WindowsFileEventFunctions.class), immutableLocationsFilter);
     }
 
     @Override

--- a/platforms/core-runtime/native/build.gradle.kts
+++ b/platforms/core-runtime/native/build.gradle.kts
@@ -20,15 +20,14 @@ dependencies {
     api(projects.fileTemp)
     api(projects.serviceLookup)
     api(projects.serviceProvider)
+    api(projects.serviceRegistryBuilder)
     api(projects.stdlibJavaExtensions)
 
-    api(libs.gradleFileEvents)
     api(libs.inject)
     api(libs.jsr305)
     api(libs.nativePlatform)
 
-    implementation(projects.serviceRegistryBuilder)
-
+    implementation(libs.gradleFileEvents)
     implementation(libs.slf4jApi)
     implementation(libs.guava)
     implementation(libs.commonsIo)

--- a/platforms/core-runtime/native/build.gradle.kts
+++ b/platforms/core-runtime/native/build.gradle.kts
@@ -22,13 +22,13 @@ dependencies {
     api(projects.serviceProvider)
     api(projects.stdlibJavaExtensions)
 
+    api(libs.gradleFileEvents)
     api(libs.inject)
     api(libs.jsr305)
     api(libs.nativePlatform)
 
     implementation(projects.serviceRegistryBuilder)
 
-    implementation(libs.gradleFileEvents)
     implementation(libs.slf4jApi)
     implementation(libs.guava)
     implementation(libs.commonsIo)

--- a/platforms/core-runtime/native/src/jmh/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessorBenchmark.java
+++ b/platforms/core-runtime/native/src/jmh/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessorBenchmark.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.nativeintegration.filesystem;
 
 import com.google.common.collect.ImmutableMap;
+import net.rubygrapefruit.platform.Native;
 import net.rubygrapefruit.platform.file.Files;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.file.FileMetadata;
@@ -50,13 +51,13 @@ import java.util.UUID;
 @Measurement(iterations = 5)
 @State(Scope.Benchmark)
 public class FileMetadataAccessorBenchmark {
+    private static final Native NATIVE_INTEGRATION = Native.init(new File("build/tmp/jmh-benchmark"));
     private static final Map<String, FileMetadataAccessor> ACCESSORS = ImmutableMap.<String, FileMetadataAccessor>builder()
         .put(FallbackFileMetadataAccessor.class.getSimpleName(), new FallbackFileMetadataAccessor())
-        .put(NativePlatformBackedFileMetadataAccessor.class.getSimpleName(), new NativePlatformBackedFileMetadataAccessor(net.rubygrapefruit.platform.Native.get(Files.class)))
+        .put(NativePlatformBackedFileMetadataAccessor.class.getSimpleName(), new NativePlatformBackedFileMetadataAccessor(NATIVE_INTEGRATION.get(Files.class)))
         .put(Jdk7FileMetadataAccessor.class.getSimpleName(), new Jdk7FileMetadataAccessor())
         .put(NioFileMetadataAccessor.class.getSimpleName(), new NioFileMetadataAccessor())
         .build();
-
 
     @Param({
         "FallbackFileMetadataAccessor",

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -315,6 +315,11 @@ public class NativeServices implements ServiceRegistrationProvider {
     }
 
     public static synchronized ServiceRegistry getInstance() {
+        if (INSTANCE == null) {
+            // If this occurs while running gradle or running integration tests, it is indicative of a problem.
+            // If this occurs while running unit tests, then either use the NativeServicesTestFixture or the '@UsesNativeServices' annotation.
+            throw new IllegalStateException("Cannot get an instance of NativeServices without first calling initialize().");
+        }
         return INSTANCE.services;
     }
 

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -81,7 +81,8 @@ import static org.gradle.internal.nativeintegration.filesystem.services.JdkFallb
  */
 public class NativeServices implements ServiceRegistrationProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(NativeServices.class);
-    private static NativeServices INSTANCE;
+    private static NativeServices instance;
+
     // TODO All this should be static
     private static final JansiBootPathConfigurer JANSI_BOOT_PATH_CONFIGURER = new JansiBootPathConfigurer();
 
@@ -231,9 +232,9 @@ public class NativeServices implements ServiceRegistrationProvider {
      */
     private static void initialize(File userHomeDir, EnumSet<NativeFeatures> requestedFeatures, NativeServicesMode mode) {
         checkNativeServicesMode(mode);
-        if (INSTANCE == null) {
+        if (instance == null) {
             try {
-                INSTANCE = new NativeServices(userHomeDir, requestedFeatures, mode);
+                instance = new NativeServices(userHomeDir, requestedFeatures, mode);
             } catch (RuntimeException e) {
                 throw new ServiceCreationException("Could not initialize native services.", e);
             }
@@ -315,12 +316,12 @@ public class NativeServices implements ServiceRegistrationProvider {
     }
 
     public static synchronized ServiceRegistry getInstance() {
-        if (INSTANCE == null) {
+        if (instance == null) {
             // If this occurs while running gradle or running integration tests, it is indicative of a problem.
             // If this occurs while running unit tests, then either use the NativeServicesTestFixture or the '@UsesNativeServices' annotation.
             throw new IllegalStateException("Cannot get an instance of NativeServices without first calling initialize().");
         }
-        return INSTANCE.services;
+        return instance.services;
     }
 
     @Provides

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.nativeintegration.services;
 
+import com.google.common.annotations.VisibleForTesting;
 import net.rubygrapefruit.platform.Native;
 import net.rubygrapefruit.platform.NativeException;
 import net.rubygrapefruit.platform.NativeIntegration;
@@ -74,6 +75,7 @@ import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.gradle.internal.nativeintegration.filesystem.services.JdkFallbackHelper.newInstanceOrFallback;
 
 /**
@@ -345,6 +347,11 @@ public class NativeServices implements ServiceRegistrationProvider {
             throw new IllegalStateException("Cannot get an instance of NativeServices without first calling initialize().");
         }
         return instance.services;
+    }
+
+    @VisibleForTesting
+    protected static synchronized Native getNative() {
+        return checkNotNull(instance).nativeIntegration;
     }
 
     @Provides

--- a/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
+++ b/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
@@ -32,7 +32,7 @@ import static org.gradle.test.fixtures.FileMetadataTestFixture.maybeRoundLastMod
 class NativePlatformBackedFileMetadataAccessorTest extends AbstractFileMetadataAccessorTest {
     @Override
     FileMetadataAccessor getAccessor() {
-        return new NativePlatformBackedFileMetadataAccessor(NativeServices.instance.get(Files.class))
+        return new NativePlatformBackedFileMetadataAccessor(NativeServices.getNative().get(Files.class))
     }
 
     @Override

--- a/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
+++ b/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
@@ -20,7 +20,7 @@ import net.rubygrapefruit.platform.file.Files
 import org.gradle.internal.file.AbstractFileMetadataAccessorTest
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.FileMetadataAccessor
-import org.gradle.testfixtures.internal.NativeServicesTestFixture
+import org.gradle.internal.nativeintegration.services.NativeServices
 import org.gradle.util.UsesNativeServices
 
 import java.nio.file.LinkOption
@@ -32,7 +32,7 @@ import static org.gradle.test.fixtures.FileMetadataTestFixture.maybeRoundLastMod
 class NativePlatformBackedFileMetadataAccessorTest extends AbstractFileMetadataAccessorTest {
     @Override
     FileMetadataAccessor getAccessor() {
-        return new NativePlatformBackedFileMetadataAccessor(NativeServicesTestFixture.instance.get(Files.class))
+        return new NativePlatformBackedFileMetadataAccessor(NativeServices.instance.get(Files.class))
     }
 
     @Override

--- a/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
+++ b/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
@@ -16,11 +16,11 @@
 
 package org.gradle.internal.nativeintegration.filesystem.services
 
-import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.file.Files
 import org.gradle.internal.file.AbstractFileMetadataAccessorTest
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.FileMetadataAccessor
+import org.gradle.testfixtures.internal.NativeServicesTestFixture
 import org.gradle.util.UsesNativeServices
 
 import java.nio.file.LinkOption
@@ -30,10 +30,9 @@ import static org.gradle.test.fixtures.FileMetadataTestFixture.maybeRoundLastMod
 
 @UsesNativeServices
 class NativePlatformBackedFileMetadataAccessorTest extends AbstractFileMetadataAccessorTest {
-
     @Override
     FileMetadataAccessor getAccessor() {
-        return new NativePlatformBackedFileMetadataAccessor(Native.get(Files.class))
+        return new NativePlatformBackedFileMetadataAccessor(NativeServicesTestFixture.instance.get(Files.class))
     }
 
     @Override

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.platform
 
 import net.rubygrapefruit.platform.SystemInfo
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.internal.nativeintegration.services.NativeServices
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
@@ -29,7 +30,6 @@ import org.gradle.nativeplatform.fixtures.binaryinfo.OtoolBinaryInfo
 import org.gradle.nativeplatform.fixtures.binaryinfo.ReadelfBinaryInfo
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.testfixtures.internal.NativeServicesTestFixture
 import spock.lang.Issue
 
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.SUPPORTS_32
@@ -56,7 +56,7 @@ model {
 
     def currentArch() {
         // On windows we currently target i386 by default, even on amd64
-        if (OperatingSystem.current().windows || NativeServicesTestFixture.instance.get(SystemInfo).architecture == SystemInfo.Architecture.i386) {
+        if (OperatingSystem.current().windows || NativeServices.instance.get(SystemInfo).architecture == SystemInfo.Architecture.i386) {
             return [name: "x86", altName: "i386"]
         }
         if (DefaultNativePlatform.getCurrentArchitecture().arm64) {

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.platform
 
-import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.SystemInfo
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.os.OperatingSystem
@@ -30,6 +29,7 @@ import org.gradle.nativeplatform.fixtures.binaryinfo.OtoolBinaryInfo
 import org.gradle.nativeplatform.fixtures.binaryinfo.ReadelfBinaryInfo
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.testfixtures.internal.NativeServicesTestFixture
 import spock.lang.Issue
 
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.SUPPORTS_32
@@ -56,7 +56,7 @@ model {
 
     def currentArch() {
         // On windows we currently target i386 by default, even on amd64
-        if (OperatingSystem.current().windows || Native.get(SystemInfo).architecture == SystemInfo.Architecture.i386) {
+        if (OperatingSystem.current().windows || NativeServicesTestFixture.instance.get(SystemInfo).architecture == SystemInfo.Architecture.i386) {
             return [name: "x86", altName: "i386"]
         }
         if (DefaultNativePlatform.getCurrentArchitecture().arm64) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -111,7 +111,7 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
             import org.gradle.internal.nativeintegration.NativeCapabilities
 
             tasks.register("doWork", WorkerTask)
-            println("Uses native integration in daemon: " + NativeServices.INSTANCE.createNativeCapabilities().useNativeIntegrations())
+            println("Uses native integration in daemon: " + NativeServices.instance.get(NativeCapabilities).useNativeIntegrations())
 
             abstract class WorkerTask extends DefaultTask {
                 @Inject
@@ -124,8 +124,9 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
             }
 
             abstract class NoOpWorkAction implements WorkAction<WorkParameters.None> {
+
                 void execute() {
-                    println("Uses native integration in worker: " + NativeServices.INSTANCE.createNativeCapabilities().useNativeIntegrations())
+                    println("Uses native integration in worker: " + NativeServices.instance.get(NativeCapabilities).useNativeIntegrations())
                 }
             }
         """)
@@ -203,7 +204,9 @@ class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
                     buildFile << \"""
                         println("Build inside a test executor initialized Native services: " + new File("${nativeDirOverride}").exists())
                         println("Build inside a test executor uses Native services: " +
-                            org.gradle.internal.nativeintegration.services.NativeServices.INSTANCE.createNativeCapabilities().useNativeIntegrations())
+                            org.gradle.internal.nativeintegration.services.NativeServices.instance
+                                .get(org.gradle.internal.nativeintegration.NativeCapabilities)
+                                .useNativeIntegrations())
                     \"""
 
                     when:

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -27,7 +27,7 @@ val jaxbVersion = "3.0.0"
 val junit5Version = "5.8.2"
 val mavenVersion = "3.9.5"
 val mavenResolverVersion = "1.9.16" // Should remain in-sync with `mavenVersion`
-val nativePlatformVersion = "0.22-milestone-27"
+val nativePlatformVersion = "0.22-milestone-28"
 val slf4jVersion = "1.7.36"
 val spockVersion = if (isBundleGroovy4) "2.3-groovy-4.0" else "2.3-groovy-3.0"
 val tomljVersion = "1.0.0"
@@ -73,7 +73,7 @@ dependencies {
         api(libs.eclipseSisuPlexus)     { version { strictly("0.3.5"); because("transitive dependency of Maven modules to process POM metadata") }}
         api(libs.errorProneAnnotations) { version { strictly("2.36.0") } } // don't forget to upgrade errorprone in gradlebuild.code-quality.gradle.kts
         api(libs.fastutil)              { version { strictly("8.5.2") }}
-        api(libs.gradleFileEvents)      { version { strictly("0.2.6") }}
+        api(libs.gradleFileEvents)      { version { strictly("0.2.7") }}
         api(libs.gradleProfiler)        { version { strictly("0.21.0-alpha-4") }}
         api(libs.develocityTestAnnotation) { version { strictly("2.0.1") }}
         api(libs.gcs)                   { version { strictly("v1-rev20220705-1.32.1") }}


### PR DESCRIPTION
This updated `native-platform` and `gradle-fileevents` to versions where the ability to load the libraries implicitly from the system temp directory has been removed.

See also:
- https://github.com/gradle/gradle/issues/31946
- https://github.com/gradle/gradle-fileevents/pull/31
- https://github.com/gradle/native-platform/pull/353

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
