### PR TITLE
Dependabot: provide configuration about the expected labels without activating PR creation to suppress label creation for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,12 @@ updates:
       - "@dev-productivity"
       - "a:chore"
       - "in:building-gradle"
+  - package-ecosystem: "gradle"
+    open-pull-requests-limit: 0
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "@dev-productivity"
+      - "a:chore"
+      - "in:building-gradle"


### PR DESCRIPTION
Fixes gradle/gradle-private#4576

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
