### PR TITLE
Remove fastjson

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -6,7 +6,7 @@
         <mockk.version>1.13.13</mockk.version>
         <bytebuddy.version>1.15.7</bytebuddy.version>
         <junit.version>5.11.3</junit.version>
-        <fastjson.version>1.2.83</fastjson.version>
+        <jackson.version>2.18.2</jackson.version>
         <dslContextParameter.branch>master</dslContextParameter.branch>
     </properties>
     <groupId>Gradle_Check</groupId>
@@ -127,11 +127,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
-            <version>${fastjson.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.jetbrains.teamcity</groupId>
             <artifactId>server-api</artifactId>
             <version>${teamcity.dsl.version}</version>
@@ -176,6 +171,22 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -1,7 +1,8 @@
 package configurations
 
-import com.alibaba.fastjson.JSONObject
-import com.alibaba.fastjson.annotation.JSONField
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import common.functionalTestExtraParameters
 import common.getBuildScanCustomValueParam
 import jetbrains.buildServer.configs.kotlin.BuildSteps
@@ -16,12 +17,13 @@ const val functionalTestTag = "FunctionalTest"
 
 sealed class ParallelizationMethod {
     open val extraBuildParameters: String
-        @JSONField(serialize = false)
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
         get() = ""
 
     val name: String = this::class.simpleName!!
 
     object None : ParallelizationMethod()
+
     object TestDistribution : ParallelizationMethod() {
         override val extraBuildParameters: String = "-DenableTestDistribution=%enableTestDistribution% -DtestDistributionPartitionSizeInSeconds=%testDistributionPartitionSizeInSeconds%"
     }
@@ -38,14 +40,19 @@ sealed class ParallelizationMethod {
     class TeamCityParallelTests(val numberOfBatches: Int) : ParallelizationMethod()
 
     companion object {
-        fun fromJson(jsonObject: JSONObject): ParallelizationMethod {
-            val methodJsonObject = jsonObject.getJSONObject("parallelizationMethod") ?: return None
-            return when (methodJsonObject.getString("name")) {
+        private val objectMapper = ObjectMapper()
+
+        fun fromJson(jsonObject: Map<String, Any>): ParallelizationMethod {
+            val methodJsonNode =
+                (jsonObject["parallelizationMethod"] as? Map<*, *>)?.let { objectMapper.valueToTree<JsonNode>(it) }
+                    ?: return None
+
+            return when (methodJsonNode.get("name")?.asText()) {
                 null -> None
                 None::class.simpleName -> None
                 TestDistribution::class.simpleName -> TestDistribution
                 TestDistributionAlpine::class.simpleName -> TestDistributionAlpine
-                TeamCityParallelTests::class.simpleName -> TeamCityParallelTests(methodJsonObject.getIntValue("numberOfBatches"))
+                TeamCityParallelTests::class.simpleName -> TeamCityParallelTests(methodJsonNode.get("numberOfBatches").asInt())
                 else -> throw IllegalArgumentException("Unknown parallelization method")
             }
         }
@@ -63,7 +70,7 @@ class FunctionalTest(
     subprojects: List<String> = listOf(),
     extraParameters: String = "",
     extraBuildSteps: BuildSteps.() -> Unit = {},
-    preBuildSteps: BuildSteps.() -> Unit = {}
+    preBuildSteps: BuildSteps.() -> Unit = {},
 ) : OsAwareBaseGradleBuildType(os = testCoverage.os, stage = stage, init = {
     this.name = name
     this.description = description
@@ -88,7 +95,9 @@ class FunctionalTest(
     }
 
     applyTestDefaults(
-        model, this, testTasks,
+        model,
+        this,
+        testTasks,
         dependsOnQuickFeedbackLinux = !testCoverage.withoutDependencies && stage.stageName > StageName.PULL_REQUEST_FEEDBACK,
         os = testCoverage.os,
         buildJvm = testCoverage.buildJvm,
@@ -97,7 +106,7 @@ class FunctionalTest(
         timeout = testCoverage.testType.timeout,
         maxParallelForks = testCoverage.testType.maxParallelForks.toString(),
         extraSteps = extraBuildSteps,
-        preSteps = preBuildSteps
+        preSteps = preBuildSteps,
     )
 
     failureConditions {

--- a/.teamcity/src/main/kotlin/model/GradleSubprojectProvider.kt
+++ b/.teamcity/src/main/kotlin/model/GradleSubprojectProvider.kt
@@ -16,7 +16,9 @@
 
 package model
 
-import com.alibaba.fastjson.JSON
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import java.io.File
 
 val ignoredSubprojects = listOf(
@@ -31,9 +33,12 @@ interface GradleSubprojectProvider {
     fun getSubprojectByName(name: String): GradleSubproject?
 }
 
-data class JsonBasedGradleSubprojectProvider(private val jsonFile: File) : GradleSubprojectProvider {
-    @Suppress("UNCHECKED_CAST")
-    override val subprojects = JSON.parseArray(jsonFile.readText()).map { toSubproject(it as Map<String, Any>) }
+data class JsonBasedGradleSubprojectProvider(
+    private val jsonFile: File,
+) : GradleSubprojectProvider {
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+
+    override val subprojects = objectMapper.readValue<List<Map<String, Any>>>(jsonFile.readText()).map { toSubproject(it) }
 
     private val nameToSubproject = subprojects.map { it.name to it }.toMap()
     override fun getSubprojectsForFunctionalTest(testConfig: TestCoverage) =


### PR DESCRIPTION
At some point, there was a sandboxing mechanism when generating TeamCity Kotlin DSL and `fastjson` was the only working JSON library then.

Now people are complaining about this issue: https://youtrack.jetbrains.com/issue/TW-85722/

It's time to remove fastjson.

```
# bo @ MacBookProM2 in ~/Projects/gradle/.teamcity on git:master x [15:32:35] 
$ diff -r ../generated-configs-new target/generated-configs 

# bo @ MacBookProM2 in ~/Projects/gradle/.teamcity on git:master x [15:33:12] 
$ echo $?
0

```