### PR TITLE
Mark 3 Android tests `@LocalOnly`

### DIFF
--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidGradleRecipesKotlinSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidGradleRecipesKotlinSmokeTest.groovy
@@ -19,10 +19,12 @@ package org.gradle.smoketests
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.test.fixtures.dsl.GradleDsl
+import org.gradle.testdistribution.LocalOnly
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.internal.VersionNumber
 import spock.lang.Issue
 
+@LocalOnly(because = "Needs Android environment")
 class AndroidGradleRecipesKotlinSmokeTest extends AbstractSmokeTest implements RunnerFactory {
 
     @Issue('https://github.com/gradle/gradle/issues/23014')

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.smoketests
 
 import org.gradle.test.fixtures.dsl.GradleDsl
+import org.gradle.testdistribution.LocalOnly
 
+@LocalOnly(because = "Needs Android environment")
 class KotlinPluginAndroidGroovyDSLSmokeTest extends AbstractKotlinPluginAndroidSmokeTest {
     @Override
     String getSampleName() {

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.smoketests
 
 import org.gradle.test.fixtures.dsl.GradleDsl
+import org.gradle.testdistribution.LocalOnly
 
+@LocalOnly(because = "Needs Android environment")
 class KotlinPluginAndroidKotlinDSLSmokeTest extends AbstractKotlinPluginAndroidSmokeTest {
     @Override
     String getSampleName() {


### PR DESCRIPTION
Run Android tests only with local executors to avoid failures.

Example: https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.smoketests.AndroidGradleRecipesKotlinSmokeTest