### PR TITLE
Allow secondary variants to be declared using register factory method

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
@@ -17,127 +17,183 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import spock.lang.Issue
 
+/**
+ * Tests the behavior of {@link org.gradle.api.artifacts.ConfigurationPublications#getVariants()}.
+ */
 class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
+
     def setup() {
         buildFile << """
             def usage = Attribute.of('usage', String)
-            def format = Attribute.of('format', String)
-            dependencies {
-                attributesSchema {
-                    attribute(usage)
+
+
+            configurations {
+                dependencyScope("deps")
+                resolvable("resolver") {
+                    extendsFrom(deps)
+                    attributes.attribute(usage, "primary")
                 }
             }
-            configurations { compile { attributes.attribute(usage, 'for-compile') } }
+
+            dependencies {
+                deps(project)
+            }
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task uses the Configuration API")
     def "cannot mutate outgoing variants after configuration is resolved"() {
         given:
         buildFile << """
-            configurations {
-                compile {
-                    attributes.attribute(usage, 'for compile')
-                    outgoing {
-                        artifact file('lib1.jar')
-                        variants {
-                            classes {
-                                attributes.attribute(format, 'classes-dir')
-                                artifact file('classes')
-                            }
-                            jar {
-                                attributes.attribute(format, 'classes-jar')
-                                artifact file('lib.jar')
-                            }
-                            sources {
-                                attributes.attribute(format, 'source-jar')
-                                artifact file('source.zip')
-                            }
+            def elements = configurations.create("elements") {
+                attributes.attribute(usage, "primary")
+                outgoing {
+                    variants {
+                        classes {
+                            attributes.attribute(usage, 'secondary')
+                            artifact(file('classes'))
                         }
                     }
                 }
             }
-            task mutateBeforeResolve {
-                doLast {
-                    def classes = configurations.compile.outgoing.variants['classes']
-                    classes.attributes.attribute(format, 'classes2')
+
+            elements.dependencies.addAllLater(provider {
+                // Try to mutate attributes late.
+                // We realize dependencies after we lock the configuration for mutation.
+                elements.outgoing.variants.classes {
+                    attributes.attribute(usage, 'tertiary')
                 }
-            }
-            task mutateAfterResolve {
+                []
+            })
+
+            task resolve {
+                def files = configurations.resolver.incoming.files
                 doLast {
-                    configurations.compile.resolve()
-                    def classes = configurations.compile.outgoing.variants['classes']
-                    classes.attributes.attribute(format, 'classes-dir')
+                    println(files*.name)
                 }
             }
         """
 
         when:
-        run 'mutateBeforeResolve'
+        fails("resolve")
 
         then:
-        noExceptionThrown()
-
-        when:
-        fails("mutateAfterResolve")
-
-        then:
-        failure.assertHasCause "Cannot change attributes of configuration ':compile' after it has been locked for mutation"
+        failure.assertHasCause "Cannot change attributes of configuration ':elements' variant classes after it has been locked for mutation"
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task uses the Configuration API")
-    def "cannot add outgoing variants after configuration is resolved"() {
+    def "cannot declare capabilities after configuration is observed"() {
         given:
         buildFile << """
-            configurations {
-                compile {
-                    attributes.attribute(usage, 'for compile')
-                    outgoing {
-                        artifact file('lib1.jar')
-                        variants {
-                            classes {
-                                attributes.attribute(format, 'classes-dir')
-                                artifact file('classes')
-                            }
-                        }
-                    }
-                }
+            def elements = configurations.create("elements") {
+                attributes.attribute(usage, "primary")
             }
-            task mutateBeforeResolve {
-                doLast {
-                    configurations.compile.outgoing.variants {
-                        jar {
-                            attributes.attribute(format, 'classes-jar')
-                            artifact file('lib.jar')
-                        }
-                    }
+
+            elements.dependencies.addAllLater(provider {
+                // Try to add capabilities late.
+                // We realize dependencies after we lock the configuration for mutation.
+                elements.outgoing {
+                    capability("foo")
                 }
-            }
-            task mutateAfterResolve {
+                []
+            })
+
+            task resolve {
+                def files = configurations.resolver.incoming.files
                 doLast {
-                    configurations.compile.resolve()
-                    configurations.compile.outgoing.variants {
-                        sources {
-                            attributes.attribute(format, 'source-jar')
-                            artifact file('source.zip')
-                        }
-                    }
+                    println(files*.name)
                 }
             }
         """
 
         when:
-        run 'mutateBeforeResolve'
+        fails("resolve")
 
         then:
-        noExceptionThrown()
+        failure.assertHasCause("Cannot declare capability 'foo' on configuration ':elements' after it has been consumed as a variant.")
+    }
+
+    def "cannot add outgoing variants after configuration is observed"() {
+        given:
+        buildFile << """
+
+            def elements = configurations.create("elements") {
+                attributes.attribute(usage, "primary")
+                outgoing.artifact(file("primary"))
+            }
+
+            if (${createVariantBefore}) {
+                elements.outgoing.variants {
+                    third {
+                        attributes.attribute(usage, 'tertiary')
+                        artifact file('third')
+                    }
+                }
+            }
+
+            elements.dependencies.addAllLater(provider {
+                // Try to add a secondary variant late.
+                // We realize dependencies after we lock the configuration for mutation.
+                elements.outgoing.variants {
+                    classes {
+                        attributes.attribute(usage, 'secondary')
+                        artifact file('classes')
+                    }
+                }
+                []
+            })
+
+            task resolve {
+                def files = configurations.resolver.incoming.artifactView {
+                    attributes.attribute(usage, "secondary")
+                }.files
+                doLast {
+                    println(files*.name)
+                }
+            }
+        """
 
         when:
-        fails("mutateAfterResolve")
+        fails("resolve")
 
         then:
-        failure.assertHasCause "Cannot create variant 'sources' after dependency configuration ':compile' has been resolved"
+        failure.assertHasCause("Cannot add secondary artifact set to configuration ':elements' after it has been consumed as a variant.")
+
+        where:
+        createVariantBefore << [true, false]
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/30367")
+    def "secondary variants can be registered lazily"() {
+        buildFile << """
+            def type = Attribute.of("color", String)
+
+            file("file1.txt").text = "file1"
+            file("file2.txt").text = "file2"
+
+            configurations {
+                consumable("outgoing") {
+                    attributes.attribute(type, "primary")
+                    outgoing.artifact(file("file1.txt"))
+                    outgoing.variants.register("my-secondary-variant") {
+                        attributes.attribute(type, "secondary")
+                        artifact(file("file2.txt"))
+                    }
+                }
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.resolver.incoming.artifactView {
+                    attributes.attribute(type, "secondary")
+                }.files
+                inputs.files(files)
+                doFirst {
+                    assert files*.name == ["file2.txt"]
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1126,13 +1126,14 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         runActionInHierarchy(conf -> {
             if (!conf.isObserved()) {
-                conf.configurationAttributes.freeze();
-                conf.outgoing.preventFromFurtherMutation();
-                conf.preventUsageMutation();
                 conf.observationReason = () -> {
                     String target = conf == this ? "it" : "it's child " + this.getDisplayName();
                     return target + " has been " + reason;
                 };
+
+                conf.configurationAttributes.freeze();
+                conf.outgoing.preventFromFurtherMutation(conf.observationReason);
+                conf.preventUsageMutation();
             }
         });
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -21,7 +21,6 @@ import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.NamedDomainObjectContainer;
-import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.ConfigurationPublications;
 import org.gradle.api.artifacts.ConfigurationVariant;
@@ -29,6 +28,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.DomainObjectCollectionInternal;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesFactory;
@@ -37,7 +37,6 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.FinalizableValue;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
@@ -45,13 +44,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
-public class DefaultConfigurationPublications implements ConfigurationPublications, FinalizableValue {
+public class DefaultConfigurationPublications implements ConfigurationPublications {
+
+    // Parent state
     private final DisplayName displayName;
-    private final PublishArtifactSet artifacts;
     private final PublishArtifactSetProvider allArtifacts;
     private final AttributeContainerInternal parentAttributes;
-    private final AttributeContainerInternal attributes;
+
+    // Services
     private final Instantiator instantiator;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
     private final NotationParser<Object, Capability> capabilityNotationParser;
@@ -59,10 +61,13 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
     private final AttributesFactory attributesFactory;
     private final DomainObjectCollectionFactory domainObjectCollectionFactory;
     private final TaskDependencyFactory taskDependencyFactory;
+
+    // Mutable state
+    private final PublishArtifactSet artifacts;
+    private final AttributeContainerInternal attributes;
     private NamedDomainObjectContainer<ConfigurationVariant> variants;
-    private ConfigurationVariantFactory variantFactory;
     private DomainObjectSet<Capability> capabilities;
-    private boolean canCreate = true;
+    private Supplier<String> observationReason;
 
     public DefaultConfigurationPublications(
         DisplayName displayName,
@@ -157,8 +162,12 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
     public NamedDomainObjectContainer<ConfigurationVariant> getVariants() {
         if (variants == null) {
             // Create variants container only as required
-            variantFactory = new ConfigurationVariantFactory();
-            variants = domainObjectCollectionFactory.newNamedDomainObjectContainer(ConfigurationVariant.class, variantFactory);
+            variants = domainObjectCollectionFactory.newNamedDomainObjectContainer(ConfigurationVariant.class, this::createVariant);
+            ((DomainObjectCollectionInternal<?>) variants).beforeCollectionChanges(variantName -> {
+                if (isObserved()) {
+                    throw new IllegalStateException("Cannot add secondary artifact set to " + displayName + " after " + observationReason.get() + ".");
+                }
+            });
         }
         return variants;
     }
@@ -170,18 +179,18 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
 
     @Override
     public void capability(Object notation) {
-        if (canCreate) {
-            if (capabilities == null) {
-                capabilities = domainObjectCollectionFactory.newDomainObjectSet(Capability.class);
-            }
-            if (notation instanceof Provider) {
-                capabilities.addLater(((Provider<?>) notation).map(capabilityNotationParser::parseNotation));
-            } else {
-                Capability descriptor = capabilityNotationParser.parseNotation(notation);
-                capabilities.add(descriptor);
-            }
+        if (isObserved()) {
+            throw new InvalidUserCodeException("Cannot declare capability '" + notation + "' on " + displayName + " after " + observationReason.get() + ".");
+        }
+
+        if (capabilities == null) {
+            capabilities = domainObjectCollectionFactory.newDomainObjectSet(Capability.class);
+        }
+        if (notation instanceof Provider) {
+            capabilities.addLater(((Provider<?>) notation).map(capabilityNotationParser::parseNotation));
         } else {
-            throw new InvalidUserCodeException("Cannot declare capability '" + notation + "' after dependency " + displayName + " has been resolved");
+            Capability descriptor = capabilityNotationParser.parseNotation(notation);
+            capabilities.add(descriptor);
         }
     }
 
@@ -190,9 +199,8 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         return capabilities == null ? Collections.emptyList() : ImmutableList.copyOf(capabilities);
     }
 
-    @Override
-    public void preventFromFurtherMutation() {
-        canCreate = false;
+    public void preventFromFurtherMutation(Supplier<String> observationReason) {
+        this.observationReason = observationReason;
         if (variants != null) {
             for (ConfigurationVariant variant : variants) {
                 ((ConfigurationVariantInternal) variant).preventFurtherMutation();
@@ -200,16 +208,21 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         }
     }
 
-    private class ConfigurationVariantFactory implements NamedDomainObjectFactory<ConfigurationVariant> {
-        @Override
-        public ConfigurationVariant create(String name) {
-            if (canCreate) {
-                return instantiator.newInstance(
-                    DefaultVariant.class, displayName, name, parentAttributes, artifactNotationParser, fileCollectionFactory, attributesFactory, domainObjectCollectionFactory, taskDependencyFactory
-                );
-            } else {
-                throw new InvalidUserCodeException("Cannot create variant '" + name + "' after dependency " + displayName + " has been resolved");
-            }
-        }
+    private boolean isObserved() {
+        return observationReason != null;
+    }
+
+    private DefaultVariant createVariant(String name) {
+        return instantiator.newInstance(
+            DefaultVariant.class,
+            displayName,
+            name,
+            parentAttributes,
+            artifactNotationParser,
+            fileCollectionFactory,
+            attributesFactory,
+            domainObjectCollectionFactory,
+            taskDependencyFactory
+        );
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -49,17 +49,19 @@ public class DefaultVariant implements ConfigurationVariantInternal {
     private Factory<List<PublishArtifact>> lazyArtifacts;
     @Nullable private String description;
 
-    public DefaultVariant(Describable parentDisplayName,
-                          String name,
-                          AttributeContainerInternal parentAttributes,
-                          NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
-                          FileCollectionFactory fileCollectionFactory,
-                          AttributesFactory cache,
-                          DomainObjectCollectionFactory domainObjectCollectionFactory,
-                          TaskDependencyFactory taskDependencyFactory) {
+    public DefaultVariant(
+        Describable parentDisplayName,
+        String name,
+        AttributeContainerInternal parentAttributes,
+        NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
+        FileCollectionFactory fileCollectionFactory,
+        AttributesFactory cache,
+        DomainObjectCollectionFactory domainObjectCollectionFactory,
+        TaskDependencyFactory taskDependencyFactory
+    ) {
         this.parentDisplayName = parentDisplayName;
         this.name = name;
-        this.attributes = new FreezableAttributeContainer(cache.mutable(parentAttributes), parentDisplayName);
+        this.attributes = new FreezableAttributeContainer(cache.mutable(parentAttributes), getDisplayName());
         this.artifactNotationParser = artifactNotationParser;
         artifacts = new DefaultPublishArtifactSet(getDisplayName(), domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class), fileCollectionFactory, taskDependencyFactory);
     }


### PR DESCRIPTION
Previously only `create` would work.

In the past we checked if the configuration was mutable at the time of instantiating the artifact set. We really want to check if the configuration is mutable when adding an element to the variant container.

This also updates some tests to be CC compatible.

Fixes #30367

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
