### PR TITLE
Don't use default artifact rule in CheckTeamCityKotlinDSL

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -103,8 +103,8 @@ fun Requirements.requiresNotSharedHost() {
  */
 const val hiddenArtifactDestination = ".teamcity/gradle-logs"
 
-fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, arch: Arch = Arch.AMD64, buildJvm: Jvm = BuildToolBuildJvm, timeout: Int = 30) {
-    artifactRules = """
+fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, arch: Arch = Arch.AMD64, buildJvm: Jvm = BuildToolBuildJvm, timeout: Int = 30, artifactRuleOverride: String? = null) {
+    artifactRules = artifactRuleOverride ?: """
         *.psoutput => $hiddenArtifactDestination
         *.threaddump => $hiddenArtifactDestination
         build/report-* => $hiddenArtifactDestination

--- a/.teamcity/src/main/kotlin/configurations/CheckTeamCityKotlinDSL.kt
+++ b/.teamcity/src/main/kotlin/configurations/CheckTeamCityKotlinDSL.kt
@@ -13,7 +13,7 @@ class CheckTeamCityKotlinDSL(model: CIBuildModel, stage: Stage) : OsAwareBaseGra
         name = "CheckTeamCityKotlinDSL"
         description = "Check Kotlin DSL in .teamcity/"
 
-        applyDefaultSettings()
+        applyDefaultSettings(artifactRuleOverride = "")
         steps {
             script {
                 name = "RUN_MAVEN_CLEAN_VERIFY"


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/4607

Because it doesn't run the clean task of the Gradle build outside the `.teamcity` Maven build.
