### PR TITLE
TeamCity: move `GradleceptionWithJavaMaxLts` to weekly validation now that #32116 is merged

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -122,7 +122,6 @@ data class CIBuildModel(
                 SpecificBuild.FlakyTestQuarantineMacOs,
                 SpecificBuild.FlakyTestQuarantineMacOsAppleSilicon,
                 SpecificBuild.FlakyTestQuarantineWindows,
-                SpecificBuild.GradleceptionWithMaxLtsJdk,
             ),
             functionalTests = listOf(
                 TestCoverage(7, TestType.parallel, Os.LINUX, JvmCategory.MAX_LTS_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
@@ -149,6 +148,9 @@ data class CIBuildModel(
             StageName.WEEKLY_VALIDATION,
             trigger = Trigger.weekly,
             runsIndependent = true,
+            specificBuilds = listOf(
+                SpecificBuild.GradleceptionWithMaxLtsJdk,
+            ),
             functionalTests = listOf(
                 TestCoverage(37, TestType.configCache, Os.MACOS, JvmCategory.MAX_VERSION, expectedBucketNumber = DEFAULT_MACOS_FUNCTIONAL_TEST_BUCKET_SIZE, arch = Arch.AARCH64),
                 TestCoverage(38, TestType.configCache, Os.WINDOWS, JvmCategory.MAX_VERSION),


### PR DESCRIPTION
* #32116

Uncovered that Gradleception with MAX LTS of Java does not use that version across all relevant build parts and thus falls short of it's original purpose.

See also 
* https://github.com/gradle/gradle-private/issues/3985
* https://github.com/gradle/gradle/pull/29245

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
