### PR TITLE
Let backwards compatibility check handle JSpecify nullability annotations

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
         api("org.asciidoctor:asciidoctor-gradle-jvm:4.0.2")
         api("org.jetbrains.kotlin:kotlin-gradle-plugin") { version { strictly(kotlinVersion) } }
         api(kotlin("compiler-embeddable")) { version { strictly(kotlinVersion) } }
-        api("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")
         api("com.autonomousapps:dependency-analysis-gradle-plugin:1.33.0")
         api("com.squareup.okio:okio:3.4.0") {
             because("Bump version brought in by dependency-analysis-gradle-plugin, to resolve CVE-2022-3635")

--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
             because("Flexmark 0.34.60 brings in a vulnerable version of pdfbox")
         }
         api("com.google.code.findbugs:jsr305:3.0.2")
+        api("org.jspecify:jspecify:1.0.0")
         api("commons-io:commons-io:2.14.0")
         api("commons-lang:commons-lang:2.6")
         api("javax.activation:activation:1.1.1")

--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
         api("org.codehaus.groovy.modules.http-builder:http-builder:0.7.2") // TODO maybe change group name when upgrading to Groovy 4
         api("org.codenarc:CodeNarc:$codenarcVersion")
         api("org.eclipse.jgit:org.eclipse.jgit:5.13.3.202401111512-r")
-        api("org.javassist:javassist:3.27.0-GA")
+        api("org.javassist:javassist:3.30.2-GA")
         api("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.9.0")
         api("org.jsoup:jsoup:1.15.3")
         api("org.junit.jupiter:junit-jupiter:5.8.2")

--- a/build-logic/binary-compatibility/build.gradle.kts
+++ b/build-logic/binary-compatibility/build.gradle.kts
@@ -11,11 +11,13 @@ dependencies {
     implementation("gradlebuild:basics")
     implementation("gradlebuild:module-identity")
 
+    implementation("com.github.javaparser:javaparser-core")
     implementation("com.google.code.gson:gson")
     implementation("com.google.guava:guava")
     implementation("org.javassist:javassist")
-    implementation("com.github.javaparser:javaparser-core")
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm")
+    implementation("org.jspecify:jspecify")
+    implementation("org.ow2.asm:asm")
     implementation(kotlin("compiler-embeddable"))
 
     testImplementation("org.jsoup:jsoup")

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/NullabilityBreakingChangesRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/NullabilityBreakingChangesRule.groovy
@@ -22,20 +22,30 @@ import japicmp.model.JApiConstructor
 import japicmp.model.JApiField
 import japicmp.model.JApiMethod
 import javassist.CtBehavior
+import javassist.CtClass
+import javassist.CtConstructor
 import javassist.CtField
 import javassist.CtMethod
 import javassist.Modifier
-import javassist.bytecode.annotation.AnnotationImpl
 import me.champeau.gradle.japicmp.report.Violation
-
-import javax.annotation.Nullable
-import java.lang.annotation.Annotation
-import java.lang.reflect.Proxy
+import org.gradle.model.internal.asm.AsmConstants
+import org.objectweb.asm.AnnotationVisitor
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.FieldVisitor
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Type
+import org.objectweb.asm.TypePath
+import org.objectweb.asm.TypeReference
 
 @CompileStatic
 class NullabilityBreakingChangesRule extends AbstractGradleViolationRule {
 
-    private static final List<Class<? extends Annotation>> NULLABLE_ANNOTATIONS = [Nullable, org.jetbrains.annotations.Nullable]
+    private static final List<String> NULLABLE_ANNOTATIONS = [
+        javax.annotation.Nullable,
+        org.jetbrains.annotations.Nullable,
+        org.jspecify.annotations.Nullable,
+    ].collect { it.name }
 
     NullabilityBreakingChangesRule(Map<String, Object> params) {
         super(params)
@@ -119,26 +129,155 @@ class NullabilityBreakingChangesRule extends AbstractGradleViolationRule {
         return null
     }
 
-    private static List<Boolean> parametersNullabilityOf(CtBehavior behavior) {
-        def annotations = behavior.parameterAnnotations as List<Object[]>
-        annotations.collect { Object[] pAnn ->
-            pAnn.flatten().any { isNullableCtAnnotation(it) }
-        }
-    }
-
     private static boolean hasNullableAnnotation(CtField field) {
-        return NULLABLE_ANNOTATIONS.any { field.hasAnnotation(it) }
+        NullableFieldVisitor visitor = new NullableFieldVisitor(field.getName())
+        new ClassReader(byteCodeFrom(field.getDeclaringClass())).accept(visitor, 0)
+        return visitor.nullable
     }
 
-    private static boolean hasNullableAnnotation(CtMethod method) {
-        return NULLABLE_ANNOTATIONS.any { method.hasAnnotation(it) }
-    }
+    static class NullableFieldVisitor extends ClassVisitor {
 
-    private static boolean isNullableCtAnnotation(Object ann) {
-        if (Proxy.isProxyClass(ann.class)) {
-            def typeName = (Proxy.getInvocationHandler(ann) as AnnotationImpl).annotation.typeName
-            return NULLABLE_ANNOTATIONS.any { it.name == typeName }
+        boolean nullable = false
+        private final String fieldName
+
+        NullableFieldVisitor(String fieldName) {
+            super(AsmConstants.ASM_LEVEL)
+            this.fieldName = fieldName
         }
-        return false
+
+        @Override
+        FieldVisitor visitField(int access, String name, String fieldDescriptor, String signature, Object value) {
+            if (fieldName == name) {
+                return new FieldVisitor(AsmConstants.ASM_LEVEL) {
+                    @Override
+                    AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+                        if (NULLABLE_ANNOTATIONS.contains(Type.getType(descriptor).getClassName())) {
+                            nullable = true
+                        }
+                        return null
+                    }
+
+                    @Override
+                    AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
+                        if (new TypeReference(typeRef).getSort() == TypeReference.FIELD &&
+                            NULLABLE_ANNOTATIONS.contains(Type.getType(descriptor).getClassName())) {
+                            nullable = true
+                        }
+                        return null
+                    }
+                }
+            }
+            return null
+        }
+    }
+
+    private static boolean hasNullableAnnotation(CtBehavior behavior) {
+        NullableMethodVisitor visitor = new NullableMethodVisitor(behavior)
+        new ClassReader(byteCodeFrom(behavior.getDeclaringClass())).accept(visitor, 0)
+        return visitor.nullable
+    }
+
+    static class NullableMethodVisitor extends ClassVisitor {
+        boolean nullable = false
+        private final CtBehavior behavior
+        private final String behaviorName
+
+        NullableMethodVisitor(CtBehavior behavior) {
+            super(AsmConstants.ASM_LEVEL)
+            this.behavior = behavior
+            this.behaviorName = behavior instanceof CtConstructor ? "<init>" : behavior.getName()
+        }
+
+        @Override
+        MethodVisitor visitMethod(int access, String name, String methodDescriptor, String signature, String[] exceptions) {
+            if (behaviorName == name && methodDescriptor == behavior.getSignature()) {
+                return new MethodVisitor(AsmConstants.ASM_LEVEL) {
+
+                    @Override
+                    AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+                        if (NULLABLE_ANNOTATIONS.contains(Type.getType(descriptor).getClassName())) {
+                            nullable = true
+                        }
+                        return null
+                    }
+
+                    @Override
+                    AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
+                        if (new TypeReference(typeRef).getSort() == TypeReference.METHOD_RETURN &&
+                            NULLABLE_ANNOTATIONS.contains(Type.getType(descriptor).getClassName())) {
+                            nullable = true
+                        }
+                        return null
+                    }
+                }
+            }
+            return null
+        }
+    }
+
+
+    private static List<Boolean> parametersNullabilityOf(CtBehavior behavior) {
+        NullableParametersVisitor visitor = new NullableParametersVisitor(behavior)
+        new ClassReader(byteCodeFrom(behavior.getDeclaringClass())).accept(visitor, 0)
+        return visitor.parametersNullability
+    }
+
+    static class NullableParametersVisitor extends ClassVisitor {
+
+        private final CtBehavior behavior
+        private final String behaviorName
+        private Integer parametersOffset = 0
+        List<Boolean> parametersNullability = null
+
+        NullableParametersVisitor(CtBehavior behavior) {
+            super(AsmConstants.ASM_LEVEL)
+            this.behavior = behavior
+            this.behaviorName = behavior instanceof CtConstructor ? "<init>" : behavior.getName()
+        }
+
+        @Override
+        MethodVisitor visitMethod(int access, String name, String methodDescriptor, String signature, String[] exceptions) {
+            if (name == behaviorName && methodDescriptor == behavior.getSignature()) {
+                Type[] argumentTypes = Type.getArgumentTypes(methodDescriptor)
+                parametersNullability = new ArrayList<>(argumentTypes.length)
+                for (Type ignored : argumentTypes) {
+                    parametersNullability.add(false)
+                }
+                return new MethodVisitor(AsmConstants.ASM_LEVEL) {
+
+                    @Override
+                    void visitAnnotableParameterCount(int parameterCount, boolean visible) {
+                        parametersOffset = argumentTypes.length - parameterCount
+                    }
+
+                    @Override
+                    AnnotationVisitor visitParameterAnnotation(int parameter, String descriptor, boolean visible) {
+                        int parameterIndex = parameter + parametersOffset
+                        if (NULLABLE_ANNOTATIONS.contains(Type.getType(descriptor).getClassName())) {
+                            parametersNullability.set(parameterIndex, true)
+                        }
+                        return null
+                    }
+
+                    @Override
+                    AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
+                        TypeReference typeReference = new TypeReference(typeRef)
+                        if (typeReference.getSort() == TypeReference.METHOD_FORMAL_PARAMETER &&
+                            NULLABLE_ANNOTATIONS.contains(Type.getType(descriptor).getClassName())) {
+                            int parameterIndex = typeReference.getFormalParameterIndex() + parametersOffset
+                            parametersNullability.set(parameterIndex, true)
+                        }
+                        return null
+                    }
+                }
+            }
+            return null
+        }
+    }
+
+    private static byte[] byteCodeFrom(CtClass ctClass) {
+        def bos = new ByteArrayOutputStream()
+        ctClass.classFile2.write(new DataOutputStream(bos))
+        return bos.toByteArray()
     }
 }

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
@@ -113,7 +113,6 @@ abstract class AbstractBinaryCompatibilityTest {
                     package com.example
 
                     import org.gradle.api.Incubating
-                    import javax.annotation.Nullable
 
                     $v1
                     """
@@ -126,7 +125,6 @@ abstract class AbstractBinaryCompatibilityTest {
                     package com.example
 
                     import org.gradle.api.Incubating
-                    import javax.annotation.Nullable
 
                     $v2
                     """
@@ -145,7 +143,6 @@ abstract class AbstractBinaryCompatibilityTest {
                     package com.example;
 
                     import org.gradle.api.Incubating;
-                    import javax.annotation.Nullable;
 
                     $v1
                     """
@@ -158,7 +155,6 @@ abstract class AbstractBinaryCompatibilityTest {
                     package com.example;
 
                     import org.gradle.api.Incubating;
-                    import javax.annotation.Nullable;
 
                     $v2
                     """
@@ -271,6 +267,8 @@ abstract class AbstractBinaryCompatibilityTest {
                         dependencies {
                             "implementation"(gradleApi())
                             "implementation"(kotlin("stdlib"))
+                            // TODO remove once JSpecify is part of the Gradle API
+                            "implementation"("org.jspecify:jspecify:1.0.0")
                         }
                     }
                     project(":v1") {

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractJavaNullabilityChangesTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractJavaNullabilityChangesTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility
+
+import org.junit.Test
+
+abstract class AbstractJavaNullabilityChangesTest : AbstractBinaryCompatibilityTest() {
+
+    protected abstract val nullableAnnotationName: String
+
+    @Test
+    fun `from non-null returning to null returning is breaking`() {
+
+        checkNotBinaryCompatibleJava(
+            v1 = """
+                public class Source {
+                    public String nonFinalField = "some";
+                    public final String finalField = "some";
+                    public String foo() { return "bar"; }
+                }
+            """,
+            v2 = """
+                import $nullableAnnotationName;
+                public class Source {
+                    @Nullable public String nonFinalField = null;
+                    @Nullable public final String finalField = null;
+                    @Nullable public String foo() { return "bar"; }
+                }
+            """
+        ) {
+            assertHasErrors(
+                "Field nonFinalField: Nullability breaking change.",
+                "Field finalField: From non-nullable to nullable breaking change.",
+                "Method com.example.Source.foo(): From non-null returning to null returning breaking change."
+            )
+            assertHasNoWarning()
+            assertHasNoInformation()
+        }
+    }
+
+    @Test
+    fun `from null accepting to non-null accepting is breaking`() {
+
+        checkNotBinaryCompatibleJava(
+            v1 = """
+                import $nullableAnnotationName;
+                public class Source {
+                    public Source(@Nullable String some) {}
+                    @Nullable public String nonFinalField = null;
+                    public String foo(@Nullable String bar) { return "some"; }
+                }
+            """,
+            v2 = """
+                public class Source {
+                    public Source(String some) {}
+                    public String nonFinalField = "some";
+                    public String foo(String bar) { return bar; }
+                }
+            """
+        ) {
+            assertHasErrors(
+                "Field nonFinalField: Nullability breaking change.",
+                "Method com.example.Source.foo(java.lang.String): Parameter 0 from null accepting to non-null accepting breaking change.",
+                "Constructor com.example.Source(java.lang.String): Parameter 0 from null accepting to non-null accepting breaking change."
+            )
+            assertHasNoWarning()
+            assertHasNoInformation()
+        }
+    }
+
+    @Test
+    fun `from null returning to non-null returning is not breaking`() {
+
+        checkBinaryCompatibleJava(
+            v1 = """
+                import $nullableAnnotationName;
+                public class Source {
+                    @Nullable public final String finalField = null;
+                    @Nullable public String foo(String bar) { return bar; }
+                }
+            """,
+            v2 = """
+                public class Source {
+                    public final String finalField = null;
+                    public String foo(String bar) { return bar; }
+                }
+            """
+        ) {
+            assertHasNoError()
+            assertHasWarnings(
+                "Field finalField: Nullability changed from nullable to non-nullable",
+                "Method com.example.Source.foo(java.lang.String): Return nullability changed from nullable to non-nullable"
+            )
+            assertHasNoInformation()
+        }
+    }
+
+    @Test
+    fun `from non-null accepting to null accepting is not breaking`() {
+
+        checkBinaryCompatibleJava(
+            v1 = """
+                public class Source {
+                    public Source(String some) {}
+                    public String foo(String bar) { return bar; }
+                }
+            """,
+            v2 = """
+                import $nullableAnnotationName;
+                public class Source {
+                    public Source(@Nullable String some) {}
+                    public String foo(@Nullable String bar) { return "some"; }
+                }
+            """
+        ) {
+            assertHasNoError()
+            assertHasWarnings(
+                "Method com.example.Source.foo(java.lang.String): Parameter 0 nullability changed from non-nullable to nullable",
+                "Constructor com.example.Source(java.lang.String): Parameter 0 nullability changed from non-nullable to nullable"
+            )
+            assertHasNoInformation()
+        }
+    }
+}

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/JSpecifyNullabilityChangesTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/JSpecifyNullabilityChangesTest.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility
+
+class JSpecifyNullabilityChangesTest : AbstractJavaNullabilityChangesTest() {
+    override val nullableAnnotationName: String = "org.jspecify.annotations.Nullable"
+}

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/JavaxAnnotationNullabilityChangesTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/JavaxAnnotationNullabilityChangesTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility
+
+class JavaxAnnotationNullabilityChangesTest : AbstractJavaNullabilityChangesTest() {
+    override val nullableAnnotationName: String = "javax.annotation.Nullable"
+}
+

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/KotlinNullabilityChangesTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/KotlinNullabilityChangesTest.kt
@@ -18,39 +18,10 @@ package gradlebuild.binarycompatibility
 import org.junit.Test
 
 
-class NullabilityChangesTest : AbstractBinaryCompatibilityTest() {
+class KotlinNullabilityChangesTest : AbstractBinaryCompatibilityTest() {
 
     @Test
-    fun `from non-null returning to null returning is breaking (java)`() {
-
-        checkNotBinaryCompatibleJava(
-            v1 = """
-                public class Source {
-                    public String nonFinalField = "some";
-                    public final String finalField = "some";
-                    public String foo() { return "bar"; }
-                }
-            """,
-            v2 = """
-                public class Source {
-                    @Nullable public String nonFinalField = null;
-                    @Nullable public final String finalField = null;
-                    @Nullable public String foo() { return "bar"; }
-                }
-            """
-        ) {
-            assertHasErrors(
-                "Field nonFinalField: Nullability breaking change.",
-                "Field finalField: From non-nullable to nullable breaking change.",
-                "Method com.example.Source.foo(): From non-null returning to null returning breaking change."
-            )
-            assertHasNoWarning()
-            assertHasNoInformation()
-        }
-    }
-
-    @Test
-    fun `from non-null returning to null returning is breaking (kotlin)`() {
+    fun `from non-null returning to null returning is breaking`() {
 
         checkNotBinaryCompatibleKotlin(
             v1 = """
@@ -81,36 +52,7 @@ class NullabilityChangesTest : AbstractBinaryCompatibilityTest() {
     }
 
     @Test
-    fun `from null accepting to non-null accepting is breaking (java)`() {
-
-        checkNotBinaryCompatibleJava(
-            v1 = """
-                public class Source {
-                    public Source(@Nullable String some) {}
-                    @Nullable public String nonFinalField = null;
-                    public String foo(@Nullable String bar) { return "some"; }
-                }
-            """,
-            v2 = """
-                public class Source {
-                    public Source(String some) {}
-                    public String nonFinalField = "some";
-                    public String foo(String bar) { return bar; }
-                }
-            """
-        ) {
-            assertHasErrors(
-                "Field nonFinalField: Nullability breaking change.",
-                "Method com.example.Source.foo(java.lang.String): Parameter 0 from null accepting to non-null accepting breaking change.",
-                "Constructor com.example.Source(java.lang.String): Parameter 0 from null accepting to non-null accepting breaking change."
-            )
-            assertHasNoWarning()
-            assertHasNoInformation()
-        }
-    }
-
-    @Test
-    fun `from null accepting to non-null accepting is breaking (kotlin)`() {
+    fun `from null accepting to non-null accepting is breaking`() {
 
         checkNotBinaryCompatibleKotlin(
             v1 = """
@@ -139,33 +81,7 @@ class NullabilityChangesTest : AbstractBinaryCompatibilityTest() {
     }
 
     @Test
-    fun `from null returning to non-null returning is not breaking (java)`() {
-
-        checkBinaryCompatibleJava(
-            v1 = """
-                public class Source {
-                    @Nullable public final String finalField = null;
-                    @Nullable public String foo(String bar) { return bar; }
-                }
-            """,
-            v2 = """
-                public class Source {
-                    public final String finalField = null;
-                    public String foo(String bar) { return bar; }
-                }
-            """
-        ) {
-            assertHasNoError()
-            assertHasWarnings(
-                "Field finalField: Nullability changed from nullable to non-nullable",
-                "Method com.example.Source.foo(java.lang.String): Return nullability changed from nullable to non-nullable"
-            )
-            assertHasNoInformation()
-        }
-    }
-
-    @Test
-    fun `from null returning to non-null returning is not breaking (kotlin)`() {
+    fun `from null returning to non-null returning is not breaking`() {
 
         checkBinaryCompatibleKotlin(
             v1 = """
@@ -191,33 +107,7 @@ class NullabilityChangesTest : AbstractBinaryCompatibilityTest() {
     }
 
     @Test
-    fun `from non-null accepting to null accepting is not breaking (java)`() {
-
-        checkBinaryCompatibleJava(
-            v1 = """
-                public class Source {
-                    public Source(String some) {}
-                    public String foo(String bar) { return bar; }
-                }
-            """,
-            v2 = """
-                public class Source {
-                    public Source(@Nullable String some) {}
-                    public String foo(@Nullable String bar) { return "some"; }
-                }
-            """
-        ) {
-            assertHasNoError()
-            assertHasWarnings(
-                "Method com.example.Source.foo(java.lang.String): Parameter 0 nullability changed from non-nullable to nullable",
-                "Constructor com.example.Source(java.lang.String): Parameter 0 nullability changed from non-nullable to nullable"
-            )
-            assertHasNoInformation()
-        }
-    }
-
-    @Test
-    fun `from non-null accepting to null accepting is not breaking (kotlin)`() {
+    fun `from non-null accepting to null accepting is not breaking`() {
 
         checkBinaryCompatibleKotlin(
             v1 = """

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -66,6 +66,7 @@
          <trust file=".*-sources[.]jar" regex="true"/>
       </trusted-artifacts>
       <ignored-keys>
+         <ignored-key id="164779204E106A76" reason="Key couldn't be downloaded from any key server"/>
          <ignored-key id="74DAFDFD6DAE2441" reason="Key couldn't be downloaded from any key server"/>
       </ignored-keys>
       <trusted-keys>
@@ -1430,6 +1431,11 @@
       <component group="org.iq80.snappy" name="snappy" version="0.5">
          <artifact name="snappy-0.5.jar">
             <pgp value="9E93DB1192CEE3D3B581AABB37E9D58EA4598641"/>
+         </artifact>
+      </component>
+      <component group="org.javassist" name="javassist" version="3.30.2-GA">
+         <artifact name="javassist-3.30.2-GA.jar">
+            <sha256 value="eba37290994b5e4868f3af98ff113f6244a6b099385d9ad46881307d3cb01aaf" reason="A key couldn't be downloaded"/>
          </artifact>
       </component>
       <component group="org.jcommander" name="jcommander" version="1.85">


### PR DESCRIPTION
This is a small step towards #24767 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
