### PR TITLE
Properly attribute deprecations in configuration callbacks

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
@@ -312,13 +312,15 @@ project.status = 'foo'
 
         then:
         def deprecationOperations = buildOps.all().findAll { !it.progress(DefaultDeprecatedUsageProgressDetails).isEmpty() }
-        deprecationOperations.size() == 1
-        def pluginId = deprecationOperations[0].details.applicationId
-
-        def pluginOperations = buildOps.all(org.gradle.api.internal.plugins.ApplyPluginBuildOperationType)
-        def associatedPlugins = pluginOperations.findAll { it.details.applicationId == pluginId }
-        associatedPlugins.size() == 1
-        associatedPlugins[0].details.pluginId == "com.example.plugin"
+        deprecationOperations.findAll { op ->
+            if (!op.details.containsKey("applicationId")) {
+                return false
+            }
+            def pluginId = op.details["applicationId"]
+            def pluginOperations = buildOps.all(org.gradle.api.internal.plugins.ApplyPluginBuildOperationType)
+            def associatedPlugins = pluginOperations.findAll { it.details.applicationId == pluginId }
+            associatedPlugins.size() == 1 && associatedPlugins[0].details.pluginId == "com.example.plugin"
+        }.size() == 1
     }
 
     def "fails if beforeResolve used to add dependencies to observed configuration"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
@@ -15,9 +15,13 @@
  */
 package org.gradle.integtests.resolve.api
 
+import org.gradle.api.artifacts.DependencyScopeConfiguration
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.internal.deprecation.DeprecationLogger
+import org.gradle.internal.featurelifecycle.DefaultDeprecatedUsageProgressDetails
 import spock.lang.Issue
 
 class ConfigurationDefaultsIntegrationTest extends AbstractDependencyResolutionTest {
@@ -239,6 +243,78 @@ project.status = 'foo'
                 }
             }
         }
+    }
+
+    def "defaultDependencies deprecations are properly attributed to source plugin"() {
+        BuildOperationsFixture buildOps = new BuildOperationsFixture(executer, temporaryFolder)
+
+        settingsFile << """
+            includeBuild("plugin")
+        """
+
+        file("plugin/build.gradle") << """
+            plugins {
+                id("java-gradle-plugin")
+            }
+
+            gradlePlugin {
+                plugins {
+                    transformPlugin {
+                        id = "com.example.plugin"
+                        implementationClass = "com.example.ExamplePlugin"
+                    }
+                }
+            }
+        """
+
+        file("plugin/src/main/java/com/example/ExamplePlugin.java") << """
+            package com.example;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import ${DeprecationLogger.name};
+            import ${DependencyScopeConfiguration.name};
+
+            public class ExamplePlugin implements Plugin<Project> {
+                public void apply(Project project) {
+                    project.getConfigurations().withType(DependencyScopeConfiguration.class).configureEach(conf -> {
+                        conf.defaultDependencies(deps -> {
+                            DeprecationLogger.deprecate("foo")
+                                .willBecomeAnErrorInGradle10()
+                                .undocumented()
+                                .nagUser();
+                        });
+                    });
+                }
+            }
+        """
+
+        buildFile.text = """
+            plugins {
+                id("com.example.plugin")
+            }
+
+            configurations {
+                dependencyScope("deps")
+            }
+
+            // triggers `defaultDependencies`
+            configurations.deps.incoming.dependencies
+        """
+
+        when:
+        executer.noDeprecationChecks()
+        succeeds("help")
+
+        then:
+        def deprecationOperations = buildOps.all().findAll { !it.progress(DefaultDeprecatedUsageProgressDetails).isEmpty() }
+        deprecationOperations.size() == 1
+        def pluginId = deprecationOperations[0].details.applicationId
+
+        def pluginOperations = buildOps.all(org.gradle.api.internal.plugins.ApplyPluginBuildOperationType)
+        def associatedPlugins = pluginOperations.findAll { it.details.applicationId == pluginId }
+        associatedPlugins.size() == 1
+        associatedPlugins[0].details.pluginId == "com.example.plugin"
     }
 
     def "fails if beforeResolve used to add dependencies to observed configuration"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
@@ -412,13 +412,15 @@ configurations.compile.withDependencies {
 
         then:
         def deprecationOperations = buildOps.all().findAll { !it.progress(DefaultDeprecatedUsageProgressDetails).isEmpty() }
-        deprecationOperations.size() == 1
-        def pluginId = deprecationOperations[0].details.applicationId
-
-        def pluginOperations = buildOps.all(org.gradle.api.internal.plugins.ApplyPluginBuildOperationType)
-        def associatedPlugins = pluginOperations.findAll { it.details.applicationId == pluginId }
-        associatedPlugins.size() == 1
-        associatedPlugins[0].details.pluginId == "com.example.plugin"
+        deprecationOperations.findAll { op ->
+            if (!op.details.containsKey("applicationId")) {
+                return false
+            }
+            def pluginId = op.details["applicationId"]
+            def pluginOperations = buildOps.all(org.gradle.api.internal.plugins.ApplyPluginBuildOperationType)
+            def associatedPlugins = pluginOperations.findAll { it.details.applicationId == pluginId }
+            associatedPlugins.size() == 1 && associatedPlugins[0].details.pluginId == "com.example.plugin"
+        }.size() == 1
     }
 
     def "can lazily add dependencies to a configuration"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.integtests.resolve.api
 
-import org.gradle.api.artifacts.DependencyScopeConfiguration
+
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
@@ -373,11 +373,10 @@ configurations.compile.withDependencies {
             import org.gradle.api.Plugin;
             import org.gradle.api.Project;
             import ${DeprecationLogger.name};
-            import ${DependencyScopeConfiguration.name};
 
             public class ExamplePlugin implements Plugin<Project> {
                 public void apply(Project project) {
-                    project.getConfigurations().withType(DependencyScopeConfiguration.class).configureEach(conf -> {
+                    project.getConfigurations().configureEach(conf -> {
                         conf.withDependencies(deps -> {
                             DeprecationLogger.deprecate("foo")
                                 .willBecomeAnErrorInGradle10()
@@ -395,16 +394,21 @@ configurations.compile.withDependencies {
             }
 
             configurations {
-                dependencyScope("deps")
+                create("deps")
             }
 
-            // triggers `defaultDependencies`
-            configurations.deps.incoming.dependencies
+            task resolve {
+                // triggers `defaultDependencies`
+                def root = configurations.deps.incoming.resolutionResult.rootComponent
+                doLast {
+                    root.get()
+                }
+            }
         """
 
         when:
         executer.noDeprecationChecks()
-        succeeds("help")
+        succeeds("resolve")
 
         then:
         def deprecationOperations = buildOps.all().findAll { !it.progress(DefaultDeprecatedUsageProgressDetails).isEmpty() }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
@@ -15,9 +15,13 @@
  */
 package org.gradle.integtests.resolve.api
 
+import org.gradle.api.artifacts.DependencyScopeConfiguration
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.internal.deprecation.DeprecationLogger
+import org.gradle.internal.featurelifecycle.DefaultDeprecatedUsageProgressDetails
 
 class ConfigurationMutationIntegrationTest extends AbstractDependencyResolutionTest {
     ResolveTestFixture resolve
@@ -339,6 +343,78 @@ configurations.compile.withDependencies {
                 }
             }
         }
+    }
+
+    def "withDependencies deprecations are properly attributed to source plugin"() {
+        BuildOperationsFixture buildOps = new BuildOperationsFixture(executer, temporaryFolder)
+
+        settingsFile << """
+            includeBuild("plugin")
+        """
+
+        file("plugin/build.gradle") << """
+            plugins {
+                id("java-gradle-plugin")
+            }
+
+            gradlePlugin {
+                plugins {
+                    transformPlugin {
+                        id = "com.example.plugin"
+                        implementationClass = "com.example.ExamplePlugin"
+                    }
+                }
+            }
+        """
+
+        file("plugin/src/main/java/com/example/ExamplePlugin.java") << """
+            package com.example;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import ${DeprecationLogger.name};
+            import ${DependencyScopeConfiguration.name};
+
+            public class ExamplePlugin implements Plugin<Project> {
+                public void apply(Project project) {
+                    project.getConfigurations().withType(DependencyScopeConfiguration.class).configureEach(conf -> {
+                        conf.withDependencies(deps -> {
+                            DeprecationLogger.deprecate("foo")
+                                .willBecomeAnErrorInGradle10()
+                                .undocumented()
+                                .nagUser();
+                        });
+                    });
+                }
+            }
+        """
+
+        buildFile.text = """
+            plugins {
+                id("com.example.plugin")
+            }
+
+            configurations {
+                dependencyScope("deps")
+            }
+
+            // triggers `defaultDependencies`
+            configurations.deps.incoming.dependencies
+        """
+
+        when:
+        executer.noDeprecationChecks()
+        succeeds("help")
+
+        then:
+        def deprecationOperations = buildOps.all().findAll { !it.progress(DefaultDeprecatedUsageProgressDetails).isEmpty() }
+        deprecationOperations.size() == 1
+        def pluginId = deprecationOperations[0].details.applicationId
+
+        def pluginOperations = buildOps.all(org.gradle.api.internal.plugins.ApplyPluginBuildOperationType)
+        def associatedPlugins = pluginOperations.findAll { it.details.applicationId == pluginId }
+        associatedPlugins.size() == 1
+        associatedPlugins[0].details.pluginId == "com.example.plugin"
     }
 
     def "can lazily add dependencies to a configuration"() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -51,6 +51,7 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.DomainObjectContext;
@@ -216,6 +217,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     private final DisplayName displayName;
     private final UserCodeApplicationContext userCodeApplicationContext;
+    private final CollectionCallbackActionDecorator collectionCallbackActionDecorator;
     private final WorkerThreadRegistry workerThreadRegistry;
     private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
@@ -251,6 +253,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         ResolveExceptionMapper exceptionMapper,
         AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
         DomainObjectCollectionFactory domainObjectCollectionFactory,
@@ -263,6 +266,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     ) {
         super(taskDependencyFactory);
         this.userCodeApplicationContext = userCodeApplicationContext;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
         this.projectStateRegistry = projectStateRegistry;
         this.workerThreadRegistry = workerThreadRegistry;
         this.domainObjectCollectionFactory = domainObjectCollectionFactory;
@@ -474,18 +478,18 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     public Configuration defaultDependencies(final Action<? super DependencySet> action) {
         warnOnDeprecatedUsage("defaultDependencies(Action)", ProperMethodUsage.DECLARABLE_AGAINST);
         validateMutation(MutationType.DEPENDENCIES);
-        defaultDependencyActions = defaultDependencyActions.add(dependencies -> {
+        defaultDependencyActions = defaultDependencyActions.add(collectionCallbackActionDecorator.decorate(dependencies -> {
             if (dependencies.isEmpty()) {
                 action.execute(dependencies);
             }
-        });
+        }));
         return this;
     }
 
     @Override
     public Configuration withDependencies(final Action<? super DependencySet> action) {
         validateMutation(MutationType.DEPENDENCIES);
-        withDependencyActions = withDependencyActions.add(action);
+        withDependencyActions = withDependencyActions.add(collectionCallbackActionDecorator.decorate(action));
         return this;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.configurations;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
@@ -63,6 +64,7 @@ public class DefaultConfigurationFactory {
     private final ResolveExceptionMapper exceptionContextualizer;
     private final AttributeDesugaring attributeDesugaring;
     private final UserCodeApplicationContext userCodeApplicationContext;
+    private final CollectionCallbackActionDecorator collectionCallbackActionDecorator;
     private final ProjectStateRegistry projectStateRegistry;
     private final WorkerThreadRegistry workerThreadRegistry;
     private final DomainObjectCollectionFactory domainObjectCollectionFactory;
@@ -83,6 +85,7 @@ public class DefaultConfigurationFactory {
         ResolveExceptionMapper exceptionMapper,
         AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
         DomainObjectCollectionFactory domainObjectCollectionFactory,
@@ -102,6 +105,7 @@ public class DefaultConfigurationFactory {
         this.exceptionContextualizer = exceptionMapper;
         this.attributeDesugaring = attributeDesugaring;
         this.userCodeApplicationContext = userCodeApplicationContext;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
         this.projectStateRegistry = projectStateRegistry;
         this.workerThreadRegistry = workerThreadRegistry;
         this.domainObjectCollectionFactory = domainObjectCollectionFactory;
@@ -140,6 +144,7 @@ public class DefaultConfigurationFactory {
             exceptionContextualizer,
             attributeDesugaring,
             userCodeApplicationContext,
+            collectionCallbackActionDecorator,
             projectStateRegistry,
             workerThreadRegistry,
             domainObjectCollectionFactory,
@@ -182,6 +187,7 @@ public class DefaultConfigurationFactory {
             exceptionContextualizer,
             attributeDesugaring,
             userCodeApplicationContext,
+            collectionCallbackActionDecorator,
             projectStateRegistry,
             workerThreadRegistry,
             domainObjectCollectionFactory,
@@ -223,6 +229,7 @@ public class DefaultConfigurationFactory {
             exceptionContextualizer,
             attributeDesugaring,
             userCodeApplicationContext,
+            collectionCallbackActionDecorator,
             projectStateRegistry,
             workerThreadRegistry,
             domainObjectCollectionFactory,
@@ -264,6 +271,7 @@ public class DefaultConfigurationFactory {
             exceptionContextualizer,
             attributeDesugaring,
             userCodeApplicationContext,
+            collectionCallbackActionDecorator,
             projectStateRegistry,
             workerThreadRegistry,
             domainObjectCollectionFactory,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.ConsumableConfiguration;
 import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
@@ -62,6 +63,7 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
         ResolveExceptionMapper exceptionMapper,
         AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
         DomainObjectCollectionFactory domainObjectCollectionFactory,
@@ -87,6 +89,7 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
             exceptionMapper,
             attributeDesugaring,
             userCodeApplicationContext,
+            collectionCallbackActionDecorator,
             projectStateRegistry,
             workerThreadRegistry,
             domainObjectCollectionFactory,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.artifacts.DependencyScopeConfiguration;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
@@ -62,6 +63,7 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
         ResolveExceptionMapper exceptionMapper,
         AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
         DomainObjectCollectionFactory domainObjectCollectionFactory,
@@ -87,6 +89,7 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
             exceptionMapper,
             attributeDesugaring,
             userCodeApplicationContext,
+            collectionCallbackActionDecorator,
             projectStateRegistry,
             workerThreadRegistry,
             domainObjectCollectionFactory,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultLegacyConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultLegacyConfiguration.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.artifacts.LegacyConfiguration;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
@@ -62,6 +63,7 @@ public class DefaultLegacyConfiguration extends DefaultConfiguration implements 
         ResolveExceptionMapper exceptionMapper,
         AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
         DomainObjectCollectionFactory domainObjectCollectionFactory,
@@ -88,6 +90,7 @@ public class DefaultLegacyConfiguration extends DefaultConfiguration implements 
             exceptionMapper,
             attributeDesugaring,
             userCodeApplicationContext,
+            collectionCallbackActionDecorator,
             projectStateRegistry,
             workerThreadRegistry,
             domainObjectCollectionFactory,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.artifacts.ResolvableConfiguration;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
@@ -62,6 +63,7 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
         ResolveExceptionMapper exceptionMapper,
         AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator,
         ProjectStateRegistry projectStateRegistry,
         WorkerThreadRegistry workerThreadRegistry,
         DomainObjectCollectionFactory domainObjectCollectionFactory,
@@ -87,6 +89,7 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
             exceptionMapper,
             attributeDesugaring,
             userCodeApplicationContext,
+            collectionCallbackActionDecorator,
             projectStateRegistry,
             workerThreadRegistry,
             domainObjectCollectionFactory,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -78,6 +78,7 @@ class DefaultConfigurationContainerSpec extends Specification {
         Stub(ResolveExceptionMapper),
         new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
         userCodeApplicationContext,
+        CollectionCallbackActionDecorator.NOOP,
         projectStateRegistry,
         Mock(WorkerThreadRegistry),
         TestUtil.domainObjectCollectionFactory(),

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -85,6 +85,7 @@ class DefaultConfigurationContainerTest extends Specification {
         Stub(ResolveExceptionMapper),
         new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
         userCodeApplicationContext,
+        CollectionCallbackActionDecorator.NOOP,
         projectStateRegistry,
         Mock(WorkerThreadRegistry),
         TestUtil.domainObjectCollectionFactory(),

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1779,6 +1779,7 @@ class DefaultConfigurationSpec extends Specification {
             new ResolveExceptionMapper(Mock(DomainObjectContext), Mock(DocumentationRegistry)),
             new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
             userCodeApplicationContext,
+            CollectionCallbackActionDecorator.NOOP,
             projectStateRegistry,
             Stub(WorkerThreadRegistry),
             TestUtil.domainObjectCollectionFactory(),


### PR DESCRIPTION
Configuration callbacks like withDependencies and defaultDependencies capture user and plugin build logic and run it later during graph resolution.

Build scans extract deprecation information from the build operations emitted by the build. It looks at parent build operations of the deprecation build operation to determine the owner of the code that emitted the deprecation.

We wrap these two configuration callbacks with a CollectionCallbackActionDecorator in order to emit build operaetions around all executions of these callbacks, so that the parent build operation of any deprecations emitted by these callbacks are properly attributed to the same plugin that registered the callbacks.

From the integ test added in this commit:

Before:
https://develocity.grdev.net/s/q6vs2tgnbdyro/deprecations?expanded=WyI5Il0
<img width="1189" alt="image" src="https://github.com/user-attachments/assets/635b21da-2df6-4880-bebd-ef4225724be2" />

After:
https://develocity.grdev.net/s/cmapbim5joz5m/deprecations?expanded=WyI5Il0
<img width="1191" alt="image" src="https://github.com/user-attachments/assets/0d22e198-4d92-40cc-91de-382118b77c3a" />

Notice the attribution change from `Script:build.gradle:11` to `Plugin:com.example.plugin`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
