### PR TITLE
Always coerce non-String attributes upon get() to handle classloader problems with included builds

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedArray.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedArray.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.snapshot.impl;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.internal.Cast;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
@@ -57,7 +58,7 @@ public class IsolatedArray extends AbstractArraySnapshot<Isolatable<?>> implemen
     @Nullable
     @Override
     public <S> S coerce(Class<S> type) {
-        return null;
+        return Cast.uncheckedCast(elements);
     }
 
     public Class<?> getArrayType() {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedArray.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedArray.java
@@ -58,16 +58,20 @@ public class IsolatedArray extends AbstractArraySnapshot<Isolatable<?>> implemen
     @Nullable
     @Override
     public <S> S coerce(Class<S> type) {
+        S result = null;
         if (type.isArray()) {
-            S result = (S) Array.newInstance(type.getComponentType(), elements.size());
-            Object[] isolated = isolate();
-            for (int i = 0; i < isolated.length; i++) {
-                Array.set(result, i, isolated[i]);
+            try {
+                result = (S) Array.newInstance(type.getComponentType(), elements.size());
+                Object[] isolated = isolate();
+                for (int i = 0; i < isolated.length; i++) {
+                    Array.set(result, i, isolated[i]);
+                }
+            } catch (Exception e) {
+                // This method's contract is a "best-effort" so if given a non-array type or a different component type that fails to populate, that's fine
+                result = null;
             }
-            return result;
-        } else {
-            return null;
         }
+        return result;
     }
 
     public Class<?> getArrayType() {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedArray.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedArray.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.snapshot.impl;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.internal.Cast;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
@@ -55,10 +54,20 @@ public class IsolatedArray extends AbstractArraySnapshot<Isolatable<?>> implemen
         return toReturn;
     }
 
+    @SuppressWarnings("unchecked")
     @Nullable
     @Override
     public <S> S coerce(Class<S> type) {
-        return Cast.uncheckedCast(elements);
+        if (type.isArray()) {
+            S result = (S) Array.newInstance(type.getComponentType(), elements.size());
+            Object[] isolated = isolate();
+            for (int i = 0; i < isolated.length; i++) {
+                Array.set(result, i, isolated[i]);
+            }
+            return result;
+        } else {
+            return null;
+        }
     }
 
     public Class<?> getArrayType() {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedList.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedList.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.snapshot.impl;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.internal.Cast;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
@@ -45,7 +46,7 @@ public class IsolatedList extends AbstractListSnapshot<Isolatable<?>> implements
 
     @Override
     public List<Object> isolate() {
-        List<Object> list = new ArrayList<Object>(elements.size());
+        List<Object> list = new ArrayList<>(elements.size());
         for (Isolatable<?> element : elements) {
             list.add(element.isolate());
         }
@@ -55,6 +56,6 @@ public class IsolatedList extends AbstractListSnapshot<Isolatable<?>> implements
     @Nullable
     @Override
     public <S> S coerce(Class<S> type) {
-        return null;
+        return Cast.uncheckedCast(elements);
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedList.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedList.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.snapshot.impl;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.internal.Cast;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
@@ -53,9 +52,14 @@ public class IsolatedList extends AbstractListSnapshot<Isolatable<?>> implements
         return list;
     }
 
+    @SuppressWarnings("unchecked")
     @Nullable
     @Override
     public <S> S coerce(Class<S> type) {
-        return Cast.uncheckedCast(elements);
+        if  (type.isAssignableFrom(List.class)) {
+            return (S) elements;
+        } else {
+            return null;
+        }
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedList.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedList.java
@@ -52,14 +52,22 @@ public class IsolatedList extends AbstractListSnapshot<Isolatable<?>> implements
         return list;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Nullable
     @Override
     public <S> S coerce(Class<S> type) {
-        if  (type.isAssignableFrom(List.class)) {
-            return (S) elements;
-        } else {
-            return null;
+        S result = null;
+        if  (List.class.isAssignableFrom(type)) {
+            try {
+                result = type.getConstructor().newInstance();
+                for (Isolatable<?> element : elements) {
+                    ((List) result).add(element.isolate());
+                }
+            } catch (Exception e) {
+                // This method's contract is a "best-effort" so if given a List type that can't be constructed or populated, that's fine
+                result = null;
+            }
         }
+        return result;
     }
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/IsolatedArrayTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/IsolatedArrayTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot.impl
+
+import org.gradle.internal.hash.ClassLoaderHierarchyHasher
+import org.gradle.internal.hash.TestHashCodes
+import org.gradle.internal.state.ManagedFactoryRegistry
+import spock.lang.Specification
+
+/**
+ * Unit tests for the {@link IsolatedArray} type.
+ */
+final class IsolatedArrayTest extends Specification {
+    def classLoaderHasher = Stub(ClassLoaderHierarchyHasher) {
+        getClassLoaderHash(_ as ClassLoader) >> TestHashCodes.hashCodeFrom(123)
+    }
+    def managedFactoryRegistry = Mock(ManagedFactoryRegistry)
+    def isolatableFactory = new DefaultIsolatableFactory(classLoaderHasher, managedFactoryRegistry)
+
+    def "can coerce back to array"() {
+        given:
+        def array = ["a", "b", "c"] as String[]
+        def isolated = isolatableFactory.isolate(array)
+
+        when:
+        def result = isolated.coerce(String[].class)
+
+        then:
+        result == array
+    }
+}

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/IsolatedListTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/IsolatedListTest.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot.impl
+
+import org.gradle.internal.hash.ClassLoaderHierarchyHasher
+import org.gradle.internal.hash.TestHashCodes
+import org.gradle.internal.state.ManagedFactoryRegistry
+import spock.lang.Specification
+
+/**
+ * Unit tests for the {@link IsolatedList} type.
+ */
+final class IsolatedListTest extends Specification {
+    def classLoaderHasher = Stub(ClassLoaderHierarchyHasher) {
+        getClassLoaderHash(_ as ClassLoader) >> TestHashCodes.hashCodeFrom(123)
+    }
+    def managedFactoryRegistry = Mock(ManagedFactoryRegistry)
+    def isolatableFactory = new DefaultIsolatableFactory(classLoaderHasher, managedFactoryRegistry)
+
+    def "can coerce back to list"() {
+        given:
+        def list = ["a", "b", "c"]
+        def isolated = isolatableFactory.isolate(list)
+
+        when:
+        def result = isolated.coerce(List.class)
+
+        then:
+        result instanceof List
+        result == list
+    }
+}

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -53,7 +53,7 @@ The change is driven by the need to interpret such default values in the scope o
 
 Providing a `null` argument when retrieving attributes from a container using `getAttribute(Attribute)` is now explicitly deprecated.
 
-Prior to this change, a `null` lookup silently returned `null`.  Now it will emit a deprecation warning.
+Previously, a `null` lookup silently returned `null`. Now, it emits a deprecation warning.  
 There should be no need to lookup null values in an `AttributeContainer`.
 
 [[deprecated_string_to_enum_coercion_for_rich_properties]]

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -48,6 +48,14 @@ The change is driven by the need to interpret such default values in the scope o
 
 === Deprecations
 
+[[null-attribute-lookup]]
+==== Looking up attributes using null keys deprecated ====
+
+Providing a null argument to when retrieving attributes from a container using the `getAttribute(Attribute)` method has been explicitly deprecated.
+
+Prior to this change, a `null` lookup silently returned `null`.  Now it will emit a deprecation warning.
+There should be no need to lookup null values in an `AttributeContainer`.
+
 [[deprecated_string_to_enum_coercion_for_rich_properties]]
 ==== Groovy String to Enum coercion for Property types is deprecated
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -51,7 +51,7 @@ The change is driven by the need to interpret such default values in the scope o
 [[null-attribute-lookup]]
 ==== Looking up attributes using null keys is deprecated ====
 
-Providing a null argument to when retrieving attributes from a container using the `getAttribute(Attribute)` method has been explicitly deprecated.
+Providing a `null` argument when retrieving attributes from a container using `getAttribute(Attribute)` is now explicitly deprecated.
 
 Prior to this change, a `null` lookup silently returned `null`.  Now it will emit a deprecation warning.
 There should be no need to lookup null values in an `AttributeContainer`.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -49,7 +49,7 @@ The change is driven by the need to interpret such default values in the scope o
 === Deprecations
 
 [[null-attribute-lookup]]
-==== Looking up attributes using null keys deprecated ====
+==== Looking up attributes using null keys is deprecated ====
 
 Providing a null argument to when retrieving attributes from a container using the `getAttribute(Attribute)` method has been explicitly deprecated.
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -54,7 +54,7 @@ The change is driven by the need to interpret such default values in the scope o
 Providing a `null` argument when retrieving attributes from a container using `getAttribute(Attribute)` is now explicitly deprecated.
 
 Previously, a `null` lookup silently returned `null`. Now, it emits a deprecation warning.  
-There should be no need to lookup null values in an `AttributeContainer`.
+There should be no need to look up `null` values in an `AttributeContainer`.
 
 [[deprecated_string_to_enum_coercion_for_rich_properties]]
 ==== Groovy String to Enum coercion for Property types is deprecated

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -51,9 +51,9 @@ The change is driven by the need to interpret such default values in the scope o
 [[null-attribute-lookup]]
 ==== Looking up attributes using null keys is deprecated ====
 
-Providing a `null` argument when retrieving attributes from a container using `getAttribute(Attribute)` is now explicitly deprecated.
+Providing a `null` argument when retrieving attributes from a container using `link:{javadocPath}/org/gradle/api/attributes/AttributeContainer.html#getAttribute(org.gradle.api.attributes.Attribute)[getAttribute(Attribute)]` is now explicitly deprecated.
 
-Previously, a `null` lookup silently returned `null`. Now, it emits a deprecation warning.  
+Previously, a `null` lookup silently returned `null`. Now, it emits a deprecation warning.
 There should be no need to look up `null` values in an `AttributeContainer`.
 
 [[deprecated_string_to_enum_coercion_for_rich_properties]]

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
@@ -123,7 +123,7 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
 
         @Nullable
         @Override
-        public <T> T getAttribute(Attribute<T> key) {
+        public <T> T getAttribute(@Nullable Attribute<T> key) {
             return getDesugared().getAttribute(key);
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
+import org.gradle.api.internal.attributes.AbstractAttributeContainer;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -93,7 +94,7 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
 
     // This does almost the same thing as passing through DesugaredAttributeContainerSerializer / DesugaringAttributeContainerSerializer.
     // Those make some assumptions about allowed attribute value types that we can't - we serialize everything else to a string instead.
-    private static final class LazyDesugaringAttributeContainer implements ImmutableAttributes {
+    private static final class LazyDesugaringAttributeContainer extends AbstractAttributeContainer implements ImmutableAttributes {
 
         private final AttributeContainer source;
         private final AttributesFactory attributesFactory;
@@ -123,7 +124,10 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
 
         @Nullable
         @Override
-        public <T> T getAttribute(@Nullable Attribute<T> key) {
+        public <T> T getAttribute(Attribute<T> key) {
+            if (!isValidAttributeRequest(key)) {
+                return null;
+            }
             return getDesugared().getAttribute(key);
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
@@ -166,6 +166,12 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
             return getDesugared().findEntry(name);
         }
 
+        @Nullable
+        @Override
+        public Attribute<?> findAttribute(String name) {
+            return getDesugared().findAttribute(name);
+        }
+
         @Override
         public String toString() {
             return getDesugared().toString();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/FreezableAttributeContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/FreezableAttributeContainer.java
@@ -27,7 +27,7 @@ import java.util.Set;
 /**
  * An attribute container which can be frozen in order to avoid subsequent mutations.
  */
-public class FreezableAttributeContainer implements AttributeContainerInternal {
+public final class FreezableAttributeContainer extends AbstractAttributeContainer {
 
     private final Describable owner;
 
@@ -95,14 +95,26 @@ public class FreezableAttributeContainer implements AttributeContainerInternal {
         return delegate.contains(key);
     }
 
-    @Override
-    public AttributeContainer getAttributes() {
-        return this;
-    }
-
     private void assertMutable() {
         if (delegate instanceof ImmutableAttributes) {
             throw new IllegalStateException(String.format("Cannot change attributes of %s after it has been locked for mutation", owner.getDisplayName()));
         }
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FreezableAttributeContainer that = (FreezableAttributeContainer) o;
+        return owner.equals(that.owner) && delegate.equals(that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = owner.hashCode();
+        result = 31 * result + delegate.hashCode();
+        return result;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/FreezableAttributeContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/FreezableAttributeContainer.java
@@ -81,7 +81,7 @@ public final class FreezableAttributeContainer extends AbstractAttributeContaine
 
     @Nullable
     @Override
-    public <T> T getAttribute(Attribute<T> key) {
+    public <T> T getAttribute(@Nullable Attribute<T> key) {
         return delegate.getAttribute(key);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/FreezableAttributeContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/FreezableAttributeContainer.java
@@ -81,7 +81,10 @@ public final class FreezableAttributeContainer extends AbstractAttributeContaine
 
     @Nullable
     @Override
-    public <T> T getAttribute(@Nullable Attribute<T> key) {
+    public <T> T getAttribute(Attribute<T> key) {
+        if (!isValidAttributeRequest(key)) {
+            return null;
+        }
         return delegate.getAttribute(key);
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
@@ -41,7 +41,6 @@ import java.util.Set;
 @HasInternalProtocol
 @UsedByScanPlugin
 public interface AttributeContainer extends HasAttributes {
-
     /**
      * Returns the set of attribute keys of this container.
      * @return the set of attribute keys.
@@ -76,14 +75,17 @@ public interface AttributeContainer extends HasAttributes {
     <T> AttributeContainer attributeProvider(Attribute<T> key, Provider<? extends T> provider);
 
     /**
-     * Returns the value of an attribute found in this container, or <code>null</code> if
+     * Returns the value of an attribute found in this container, or {@code null} if
      * this container doesn't have it.
+     * <p>
+     * Supplying a {@code null} argument is deprecated and will return {@code null}.
+     *
      * @param <T> the type of the attribute
-     * @param key the attribute key
-     * @return the attribute value, or null if not found
+     * @param key the attribute key (should not be {@code null})
+     * @return the attribute value, or {@code null} if not found
      */
     @Nullable
-    <T> T getAttribute(@Nullable Attribute<T> key);
+    <T> T getAttribute(Attribute<T> key);
 
     /**
      * Returns true if this container is empty.
@@ -97,5 +99,4 @@ public interface AttributeContainer extends HasAttributes {
      * @return true if this attribute is found in this container.
      */
     boolean contains(Attribute<?> key);
-
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
@@ -83,7 +83,7 @@ public interface AttributeContainer extends HasAttributes {
      * @return the attribute value, or null if not found
      */
     @Nullable
-    <T> T getAttribute(Attribute<T> key);
+    <T> T getAttribute(@Nullable Attribute<T> key);
 
     /**
      * Returns true if this container is empty.

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
@@ -62,7 +62,7 @@ public interface AttributeContainer extends HasAttributes {
      * Sets an attribute to have the same value as the given provider.
      * This attribute will track the value of the provider and query its value when this container is finalized.
      * <p>
-     * This method can NOT be used to discard the value of an property. Specifying a {@code null} provider will result
+     * This method can NOT be used to discard the value of a property. Specifying a {@code null} provider will result
      * in an {@code IllegalArgumentException} being thrown. When the provider has no value at finalization time,
      * an {@code IllegalStateException} - regardless of whether or not a convention has been set.
      * </p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
@@ -75,13 +75,13 @@ public interface AttributeContainer extends HasAttributes {
     <T> AttributeContainer attributeProvider(Attribute<T> key, Provider<? extends T> provider);
 
     /**
-     * Returns the value of an attribute found in this container, or {@code null} if
-     * this container doesn't have it.
+     * Returns the value of an attribute found in this container with the type specified
+     * by the given {@code key}, or {@code null} if this container doesn't have it.
      * <p>
      * Supplying a {@code null} argument is deprecated and will return {@code null}.
      *
      * @param <T> the type of the attribute
-     * @param key the attribute key (should not be {@code null})
+     * @param key the attribute key
      * @return the attribute value, or {@code null} if not found
      */
     @Nullable

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/attributes/AttributeCoercionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/attributes/AttributeCoercionIntegrationTest.groovy
@@ -1,0 +1,480 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes
+
+import org.gradle.api.Named
+import org.gradle.api.NamedDomainObjectProvider
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.DependencyScopeConfiguration
+import org.gradle.api.attributes.Attribute
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+/**
+ * Integration tests that verify attributes can always be retrieved from a resolved variants' attributes.
+ */
+@Issue("https://github.com/gradle/gradle/issues/28695")
+final class AttributeCoercionIntegrationTest extends AbstractIntegrationSpec {
+    def "new attribute type created by producer, used by consumer works"() {
+        given:
+        settingsFile("""
+            include 'consumer', 'producer'
+        """)
+
+        and: "a producer that adds a new attribute type; a variant using it, and a resolvable configuration for it"
+        file("producer/output.txt") << "sample output"
+        groovyFile("producer/build.gradle", """
+            interface MyAttributeType extends Named {}
+
+            def MY_ATTRIBUTE_NAME = "myAttribute"
+            Attribute<MyAttributeType> ATTRIBUTE_TYPE = Attribute.of(MY_ATTRIBUTE_NAME, MyAttributeType.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes {
+                        attribute(ATTRIBUTE_TYPE, project.objects.named(MyAttributeType.class, 'myValue'))
+                    }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+        """)
+
+        and: "a consumer build can resolve a variant of the producer using the new attribute type"
+        groovyFile("consumer/build.gradle", """
+            interface MyAttributeType extends Named {}
+
+            def MY_ATTRIBUTE_NAME = "myAttribute"
+            Attribute<MyAttributeType> ATTRIBUTE_TYPE = Attribute.of(MY_ATTRIBUTE_NAME, MyAttributeType.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+
+                    attributes {
+                        $attributeCreationLogic
+                    }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            ${defineResolveTask()}
+        """)
+
+        expect: "the resolution succeeds (and the attribute value used to resolve can be retrieved from the resolved variant) or fails as expected"
+        if (result) {
+            succeeds(":consumer:resolve")
+            outputContains("Resolved: output.txt")
+            outputContains("Attribute type: myValue")
+        } else {
+            fails("resolve")
+            failure.assertHasErrorOutput("No matching variant of project :producer was found.")
+        }
+
+        where:
+        result  | attributeCreationLogic
+        true    | "attribute(ATTRIBUTE_TYPE, project.objects.named(MyAttributeType.class, 'myValue'))"
+        false   | "attribute(ATTRIBUTE_TYPE, project.objects.named(MyAttributeType.class, 'incorrectValue'))"
+        true    | "attribute(Attribute.of('myAttribute', String), 'myValue')"
+        false   | "attribute(Attribute.of('myAttribute', String), 'incorrectValue')"
+    }
+
+    def "new attribute type created by producer as an included build, used by consumer works"() {
+        given:
+        settingsFile("""
+            includeBuild 'producer'
+            include 'consumer'
+        """)
+
+        and: "a producer that adds a new attribute type; a variant using it, and a resolvable configuration for it"
+        file("producer/output.txt") << "sample output"
+        groovyFile("producer/build.gradle", """
+            interface MyAttributeType extends Named {}
+
+            def MY_ATTRIBUTE_NAME = "myAttribute"
+            Attribute<MyAttributeType> ATTRIBUTE_TYPE = Attribute.of(MY_ATTRIBUTE_NAME, MyAttributeType.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes {
+                        attribute(ATTRIBUTE_TYPE, objects.named(MyAttributeType.class, 'myValue'))
+                    }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+
+            group = 'org.gradle.example'
+            version = '1.0'
+        """)
+
+        and: "a consumer build can resolve a variant of the producer using the new attribute type"
+        groovyFile("consumer/build.gradle", """
+            interface MyAttributeType extends Named {}
+
+            def MY_ATTRIBUTE_NAME = "myAttribute"
+            Attribute<MyAttributeType> ATTRIBUTE_TYPE = Attribute.of(MY_ATTRIBUTE_NAME, MyAttributeType.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+
+                    attributes {
+                        $attributeCreationLogic
+                    }
+                }
+            }
+
+            dependencies {
+                myDeps("org.gradle.example:producer:1.0")
+            }
+
+            ${defineResolveTask()}
+        """)
+
+        expect: "the resolution succeeds (and the attribute value used to resolve can be retrieved from the resolved variant) or fails as expected"
+        if (result) {
+            succeeds(":consumer:resolve")
+            outputContains("Resolved: output.txt")
+            outputContains("Attribute type: myValue")
+        } else {
+            fails("resolve")
+            failure.assertHasErrorOutput("No matching variant of project :producer was found.")
+        }
+
+        where:
+        result  | attributeCreationLogic
+        true    | "attribute(ATTRIBUTE_TYPE, objects.named(MyAttributeType.class, 'myValue'))"
+        false   | "attribute(ATTRIBUTE_TYPE, objects.named(MyAttributeType.class, 'incorrectValue'))"
+        true    | "attribute(Attribute.of('myAttribute', String), 'myValue')"
+        false   | "attribute(Attribute.of('myAttribute', String), 'incorrectValue')"
+    }
+
+    def "new attribute type created by producer as an included build, used by consumer as an included build works"() {
+        given:
+        settingsFile("""
+            includeBuild 'producer'
+            includeBuild 'consumer'
+        """)
+
+        and: "a producer that adds a new attribute type; a variant using it, and a resolvable configuration for it"
+        file("producer/output.txt") << "sample output"
+        groovyFile("producer/build.gradle", """
+            interface MyAttributeType extends Named {}
+
+            def MY_ATTRIBUTE_NAME = "myAttribute"
+            Attribute<MyAttributeType> ATTRIBUTE_TYPE = Attribute.of(MY_ATTRIBUTE_NAME, MyAttributeType.class)
+
+            configurations {
+                consumable("myVariant") {
+                    attributes {
+                        attribute(ATTRIBUTE_TYPE, project.objects.named(MyAttributeType.class, 'myValue'))
+                    }
+                    outgoing.artifact(file("output.txt"))
+                }
+            }
+
+            group = 'org.gradle.example'
+            version = '1.0'
+        """)
+
+        and: "a consumer build can resolve a variant of the producer using the new attribute type"
+        groovyFile("consumer/build.gradle", """
+            interface MyAttributeType extends Named {}
+
+            def MY_ATTRIBUTE_NAME = "myAttribute"
+            Attribute<MyAttributeType> ATTRIBUTE_TYPE = Attribute.of(MY_ATTRIBUTE_NAME, MyAttributeType.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+
+                    attributes {
+                        $attributeCreationLogic
+                    }
+                }
+            }
+
+            dependencies {
+                myDeps("org.gradle.example:producer:1.0")
+            }
+
+            ${defineResolveTask()}
+        """)
+
+        expect: "the resolution succeeds (and the attribute value used to resolve can be retrieved from the resolved variant) or fails as expected"
+        if (result) {
+            succeeds(":consumer:resolve")
+            outputContains("Resolved: output.txt")
+            outputContains("Attribute type: myValue")
+        } else {
+            fails(":consumer:resolve")
+            failure.assertHasErrorOutput("No matching variant of project :producer was found.")
+        }
+
+        where:
+        result  | attributeCreationLogic
+        true    | "attribute(ATTRIBUTE_TYPE, project.objects.named(MyAttributeType.class, 'myValue'))"
+        false   | "attribute(ATTRIBUTE_TYPE, project.objects.named(MyAttributeType.class, 'incorrectValue'))"
+        true    | "attribute(Attribute.of('myAttribute', String), 'myValue')"
+        false   | "attribute(Attribute.of('myAttribute', String), 'incorrectValue')"
+    }
+
+    def "new attribute type created by producer via plugin, used by consumer works"() {
+        given: "a plugin that adds a new attribute type; a variant using it, and a resolvable configuration for it"
+        definePluginBuild()
+
+        and:
+        settingsFile("""
+            pluginManagement {
+                includeBuild 'build-logic'
+            }
+            include 'consumer', 'producer'
+        """)
+
+        and: "a producer build that uses the plugin"
+        file("producer/output.txt") << "sample output"
+        groovyFile("producer/build.gradle", """
+            plugins {
+                id 'org.gradle.example.myPlugin'
+            }
+        """)
+
+        and: "a consumer build can resolve a variant of the producer using the new attribute type"
+        groovyFile("consumer/build.gradle", """
+            interface MyAttributeType extends Named {}
+
+            def MY_ATTRIBUTE_NAME = "myAttribute"
+            Attribute<MyAttributeType> ATTRIBUTE_TYPE = Attribute.of(MY_ATTRIBUTE_NAME, MyAttributeType.class)
+
+            configurations {
+                dependencyScope("myDeps")
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+
+                    attributes {
+                        $attributeCreationLogic
+                    }
+                }
+            }
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            ${defineResolveTask()}
+        """)
+
+        expect: "the resolution succeeds (and the attribute value used to resolve can be retrieved from the resolved variant) or fails as expected"
+        if (result) {
+            succeeds(":consumer:resolve")
+            outputContains("Resolved: output.txt")
+            outputContains("Attribute type: myValue")
+        } else {
+            fails("resolve")
+            failure.assertHasErrorOutput("No matching variant of project :producer was found.")
+        }
+
+        where:
+        result  | attributeCreationLogic
+        true    | "attribute(ATTRIBUTE_TYPE, project.objects.named(MyAttributeType.class, 'myValue'))"
+        false   | "attribute(ATTRIBUTE_TYPE, project.objects.named(MyAttributeType.class, 'incorrectValue'))"
+        true    | "attribute(Attribute.of('myAttribute', String), 'myValue')"
+        false   | "attribute(Attribute.of('myAttribute', String), 'incorrectValue')"
+    }
+
+    def "new attribute type created by producer via plugin, used by a consumer using the attribute type imported from the same plugin works"() {
+        given: "a plugin that adds a new attribute type; a variant using it, and a resolvable configuration for it"
+        definePluginBuild()
+
+        and:
+        settingsFile("""
+            pluginManagement {
+                includeBuild 'build-logic'
+            }
+            include 'consumer', 'producer'
+        """)
+
+        and: "a producer build that uses the plugin"
+        groovyFile("producer/build.gradle", """
+            plugins {
+                id 'org.gradle.example.myPlugin'
+            }
+        """)
+
+        and: "a consumer build can resolve a variant of the producer using the new attribute type using the configuration added by the plugin"
+        groovyFile("consumer/build.gradle", """
+            import org.gradle.example.MyAttributeType
+
+            plugins {
+                id 'org.gradle.example.myPlugin'
+            }
+
+            def MY_ATTRIBUTE_NAME = "myAttribute";
+            def ATTRIBUTE_TYPE = Attribute.of(MY_ATTRIBUTE_NAME, MyAttributeType.class);
+
+            dependencies {
+                myDeps(project(":producer"))
+            }
+
+            ${defineResolveTask()}
+        """)
+
+        expect: "the resolution succeeds as expected and the attribute value used to resolve can be retrieved from the resolved variant"
+        succeeds(":consumer:resolve")
+        outputContains("Resolved: output.txt")
+        outputContains("Attribute type: myValue")
+    }
+
+    def "new attribute type created by a plugin applied to an included producer, and an included consumer project which resolves it works"() {
+        given: "a plugin that adds a new attribute type; a variant using it, and a resolvable configuration for it"
+        definePluginBuild()
+
+        and:
+        settingsFile("""
+            includeBuild 'producer'
+            includeBuild 'consumer'
+        """)
+
+        and: "an consumer build that uses the plugin and depends on an included producer build"
+        groovyFile("consumer/settings.gradle", """
+            includeBuild '../producer'
+        """)
+        groovyFile("consumer/build.gradle", """
+            public interface MyAttributeType extends Named {}
+            def MY_ATTRIBUTE_NAME = "myAttribute"
+            Attribute<MyAttributeType> ATTRIBUTE_TYPE = Attribute.of(MY_ATTRIBUTE_NAME, MyAttributeType.class)
+
+            configurations {
+                dependencyScope("myDeps")
+
+                resolvable("myResolver") {
+                    extendsFrom(configurations.getByName("myDeps"))
+                    attributes {
+                        attribute(ATTRIBUTE_TYPE, objects.named(MyAttributeType.class, 'myValue'))
+                    }
+                }
+            }
+
+            dependencies {
+                myDeps("org.gradle.example:producer:1.0")
+            }
+
+            ${defineResolveTask()}
+        """)
+
+        and: "a producer build that uses the plugin"
+        groovyFile("producer/settings.gradle", """
+            pluginManagement {
+                includeBuild '../build-logic'
+            }
+        """)
+        groovyFile("producer/build.gradle", """
+            plugins {
+                id 'org.gradle.example.myPlugin'
+            }
+
+            group = 'org.gradle.example'
+            version = '1.0'
+        """)
+
+        expect: "the resolution succeeds as expected and the attribute value used to resolve can be retrieved from the resolved variant"
+        succeeds(":consumer:resolve")
+        outputContains("Resolved: output.txt")
+        outputContains("Attribute type: myValue")
+    }
+
+    private void definePluginBuild() {
+        file("producer/output.txt") << "sample output"
+        javaFile("build-logic/src/main/java/org/gradle/example/MyPlugin.java", """
+            package org.gradle.example;
+
+            import ${Attribute.name};
+            import ${DependencyScopeConfiguration.name};
+            import ${NamedDomainObjectProvider.name};
+            import ${Plugin.name};
+            import ${Project.name};
+
+            public abstract class MyPlugin implements Plugin<Project> {
+                private static final String MY_ATTRIBUTE_NAME = "myAttribute";
+                private static final Attribute<MyAttributeType> ATTRIBUTE_TYPE = Attribute.of(MY_ATTRIBUTE_NAME, MyAttributeType.class);
+
+                public void apply(Project project) {
+                    project.getConfigurations().consumable("myVariant", c -> {
+                        c.getAttributes().attribute(ATTRIBUTE_TYPE, project.getObjects().named(MyAttributeType.class, "myValue"));
+                        c.getOutgoing().artifact(project.file("output.txt"));
+                    });
+
+                    NamedDomainObjectProvider<DependencyScopeConfiguration> myDeps = project.getConfigurations().dependencyScope("myDeps");
+
+                    project.getConfigurations().resolvable("myResolver", c -> {
+                        c.extendsFrom(myDeps.get());
+                        c.getAttributes().attribute(ATTRIBUTE_TYPE, project.getObjects().named(MyAttributeType.class, "myValue"));
+                    });
+                }
+            }
+        """)
+        javaFile("build-logic/src/main/java/org/gradle/example/MyAttributeType.java", """
+            package org.gradle.example;
+
+            import ${Named.name};
+
+            public interface MyAttributeType extends Named {}
+        """)
+
+        groovyFile("build-logic/build.gradle", """
+            plugins {
+                id 'java-gradle-plugin'
+            }
+
+            gradlePlugin {
+                plugins {
+                    myPlugin {
+                        id = 'org.gradle.example.myPlugin'
+                        implementationClass = 'org.gradle.example.MyPlugin'
+                    }
+                }
+            }
+        """)
+    }
+
+    private String defineResolveTask(String configurationName = "myResolver") {
+        return """
+            tasks.register("resolve") {
+                def myFiles = configurations.$configurationName
+                    .incoming.artifactView {}
+                    .artifacts
+                    .resolvedArtifacts
+                    .map { resolvedArtifactResults ->
+                        resolvedArtifactResults.each { r ->
+                            println("Attribute type: " + r.variant.attributes.getAttribute(ATTRIBUTE_TYPE))
+                        }
+                    }
+
+                inputs.files(configurations.$configurationName)
+                doLast {
+                    myFiles.get().each { println("Resolved: " + it.file.name) }
+                }
+            }
+        """
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AbstractAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AbstractAttributeContainer.java
@@ -65,7 +65,7 @@ public abstract class AbstractAttributeContainer implements AttributeContainerIn
     protected boolean isValidAttributeRequest(@Nullable Attribute<?> key) {
         if (key == null) {
             DeprecationLogger.deprecateInvocation("getAttribute with a null key")
-                .withAdvice("Don't request attributes using null keys.")
+                .withAdvice("Don't request attributes from attribute containers using null keys.")
                 .willBecomeAnErrorInGradle10()
                 .undocumented()
                 .nagUser();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AbstractAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AbstractAttributeContainer.java
@@ -18,7 +18,9 @@ package org.gradle.api.internal.attributes;
 
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -51,4 +53,25 @@ public abstract class AbstractAttributeContainer implements AttributeContainerIn
     public abstract boolean equals(Object o);
     @Override
     public abstract int hashCode();
+
+    /**
+     * Verifies that the given key is a valid attribute request.
+     * <p>
+     * Requesting null keys is not allowed, and is deprecated.
+     *
+     * @param key the requested attribute to validate
+     * @return {@code true} is valid request; {@code false} otherwise
+     */
+    protected boolean isValidAttributeRequest(@Nullable Attribute<?> key) {
+        if (key == null) {
+            DeprecationLogger.deprecateInvocation("getAttribute with a null key")
+                .withAdvice("Don't request attributes using null keys.")
+                .willBecomeAnErrorInGradle10()
+                .undocumented()
+                .nagUser();
+            return false;
+        } else {
+            return true;
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AbstractAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AbstractAttributeContainer.java
@@ -64,10 +64,10 @@ public abstract class AbstractAttributeContainer implements AttributeContainerIn
      */
     protected boolean isValidAttributeRequest(@Nullable Attribute<?> key) {
         if (key == null) {
-            DeprecationLogger.deprecateInvocation("getAttribute with a null key")
+            DeprecationLogger.deprecateBehaviour("Retrieving attribute with a null key.")
                 .withAdvice("Don't request attributes from attribute containers using null keys.")
                 .willBecomeAnErrorInGradle10()
-                .undocumented()
+                .withUpgradeGuideSection(8, "null-attribute-lookup")
                 .nagUser();
             return false;
         } else {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeContainerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeContainerInternal.java
@@ -22,6 +22,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import java.util.Map;
 
 public interface AttributeContainerInternal extends AttributeContainer {
+
     /**
      * Returns an immutable copy of this attribute set. Implementations are not required to return a distinct instance for each call.
      * Changes to this set are <em>not</em> reflected in the immutable copy.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeContainerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeContainerInternal.java
@@ -22,7 +22,6 @@ import org.gradle.api.attributes.AttributeContainer;
 import java.util.Map;
 
 public interface AttributeContainerInternal extends AttributeContainer {
-
     /**
      * Returns an immutable copy of this attribute set. Implementations are not required to return a distinct instance for each call.
      * Changes to this set are <em>not</em> reflected in the immutable copy.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeMergingException.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeMergingException.java
@@ -17,12 +17,17 @@ package org.gradle.api.internal.attributes;
 
 import org.gradle.api.attributes.Attribute;
 
-public class AttributeMergingException extends Exception {
+public class AttributeMergingException extends RuntimeException {
     private final Attribute<?> attribute;
     private final Object leftValue;
     private final Object rightValue;
 
     public AttributeMergingException(Attribute<?> attribute, Object leftValue, Object rightValue) {
+        this(attribute, leftValue, rightValue, "An attribute named '" + attribute.getName() + "' of type '" + attribute.getType().getName() + "' already exists in this container");
+    }
+
+    public AttributeMergingException(Attribute<?> attribute, Object leftValue, Object rightValue, String message) {
+        super(message);
         this.attribute = attribute;
         this.leftValue = leftValue;
         this.rightValue = rightValue;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
@@ -56,6 +56,9 @@ public interface AttributeValue<T> {
 
     /**
      * Returns the value of this attribute.
+     * <p>
+     * This should <strong>NOT</strong> be called on {@link AttributeValue#MISSING}.
+     *
      * @return the value of this attribute. Throws an error if called on a missing or unknown attribute value.
      */
     T get();
@@ -63,7 +66,10 @@ public interface AttributeValue<T> {
     /**
      * Coerces this value to the type of the other attribute, so it can be compared
      * to a value of that other attribute.
+     * <p>
+     * This should <strong>NOT</strong> be called on {@link AttributeValue#MISSING}.
      *
+     * @param otherAttribute the other attribute to attempt to coerce the this attribute to
      * @throws IllegalArgumentException if this attribute is not compatible with the other one
      */
     <S> S coerce(Attribute<S> otherAttribute);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
@@ -18,8 +18,6 @@ package org.gradle.api.internal.attributes;
 
 import org.gradle.api.attributes.Attribute;
 
-import javax.annotation.Nullable;
-
 /**
  * Represents an optional attribute value, as found in an attribute container. There are 3 possible cases:
  * <ul>
@@ -38,7 +36,6 @@ public interface AttributeValue<T> {
             return false;
         }
 
-        @Nullable
         @Override
         public <S> S coerce(Attribute<S> type) {
             throw new UnsupportedOperationException("coerce() should not be called on a missing attribute value");
@@ -61,7 +58,6 @@ public interface AttributeValue<T> {
      * Returns the value of this attribute.
      * @return the value of this attribute. Throws an error if called on a missing or unknown attribute value.
      */
-    @Nullable
     T get();
 
     /**
@@ -70,6 +66,5 @@ public interface AttributeValue<T> {
      *
      * @throws IllegalArgumentException if this attribute is not compatible with the other one
      */
-    @Nullable
     <S> S coerce(Attribute<S> otherAttribute);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
@@ -61,6 +61,7 @@ public interface AttributeValue<T> {
      * Returns the value of this attribute.
      * @return the value of this attribute. Throws an error if called on a missing or unknown attribute value.
      */
+    @Nullable
     T get();
 
     /**
@@ -69,5 +70,6 @@ public interface AttributeValue<T> {
      *
      * @throws IllegalArgumentException if this attribute is not compatible with the other one
      */
+    @Nullable
     <S> S coerce(Attribute<S> otherAttribute);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributeValue.java
@@ -57,7 +57,7 @@ public interface AttributeValue<T> {
     /**
      * Returns the value of this attribute.
      * <p>
-     * This should <strong>NOT</strong> be called on {@link AttributeValue#MISSING}.
+     * This should <strong>NOT</strong> be called when {@link #isPresent()} is {@code false}.
      *
      * @return the value of this attribute. Throws an error if called on a missing or unknown attribute value.
      */
@@ -67,9 +67,9 @@ public interface AttributeValue<T> {
      * Coerces this value to the type of the other attribute, so it can be compared
      * to a value of that other attribute.
      * <p>
-     * This should <strong>NOT</strong> be called on {@link AttributeValue#MISSING}.
+     * This should <strong>NOT</strong> be called when {@link #isPresent()} is {@code false}.
      *
-     * @param otherAttribute the other attribute to attempt to coerce the this attribute to
+     * @param otherAttribute the other attribute to attempt to coerce this attribute to
      * @throws IllegalArgumentException if this attribute is not compatible with the other one
      */
     <S> S coerce(Attribute<S> otherAttribute);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributesFactory.java
@@ -22,6 +22,10 @@ import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Map;
 
+// TODO: We should consider renaming every concat method here to "merge" or something,
+//       as these are not concatenation operations, and it is confusing to expect them
+//       to behave as such.  They REPLACE duplicate keys, and sometimes result in adding
+//       MULTIPLE values to the result for a single key.
 @ServiceScope(Scope.BuildSession.class)
 public interface AttributesFactory {
     /**
@@ -64,12 +68,12 @@ public interface AttributesFactory {
     ImmutableAttributes fromMap(Map<Attribute<?>, Isolatable<?>> attributes);
 
     /**
-     * Adds the given attribute to the given container. Note: the container _should not_ contain the given attribute.
+     * Merges the given attribute to the given container. Note: the container _should not_ contain the given attribute.
      */
     <T> ImmutableAttributes concat(ImmutableAttributes node, Attribute<T> key, T value);
 
     /**
-     * Adds the given attribute to the given container. Note: the container _should not_ contain the given attribute.
+     * Merges the given attribute to the given container. Note: the container _should not_ contain the given attribute.
      */
     <T> ImmutableAttributes concat(ImmutableAttributes node, Attribute<T> key, Isolatable<T> value);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.attributes;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.Cast;
@@ -28,7 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class DefaultAttributesFactory implements AttributesFactory {
+public final class DefaultAttributesFactory implements AttributesFactory {
     private final ImmutableAttributes root;
     private final Map<ImmutableAttributes, ImmutableList<DefaultImmutableAttributesContainer>> children;
     private final AttributeValueIsolator attributeValueIsolator;
@@ -84,6 +85,7 @@ public class DefaultAttributesFactory implements AttributesFactory {
     }
 
     ImmutableAttributes doConcatIsolatable(ImmutableAttributes node, Attribute<?> key, Isolatable<?> value) {
+        assertAttributeNotAlreadyPresent(node, key);
 
         // Try to retrieve a cached value without locking
         ImmutableList<DefaultImmutableAttributesContainer> cachedChildren = children.get(node);
@@ -139,6 +141,7 @@ public class DefaultAttributesFactory implements AttributesFactory {
             .build();
     }
 
+    @SuppressWarnings("DataFlowIssue")
     @Override
     public ImmutableAttributes concat(ImmutableAttributes fallback, ImmutableAttributes primary) {
         if (fallback == ImmutableAttributes.EMPTY) {
@@ -160,6 +163,7 @@ public class DefaultAttributesFactory implements AttributesFactory {
         return current;
     }
 
+    @SuppressWarnings("DataFlowIssue")
     @Override
     public ImmutableAttributes safeConcat(ImmutableAttributes attributes1, ImmutableAttributes attributes2) throws AttributeMergingException {
         if (attributes1 == ImmutableAttributes.EMPTY) {
@@ -208,4 +212,23 @@ public class DefaultAttributesFactory implements AttributesFactory {
         return concat(attributes, key, castValue);
     }
 
+
+    /**
+     * Verifies that an attribute with the same name but different types as the given key is not
+     * already present in the given container.
+     *
+     * @param container the container to check
+     * @param key the attribute to check for
+     * @throws IllegalArgumentException if attribute with same name and different type already exists
+     */
+    public void assertAttributeNotAlreadyPresent(AttributeContainer container, Attribute<?> key) {
+        for (Attribute<?> attribute : container.keySet()) {
+            String name = key.getName();
+            if (attribute.getName().equals(name) && attribute.getType() != key.getType()) {
+                throw new IllegalArgumentException("Cannot have two attributes with the same name but different types. "
+                    + "This container already has an attribute named '" + name + "' of type '" + attribute.getType().getName()
+                    + "' and you are trying to store another one of type '" + key.getType().getName() + "'");
+            }
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesContainer.java
@@ -128,11 +128,11 @@ final class DefaultImmutableAttributesContainer implements ImmutableAttributes, 
 
     @Override
     @Nullable
-    public <T> T getAttribute(Attribute<T> key) {
+    public <T> T getAttribute(@Nullable Attribute<T> key) {
         Isolatable<T> isolatable = getIsolatableAttribute(key);
         if (isolatable == null) {
             return null;
-        } else if (isolatable.getClass() != key.getClass() && isolatable.getClass().getName().equals(key.getClass().getName())) {
+        } else if (key != null && isolatable.getClass() != key.getClass() && isolatable.getClass().getName().equals(key.getClass().getName())) {
             return isolatable.coerce(key.getType());
         } else {
             return isolatable.isolate();
@@ -140,8 +140,8 @@ final class DefaultImmutableAttributesContainer implements ImmutableAttributes, 
     }
 
     @Nullable
-    /* package */ <T> Isolatable<T> getIsolatableAttribute(Attribute<T> key) {
-        DefaultImmutableAttributesContainer attributes = hierarchyByName.get(key.getName());
+    /* package */ <T> Isolatable<T> getIsolatableAttribute(@Nullable Attribute<T> key) {
+        DefaultImmutableAttributesContainer attributes = key != null ? hierarchyByName.get(key.getName()) : null;
         return Cast.uncheckedCast(attributes == null ? null : attributes.value);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesContainer.java
@@ -224,7 +224,7 @@ public final class DefaultImmutableAttributesContainer extends AbstractAttribute
     @SuppressWarnings("DataFlowIssue")
     @Override
     public Object get() {
-        Preconditions.checkState(value != null, "value should never be null when get() is called");
+        Preconditions.checkState(value != null, "When calling get() value should never be null");
         return value.isolate();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesContainer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.attributes;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Named;
@@ -148,8 +149,8 @@ final class DefaultImmutableAttributesContainer extends AbstractAttributeContain
     }
 
     @Nullable
-    /* package */ <T> Isolatable<T> getIsolatableAttribute(@Nullable Attribute<T> key) {
-        DefaultImmutableAttributesContainer attributes = key != null ? hierarchyByName.get(key.getName()) : null;
+    /* package */ <T> Isolatable<T> getIsolatableAttribute(Attribute<T> key) {
+        DefaultImmutableAttributesContainer attributes = hierarchyByName.get(key.getName());
         return Cast.uncheckedCast(attributes == null ? null : attributes.value);
     }
 
@@ -176,13 +177,13 @@ final class DefaultImmutableAttributesContainer extends AbstractAttributeContain
         return attributes == null ? MISSING : attributes;
     }
 
+    @SuppressWarnings("DataFlowIssue")
     @Override
-    @Nullable
     public Object get() {
+        Preconditions.checkState(value != null, "value should never be null when get() is called");
         return value.isolate();
     }
 
-    @SuppressWarnings("DataFlowIssue")
     @Nullable
     private String desugar() {
         // We support desugaring for all non-primitive types supported in GradleModuleMetadataWriter.writeAttributes(), which are:
@@ -206,7 +207,6 @@ final class DefaultImmutableAttributesContainer extends AbstractAttributeContain
     }
 
     @Override
-    @Nullable
     public <S> S coerce(Attribute<S> otherAttribute) {
         S s = Cast.uncheckedCast(coercionCache.get(otherAttribute));
         if (s == null) {
@@ -216,9 +216,6 @@ final class DefaultImmutableAttributesContainer extends AbstractAttributeContain
         return s;
     }
 
-
-    @SuppressWarnings("DataFlowIssue")
-    @Nullable
     private <S> S uncachedCoerce(Attribute<S> otherAttribute) {
         Class<S> otherAttributeType = otherAttribute.getType();
         // If attribute types are already compatible, go with it. There are two cases covered here:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesContainer.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
-final class DefaultImmutableAttributesContainer implements ImmutableAttributes, AttributeValue<Object> {
+final class DefaultImmutableAttributesContainer extends AbstractAttributeContainer implements ImmutableAttributes, AttributeValue<Object> {
     private static final Comparator<Attribute<?>> ATTRIBUTE_NAME_COMPARATOR = Comparator.comparing(Attribute::getName);
     // Coercion is an expensive process, so we cache the result of coercing to other attribute types.
     // We can afford using a hashmap here because attributes are interned, and their lifetime doesn't
@@ -84,7 +84,7 @@ final class DefaultImmutableAttributesContainer implements ImmutableAttributes, 
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }
@@ -126,9 +126,14 @@ final class DefaultImmutableAttributesContainer implements ImmutableAttributes, 
         throw new UnsupportedOperationException("Mutation of attributes is not allowed");
     }
 
+    @SuppressWarnings({"ConstantValue"})
     @Override
     @Nullable
-    public <T> T getAttribute(@Nullable Attribute<T> key) {
+    public <T> T getAttribute(Attribute<T> key) {
+        if (!isValidAttributeRequest(key)) {
+            return null;
+        }
+
         Isolatable<T> isolatable = getIsolatableAttribute(key);
         if (isolatable == null) {
             return null;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesContainer.java
@@ -132,10 +132,13 @@ final class DefaultImmutableAttributesContainer implements ImmutableAttributes, 
         Isolatable<T> isolatable = getIsolatableAttribute(key);
         if (isolatable == null) {
             return null;
-        } else if (key != null && isolatable.getClass() != key.getClass() && isolatable.getClass().getName().equals(key.getClass().getName())) {
+        }
+
+        T value = isolatable.isolate();
+        if (key != null && value != null && value.getClass() != key.getType() && key.getType() != Object.class) {
             return isolatable.coerce(key.getType());
         } else {
-            return isolatable.isolate();
+            return value;
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
@@ -76,7 +76,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
         return this;
     }
 
-    private <T> void doInsertion(@Nullable Attribute<T> key, T value) {
+    private <T> void doInsertion(Attribute<T> key, T value) {
         assertAttributeValueIsNotNull(value);
         assertAttributeTypeIsValid(value.getClass(), key);
         immutableValue = null;
@@ -84,7 +84,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
         removeLazyAttributeIfPresent(key);
     }
 
-    private <T> void removeLazyAttributeIfPresent(@Nullable Attribute<T> key) {
+    private <T> void removeLazyAttributeIfPresent(Attribute<T> key) {
         lazyAttributes.remove(key);
     }
 
@@ -125,8 +125,8 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
      * @param valueType the value type to check
      * @param attribute the attribute containing a type to check against
      */
-    private <T> void assertAttributeTypeIsValid(Class<?> valueType, @Nullable Attribute<T> attribute) {
-        if (attribute != null && !attribute.getType().isAssignableFrom(valueType)) {
+    private <T> void assertAttributeTypeIsValid(Class<?> valueType, Attribute<T> attribute) {
+        if (!attribute.getType().isAssignableFrom(valueType)) {
             throw new IllegalArgumentException(String.format("Unexpected type for attribute '%s' provided. Expected a value of type %s but found a value of type %s.", attribute.getName(), attribute.getType().getName(), valueType.getName()));
         }
     }
@@ -208,7 +208,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
         attributes.remove(key);
     }
 
-    private <T> T realizeLazyAttribute(@Nullable Attribute<T> key) {
+    private <T> T realizeLazyAttribute(Attribute<T> key) {
         @SuppressWarnings("unchecked") final T value = (T) lazyAttributes.get(key).get();
         doInsertion(key, value);
         return value;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
@@ -138,6 +138,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
     }
 
     @Override
+    @Nullable
     public <T> T getAttribute(Attribute<T> key) {
         maybeEmitRecursiveQueryDeprecation();
         Isolatable<?> value = attributes.get(key);
@@ -172,7 +173,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
@@ -76,7 +76,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
         return this;
     }
 
-    private <T> void doInsertion(Attribute<T> key, T value) {
+    private <T> void doInsertion(@Nullable Attribute<T> key, T value) {
         assertAttributeValueIsNotNull(value);
         assertAttributeTypeIsValid(value.getClass(), key);
         immutableValue = null;
@@ -84,7 +84,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
         removeLazyAttributeIfPresent(key);
     }
 
-    private <T> void removeLazyAttributeIfPresent(Attribute<T> key) {
+    private <T> void removeLazyAttributeIfPresent(@Nullable Attribute<T> key) {
         lazyAttributes.remove(key);
     }
 
@@ -125,8 +125,8 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
      * @param valueType the value type to check
      * @param attribute the attribute containing a type to check against
      */
-    private <T> void assertAttributeTypeIsValid(Class<?> valueType, Attribute<T> attribute) {
-        if (!attribute.getType().isAssignableFrom(valueType)) {
+    private <T> void assertAttributeTypeIsValid(Class<?> valueType, @Nullable Attribute<T> attribute) {
+        if (attribute != null && !attribute.getType().isAssignableFrom(valueType)) {
             throw new IllegalArgumentException(String.format("Unexpected type for attribute '%s' provided. Expected a value of type %s but found a value of type %s.", attribute.getName(), attribute.getType().getName(), valueType.getName()));
         }
     }
@@ -139,7 +139,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
 
     @Override
     @Nullable
-    public <T> T getAttribute(Attribute<T> key) {
+    public <T> T getAttribute(@Nullable Attribute<T> key) {
         maybeEmitRecursiveQueryDeprecation();
         Isolatable<?> value = attributes.get(key);
         if (value == null) {
@@ -204,7 +204,7 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
         attributes.remove(key);
     }
 
-    private <T> T realizeLazyAttribute(Attribute<T> key) {
+    private <T> T realizeLazyAttribute(@Nullable Attribute<T> key) {
         @SuppressWarnings("unchecked") final T value = (T) lazyAttributes.get(key).get();
         doInsertion(key, value);
         return value;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
-final class DefaultMutableAttributeContainer extends AbstractAttributeContainer implements AttributeContainerInternal {
+final class DefaultMutableAttributeContainer extends AbstractAttributeContainer {
     private final Map<Attribute<?>, Isolatable<?>> attributes = new LinkedHashMap<>(); // Need to maintain insertion order here, this is indirectly tested
     private Map<Attribute<?>, Provider<?>> lazyAttributes = Cast.uncheckedCast(Collections.EMPTY_MAP);
     private boolean realizingAttributes = false;
@@ -139,8 +139,12 @@ final class DefaultMutableAttributeContainer extends AbstractAttributeContainer 
 
     @Override
     @Nullable
-    public <T> T getAttribute(@Nullable Attribute<T> key) {
+    public <T> T getAttribute(Attribute<T> key) {
+        if (!isValidAttributeRequest(key)) {
+            return null;
+        }
         maybeEmitRecursiveQueryDeprecation();
+
         Isolatable<?> value = attributes.get(key);
         if (value == null) {
             if (lazyAttributes.containsKey(key)) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
-final class DefaultMutableAttributeContainer extends AbstractAttributeContainer {
+public final class DefaultMutableAttributeContainer extends AbstractAttributeContainer {
     private final Map<Attribute<?>, Isolatable<?>> attributes = new LinkedHashMap<>(); // Need to maintain insertion order here, this is indirectly tested
     private Map<Attribute<?>, Provider<?>> lazyAttributes = Cast.uncheckedCast(Collections.EMPTY_MAP);
     private boolean realizingAttributes = false;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainer.java
@@ -63,7 +63,11 @@ final class HierarchicalMutableAttributeContainer extends AbstractAttributeConta
 
     @Nullable
     @Override
-    public <T> T getAttribute(@Nullable Attribute<T> key) {
+    public <T> T getAttribute(Attribute<T> key) {
+        if (!isValidAttributeRequest(key)) {
+            return null;
+        }
+
         T attribute = primary.getAttribute(key);
         if (attribute != null) {
             return attribute;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainer.java
@@ -33,7 +33,7 @@ import java.util.TreeMap;
  * container will override attributes in the fallback container. All mutation operations are
  * forwarded to the primary container.
  */
-final class HierarchicalMutableAttributeContainer extends AbstractAttributeContainer {
+public final class HierarchicalMutableAttributeContainer extends AbstractAttributeContainer {
     private final AttributesFactory attributesFactory;
     private final AttributeContainerInternal fallback;
     private final AttributeContainerInternal primary;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainer.java
@@ -63,7 +63,7 @@ final class HierarchicalMutableAttributeContainer extends AbstractAttributeConta
 
     @Nullable
     @Override
-    public <T> T getAttribute(Attribute<T> key) {
+    public <T> T getAttribute(@Nullable Attribute<T> key) {
         T attribute = primary.getAttribute(key);
         if (attribute != null) {
             return attribute;
@@ -83,7 +83,7 @@ final class HierarchicalMutableAttributeContainer extends AbstractAttributeConta
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainer.java
@@ -33,7 +33,7 @@ import java.util.TreeMap;
  * container will override attributes in the fallback container. All mutation operations are
  * forwarded to the primary container.
  */
-public final class HierarchicalMutableAttributeContainer extends AbstractAttributeContainer {
+/* package */ final class HierarchicalMutableAttributeContainer extends AbstractAttributeContainer {
     private final AttributesFactory attributesFactory;
     private final AttributeContainerInternal fallback;
     private final AttributeContainerInternal primary;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributes.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributes.java
@@ -19,6 +19,8 @@ package org.gradle.api.internal.attributes;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.attributes.Attribute;
 
+import javax.annotation.Nullable;
+
 public interface ImmutableAttributes extends AttributeContainerInternal {
     ImmutableAttributes EMPTY = new DefaultImmutableAttributesContainer();
 
@@ -47,6 +49,15 @@ public interface ImmutableAttributes extends AttributeContainerInternal {
      * @return the value for the attribute in this container, or {@link AttributeValue#MISSING} if not present
      */
     AttributeValue<?> findEntry(String name);
+
+    /**
+     * Locates the {@link Attribute} with given name.
+     *
+     * @param name the name of an attribute to locate in this container
+     * @return the attribute with this name in this container; or {@code null} if not present
+     */
+    @Nullable
+    Attribute<?> findAttribute(String name);
 
     @Override
     ImmutableSet<Attribute<?>> keySet();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/UsageCompatibilityHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/UsageCompatibilityHandler.java
@@ -34,6 +34,8 @@ class UsageCompatibilityHandler {
     }
 
     public <T> ImmutableAttributes doConcat(DefaultAttributesFactory factory, ImmutableAttributes node, Attribute<T> key, Isolatable<T> value) {
+        factory.assertAttributeNotAlreadyPresent(node, key);
+
         assert key.getName().equals(Usage.USAGE_ATTRIBUTE.getName()) : "Should only be invoked for 'org.gradle.usage', got '" + key.getName() + "'";
         // Replace deprecated usage values
         String val;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/AbstractAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/AbstractAttributeContainerTest.groovy
@@ -62,7 +62,7 @@ import spock.lang.Specification
         and:
         def events = outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }
         events.size() == 1
-        events[0].message.startsWith('Using method getAttribute with a null key has been deprecated.')
+        events[0].message.startsWith('Calling getAttribute() with a null key has been deprecated.')
 
         where:
         containerStatus                 | preppedContainer

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/AbstractAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/AbstractAttributeContainerTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.internal.problems.NoOpProblemDiagnosticsFactory
 import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
+
 /**
  * Abstract base class for testing functionality common to all {@link AbstractAttributeContainer} implementations.
  */

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/AbstractAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/AbstractAttributeContainerTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes
+
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.configuration.WarningMode
+import org.gradle.internal.deprecation.DeprecationLogger
+import org.gradle.internal.logging.CollectingTestOutputEventListener
+import org.gradle.internal.logging.ConfigureLogging
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter
+import org.gradle.internal.problems.NoOpProblemDiagnosticsFactory
+import org.gradle.util.TestUtil
+import org.junit.Rule
+import spock.lang.Specification
+
+/**
+ * Abstract base class for testing functionality common to all {@link AbstractAttributeContainer} implementations.
+ */
+/* package */ abstract class AbstractAttributeContainerTest extends Specification {
+    protected final CollectingTestOutputEventListener outputEventListener = new CollectingTestOutputEventListener()
+    @Rule
+    protected final ConfigureLogging logging = new ConfigureLogging(outputEventListener)
+
+    def setup() {
+        def diagnosticsFactory = new NoOpProblemDiagnosticsFactory()
+        def buildOperationProgressEventEmitter = Mock(BuildOperationProgressEventEmitter)
+        DeprecationLogger.reset()
+        DeprecationLogger.init(WarningMode.All, buildOperationProgressEventEmitter, TestUtil.problemsService(), diagnosticsFactory.newUnlimitedStream())
+    }
+
+    /**
+     * Returns a new instance of the container type tested by this class.
+     *
+     * @param attributes optional map of attributes with values to populate the container with if present
+     * @return the container, populated with any given attributes from the argument
+     */
+    protected abstract <T> AbstractAttributeContainer getContainer(Map<Attribute<T>, T> attributes = [:])
+
+    def "requesting a null key emits a deprecation message using #containerStatus"() {
+        when:
+        def result = preppedContainer.getAttribute(null)
+
+        then:
+        result == null
+
+        and:
+        def events = outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }
+        events.size() == 1
+        events[0].message.startsWith('Using method getAttribute with a null key has been deprecated.')
+
+        where:
+        containerStatus                 | preppedContainer
+        "empty container"               | getContainer()
+        "container with elements"       | getContainer([(Attribute.of("testString", String)): "testValue", (Attribute.of("testInt", Integer)): 1])
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/AbstractAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/AbstractAttributeContainerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.attributes
 
+import org.gradle.api.Named
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.configuration.WarningMode
@@ -27,7 +28,6 @@ import org.gradle.internal.problems.NoOpProblemDiagnosticsFactory
 import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
-
 /**
  * Abstract base class for testing functionality common to all {@link AbstractAttributeContainer} implementations.
  */
@@ -67,5 +67,50 @@ import spock.lang.Specification
         containerStatus                 | preppedContainer
         "empty container"               | getContainer()
         "container with elements"       | getContainer([(Attribute.of("testString", String)): "testValue", (Attribute.of("testInt", Integer)): 1])
+    }
+
+    def "can't contain 2 identically named attributes with different types from the same classloader"() {
+        when:
+        getContainer([(Attribute.of("test", String)): "a", (Attribute.of("test", Integer)): 1])
+
+        then:
+        def exception = thrown(Exception)
+        exception.message == "Cannot have two attributes with the same name but different types. This container already has an attribute named 'test' of type 'java.lang.String' and you are trying to store another one of type 'java.lang.Integer'"
+    }
+
+    def "can't contain 2 identically named attributes with the same type loaded from different classloaders"() {
+        given: "a second classloader, that has no parent, and can load the Named class"
+        def pathToClass = Thread.currentThread().getContextClassLoader().getResource(Named.name.replace(".", "/") + ".class").toString()
+        def pathToJar = pathToClass.substring("jar:".length(), pathToClass.indexOf('!'))
+        def urls = new URL[] { new URL(pathToJar) }
+        ClassLoader loader2 = new URLClassLoader(urls, (ClassLoader) null) // Loader 2 only has the URL of the jar containing Named
+
+        when: "that alternate classloader is used to load the Named class"
+        Class<?> named2 = loader2.loadClass(Named.name)
+
+        then: "2 copies of the class Named exist, loaded from the default classloader and the alternate classloader"
+        Named.name == named2.name
+        Named.classLoader != named2.classLoader
+        Named != named2
+
+        when:
+        getContainer([(Attribute.of("test", Named)): new MyNamed("name1"), (Attribute.of("test", named2)): new MyNamed("name2")])
+
+        then:
+        def exception = thrown(Exception)
+        exception.message == "Cannot have two attributes with the same name but different types. This container already has an attribute named 'test' of type 'org.gradle.api.Named' and you are trying to store another one of type 'org.gradle.api.Named'"
+    }
+
+    private static final class MyNamed implements Named, Serializable {
+        private final String name
+
+        MyNamed(String name) {
+            this.name = name
+        }
+
+        @Override
+        String getName() {
+            return null
+        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/AbstractAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/AbstractAttributeContainerTest.groovy
@@ -62,7 +62,7 @@ import spock.lang.Specification
         and:
         def events = outputEventListener.events.findAll { it.logLevel == LogLevel.WARN }
         events.size() == 1
-        events[0].message.startsWith('Calling getAttribute() with a null key has been deprecated.')
+        events[0].message.startsWith('Using method getAttribute with a null key has been deprecated.')
 
         where:
         containerStatus                 | preppedContainer

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
@@ -151,8 +151,8 @@ class DefaultAttributesFactoryTest extends Specification implements TestsImmutab
 
     def "can replace attribute with same name and different type"() {
         given:
-        def set1 = factory.concat(factory.of(FOO, "foo1"), factory.of(OTHER_BAR, "bar1"))
-        def set2 = factory.of(BAR, "bar2")
+        def set1 = factory.concat(factory.of(FOO, "foo1"), factory.of(OTHER_BAR, "bar1")) // Object-typed bar
+        def set2 = factory.of(BAR, "bar2") // String-typed bar
 
         when:
         def concat = factory.concat(set1, set2)
@@ -180,8 +180,8 @@ class DefaultAttributesFactoryTest extends Specification implements TestsImmutab
 
     def "can detect incompatible attributes with different types when merging"() {
         given:
-        def set1 = factory.concat(factory.of(FOO, "foo1"), factory.of(OTHER_BAR, "bar1"))
-        def set2 = factory.concat(factory.of(FOO, "foo1"), factory.of(BAR, "bar2"))
+        def set1 = factory.concat(factory.of(FOO, "foo1"), factory.of(OTHER_BAR, "bar1")) // Object-typed bar
+        def set2 = factory.concat(factory.of(FOO, "foo1"), factory.of(BAR, "bar2")) // String-typed bar
 
         when:
         factory.safeConcat(set1, set2)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
@@ -191,5 +191,19 @@ class DefaultAttributesFactoryTest extends Specification implements TestsImmutab
         e.attribute == OTHER_BAR
         e.leftValue == "bar1"
         e.rightValue == "bar2"
+        e.message == "Cannot have two attributes with the same name but different types. This container already has an attribute named 'bar' of type 'java.lang.String' and you are trying to store another one of type 'java.lang.Object'"
+    }
+
+    def "can detect incompatible attributes with different types when merging; same value but different types"() {
+        given:
+        def set1 = factory.concat(factory.of(FOO, "foo1"), factory.of(OTHER_BAR, "bar1")) // Object-typed bar
+        def set2 = factory.concat(factory.of(FOO, "foo1"), factory.of(BAR, "bar1")) // String-typed bar
+
+        when:
+        factory.safeConcat(set1, set2)
+
+        then:
+        Exception e = thrown()
+        e.message == "Cannot have two attributes with the same name but different types. This container already has an attribute named 'bar' of type 'java.lang.String' and you are trying to store another one of type 'java.lang.Object'"
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributeContainerTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes
+
+import org.gradle.api.attributes.Attribute
+
+/**
+ * Unit tests for the {@link DefaultImmutableAttributesContainer} class.
+ */
+final class DefaultImmutableAttributeContainerTest extends AbstractAttributeContainerTest {
+    @SuppressWarnings(['GroovyAssignabilityCheck', 'GrReassignedInClosureLocalVar'])
+    @Override
+    protected <T> DefaultImmutableAttributesContainer getContainer(Map<Attribute<T>, T> attributes = [:]) {
+        DefaultImmutableAttributesContainer container = new DefaultImmutableAttributesContainer()
+        container.asMap().forEach { (key, T value) ->
+            container = AttributesFactory.concat(container, key, value)
+        }
+        return container
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributeContainerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.attributes
 
+import org.gradle.api.Named
 import org.gradle.api.attributes.Attribute
 import org.gradle.util.AttributeTestUtil
 
@@ -31,5 +32,18 @@ final class DefaultImmutableAttributeContainerTest extends AbstractAttributeCont
             container = AttributeTestUtil.attributesFactory().concat(container, key, value)
         }
         return container
+    }
+
+    // This lenient coercing behavior is only available in the immutable container.  The mutable containers shouldn't ever need it
+    def "if there is a string in the container, and you ask for it as a Named, you get back the same value do to coercion"() {
+        given:
+        def container = getContainer([(Attribute.of("test", String)): "value"])
+
+        when:
+        //noinspection GroovyAssignabilityCheck
+        def result = (String) container.getAttribute(Attribute.of("test", Named))
+
+        then:
+        result == "value"
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributeContainerTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.attributes
 
 import org.gradle.api.attributes.Attribute
+import org.gradle.util.AttributeTestUtil
 
 /**
  * Unit tests for the {@link DefaultImmutableAttributesContainer} class.
@@ -26,8 +27,8 @@ final class DefaultImmutableAttributeContainerTest extends AbstractAttributeCont
     @Override
     protected <T> DefaultImmutableAttributesContainer getContainer(Map<Attribute<T>, T> attributes = [:]) {
         DefaultImmutableAttributesContainer container = new DefaultImmutableAttributesContainer()
-        container.asMap().forEach { (key, T value) ->
-            container = AttributesFactory.concat(container, key, value)
+        attributes.forEach { key, value ->
+            container = AttributeTestUtil.attributesFactory().concat(container, key, value)
         }
         return container
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
 
 /**
  * Unit tests for the {@link DefaultMutableAttributeContainer} class.
@@ -380,7 +381,7 @@ final class DefaultMutableAttributeContainerTest extends AbstractAttributeContai
     }
 
     def "can add deprecated usage then add libraryelements and convert to immutable"() {
-        def container = mutable()
+        def container = getContainer()
 
         when:
         container.attribute(Usage.USAGE_ATTRIBUTE, TestUtil.objectInstantiator().named(Usage, JavaEcosystemSupport.DEPRECATED_JAVA_API_JARS))
@@ -394,7 +395,7 @@ final class DefaultMutableAttributeContainerTest extends AbstractAttributeContai
     }
 
     def "can add libraryelements then add deprecated usage and convert to immutable"() {
-        def container = mutable()
+        def container = getContainer()
 
         when:
         container.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, TestUtil.objectInstantiator().named(LibraryElements, "aar"))

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.util.AttributeTestUtil
+
 /**
  * Unit tests for the {@link DefaultMutableAttributeContainer} class.
  */

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -26,40 +26,24 @@ import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.internal.deprecation.DeprecationLogger
-import org.gradle.internal.logging.CollectingTestOutputEventListener
-import org.gradle.internal.logging.ConfigureLogging
-import org.gradle.internal.operations.BuildOperationProgressEventEmitter
-import org.gradle.internal.problems.NoOpProblemDiagnosticsFactory
 import org.gradle.util.AttributeTestUtil
-import org.gradle.util.TestUtil
-import org.junit.Rule
-import spock.lang.Specification
-
-class DefaultMutableAttributeContainerTest extends Specification {
-
-    CollectingTestOutputEventListener outputEventListener = new CollectingTestOutputEventListener()
-
-    @Rule
-    ConfigureLogging logging = new ConfigureLogging(outputEventListener)
-
-    def setup() {
-        final diagnosticsFactory = new NoOpProblemDiagnosticsFactory()
-        def buildOperationProgressEventEmitter = Mock(BuildOperationProgressEventEmitter)
-        DeprecationLogger.init(WarningMode.All, buildOperationProgressEventEmitter, TestUtil.problemsService(), diagnosticsFactory.newUnlimitedStream())
-    }
-
-    def attributesFactory = AttributeTestUtil.attributesFactory()
-
-    private DefaultMutableAttributeContainer mutable() {
-        return new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator())
+/**
+ * Unit tests for the {@link DefaultMutableAttributeContainer} class.
+ */
+final class DefaultMutableAttributeContainerTest extends AbstractAttributeContainerTest {
+    @Override
+    protected <T> DefaultMutableAttributeContainer getContainer(Map<Attribute<T>, T> attributes = [:]) {
+        DefaultMutableAttributeContainer container = new DefaultMutableAttributeContainer(AttributeTestUtil.attributesFactory(), AttributeTestUtil.attributeValueIsolator())
+        attributes.forEach {key, value ->
+            container.attribute(key, value)
+        }
+        return container
     }
 
     def "lazy attributes are evaluated in insertion order"() {
-        def container = mutable()
+        def container = getContainer()
         def actual = []
         def expected = []
         (1..100).each { idx ->
@@ -76,7 +60,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     }
 
     def "realizing the value of lazy attributes may cause other attributes to be realized"() {
-        def container = mutable()
+        def container = getContainer()
         def firstAttribute = Attribute.of("first", String)
         def secondAttribute = Attribute.of("second", String)
         container.attributeProvider(firstAttribute, Providers.<String>changing {
@@ -97,7 +81,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     }
 
     def "realizing the value of lazy attributes cannot add new attributes to the container"() {
-        def container = mutable()
+        def container = getContainer()
         def firstAttribute = Attribute.of("first", String)
         def secondAttribute = Attribute.of("second", String)
         container.attributeProvider(firstAttribute, Providers.<String>changing {
@@ -113,7 +97,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     }
 
     def "realizing the value of lazy attributes cannot add new lazy attributes to the container"() {
-        def container = mutable()
+        def container = getContainer()
         def firstAttribute = Attribute.of("first", String)
         def secondAttribute = Attribute.of("second", String)
         container.attributeProvider(firstAttribute, Providers.<String>changing {
@@ -131,7 +115,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     def "adding mismatched attribute types fails fast"() {
         Property<Integer> testProperty = new DefaultProperty<>(Mock(PropertyHost), Integer).convention(1)
         def testAttribute = Attribute.of("test", String)
-        def container = mutable()
+        def container = getContainer()
 
         when:
         //noinspection GroovyAssignabilityCheck - meant to fail
@@ -144,7 +128,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     def "adding mismatched attribute types fails when retrieving the key when the provider does not know the type"() {
         Provider<?> testProperty = new DefaultProvider<?>( { 1 })
         def testAttribute = Attribute.of("test", String)
-        def container = mutable()
+        def container = getContainer()
 
         when:
         //noinspection GroovyAssignabilityCheck - meant to fail
@@ -159,8 +143,8 @@ class DefaultMutableAttributeContainerTest extends Specification {
         Property<String> testProperty1 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value")
         Property<String> testProperty2 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value")
         def testAttribute = Attribute.of("test", String)
-        def container1 = mutable()
-        def container2 = mutable()
+        def container1 = getContainer()
+        def container2 = getContainer()
 
         when:
         container1.attributeProvider(testAttribute, testProperty1)
@@ -175,8 +159,8 @@ class DefaultMutableAttributeContainerTest extends Specification {
         Property<String> testProperty1 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value1")
         Property<String> testProperty2 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value2")
         def testAttribute = Attribute.of("test", String)
-        def container1 = mutable()
-        def container2 = mutable()
+        def container1 = getContainer()
+        def container2 = getContainer()
 
         when:
         container1.attributeProvider(testAttribute, testProperty1)
@@ -191,8 +175,8 @@ class DefaultMutableAttributeContainerTest extends Specification {
         Property<String> testProperty1 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value")
         Property<String> testProperty2 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value")
         def testAttribute = Attribute.of("test", String)
-        def container1 = mutable()
-        def container2 = mutable()
+        def container1 = getContainer()
+        def container2 = getContainer()
 
         when:
         container1.attributeProvider(testAttribute, testProperty1)
@@ -206,8 +190,8 @@ class DefaultMutableAttributeContainerTest extends Specification {
         Property<String> testProperty1 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value1")
         Property<String> testProperty2 = new DefaultProperty<>(Mock(PropertyHost), String).convention("value2")
         def testAttribute = Attribute.of("test", String)
-        def container1 = mutable()
-        def container2 = mutable()
+        def container1 = getContainer()
+        def container2 = getContainer()
 
         when:
         container1.attributeProvider(testAttribute, testProperty1)
@@ -220,7 +204,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     def "adding attribute should override replace existing lazy attribute"() {
         given: "a container with testAttr set to a provider"
         def testAttr = Attribute.of("test", String)
-        def container = mutable()
+        def container = getContainer()
         Property<String> testProvider = new DefaultProperty<>(Mock(PropertyHost), String).convention("lazy value")
         container.attributeProvider(testAttr, testProvider)
 
@@ -234,7 +218,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
     def "adding lazy attribute should override replace existing attribute"() {
         given: "a container with testAttr set to a fixed value"
         def testAttr = Attribute.of("test", String)
-        def container = mutable()
+        def container = getContainer()
         container.attribute(testAttr, "set value")
 
         when: "adding a lazy testAttr"
@@ -245,9 +229,10 @@ class DefaultMutableAttributeContainerTest extends Specification {
         "lazy value" == container.getAttribute(testAttr)
     }
 
+    @SuppressWarnings('GroovyAccessibility')
     def "toString should not change the internal state of the class"() {
         given: "a container and a lazy and non-lazy attribute"
-        def container = mutable()
+        def container = getContainer()
         def testEager = Attribute.of("eager", String)
         def testLazy = Attribute.of("lazy", String)
         Property<String> testProvider = new DefaultProperty<>(Mock(PropertyHost), String).convention("lazy value")
@@ -278,7 +263,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
         def thing2 = Attribute.of("thing2", String)
 
         when:
-        def container = mutable()
+        def container = getContainer()
 
         then:
         container.empty
@@ -308,7 +293,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
 
     def "A copy of an attribute container contains the same attributes and the same values as the original"() {
         given:
-        def container = mutable()
+        def container = getContainer()
         container.attribute(Attribute.of("a1", Integer), 1)
         container.attribute(Attribute.of("a2", String), "2")
         container.attributeProvider(Attribute.of("a3", String), Providers.of("3"))
@@ -325,7 +310,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
 
     def "changes to attribute container are not seen by immutable copy"() {
         given:
-        AttributeContainerInternal container = mutable()
+        AttributeContainerInternal container = getContainer()
         container.attribute(Attribute.of("a1", Integer), 1)
         container.attribute(Attribute.of("a2", String), "2")
         container.attributeProvider(Attribute.of("a3", String), Providers.of("3"))
@@ -345,7 +330,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
 
     def "An attribute container can provide the attributes through the HasAttributes interface"() {
         given:
-        def container = mutable()
+        def container = getContainer()
         container.attribute(Attribute.of("a1", Integer), 1)
         container.attributeProvider(Attribute.of("a2", String), Providers.of("2"))
 
@@ -364,7 +349,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
         def c = Attribute.of("c", String)
 
         when:
-        def container = mutable()
+        def container = getContainer()
 
         then:
         container.toString() == "{}"
@@ -381,14 +366,14 @@ class DefaultMutableAttributeContainerTest extends Specification {
     }
 
     def "can access lazy elements while iterating over keySet"() {
-        def container = mutable()
+        def container = getContainer()
 
         when:
         container.attributeProvider(Attribute.of("a", String), Providers.of("foo"))
         container.attributeProvider(Attribute.of("b", String), Providers.of("foo"))
 
         then:
-        for (Attribute<?> attribute : container.keySet()) {
+        for (Attribute<Object> attribute : container.keySet()) {
             container.getAttribute(attribute)
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/FreezableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/FreezableAttributeContainerTest.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes
+
+import org.gradle.api.Describable
+import org.gradle.api.attributes.Attribute
+import org.gradle.util.AttributeTestUtil
+
+/**
+ * Unit tests for the {@link FreezableAttributeContainer} class.
+ */
+final class FreezableAttributeContainerTest extends AbstractAttributeContainerTest {
+    @Override
+    protected <T> FreezableAttributeContainer getContainer(Map<Attribute<T>, T> attributes = [:]) {
+        def attributesFactory = AttributeTestUtil.attributesFactory()
+        def mutableContainer = new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator())
+        FreezableAttributeContainer container = new FreezableAttributeContainer(mutableContainer, { "owner" } as Describable);
+        attributes.forEach { key, value ->
+            container.attribute(key, value)
+        }
+        return container
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/FreezableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/FreezableAttributeContainerTest.groovy
@@ -23,15 +23,31 @@ import org.gradle.util.AttributeTestUtil
 /**
  * Unit tests for the {@link FreezableAttributeContainer} class.
  */
-final class FreezableAttributeContainerTest extends AbstractAttributeContainerTest {
+final class FreezableAttributeContainerTest extends BaseAttributeContainerTest {
     @Override
-    protected <T> FreezableAttributeContainer getContainer(Map<Attribute<T>, T> attributes = [:]) {
-        def attributesFactory = AttributeTestUtil.attributesFactory()
+    protected FreezableAttributeContainer createContainer(Map<Attribute<?>, ?> attributes = [:], Map<Attribute<?>, ?> moreAttributes = [:]) {
         def mutableContainer = new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator())
         FreezableAttributeContainer container = new FreezableAttributeContainer(mutableContainer, { "owner" } as Describable);
         attributes.forEach { key, value ->
             container.attribute(key, value)
         }
+        moreAttributes.forEach { key, value ->
+            container.attribute(key, value)
+        }
         return container
+    }
+
+    def "can add 2 identically named attributes with the same type, resulting in a single entry and no exception thrown"() {
+        def container = createContainer()
+
+        when:
+        container.attribute(Attribute.of("test", String), "a")
+        container.attribute(Attribute.of("test", String), "b")
+
+        then:
+        container.asMap().with {
+            assert it.size() == 1
+            assert it[Attribute.of("test", String)] == "b" // Second attribute to be added remains
+        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/HierarchicalMutableAttributeContainerTest.groovy
@@ -19,25 +19,29 @@ package org.gradle.api.internal.attributes
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.provider.Providers
 import org.gradle.util.AttributeTestUtil
-import spock.lang.Specification
 
 /**
- * Tests {@link HierarchicalMutableAttributeContainer}.
+ * Unit tests for the {@link HierarchicalMutableAttributeContainer} class.
  */
-class HierarchicalMutableAttributeContainerTest extends Specification {
-    def attributesFactory = AttributeTestUtil.attributesFactory()
+final class HierarchicalMutableAttributeContainerTest extends AbstractAttributeContainerTest {
+    private attributesFactory = AttributeTestUtil.attributesFactory()
 
-    def one = Attribute.of("one", String)
-    def two = Attribute.of("two", String)
+    private one = Attribute.of("one", String)
+    private two = Attribute.of("two", String)
 
-    private DefaultMutableAttributeContainer mutable() {
-        return new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator())
+    @Override
+    protected <T> DefaultMutableAttributeContainer getContainer(Map<Attribute<T>, T> attributes = [:]) {
+        DefaultMutableAttributeContainer container = new DefaultMutableAttributeContainer(attributesFactory, AttributeTestUtil.attributeValueIsolator())
+        attributes.forEach { key, value ->
+            container.attribute(key, value)
+        }
+        return container
     }
 
     def "can override attributes from fallback"() {
         given:
-        def fallback = mutable()
-        def primary = mutable()
+        def fallback = getContainer()
+        def primary = getContainer()
         def joined = new HierarchicalMutableAttributeContainer(attributesFactory, fallback, primary)
 
         when:
@@ -52,8 +56,8 @@ class HierarchicalMutableAttributeContainerTest extends Specification {
 
     def "immutable containers are not modified when updating fallback or primary"() {
         given:
-        def fallback = mutable()
-        def primary = mutable()
+        def fallback = getContainer()
+        def primary = getContainer()
         def joined = new HierarchicalMutableAttributeContainer(attributesFactory, fallback, primary)
 
         fallback.attributeProvider(one, Providers.of("fallback"))
@@ -89,8 +93,8 @@ class HierarchicalMutableAttributeContainerTest extends Specification {
 
     def "keySet contains attributes from both fallback and primary"() {
         given:
-        def fallback = mutable()
-        def primary = mutable()
+        def fallback = getContainer()
+        def primary = getContainer()
         def joined = new HierarchicalMutableAttributeContainer(attributesFactory, fallback, primary)
 
         when:
@@ -120,8 +124,8 @@ class HierarchicalMutableAttributeContainerTest extends Specification {
 
     def "mutations are passed to primary container"() {
         given:
-        def fallback = mutable()
-        def primary = mutable()
+        def fallback = getContainer()
+        def primary = getContainer()
         def joined = new HierarchicalMutableAttributeContainer(attributesFactory, fallback, primary)
 
         when:
@@ -143,9 +147,9 @@ class HierarchicalMutableAttributeContainerTest extends Specification {
 
     def "can chain joined containers"() {
         given:
-        def fallback = mutable()
-        def middle = mutable()
-        def primary = mutable()
+        def fallback = getContainer()
+        def middle = getContainer()
+        def primary = getContainer()
         def chain = new HierarchicalMutableAttributeContainer(attributesFactory, fallback,
             new HierarchicalMutableAttributeContainer(attributesFactory, middle, primary))
 
@@ -170,12 +174,12 @@ class HierarchicalMutableAttributeContainerTest extends Specification {
 
     def "joined containers are equal if their fallbacks and primaryren are equal"() {
         given:
-        def hasNone = mutable()
-        def hasOne = mutable()
+        def hasNone = getContainer()
+        def hasOne = getContainer()
         hasOne.attribute(one, "one")
-        def hasTwo = mutable()
+        def hasTwo = getContainer()
         hasTwo.attribute(two, "two")
-        def hasBoth = mutable()
+        def hasBoth = getContainer()
         hasBoth.attribute(one, "one").attribute(two, "two")
 
         expect:
@@ -193,8 +197,8 @@ class HierarchicalMutableAttributeContainerTest extends Specification {
 
     def "has useful toString"() {
         given:
-        def fallback = mutable()
-        def primary = mutable()
+        def fallback = getContainer()
+        def primary = getContainer()
         def joined = new HierarchicalMutableAttributeContainer(attributesFactory, fallback, primary)
 
         when:
@@ -208,8 +212,8 @@ class HierarchicalMutableAttributeContainerTest extends Specification {
 
     def "can inherit attributes from fallback container"() {
         given:
-        def fallback = mutable()
-        def primary = mutable()
+        def fallback = getContainer()
+        def primary = getContainer()
         def joined = new HierarchicalMutableAttributeContainer(attributesFactory, fallback, primary)
 
         expect:
@@ -248,8 +252,8 @@ class HierarchicalMutableAttributeContainerTest extends Specification {
         joined.asImmutable().keySet() == [one, two] as Set
 
         when:
-        def primary2 = mutable()
-        def joined2 = new HierarchicalMutableAttributeContainer(attributesFactory, mutable(), primary2)
+        def primary2 = getContainer()
+        def joined2 = new HierarchicalMutableAttributeContainer(attributesFactory, getContainer(), primary2)
         primary2.attribute(one, "primary")
 
         then:

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -39,7 +39,7 @@ class AndroidSantaTrackerDeprecationSmokeTest extends AndroidSantaTrackerSmokeTe
 
         when:
         def result = runnerForLocation(checkoutDir, agpVersion, "assembleDebug")
-            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Calling getAttribute() with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
+            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Using method getAttribute with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
             .build()
 
         then:
@@ -125,7 +125,7 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
         // Use --continue so that a deterministic set of tasks runs when some tasks fail
         runner.withArguments(runner.arguments + "--continue")
         def result = runner
-            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Calling getAttribute() with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
+            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Using method getAttribute with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
             .buildAndFail()
 
         then:
@@ -141,7 +141,7 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
         )
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(checkoutDir, homeDir)
         runner.withArguments(runner.arguments + "--continue")
-            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Calling getAttribute() with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
+            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Using method getAttribute with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
             .buildAndFail()
 
         then:

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -122,7 +122,9 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(checkoutDir, homeDir)
         // Use --continue so that a deterministic set of tasks runs when some tasks fail
         runner.withArguments(runner.arguments + "--continue")
-        def result = runner.buildAndFail()
+        def result = runner
+            .expectDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Using method getAttribute with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes using null keys.", null)
+            .buildAndFail()
 
         then:
         if (GradleContextualExecuter.isConfigCache()) {
@@ -137,7 +139,8 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
         )
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(checkoutDir, homeDir)
         runner.withArguments(runner.arguments + "--continue")
-        result = runner.buildAndFail()
+            .expectDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Using method getAttribute with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes using null keys.", null)
+            .buildAndFail()
 
         then:
         if (GradleContextualExecuter.isConfigCache()) {

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -38,7 +38,9 @@ class AndroidSantaTrackerDeprecationSmokeTest extends AndroidSantaTrackerSmokeTe
         setupCopyOfSantaTracker(checkoutDir)
 
         when:
-        def result = buildLocation(checkoutDir, agpVersion)
+        def result = runnerForLocation(checkoutDir, agpVersion, "assembleDebug")
+            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Calling getAttribute() with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
+            .build()
 
         then:
         if (GradleContextualExecuter.isConfigCache()) {
@@ -46,7 +48,7 @@ class AndroidSantaTrackerDeprecationSmokeTest extends AndroidSantaTrackerSmokeTe
         }
 
         where:
-        agpVersion << TestedVersions.androidGradle.versions
+        agpVersion << TestedVersions.androidGradle.versions.findAll { it.startsWith("8.8") }
     }
 }
 
@@ -123,7 +125,7 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
         // Use --continue so that a deterministic set of tasks runs when some tasks fail
         runner.withArguments(runner.arguments + "--continue")
         def result = runner
-            .expectDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Using method getAttribute with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes using null keys.", null)
+            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Calling getAttribute() with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
             .buildAndFail()
 
         then:
@@ -139,7 +141,7 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
         )
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(checkoutDir, homeDir)
         runner.withArguments(runner.arguments + "--continue")
-            .expectDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Using method getAttribute with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes using null keys.", null)
+            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Calling getAttribute() with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
             .buildAndFail()
 
         then:
@@ -149,7 +151,7 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
         result.output.contains("Lint found errors in the project; aborting build.")
 
         where:
-        agpVersion << TestedVersions.androidGradle.versions
+        agpVersion << TestedVersions.androidGradle.versions.findAll { it.startsWith("8.8") }
     }
 }
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.scripts.DefaultScriptFileResolver
+import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
 
 import java.util.jar.JarOutputStream
@@ -39,7 +40,7 @@ class AndroidSantaTrackerDeprecationSmokeTest extends AndroidSantaTrackerSmokeTe
 
         when:
         def result = runnerForLocation(checkoutDir, agpVersion, "assembleDebug")
-            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Using method getAttribute with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
+            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Retrieving attribute with a null key. This behavior has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#null-attribute-lookup")
             .build()
 
         then:
@@ -48,7 +49,7 @@ class AndroidSantaTrackerDeprecationSmokeTest extends AndroidSantaTrackerSmokeTe
         }
 
         where:
-        agpVersion << TestedVersions.androidGradle.versions.findAll { it.startsWith("8.8") }
+        agpVersion << TestedVersions.androidGradle.versions
     }
 }
 
@@ -125,7 +126,7 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
         // Use --continue so that a deterministic set of tasks runs when some tasks fail
         runner.withArguments(runner.arguments + "--continue")
         def result = runner
-            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Using method getAttribute with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
+            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Retrieving attribute with a null key. This behavior has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#null-attribute-lookup")
             .buildAndFail()
 
         then:
@@ -141,7 +142,7 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
         )
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(checkoutDir, homeDir)
         runner.withArguments(runner.arguments + "--continue")
-            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Using method getAttribute with a null key has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys.")
+            .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Retrieving attribute with a null key. This behavior has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#null-attribute-lookup")
             .buildAndFail()
 
         then:
@@ -151,7 +152,7 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
         result.output.contains("Lint found errors in the project; aborting build.")
 
         where:
-        agpVersion << TestedVersions.androidGradle.versions.findAll { it.startsWith("8.8") }
+        agpVersion << TestedVersions.androidGradle.versions
     }
 }
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -141,7 +141,7 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
             "common:lintDebug", "playgames:lintDebug", "doodles-lib:lintDebug"
         )
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(checkoutDir, homeDir)
-        runner.withArguments(runner.arguments + "--continue")
+        result = runner.withArguments(runner.arguments + "--continue")
             .maybeExpectLegacyDeprecationWarningIf(VersionNumber.parse(agpVersion) >= VersionNumber.parse("8.8.0"), "Retrieving attribute with a null key. This behavior has been deprecated. This will fail with an error in Gradle 10.0. Don't request attributes from attribute containers using null keys. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#null-attribute-lookup")
             .buildAndFail()
 


### PR DESCRIPTION
If an attribute is produced in an included build, and consumed from a different included build, the type of the Attribute won't match, despite having the same name.  So we'll need to coerce these to get the expected attribute lookup behavior.

Fixes #28695.

Also patches a number of other holes in attribute containers, adding tests to ensure desired behavior.