### PR TITLE
Key SelectorState on ComponentSelector

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyResolveIntegrationTest.groovy
@@ -497,7 +497,7 @@ class IvyResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
         fails("resolve")
 
         then:
-        failure.assertHasCause("Could not resolve org:transitive:1.0")
+        failure.assertHasCause("Could not resolve project ':included' (Requested: org:transitive:1.0).")
         failure.assertHasErrorOutput("No variants exist.")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
@@ -550,6 +550,7 @@ class VersionConflictResolutionIntegrationTest extends AbstractIntegrationSpec {
                 project(":api", "test:api:") {
                     edge("org:foo:1.4.4", "org:foo:1.4.9") {
                         forced()
+                        notRequested() // Forcing substitutes the original requested dependency
                         byReason("didn't match version 1.6.0")
                     }
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphSelector.java
@@ -24,8 +24,8 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 public interface DependencyGraphSelector {
 
     /**
-     * Returns the requested dependency.
+     * Returns the component selector that this selector is based on.
      */
-    ComponentSelector getRequested();
+    ComponentSelector getComponentSelector();
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -467,7 +467,7 @@ public class DependencyGraphBuilder {
         for (NodeState node : cs.getNodes()) {
             List<EdgeState> incomingEdges = node.getIncomingEdges();
             for (EdgeState incomingEdge : incomingEdges) {
-                ComponentSelector selector = incomingEdge.getSelector().getSelector();
+                ComponentSelector selector = incomingEdge.getSelector().getComponentSelector();
                 incomingEdge.failWith(new ModuleVersionResolveException(selector, () ->
                     String.format("Could not resolve %s: Resolution strategy disallows usage of dynamic versions", selector)));
             }
@@ -481,7 +481,7 @@ public class DependencyGraphBuilder {
             List<EdgeState> incomingEdges = node.getIncomingEdges();
             for (EdgeState incomingEdge : incomingEdges) {
                 if (moduleIsChanging || incomingEdge.getDependencyMetadata().isChanging()) {
-                    ComponentSelector selector = incomingEdge.getSelector().getSelector();
+                    ComponentSelector selector = incomingEdge.getSelector().getComponentSelector();
                     incomingEdge.failWith(new ModuleVersionResolveException(selector, () ->
                         String.format("Could not resolve %s: Resolution strategy disallows usage of changing versions", selector)));
                 }
@@ -583,7 +583,7 @@ public class DependencyGraphBuilder {
                     for (EdgeState incomingEdge : nodeState.getIncomingEdges()) {
                         SelectorState selector = incomingEdge.getSelector();
                         if (isPlatformForcedEdge(selector)) {
-                            ComponentSelector componentSelector = selector.getSelector();
+                            ComponentSelector componentSelector = selector.getComponentSelector();
                             if (componentSelector instanceof ModuleComponentSelector) {
                                 ModuleComponentSelector mcs = (ModuleComponentSelector) componentSelector;
                                 if (!incomingEdge.getFrom().getComponent().getModule().equals(module)) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -37,6 +37,7 @@ import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.GraphVariantSelector;
+import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.jspecify.annotations.Nullable;
@@ -102,10 +103,11 @@ class EdgeState implements DependencyGraphEdge {
 
     boolean computeSelector(StrictVersionConstraints ancestorsStrictVersions, boolean deferSelection) {
         boolean ignoreVersion = !dependencyState.isForced() && ancestorsStrictVersions.contains(dependencyState.getModuleIdentifier(resolveState.getComponentSelectorConverter()));
-        SelectorState newSelector = resolveState.computeSelectorFor(dependencyState, ignoreVersion);
+        ComponentSelector componentSelector = dependencyState.getDependency().getSelector();
+        SelectorState newSelector = resolveState.computeSelectorFor(componentSelector, ignoreVersion);
         if (this.selector != newSelector) {
             clearSelector();
-            newSelector.use(deferSelection, isConstraint);
+            newSelector.use(this, deferSelection);
             this.selector = newSelector;
             return true;
         }
@@ -117,9 +119,32 @@ class EdgeState implements DependencyGraphEdge {
         if (this.selector != null) {
             SelectorState currentSelector = this.selector;
             this.selector = null;
-            return currentSelector.release(isConstraint);
+            return currentSelector.release(this);
         }
         return false;
+    }
+
+    /**
+     * True if this edge forces the version of the component selector it resolves, excluding
+     * the lenient forcing applied by virtual platform alignment.
+     */
+    boolean isHardForcing() {
+        return dependencyState.isForced() && !(dependencyMetadata instanceof LenientPlatformDependencyMetadata);
+    }
+
+    /**
+     * True if this edge leniently forces the version of the component selector it resolves,
+     * as part of virtual platform alignment.
+     */
+    boolean isSoftForcing() {
+        return dependencyState.isForced() && dependencyMetadata instanceof LenientPlatformDependencyMetadata;
+    }
+
+    /**
+     * Get the artifacts that this edge explicitly requests from the target component.
+     */
+    ImmutableList<IvyArtifactName> getDependencyArtifacts() {
+        return dependencyMetadata.getArtifacts();
     }
 
     @Override
@@ -143,7 +168,7 @@ class EdgeState implements DependencyGraphEdge {
      */
     @Nullable
     ComponentState getTargetComponent() {
-        if (selector == null || !selector.isResolved() || selector.getFailure() != null) {
+        if (selector == null || selector.requiresSelection() || selector.getFailure() != null) {
             return null;
         }
         ModuleResolveState targetModule = selector.getTargetModule();
@@ -286,6 +311,9 @@ class EdgeState implements DependencyGraphEdge {
                         continue;
                     }
                     ModuleVersionResolveException targetNodeFailure = unattachedEdge.targetNodeSelectionFailure;
+                    if (targetNodeFailure == null) {
+                        targetNodeFailure = unattachedEdge.dependencyState.getSubstitutionFailure();
+                    }
                     if (targetNodeFailure == null && unattachedEdge.selector != null) {
                         targetNodeFailure = unattachedEdge.selector.getFailure();
                     }
@@ -435,6 +463,9 @@ class EdgeState implements DependencyGraphEdge {
 
     @Override
     public @Nullable ModuleVersionResolveException getFailure() {
+        if (dependencyState.getSubstitutionFailure() != null) {
+            return dependencyState.getSubstitutionFailure();
+        }
         if (targetNodeSelectionFailure != null) {
             return targetNodeSelectionFailure;
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -105,7 +105,7 @@ class EdgeState implements DependencyGraphEdge {
         SelectorState newSelector = resolveState.computeSelectorFor(dependencyState, ignoreVersion);
         if (this.selector != newSelector) {
             clearSelector();
-            newSelector.use(deferSelection);
+            newSelector.use(deferSelection, isConstraint);
             this.selector = newSelector;
             return true;
         }
@@ -117,7 +117,7 @@ class EdgeState implements DependencyGraphEdge {
         if (this.selector != null) {
             SelectorState currentSelector = this.selector;
             this.selector = null;
-            return currentSelector.release();
+            return currentSelector.release(isConstraint);
         }
         return false;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -207,7 +207,17 @@ class EdgeState implements DependencyGraphEdge {
      * end fail resolution.
      */
     void failWith(Throwable err) {
-        targetNodeSelectionFailure = new ModuleVersionResolveException(selector.getSelector(), err);
+        ComponentSelector requested = dependencyState.getRequested();
+        ComponentSelector attempted = selector.getComponentSelector();
+        if (attempted.equals(requested)) {
+            targetNodeSelectionFailure = new ModuleVersionResolveException(attempted, err);
+        } else {
+            targetNodeSelectionFailure = new ModuleVersionResolveException(
+                attempted,
+                () -> String.format("Could not resolve %s (Requested: %s).", attempted.getDisplayName(), requested.getDisplayName()),
+                err
+            );
+        }
     }
 
     /**
@@ -292,7 +302,7 @@ class EdgeState implements DependencyGraphEdge {
         try {
             targetVariants = selectTargetVariants(targetComponentState);
         } catch (AttributeMergingException mergeError) {
-            targetNodeSelectionFailure = new ModuleVersionResolveException(getRequested(), () -> {
+            targetNodeSelectionFailure = new ModuleVersionResolveException(selector.getComponentSelector(), () -> {
                 Attribute<?> attribute = mergeError.getAttribute();
                 Object constraintValue = mergeError.getLeftValue();
                 Object dependencyValue = mergeError.getRightValue();
@@ -301,7 +311,7 @@ class EdgeState implements DependencyGraphEdge {
             return;
         } catch (Exception t) {
             // Failure to select the target variant/configurations from this component, given the dependency attributes/metadata.
-            targetNodeSelectionFailure = new ModuleVersionResolveException(getRequested(), t);
+            failWith(t);
             return;
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesException.java
@@ -91,7 +91,7 @@ public class IncompatibleDependencyAttributesException extends GraphValidationEx
     }
 
     private static @Nullable Object findRequestedAttributeValue(EdgeState edge, Attribute<?> attribute) {
-        ComponentSelector selector = edge.getSelector().getSelector();
+        ComponentSelector selector = edge.getSelector().getComponentSelector();
         if (selector instanceof ModuleComponentSelector) {
             return selector.getAttributes().getAttribute(attribute);
         }
@@ -100,7 +100,7 @@ public class IncompatibleDependencyAttributesException extends GraphValidationEx
 
     private static String formatAttributeQuery(SelectorState state, Attribute<?> attribute, Object value, boolean isConstraint) {
         String verb = isConstraint ? "requires" : "depends on";
-        return verb + " '" + state.getRequested() + "' with attribute '" + attribute.getName() + "' = '" + value + "'";
+        return verb + " '" + state.getComponentSelector() + "' with attribute '" + attribute.getName() + "' = '" + value + "'";
     }
 
     private static List<String> buildResolutions(Attribute<?> attribute) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -73,7 +73,11 @@ public class ModuleResolveState implements CandidateModule {
     private SelectorStateResolver<ComponentState> selectorStateResolver;
     private final PendingDependencies pendingDependencies;
     private @Nullable ComponentState selected;
-    private ImmutableAttributes mergedConstraintAttributes = ImmutableAttributes.EMPTY;
+    /**
+     * The merged attributes of all component selectors that are currently used by at least
+     * one constraint edge. Null when invalidated. Recomputed on demand.
+     */
+    private @Nullable ImmutableAttributes mergedConstraintAttributes = ImmutableAttributes.EMPTY;
     private @Nullable AttributeMergingException attributeMergingError;
     private @Nullable VirtualPlatformState platformState;
     private boolean overriddenSelection;
@@ -316,7 +320,6 @@ public class ModuleResolveState implements CandidateModule {
 
     void addSelector(SelectorState selector, boolean deferSelection) {
         selectors.add(selector, deferSelection);
-        mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selector);
         if (overriddenSelection) {
             assert selected != null : "An overridden module cannot have selected == null";
             selector.overrideSelection(selected);
@@ -325,10 +328,6 @@ public class ModuleResolveState implements CandidateModule {
 
     void removeSelector(SelectorState selector) {
         selectors.remove(selector);
-        mergedConstraintAttributes = ImmutableAttributes.EMPTY;
-        for (SelectorState selectorState : selectors) {
-            mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selectorState);
-        }
     }
 
     public ModuleSelectors<SelectorState> getSelectors() {
@@ -340,18 +339,34 @@ public class ModuleResolveState implements CandidateModule {
     }
 
     ImmutableAttributes getMergedConstraintAttributes() {
+        if (mergedConstraintAttributes == null) {
+            ImmutableAttributes merged = ImmutableAttributes.EMPTY;
+            for (SelectorState selectorState : selectors) {
+                merged = appendConstraintAttributes(merged, selectorState);
+            }
+            mergedConstraintAttributes = merged;
+        }
         if (attributeMergingError != null) {
             throw new IncompatibleDependencyAttributesException(this, attributeMergingError);
         }
         return mergedConstraintAttributes;
     }
 
-    private ImmutableAttributes appendAttributes(ImmutableAttributes dependencyAttributes, SelectorState selectorState) {
+    /**
+     * Invalidate the merged constraint attributes, for example, when a selector starts or
+     * stops being used by constraint edges.
+     */
+    // TODO: The merged constraint attributes feed back into the resolution of this module's
+    //  selectors. When the merged attributes change, any existing resolution of this module's
+    //  selectors is potentially stale and should be invalidated as well.
+    void invalidateMergedConstraintAttributes() {
+        mergedConstraintAttributes = null;
+    }
+
+    private ImmutableAttributes appendConstraintAttributes(ImmutableAttributes dependencyAttributes, SelectorState selectorState) {
         try {
-            DependencyMetadata dependencyMetadata = selectorState.getDependencyMetadata();
-            boolean constraint = dependencyMetadata.isConstraint();
-            if (constraint) {
-                ComponentSelector selector = dependencyMetadata.getSelector();
+            if (selectorState.isUsedByConstraint()) {
+                ComponentSelector selector = selectorState.getComponentSelector();
                 ImmutableAttributes attributes = ((AttributeContainerInternal) selector.getAttributes()).asImmutable();
                 dependencyAttributes = attributesFactory.safeConcat(attributes, dependencyAttributes);
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -415,8 +415,8 @@ public class NodeState implements DependencyGraphNode {
             for (ModuleIdentifier identifier : upcomingNoLongerPendingConstraints) {
                 ModuleResolveState module = resolveState.getModule(identifier);
                 for (EdgeState unattachedEdge : module.getUnattachedEdges()) {
-                    if (!unattachedEdge.getSelector().isResolved()) {
-                        // Unresolved - we have a selector that was deferred but the constraint has been removed in between
+                    if (unattachedEdge.getSelector().requiresSelection()) {
+                        // We have a selector that was deferred but the constraint has been removed in between
                         NodeState from = unattachedEdge.getFrom();
                         from.prepareToRecomputeEdge(unattachedEdge);
                     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -242,7 +242,7 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
         boolean isVirtualPlatformEdge = dependencyState.getDependency() instanceof LenientPlatformDependencyMetadata;
         SelectorState selectorState = selectors.computeIfAbsent(new SelectorCacheKey(dependencyState.getRequested(), ignoreVersion, isVirtualPlatformEdge), req -> {
             ModuleIdentifier moduleIdentifier = dependencyState.getModuleIdentifier(getComponentSelectorConverter());
-            return new SelectorState(dependencyState, idResolver, this, moduleIdentifier, ignoreVersion);
+            return new SelectorState(dependencyState.getDependency().getSelector(), idResolver, this, moduleIdentifier, ignoreVersion);
         });
         selectorState.update(dependencyState);
         return selectorState;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -238,14 +238,18 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
         return selectors.values();
     }
 
-    public SelectorState computeSelectorFor(DependencyState dependencyState, boolean ignoreVersion) {
-        boolean isVirtualPlatformEdge = dependencyState.getDependency() instanceof LenientPlatformDependencyMetadata;
-        SelectorState selectorState = selectors.computeIfAbsent(new SelectorCacheKey(dependencyState.getRequested(), ignoreVersion, isVirtualPlatformEdge), req -> {
-            ModuleIdentifier moduleIdentifier = dependencyState.getModuleIdentifier(getComponentSelectorConverter());
-            return new SelectorState(dependencyState.getDependency().getSelector(), idResolver, this, moduleIdentifier, ignoreVersion);
+    public SelectorState computeSelectorFor(ComponentSelector selector, boolean ignoreVersion) {
+        return selectors.computeIfAbsent(new SelectorCacheKey(selector, ignoreVersion), req -> {
+            ModuleIdentifier moduleIdentifier = getModuleIdentifier(selector);
+            return new SelectorState(selector, idResolver, this, moduleIdentifier, ignoreVersion);
         });
-        selectorState.update(dependencyState);
-        return selectorState;
+    }
+
+    private ModuleIdentifier getModuleIdentifier(ComponentSelector selector) {
+        if (selector instanceof ModuleComponentSelector) {
+            return ((ModuleComponentSelector) selector).getModuleIdentifier();
+        }
+        return getComponentSelectorConverter().getModuleVersionId(selector).getModule();
     }
 
     @Nullable
@@ -339,28 +343,23 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
 
         private final ComponentSelector componentSelector;
         private final boolean ignoreVersion;
-        private final boolean virtualPlatformEdge;
         private final int hashCode;
 
         private SelectorCacheKey(
             ComponentSelector componentSelector,
-            boolean ignoreVersion,
-            boolean virtualPlatformEdge
+            boolean ignoreVersion
         ) {
             this.componentSelector = componentSelector;
             this.ignoreVersion = ignoreVersion;
-            this.virtualPlatformEdge = virtualPlatformEdge;
-            this.hashCode = computeHashCode(componentSelector, ignoreVersion, virtualPlatformEdge);
+            this.hashCode = computeHashCode(componentSelector, ignoreVersion);
         }
 
         private static int computeHashCode(
             ComponentSelector componentSelector,
-            boolean ignoreVersion,
-            boolean virtualPlatformEdge
+            boolean ignoreVersion
         ) {
             int result = componentSelector.hashCode();
             result = 31 * result + Boolean.hashCode(ignoreVersion);
-            result = 31 * result + Boolean.hashCode(virtualPlatformEdge);
             return result;
         }
 
@@ -374,7 +373,6 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
             }
             SelectorCacheKey that = (SelectorCacheKey) o;
             return ignoreVersion == that.ignoreVersion &&
-                virtualPlatformEdge == that.virtualPlatformEdge &&
                 componentSelector.equals(that.componentSelector);
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -56,11 +56,11 @@ import static org.gradle.util.internal.TextUtil.getPluralEnding;
  * Resolution state for a given component selector.
  * <p>
  * There are 3 possible states:
- * 1. The selector has been newly added to a `ModuleResolveState`. In this case {@link #resolved} will be `false`.
+ * 1. The selector has been newly added to a `ModuleResolveState`. In this case {@link #requiresSelection} will be `true`.
  * 2. The selector failed to resolve. In this case {@link #failure} will be `!= null`.
  * 3. The selector was part of resolution to a particular component.
  * <p>
- * In this case {@link #resolved} will be `true` and {@link ModuleResolveState#getSelected()} will point to the selected component.
+ * In this case {@link #requiresSelection} will be `false` and {@link ModuleResolveState#getSelected()} will point to the selected component.
  */
 class SelectorState implements DependencyGraphSelector, ResolvableSelectorState {
 
@@ -75,24 +75,28 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     private @Nullable ComponentIdResolveResult requireResult;
     private @Nullable ModuleVersionResolveException failure;
     private ModuleResolveState targetModule;
-    private boolean resolved;
-    private boolean forced;
-    private boolean softForced;
-    private boolean fromLock;
+
+    /**
+     * When true, the target module's current selection does not yet account for this selector's
+     * state, and selection must run again before this selector's opinion is reflected in the graph.
+     */
+    private boolean requiresSelection = true;
+
     private boolean reusable;
     private boolean markedReusableAlready;
-    private boolean changing;
 
-    // An internal counter used to track the number of outgoing edges
-    // that use this selector. Since a module resolve state tracks all selectors
-    // for this module, when considering selectors that need to be used when
-    // choosing a version, we must only consider the ones which currently have
-    // outgoing edges pointing to them. If not, then it means the module was
-    // evicted, but it can still be reintegrated later in a different path.
+    // Counters used to track accumulated state of all outgoing edges that use this selector.
+    // Since a ModuleResolveState tracks all selectors targeting itself, when considering
+    // selectors that need to be used when choosing a version, a module must only consider
+    // the selectors that currently have outgoing edges pointing to it. If not, then it means
+    // the module was evicted, but it can still be reintegrated later in a different path.
     private int outgoingEdgeCount;
     private int outgoingConstraintEdgeCount;
+    private int hardForcingEdgeCount;
+    private int softForcingEdgeCount;
+    private int lockingEdgeCount;
+    private int changingEdgeCount;
 
-    private @Nullable ModuleVersionResolveException dependencyFailure;
     private @Nullable IvyArtifactName firstDependencyArtifact;
 
     SelectorState(ComponentSelector componentSelector, DependencyToComponentIdResolver resolver, ResolveState resolveState, ModuleIdentifier targetModuleId, boolean versionByAncestor) {
@@ -113,28 +117,71 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         return isProjectSelector;
     }
 
-    public void use(boolean deferSelection, boolean constraint) {
-        outgoingEdgeCount++;
-        if (outgoingEdgeCount == 1) {
-            targetModule.addSelector(this, deferSelection);
-        }
-
-        if (constraint) {
+    /**
+     * Register an edge that uses this selector. Contributions are reference counted
+     * so that if the edge leaves the graph, their contributions to this selector can
+     * be reverted.
+     */
+    public void use(EdgeState edge, boolean deferSelection) {
+        if (edge.isConstraint()) {
             outgoingConstraintEdgeCount++;
             if (outgoingConstraintEdgeCount == 1) {
                 targetModule.invalidateMergedConstraintAttributes();
             }
         }
+
+        if (edge.isHardForcing()) {
+            hardForcingEdgeCount++;
+            if (hardForcingEdgeCount == 1) {
+                this.requiresSelection = true;
+            }
+        }
+
+        if (edge.isSoftForcing()) {
+            softForcingEdgeCount++;
+            if (softForcingEdgeCount == 1) {
+                targetModule.resolveOptimizations.declareForcedPlatformInUse();
+                this.requiresSelection = true;
+            }
+        }
+
+        if (edge.isFromLock()) {
+            lockingEdgeCount++;
+            if (lockingEdgeCount == 1) {
+                this.requiresSelection = true;
+            }
+        }
+
+        if (edge.getDependencyMetadata().isChanging()) {
+            changingEdgeCount++;
+        }
+
+        // TODO: The first dependency artifact is not reference counted, since it is arbitrary anyway.
+        // We should fix this at some point.
+        if (this.firstDependencyArtifact == null) {
+            List<IvyArtifactName> artifacts = edge.getDependencyArtifacts();
+            this.firstDependencyArtifact = artifacts.isEmpty() ? null : artifacts.get(0);
+        }
+
+        outgoingEdgeCount++;
+        if (outgoingEdgeCount == 1) {
+            // Register with the target module last, since the module orders its selectors
+            // based on the state contributed above, (locking and forcing).
+            targetModule.addSelector(this, deferSelection);
+        }
     }
 
     /**
-     * Decrease the count of edges using this selector, updating state on the target module if
-     * this selector is no longer used by any edges.
+     * Decrease the count of edges using this selector, subtracting the state the released
+     * edge contributed to this selector and updating the state on the target module if this
+     * selector is no longer used by any edges.
      *
      * @return True if releasing this selector requires the target module to be reselected.
      */
-    public boolean release(boolean constraint) {
-        if (constraint) {
+    public boolean release(EdgeState edge) {
+        boolean needsSelection = false;
+
+        if (edge.isConstraint()) {
             outgoingConstraintEdgeCount--;
             assert outgoingConstraintEdgeCount >= 0 : "Inconsistent selector state detected for '" + this + "': outgoing constraint edge count cannot be negative";
             if (outgoingConstraintEdgeCount == 0) {
@@ -142,15 +189,47 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
             }
         }
 
+        if (edge.isHardForcing()) {
+            hardForcingEdgeCount--;
+            assert hardForcingEdgeCount >= 0 : "Inconsistent selector state detected for '" + this + "': hard forcing edge count cannot be negative";
+            if (hardForcingEdgeCount == 0) {
+                this.requiresSelection = true;
+                needsSelection = true;
+            }
+        }
+
+        if (edge.isSoftForcing()) {
+            softForcingEdgeCount--;
+            assert softForcingEdgeCount >= 0 : "Inconsistent selector state detected for '" + this + "': soft forcing edge count cannot be negative";
+            if (softForcingEdgeCount == 0) {
+                this.requiresSelection = true;
+                needsSelection = true;
+            }
+        }
+
+        if (edge.isFromLock()) {
+            lockingEdgeCount--;
+            assert lockingEdgeCount >= 0 : "Inconsistent selector state detected for '" + this + "': locking edge count cannot be negative";
+            if (lockingEdgeCount == 0) {
+                this.requiresSelection = true;
+                needsSelection = true;
+            }
+        }
+
+        if (edge.getDependencyMetadata().isChanging()) {
+            changingEdgeCount--;
+            assert changingEdgeCount >= 0 : "Inconsistent selector state detected for '" + this + "': changing edge count cannot be negative";
+        }
+
         outgoingEdgeCount--;
         assert outgoingEdgeCount >= 0 : "Inconsistent selector state detected for '" + this + "': outgoing edge count cannot be negative";
         if (outgoingEdgeCount == 0) {
             targetModule.removeSelector(this);
-            boolean needsSelection = markForReuse();
-            resolved = false;
-            return needsSelection;
+            needsSelection |= markForReuse();
+            this.requiresSelection = true;
         }
-        return false;
+
+        return needsSelection;
     }
 
     /**
@@ -203,13 +282,9 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
             }
 
             BuildableComponentIdResolveResult idResolveResult = new DefaultBuildableComponentIdResolveResult();
-            if (dependencyFailure != null) {
-                idResolveResult.failed(dependencyFailure);
-            } else {
-                ComponentOverrideMetadata overrideMetadata = DefaultComponentOverrideMetadata.forDependency(changing, firstDependencyArtifact);
-                ImmutableAttributes requestAttributes = resolveState.getAttributesFactory().concat(resolveState.getConsumerAttributes(), targetModule.getMergedConstraintAttributes());
-                resolver.resolve(componentSelector, overrideMetadata, selector, rejector, idResolveResult, requestAttributes);
-            }
+            ComponentOverrideMetadata overrideMetadata = DefaultComponentOverrideMetadata.forDependency(isChanging(), firstDependencyArtifact);
+            ImmutableAttributes requestAttributes = resolveState.getAttributesFactory().concat(resolveState.getConsumerAttributes(), targetModule.getMergedConstraintAttributes());
+            resolver.resolve(componentSelector, overrideMetadata, selector, rejector, idResolveResult, requestAttributes);
 
             if (idResolveResult.getFailure() != null) {
                 failure = idResolveResult.getFailure();
@@ -217,7 +292,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
 
             return idResolveResult;
         } finally {
-            this.resolved = true;
+            this.requiresSelection = false;
         }
     }
 
@@ -243,12 +318,12 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     @Override
-    public void markResolved() {
-        this.resolved = true;
+    public void markSelectionCompleted() {
+        this.requiresSelection = false;
     }
 
-    public boolean isResolved() {
-        return resolved;
+    public boolean requiresSelection() {
+        return requiresSelection;
     }
 
     /**
@@ -258,7 +333,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
      * @return true if marking this selector for reuse requires the target module to be reselected
      */
     boolean markForReuse() {
-        if (!resolved) {
+        if (requiresSelection) {
             // Selector was marked for deferred selection - let's not trigger selection now
             return false;
         }
@@ -283,7 +358,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         if (reusable) {
             return true;
         }
-        return !resolved;
+        return requiresSelection;
     }
 
     /**
@@ -291,7 +366,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
      * This happens when the `ModuleResolveState` is restarted, during conflict resolution or version range merging.
      */
     public void overrideSelection(ComponentState selected) {
-        this.resolved = true;
+        this.requiresSelection = false;
         this.reusable = false;
 
         // Target module can change, if this is called as the result of a module or capability replacement conflict.
@@ -365,7 +440,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
 
     @Override
     public boolean isChanging() {
-        return changing;
+        return changingEdgeCount > 0;
     }
 
     @Override
@@ -381,48 +456,22 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
 
     @Override
     public boolean isForce() {
-        return forced;
+        return hardForcingEdgeCount > 0 || softForcingEdgeCount > 0;
     }
 
     @Override
     public boolean isSoftForce() {
-        return softForced;
+        return softForcingEdgeCount > 0 && hardForcingEdgeCount == 0;
     }
 
     @Override
     public boolean isFromLock() {
-        return fromLock;
+        return lockingEdgeCount > 0;
     }
 
     @Override
     public boolean hasStrongOpinion() {
-        return forced || (versionConstraint != null && versionConstraint.isStrict());
-    }
-
-    public void update(DependencyState dependencyState) {
-        if (!forced && dependencyState.isForced()) {
-            forced = true;
-            if (dependencyState.getDependency() instanceof LenientPlatformDependencyMetadata) {
-                softForced = true;
-                targetModule.resolveOptimizations.declareForcedPlatformInUse();
-            }
-            resolved = false; // when a selector changes from non forced to forced, we must reselect
-        }
-        if (!fromLock && dependencyState.isFromLock()) {
-            fromLock = true;
-            resolved = false; // when a selector changes from non lock to lock, we must reselect
-        }
-
-        changing = changing || dependencyState.getDependency().isChanging();
-
-        if (firstDependencyArtifact == null) {
-            List<IvyArtifactName> artifacts = dependencyState.getDependency().getArtifacts();
-            this.firstDependencyArtifact = artifacts.isEmpty() ? null : artifacts.get(0);
-        }
-
-        if (dependencyFailure == null && dependencyState.getSubstitutionFailure() != null) {
-            this.dependencyFailure = dependencyState.getSubstitutionFailure();
-        }
+        return isForce() || (versionConstraint != null && versionConstraint.isStrict());
     }
 
     private static class UnmatchedVersionsReason implements Describable {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -28,7 +28,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
@@ -71,7 +70,6 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     private final ResolvedVersionConstraint versionConstraint;
     private final boolean versionByAncestor;
     private final boolean isProjectSelector;
-    private final AttributeDesugaring attributeDesugaring;
 
     private @Nullable ComponentIdResolveResult preferResult;
     private @Nullable ComponentIdResolveResult requireResult;
@@ -103,8 +101,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         this.versionConstraint = versionByAncestor ?
             resolveState.resolveVersionConstraint(DefaultImmutableVersionConstraint.of()) :
             resolveState.resolveVersionConstraint(dependencyState.getDependency().getSelector());
-        this.isProjectSelector = getSelector() instanceof ProjectComponentSelector;
-        this.attributeDesugaring = resolveState.getAttributeDesugaring();
+        this.isProjectSelector = getComponentSelector() instanceof ProjectComponentSelector;
     }
 
     @Override
@@ -143,10 +140,6 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         return dependencyState.getDependency().toString();
     }
 
-    @Override
-    public ComponentSelector getRequested() {
-        return attributeDesugaring.desugarSelector(dependencyState.getRequested());
-    }
 
     public ModuleResolveState getTargetModule() {
         return targetModule;
@@ -364,7 +357,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     @Override
-    public ComponentSelector getSelector() {
+    public ComponentSelector getComponentSelector() {
         return dependencyState.getDependency().getSelector();
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -31,7 +31,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
-import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -54,17 +53,18 @@ import java.util.function.Consumer;
 import static org.gradle.util.internal.TextUtil.getPluralEnding;
 
 /**
- * Resolution state for a given module version selector.
- *
+ * Resolution state for a given component selector.
+ * <p>
  * There are 3 possible states:
  * 1. The selector has been newly added to a `ModuleResolveState`. In this case {@link #resolved} will be `false`.
  * 2. The selector failed to resolve. In this case {@link #failure} will be `!= null`.
- * 3. The selector was part of resolution to a particular module version.
+ * 3. The selector was part of resolution to a particular component.
+ * <p>
  * In this case {@link #resolved} will be `true` and {@link ModuleResolveState#getSelected()} will point to the selected component.
  */
 class SelectorState implements DependencyGraphSelector, ResolvableSelectorState {
 
-    private final DependencyState dependencyState;
+    private final ComponentSelector componentSelector;
     private final DependencyToComponentIdResolver resolver;
     private final ResolveState resolveState;
     private final ResolvedVersionConstraint versionConstraint;
@@ -90,18 +90,21 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     // outgoing edges pointing to them. If not, then it means the module was
     // evicted, but it can still be reintegrated later in a different path.
     private int outgoingEdgeCount;
+    private int outgoingConstraintEdgeCount;
 
-    SelectorState(DependencyState dependencyState, DependencyToComponentIdResolver resolver, ResolveState resolveState, ModuleIdentifier targetModuleId, boolean versionByAncestor) {
+    private @Nullable ModuleVersionResolveException dependencyFailure;
+    private @Nullable IvyArtifactName firstDependencyArtifact;
+
+    SelectorState(ComponentSelector componentSelector, DependencyToComponentIdResolver resolver, ResolveState resolveState, ModuleIdentifier targetModuleId, boolean versionByAncestor) {
         this.resolver = resolver;
         this.resolveState = resolveState;
         this.targetModule = resolveState.getModule(targetModuleId);
         this.versionByAncestor = versionByAncestor;
-        update(dependencyState);
-        this.dependencyState = dependencyState;
+        this.componentSelector = componentSelector;
         this.versionConstraint = versionByAncestor ?
             resolveState.resolveVersionConstraint(DefaultImmutableVersionConstraint.of()) :
-            resolveState.resolveVersionConstraint(dependencyState.getDependency().getSelector());
-        this.isProjectSelector = getComponentSelector() instanceof ProjectComponentSelector;
+            resolveState.resolveVersionConstraint(componentSelector);
+        this.isProjectSelector = componentSelector instanceof ProjectComponentSelector;
     }
 
     @Override
@@ -110,10 +113,17 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         return isProjectSelector;
     }
 
-    public void use(boolean deferSelection) {
+    public void use(boolean deferSelection, boolean constraint) {
         outgoingEdgeCount++;
         if (outgoingEdgeCount == 1) {
             targetModule.addSelector(this, deferSelection);
+        }
+
+        if (constraint) {
+            outgoingConstraintEdgeCount++;
+            if (outgoingConstraintEdgeCount == 1) {
+                targetModule.invalidateMergedConstraintAttributes();
+            }
         }
     }
 
@@ -123,7 +133,15 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
      *
      * @return True if releasing this selector requires the target module to be reselected.
      */
-    public boolean release() {
+    public boolean release(boolean constraint) {
+        if (constraint) {
+            outgoingConstraintEdgeCount--;
+            assert outgoingConstraintEdgeCount >= 0 : "Inconsistent selector state detected for '" + this + "': outgoing constraint edge count cannot be negative";
+            if (outgoingConstraintEdgeCount == 0) {
+                targetModule.invalidateMergedConstraintAttributes();
+            }
+        }
+
         outgoingEdgeCount--;
         assert outgoingEdgeCount >= 0 : "Inconsistent selector state detected for '" + this + "': outgoing edge count cannot be negative";
         if (outgoingEdgeCount == 0) {
@@ -135,11 +153,17 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         return false;
     }
 
-    @Override
-    public String toString() {
-        return dependencyState.getDependency().toString();
+    /**
+     * True if this selector is currently used by at least one constraint edge.
+     */
+    boolean isUsedByConstraint() {
+        return outgoingConstraintEdgeCount > 0;
     }
 
+    @Override
+    public String toString() {
+        return componentSelector.toString();
+    }
 
     public ModuleResolveState getTargetModule() {
         return targetModule;
@@ -179,13 +203,12 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
             }
 
             BuildableComponentIdResolveResult idResolveResult = new DefaultBuildableComponentIdResolveResult();
-            if (dependencyState.getSubstitutionFailure() != null) {
-                idResolveResult.failed(dependencyState.getSubstitutionFailure());
+            if (dependencyFailure != null) {
+                idResolveResult.failed(dependencyFailure);
             } else {
-                IvyArtifactName firstArtifact = getFirstDependencyArtifact();
-                ComponentOverrideMetadata overrideMetadata = DefaultComponentOverrideMetadata.forDependency(changing, firstArtifact);
+                ComponentOverrideMetadata overrideMetadata = DefaultComponentOverrideMetadata.forDependency(changing, firstDependencyArtifact);
                 ImmutableAttributes requestAttributes = resolveState.getAttributesFactory().concat(resolveState.getConsumerAttributes(), targetModule.getMergedConstraintAttributes());
-                resolver.resolve(dependencyState.getDependency().getSelector(), overrideMetadata, selector, rejector, idResolveResult, requestAttributes);
+                resolver.resolve(componentSelector, overrideMetadata, selector, rejector, idResolveResult, requestAttributes);
             }
 
             if (idResolveResult.getFailure() != null) {
@@ -335,14 +358,9 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         }
     }
 
-    public DependencyMetadata getDependencyMetadata() {
-        return dependencyState.getDependency();
-    }
-
     @Override
     public IvyArtifactName getFirstDependencyArtifact() {
-        List<IvyArtifactName> artifacts = dependencyState.getDependency().getArtifacts();
-        return artifacts.isEmpty() ? null : artifacts.get(0);
+        return firstDependencyArtifact;
     }
 
     @Override
@@ -358,7 +376,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
 
     @Override
     public ComponentSelector getComponentSelector() {
-        return dependencyState.getDependency().getSelector();
+        return componentSelector;
     }
 
     @Override
@@ -382,21 +400,28 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     public void update(DependencyState dependencyState) {
-        if (dependencyState != this.dependencyState) {
-            if (!forced && dependencyState.isForced()) {
-                forced = true;
-                if (dependencyState.getDependency() instanceof LenientPlatformDependencyMetadata) {
-                    softForced = true;
-                    targetModule.resolveOptimizations.declareForcedPlatformInUse();
-                }
-                resolved = false; // when a selector changes from non forced to forced, we must reselect
+        if (!forced && dependencyState.isForced()) {
+            forced = true;
+            if (dependencyState.getDependency() instanceof LenientPlatformDependencyMetadata) {
+                softForced = true;
+                targetModule.resolveOptimizations.declareForcedPlatformInUse();
             }
-            if (!fromLock && dependencyState.isFromLock()) {
-                fromLock = true;
-                resolved = false; // when a selector changes from non lock to lock, we must reselect
-            }
+            resolved = false; // when a selector changes from non forced to forced, we must reselect
+        }
+        if (!fromLock && dependencyState.isFromLock()) {
+            fromLock = true;
+            resolved = false; // when a selector changes from non lock to lock, we must reselect
+        }
 
-            changing = changing || dependencyState.getDependency().isChanging();
+        changing = changing || dependencyState.getDependency().isChanging();
+
+        if (firstDependencyArtifact == null) {
+            List<IvyArtifactName> artifacts = dependencyState.getDependency().getArtifacts();
+            this.firstDependencyArtifact = artifacts.isEmpty() ? null : artifacts.get(0);
+        }
+
+        if (dependencyFailure == null && dependencyState.getSubstitutionFailure() != null) {
+            this.dependencyFailure = dependencyState.getSubstitutionFailure();
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
@@ -77,9 +77,9 @@ public class VirtualPlatformState {
         String version = null;
         for (SelectorState selector : platformModule.getSelectors()) {
             if (selector.hasStrongOpinion()) {
-                ComponentSelector requested = selector.getRequested();
-                if (requested instanceof ModuleComponentSelector) {
-                    String nv = ((ModuleComponentSelector) requested).getVersion();
+                ComponentSelector componentSelector = selector.getComponentSelector();
+                if (componentSelector instanceof ModuleComponentSelector mcs) {
+                    String nv = mcs.getVersion();
                     if (version == null || vC.compare(nv, version) < 0) {
                         version = nv;
                     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
@@ -48,11 +48,11 @@ public interface ResolvableSelectorState {
     ComponentIdResolveResult resolvePrefer(VersionSelector allRejects);
 
     /**
-     * Mark the selector as resolved.
+     * Mark this selector as accounted for by the current selection of the target module.
      * This is used when another selector resolved to a component identifier that satisfies this selector.
      * In that case, a call to {@link #resolve(VersionSelector)} is not required.
      */
-    void markResolved();
+    void markSelectionCompleted();
 
     boolean isForce();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
@@ -27,7 +27,7 @@ public interface ResolvableSelectorState {
     /**
      * The raw component selector being resolved, after any substitution.
      */
-    ComponentSelector getSelector();
+    ComponentSelector getComponentSelector();
 
     /**
      * The version constraint that applies to this selector, if any.
@@ -68,6 +68,6 @@ public interface ResolvableSelectorState {
     boolean isChanging();
 
     default boolean isProject() {
-        return getSelector() instanceof ProjectComponentSelector;
+        return getComponentSelector() instanceof ProjectComponentSelector;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
@@ -195,7 +195,7 @@ class SelectorStateResolverResults {
         }
         ResolvedVersionConstraint versionConstraint = dep.getVersionConstraint();
         if (versionConstraint == null) {
-            return dep.getSelector().matchesStrictly(candidate.getId());
+            return dep.getComponentSelector().matchesStrictly(candidate.getId());
         }
         VersionSelector versionSelector = versionConstraint.getRequiredSelector();
         if (versionSelector != null &&

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
@@ -131,7 +131,7 @@ class SelectorStateResolverResults {
             ComponentIdResolveResult discovered = registration.result;
             if (selectorAcceptsCandidate(selector, discovered, registration.selector.isFromLock())) {
                 found = discovered;
-                selector.markResolved();
+                selector.markSelectionCompleted();
                 break;
             }
         }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesExceptionTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesExceptionTest.groovy
@@ -109,8 +109,7 @@ class IncompatibleDependencyAttributesExceptionTest extends Specification {
         componentSelector.getAttributes() >> attrs
         componentSelector.toString() >> 'org.example:lib:1.0'
         def selector = Mock(SelectorState)
-        selector.getSelector() >> componentSelector
-        selector.getRequested() >> componentSelector
+        selector.getComponentSelector() >> componentSelector
         def root = Mock(NodeState)
         root.getIncomingEdges() >> []
         root.getDisplayName() >> 'root'

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
@@ -56,7 +56,7 @@ public class TestModuleSelectorState implements ResolvableSelectorState {
     }
 
     @Override
-    public ComponentSelector getSelector() {
+    public ComponentSelector getComponentSelector() {
         return new TestComponentSelector();
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
@@ -92,7 +92,7 @@ public class TestModuleSelectorState implements ResolvableSelectorState {
     }
 
     @Override
-    public void markResolved() {
+    public void markSelectionCompleted() {
     }
 
     @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
@@ -62,7 +62,7 @@ class TestProjectSelectorState implements ResolvableSelectorState {
     }
 
     @Override
-    void markResolved() {
+    void markSelectionCompleted() {
     }
 
     @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
@@ -44,7 +44,7 @@ class TestProjectSelectorState implements ResolvableSelectorState {
     }
 
     @Override
-    ComponentSelector getSelector() {
+    ComponentSelector getComponentSelector() {
         return new DefaultProjectComponentSelector(projectId, ImmutableAttributes.EMPTY, ImmutableSet.of())
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
@@ -205,7 +205,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
 
     private DependencyGraphEdge dep(DependencyGraphSelector selector, DependencyGraphNode selected) {
         def edge = Stub(DependencyGraphEdge)
-        _ * edge.requested >> selector.requested
+        _ * edge.requested >> selector.componentSelector
         _ * edge.selector >> selector
         _ * edge.failure >> null
         _ * edge.targetNodes >> [selected]
@@ -215,9 +215,9 @@ class StreamingResolutionResultBuilderTest extends Specification {
     private DependencyGraphEdge dep(DependencyGraphSelector selector, Throwable failure) {
         def edge = Stub(DependencyGraphEdge)
         _ * edge.selector >> selector
-        _ * edge.requested >> selector.requested
+        _ * edge.requested >> selector.componentSelector
         _ * edge.reason >> ComponentSelectionReasons.requested()
-        _ * edge.failure >> new ModuleVersionResolveException(selector.requested, failure)
+        _ * edge.failure >> new ModuleVersionResolveException(selector.componentSelector, failure)
         return edge
     }
 
@@ -249,7 +249,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
 
     private DependencyGraphSelector selector(String org, String name, String ver) {
         def selector = Stub(DependencyGraphSelector)
-        selector.requested >> DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(org, name), new DefaultMutableVersionConstraint(ver))
+        selector.componentSelector >> DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(org, name), new DefaultMutableVersionConstraint(ver))
         return selector
     }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -793,7 +793,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         fails ':a:check_compileFree'
 
         then:
-        failure.assertHasCause("Could not resolve com.acme.external:external:1.0.")
+        failure.assertHasCause("Could not resolve project ':includedBuild' (Requested: com.acme.external:external:1.0).")
         failure.assertHasCause("""No matching variant of project ':includedBuild' was found. The consumer was configured to find attribute 'flavor' with value 'free' but:
   - Variant 'bar':
       - Incompatible because this component declares attribute 'flavor' with value 'blue' and the consumer needed attribute 'flavor' with value 'free'
@@ -804,7 +804,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         fails ':a:check_compilePaid'
 
         then:
-        failure.assertHasCause("Could not resolve com.acme.external:external:1.0.")
+        failure.assertHasCause("Could not resolve project ':includedBuild' (Requested: com.acme.external:external:1.0).")
         failure.assertHasCause("""The consumer was configured to find attribute 'flavor' with value 'paid'. However we cannot choose between the following variants of project ':includedBuild':
   - bar
   - foo


### PR DESCRIPTION
We have a hash map of component selectors. The key to the map did not correspond to the the selector it described. The SelectorState is a function of the component selector that it resolves to a component identifier. That should be the only key to the map that caches SelectorState instances.

This commit ensures we avoid re-resolving component selectors by using a cache key that more accurately describes the selector being cached. It also reduces a likely cause of hard-to-find bugs, as the inaccurate cache key that was previously used could cause collisions when dependency substituion was used -- as the prior key used the original requested component selector as key, while the SelectorState resolved the substituted component selector.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
