### PR TITLE
Re-deprecate upload task and related methods

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.configurations;
 
-import org.apache.commons.lang.StringUtils;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.capabilities.Capability;
 
@@ -31,11 +30,6 @@ public class Configurations {
             }
         }
         return out;
-    }
-
-    @Deprecated // TODO:Finalize Upload Removal - Issue #21439
-    public static String uploadTaskName(String configurationName) {
-        return "upload" + StringUtils.capitalize(configurationName);
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import groovy.lang.Closure;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Describable;
@@ -1081,10 +1082,15 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         return this;
     }
 
-    @Deprecated // TODO:Finalize Upload Removal - Issue #21439
+    @Deprecated
     @Override
     public String getUploadTaskName() {
-        return Configurations.uploadTaskName(getName());
+        DeprecationLogger.deprecateMethod(Configuration.class, "getUploadTaskName()")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
+
+        return "upload" + StringUtils.capitalize(getName());
     }
 
     @Override

--- a/platforms/software/publish/src/integTest/groovy/org/gradle/api/tasks/UploadTaskIntegrationTest.groovy
+++ b/platforms/software/publish/src/integTest/groovy/org/gradle/api/tasks/UploadTaskIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.util.GradleVersion
  and its properties accessed for backwards compatibility; but that it throws an exception upon usage.
  */
 class UploadTaskIntegrationTest extends AbstractIntegrationSpec {
-    def "deprecated Upload task class can be registered and properties accessed, but fails at execution time"() {
+    def "deprecated Upload task class can be registered, but accessing properties are deprecated and fails at execution time"() {
         given:
         buildFile << """
             plugins {
@@ -48,12 +48,28 @@ class UploadTaskIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        expectDeprecations()
         succeeds 'tasks'
 
-        and:
+        when:
         executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-        fails 'upload'
+        expectDeprecations()
+        fails('upload')
+
+        then:
         result.assertHasErrorOutput "The legacy `Upload` task was removed in Gradle 8. Please use the `maven-publish` or `ivy-publish` plugin instead. " +
             "For more on publishing on maven repositories, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/publishing_maven.html#publishing_maven in the Gradle documentation."
+    }
+
+    def expectDeprecations() {
+        executer.expectDocumentedDeprecationWarning("The Upload.isUploadDescriptor() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#upload_task_deprecation")
+        executer.expectDocumentedDeprecationWarning("The Upload.setUploadDescriptor(boolean) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#upload_task_deprecation")
+        executer.expectDocumentedDeprecationWarning("The Upload.getDescriptorDestination() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#upload_task_deprecation")
+        executer.expectDocumentedDeprecationWarning("The Upload.setDescriptorDestination(File) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#upload_task_deprecation")
+        executer.expectDocumentedDeprecationWarning("The Upload.getRepositories() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#upload_task_deprecation")
+        executer.expectDocumentedDeprecationWarning("The Upload.repositories(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#upload_task_deprecation")
+        executer.expectDocumentedDeprecationWarning("The Upload.getConfiguration() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#upload_task_deprecation")
+        executer.expectDocumentedDeprecationWarning("The Upload.setConfiguration(Configuration) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#upload_task_deprecation")
+        executer.expectDocumentedDeprecationWarning("The Upload.getArtifacts() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#upload_task_deprecation")
     }
 }

--- a/platforms/software/publish/src/main/java/org/gradle/api/tasks/Upload.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/tasks/Upload.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.work.DisableCachingByDefault;
 
 import javax.annotation.Nullable;
@@ -33,16 +34,17 @@ import java.io.File;
 
 /**
  * This task is <strong>no longer supported</strong> and will <strong>throw an exception</strong> if you try to use it.
- * It is preserved solely for backwards compatibility and may be removed in a future version.
  *
- * @deprecated This class is scheduled for removal in a future version. To upload artifacts, use the `maven-publish` or `ivy-publish` plugins instead.
+ * @deprecated This class is scheduled for removal in Gradle 9.0. To publish artifacts,
+ *      use the {@code maven-publish} or {@code ivy-publish} plugins instead.
  */
-@Deprecated // TODO:Finalize Upload Removal - Issue #21439
+@Deprecated
 @DisableCachingByDefault(because = "Produces no cacheable output")
 public abstract class Upload extends ConventionTask {
+
     /**
      * Do not use this method, it is for internal use only.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @Deprecated
     @Inject
@@ -59,102 +61,145 @@ public abstract class Upload extends ConventionTask {
 
     /**
      * Do not use this method, it will always return {@code false}.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @Input
     @Deprecated
     public boolean isUploadDescriptor() {
+        DeprecationLogger.deprecateMethod(Upload.class, "isUploadDescriptor()")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
         return false;
     }
 
     /**
      * Do not use this method, it does nothing.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @Deprecated
     @SuppressWarnings("UnusedDeclaration")
-    public void setUploadDescriptor(boolean uploadDescriptor) { /* empty */ }
+    public void setUploadDescriptor(boolean uploadDescriptor) {
+        DeprecationLogger.deprecateMethod(Upload.class, "setUploadDescriptor(boolean)")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
+    }
 
     /**
      * Do not use this method, it will always return {@code null}.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @Internal
     @Nullable
     @Deprecated
     public File getDescriptorDestination() {
+        DeprecationLogger.deprecateMethod(Upload.class, "getDescriptorDestination()")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
         return null;
     }
 
     /**
      * Do not use this method, it does nothing.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @SuppressWarnings("UnusedDeclaration")
     @Deprecated
-    public void setDescriptorDestination(@Nullable File descriptorDestination) { /* empty */ }
+    public void setDescriptorDestination(@Nullable File descriptorDestination) {
+        DeprecationLogger.deprecateMethod(Upload.class, "setDescriptorDestination(File)")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
+    }
 
     /**
      * Do not use this method, it will always return {@code null}.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @Internal
     @Nullable
     @Deprecated
     public RepositoryHandler getRepositories() {
+        DeprecationLogger.deprecateMethod(Upload.class, "getRepositories()")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
         return null;
     }
 
     /**
      * Do not use this method, it will always return {@code null}.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @Internal
     @Nullable
     @Deprecated
     public Configuration getConfiguration() {
+        DeprecationLogger.deprecateMethod(Upload.class, "getConfiguration()")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
         return null;
     }
 
     /**
      * Do not use this method, it does nothing.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @Deprecated
     @SuppressWarnings("UnusedDeclaration")
-    public void setConfiguration(@Nullable Configuration configuration) { /* empty */ }
+    public void setConfiguration(@Nullable Configuration configuration) {
+        DeprecationLogger.deprecateMethod(Upload.class, "setConfiguration(Configuration)")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
+    }
 
     /**
      * Do not use this method, it will always return {@code null}.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @Nullable
     @Deprecated
     @SuppressWarnings({"UnusedDeclaration", "rawtypes"})
     public RepositoryHandler repositories(@Nullable @DelegatesTo(RepositoryHandler.class) Closure configureClosure) {
+        DeprecationLogger.deprecateMethod(Upload.class, "repositories(Closure)")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
         return null;
     }
 
     /**
      * Do not use this method, it will always return {@code null}.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @Nullable
     @Deprecated
     @SuppressWarnings("UnusedDeclaration")
     public RepositoryHandler repositories(Action<? super RepositoryHandler> configureAction) {
+        DeprecationLogger.deprecateMethod(Upload.class, "repositories(Action)")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
         return null;
     }
 
     /**
      * Do not use this method, it must return a non-{@code null} value as an input property to all the task to run,
      * but this value <strong>should not be relied upon</strong> for anything.
-     * @deprecated This class is scheduled for removal in a future version, this method <strong>should not be used</strong>.
+     * @deprecated This class is scheduled for removal in Gradle 9.0, this method <strong>should not be used</strong>.
      */
     @PathSensitive(PathSensitivity.NAME_ONLY)
     @InputFiles
     @Deprecated
     public FileCollection getArtifacts() {
+        DeprecationLogger.deprecateMethod(Upload.class, "getArtifacts()")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "upload_task_deprecation")
+            .nagUser();
         return getProject().files();
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -343,13 +343,14 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     ResolvedConfiguration getResolvedConfiguration();
 
     /**
-     * Returns the name of the task that upload the artifacts of this configuration to repositories
-     * declared by the user.
+     * Returns a string. The returned value should not be interpreted as a task name,
+     * as no task with this name is created by default.
      *
-     * @return The name of the associated upload task
-     * @see org.gradle.api.tasks.Upload
+     * @return A string.
+     *
+     * @deprecated This method will be removed in Gradle 9.0
      */
-    @Deprecated // TODO:Finalize Upload Removal - Issue #21439
+    @Deprecated
     String getUploadTaskName();
 
     /**


### PR DESCRIPTION
The Upload task was mostly removed in Gradle 8, but some parts remained. These remaining parts did not have deprecation warnings.

We add these deprecation warnings back so that we can safely remove the last remaining classes and methods in Gradle 9.0

Fixes: https://github.com/gradle/gradle/issues/21439

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
