### PR TITLE
Disallow Groovy production code in distribution modules

### DIFF
--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution-module.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution-module.gradle.kts
@@ -31,6 +31,15 @@ plugins {
 
 val libs = project.the<ExternalModulesExtension>()
 
+// Disallow Groovy production code in distribution modules
+pluginManager.withPlugin("groovy") {
+    tasks.named<GroovyCompile>("compileGroovy") {
+        doFirst {
+            throw Exception("You must not add Groovy production code in a distribution module")
+        }
+    }
+}
+
 val apiStubElements = configurations.consumable("apiStubElements") {
     isVisible = false
     extendsFrom(configurations.named("implementation").get())


### PR DESCRIPTION
This is a follow up for
* https://github.com/gradle/gradle/pull/32350


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
