### PR TITLE
Revert "Correct suggestion about printing stack traces for deprecation warning (#31821)"

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -71,6 +71,9 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
 
     def 'DeprecatedPlugin and DeprecatedTask - #scenario'() {
         given:
+        executer.beforeExecute {
+            withoutInternalDeprecationStackTraceFlag()
+        }
         buildFile << """
             apply plugin: DeprecatedPlugin // line 2
 
@@ -86,7 +89,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         if (fullStacktraceEnabled) {
-            executer.withFullDeprecationStackTraceEnabled()
+            executer.withStacktraceEnabled()
         }
         if (warningsCount > 0) {
             executer.expectDeprecationWarnings(warningsCount)

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.util.internal.DefaultGradleVersion
 
 class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
     public static final String PLUGIN_DEPRECATION_MESSAGE = 'The DeprecatedPlugin plugin has been deprecated'
-    private static final String RUN_WITH_STACKTRACE = "(Run with -D${LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME}=true to print the full stack trace for this deprecation warning.)"
+    private static final String RUN_WITH_STACKTRACE = '(Run with --stacktrace to get the full stack trace of this deprecation warning.)'
 
     def setup() {
         file('buildSrc/src/main/java/DeprecatedTask.java') << """
@@ -287,75 +287,6 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
             outputContains("Build file '${file("buildSrc/build.gradle")}': line 5")
             outputContains("Build file '${buildFile}': line 5")
         }
-    }
-
-    def "prints correct deprecation trace property value to use to display stack traces for deprecation warnings"() {
-        disableProblemsApiCheck()
-
-        given:
-        buildFile << """
-            def myConf = project.configurations.resolvable("myConf")
-            def myDetached = project.configurations.detachedConfiguration()
-            myDetached.extendsFrom(myConf.get())
-        """
-
-        expect:
-        executer.expectDocumentedDeprecationWarning("Calling extendsFrom on configuration ':detachedConfiguration1' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'myConf'. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-        succeeds "tasks"
-
-        and: "stack trace suggestion is printed"
-        outputContains("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
-
-        and: "we can verify the stack trace is not printed"
-        String notExpected = """run(${buildFile.absolutePath}:4)
-\tat org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory\$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java"""
-        result.assertNotOutput(notExpected)
-    }
-
-    def "does not print stack traces for deprecation warnings if --stacktrace is set"() {
-        disableProblemsApiCheck()
-
-        given:
-        buildFile << """
-            def myConf = project.configurations.resolvable("myConf")
-            def myDetached = project.configurations.detachedConfiguration()
-            myDetached.extendsFrom(myConf.get())
-        """
-
-        expect:
-        executer.expectDocumentedDeprecationWarning("Calling extendsFrom on configuration ':detachedConfiguration1' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'myConf'. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-        succeeds "tasks", "--stacktrace"
-
-        and: "stack trace suggestion is printed"
-        outputContains("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
-
-        and: "we can verify the stack trace is not printed"
-        String notExpected = """run($buildFile.absolutePath}:4)
-\tat org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory\$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java"""
-        result.assertNotOutput(notExpected)
-    }
-
-    def "prints stack traces for deprecation warnings if deprecation trace property value is set"() {
-        disableProblemsApiCheck()
-
-        given:
-        buildFile << """
-            def myConf = project.configurations.resolvable("myConf")
-            def myDetached = project.configurations.detachedConfiguration()
-            myDetached.extendsFrom(myConf.get())
-        """
-
-        expect:
-        executer.expectDocumentedDeprecationWarning("Calling extendsFrom on configuration ':detachedConfiguration1' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'myConf'. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-        succeeds "tasks", "-Dorg.gradle.deprecation.trace=true"
-
-        and: "stack trace suggestion is not printed"
-        result.assertNotOutput("\t(Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.)")
-
-        and: "we can verify the part of the stack trace that should be unchanged is printed"
-        String expected = """run(${buildFile.absolutePath}:4)
-\tat org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory\$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java"""
-        outputContains(expected)
     }
 
     String deprecatedMethodUsage() {

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -55,7 +55,7 @@ public class LoggingDeprecatedFeatureHandler implements FeatureHandler<Deprecate
     private static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry();
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingDeprecatedFeatureHandler.class);
     private static final String ELEMENT_PREFIX = "\tat ";
-    private static final String RUN_WITH_STACKTRACE_INFO = "\t(Run with -D" + ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME + "=true to print the full stack trace for this deprecation warning.)";
+    private static final String RUN_WITH_STACKTRACE_INFO = "\t(Run with --stacktrace to get the full stack trace of this deprecation warning.)";
     private static boolean traceLoggingEnabled;
 
     private final Set<String> loggedMessages = new CopyOnWriteArraySet<String>();

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -136,10 +136,10 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         and:
         events[0].message == TextUtil.toPlatformLineSeparators("""feature1 removal
 \tat some.KotlinGradleScript.foo(GradleScript.gradle.kts:31337)
-\t(Run with -D${LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME}=true to print the full stack trace for this deprecation warning.)""")
+\t(Run with --stacktrace to get the full stack trace of this deprecation warning.)""")
         events[1].message == TextUtil.toPlatformLineSeparators("""feature1 removal
 \tat some.KotlinGradleScript.foo(GradleScript.gradle.kts:7)
-\t(Run with -D${LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME}=true to print the full stack trace for this deprecation warning.)""")
+\t(Run with --stacktrace to get the full stack trace of this deprecation warning.)""")
 
         where:
         fakeStackTrace1 = [

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -14,8 +14,6 @@ We are excited to announce Gradle @version@ (released [@releaseDate@](https://gr
 
 This release introduces [Daemon JVM auto-provisioning](#toolchain), which automatically downloads a JVM compatible with the daemon requested one when necessary.
 
-[Deprecation warning messages](#error-warning) have been corrected to provide accurate instructions for enabling full stack traces.
-
 Gradle @version@ brings several enhancements for [build authors and plugin developers](#build-authoring), including updates to the `ProjectLayout` and `TestEventReporting` APIs, a new `artifactTransforms` task, the `distribution-base` plugin, and support for explicitly declaring the Scala version in the `scala` extension.
 
 Additionally, JUnit XML timestamps now include [millisecond precision](#other).
@@ -116,30 +114,6 @@ toolchainVersion=17
 
 The JVM vendors and URLs are customizable.
 For more details, see the [Daemon JVM criteria documentation](userguide/gradle_daemon.html#sec:daemon_jvm_criteria).
-
-<a name="error-warning"></a>
-### Error and warning reporting improvements
-
-Gradle provides a rich set of [error and warning messages](userguide/logging.html) to help you understand and resolve problems in your build.
-
-#### Corrected deprecation warning messages for full stack trace flag
-
-[Deprecations](userguide/feature_lifecycle.html#sec:deprecated) indicate features or APIs that will be removed or replaced in future versions of Gradle.
-These warnings help guide users to update their build scripts accordingly.
-
-The instructions printed under a deprecation warning now correctly indicate how to enable full stack traces.
-
-The console properly prints out:
-
-```text
-Run with -Dorg.gradle.deprecation.trace=true to print the full stack trace for this deprecation warning.
-```
-
-Previously, the console printed the incorrect suggestion:
-
-```text
-Run with --stacktrace to get the full stack trace of this deprecation warning.
-```
 
 <a name="build-authoring"></a>
 ### Build authoring improvements

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -203,6 +203,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
     protected boolean noExplicitNativeServicesDir;
     private boolean fullDeprecationStackTrace;
+    private boolean useInternalDeprecationStackTraceFlag = true;
     private boolean checkDeprecations = true;
     private boolean filterJavaVersionDeprecation = true;
     private boolean checkDaemonCrash = true;
@@ -384,6 +385,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         }
         if (fullDeprecationStackTrace) {
             executer.withFullDeprecationStackTraceEnabled();
+        }
+        if (!useInternalDeprecationStackTraceFlag) {
+            executer.withoutInternalDeprecationStackTraceFlag();
         }
         if (defaultLocale != null) {
             executer.withDefaultLocale(defaultLocale);
@@ -1199,7 +1203,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         if (!noExplicitNativeServicesDir) {
             properties.put(NativeServices.NATIVE_DIR_OVERRIDE, buildContext.getNativeServicesDir().getAbsolutePath());
         }
-        properties.put(LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME, Boolean.toString(fullDeprecationStackTrace));
+        if (useInternalDeprecationStackTraceFlag) {
+            properties.put(LoggingDeprecatedFeatureHandler.ORG_GRADLE_DEPRECATION_TRACE_PROPERTY_NAME, Boolean.toString(fullDeprecationStackTrace));
+        }
 
         boolean useCustomGradleUserHomeDir = gradleUserHomeDir != null && !gradleUserHomeDir.equals(buildContext.getGradleUserHomeDir());
         if (useOwnUserHomeServices || useCustomGradleUserHomeDir) {
@@ -1542,6 +1548,12 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     @Override
     public GradleExecuter withFullDeprecationStackTraceEnabled() {
         fullDeprecationStackTrace = true;
+        return this;
+    }
+
+    @Override
+    public GradleExecuter withoutInternalDeprecationStackTraceFlag() {
+        useInternalDeprecationStackTraceFlag = false;
         return this;
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -227,6 +227,8 @@ public interface GradleExecuter extends Stoppable {
      */
     GradleExecuter withFullDeprecationStackTraceEnabled();
 
+    GradleExecuter withoutInternalDeprecationStackTraceFlag();
+
     /**
      * Downloads and sets up the JVM arguments for running the Gradle daemon with the file leak detector: https://github.com/jenkinsci/lib-file-leak-detector
      *


### PR DESCRIPTION
`--stacktrace` works for deprecation warnings, and users should not use the system property.

This reverts commit 872d9563dcd843a668c62e8deef4c076b26aef88, reversing changes made to 68bb57a7d4992e21449ed505d0f2e9a212c50107.