### PR TITLE
Update Markdown processing for Release Notes

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/ReleaseNotesTransformer.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/ReleaseNotesTransformer.java
@@ -153,7 +153,7 @@ public class ReleaseNotesTransformer extends FilterReader {
 
         head.appendElement("link")
             .attr("rel", "stylesheet")
-            .attr("href", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css");
+            .attr("href", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css");
 
         head.appendElement("script")
             .attr("src", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js");

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/ReleaseNotesTransformer.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/ReleaseNotesTransformer.java
@@ -153,7 +153,7 @@ public class ReleaseNotesTransformer extends FilterReader {
 
         head.appendElement("link")
             .attr("rel", "stylesheet")
-            .attr("href", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css");
+            .attr("href", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css");
 
         head.appendElement("script")
             .attr("src", "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js");

--- a/platforms/documentation/docs/src/docs/css/base.css
+++ b/platforms/documentation/docs/src/docs/css/base.css
@@ -41,7 +41,7 @@ a {
 }
 
 a:hover, a:focus {
-    text-decoration: underline;
+    text-decoration: none;
 }
 
 a strong {
@@ -81,6 +81,10 @@ th {
 }
 
 /* typography */
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+    color: #02303A
+}
+
 h1, h2, h3, h4, h5, h6 {
     margin-top: 0;
     margin-bottom: 1rem;
@@ -267,6 +271,11 @@ blockquote p:last-child {
         margin-top: 0;
         margin-bottom: 0;
     }
+}
+
+/* code */
+code {
+    font-size: 90%;
 }
 
 /* util classes */

--- a/platforms/documentation/docs/src/docs/css/base.css
+++ b/platforms/documentation/docs/src/docs/css/base.css
@@ -41,6 +41,15 @@ a {
 }
 
 a:hover, a:focus {
+    text-decoration: underline;
+}
+
+h1 a:hover, h1 a:focus,
+h2 a:hover, h2 a:focus,
+h3 a:hover, h3 a:focus,
+h4 a:hover, h4 a:focus,
+h5 a:hover, h5 a:focus,
+h6 a:hover, h6 a:focus {
     text-decoration: none;
 }
 
@@ -82,7 +91,7 @@ th {
 
 /* typography */
 h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
-    color: #02303A
+    color: inherit;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/platforms/documentation/docs/src/docs/css/base.css
+++ b/platforms/documentation/docs/src/docs/css/base.css
@@ -276,6 +276,17 @@ blockquote p:last-child {
 /* code */
 code {
     font-size: 90%;
+    background-color: #f7f7f8;
+    border-radius: 4px;
+}
+
+*:not(pre) > code {
+    letter-spacing: 0;
+    padding: 0.1em 0.5ex;
+}
+
+.hljs {
+    background: #f7f7f8 !important;
 }
 
 /* util classes */

--- a/platforms/documentation/docs/src/docs/release/notes-template.md
+++ b/platforms/documentation/docs/src/docs/release/notes-template.md
@@ -10,7 +10,7 @@
 <meta name="twitter:description" content="TO DO">
 <meta name="twitter:image" content="https://gradle.org/images/releases/gradle-@version@.png">
 
-The Gradle team is excited to announce Gradle @version@ (released [@releaseDate@](https://gradle.org/releases/)).
+We are excited to announce Gradle @version@ (released [@releaseDate@](https://gradle.org/releases/)).
 
 This release features [1](), [2](), ... [n](), and more.
 
@@ -29,7 +29,9 @@ Be sure to check out the [public roadmap](https://blog.gradle.org/roadmap-announ
 
 Switch your build to use Gradle @version@ by updating the [Wrapper](userguide/gradle_wrapper.html) in your project:
 
-`./gradlew wrapper --gradle-version=@version@ && ./gradlew wrapper`
+```
+./gradlew wrapper --gradle-version=@version@ && ./gradlew wrapper
+```
 
 See the [Gradle 8.x upgrade guide](userguide/upgrading_version_8.html#changes_@baseVersion@) to learn about deprecations, breaking changes, and other considerations when upgrading to Gradle @version@.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -10,7 +10,7 @@
 <meta name="twitter:description" content="TO DO">
 <meta name="twitter:image" content="https://gradle.org/images/releases/gradle-@version@.png">
 
-The Gradle team is excited to announce Gradle @version@ (released [@releaseDate@](https://gradle.org/releases/)).
+We are excited to announce Gradle @version@ (released [@releaseDate@](https://gradle.org/releases/)).
 
 This release features [1](), [2](), ... [n](), and more.
 
@@ -42,7 +42,9 @@ Be sure to check out the [public roadmap](https://roadmap.gradle.org/) for insig
 
 Switch your build to use Gradle @version@ by updating the [Wrapper](userguide/gradle_wrapper.html) in your project:
 
-`./gradlew wrapper --gradle-version=@version@ && ./gradlew wrapper`
+```
+./gradlew wrapper --gradle-version=@version@ && ./gradlew wrapper
+```
 
 See the [Gradle 8.x upgrade guide](userguide/upgrading_version_8.html#changes_@baseVersion@) to learn about deprecations, breaking changes, and other considerations when upgrading to Gradle @version@.
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
Make upgrades to release notes for @alllex:

- [x] Remove underline to links on hover
- [x] Make code smaller font
- [x] Make linkable headers black font (not blue font)
- [x] Use better highlight.js theme with grey background
- [x] Make release announcement text one line
- [ ] Fix font family for code - **not seeing this issue**
- [ ] Reminder in release notes with TODO in metadata - **to become part of internal release process and to be documented internally**
