### PR TITLE
Only run update-jdks action in gradle/gradle repository

### DIFF
--- a/.github/workflows/update-jdks.yml
+++ b/.github/workflows/update-jdks.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   update-jdks:
+    if: github.repository == 'gradle/gradle'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
`update-jdks` action is only supposed to run in `gradle/gradle`, however, we notice it also runs in forked repos:

- https://github.com/ljacomet/gradle/pull/1
- https://github.com/moqimoqidea/gradle/pull/22

This PR adds a condition to avoid this.