### PR TITLE
Fix deprecated property of updateDaemonJvm

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
@@ -9,8 +9,8 @@ import java.net.URI
 
 
 tasks.named<UpdateDaemonJvm>("updateDaemonJvm") {
-    jvmVersion = JavaLanguageVersion.of(17)
-    jvmVendor = "adoptium"
+    languageVersion = JavaLanguageVersion.of(17)
+    vendor = JvmVendorSpec.ADOPTIUM
 }
 
 tasks.withType<UpdateReleasedVersions>().configureEach {


### PR DESCRIPTION
```
> Task :updateDaemonJvm FAILED
Execution failed for task ':updateDaemonJvm'. java.lang.IllegalStateException: Configuring 'jvmVendor' is no longer supported.
```