### PR TITLE
Improve provider compatibility of PublishArtifact and PublicationArtifact

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
@@ -17,17 +17,16 @@
 package org.gradle.api.internal.file;
 
 import org.gradle.api.Action;
-import org.gradle.api.Buildable;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.file.collections.FileCollectionObservationListener;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.internal.provider.PropertyHost;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
-import org.gradle.api.tasks.TaskDependency;
+import org.gradle.api.provider.Provider;
 import org.gradle.internal.Factory;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.service.scopes.Scope;
@@ -37,7 +36,6 @@ import java.io.File;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Consumer;
 
 @ServiceScope({Scope.Global.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
 public interface FileCollectionFactory {
@@ -58,22 +56,12 @@ public interface FileCollectionFactory {
     FileCollectionInternal create(MinimalFileSet contents);
 
     /**
-     * Creates a {@link FileCollection} with the given contents, and built by the given tasks.
-     *
-     * The collection is live, so that the contents are queried as required on query of the collection.
+     *  Create a file collection which is backed by a provider of file system locations.
+     *  <p>
+     *  Preferable over {@link #create(MinimalFileSet)} when the file elements are derived from
+     *  providers with task dependencies.
      */
-    FileCollectionInternal create(TaskDependency builtBy, MinimalFileSet contents);
-
-    /**
-     * Creates a {@link FileCollection} with the given contents, and visiting its task dependencies (the tasks that it is built by) in the specified way.
-     * <p>
-     * The collection is live, so that the contents are queried as required on query of the collection.
-     *
-     * @param contents The file set contents for the constructed file collection
-     * @param visitTaskDependencies The implementation of visiting dependencies for the constructed file collection's {@link Buildable#getBuildDependencies()}
-     * @see org.gradle.api.internal.tasks.TaskDependencyFactory#visitingDependencies(Consumer)
-     */
-    FileCollectionInternal create(MinimalFileSet contents, Consumer<? super TaskDependencyResolveContext> visitTaskDependencies);
+    FileCollection fromProvider(Provider<List<FileSystemLocation>> elements);
 
     /**
      * Creates an empty {@link FileCollection}

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/UnpackingVisitor.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/UnpackingVisitor.java
@@ -72,7 +72,6 @@ public class UnpackingVisitor {
             return;
         }
         if (element instanceof ProviderInternal) {
-            // ProviderInternal is-a TaskDependencyContainer, so check first
             ProviderInternal<?> provider = (ProviderInternal<?>) element;
             visitor.accept(new ProviderBackedFileCollection(provider, resolver, taskDependencyFactory, patternSetFactory, providerResolutionStrategy));
             return;

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -66,26 +66,6 @@ class DefaultFileCollectionFactoryTest extends Specification {
         0 * contents._
     }
 
-    def "lazily queries dependencies of collection created from MinimalFileSet"() {
-        def contents = Mock(MinimalFileSet)
-        def builtBy = Mock(TaskDependencyInternal)
-        def task = Stub(Task)
-
-        when:
-        def collection = factory.create(builtBy, contents)
-
-        then:
-        0 * builtBy._
-
-        when:
-        def tasks = collection.buildDependencies.getDependencies(null)
-
-        then:
-        tasks == [task] as Set
-        1 * builtBy.getDependenciesForInternalUse(_) >> [task]
-        0 * _
-    }
-
     def "constructs a configurable collection"() {
         expect:
         def collection = factory.configurableFiles("some collection")

--- a/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
+++ b/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSetOutput;
-import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import javax.annotation.Nullable;
@@ -44,7 +43,7 @@ public abstract class DefaultSourceSetOutput extends CompositeFileCollection imp
     private final ConfigurableFileCollection generatedSourcesDirs;
     private final FileResolver fileResolver;
 
-    private DirectoryContribution resourcesContributor;
+    private Provider<File> resourcesContributor;
 
     @Inject
     public DefaultSourceSetOutput(String sourceSetDisplayName, TaskDependencyFactory taskDependencyFactory, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
@@ -86,14 +85,13 @@ public abstract class DefaultSourceSetOutput extends CompositeFileCollection imp
     }
 
     /**
-     * Set the task contributor to the provided resources directory. The provided resources
+     * Set the contributor to the provided resources directory. The provided resources
      * directory provider should resolve to the same directory set by {@link #setResourcesDir}.
      *
      * @param directory The resources directory provider.
-     * @param task The task which generates {@code directory}.
      */
-    public void setResourcesContributor(Provider<File> directory, TaskProvider<?> task) {
-        this.resourcesContributor = new DirectoryContribution(directory, task);
+    public void setResourcesContributor(Provider<File> directory) {
+        this.resourcesContributor = directory;
     }
 
     @Override
@@ -147,28 +145,8 @@ public abstract class DefaultSourceSetOutput extends CompositeFileCollection imp
     }
 
     @Nullable
-    public DirectoryContribution getResourcesContribution() {
+    public Provider<File> getResourcesContribution() {
         return resourcesContributor;
     }
 
-    /**
-     * A mapping from a directory to the task which provides that directory.
-     */
-    public static class DirectoryContribution {
-        private final Provider<File> directory;
-        private final TaskProvider<?> task;
-
-        public DirectoryContribution(Provider<File> directory, TaskProvider<?> task) {
-            this.directory = directory;
-            this.task = task;
-        }
-
-        public Provider<File> getDirectory() {
-            return directory;
-        }
-
-        public TaskProvider<?> getTask() {
-            return task;
-        }
-    }
 }

--- a/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/AbstractJvmPluginServicesTest.groovy
+++ b/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/AbstractJvmPluginServicesTest.groovy
@@ -69,9 +69,9 @@ abstract class AbstractJvmPluginServicesTest extends Specification {
     @Subject
     DefaultJvmPluginServices services = new DefaultJvmPluginServices(
         TestUtil.objectFactory(),
-        TestUtil.providerFactory(),
         TestUtil.instantiatorFactory().decorateScheme().instantiator(),
-        project
+        project,
+        TestFiles.fileFactory()
     )
 
     DefaultJvmLanguageUtilities jvmLanguageUtilities = new DefaultJvmLanguageUtilities(

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -249,7 +249,7 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
             resourcesTask.from(resourceSet);
         });
         DefaultSourceSetOutput output = Cast.uncheckedCast(sourceSet.getOutput());
-        output.setResourcesContributor(processResources.map(Copy::getDestinationDir), processResources);
+        output.setResourcesContributor(processResources.map(Copy::getDestinationDir));
     }
 
     private void createClassesTask(final SourceSet sourceSet, Project target) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/FileSystemPublishArtifact.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/FileSystemPublishArtifact.java
@@ -16,9 +16,11 @@
 
 package org.gradle.api.internal.artifacts.dsl;
 
-import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.internal.artifacts.PublishArtifactInternal;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskDependency;
 
 import javax.annotation.Nullable;
@@ -37,6 +39,11 @@ public class FileSystemPublishArtifact implements PublishArtifactInternal {
     }
 
     @Override
+    public Provider<FileSystemLocation> getFileProvider() {
+        return Providers.of(fileSystemLocation);
+    }
+
+    @Override
     public String getName() {
         return getValue().getName();
     }
@@ -48,7 +55,7 @@ public class FileSystemPublishArtifact implements PublishArtifactInternal {
 
     @Override
     public String getType() {
-        return "";
+        return getValue().getExtension();
     }
 
     @Override
@@ -63,7 +70,7 @@ public class FileSystemPublishArtifact implements PublishArtifactInternal {
 
     @Override
     public Date getDate() {
-        return new Date();
+        return null;
     }
 
     @Override

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/ArchiveTaskBasedIvyArtifact.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/ArchiveTaskBasedIvyArtifact.java
@@ -16,25 +16,20 @@
 
 package org.gradle.api.publish.ivy.internal.artifact;
 
-import com.google.common.collect.ImmutableSet;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationCoordinates;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
-
-import java.io.File;
 
 public class ArchiveTaskBasedIvyArtifact extends AbstractIvyArtifact {
     private final AbstractArchiveTask archiveTask;
     private final IvyPublicationCoordinates coordinates;
-    private final TaskDependencyInternal buildDependencies;
 
     public ArchiveTaskBasedIvyArtifact(AbstractArchiveTask archiveTask, IvyPublicationCoordinates coordinates, TaskDependencyFactory taskDependencyFactory) {
-        super(taskDependencyFactory);
+        super(taskDependencyFactory, archiveTask);
         this.archiveTask = archiveTask;
         this.coordinates = coordinates;
-        this.buildDependencies = taskDependencyFactory.configurableDependency(ImmutableSet.of(archiveTask));
     }
 
     @Override
@@ -63,13 +58,8 @@ public class ArchiveTaskBasedIvyArtifact extends AbstractIvyArtifact {
     }
 
     @Override
-    protected TaskDependency getDefaultBuildDependencies() {
-        return buildDependencies;
-    }
-
-    @Override
-    public File getFile() {
-        return archiveTask.getArchiveFile().get().getAsFile();
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        return archiveTask.getArchiveFile();
     }
 
     @Override

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/DerivedIvyArtifact.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/DerivedIvyArtifact.java
@@ -16,12 +16,13 @@
 
 package org.gradle.api.publish.ivy.internal.artifact;
 
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.internal.file.DefaultFileSystemLocation;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
-import org.gradle.api.tasks.TaskDependency;
-
-import java.io.File;
 
 import static com.google.common.io.Files.getFileExtension;
 
@@ -30,7 +31,7 @@ public class DerivedIvyArtifact extends AbstractIvyArtifact {
     private final PublicationInternal.DerivedArtifact derived;
 
     public DerivedIvyArtifact(IvyArtifact original, PublicationInternal.DerivedArtifact derived, TaskDependencyFactory taskDependencyFactory) {
-        super(taskDependencyFactory);
+        super(taskDependencyFactory, original);
         this.original = original;
         this.derived = derived;
     }
@@ -61,13 +62,8 @@ public class DerivedIvyArtifact extends AbstractIvyArtifact {
     }
 
     @Override
-    protected TaskDependency getDefaultBuildDependencies() {
-        return original.getBuildDependencies();
-    }
-
-    @Override
-    public File getFile() {
-        return derived.create();
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        return Providers.of(new DefaultFileSystemLocation(derived.create()));
     }
 
     @Override

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/FileBasedIvyArtifact.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/FileBasedIvyArtifact.java
@@ -17,10 +17,12 @@
 package org.gradle.api.publish.ivy.internal.artifact;
 
 import com.google.common.io.Files;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.internal.file.DefaultFileSystemLocation;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationCoordinates;
-import org.gradle.api.tasks.TaskDependency;
 
 import java.io.File;
 
@@ -35,7 +37,6 @@ public class FileBasedIvyArtifact extends AbstractIvyArtifact {
         extension = Files.getFileExtension(file.getName());
         this.coordinates = coordinates;
     }
-
     @Override
     protected String getDefaultName() {
         return coordinates.getModule().get();
@@ -62,14 +63,10 @@ public class FileBasedIvyArtifact extends AbstractIvyArtifact {
     }
 
     @Override
-    protected TaskDependency getDefaultBuildDependencies() {
-        return TaskDependencyInternal.EMPTY;
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        return Providers.of(new DefaultFileSystemLocation(file));
     }
 
-    @Override
-    public File getFile() {
-        return file;
-    }
 
     @Override
     public boolean shouldBePublished() {

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/NormalizedIvyArtifact.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/NormalizedIvyArtifact.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.publish.ivy.internal.artifact;
 
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskDependency;
@@ -44,6 +45,11 @@ public class NormalizedIvyArtifact implements IvyArtifactInternal, Serializable 
         this.extension = artifact.getExtension();
         this.classifier = artifact.getClassifier();
         this.shouldBePublished = new DefaultProvider<>(artifact::shouldBePublished);
+    }
+
+    @Override
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        throw new IllegalStateException();
     }
 
     @Override

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/PublishArtifactBasedIvyArtifact.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/PublishArtifactBasedIvyArtifact.java
@@ -16,20 +16,18 @@
 
 package org.gradle.api.publish.ivy.internal.artifact;
 
-import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationCoordinates;
-import org.gradle.api.tasks.TaskDependency;
-
-import java.io.File;
 
 public class PublishArtifactBasedIvyArtifact extends AbstractIvyArtifact {
-    private final PublishArtifact artifact;
+    private final PublishArtifactInternal artifact;
     private final IvyPublicationCoordinates coordinates;
 
-    public PublishArtifactBasedIvyArtifact(PublishArtifact artifact, IvyPublicationCoordinates coordinates, TaskDependencyFactory taskDependencyFactory) {
-        super(taskDependencyFactory);
+    public PublishArtifactBasedIvyArtifact(PublishArtifactInternal artifact, IvyPublicationCoordinates coordinates, TaskDependencyFactory taskDependencyFactory) {
+        super(taskDependencyFactory, artifact);
         this.artifact = artifact;
         this.coordinates = coordinates;
     }
@@ -60,13 +58,8 @@ public class PublishArtifactBasedIvyArtifact extends AbstractIvyArtifact {
     }
 
     @Override
-    protected TaskDependency getDefaultBuildDependencies() {
-        return artifact.getBuildDependencies();
-    }
-
-    @Override
-    public File getFile() {
-        return artifact.getFile();
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        return artifact.getFileProvider();
     }
 
     @Override

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
@@ -17,15 +17,15 @@
 package org.gradle.api.publish.ivy.internal.artifact;
 
 import org.gradle.api.Task;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.file.DefaultFileSystemLocation;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationCoordinates;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
 
 import javax.annotation.Nullable;
-import java.io.File;
 
 public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
 
@@ -34,18 +34,14 @@ public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
     private final String extension;
     private final String type;
     private final String classifier;
-    private final TaskDependencyInternal buildDependencies;
 
     public SingleOutputTaskIvyArtifact(TaskProvider<? extends Task> generator, IvyPublicationCoordinates coordinates, String extension, String type, @Nullable String classifier, TaskDependencyFactory taskDependencyFactory) {
-        super(taskDependencyFactory);
+        super(taskDependencyFactory, generator);
         this.generator = generator;
         this.coordinates = coordinates;
         this.extension = extension;
         this.type = type;
         this.classifier = classifier;
-        this.buildDependencies = taskDependencyFactory.visitingDependencies(context -> {
-            context.add(generator.get());
-        });
     }
 
     @Override
@@ -74,13 +70,8 @@ public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
     }
 
     @Override
-    protected TaskDependency getDefaultBuildDependencies() {
-        return buildDependencies;
-    }
-
-    @Override
-    public File getFile() {
-        return generator.get().getOutputs().getFiles().getSingleFile();
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        return generator.map(task -> new DefaultFileSystemLocation(task.getOutputs().getFiles().getSingleFile()));
     }
 
     public boolean isEnabled() {

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -129,9 +129,9 @@ public abstract class DefaultIvyPublication implements IvyPublicationInternal {
         this.componentConfigurations.convention(getComponent().map(ivyComponentParser::parseConfigurations));
         this.componentConfigurations.finalizeValueOnRead();
 
-        this.mainArtifacts = instantiator.newInstance(DefaultIvyArtifactSet.class, name, ivyArtifactNotationParser, fileCollectionFactory, collectionCallbackActionDecorator);
-        this.metadataArtifacts = new DefaultPublicationArtifactSet<>(IvyArtifact.class, "metadata artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
-        this.derivedArtifacts = new DefaultPublicationArtifactSet<>(IvyArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
+        this.mainArtifacts = instantiator.newInstance(DefaultIvyArtifactSet.class, ivyArtifactNotationParser, fileCollectionFactory, collectionCallbackActionDecorator);
+        this.metadataArtifacts = new DefaultPublicationArtifactSet<>(IvyArtifact.class, fileCollectionFactory, collectionCallbackActionDecorator);
+        this.derivedArtifacts = new DefaultPublicationArtifactSet<>(IvyArtifact.class, fileCollectionFactory, collectionCallbackActionDecorator);
         this.publishableArtifacts = new CompositePublicationArtifactSet<>(taskDependencyFactory, IvyArtifact.class, Cast.uncheckedCast(new PublicationArtifactSet<?>[]{mainArtifacts, metadataArtifacts, derivedArtifacts}));
 
         this.configurations = instantiator.newInstance(DefaultIvyConfigurationContainer.class, instantiator, collectionCallbackActionDecorator);

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/ArchiveTaskBasedMavenArtifact.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/ArchiveTaskBasedMavenArtifact.java
@@ -16,26 +16,22 @@
 
 package org.gradle.api.publish.maven.internal.artifact;
 
-import com.google.common.collect.ImmutableSet;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
-
-import java.io.File;
 
 public class ArchiveTaskBasedMavenArtifact extends AbstractMavenArtifact {
     private final AbstractArchiveTask archiveTask;
-    private final TaskDependencyInternal buildDependencies;
 
     public ArchiveTaskBasedMavenArtifact(AbstractArchiveTask archiveTask, TaskDependencyFactory taskDependencyFactory) {
-        super(taskDependencyFactory);
+        super(taskDependencyFactory, archiveTask);
         this.archiveTask = archiveTask;
-        this.buildDependencies = taskDependencyFactory.configurableDependency(ImmutableSet.of(archiveTask));
     }
 
     @Override
-    public File getFile() {
-        return archiveTask.getArchiveFile().get().getAsFile();
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        return archiveTask.getArchiveFile();
     }
 
     @Override
@@ -46,11 +42,6 @@ public class ArchiveTaskBasedMavenArtifact extends AbstractMavenArtifact {
     @Override
     protected String getDefaultClassifier() {
         return archiveTask.getArchiveClassifier().getOrNull();
-    }
-
-    @Override
-    protected TaskDependencyInternal getDefaultBuildDependencies() {
-        return buildDependencies;
     }
 
     @Override

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/DerivedMavenArtifact.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/DerivedMavenArtifact.java
@@ -16,11 +16,12 @@
 
 package org.gradle.api.publish.maven.internal.artifact;
 
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.internal.file.DefaultFileSystemLocation;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.internal.PublicationInternal;
-
-import java.io.File;
 
 import static com.google.common.io.Files.getFileExtension;
 
@@ -35,8 +36,8 @@ public class DerivedMavenArtifact extends AbstractMavenArtifact {
     }
 
     @Override
-    public File getFile() {
-        return derivedFile.create();
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        return Providers.of(new DefaultFileSystemLocation(derivedFile.create()));
     }
 
     @Override
@@ -47,11 +48,6 @@ public class DerivedMavenArtifact extends AbstractMavenArtifact {
     @Override
     protected String getDefaultClassifier() {
         return original.getClassifier();
-    }
-
-    @Override
-    protected TaskDependencyInternal getDefaultBuildDependencies() {
-        return TaskDependencyInternal.EMPTY;
     }
 
     @Override

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/FileBasedMavenArtifact.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/FileBasedMavenArtifact.java
@@ -17,8 +17,11 @@
 package org.gradle.api.publish.maven.internal.artifact;
 
 import com.google.common.io.Files;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.internal.file.DefaultFileSystemLocation;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.provider.Provider;
 
 import java.io.File;
 
@@ -33,8 +36,8 @@ public class FileBasedMavenArtifact extends AbstractMavenArtifact {
     }
 
     @Override
-    public File getFile() {
-        return file;
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        return Providers.of(new DefaultFileSystemLocation(file));
     }
 
     @Override
@@ -45,11 +48,6 @@ public class FileBasedMavenArtifact extends AbstractMavenArtifact {
     @Override
     protected String getDefaultClassifier() {
         return null;
-    }
-
-    @Override
-    protected TaskDependencyInternal getDefaultBuildDependencies() {
-        return TaskDependencyInternal.EMPTY;
     }
 
     @Override

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/PublishArtifactBasedMavenArtifact.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/PublishArtifactBasedMavenArtifact.java
@@ -16,24 +16,22 @@
 
 package org.gradle.api.publish.maven.internal.artifact;
 
-import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
-import org.gradle.api.tasks.TaskDependency;
-
-import java.io.File;
+import org.gradle.api.provider.Provider;
 
 public class PublishArtifactBasedMavenArtifact extends AbstractMavenArtifact {
-    private final PublishArtifact publishArtifact;
+    private final PublishArtifactInternal publishArtifact;
 
-    public PublishArtifactBasedMavenArtifact(PublishArtifact publishArtifact, TaskDependencyFactory taskDependencyFactory) {
-        super(taskDependencyFactory);
+    public PublishArtifactBasedMavenArtifact(PublishArtifactInternal publishArtifact, TaskDependencyFactory taskDependencyFactory) {
+        super(taskDependencyFactory, publishArtifact);
         this.publishArtifact = publishArtifact;
     }
 
     @Override
-    public File getFile() {
-        return publishArtifact.getFile();
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        return publishArtifact.getFileProvider();
     }
 
     @Override
@@ -44,11 +42,6 @@ public class PublishArtifactBasedMavenArtifact extends AbstractMavenArtifact {
     @Override
     protected String getDefaultClassifier() {
         return publishArtifact.getClassifier();
-    }
-
-    @Override
-    protected TaskDependency getDefaultBuildDependencies() {
-        return publishArtifact.getBuildDependencies();
     }
 
     @Override

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
@@ -17,33 +17,27 @@
 package org.gradle.api.publish.maven.internal.artifact;
 
 import org.gradle.api.Task;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
-import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.internal.file.DefaultFileSystemLocation;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
-
-import java.io.File;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskProvider;
 
 public class SingleOutputTaskMavenArtifact extends AbstractMavenArtifact {
     private final TaskProvider<? extends Task> generator;
     private final String extension;
     private final String classifier;
-    private final TaskDependencyInternal buildDependencies;
 
     public SingleOutputTaskMavenArtifact(TaskProvider<? extends Task> generator, String extension, String classifier, TaskDependencyFactory taskDependencyFactory) {
-        super(taskDependencyFactory);
+        super(taskDependencyFactory, generator);
         this.generator = generator;
         this.extension = extension;
         this.classifier = classifier;
-        this.buildDependencies = taskDependencyFactory.visitingDependencies(context -> context.add(getGenerator()));
     }
 
     @Override
-    public File getFile() {
-        return getGenerator().getOutputs().getFiles().getSingleFile();
-    }
-
-    private Task getGenerator() {
-        return generator.get();
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        return generator.map(task -> new DefaultFileSystemLocation(task.getOutputs().getFiles().getSingleFile()));
     }
 
     @Override
@@ -56,13 +50,8 @@ public class SingleOutputTaskMavenArtifact extends AbstractMavenArtifact {
         return classifier;
     }
 
-    @Override
-    protected TaskDependencyInternal getDefaultBuildDependencies() {
-        return buildDependencies;
-    }
-
     public boolean isEnabled() {
-        return getGenerator().getEnabled();
+        return generator.get().getEnabled();
     }
 
     @Override

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/DefaultPublicationArtifactSet.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/DefaultPublicationArtifactSet.java
@@ -16,52 +16,27 @@
 
 package org.gradle.api.publish.internal;
 
+import com.google.common.collect.Collections2;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.file.collections.MinimalFileSet;
+import org.gradle.api.internal.provider.MergeProvider;
 import org.gradle.api.publish.PublicationArtifact;
-
-import java.io.File;
-import java.util.LinkedHashSet;
-import java.util.Set;
 
 public class DefaultPublicationArtifactSet<T extends PublicationArtifact> extends DefaultDomainObjectSet<T> implements PublicationArtifactSet<T> {
 
-    private final String name;
     private final FileCollection files;
 
     public DefaultPublicationArtifactSet(
         Class<T> type,
-        String name,
         FileCollectionFactory fileCollectionFactory,
         CollectionCallbackActionDecorator collectionCallbackActionDecorator
     ) {
         super(type, collectionCallbackActionDecorator);
-        this.name = name;
-        files = fileCollectionFactory.create(
-            new MinimalFileSet() {
-                @Override
-                public String getDisplayName() {
-                    return DefaultPublicationArtifactSet.this.name;
-                }
-
-                @Override
-                public Set<File> getFiles() {
-                    Set<File> result = new LinkedHashSet<File>();
-                    for (PublicationArtifact artifact : DefaultPublicationArtifactSet.this) {
-                        result.add(artifact.getFile());
-                    }
-                    return result;
-                }
-            },
-            context -> {
-                for (PublicationArtifact artifact : DefaultPublicationArtifactSet.this) {
-                    context.add(artifact.getBuildDependencies());
-                }
-            }
-        );
+        this.files = fileCollectionFactory.fromProvider(MergeProvider.of(
+            Collections2.transform(this, artifact -> ((PublicationArtifactInternal) artifact).getFileProvider())
+        ));
     }
 
     @Override

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/PublicationArtifactInternal.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/PublicationArtifactInternal.java
@@ -15,8 +15,19 @@
  */
 package org.gradle.api.publish.internal;
 
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.PublicationArtifact;
 
 public interface PublicationArtifactInternal extends PublicationArtifact {
+
+    /**
+     * Returns the same value as {@link #getFile()}, but also carries
+     * dependencies from {@link #getBuildDependencies()}.
+     *
+     * TODO: Eventually, the public API should expose this provider.
+     */
+    Provider<? extends FileSystemLocation> getFileProvider();
+
     boolean shouldBePublished();
 }

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Signature.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Signature.java
@@ -20,7 +20,7 @@ import org.gradle.api.Buildable;
 import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.internal.artifacts.publish.AbstractPublishArtifact;
+import org.gradle.api.internal.artifacts.publish.AbstractConfigurablePublishArtifact;
 import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
@@ -45,7 +45,7 @@ import static org.gradle.internal.UncheckedException.uncheckedCall;
  *
  * <p>A signature file is always generated from another file, which may be a {@link PublishArtifact}.</p>
  */
-public class Signature extends AbstractPublishArtifact {
+public class Signature extends AbstractConfigurablePublishArtifact {
 
     /**
      * The specification of how to generate the signature.
@@ -200,6 +200,7 @@ public class Signature extends AbstractPublishArtifact {
         return uncheckedCall(toSignGenerator);
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }
@@ -231,6 +232,7 @@ public class Signature extends AbstractPublishArtifact {
         return file != null ? file.getName() : null;
     }
 
+    @Override
     public void setExtension(String extension) {
         this.extension = extension;
     }
@@ -257,6 +259,7 @@ public class Signature extends AbstractPublishArtifact {
         return signatureType != null ? signatureType.getExtension() : null;
     }
 
+    @Override
     public void setType(String type) {
         this.type = type;
     }
@@ -287,6 +290,7 @@ public class Signature extends AbstractPublishArtifact {
             : null;
     }
 
+    @Override
     public void setClassifier(String classifier) {
         this.classifier = classifier;
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/PublishArtifact.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/PublishArtifact.java
@@ -72,7 +72,7 @@ public interface PublishArtifact extends Buildable {
      * Returns the date that should be used when publishing this artifact. This is used
      * in the module descriptor accompanying this artifact (the ivy.xml). If the date is
      * not specified, the current date is used. If this artifact
-     * is published without an module descriptor, this property has no relevance.
+     * is published without a module descriptor, this property has no relevance.
      *
      * @return The date. May be null.
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/PublishArtifactInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/PublishArtifactInternal.java
@@ -16,8 +16,19 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.provider.Provider;
 
 public interface PublishArtifactInternal extends PublishArtifact {
+
+    /**
+     * Returns the same value as {@link #getFile()}, but also carries
+     * dependencies from {@link #getBuildDependencies()}.
+     *
+     * TODO: Eventually, the public API should expose a file provider/property.
+     */
+    Provider<? extends FileSystemLocation> getFileProvider();
+
     boolean shouldBePublished();
 
     static boolean shouldBePublished(PublishArtifact artifact) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/AbstractConfigurablePublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/AbstractConfigurablePublishArtifact.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2007-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.publish;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.ConfigurablePublishArtifact;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.internal.artifacts.PublishArtifactInternal;
+import org.gradle.api.internal.file.DefaultFileSystemLocation;
+import org.gradle.api.internal.lambdas.SerializableLambdas;
+import org.gradle.api.internal.provider.BuildableBackedProvider;
+import org.gradle.api.internal.tasks.DefaultTaskDependency;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskDependency;
+
+/**
+ * Implements {@link org.gradle.api.Buildable} and {@link #builtBy(Object...)} for {@link ConfigurablePublishArtifact}.
+ * <p>
+ * In future versions, We should drop {@link org.gradle.api.Buildable} from
+ * {@link org.gradle.api.artifacts.PublishArtifact}, and therefore this class will no longer be needed.
+ */
+public abstract class AbstractConfigurablePublishArtifact implements ConfigurablePublishArtifact, PublishArtifactInternal, TaskDependencyContainer {
+
+    private final DefaultTaskDependency taskDependency;
+
+    public AbstractConfigurablePublishArtifact(
+        TaskDependencyFactory taskDependencyFactory,
+        Object... dependencies
+    ) {
+        taskDependency = taskDependencyFactory.configurableDependency(ImmutableSet.copyOf(dependencies));
+    }
+
+    @Override
+    public ConfigurablePublishArtifact builtBy(Object... tasks) {
+        taskDependency.add(tasks);
+        return this;
+    }
+
+    @Override
+    public Provider<? extends FileSystemLocation> getFileProvider() {
+        // Ideally, subclasses would implement this method directly, but since we need to
+        // include dependencies from `builtBy`, we implement this here and delegate to getFile().
+        return new BuildableBackedProvider<>(this, FileSystemLocation.class, SerializableLambdas.factory(() -> new DefaultFileSystemLocation(getFile())));
+    }
+
+    @Override
+    public TaskDependency getBuildDependencies() {
+        return taskDependency;
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        context.add(taskDependency);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " " + getName() + ":" + getType() + ":" + getExtension()  + ":" + getClassifier();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DecoratingPublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DecoratingPublishArtifact.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.publish;
 
-import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -24,27 +23,26 @@ import org.gradle.util.internal.GUtil;
 import java.io.File;
 import java.util.Date;
 
-public class DecoratingPublishArtifact extends AbstractPublishArtifact implements ConfigurablePublishArtifact {
+/**
+ * Wraps a {@link PublishArtifactInternal} to provide mutability, by implementing the
+ * {@link org.gradle.api.artifacts.ConfigurablePublishArtifact} interface.
+ */
+public class DecoratingPublishArtifact extends AbstractConfigurablePublishArtifact {
+
     private String name;
     private String extension;
     private String type;
     private String classifier;
-    private final PublishArtifact publishArtifact;
+    private final PublishArtifactInternal publishArtifact;
     private boolean classifierSet;
 
-    public DecoratingPublishArtifact(TaskDependencyFactory taskDependencyFactory, PublishArtifact publishArtifact) {
+    public DecoratingPublishArtifact(TaskDependencyFactory taskDependencyFactory, PublishArtifactInternal publishArtifact) {
         super(taskDependencyFactory, publishArtifact.getBuildDependencies());
         this.publishArtifact = publishArtifact;
     }
 
     public PublishArtifact getPublishArtifact() {
         return publishArtifact;
-    }
-
-    @Override
-    public DecoratingPublishArtifact builtBy(Object... tasks) {
-        super.builtBy(tasks);
-        return this;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DefaultPublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DefaultPublishArtifact.java
@@ -16,14 +16,26 @@
 
 package org.gradle.api.internal.artifacts.publish;
 
-import org.gradle.api.artifacts.ConfigurablePublishArtifact;
+import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
-import org.gradle.api.internal.tasks.TaskDependencyFactory;
 
 import java.io.File;
 import java.util.Date;
 
-public class DefaultPublishArtifact extends AbstractPublishArtifact implements ConfigurablePublishArtifact {
+/**
+ * This is only used for testing. Prefer:
+ * <ui>
+ *     <li>{@link org.gradle.api.internal.artifacts.dsl.FileSystemPublishArtifact} for fixed files</li>
+ *     <li>{@link org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact} for providers of unknown type</li>
+ *     <li>{@link org.gradle.api.internal.artifacts.publish.AbstractProviderBackedPublishArtifact} for providers of known types</li>
+ * </ui>
+ *
+ * If necessary, any of the above implementations can be wrapped in
+ * {@link DecoratingPublishArtifact} to provide mutability.
+ */
+@VisibleForTesting
+public class DefaultPublishArtifact extends AbstractConfigurablePublishArtifact {
+
     private String name;
     private String extension;
     private String type;
@@ -32,20 +44,14 @@ public class DefaultPublishArtifact extends AbstractPublishArtifact implements C
     private File file;
 
     public DefaultPublishArtifact(
-        TaskDependencyFactory taskDependencyFactory,
-        String name, String extension, String type,
-        String classifier, Date date, File file, Object... tasks) {
-        super(taskDependencyFactory, tasks);
-        this.name = name;
-        this.extension = extension;
-        this.type = type;
-        this.date = date;
-        this.classifier = classifier;
-        this.file = file;
-    }
-
-    public DefaultPublishArtifact(String name, String extension, String type,
-                                  String classifier, Date date, File file, Object... tasks) {
+        String name,
+        String extension,
+        String type,
+        String classifier,
+        Date date,
+        File file,
+        Object... tasks
+    ) {
         super(DefaultTaskDependencyFactory.withNoAssociatedProject(), tasks);
         this.name = name;
         this.extension = extension;
@@ -53,12 +59,6 @@ public class DefaultPublishArtifact extends AbstractPublishArtifact implements C
         this.date = date;
         this.classifier = classifier;
         this.file = file;
-    }
-
-    @Override
-    public DefaultPublishArtifact builtBy(Object... tasks) {
-        super.builtBy(tasks);
-        return this;
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/AbstractConfigurablePublishArtifactTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/AbstractConfigurablePublishArtifactTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.publish
 import org.gradle.api.artifacts.PublishArtifact
 import spock.lang.Specification
 
-public abstract class AbstractPublishArtifactTest extends Specification {
+abstract class AbstractConfigurablePublishArtifactTest extends Specification {
     private static final File TEST_FILE = new File("artifactFile");
     private static final String TEST_NAME = "myfile-1";
     private static final String TEST_EXT = "ext";

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/ArchivePublishArtifactTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/ArchivePublishArtifactTest.groovy
@@ -37,7 +37,6 @@ class ArchivePublishArtifactTest extends Specification {
         def a = new ArchivePublishArtifact(TestFiles.taskDependencyFactory(), quiteEmptyJar)
 
         then:
-        a.archiveTask == quiteEmptyJar
         a.classifier == ""
         a.date.time == quiteEmptyJar.archiveFile.get().asFile.lastModified()
         a.extension == "jar"

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/DefaultPublishArtifactTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/DefaultPublishArtifactTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.publish
 
 import org.gradle.api.Task
 
-public class DefaultPublishArtifactTest extends AbstractPublishArtifactTest {
+class DefaultPublishArtifactTest extends AbstractConfigurablePublishArtifactTest {
 
     def "init"() {
         given:


### PR DESCRIPTION
PublishArtifact and PublicationArtifact are similar, and describe a single artifact for a local or published variant, respectively. They both implement Buildable, and rely on that interface to carry task dependencies of the artifact they describe.

We have noticed some problems with the way publishing deals with mapped providers, and it is clear that publishing is reading task outputs before they have been executed. In many cases this can work but in other cases can silently cause errors or in the case of mapped providers, loud errors.

We update PublishArtifact and PublicationArtifact to both track their task dependencies using a Provider. This provider is internal at the moment, but we can expose it later as part of the provider API migration.

The Buildable interface is now derived from the dependenices of this provider when possible.

When delaying access of files to execution time, we discovered we are not properly creating file collections in a configuration cache safe manner. We introduce a new method of creating a file collection from a provider of list of files, making it much easier to create a file collection from a set of publish artifacts.

This does not solve the problem, but lays some initial groundwork to making it possible to define proper inputs for the publish tasks, so that they are able to generate inputs that are cc safe and avoid reading task outputs before task execution.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
