### PR TITLE
Refine update-jdks action

### DIFF
--- a/.github/workflows/update-jdks.yml
+++ b/.github/workflows/update-jdks.yml
@@ -2,8 +2,8 @@ name: Update jdks.yaml
 
 on:
   workflow_dispatch: # Allows manual triggering of the action
-  schedule: # Runs the action daily at 3:42 UTC
-    - cron: '42 3 * * *'
+  schedule: # Runs the action weekly on Monday at 3:42 UTC
+    - cron: '42 3 * * 1'
 
 permissions:
   contents: write
@@ -26,7 +26,6 @@ jobs:
       - name: Add verification comment
         # https://github.com/gradle/gradle-private/issues/4518
         run: |
-          # Create new file with comment
           cat << 'EOF' > .teamcity/jdks.yaml.tmp
           # To verify the change, run the build with:
           # @bot-gradle test ReadyForNightly


### PR DESCRIPTION
This PR does:

- Avoid updating jdk.yaml with duplicate comments like https://github.com/gradle/gradle/pull/32353
- Run the action weekly in case we don't merge it at the day, a duplicate PR will appear the next day.