### PR TITLE
Rephrase and include type in error message

### DIFF
--- a/platforms/core-configuration/declarative-dsl-evaluator/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/EvaluationFailureMessageGenerator.kt
+++ b/platforms/core-configuration/declarative-dsl-evaluator/src/main/kotlin/org/gradle/internal/declarativedsl/evaluator/EvaluationFailureMessageGenerator.kt
@@ -110,7 +110,7 @@ object EvaluationFailureMessageGenerator {
         is ErrorReason.DuplicateLocalValue -> "duplicate local 'val ${errorReason.name}'"
         is ErrorReason.ExternalReassignment -> "assignment to external property"
         ErrorReason.MissingConfigureLambda -> "a configuring block expected but not found"
-        is ErrorReason.ReadOnlyPropertyAssignment -> "assignment to read-only property '${errorReason.property.name}"
+        is ErrorReason.ReadOnlyPropertyAssignment -> "assignment to property '${errorReason.property.name}' with read-only type '${errorReason.property.valueType}'"
         ErrorReason.UnitAssignment -> "assignment of a Unit value"
         ErrorReason.UnresolvedAssignmentLhs -> "unresolved assignment target"
         ErrorReason.UnresolvedAssignmentRhs -> "unresolved assigned value"

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/WorkingWithFilesIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/WorkingWithFilesIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.declarativedsl.settings.SoftwareTypeFixture
 
 class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements SoftwareTypeFixture {
-
     def 'set #name'() {
         given:
         withSoftwareTypePlugins(
@@ -46,7 +45,33 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
         withJavaBeanPropertiesOfFileSystemLocations     | "Directory and RegularFile Java Bean properties"
     }
 
-    static String getWithFileSystemLocationProperties() {
+    def "using a read-only property by mistake gives a helpful error message for #name"() {
+        given:
+        withSoftwareTypePlugins(
+            extensionClassContent,
+            getProjectPluginThatRegistersItsOwnExtension(true, "extension", null),
+            settingsPluginThatRegistersSoftwareType
+        ).prepareToExecute()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        file("build.gradle.dcl") << declarativeScriptThatConfiguresOnlyTestSoftwareType
+
+        when:
+        fails(":printTestSoftwareTypeExtensionConfiguration")
+
+        then:
+        failureCauseContains("Failed to interpret the declarative DSL file '${file("build.gradle.dcl").path}':")
+        failureCauseContains("Failures in resolution:")
+        failureCauseContains("assignment to property '$propName' with read-only type '$name'")
+
+        where:
+        extensionClassContent                           | name              | propName
+        withReadOnlyDirectoryProperty                   | "Directory"       | "dir"
+        withReadOnlyRegularFileProperty                 | "RegularFile"     | "file"
+    }
+
+    private static String getWithFileSystemLocationProperties() {
         """
                 package org.gradle.test;
 
@@ -72,7 +97,49 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
             """
     }
 
-    static String getWithPropertiesOfFileSystemLocations() {
+    private static String getWithReadOnlyDirectoryProperty() {
+        """
+                package org.gradle.test;
+
+                import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+                import org.gradle.api.file.Directory;
+                import org.gradle.api.file.RegularFileProperty;
+                import org.gradle.api.provider.Property;
+
+                @Restricted
+                public interface TestSoftwareTypeExtension {
+                    @Restricted
+                    Directory getDir();
+
+                    @Restricted
+                    RegularFileProperty getFile();
+                }
+            """
+    }
+
+    private static String getWithReadOnlyRegularFileProperty() {
+        """
+                package org.gradle.test;
+
+                import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+                import org.gradle.api.file.DirectoryProperty;
+                import org.gradle.api.file.RegularFile;
+                import org.gradle.api.provider.Property;
+
+                @Restricted
+                public interface TestSoftwareTypeExtension {
+                    @Restricted
+                    DirectoryProperty getDir();
+
+                    @Restricted
+                    RegularFile getFile();
+                }
+            """
+    }
+
+    private static String getWithPropertiesOfFileSystemLocations() {
         """
                 package org.gradle.test;
 
@@ -116,7 +183,7 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
             """
     }
 
-    static String getWithJavaBeanPropertiesOfFileSystemLocations() {
+    private static String getWithJavaBeanPropertiesOfFileSystemLocations() {
         """
                 package org.gradle.test;
 
@@ -165,7 +232,7 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
             """
     }
 
-    static String getPluginsFromIncludedBuild() {
+    private static String getPluginsFromIncludedBuild() {
         return """
             pluginManagement {
                 includeBuild("plugins")
@@ -176,7 +243,7 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
         """
     }
 
-    static String getDeclarativeScriptThatConfiguresOnlyTestSoftwareType() {
+    private static String getDeclarativeScriptThatConfiguresOnlyTestSoftwareType() {
         return """
             testSoftwareType {
                 dir = layout.projectDirectory.dir("someDir")
@@ -185,8 +252,7 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
         """
     }
 
-    void assertThatDeclaredValuesAreSetProperly() {
+    private void assertThatDeclaredValuesAreSetProperly() {
         outputContains("dir = ${testDirectory.file("someDir").path}\nfile = ${testDirectory.file("someFile").path}")
     }
-
 }


### PR DESCRIPTION
I was confused the first time I saw the error message for a "read-only property".  It took me a couple of minutes, and looking up the PR that added this functionality, to realize I needed to use different types.  

I think rephrasing the error message slightly to make it clear that the problem isn't that the **property** is read-only (since all `getXYZ()` methods kind of look the same), but rather the return **type** is incorrect, would help authors understand quicker here.