### PR TITLE
Enable IP tests for projects that have no integ tests

### DIFF
--- a/platforms/core-configuration/api-metadata/build.gradle.kts
+++ b/platforms/core-configuration/api-metadata/build.gradle.kts
@@ -4,6 +4,3 @@ plugins {
 }
 
 description = "Generated metadata about Gradle API needed by Kotlin DSL"
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/base-services-groovy/build.gradle.kts
+++ b/platforms/core-configuration/base-services-groovy/build.gradle.kts
@@ -14,6 +14,3 @@ dependencies {
 
     testImplementation(testFixtures(projects.core))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/bean-serialization-services/build.gradle.kts
+++ b/platforms/core-configuration/bean-serialization-services/build.gradle.kts
@@ -45,6 +45,3 @@ dependencies {
     implementation(libs.groovy)
     implementation(libs.guava)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/configuration-cache-base/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache-base/build.gradle.kts
@@ -34,6 +34,3 @@ dependencies {
     implementation(projects.baseServices)
     implementation(projects.serviceLookup)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/configuration-problems-base/build.gradle.kts
+++ b/platforms/core-configuration/configuration-problems-base/build.gradle.kts
@@ -62,6 +62,3 @@ dependencies {
     implementation(projects.hashing)
     implementation(projects.stdlibKotlinExtensions)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/core-kotlin-extensions/build.gradle.kts
+++ b/platforms/core-configuration/core-kotlin-extensions/build.gradle.kts
@@ -22,6 +22,3 @@ dependencies {
     implementation(projects.serviceProvider)
     implementation(projects.stdlibKotlinExtensions)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
@@ -64,6 +64,3 @@ dependencies {
     implementation(libs.groovy)
     implementation(libs.guava)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/declarative-dsl-api/build.gradle.kts
+++ b/platforms/core-configuration/declarative-dsl-api/build.gradle.kts
@@ -8,6 +8,3 @@ description = "Annotation classes used by the Declarative DSL"
 dependencies {
     implementation(projects.stdlibJavaExtensions)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/declarative-dsl-evaluator/build.gradle.kts
+++ b/platforms/core-configuration/declarative-dsl-evaluator/build.gradle.kts
@@ -41,6 +41,3 @@ dependencies {
 
     api(libs.futureKotlin("stdlib"))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/declarative-dsl-tooling-builders/build.gradle.kts
+++ b/platforms/core-configuration/declarative-dsl-tooling-builders/build.gradle.kts
@@ -18,6 +18,3 @@ dependencies {
 
     crossVersionTestDistributionRuntimeOnly(projects.distributionsBasics)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/declarative-dsl-tooling-models/build.gradle.kts
+++ b/platforms/core-configuration/declarative-dsl-tooling-models/build.gradle.kts
@@ -41,6 +41,3 @@ tasks.withType<KotlinCompile>().configureEach {
         languageVersion.set(KotlinVersion.KOTLIN_1_9)
     }
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/dependency-management-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/build.gradle.kts
@@ -49,6 +49,3 @@ dependencies {
 
     implementation(libs.guava)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/encryption-services/build.gradle.kts
+++ b/platforms/core-configuration/encryption-services/build.gradle.kts
@@ -35,6 +35,3 @@ dependencies {
     implementation(projects.persistentCache)
     implementation(projects.stdlibKotlinExtensions)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/graph-serialization/build.gradle.kts
+++ b/platforms/core-configuration/graph-serialization/build.gradle.kts
@@ -38,6 +38,3 @@ dependencies {
 
     implementation(libs.fastutil)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/guava-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/guava-serialization-codecs/build.gradle.kts
@@ -25,6 +25,3 @@ dependencies {
     api(libs.kotlinStdlib)
     api(libs.guava)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/input-tracking/build.gradle.kts
+++ b/platforms/core-configuration/input-tracking/build.gradle.kts
@@ -10,6 +10,3 @@ dependencies {
 
     implementation(projects.stdlibJavaExtensions)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
@@ -89,6 +89,3 @@ pluginPublish {
         pluginClass = "org.gradle.kotlin.dsl.plugins.precompiled.PrecompiledScriptPlugins"
     )
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/build.gradle.kts
@@ -51,6 +51,3 @@ dependencies {
 packageCycles {
     excludePatterns.add("org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/**")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/build.gradle.kts
@@ -43,6 +43,3 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly = true
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/kotlin-dsl-tooling-models/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-tooling-models/build.gradle.kts
@@ -7,6 +7,3 @@ description = "Kotlin DSL Tooling Models for IDEs"
 dependencies {
     api(libs.jsr305)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/stdlib-kotlin-extensions/build.gradle.kts
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/build.gradle.kts
@@ -24,6 +24,3 @@ dependencies {
     api(libs.kotlinStdlib)
     implementation(projects.stdlibJavaExtensions)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-configuration/stdlib-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/stdlib-serialization-codecs/build.gradle.kts
@@ -29,6 +29,3 @@ dependencies {
     implementation(projects.serialization)
     implementation(projects.stdlibKotlinExtensions)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-execution/build-cache-base/build.gradle.kts
+++ b/platforms/core-execution/build-cache-base/build.gradle.kts
@@ -13,6 +13,3 @@ dependencies {
 
     testImplementation(testFixtures(projects.hashing))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-execution/build-cache-example-client/build.gradle.kts
+++ b/platforms/core-execution/build-cache-example-client/build.gradle.kts
@@ -48,6 +48,3 @@ dependencies {
 application {
     mainClass = "org.gradle.caching.example.ExampleBuildCacheClient"
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-execution/build-cache-packaging/build.gradle.kts
+++ b/platforms/core-execution/build-cache-packaging/build.gradle.kts
@@ -28,6 +28,3 @@ dependencies {
     testImplementation(testFixtures(projects.coreApi))
     testImplementation(testFixtures(projects.snapshots))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-execution/hashing/build.gradle.kts
+++ b/platforms/core-execution/hashing/build.gradle.kts
@@ -13,6 +13,3 @@ dependencies {
     implementation(libs.guava)
     api(libs.jsr305)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-execution/worker-main/build.gradle.kts
+++ b/platforms/core-execution/worker-main/build.gradle.kts
@@ -29,6 +29,3 @@ dependencies {
 
     testImplementation(testFixtures(projects.core))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/base-asm/build.gradle.kts
+++ b/platforms/core-runtime/base-asm/build.gradle.kts
@@ -26,6 +26,3 @@ dependencies {
     api(libs.asm)
     api(libs.jsr305)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/build-operations/build.gradle.kts
+++ b/platforms/core-runtime/build-operations/build.gradle.kts
@@ -19,6 +19,3 @@ dependencies {
     testImplementation(testFixtures(projects.time))
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/build-option/build.gradle.kts
+++ b/platforms/core-runtime/build-option/build.gradle.kts
@@ -15,6 +15,3 @@ dependencies {
 
     implementation(projects.baseServices)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/build-process-services/build.gradle.kts
+++ b/platforms/core-runtime/build-process-services/build.gradle.kts
@@ -16,6 +16,3 @@ dependencies {
 
     testRuntimeOnly(projects.resources)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/build-state/build.gradle.kts
+++ b/platforms/core-runtime/build-state/build.gradle.kts
@@ -40,6 +40,3 @@ dependencies {
     implementation(projects.serialization)
 
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/cli/build.gradle.kts
+++ b/platforms/core-runtime/cli/build.gradle.kts
@@ -6,6 +6,3 @@ description = "Utilities for parsing command line arguments"
 
 gradlebuildJava.usedInWorkers()
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/client-services/build.gradle.kts
+++ b/platforms/core-runtime/client-services/build.gradle.kts
@@ -78,6 +78,3 @@ dependencies {
     }
     testImplementation(testFixtures(projects.daemonProtocol))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/concurrent/build.gradle.kts
+++ b/platforms/core-runtime/concurrent/build.gradle.kts
@@ -29,6 +29,3 @@ dependencies {
 
     implementation(libs.slf4jApi)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/daemon-main/build.gradle.kts
+++ b/platforms/core-runtime/daemon-main/build.gradle.kts
@@ -34,6 +34,3 @@ dependencies {
     manifestClasspath(projects.concurrent)
     manifestClasspath(projects.serviceLookup)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/daemon-protocol/build.gradle.kts
+++ b/platforms/core-runtime/daemon-protocol/build.gradle.kts
@@ -45,6 +45,3 @@ dependencies {
     testImplementation(testFixtures(projects.serialization))
     testImplementation(testFixtures(projects.core))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/daemon-server/build.gradle.kts
+++ b/platforms/core-runtime/daemon-server/build.gradle.kts
@@ -37,6 +37,3 @@ dependencies {
     implementation(projects.core)
     implementation(projects.daemonProtocol)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/daemon-services/build.gradle.kts
+++ b/platforms/core-runtime/daemon-services/build.gradle.kts
@@ -40,6 +40,3 @@ dependencies {
 
     testImplementation(testFixtures(projects.time))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/file-temp/build.gradle.kts
+++ b/platforms/core-runtime/file-temp/build.gradle.kts
@@ -27,6 +27,3 @@ dependencies {
 
     api(libs.jsr305)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/files/build.gradle.kts
+++ b/platforms/core-runtime/files/build.gradle.kts
@@ -21,6 +21,3 @@ dependencies {
     }
     testImplementation(testFixtures(projects.native))
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/functional/build.gradle.kts
+++ b/platforms/core-runtime/functional/build.gradle.kts
@@ -12,6 +12,3 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.fastutil)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/gradle-cli-main/build.gradle.kts
+++ b/platforms/core-runtime/gradle-cli-main/build.gradle.kts
@@ -40,6 +40,3 @@ dependencies {
 
     agentsClasspath(projects.instrumentationAgent)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/gradle-cli/build.gradle.kts
+++ b/platforms/core-runtime/gradle-cli/build.gradle.kts
@@ -59,6 +59,3 @@ dependencies {
         because("Tests instantiate DefaultClassLoaderRegistry which requires a 'gradle-plugins.properties' through DefaultPluginModuleRegistry")
     }
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/installation-beacon/build.gradle.kts
+++ b/platforms/core-runtime/installation-beacon/build.gradle.kts
@@ -5,6 +5,3 @@ plugins {
 description = "Marker class file used to locate the Gradle distribution base directory"
 
 // This lib should not have any dependencies.
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/instrumentation-agent/build.gradle.kts
+++ b/platforms/core-runtime/instrumentation-agent/build.gradle.kts
@@ -14,6 +14,3 @@ tasks.named<Jar>("jar") {
         ))
     }
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/instrumentation-declarations/build.gradle.kts
+++ b/platforms/core-runtime/instrumentation-declarations/build.gradle.kts
@@ -29,6 +29,3 @@ tasks.named<JavaCompile>("compileJava") {
     // Without this, javac will complain about unclaimed org.gradle.api.NonNullApi annotation
     options.compilerArgs.add("-Xlint:-processing")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/internal-instrumentation-api/build.gradle.kts
+++ b/platforms/core-runtime/internal-instrumentation-api/build.gradle.kts
@@ -29,6 +29,3 @@ dependencies {
     implementation(libs.groovy)
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/internal-instrumentation-processor/build.gradle.kts
+++ b/platforms/core-runtime/internal-instrumentation-processor/build.gradle.kts
@@ -58,6 +58,3 @@ tasks.named<Test>("test").configure {
         )
     }
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/io/build.gradle.kts
+++ b/platforms/core-runtime/io/build.gradle.kts
@@ -28,6 +28,3 @@ dependencies {
 
     implementation(projects.stdlibJavaExtensions)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/logging-api/build.gradle.kts
+++ b/platforms/core-runtime/logging-api/build.gradle.kts
@@ -28,6 +28,3 @@ dependencies {
     implementation(projects.stdlibJavaExtensions)
     implementation(projects.internalInstrumentationApi)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/native/build.gradle.kts
+++ b/platforms/core-runtime/native/build.gradle.kts
@@ -48,9 +48,6 @@ jmh {
     warmupIterations = 10
     synchronizeIterations = false
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}
 
 packageCycles {
     // Cycle between public interface, Factory and implementation class in internal package

--- a/platforms/core-runtime/process-services/build.gradle.kts
+++ b/platforms/core-runtime/process-services/build.gradle.kts
@@ -18,6 +18,3 @@ dependencies {
 packageCycles {
     excludePatterns.add("org/gradle/process/internal/**")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/serialization/build.gradle.kts
+++ b/platforms/core-runtime/serialization/build.gradle.kts
@@ -39,6 +39,3 @@ dependencies {
 
     compileOnly(libs.errorProneAnnotations)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/service-lookup/build.gradle.kts
+++ b/platforms/core-runtime/service-lookup/build.gradle.kts
@@ -11,6 +11,3 @@ dependencies {
 
     api(libs.jsr305)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/service-provider/build.gradle.kts
+++ b/platforms/core-runtime/service-provider/build.gradle.kts
@@ -13,6 +13,3 @@ dependencies {
     api(libs.jsr305)
     api(libs.errorProneAnnotations)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/service-registry-builder/build.gradle.kts
+++ b/platforms/core-runtime/service-registry-builder/build.gradle.kts
@@ -13,6 +13,3 @@ dependencies {
 
     implementation(projects.serviceRegistryImpl)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/service-registry-impl/build.gradle.kts
+++ b/platforms/core-runtime/service-registry-impl/build.gradle.kts
@@ -18,6 +18,3 @@ dependencies {
     implementation(libs.inject)
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/stdlib-java-extensions/build.gradle.kts
+++ b/platforms/core-runtime/stdlib-java-extensions/build.gradle.kts
@@ -14,6 +14,3 @@ dependencies {
 
     api(libs.jsr305)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/time/build.gradle.kts
+++ b/platforms/core-runtime/time/build.gradle.kts
@@ -26,6 +26,3 @@ gradlebuildJava.usedInWorkers()
 dependencies {
     api(projects.stdlibJavaExtensions)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/core-runtime/tooling-api-provider/build.gradle.kts
+++ b/platforms/core-runtime/tooling-api-provider/build.gradle.kts
@@ -37,6 +37,3 @@ dependencies {
     implementation(projects.logging)
     implementation(projects.native)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/enterprise/enterprise-logging/build.gradle.kts
+++ b/platforms/enterprise/enterprise-logging/build.gradle.kts
@@ -13,6 +13,3 @@ dependencies {
 
     api(libs.jsr305)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/enterprise/enterprise-operations/build.gradle.kts
+++ b/platforms/enterprise/enterprise-operations/build.gradle.kts
@@ -12,6 +12,3 @@ dependencies {
 
     implementation(projects.stdlibJavaExtensions)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/enterprise/enterprise-plugin-performance/build.gradle.kts
+++ b/platforms/enterprise/enterprise-plugin-performance/build.gradle.kts
@@ -89,6 +89,3 @@ internal
 class DevelocityPluginInfoDirPropertyProvider(@InputFiles @PathSensitive(PathSensitivity.RELATIVE) val pluginInfoDir: Provider<File>) : CommandLineArgumentProvider {
     override fun asArguments() = listOf("-Dorg.gradle.performance.develocity.plugin.infoDir=${pluginInfoDir.get().path}")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/enterprise/enterprise-workers/build.gradle.kts
+++ b/platforms/enterprise/enterprise-workers/build.gradle.kts
@@ -10,6 +10,3 @@ gradlebuildJava.usedInWorkers()
 dependencies {
     api(libs.jsr305)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/ide/base-ide-plugins/build.gradle.kts
+++ b/platforms/ide/base-ide-plugins/build.gradle.kts
@@ -49,6 +49,3 @@ packageCycles {
     excludePatterns.add("org/gradle/plugins/ide/idea/internal/**")
     excludePatterns.add("org/gradle/plugins/ide/idea/model/internal/**")
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/ide/problems-rendering/build.gradle.kts
+++ b/platforms/ide/problems-rendering/build.gradle.kts
@@ -29,6 +29,3 @@ dependencies {
     integTestImplementation(testFixtures(projects.logging))
     integTestDistributionRuntimeOnly(projects.distributionsFull)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/ide/tooling-api-builders/build.gradle.kts
+++ b/platforms/ide/tooling-api-builders/build.gradle.kts
@@ -50,6 +50,3 @@ dependencies {
 strictCompile {
     ignoreDeprecations()
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/jvm/java-compiler-plugin/build.gradle.kts
+++ b/platforms/jvm/java-compiler-plugin/build.gradle.kts
@@ -13,6 +13,3 @@ tasks.withType<Test>().configureEach {
         classpath += javaLauncher.get().metadata.installationPath.files("lib/tools.jar")
     }
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/jvm/normalization-java/build.gradle.kts
+++ b/platforms/jvm/normalization-java/build.gradle.kts
@@ -43,6 +43,3 @@ listOf(configurations["apiElements"], configurations["runtimeElements"]).forEach
     }
 }
 
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/jvm/testing-junit-platform/build.gradle.kts
+++ b/platforms/jvm/testing-junit-platform/build.gradle.kts
@@ -23,6 +23,3 @@ dependencies {
 
     implementation(libs.jsr305)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/jvm/testing-jvm-infrastructure/build.gradle.kts
+++ b/platforms/jvm/testing-jvm-infrastructure/build.gradle.kts
@@ -82,6 +82,3 @@ dependencyAnalysis {
         }
     }
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/jvm/toolchains-jvm-shared/build.gradle.kts
+++ b/platforms/jvm/toolchains-jvm-shared/build.gradle.kts
@@ -60,6 +60,3 @@ packageCycles {
 }
 
 integTest.usesJavadocCodeSnippets.set(true)
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/native/tooling-native/build.gradle.kts
+++ b/platforms/native/tooling-native/build.gradle.kts
@@ -31,6 +31,3 @@ dependencies {
 
     crossVersionTestDistributionRuntimeOnly(projects.distributionsNative)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/software/security/build.gradle.kts
+++ b/platforms/software/security/build.gradle.kts
@@ -17,6 +17,3 @@ dependencies {
     implementation(libs.bouncycastleProvider)
     implementation(libs.guava)
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}

--- a/platforms/software/test-suites-base/build.gradle.kts
+++ b/platforms/software/test-suites-base/build.gradle.kts
@@ -30,6 +30,3 @@ dependencies {
         because("ProjectBuilder tests load services from a Gradle distribution.")
     }
 }
-tasks.isolatedProjectsIntegTest {
-    enabled = false
-}


### PR DESCRIPTION
This is a no-op in terms of coverage changes, but removes clutter in the build logic