### PR TITLE
Fix issue with exec process not being stopped when build is canceled

### DIFF
--- a/platforms/core-execution/workers/build.gradle.kts
+++ b/platforms/core-execution/workers/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     api(libs.jsr305)
 
     implementation(projects.fileTemp)
-    implementation(projects.processServices)
     implementation(projects.fileCollections)
     implementation(projects.fileOperations)
     implementation(projects.time)

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -63,7 +63,6 @@ import org.gradle.internal.service.scopes.WorkerSharedGlobalScopeServices;
 import org.gradle.internal.service.scopes.WorkerSharedProjectScopeServices;
 import org.gradle.internal.service.scopes.WorkerSharedUserHomeScopeServices;
 import org.gradle.internal.state.ManagedFactoryRegistry;
-import org.gradle.process.internal.ClientExecHandleBuilderFactory;
 import org.gradle.process.internal.DefaultExecActionFactory;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.process.internal.worker.RequestHandler;
@@ -230,8 +229,7 @@ public class WorkerDaemonServer implements RequestHandler<TransportableActionExe
             ObjectFactory objectFactory,
             ExecutorFactory executorFactory,
             TemporaryFileProvider temporaryFileProvider,
-            BuildCancellationToken buildCancellationToken,
-            ClientExecHandleBuilderFactory execHandleFactory
+            BuildCancellationToken buildCancellationToken
         ) {
             return DefaultExecActionFactory.of(
                 fileResolver,
@@ -240,8 +238,7 @@ public class WorkerDaemonServer implements RequestHandler<TransportableActionExe
                 executorFactory,
                 temporaryFileProvider,
                 buildCancellationToken,
-                objectFactory,
-                execHandleFactory
+                objectFactory
             );
         }
 

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
@@ -54,7 +54,7 @@ import org.gradle.launcher.daemon.context.DaemonRequestContext;
 import org.gradle.launcher.daemon.diagnostics.DaemonStartupInfo;
 import org.gradle.launcher.daemon.registry.DaemonDir;
 import org.gradle.launcher.daemon.toolchain.DaemonJvmCriteria;
-import org.gradle.process.internal.DefaultClientExecHandleBuilderFactory;
+import org.gradle.process.internal.DefaultClientExecHandleBuilderFactory.RootClientExecHandleBuilderFactory;
 import org.gradle.process.internal.ExecHandle;
 import org.gradle.process.internal.JvmOptions;
 import org.gradle.util.GradleVersion;
@@ -243,7 +243,7 @@ public class DefaultDaemonStarter implements DaemonStarter {
             DaemonOutputConsumer outputConsumer = new DaemonOutputConsumer();
 
             // This factory should be injected but leaves non-daemon threads running when used from the tooling API client
-            DefaultClientExecHandleBuilderFactory execActionFactory = DefaultClientExecHandleBuilderFactory.root(gradleUserHome);
+            RootClientExecHandleBuilderFactory execActionFactory = RootClientExecHandleBuilderFactory.of(gradleUserHome);
             try {
                 ExecHandle handle = new DaemonExecHandleBuilder().build(args, workingDir, outputConsumer, stdInput, execActionFactory.newExecHandleBuilder());
 

--- a/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/ClientExecHandleBuilderFactory.java
+++ b/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/ClientExecHandleBuilderFactory.java
@@ -20,6 +20,12 @@ import org.gradle.api.NonNullApi;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
+/**
+ * A factory for creating low level {@link ClientExecHandleBuilder} instances.
+ *
+ * This is very low level process API factory. It is not intended to be used directly except in very specific cases.
+ * For starting a process prefer using ExecFactory.
+ */
 @NonNullApi
 @ServiceScope({Scope.Global.class})
 public interface ClientExecHandleBuilderFactory {

--- a/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/ClientExecHandleBuilderFactory.java
+++ b/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/ClientExecHandleBuilderFactory.java
@@ -17,21 +17,15 @@
 package org.gradle.process.internal;
 
 import org.gradle.api.NonNullApi;
-import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 @NonNullApi
-@ServiceScope({Scope.Global.class, Scope.BuildSession.class})
+@ServiceScope({Scope.Global.class})
 public interface ClientExecHandleBuilderFactory {
 
     /**
      * Returns a new {@link ClientExecHandleBuilder} to build a new {@link ExecHandle}.
      */
     ClientExecHandleBuilder newExecHandleBuilder();
-
-    /**
-     * Returns a new instance of this factory with the given file resolver.
-     */
-    ClientExecHandleBuilderFactory withFileResolver(PathToFileResolver fileResolver);
 }

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     integTestImplementation(projects.messaging)
     // TODO: Make these available for all integration tests? Maybe all tests?
     integTestImplementation(libs.jetbrainsAnnotations)
+    integTestImplementation(libs.commonsHttpclient)
 
     testFixturesApi(testFixtures(projects.languageJvm))
     testFixturesImplementation(projects.baseServices)

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -17,12 +17,19 @@
 
 package org.gradle.integtests
 
+import org.apache.http.HttpResponse
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.HttpClientBuilder
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.integtests.fixtures.daemon.DaemonClientFixture
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.process.TestExecHttpServer
 import org.gradle.process.TestJavaMain
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.precondition.Requires
@@ -30,6 +37,8 @@ import org.gradle.test.preconditions.UnitTestPreconditions
 import org.gradle.util.internal.TextUtil
 import org.junit.Rule
 import spock.lang.Issue
+
+import java.util.concurrent.TimeUnit
 
 class ExecIntegrationTest extends AbstractIntegrationSpec {
     @Rule
@@ -810,6 +819,52 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         "JavaExec" | javaExecSpec()
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/32213")
+    @UnsupportedWithConfigurationCache(because = "Uses script or project at execution time")
+    def "project.#method process is stopped when build is cancelled"() {
+        settingsFile << "include 'a'"
+        file("a/build.gradle") << """
+            tasks.register("appStart") {
+                doLast {
+                    // Using a new Thread is important to reproduce the issue to escape the task lifecycle
+                    Thread.start {
+                        project.${method} {
+                            ${configuration(getHttpServerInfoFile())}
+                        }
+                    }.join()
+                }
+            }
+        """
+
+        when:
+        executer
+            .requireDaemon()
+            .requireIsolatedDaemons()
+            .noDeprecationChecks()
+            .withStackTraceChecksDisabled()
+            // Needed to get client pid
+            .withArgument("--debug")
+            .withTasks("appStart")
+        def client = new DaemonClientFixture(executer.start())
+
+        then:
+        long port = waitForHttpServerPort()
+        callGet("http://127.0.0.1:$port/test").statusLine.statusCode == 200
+
+        when:
+        client.kill()
+        callGet("http://127.0.0.1:$port/test")
+
+        then:
+        def e = thrown(ConnectException)
+        e.message.contains("Connection refused")
+
+        where:
+        method     | configuration
+        "exec"     | { File serverInfoFile -> execSpecWithHttpServerExecutable(serverInfoFile) }
+        "javaexec" | { File serverInfoFile -> javaExecSpecWithHttpServer(serverInfoFile) }
+    }
+
     private static def execSpec(def owner = "") {
         "${prop(owner, "commandLine")}(${echoCommandLineArgs("Hello")});"
     }
@@ -818,6 +873,13 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         """
             ${prop(owner, "executable")}(org.gradle.internal.jvm.Jvm.current().getJavaExecutable())
             ${prop(owner, "args")}('-cp',${javaExecClasspath()}, '${TestJavaMain.name}', "Hello")
+        """
+    }
+
+    private static def execSpecWithHttpServerExecutable(File serverInfoFile, def owner = "") {
+        """
+            ${prop(owner, "executable")}(org.gradle.internal.jvm.Jvm.current().getJavaExecutable())
+            ${prop(owner, "args")}('-cp',${javaExecHttpServerClasspath()}, '${TestExecHttpServer.name}', '${serverInfoFile.absolutePath}')
         """
     }
 
@@ -836,12 +898,24 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
+    private static def javaExecSpecWithHttpServer(File serverInfo, def owner = "") {
+        """
+            ${prop(owner, "getMainClass()")}.set("${TestExecHttpServer.name}");
+            ${prop(owner, "classpath")}(${javaExecHttpServerClasspath()});
+            ${prop(owner, "args")}("${serverInfo.absolutePath}");
+        """
+    }
+
     private static String prop(String owner, String propertyName) {
         return owner ? owner + '.' + propertyName : propertyName
     }
 
     private static def javaExecClasspath() {
         """ "${TextUtil.escapeString(TestJavaMain.classLocation)}" """.trim()
+    }
+
+    private static def javaExecHttpServerClasspath() {
+        """ "${TextUtil.escapeString(TestExecHttpServer.classLocation)}" """.trim()
     }
 
     private void expectExecMethodDeprecation(String deprecation, String replacements) {
@@ -856,5 +930,33 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
             "This will fail with an error in Gradle 10.0. " +
             "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
+    }
+
+    private long waitForHttpServerPort(int waitTimeSeconds = 5) {
+        // Server needs some time to start so we wait for the server info file with port to be created
+        File serverInfoFile = getHttpServerInfoFile()
+        long start = System.currentTimeMillis()
+        while (System.currentTimeMillis() - start < TimeUnit.SECONDS.toMillis(waitTimeSeconds)) {
+            if (serverInfoFile.exists()) {
+                try {
+                    return Long.parseLong(serverInfoFile.text)
+                } catch (Exception ignore) {
+                }
+            }
+            Thread.sleep(25)
+        }
+        throw new IllegalStateException("Cannot get server port. Was the server started?")
+    }
+
+    private File getHttpServerInfoFile() {
+        return testDirectory.file("httpServerInfo")
+    }
+
+    private static HttpResponse callGet(String url) {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            CloseableHttpResponse response = client.execute(new HttpGet(url))
+            response.close()
+            return response
+        }
     }
 }

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -924,7 +924,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
     private static def execSpecWithHttpServerExecutable(File serverInfoFile, def owner = "") {
         """
             ${prop(owner, "executable")}(org.gradle.internal.jvm.Jvm.current().getJavaExecutable())
-            ${prop(owner, "args")}('-cp',${javaExecHttpServerClasspath()}, '${TestExecHttpServer.name}', '${serverInfoFile.absolutePath}')
+            ${prop(owner, "args")}('-cp',${javaExecHttpServerClasspath()}, '${TestExecHttpServer.name}', '${TextUtil.normaliseFileSeparators(serverInfoFile.absolutePath)}')
         """
     }
 
@@ -947,7 +947,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         """
             ${prop(owner, "getMainClass()")}.set("${TestExecHttpServer.name}");
             ${prop(owner, "classpath")}(${javaExecHttpServerClasspath()});
-            ${prop(owner, "args")}("${serverInfo.absolutePath}");
+            ${prop(owner, "args")}("${TextUtil.normaliseFileSeparators(serverInfo.absolutePath)}");
         """
     }
 
@@ -977,7 +977,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
     }
 
-    private long waitForHttpServerPort(int waitTimeSeconds = 5) {
+    private long waitForHttpServerPort(int waitTimeSeconds = 20) {
         // Server needs some time to start so we wait for the server info file with port to be created
         File serverInfoFile = getHttpServerInfoFile()
         long start = System.currentTimeMillis()

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -826,7 +826,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         file("a/build.gradle") << """
             tasks.register("appStart") {
                 doLast {
-                    // Using a new Thread is important to reproduce the issue to escape the task lifecycle
+                    // Using a new Thread is important to escape the task lifecycle and reproduce the issue
                     Thread.start {
                         project.${method} {
                             ${configuration(getHttpServerInfoFile())}
@@ -872,7 +872,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
             tasks.register("appStart") {
                 def execOperations = services.get(ExecOperations)
                 doLast {
-                    // Using a new Thread is important to reproduce the issue to escape the task lifecycle
+                    // Using a new Thread is important to escape the task lifecycle and reproduce the issue
                     Thread.start {
                         execOperations.${method} {
                             ${configuration(getHttpServerInfoFile())}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreBuildSessionServices.java
@@ -69,7 +69,6 @@ import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.AsyncWorkTracker;
 import org.gradle.internal.work.DefaultAsyncWorkTracker;
-import org.gradle.process.internal.ClientExecHandleBuilderFactory;
 import org.gradle.process.internal.ExecFactory;
 
 import java.io.File;
@@ -164,8 +163,7 @@ public class CoreBuildSessionServices implements ServiceRegistrationProvider {
         Instantiator instantiator,
         BuildCancellationToken buildCancellationToken,
         ObjectFactory objectFactory,
-        JavaModuleDetector javaModuleDetector,
-        ClientExecHandleBuilderFactory clientExecHandleBuilderFactory
+        JavaModuleDetector javaModuleDetector
     ) {
         return execFactory.forContext()
             .withFileResolver(fileResolver)
@@ -174,7 +172,6 @@ public class CoreBuildSessionServices implements ServiceRegistrationProvider {
             .withBuildCancellationToken(buildCancellationToken)
             .withObjectFactory(objectFactory)
             .withJavaModuleDetector(javaModuleDetector)
-            .withExecHandleFactory(clientExecHandleBuilderFactory)
             .build();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -116,7 +116,6 @@ import org.gradle.model.internal.manage.schema.extract.ModelSchemaAspectExtracti
 import org.gradle.model.internal.manage.schema.extract.ModelSchemaAspectExtractor;
 import org.gradle.model.internal.manage.schema.extract.ModelSchemaExtractionStrategy;
 import org.gradle.model.internal.manage.schema.extract.ModelSchemaExtractor;
-import org.gradle.process.internal.ClientExecHandleBuilderFactory;
 import org.gradle.process.internal.DefaultExecActionFactory;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.process.internal.health.memory.DefaultJvmMemoryInfo;
@@ -304,8 +303,7 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         ObjectFactory objectFactory,
         ExecutorFactory executorFactory,
         TemporaryFileProvider temporaryFileProvider,
-        BuildCancellationToken buildCancellationToken,
-        ClientExecHandleBuilderFactory execHandleFactory
+        BuildCancellationToken buildCancellationToken
     ) {
         return DefaultExecActionFactory.of(
             fileResolver,
@@ -314,8 +312,7 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
             executorFactory,
             temporaryFileProvider,
             buildCancellationToken,
-            objectFactory,
-            execHandleFactory
+            objectFactory
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultClientExecHandleBuilderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultClientExecHandleBuilderFactory.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Executor;
 import static java.util.Objects.requireNonNull;
 
 @NonNullApi
-public class DefaultClientExecHandleBuilderFactory implements ClientExecHandleBuilderFactory, Stoppable {
+public class DefaultClientExecHandleBuilderFactory implements ClientExecHandleBuilderFactory {
 
     private final PathToFileResolver fileResolver;
     private final Executor executor;
@@ -54,11 +54,6 @@ public class DefaultClientExecHandleBuilderFactory implements ClientExecHandleBu
         return new DefaultClientExecHandleBuilder(fileResolver, executor, buildCancellationToken);
     }
 
-    public static DefaultClientExecHandleBuilderFactory root(File gradleUserHome) {
-        requireNonNull(gradleUserHome, "gradleUserHome");
-        return of(new DefaultFileLookup().getFileResolver(), new DefaultExecutorFactory(), new DefaultBuildCancellationToken());
-    }
-
     public static DefaultClientExecHandleBuilderFactory of(
         PathToFileResolver fileResolver,
         ExecutorFactory executorFactory,
@@ -76,8 +71,38 @@ public class DefaultClientExecHandleBuilderFactory implements ClientExecHandleBu
         return new DefaultClientExecHandleBuilderFactory(fileResolver, executor, buildCancellationToken);
     }
 
-    @Override
-    public void stop() {
-        CompositeStoppable.stoppable(executor).stop();
+    /**
+     * An instance of {@link ClientExecHandleBuilderFactory} that delegates to DefaultClientExecHandleBuilderFactory, but is also Stoppable.
+     *
+     * This is only used in DefaultDaemonStarter, and it should also stay this way. Ideally we would even remove it at one point.
+     */
+    @NonNullApi
+    public static class RootClientExecHandleBuilderFactory implements ClientExecHandleBuilderFactory, Stoppable {
+        private final DefaultClientExecHandleBuilderFactory delegate;
+
+        private RootClientExecHandleBuilderFactory(DefaultClientExecHandleBuilderFactory delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ClientExecHandleBuilder newExecHandleBuilder() {
+            return delegate.newExecHandleBuilder();
+        }
+
+        @Override
+        public void stop() {
+            CompositeStoppable.stoppable(delegate.executor).stop();
+        }
+
+        /**
+         * Creates a new {@link RootClientExecHandleBuilderFactory} for Daemon starter.
+         *
+         * This instance has unmanaged executor so the caller has to call {@link #stop()} to stop when instance is not needed anymore.
+         */
+        public static RootClientExecHandleBuilderFactory of(File gradleUserHome) {
+            requireNonNull(gradleUserHome, "gradleUserHome");
+            DefaultClientExecHandleBuilderFactory clientExecHandleBuilderFactory = DefaultClientExecHandleBuilderFactory.of(new DefaultFileLookup().getFileResolver(), new DefaultExecutorFactory(), new DefaultBuildCancellationToken());
+            return new RootClientExecHandleBuilderFactory(clientExecHandleBuilderFactory);
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultClientExecHandleBuilderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultClientExecHandleBuilderFactory.java
@@ -54,11 +54,6 @@ public class DefaultClientExecHandleBuilderFactory implements ClientExecHandleBu
         return new DefaultClientExecHandleBuilder(fileResolver, executor, buildCancellationToken);
     }
 
-    @Override
-    public ClientExecHandleBuilderFactory withFileResolver(PathToFileResolver fileResolver) {
-        return new DefaultClientExecHandleBuilderFactory(fileResolver, executor, buildCancellationToken);
-    }
-
     public static DefaultClientExecHandleBuilderFactory root(File gradleUserHome) {
         requireNonNull(gradleUserHome, "gradleUserHome");
         return of(new DefaultFileLookup().getFileResolver(), new DefaultExecutorFactory(), new DefaultBuildCancellationToken());
@@ -70,6 +65,14 @@ public class DefaultClientExecHandleBuilderFactory implements ClientExecHandleBu
         BuildCancellationToken buildCancellationToken
     ) {
         ManagedExecutor executor = executorFactory.create("Exec process");
+        return new DefaultClientExecHandleBuilderFactory(fileResolver, executor, buildCancellationToken);
+    }
+
+    public static DefaultClientExecHandleBuilderFactory of(
+        PathToFileResolver fileResolver,
+        Executor executor,
+        BuildCancellationToken buildCancellationToken
+    ) {
         return new DefaultClientExecHandleBuilderFactory(fileResolver, executor, buildCancellationToken);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -78,7 +78,7 @@ public class DefaultExecActionFactory implements ExecFactory {
         this.instantiator = instantiator;
         this.externalProcessStartedListener = externalProcessStartedListener;
         // Create execHandleFactory bound to this instance that uses fileResolver, executor and buildCancellationToken passed to this factory,
-        // this is important so that process working directory is resolved correctly and processes are stopped in the same scope
+        // this is important so that process directories are resolved correctly and process is stopped in the same scope
         this.execHandleFactory = DefaultClientExecHandleBuilderFactory.of(fileResolver, executor, buildCancellationToken);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -64,7 +64,6 @@ public class DefaultExecActionFactory implements ExecFactory {
         TemporaryFileProvider temporaryFileProvider,
         BuildCancellationToken buildCancellationToken,
         ObjectFactory objectFactory,
-        ClientExecHandleBuilderFactory execHandleFactory,
         @Nullable JavaModuleDetector javaModuleDetector,
         @Nullable ExternalProcessStartedListener externalProcessStartedListener
     ) {
@@ -89,8 +88,7 @@ public class DefaultExecActionFactory implements ExecFactory {
         ExecutorFactory executorFactory,
         TemporaryFileProvider temporaryFileProvider,
         BuildCancellationToken buildCancellationToken,
-        ObjectFactory objectFactory,
-        ClientExecHandleBuilderFactory clientExecHandleBuilderFactory
+        ObjectFactory objectFactory
     ) {
         return new DefaultExecActionFactory(
             fileResolver,
@@ -100,7 +98,6 @@ public class DefaultExecActionFactory implements ExecFactory {
             temporaryFileProvider,
             buildCancellationToken,
             objectFactory,
-            clientExecHandleBuilderFactory,
             null,
             null
         );
@@ -229,8 +226,7 @@ public class DefaultExecActionFactory implements ExecFactory {
             .withFileCollectionFactory(fileCollectionFactory)
             .withBuildCancellationToken(buildCancellationToken)
             .withObjectFactory(objectFactory)
-            .withJavaModuleDetector(javaModuleDetector)
-            .withExecHandleFactory(execHandleFactory);
+            .withJavaModuleDetector(javaModuleDetector);
     }
 
     private static class BuilderImpl implements Builder {
@@ -244,7 +240,6 @@ public class DefaultExecActionFactory implements ExecFactory {
         private Instantiator instantiator;
         private BuildCancellationToken buildCancellationToken;
         private ObjectFactory objectFactory;
-        private ClientExecHandleBuilderFactory clientExecHandleBuilderFactory;
         @Nullable
         private JavaModuleDetector javaModuleDetector;
 
@@ -302,12 +297,6 @@ public class DefaultExecActionFactory implements ExecFactory {
         }
 
         @Override
-        public Builder withExecHandleFactory(ClientExecHandleBuilderFactory execHandleBuilderFactory) {
-            this.clientExecHandleBuilderFactory = execHandleBuilderFactory;
-            return this;
-        }
-
-        @Override
         public Builder withoutExternalProcessStartedListener() {
             this.externalProcessStartedListener = null;
             return this;
@@ -320,7 +309,6 @@ public class DefaultExecActionFactory implements ExecFactory {
             Preconditions.checkState(instantiator != null, "instantiator is not set");
             Preconditions.checkState(buildCancellationToken != null, "buildCancellationToken is not set");
             Preconditions.checkState(objectFactory != null, "objectFactory is not set");
-            Preconditions.checkState(clientExecHandleBuilderFactory != null, "clientExecHandleFactory is not set");
             return new DefaultExecActionFactory(
                 fileResolver,
                 fileCollectionFactory,
@@ -329,7 +317,6 @@ public class DefaultExecActionFactory implements ExecFactory {
                 temporaryFileProvider,
                 buildCancellationToken,
                 objectFactory,
-                clientExecHandleBuilderFactory,
                 javaModuleDetector,
                 externalProcessStartedListener
             );

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -75,10 +75,11 @@ public class DefaultExecActionFactory implements ExecFactory {
         this.javaModuleDetector = javaModuleDetector;
         this.buildCancellationToken = buildCancellationToken;
         this.executor = executor;
-        // Use the same file resolver for low level process operations
-        this.execHandleFactory = execHandleFactory.withFileResolver(fileResolver);
         this.instantiator = instantiator;
         this.externalProcessStartedListener = externalProcessStartedListener;
+        // Create execHandleFactory bound to this instance that uses fileResolver, executor and buildCancellationToken passed to this factory,
+        // this is important so that process working directory is resolved correctly and processes are stopped in the same scope
+        this.execHandleFactory = DefaultClientExecHandleBuilderFactory.of(fileResolver, executor, buildCancellationToken);
     }
 
     public static DefaultExecActionFactory of(

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
@@ -58,8 +58,6 @@ public interface ExecFactory extends ExecActionFactory, ExecHandleFactory, JavaE
 
         Builder withExternalProcessStartedListener(ExternalProcessStartedListener externalProcessStartedListener);
 
-        Builder withExecHandleFactory(ClientExecHandleBuilderFactory execHandleBuilderFactory);
-
         Builder withoutExternalProcessStartedListener();
 
         ExecFactory build();

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
@@ -32,7 +32,6 @@ class DefaultExecActionFactoryTest extends ConcurrentSpec {
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def resolver = TestFiles.resolver(tmpDir.testDirectory)
-    def execHandleFactory = TestFiles.execHandleFactory(tmpDir.testDirectory)
     def fileCollectionFactory = TestFiles.fileCollectionFactory(tmpDir.testDirectory)
     def instantiator = TestUtil.instantiatorFactory()
     def factory = DefaultExecActionFactory.of(
@@ -42,8 +41,7 @@ class DefaultExecActionFactoryTest extends ConcurrentSpec {
         executorFactory,
         TestFiles.tmpDirTemporaryFileProvider(tmpDir.createDir("tmp")),
         new DefaultBuildCancellationToken(),
-        TestUtil.objectFactory(),
-        execHandleFactory
+        TestUtil.objectFactory()
     )
 
     def javaexec() {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -243,8 +243,7 @@ public class TestFiles {
             new DefaultExecutorFactory(),
             NativeServicesTestFixture.getInstance().get(TemporaryFileProvider.class),
             new DefaultBuildCancellationToken(),
-            objectFactory(),
-            execHandleFactory()
+            objectFactory()
         );
     }
 
@@ -253,7 +252,6 @@ public class TestFiles {
             .withFileResolver(resolver(baseDir))
             .withFileCollectionFactory(fileCollectionFactory(baseDir))
             .withInstantiator(TestUtil.instantiatorFactory().inject())
-            .withExecHandleFactory(execHandleFactory(baseDir))
             .withObjectFactory(objectFactory())
             .build();
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestExecHttpServer.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestExecHttpServer.java
@@ -58,7 +58,7 @@ public class TestExecHttpServer {
 
     public static String getClassLocation() {
         try {
-            return new File(TestJavaMain.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getAbsolutePath();
+            return new File(TestExecHttpServer.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getAbsolutePath();
         } catch (URISyntaxException e) {
             throw new IllegalStateException(e);
         }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestExecHttpServer.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestExecHttpServer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.util.concurrent.Executors;
+
+public class TestExecHttpServer {
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        if (args.length == 0) {
+            throw new IllegalArgumentException("Expected at least one argument");
+        }
+
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.createContext("/test", new TestHandler());
+        server.start();
+        System.out.println("Server started on port " + server.getAddress().getPort());
+        Files.write(new File(args[0]).toPath(), String.valueOf(server.getAddress().getPort()).getBytes());
+    }
+
+    static class TestHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange t) throws IOException {
+            System.out.println("Received request: " + t.getRequestURI());
+            String response = "OK";
+            t.sendResponseHeaders(200, response.getBytes().length);
+            OutputStream os = t.getResponseBody();
+            os.write(response.getBytes());
+            os.close();
+        }
+    }
+
+    public static String getClassLocation() {
+        try {
+            return new File(TestJavaMain.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getAbsolutePath();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestExecHttpServer.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestExecHttpServer.java
@@ -35,6 +35,7 @@ public class TestExecHttpServer {
             throw new IllegalArgumentException("Expected at least one argument");
         }
 
+        System.out.println("Starting server with server info file: " + args[0]);
         HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
         server.setExecutor(Executors.newCachedThreadPool());
         server.createContext("/test", new TestHandler());


### PR DESCRIPTION
Gretty basically does:
```
tasks.register("appStart") {
    doLast {
        Thread.start {
            // Start the server
            project.javaExec {
            }
        }.join()
    }
}
```
This unveils a bug in our process cancelation introduced with Gradle 8.12.1 where `javaExec` is not stopped when build is cancelled. 
Since javaExec is started in a new thread and process cancelation doesn't work correctly, the process is kept alive even after the build is canceled. And it's kept alive until daemon is killed. 
Note: it seems this hanging thread then also blocks killing the daemon so `./gradle --stop` doesn't stop the daemon.

This fixes it. Tested also with reproducer from the issue.

Fixes https://github.com/gradle/gradle/issues/32213