### PR TITLE
Fix Kotlin metadata missing from publihsed Gradle API

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-jar.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-jar.gradle.kts
@@ -64,6 +64,7 @@ val task = tasks.register<Jar>("jarGradleApi") {
     }) {
         // TODO Use better filtering
         include("**/*.class")
+        include("META-INF/*.kotlin_module")
     }
     destinationDirectory = layout.buildDirectory.dir("public-api/gradle-api")
     // This is needed because of the duplicate package-info.class files

--- a/testing/public-api-tests/src/integTest/groovy/org/gradle/api/PublicApiIntegrationTest.groovy
+++ b/testing/public-api-tests/src/integTest/groovy/org/gradle/api/PublicApiIntegrationTest.groovy
@@ -139,6 +139,9 @@ class PublicApiIntegrationTest extends AbstractIntegrationSpec implements JavaTo
             import org.gradle.api.Plugin
             import org.gradle.api.Project
 
+            // Test if extension methods are available
+            import org.gradle.kotlin.dsl.the
+
             class PublishedApiTestPlugin : Plugin<Project> {
                 override fun apply(project: Project) {
                     project.tasks.register("myTask", CustomTask::class.java) { task ->

--- a/testing/public-api-tests/src/integTest/groovy/org/gradle/api/PublicApiIntegrationTest.groovy
+++ b/testing/public-api-tests/src/integTest/groovy/org/gradle/api/PublicApiIntegrationTest.groovy
@@ -138,14 +138,12 @@ class PublicApiIntegrationTest extends AbstractIntegrationSpec implements JavaTo
 
             import org.gradle.api.Plugin
             import org.gradle.api.Project
-
-            // Test if extension methods are available
-            import org.gradle.kotlin.dsl.the
+            import org.gradle.kotlin.dsl.*
 
             class PublishedApiTestPlugin : Plugin<Project> {
                 override fun apply(project: Project) {
-                    project.tasks.register("myTask", CustomTask::class.java) { task ->
-                        task.mapValues.set(mapOf("alma" to 1, "bela" to 2))
+                    val myTask by project.tasks.registering(CustomTask::class) {
+                        mapValues.set(mapOf("alma" to 1, "bela" to 2))
                         println("Hello from plugin")
                     }
                 }


### PR DESCRIPTION
We accidentally removed `META-INF/*.kotlin_module` files at some point. This adds them back along with a test that ensure we don't remove them accidentally again.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
