### PR TITLE
Static OG by default in Release Notes

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes-template.md
+++ b/platforms/documentation/docs/src/docs/release/notes-template.md
@@ -1,14 +1,14 @@
-<meta property="og:image" content="https://gradle.org/images/releases/gradle-@version@.png" />
+<meta property="og:image" content="https://gradle.org/images/releases/gradle-default.png" />
 <meta property="og:type"  content="article" />
 <meta property="og:title" content="Gradle @version@ Release Notes" />
 <meta property="og:site_name" content="Gradle Release Notes">
-<meta property="og:description" content="TO DO">
+<meta property="og:description" content="We are excited to announce Gradle @version@">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@gradle">
 <meta name="twitter:creator" content="@gradle">
 <meta name="twitter:title" content="Gradle @version@ Release Notes">
-<meta name="twitter:description" content="TO DO">
-<meta name="twitter:image" content="https://gradle.org/images/releases/gradle-@version@.png">
+<meta name="twitter:description" content="We are excited to announce Gradle @version@">
+<meta name="twitter:image" content="https://gradle.org/images/releases/gradle-default.png">
 
 We are excited to announce Gradle @version@ (released [@releaseDate@](https://gradle.org/releases/)).
 

--- a/platforms/documentation/docs/src/docs/release/notes-template.md
+++ b/platforms/documentation/docs/src/docs/release/notes-template.md
@@ -2,12 +2,12 @@
 <meta property="og:type"  content="article" />
 <meta property="og:title" content="Gradle @version@ Release Notes" />
 <meta property="og:site_name" content="Gradle Release Notes">
-<meta property="og:description" content="We are excited to announce Gradle @version@">
+<meta property="og:description" content="We are excited to announce Gradle @version@.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@gradle">
 <meta name="twitter:creator" content="@gradle">
 <meta name="twitter:title" content="Gradle @version@ Release Notes">
-<meta name="twitter:description" content="We are excited to announce Gradle @version@">
+<meta name="twitter:description" content="We are excited to announce Gradle @version@".>
 <meta name="twitter:image" content="https://gradle.org/images/releases/gradle-default.png">
 
 We are excited to announce Gradle @version@ (released [@releaseDate@](https://gradle.org/releases/)).


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- Fix OG (Open Graph in release notes so it contains more static defaults.