### PR TITLE
Improve expression resolution error message

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/ResolutionTracer.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/ResolutionTracer.kt
@@ -66,7 +66,9 @@ class ResolutionTracer(
 
     override fun expressionResolution(expr: Expr): ResolutionTrace.ResolutionOrErrors<ObjectOrigin> =
         expressionResolution[expr]?.let { resolution ->
-            check(expr !in elementErrors)
+            check(expr !in elementErrors) {
+                "Unknown expression: $expr at: ${expr.sourceData.sourceIdentifier.fileIdentifier}:${expr.sourceData.lineRange.start}"
+            }
             Resolution(resolution)
         } ?: elementErrors[expr]?.let { errors ->
             Errors(errors)

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/language/LanguageTree.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/language/LanguageTree.kt
@@ -13,9 +13,15 @@ sealed interface FunctionArgument : LanguageTreeElement {
         val expr: Expr
     }
 
-    data class Positional(override val expr: Expr, override val sourceData: SourceData) : ValueArgument
-    data class Named(val name: String, override val expr: Expr, override val sourceData: SourceData) : ValueArgument
-    data class Lambda(val block: Block, override val sourceData: SourceData) : FunctionArgument
+    data class Positional(override val expr: Expr, override val sourceData: SourceData) : ValueArgument {
+        override fun toString() = "$expr"
+    }
+    data class Named(val name: String, override val expr: Expr, override val sourceData: SourceData) : ValueArgument {
+        override fun toString() = "$name: $expr"
+    }
+    data class Lambda(val block: Block, override val sourceData: SourceData) : FunctionArgument {
+        override fun toString() = "{}"
+    }
 }
 
 
@@ -49,10 +55,14 @@ data class Import(val name: AccessChain, override val sourceData: SourceData) : 
 data class AccessChain(val nameParts: List<String>)
 
 
-data class NamedReference(val receiver: Expr?, val name: String, override val sourceData: SourceData) : Expr
+data class NamedReference(val receiver: Expr?, val name: String, override val sourceData: SourceData) : Expr {
+    override fun toString() = name
+}
 
 
-data class FunctionCall(val receiver: Expr?, val name: String, val args: List<FunctionArgument>, override val sourceData: SourceData) : Expr
+data class FunctionCall(val receiver: Expr?, val name: String, val args: List<FunctionArgument>, override val sourceData: SourceData) : Expr {
+    override fun toString() = "$name() with args: ${args.joinToString(", ")}"
+}
 
 
 data class Assignment(val lhs: NamedReference, val rhs: Expr, override val sourceData: SourceData) : DataStatement
@@ -71,6 +81,8 @@ sealed interface Literal<T : Any> : Expr {
     ) : Literal<String> {
         override val type: DataType.StringDataType
             get() = DataTypeInternal.DefaultStringDataType
+
+        override fun toString() = "\"$value\""
     }
 
     data class IntLiteral(
@@ -79,6 +91,7 @@ sealed interface Literal<T : Any> : Expr {
     ) : Literal<Int> {
         override val type: DataType.IntDataType
             get() = DataTypeInternal.DefaultIntDataType
+        override fun toString() = value.toString()
     }
 
     data class LongLiteral(
@@ -87,6 +100,7 @@ sealed interface Literal<T : Any> : Expr {
     ) : Literal<Long> {
         override val type: DataType.LongDataType
             get() = DataTypeInternal.DefaultLongDataType
+        override fun toString() = value.toString()
     }
 
     data class BooleanLiteral(
@@ -95,11 +109,16 @@ sealed interface Literal<T : Any> : Expr {
     ) : Literal<Boolean> {
         override val type: DataType.BooleanDataType
             get() = DataTypeInternal.DefaultBooleanDataType
+        override fun toString() = value.toString()
     }
 }
 
 
-data class Null(override val sourceData: SourceData) : Expr
+data class Null(override val sourceData: SourceData) : Expr {
+    override fun toString() = "null"
+}
 
 
-data class This(override val sourceData: SourceData) : Expr
+data class This(override val sourceData: SourceData) : Expr {
+    override fun toString() = "this"
+}

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/DclInterpreterIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/DclInterpreterIntegrationTest.kt
@@ -50,7 +50,7 @@ class DclInterpreterIntegrationTest : AbstractKotlinIntegrationTest() {
             assertOutputContains("[bar, foo]")
             assertTrue {
                 output.lines().single { "Failed to interpret Kotlin DSL script ${file("build.gradle.kts").absolutePath} with DCL." in it }
-                    .contains("UnresolvedFunctionCallSignature(functionCall=FunctionCall(receiver=null, name=println")
+                    .contains("FailuresInResolution(errors=[ResolutionError(element=println() with args: \"not declarative anymore!\"")
             }
         }
     }


### PR DESCRIPTION
Add some sensible `toString` implementations and provide a better error message when `check()` fails.

Previous error message:
```
* What went wrong:
A problem occurred configuring project ':gradle-client'.
> Check failed.

```
New error message:
```
* What went wrong:
A problem occurred configuring project ':gradle-client'.
> Unknown expression: kotlinApplication() with args: {} at: /Users/ttresansky/Projects/gradle-client/gradle-client/build.gradle.kts:12

```