### PR TITLE
Implement += support for collection Properties and ConfigurableFileCollections in Groovy build scripts

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/CompoundAssignmentResult.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/CompoundAssignmentResult.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import com.google.common.base.Preconditions;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.file.UnionFileCollection;
+import org.gradle.api.internal.provider.support.SupportsCompoundAssignment;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
+
+import javax.annotation.Nullable;
+
+/**
+ * A helper class to implement an intermediate result of a compound assignment operation, like "+=".
+ * It is then assigned to the left-hand side operand. When the LHS is a ConfigurableFileCollection-typed property of some Gradle-enhanced object, then the assignment action is invoked.
+ */
+class CompoundAssignmentResult extends UnionFileCollection implements SupportsCompoundAssignment.Result<FileCollection> {
+    @Nullable
+    private ConfigurableFileCollection owner;
+    private final FileCollectionInternal rhs;
+
+    public CompoundAssignmentResult(TaskDependencyFactory taskDependencyFactory, DefaultConfigurableFileCollection owner, FileCollectionInternal rhs) {
+        super(taskDependencyFactory, owner, rhs);
+        this.owner = owner;
+        this.rhs = rhs;
+    }
+
+    public boolean isOwnedBy(ConfigurableFileCollection owner) {
+        return this.owner == owner;
+    }
+
+    public void assignToOwner() {
+        ConfigurableFileCollection theOwner = owner;
+        owner = null;
+        Preconditions.checkState(theOwner != null, "The collection is already consumed by the owner");
+        theOwner.from(rhs);
+    }
+
+    @Override
+    public FileCollection unwrap() {
+        // When the expression involves a variable on the left side as opposed to a field, then this collection becomes its value.
+        // It must lose all "magical" properties towards its owner, because it may be used to set its value outside the original expression.
+        owner = null;
+        // Unlike the Property, we cannot discard the += value without losing backward compatibility.
+        return this;
+    }
+}

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -839,7 +839,13 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         return new CompoundAssignmentStandIn();
     }
 
+    /**
+     * This class acts as a replacement to call {@code +} on when evaluating {@code DefaultConfigurableFileCollection += <RHS>} expressions in Groovy code.
+     *
+     * @see SupportsCompoundAssignment
+     */
     public class CompoundAssignmentStandIn {
+        // Called for fileCollection += fileCollection
         public Object plus(FileCollectionInternal rhs) {
             return new CompoundAssignmentResult(taskDependencyFactory, DefaultConfigurableFileCollection.this, rhs);
         }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -213,7 +213,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         // Currently we support just FileCollection for Groovy assign, so first try to cast to FileCollection
         FileCollectionInternal fileCollection = Cast.castNullable(FileCollectionInternal.class, Cast.castNullable(FileCollection.class, object));
 
-        // Don't allow a = (a + b), this is not support
+        // Don't allow a = (a + b), this is not supported yet
         fileCollection.visitStructure(new FileCollectionStructureVisitor() {
             @Override
             public boolean startVisit(FileCollectionInternal.Source source, FileCollectionInternal fileCollection) {

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractProviderOperatorIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractProviderOperatorIntegrationTest.groovy
@@ -41,7 +41,7 @@ abstract class AbstractProviderOperatorIntegrationTest extends AbstractIntegrati
         }
     }
 
-    private static interface Failure {
+    static interface Failure {
         void assertHasExpectedFailure(ExecutionFailure failure);
     }
 

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
@@ -16,9 +16,13 @@
 
 package org.gradle.api.provider
 
+import org.gradle.util.internal.ToBeImplemented
+
 import static org.gradle.integtests.fixtures.executer.GradleContextualExecuter.configCache
 
 class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIntegrationTest {
+    protected static final String EXPRESSION_PREFIX = "Expression value: "
+
     def "eager object properties assignment for #description"() {
         def inputDeclaration = "$inputType input"
         groovyBuildFile(inputDeclaration, inputValue, "=")
@@ -48,7 +52,7 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         where:
         description                                     | inputType            | inputValue                               | expectedResult
-        "T = null" | "Property<MyObject>" | 'null' | "undefined"
+        "T = null"                                      | "Property<MyObject>" | 'null'                                   | "undefined"
         "T = T"                                         | "Property<MyObject>" | 'new MyObject("hello")'                  | "hello"
         "T = provider { null }"                         | "Property<MyObject>" | 'provider { null }'                      | "undefined"
         "T = Provider<T>"                               | "Property<MyObject>" | 'provider { new MyObject("hello") }'     | "hello"
@@ -119,32 +123,39 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expressionValue)
+        }
 
         where:
-        description                              | operation | inputType                       | inputValue                                               | expectedResult
-        "Collection<T> = null"                   | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'undefined'
-        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("Cannot set the value of a property of type java.util.List using an instance of type [LMyObject;")
-        "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'
-        "Collection<T> = provider { null }"      | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'
-        "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'
-        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T"                     | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<T>"           | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T[]"                   | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> << Iterable<T>"           | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<Iterable<T>>" | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
-        "Map<K, V> = null"                       | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'undefined'
-        "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '{a=b}'
-        "Map<K, V> = provider { null }"          | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'
-        "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '{a=b}'
-        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Map<K, V>"                 | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Provider<Map<K, V>>"       | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
+        description                               | operation | inputType                       | inputValue                                               | expressionValue | expectedResult
+        "Collection<T> = null"                    | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'null'          | 'undefined'
+        "Collection<T> = T[]"                     | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | _               | unsupportedWithCause("Cannot set the value of a property of type java.util.List using an instance of type [LMyObject;")
+        "Collection<T> = Iterable<T>"             | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'           | '[a]'
+        "Collection<T> = provider { null }"       | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Collection<T> = Provider<Iterable<T>>"   | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'           | '[a]'
+        "Collection<T> += T"                      | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | 'null'          | '[a]'
+        "Collection<T> += !T"                     | "+="      | "ListProperty<MyObject>"        | '"a"'                                                    | _               | unsupportedWithCause("Cannot add an element of type String to a property of type List<MyObject>")
+        "Collection<T> << T"                      | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += provider { null }"      | "+="      | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'null'          | 'undefined'
+        "Collection<T> += Provider<T>"            | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | 'null'          | '[a]'
+        "Collection<T> += Provider<!T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { "a" }'                                       | _               | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.lang.String")
+        "Collection<T> << Provider<T>"            | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += T[]"                    | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | 'null'          | '[a]'
+        "Collection<T> << T[]"                    | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += Iterable<T>"            | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | 'null'          | '[a]'
+        "Collection<T> << Iterable<T>"            | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += Provider<Iterable<T>>"  | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | 'null'          | '[a]'
+        "Collection<T> += Provider<Iterable<!T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { ["a"] as Iterable<String> }'                 | _               | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.lang.String.")
+        "Collection<T> << Provider<Iterable<T>>"  | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | _               | unsupportedWithCause("No signature of method")
+        "Map<K, V> = null"                        | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'null'          | 'undefined'
+        "Map<K, V> = Map<K, V>"                   | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'         | '{a=b}'
+        "Map<K, V> = provider { null }"           | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Map<K, V> = Provider<Map<K, V>>"         | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'         | '{a=b}'
+        "Map<K, V> += Map<K, V>"                  | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | 'null'          | '{a=b}'
+        "Map<K, V> << Map<K, V>"                  | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | _               | unsupportedWithCause("No signature of method")
+        "Map<K, V> += Provider<Map<K, V>>"        | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | 'null'          | '{a=b}'
+        "Map<K, V> << Provider<Map<K, V>>"        | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | _               | unsupportedWithCause("No signature of method")
     }
 
     def "lazy collection variables assignment for #description"() {
@@ -153,32 +164,36 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expressionValue)
+        }
 
         where:
-        description                              | operation | inputType                       | inputValue                                               | expectedResult
-        "Collection<T> = null"                   | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'null'
-        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | '[a]'
-        "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'
-        "Collection<T> = provider { null }"      | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'
-        "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'
-        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T"                     | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<T>"           | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T[]"                   | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> << Iterable<T>"           | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<Iterable<T>>" | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
-        "Map<K, V> = null"                       | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'null'
-        "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'
-        "Map<K, V> = provider { null }"          | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'
-        "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'
-        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Map<K, V>"                 | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Provider<Map<K, V>>"       | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
+        description                              | operation | inputType                       | inputValue                                               | expressionValue | expectedResult
+        "Collection<T> = null"                   | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'null'          | 'null'
+        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | '[a]'           | '[a]'
+        "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'           | '[a]'
+        "Collection<T> = provider { null }"      | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'           | '[a]'
+        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | 'null'          | '[a]'
+        "Collection<T> << T"                     | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += provider { null }"     | "+="      | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'null'          | 'undefined'
+        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | 'null'          | '[a]'
+        "Collection<T> << Provider<T>"           | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | 'null'          | '[a]'
+        "Collection<T> << T[]"                   | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | 'null'          | '[a]'
+        "Collection<T> << Iterable<T>"           | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | 'null'          | '[a]'
+        "Collection<T> << Provider<Iterable<T>>" | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | _               | unsupportedWithCause("No signature of method")
+        "Map<K, V> = null"                       | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'null'          | 'null'
+        "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'         | '[a:b]'
+        "Map<K, V> = provider { null }"          | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'         | '[a:b]'
+        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | 'null'          | '[a:b]'
+        "Map<K, V> << Map<K, V>"                 | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | _               | unsupportedWithCause("No signature of method")
+        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | 'null'          | '[a:b]'
+        "Map<K, V> << Provider<Map<K, V>>"       | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | _               | unsupportedWithCause("No signature of method")
     }
 
     def "eager FileCollection properties assignment for #description"() {
@@ -307,6 +322,75 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         run("help")
     }
 
+    @ToBeImplemented
+    def "compound assignments work in plugins too"() {
+        given:
+        createDir("plugin") {
+            buildFile(file("build.gradle"), """
+                plugins {
+                    id "groovy"
+                    id "java-gradle-plugin"
+                }
+
+                dependencies {
+                    implementation gradleApi()
+                    implementation localGroovy()
+                }
+
+                gradlePlugin {
+                    plugins {
+                        pluginInGroovy {
+                            id = "org.example.plugin-in-groovy"
+                            implementationClass = "org.example.PluginInGroovy"
+                        }
+                    }
+                }
+            """)
+
+            file("src/main/groovy/org/example/PluginInGroovy.groovy") << """
+                package org.example
+
+                import org.gradle.api.Plugin
+                import org.gradle.api.Project
+                import org.gradle.api.provider.ListProperty
+
+                abstract class PluginInGroovy implements Plugin<Project> {
+                    abstract ListProperty<String> getStringList()
+
+                    @Override
+                    void apply(Project target) {
+                        stringList += ["a", "b"]
+
+                        target.tasks.register("printProperties") {
+                            def stringList = stringList
+                            doLast {
+                                println("stringList = \${stringList.get()}")
+                            }
+                        }
+                    }
+                }
+            """
+        }
+
+        settingsFile """
+            pluginManagement {
+                includeBuild("plugin")
+            }
+        """
+
+        buildFile """
+            plugins {
+                id("org.example.plugin-in-groovy")
+            }
+        """
+
+        expect:
+        fails("printProperties")
+
+        // TODO(mlopatkin): With the AST transformation applied globally this should succeed and print the property.
+        // outputContains("stringList = [a, b]")
+    }
+
     private void groovyBuildFile(String inputDeclaration, String inputValue, String operation) {
         buildFile.text = """
             ${groovyTypesDefinition()}
@@ -317,12 +401,16 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
                 @TaskAction
                 void run() {
-                    ${groovyInputPrintRoutine()}
+                    ${groovyInputPrintRoutine(RESULT_PREFIX, "input")}
                 }
             }
 
             tasks.register("myTask", MyTask) {
-                input $operation $inputValue
+                def result = (input $operation $inputValue)
+
+                doLast {
+                    ${groovyInputPrintRoutine(EXPRESSION_PREFIX, "result")}
+                }
             }
         """
     }
@@ -333,10 +421,11 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
             tasks.register("myTask") {
                 def input = $inputInitializer
-                input $operation $inputValue
+                def result = (input $operation $inputValue)
                 ${expectedType ? "assert input instanceof $expectedType" : ""}
                 doLast {
-                    ${groovyInputPrintRoutine()}
+                    ${groovyInputPrintRoutine(RESULT_PREFIX, "input")}
+                    ${groovyInputPrintRoutine(EXPRESSION_PREFIX, "result")}
                 }
             }
         """
@@ -360,21 +449,27 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         """
     }
 
-    private String groovyInputPrintRoutine() {
+    private String groovyInputPrintRoutine(String prefix = RESULT_PREFIX, String variable = "input") {
         """
-            if (input instanceof FileSystemLocationProperty) {
-                println("$RESULT_PREFIX" + input.map { it.asFile.name }.getOrElse("undefined"))
-            } else if (input instanceof File) {
-               println("$RESULT_PREFIX" + input.name)
-            } else if (input instanceof Provider) {
-                println("$RESULT_PREFIX" + input.map { it.toString() }.getOrElse("undefined"))
-            } else if (input instanceof FileCollection) {
-                println("$RESULT_PREFIX" + input.files.collect { it.name })
-            } else if (input instanceof Iterable) {
-                println("$RESULT_PREFIX" + input.collect { it instanceof File ? it.name : it })
+            if (${variable} instanceof FileSystemLocationProperty) {
+                println("$prefix" + ${variable}.map { it.asFile.name }.getOrElse("undefined"))
+            } else if (${variable} instanceof File) {
+               println("$prefix" + ${variable}.name)
+            } else if (${variable} instanceof Provider) {
+                println("$prefix" + ${variable}.map { it.toString() }.getOrElse("undefined"))
+            } else if (${variable} instanceof FileCollection) {
+                println("$prefix" + ${variable}.files.collect { it.name })
+            } else if (${variable} instanceof Iterable) {
+                println("$prefix" + ${variable}.collect { it instanceof File ? it.name : it })
+            } else if (${variable}?.getClass()?.isArray()) {
+                println("$prefix" + Arrays.toString(${variable}))
             } else {
-                println("$RESULT_PREFIX" + input.toString())
+                println("$prefix" + ${variable})
             }
         """
+    }
+
+    private void assertExpression(def value) {
+        outputContains(EXPRESSION_PREFIX + value)
     }
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
@@ -214,10 +214,10 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         "FileCollection = Iterable<File>"  | "="       | "FileCollection" | '[file("a.txt")]' | unsupportedWithCause("Cannot cast object")
         "FileCollection += FileCollection" | "+="      | "FileCollection" | 'files("a.txt")'  | '[a.txt]'
         "FileCollection << FileCollection" | "<<"      | "FileCollection" | 'files("a.txt")'  | unsupportedWithCause("No signature of method")
-        "FileCollection += Object"         | "+="      | "FileCollection" | '"a.txt"'         | unsupportedWithCause("Cannot cast object")
-        "FileCollection += File"           | "+="      | "FileCollection" | 'file("a.txt")'   | unsupportedWithCause("Cannot cast object")
-        "FileCollection += Iterable<?>"    | "+="      | "FileCollection" | '["a.txt"]'       | unsupportedWithCause("Cannot cast object")
-        "FileCollection += Iterable<File>" | "+="      | "FileCollection" | '[file("a.txt")]' | unsupportedWithCause("Cannot cast object")
+        "FileCollection += Object"         | "+="      | "FileCollection" | '"a.txt"'         | unsupportedWithCause("No signature of method")
+        "FileCollection += File"           | "+="      | "FileCollection" | 'file("a.txt")'   | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<?>"    | "+="      | "FileCollection" | '["a.txt"]'       | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<File>" | "+="      | "FileCollection" | '[file("a.txt")]' | unsupportedWithCause("No signature of method")
     }
 
     def "lazy FileCollection properties assignment for #description"() {
@@ -237,13 +237,13 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         "FileCollection = Object"          | "="       | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("Failed to cast object")
         "FileCollection = File"            | "="       | "ConfigurableFileCollection" | 'file("a.txt")'         | unsupportedWithCause("Failed to cast object")
         "FileCollection = Iterable<File>"  | "="       | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("Failed to cast object")
-        "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | unsupportedWithCause("Self-referencing ConfigurableFileCollections are not supported. Use the from() method to add to a ConfigurableFileCollection.")
+        "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | '[a.txt]'
         "FileCollection << FileCollection" | "<<"      | "ConfigurableFileCollection" | 'files("a.txt")'        | unsupportedWithCause("No signature of method")
-        "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | unsupportedWithCause("Failed to cast object")
-        "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("Failed to cast object")
-        "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'         | unsupportedWithCause("Failed to cast object")
-        "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | '["a.txt"]'             | unsupportedWithCause("Failed to cast object")
-        "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("Failed to cast object")
+        "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | unsupportedWithCause("No signature of method")
+        "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("No signature of method")
+        "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'         | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | '["a.txt"]'             | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("No signature of method")
     }
 
     def "lazy FileCollection variables assignment for #description"() {
@@ -265,11 +265,11 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         "FileCollection = Iterable<File>"  | "="       | "ConfigurableFileCollection" | '[file("a.txt")]'       | "List"                       | "[a.txt]"
         "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | "FileCollection"             | "[a.txt]"
         "FileCollection << FileCollection" | "<<"      | "ConfigurableFileCollection" | 'files("a.txt")'        | ""                           | unsupportedWithCause("No signature of method")
-        "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | "List"                       | "[a.txt]"
-        "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | "List"                       | "[a.txt]"
-        "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'         | "List"                       | "[a.txt]"
-        "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | '["a.txt"]'             | "List"                       | "[a.txt]"
-        "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | "List"                       | "[a.txt]"
+        "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | "List"                       | unsupportedWithCause("No signature of method")
+        "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | "List"                       | unsupportedWithCause("No signature of method")
+        "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'         | "List"                       | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | '["a.txt"]'             | "List"                       | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | "List"                       | unsupportedWithCause("No signature of method")
     }
 
     def "Groovy assignment for ConfigurableFileCollection doesn't resolve a Configuration"() {

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
@@ -202,6 +202,9 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expectedResult)
+        }
 
         where:
         description                        | operation | inputType        | inputValue        | expectedResult
@@ -223,6 +226,9 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expectedResult)
+        }
 
         where:
         description                        | operation | inputType                    | inputValue              | expectedResult
@@ -246,6 +252,9 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expectedResult)
+        }
 
         where:
         description                        | operation | inputType                    | inputValue              | expectedType                 | expectedResult

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -614,7 +614,13 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         return new CompoundAssignmentStandIn();
     }
 
+    /**
+     * This class acts as a replacement to call {@code +} on when evaluating {@code AbstractCollectionProperty += <RHS>} expressions in Groovy code.
+     *
+     * @see SupportsCompoundAssignment
+     */
     public class CompoundAssignmentStandIn {
+        // Called for:
         // property += Provider<Iterable<T>>
         // property += Provider<T>
         public Object plus(Provider<?> provider) {
@@ -627,7 +633,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
             );
         }
 
-        // property += Iterable<T>
+        // Called for property += Iterable<T>
         public Object plus(Iterable<? extends T> items) {
             return new CompoundAssignmentResult<>(
                 Providers.internal(map(transformer(thisItems -> Iterables.concat(thisItems, items)))),
@@ -636,7 +642,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
             );
         }
 
-        // property += T[]
+        // Called for property += T[]
         public Object plus(T[] items) {
             return new CompoundAssignmentResult<>(
                 Providers.internal(map(transformer(thisItems -> Iterables.concat(thisItems, Arrays.asList(items))))),
@@ -645,7 +651,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
             );
         }
 
-        // property += T
+        // Called for property += T
         public Object plus(Object item) {
             Preconditions.checkNotNull(item, "Cannot add a null element to a property of type %s.", collectionType.getSimpleName());
             Preconditions.checkArgument(
@@ -671,7 +677,6 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                 if (value instanceof Iterable) {
                     return Cast.<Iterable<T>>uncheckedCast(value);
                 }
-                // Technically, the value can be null here.
                 return Collections.singleton(Cast.uncheckedCast(value));
             }));
         }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CompoundAssignmentResult.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CompoundAssignmentResult.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import com.google.common.base.Preconditions;
+import org.gradle.api.internal.provider.support.SupportsCompoundAssignment;
+import org.gradle.api.provider.Provider;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * A helper class to implement an intermediate result of a compound assignment operation, like "+=".
+ * It is then assigned to the left-hand side operand. When the LHS is a Property-typed property of some Gradle-enhanced object, then the assignment action is invoked.
+ */
+public final class CompoundAssignmentResult<T> extends AbstractMinimalProvider<T> implements SupportsCompoundAssignment.Result<Provider<T>> {
+    private final ProviderInternal<T> value;
+    private final Object owner;
+    @Nullable
+    private Runnable assignToOwnerAction;
+
+    /**
+     * Creates the result for {@code owner <OP> rhs} operation.
+     *
+     * @param value the intermediate value of the operation, used when LHS is a variable or non-Gradle enhanced property
+     * @param owner the LHS operand of the compound operation
+     * @param assignToOwnerAction the mutation of the owner
+     */
+    public CompoundAssignmentResult(ProviderInternal<T> value, Object owner, Runnable assignToOwnerAction) {
+        this.value = value;
+        this.owner = owner;
+        this.assignToOwnerAction = Objects.requireNonNull(assignToOwnerAction);
+    }
+
+    public boolean isOwnedBy(Object target) {
+        // It might be that this object was unwrapped, in which case it is considered a normal provider.
+        return assignToOwnerAction != null && target == owner;
+    }
+
+    public void assignToOwner() {
+        Runnable action = assignToOwnerAction;
+        Preconditions.checkState(action != null, "The property is already consumed by the owner");
+        assignToOwnerAction = null;
+        action.run();
+    }
+
+    @Override
+    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+        return value.calculateValue(consumer);
+    }
+
+    @Override
+    public boolean calculatePresence(ValueConsumer consumer) {
+        return value.calculatePresence(consumer);
+    }
+
+    @Override
+    public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+        return value.calculateExecutionTimeValue();
+    }
+
+    @Nullable
+    @Override
+    public Class<T> getType() {
+        return value.getType();
+    }
+
+    @Override
+    @Nullable
+    public Provider<T> unwrap() {
+        // When the expression involves a variable on the left side as opposed to a field, then this provider becomes its value.
+        // It must lose all "magical" properties towards its owner, because it may be used to set its value outside the original expression.
+        assignToOwnerAction = null;
+        return null;
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CompoundAssignmentResult.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CompoundAssignmentResult.java
@@ -80,6 +80,16 @@ public final class CompoundAssignmentResult<T> extends AbstractMinimalProvider<T
     }
 
     @Override
+    public ValueProducer getProducer() {
+        return value.getProducer();
+    }
+
+    @Override
+    protected String toStringNoReentrance() {
+        return value.toString();
+    }
+
+    @Override
     @Nullable
     public Provider<T> unwrap() {
         // When the expression involves a variable on the left side as opposed to a field, then this provider becomes its value.

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.gradle.api.internal.lambdas.SerializableLambdas.bifunction;
+import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
 import static org.gradle.api.internal.provider.AppendOnceList.toAppendOnceList;
 import static org.gradle.internal.Cast.uncheckedCast;
 import static org.gradle.internal.Cast.uncheckedNonnullCast;
@@ -691,7 +693,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     public class CompoundAssignmentStandIn {
         public Object plus(Provider<? extends Map<K, V>> provider) {
             return new CompoundAssignmentResult<>(
-                Providers.internal(zip(provider, DefaultMapProperty::concat)),
+                Providers.internal(zip(provider, bifunction(DefaultMapProperty::concat))),
                 DefaultMapProperty.this,
                 () -> DefaultMapProperty.this.putAll(provider));
 
@@ -699,7 +701,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
         public Object plus(Map<K, V> map) {
             return new CompoundAssignmentResult<>(
-                Providers.internal(map(left -> concat(left, map))),
+                Providers.internal(map(transformer(left -> concat(left, map)))),
                 DefaultMapProperty.this, () -> DefaultMapProperty.this.putAll(map));
         }
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -690,7 +690,13 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         return new CompoundAssignmentStandIn();
     }
 
+    /**
+     * This class acts as a replacement to call {@code +} on when evaluating {@code DefaultMapProperty += <RHS>} expressions in Groovy code.
+     *
+     * @see SupportsCompoundAssignment
+     */
     public class CompoundAssignmentStandIn {
+        // Called for property += Provider<Map<K,V>>
         public Object plus(Provider<? extends Map<K, V>> provider) {
             return new CompoundAssignmentResult<>(
                 Providers.internal(zip(provider, bifunction(DefaultMapProperty::concat))),
@@ -699,6 +705,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
         }
 
+        // Called for property += Map<K,V>
         public Object plus(Map<K, V> map) {
             return new CompoundAssignmentResult<>(
                 Providers.internal(map(transformer(left -> concat(left, map)))),

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/LazyGroovySupport.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/LazyGroovySupport.java
@@ -20,6 +20,8 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.instantiation.generator.AsmBackedClassGenerator;
 
+import javax.annotation.Nullable;
+
 /**
  * An interface used to support lazy assignment for types like {@link Property} and {@link ConfigurableFileCollection} in Groovy DSL.
  * Call to this interface is generated via {@link AsmBackedClassGenerator}.
@@ -29,5 +31,5 @@ public interface LazyGroovySupport {
     /**
      * Sets the value from some arbitrary object. Used from the Groovy DSL.
      */
-    void setFromAnyValue(Object object);
+    void setFromAnyValue(@Nullable Object object);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/SupportsCompoundAssignment.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/SupportsCompoundAssignment.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.support;
+
+import javax.annotation.Nullable;
+
+/**
+ * Implementors of this interface support custom handling of the compound assignment operators ({@code +=, -=}) in Groovy.
+ * Groovy doesn't support overloading of just compound assignments, and instead generates a combination of a base operator and an assignment.
+ * For example, an expression {@code a += b} is transformed into {@code a = a + b}.
+ * <p>
+ * A Groovy AST transformation is used to intercept {@code +=}. An expression {@code a += b} is then transformed into:
+ * {@code SupportsCompoundAssignment.unwrap(a = SupportsCompoundAssignment.wrap(a) + b)}.
+ * When the {@code a} doesn't implement this interface, the functions are no-op.
+ * This way you can opt into the custom protocol and provide a dedicated expression value that doesn't have to be the same value that
+ * is assigned to the target.
+ * <p>
+ * Implementing this interface allows an object to provide a stand-in operand for the base operator invocation.
+ * The stand-in can implement necessary protocol even if the class itself doesn't overload the operator.
+ * <p>
+ * Methods of this class are not intended to be called by the handwritten code. The transformed code relies on Groovy's
+ * dynamic dispatch to resolve it correctly.
+ * As the AST transformation typically doesn't know the type of the arguments, it has to emit the wrap/unwrap calls every time.
+ * That's why the class provides the no-op methods.
+ * <p>
+ * See {@code org.gradle.groovy.scripts.internal.CompoundAssignmentTransformer} for the actual transformation.
+ *
+ * @param <T> the type of the stand-in
+ */
+public interface SupportsCompoundAssignment<T> {
+
+    /**
+     * Produces a compound assignment stand-in. The returned object will be used as left operand of the compound expression.
+     *
+     * @return the stand-in
+     */
+    T toCompoundOperand();
+
+    /**
+     * The interface that provides return value replacement.
+     *
+     * @param <T> the type of the replaced return value
+     */
+    interface Result<T> {
+        /**
+         * Returns the replacement for this result, to be used as a value of the compound assignment subexpression.
+         * Note that this is the value of the whole {@code a += b}, it isn't the value that will be stored in {@code a}.
+         * In fact, if {@code a} is a variable, then this object will be its new value.
+         * <p>
+         * By the time this method is called, the assignment has already happened.
+         *
+         * @return the replacement, can be null
+         */
+        @Nullable
+        T unwrap();
+    }
+
+    /**
+     * Retrieves the stand-in from the argument. The AST transformer knows the name of this method.
+     *
+     * @param lhs the original argument
+     * @param <T> the stand-in type.
+     * @return the stand-in
+     */
+    static <T> T wrap(SupportsCompoundAssignment<T> lhs) {
+        return lhs.toCompoundOperand();
+    }
+
+    /**
+     * No-op implementation, return the argument. The AST transformer knows the name of this method.
+     * This method is called when the compound assignment expression should use the default Groovy logic.
+     *
+     * @param lhs the original argument
+     * @return the give argument
+     */
+    @Nullable
+    static Object wrap(@Nullable Object lhs) {
+        return lhs;
+    }
+
+    /**
+     * Retrieves the result replacement. The AST transformer knows the name of this method.
+     *
+     * @param result the original result, already assigned to the target
+     * @param <T> the replacement type
+     * @return the replaced result, can be null
+     */
+    @Nullable
+    static <T> T unwrap(Result<T> result) {
+        return result.unwrap();
+    }
+
+    /**
+     * No-op implementation, return the given result. The AST transformer knows the name of this method.
+     * This method is called when the compound assignment expression should use the default Groovy logic.
+     *
+     * @param result the original result
+     * @return the given result
+     */
+    @Nullable
+    static Object unwrap(@Nullable Object result) {
+        return result;
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/package-info.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes and interfaces that help provide syntactic sugar for Providers and Properties.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.api.internal.provider.support;

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CompoundAssignmentPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CompoundAssignmentPropertySpec.groovy
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import org.gradle.api.internal.provider.support.LazyGroovySupport
+import org.gradle.api.internal.provider.support.SupportsCompoundAssignment
+import org.gradle.api.provider.Provider
+import org.gradle.internal.evaluation.CircularEvaluationException
+import spock.lang.Specification
+
+abstract class CompoundAssignmentPropertySpec<T extends LazyGroovySupport & Provider<?>> extends Specification {
+    // This test checks various stages of the rewritten compound assignment expression.
+    // In short, the compound assignment to a field: lhs += ["a"] is rewritten into:
+    //      def intermediate = wrap(lhs) + ["a"]
+    //      lhs = intermediate -> setLhs(intermediate) -> lhs.setFromAnyValue(intermediate)
+    //      unwrap(intermediate) <- this becomes the value of the expression (not the field)
+    // The compound assignment to a variable is simpler:
+    //      def intermediate = wrap(lhs) + ["a"]
+    //      lhs = intermediate
+    //      unwrap(intermediate) <- this is the value of the expression (not the variable)
+    // See SupportsCompoundAssignment javadoc for details.
+    protected PropertyHost host = Mock()
+
+    abstract T property()
+
+    abstract def value(String v)
+
+    abstract def asValue(def v)
+
+    abstract def addValue(T property, String v)
+
+    def "compound operand can be applied to property"() {
+        given:
+        def lhs = property()
+
+        when:
+        def intermediate = SupportsCompoundAssignment.wrap(lhs) + value("a")
+        lhs.setFromAnyValue(intermediate)
+        SupportsCompoundAssignment.unwrap(intermediate)
+
+        then:
+        asValue(lhs.get()) == value("a")
+    }
+
+    def "compound operand can be applied to variable"() {
+        given:
+        def lhs = property()
+
+        when:
+        def intermediate = SupportsCompoundAssignment.wrap(lhs) + value("a")
+        lhs = intermediate
+        SupportsCompoundAssignment.unwrap(intermediate)
+
+        then:
+        asValue(lhs.get()) == value("a")
+    }
+
+    def "variable updated with compound operand tracks lhs updates"() {
+        given:
+        def origin = property()
+        def lhs = origin
+        def intermediate = SupportsCompoundAssignment.wrap(lhs) + value("a")
+        lhs = intermediate
+        SupportsCompoundAssignment.unwrap(intermediate)
+
+        when:
+        addValue(origin, "b")
+
+        then:
+        // note that lhs += "a" results in lhs + ["a"], so adding "b" to lhs effectively prepends it to the result.
+        asValue(lhs.get()) == value("b") + value("a")
+    }
+
+    def "special compound handling only applies inside the compound assignment expression"() {
+        // It is possible to snatch the result of the compound assignment and assign it back to the LHS property instance.
+        // For example, here origin is a field. In plain Groovy code it looks like:
+        // def lhs = owner.origin
+        // lhs += ["a"] // lhs now is the sum provider.
+        // owner.origin = lhs // there is no special handling when assigning this provider even though it originates from compound assignment involving this property.
+        given:
+        final def origin = property()
+        def lhs = origin
+        def intermediate = SupportsCompoundAssignment.wrap(lhs) + value("a")
+        lhs = intermediate
+        SupportsCompoundAssignment.unwrap(intermediate)
+
+        when:
+        origin.setFromAnyValue(lhs)
+        origin.get()
+
+        then:
+        thrown(CircularEvaluationException)
+    }
+
+    def "compound assignment expression with variable has null value"() {
+        given:
+        def lhs = property()
+
+        when:
+        def intermediate = SupportsCompoundAssignment.wrap(lhs) + value("a")
+
+        then:
+        SupportsCompoundAssignment.unwrap(intermediate) == null
+    }
+
+    def "compound assignment expression with field has null value"() {
+        given:
+        def lhs = property()
+
+        when:
+        def intermediate = SupportsCompoundAssignment.wrap(lhs) + value("a")
+        lhs.setFromAnyValue(intermediate)
+
+        then:
+        SupportsCompoundAssignment.unwrap(intermediate) == null
+    }
+
+    static class CompoundAssignmentListPropertyTest extends CompoundAssignmentPropertySpec<DefaultListProperty<String>> {
+        @Override
+        DefaultListProperty<String> property() { new DefaultListProperty<>(host, String) }
+
+        @Override
+        def value(String v) { [v] }
+
+        @Override
+        def asValue(def result) { result as List<String> }
+
+        @Override
+        def addValue(DefaultListProperty<String> property, String v) { property.add(v) }
+    }
+
+    static class CompoundAssignmentSetPropertyTest extends CompoundAssignmentPropertySpec<DefaultSetProperty<String>> {
+        @Override
+        DefaultSetProperty<String> property() { new DefaultSetProperty<>(host, String) }
+
+        @Override
+        def value(String v) { [v] }
+
+        @Override
+        def asValue(def result) { result as List<String> }
+
+        @Override
+        def addValue(DefaultSetProperty<String> property, String v) { property.add(v) }
+    }
+
+    static class CompoundAssignmentMapPropertyTest extends CompoundAssignmentPropertySpec<DefaultMapProperty<String, String>> {
+        @Override
+        DefaultMapProperty<String, String> property() { new DefaultMapProperty<>(host, String, String) }
+
+        @Override
+        def value(String v) { [(v): v] }
+
+        @Override
+        def asValue(def result) { result as Map<String, String> }
+
+        @Override
+        def addValue(DefaultMapProperty<String, String> property, String v) { property.put(v, v) }
+    }
+}

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/TestCompoundAssignmentTransform.java
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/TestCompoundAssignmentTransform.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+import org.gradle.groovy.scripts.internal.CompoundAssignmentTransformer;
+
+/**
+ * Applies compound operation transformer to a class or a method.
+ *
+ * @see org.gradle.api.internal.provider.support.SupportsCompoundAssignment
+ */
+@SuppressWarnings("unused")  // Applied through
+@GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
+public class TestCompoundAssignmentTransform implements ASTTransformation {
+    @Override
+    public void visit(ASTNode[] nodes, SourceUnit source) {
+        new CompoundAssignmentTransformer().call(nodes[1], source);
+    }
+}

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/TransformCompoundAssignments.java
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/TransformCompoundAssignments.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.codehaus.groovy.transform.GroovyASTTransformationClass;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Applies the compound assignment transformation to a body of a unit test class/method.
+ * Useful for testing the assignment protocol.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@GroovyASTTransformationClass("org.gradle.api.internal.provider.TestCompoundAssignmentTransform")
+public @interface TransformCompoundAssignments {}

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScriptTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScriptTransformer.java
@@ -53,6 +53,7 @@ public class BuildScriptTransformer implements Transformer, Factory<BuildScriptD
         new StatementLabelsScriptTransformer().register(compilationUnit);
         new ModelBlockTransformer(scriptSource.getDisplayName(), scriptSource.getResource().getLocation().getURI()).register(compilationUnit);
         imperativeStatementDetectingTransformer.register(compilationUnit);
+        new CompoundAssignmentTransformer().register(compilationUnit);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/CompoundAssignmentTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/CompoundAssignmentTransformer.java
@@ -17,8 +17,11 @@
 package org.gradle.groovy.scripts.internal;
 
 import com.google.common.collect.ImmutableMap;
+import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
 import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
@@ -50,6 +53,24 @@ public class CompoundAssignmentTransformer extends AbstractScriptTransformer {
         source.getAST().getStatementBlock().visit(visitor);
         source.getAST().getClasses().forEach(visitor::visitClass);
         source.getAST().getMethods().forEach(visitor::visitMethod);
+    }
+
+    /**
+     * Transforms a single AST node. This is useful for unit tests that want to apply the transform.
+     *
+     * @param node the ClassNode or the MethodNode
+     * @param source the source unit in which the AST node resides
+     * @throws CompilationFailedException if the transformation cannot be applied.
+     */
+    public void call(ASTNode node, SourceUnit source) throws CompilationFailedException {
+        CompoundAssignmentExpressionRewriter visitor = new CompoundAssignmentExpressionRewriter(source);
+        if (node instanceof ClassNode) {
+            visitor.visitClass((ClassNode) node);
+        } else if (node instanceof MethodNode) {
+            visitor.visitMethod((MethodNode) node);
+        } else {
+            throw new IllegalArgumentException("Cannot apply the transformation to node " + node + " of type " + node.getClass());
+        }
     }
 
     private static class CompoundAssignmentExpressionRewriter extends ClassCodeExpressionTransformer {

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/CompoundAssignmentTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/CompoundAssignmentTransformer.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts.internal;
+
+import com.google.common.collect.ImmutableMap;
+import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.Phases;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.syntax.Token;
+import org.codehaus.groovy.syntax.Types;
+import org.gradle.api.internal.provider.support.SupportsCompoundAssignment;
+
+import java.util.Map;
+
+/**
+ * Rewrites some compound assignment expressions, like {@code +=}, in a way they can be intercepted at runtime and a custom behavior applied.
+ */
+public class CompoundAssignmentTransformer extends AbstractScriptTransformer {
+    @Override
+    protected int getPhase() {
+        return Phases.CANONICALIZATION;
+    }
+
+    @Override
+    public void call(SourceUnit source) throws CompilationFailedException {
+        CompoundAssignmentExpressionRewriter visitor = new CompoundAssignmentExpressionRewriter(source);
+        source.getAST().getStatementBlock().visit(visitor);
+        source.getAST().getClasses().forEach(visitor::visitClass);
+        source.getAST().getMethods().forEach(visitor::visitMethod);
+    }
+
+    private static class CompoundAssignmentExpressionRewriter extends ClassCodeExpressionTransformer {
+        // This only includes operators we want to transform.
+        // TODO(mlopatkin): ConfigurableFileCollections support `-`, so they should probably support `-=` too.
+        private static final Map<String, Integer> COMPOUND_TO_OPERATOR = ImmutableMap.of(
+            "+=", Types.PLUS
+        );
+        private final SourceUnit sourceUnit;
+
+        public CompoundAssignmentExpressionRewriter(SourceUnit sourceUnit) {
+            this.sourceUnit = sourceUnit;
+        }
+
+        @Override
+        public Expression transform(Expression expr) {
+            Expression transformedExpr = super.transform(expr);
+            if (transformedExpr instanceof BinaryExpression) {
+                return transformBinaryExpression((BinaryExpression) transformedExpr);
+            }
+            if (transformedExpr instanceof ClosureExpression) {
+                // Closure expression contains code, but ClosureExpression.transform doesn't descend into it.
+                ClosureExpression closureExpression = (ClosureExpression) transformedExpr;
+                closureExpression.visit(this);
+            }
+            return transformedExpr;
+        }
+
+        private Expression transformBinaryExpression(BinaryExpression expr) {
+            String operation = expr.getOperation().getText();
+            Integer compoundOpType = COMPOUND_TO_OPERATOR.get(operation);
+            if (compoundOpType != null) {
+                return transformCompoundAssignment(expr, compoundOpType);
+            }
+            return expr;
+        }
+
+        /**
+         * Rewrites {@code foo <OP>= bar} into {@code SupportsCompoundAssignment.unwrap(foo = SupportsCompoundAssignment.wrap(foo) <OP> (bar))}.
+         *
+         * @param original the original compound assignment expression
+         * @param compoundOperation the added operation of assignment ({@code OP})
+         * @return the transformed expression
+         */
+        private Expression transformCompoundAssignment(BinaryExpression original, int compoundOperation) {
+            Expression lhs = original.getLeftExpression();
+            Expression rhs = original.getRightExpression();
+
+            if (!isValidDestination(lhs)) {
+                // Skip array element assignments and the likes?
+                return original;
+            }
+
+            // Rewriting `foo <OP>= bar` into `foo = SupportsCompoundAssignment.wrap(foo) <OP> (bar)`.
+            BinaryExpression assignment = new BinaryExpression(
+                lhs,
+                rewriteToken(original.getOperation(), Types.ASSIGN),
+                new BinaryExpression(
+                    applyWrap(lhs),
+                    rewriteToken(original.getOperation(), compoundOperation),
+                    rhs
+                )
+            );
+            // Final rewrite: decorate result with SupportsCompoundAssignment.unwrap()
+            return withSourceLocationOf(original, applyUnwrap(assignment));
+        }
+
+        /**
+         * Builds a new token from the original, keeping the source position.
+         * @param originalOperation the original operation token
+         * @param newType the new token type
+         * @return the new token
+         */
+        private Token rewriteToken(Token originalOperation, int newType) {
+            return Token.newSymbol(newType, originalOperation.getStartLine(), originalOperation.getStartColumn());
+        }
+
+        private Expression applyWrap(Expression expr) {
+            return callSupportMethodOn("wrap", expr);
+        }
+
+        private Expression applyUnwrap(Expression expr) {
+            return callSupportMethodOn("unwrap", expr);
+        }
+
+        private Expression callSupportMethodOn(String methodName, Expression argument) {
+            return new StaticMethodCallExpression(ClassHelper.make(SupportsCompoundAssignment.class), methodName, new ArgumentListExpression(argument));
+
+        }
+
+        private static boolean isValidDestination(Expression expr) {
+            return expr instanceof VariableExpression || expr instanceof PropertyExpression;
+        }
+
+        private static <T extends Expression> T withSourceLocationOf(Expression original, T transformed) {
+            transformed.setSourcePosition(original);
+            return transformed;
+        }
+
+        @Override
+        protected SourceUnit getSourceUnit() {
+            return sourceUnit;
+        }
+    }
+}

--- a/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
@@ -529,7 +529,6 @@ Class <org.gradle.api.internal.provider.sources.process.ProcessOutputValueSource
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleBaseExecSpec> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProviderCompatibleBaseExecSpec.java:0)
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleExecSpec> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProviderCompatibleExecSpec.java:0)
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleJavaExecSpec> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProviderCompatibleJavaExecSpec.java:0)
-Class <org.gradle.api.internal.provider.support.LazyGroovySupport> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (LazyGroovySupport.java:0)
 Class <org.gradle.api.internal.resolve.DefaultLocalLibraryResolver> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (DefaultLocalLibraryResolver.java:0)
 Class <org.gradle.api.internal.resolve.DefaultProjectModelResolver> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (DefaultProjectModelResolver.java:0)
 Class <org.gradle.api.internal.resolve.LibraryResolutionErrorMessageBuilder> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (LibraryResolutionErrorMessageBuilder.java:0)


### PR DESCRIPTION
This only supports `+=` and not `+`. Unlike Kotlin, this is much more involved because of the Groovy overloading restrictions. Groovy only supports overloading of +, and uses it to implement +=, by basically rewriting `a += b` into `a = a + b`. This doesn't play well with Properties, because a sensible implementation of plus operator (e.g. `a.zip(b) { l1, l2 -> l1 + l2 }`) will likely cause a self-referencing chain to happen. While this can also be solved upon assignment, we don't really want users to have "action-at-distance" when you can set `c = a + b`, and, a thousand lines after, happily assign `a = c` and get some strange results. The latter should cause circular evaluation failure.

In order to support `+=`, and not arbitrary self-referencing `+` expressions, we employ an AST transformation. The transformation allows properties to provide a stand-in, which will be concatenated with the right-hand operand.

This works for fields of Property types, where setting the property value to the stand-in simply invokes appropriate mutation operation, like `add` or `addAll`. This also works for variable, where the stand-in becomes the new value of the property. The stand-in acts as a `zip`-ped provider.

Again, unlike Kotlin, the += is an expression in Groovy. To make both DSLs consistent, the value of += expression involving Properties is `null`. While it is still possible to write `foo = (a += b)` in Groovy, it is now rather pointless thing to do. All my attempts to give this expression some sensible value (e.g. return lhs operand or a shallow copy) faced different complicated corner cases. This, however, only applies to Property types, because ConfigurableFileCollections can already participate in `+=` expressions.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
