### PR TITLE
Capture actual file path in Location

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi813PlusCrossVersionTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi813PlusCrossVersionTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.tooling.events.problems.Problem
 import org.gradle.tooling.events.problems.Severity
 import org.gradle.tooling.events.problems.SingleProblemEvent
 import org.gradle.tooling.events.problems.internal.DefaultAdditionalData
+import org.gradle.util.GradleVersion
 
 @ToolingApiVersion(">=8.13")
 @TargetGradleVersion(">=8.10")
@@ -83,7 +84,9 @@ class ConfigurationCacheProblemsTapi813PlusCrossVersionTest extends ToolingApiSp
             definition.id.group.name == "configuration-cache"
             definition.severity == Severity.ERROR
             (originLocations[0] as LineInFileLocation).path == "build file 'build.gradle'" // FIXME: the path should not contain a prefix nor extra quotes
-            (originLocations[1] as LineInFileLocation).path == "build file '$buildFile.path'"
+            (originLocations[1] as LineInFileLocation).path == (targetVersion.baseVersion >= GradleVersion.version("8.14")
+                ? buildFile.path
+                : "build file '$buildFile.path'")
             additionalData instanceof DefaultAdditionalData
             additionalData.asMap.isEmpty()
         }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.configurationcache
+package org.gradle.internal.cc.impl
 
 import org.gradle.api.problems.Severity
-import org.gradle.internal.cc.impl.AbstractConfigurationCacheIntegrationTest
 
 class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCacheIntegrationTest {
 
@@ -56,7 +55,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
             originLocations.size() == 2
             originLocations[0].path == "build file 'build.gradle'"
             originLocations[0].line == 2
-            originLocations[1].path == "build file '${buildFile.absolutePath}'"
+            originLocations[1].path == buildFile.absolutePath
             originLocations[1].line == 2
             additionalData.asMap.trace == "build file 'build.gradle': line 2"
         }
@@ -72,7 +71,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
             definition.documentationLink.url.endsWith("/userguide/configuration_cache.html#config_cache:requirements:build_listeners")
             originLocations[0].path == "build file 'build.gradle'"
             originLocations[0].line == 2
-            originLocations[1].path == "build file '${buildFile.absolutePath}'"
+            originLocations[1].path == buildFile.absolutePath
             originLocations[1].line == 2
             additionalData.asMap.trace == "build file 'build.gradle': line 2"
 

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -138,7 +138,7 @@ public class LoggingDeprecatedFeatureHandler implements FeatureHandler<Deprecate
         if (location == null) {
             return;
         }
-        deprecationProblemBuilder.lineInFileLocation(location.getSourceLongDisplayName().getDisplayName(), location.getLineNumber());
+        deprecationProblemBuilder.lineInFileLocation(location.getFilePath(), location.getLineNumber());
     }
 
     private void maybeLogUsage(DeprecatedFeatureUsage usage, ProblemDiagnostics diagnostics) {

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -105,7 +105,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
     def 'includes problem location in message'() {
         given:
-        useLocation("<long>", 123)
+        useLocation("<long>", "<path to source>", 123)
 
         when:
         handler.featureUsed(deprecatedFeatureUsage('feature'))
@@ -156,10 +156,10 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
 
     def 'logs deprecation warning once for each unique location'() {
         given:
-        useLocation("<one>", 123)
-        useLocation("<one>", 1)
-        useLocation("<one>", 123)
-        useLocation("<one>", 1)
+        useLocation("<one>", "<path to source>", 123)
+        useLocation("<one>", "<path to source>", 1)
+        useLocation("<one>", "<path to source>", 123)
+        useLocation("<one>", "<path to source>", 1)
 
         when:
         handler.featureUsed(deprecatedFeatureUsage('feature1'))
@@ -181,9 +181,9 @@ feature1 removal""")
     def 'does not log deprecation warning without stack trace if the same warning has already been seen with a stack trace'() {
         given:
         useStackTrace(fakeStackTrace)
-        useLocation("<plugin>", 123, fakeStackTrace)
+        useLocation("<plugin>", "<path to source>", 123, fakeStackTrace)
         useStackTrace()
-        useLocation("<plugin>", 123)
+        useLocation("<plugin>", "<path to source>", 123)
 
         when:
         handler.featureUsed(deprecatedFeatureUsage('feature1'))
@@ -507,10 +507,10 @@ feature1 removal""")
         }
     }
 
-    private void useLocation(String displayName, int lineNumber, List<StackTraceElement> stackTrace = []) {
+    private void useLocation(String displayName, String filePath, int lineNumber, List<StackTraceElement> stackTrace = []) {
         1 * problemStream.forCurrentCaller(_) >> Stub(ProblemDiagnostics) {
             _ * getStack() >> stackTrace
-            _ * getLocation() >> new Location(Describables.of(displayName), Describables.of("<short>"), lineNumber)
+            _ * getLocation() >> new Location(Describables.of(displayName), Describables.of("<short>"), filePath, lineNumber)
         }
     }
 

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -51,7 +51,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 length == -1
                 column == -1
                 line == 13
-                path == "build file '$buildFile.absolutePath'"
+                path == buildFile.absolutePath
             }
             with(oneLocation(TaskPathLocation)) {
                 buildTreePath == ':reportProblem'
@@ -95,7 +95,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                     length == -1
                     column == -1
                     line == 10
-                    path == "build file '$buildFile.absolutePath'"
+                    path == buildFile.absolutePath
                 }
             }
         }
@@ -122,7 +122,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 length == -1
                 column == -1
                 line == 13
-                path == "build file '$buildFile.absolutePath'"
+                path == buildFile.absolutePath
             }
         }
 
@@ -168,7 +168,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 length == -1
                 column == -1
                 line == 13
-                path == "build file '$buildFile.absolutePath'"
+                path == buildFile.absolutePath
             }
         }
     }
@@ -198,7 +198,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 length == -1
                 column == -1
                 line == 13
-                path == "build file '$buildFile.absolutePath'"
+                path == buildFile.absolutePath
             }
         }
     }
@@ -317,7 +317,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 length == -1
                 column == -1
                 line == 13
-                path == "build file '$buildFile.absolutePath'"
+                path == buildFile.absolutePath
             }
         }
     }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
@@ -146,7 +146,7 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
     }
 
     private static FileLocation getFileLocation(Location loc) {
-        String path = loc.getSourceLongDisplayName().getDisplayName();
+        String path = loc.getFilePath();
         int line = loc.getLineNumber();
         return DefaultLineInFileLocation.from(path, line);
     }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/problems/Location.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/problems/Location.java
@@ -22,13 +22,15 @@ import org.gradle.internal.DisplayName;
  * A source file location.
  */
 public class Location {
+    private final String filePath;
     private final int lineNumber;
     private final DisplayName sourceLongDisplayName;
     private final DisplayName sourceShortDisplayName;
 
-    public Location(DisplayName sourceLongDisplayName, DisplayName sourceShortDisplayName, int lineNumber) {
+    public Location(DisplayName sourceLongDisplayName, DisplayName sourceShortDisplayName, String filePath, int lineNumber) {
         this.sourceLongDisplayName = sourceLongDisplayName;
         this.sourceShortDisplayName = sourceShortDisplayName;
+        this.filePath = filePath;
         this.lineNumber = lineNumber;
     }
 
@@ -44,6 +46,10 @@ public class Location {
      */
     public DisplayName getSourceShortDisplayName() {
         return sourceShortDisplayName;
+    }
+
+    public String getFilePath() {
+        return filePath;
     }
 
     public int getLineNumber() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/ProblemProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r812/ProblemProgressEventCrossVersionTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.tooling.events.problems.LineInFileLocation
 import org.gradle.tooling.events.problems.Problem
 import org.gradle.tooling.events.problems.Severity
 import org.gradle.tooling.events.problems.SingleProblemEvent
+import org.gradle.util.GradleVersion
 import org.junit.Assume
 
 import static org.gradle.integtests.fixtures.AvailableJavaHomes.getJdk17
@@ -88,12 +89,15 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
         then:
         thrown(BuildException)
         listener.problems.size() == 2
+        def expectedPath = targetVersion.baseVersion >= GradleVersion.version("8.14")
+            ? buildFile.path
+            : "build file '$buildFile.path'"
         verifyAll(listener.problems[0]) {
             definition.id.displayName.contains("The RepositoryHandler.jcenter() method has been deprecated.")
             definition.id.group.displayName in ["Deprecation", "deprecation", "repository-jcenter"]
             definition.id.group.name in ["deprecation", "repository-jcenter", "deprecation-logger"]
             definition.severity == Severity.WARNING
-            locations(it).find { l -> l instanceof LineInFileLocation && l.path == "build file '$buildFile.path'" } // FIXME: the path should not contain a prefix nor extra quotes
+            locations(it).find { l -> l instanceof LineInFileLocation && l.path == expectedPath }
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/problems/DefaultProblemLocationAnalyzer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/problems/DefaultProblemLocationAnalyzer.java
@@ -146,6 +146,6 @@ public class DefaultProblemLocationAnalyzer implements ProblemLocationAnalyzer, 
             return null;
         }
 
-        return new Location(source.getLongDisplayName(), source.getShortDisplayName(), lineNumber);
+        return new Location(source.getLongDisplayName(), source.getShortDisplayName(), frame.getFileName(), lineNumber);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/exception/DefaultExceptionAnalyserTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/exception/DefaultExceptionAnalyserTest.groovy
@@ -91,7 +91,7 @@ class DefaultExceptionAnalyserTest extends Specification {
         def result = []
 
         given:
-        _ * diagnosticsFactory.forException(failure) >> location("<source>", 7)
+        _ * diagnosticsFactory.forException(failure) >> location("<source>", "<path to source>", 7)
 
         when:
         analyser.collectFailures(failure, result)
@@ -112,8 +112,8 @@ class DefaultExceptionAnalyserTest extends Specification {
         def result = []
 
         given:
-        _ * diagnosticsFactory.forException(failure) >> location("<source>", 12)
-        _ * diagnosticsFactory.forException(cause) >> location("<source>", 7)
+        _ * diagnosticsFactory.forException(failure) >> location("<source>", "<path to source>", 12)
+        _ * diagnosticsFactory.forException(cause) >> location("<source>", "<path to source>", 7)
 
         when:
         analyser.collectFailures(failure, result)
@@ -244,7 +244,7 @@ class DefaultExceptionAnalyserTest extends Specification {
         def result = []
 
         given:
-        _ * diagnosticsFactory.forException(failure) >> location("<source>", 7)
+        _ * diagnosticsFactory.forException(failure) >> location("<source>", "<path to source>", 7)
 
         when:
         analyser.collectFailures(failure, result)
@@ -324,8 +324,8 @@ class DefaultExceptionAnalyserTest extends Specification {
         return failure
     }
 
-    private ProblemDiagnostics location(String longDisplayName, int line) {
-        def location = new Location(Describables.of(longDisplayName), Describables.of("short"), line)
+    private ProblemDiagnostics location(String longDisplayName, String fileName, int line) {
+        def location = new Location(Describables.of(longDisplayName), Describables.of("short"), fileName, line)
         return Stub(ProblemDiagnostics) {
             getLocation() >> location
         }


### PR DESCRIPTION
So we can report the path, and not the display name in problem locations.