### PR TITLE
Ensure published projects depend only on other published projects

### DIFF
--- a/build-logic-commons/module-identity/src/main/kotlin/gradlebuild/identity/extension/ModuleIdentityExtension.kt
+++ b/build-logic-commons/module-identity/src/main/kotlin/gradlebuild/identity/extension/ModuleIdentityExtension.kt
@@ -16,40 +16,29 @@
 
 package gradlebuild.identity.extension
 
-import gradlebuild.basics.buildCommitId
-import gradlebuild.identity.tasks.BuildReceipt
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.bundling.Jar
-import org.gradle.kotlin.dsl.*
 import org.gradle.util.GradleVersion
 
+/**
+ * Describes defining properties of a Gradle module.
+ */
+interface ModuleIdentityExtension {
 
-abstract class ModuleIdentityExtension(val tasks: TaskContainer, val objects: ObjectFactory) {
+    /**
+     * The name of this Gradle module as it should appear in output files and published metadata.
+     */
+    val baseName: Property<String>
 
-    abstract val version: Property<GradleVersion>
+    /**
+     * Declares whether this module is published to an external repository.
+     */
+    val published: Property<Boolean>
 
-    abstract val baseName: Property<String>
+    // TODO: These are build-wide properties, we should not configure them per module.
+    val version: Property<GradleVersion>
+    val buildTimestamp: Property<String>
+    val snapshot: Property<Boolean>
+    val promotionBuild: Property<Boolean>
+    val releasedVersions: Property<ReleasedVersionsDetails>
 
-    abstract val buildTimestamp: Property<String>
-    abstract val snapshot: Property<Boolean>
-    abstract val promotionBuild: Property<Boolean>
-
-    abstract val releasedVersions: Property<ReleasedVersionsDetails>
-
-    fun createBuildReceipt() {
-        val createBuildReceipt by tasks.registering(BuildReceipt::class) {
-            this.version = this@ModuleIdentityExtension.version.map { it.version }
-            this.baseVersion = this@ModuleIdentityExtension.version.map { it.baseVersion.version }
-            this.snapshot = this@ModuleIdentityExtension.snapshot
-            this.promotionBuild = this@ModuleIdentityExtension.promotionBuild
-            this.buildTimestampFrom(this@ModuleIdentityExtension.buildTimestamp)
-            this.commitId = project.buildCommitId
-            this.receiptFolder = project.layout.buildDirectory.dir("generated-resources/build-receipt")
-        }
-        tasks.named<Jar>("jar").configure {
-            from(createBuildReceipt.map { it.receiptFolder })
-        }
-    }
 }

--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -19,8 +19,13 @@ import java.time.Year
 plugins {
     id("gradlebuild.module-identity")
     id("gradlebuild.publish-defaults")
+    id("java-library")
     id("signing")
     `maven-publish`
+}
+
+moduleIdentity {
+    published = true
 }
 
 configureJavadocVariant()

--- a/build-logic/uber-plugins/build.gradle.kts
+++ b/build-logic/uber-plugins/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Provides plugins that combine and configure other plugins for dif
 
 dependencies {
     implementation("gradlebuild:basics")
+    implementation("gradlebuild:module-identity")
     implementation("gradlebuild:publishing")
 
     implementation(projects.buildquality)

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution-module.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution-module.gradle.kts
@@ -1,3 +1,4 @@
+import gradlebuild.attributes.ExternallyAvailableLibraryAttribute
 import gradlebuild.basics.ClassFileContentsAttribute
 import gradlebuild.configureAsRuntimeJarClasspath
 import gradlebuild.modules.extension.ExternalModulesExtension
@@ -45,6 +46,8 @@ val apiStubElements = configurations.consumable("apiStubElements") {
     extendsFrom(configurations.named("implementation").get())
     extendsFrom(configurations.named("compileOnly").get())
     attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named("api-stubs"))
+        attribute(ExternallyAvailableLibraryAttribute.attribute, false)
         attribute(ClassFileContentsAttribute.attribute, ClassFileContentsAttribute.STUBS)
     }
 }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild/attributes/ExternallyAvailableLibraryAttribute.kt
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild/attributes/ExternallyAvailableLibraryAttribute.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.attributes
+
+import org.gradle.api.attributes.Attribute
+
+/**
+ * An attribute describing whether a library is externally available or not.
+ * <p>
+ * All local Gradle JVM variants should be marked as not externally available except for
+ * those which are published.
+ */
+object ExternallyAvailableLibraryAttribute {
+
+    val attribute: Attribute<Boolean> = Attribute.of("gradlebuild.externally-available", Boolean::class.javaObjectType)
+
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ComponentMetadataHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ComponentMetadataHandler.java
@@ -24,7 +24,8 @@ import org.gradle.api.artifacts.ComponentMetadataRule;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
- * Allows the build to provide rules that modify the metadata of depended-on software components.
+ * Allows the build to provide rules that modify the metadata of software components
+ * resolved from external repositories.
  *
  * Component metadata rules are applied in the components section of the dependencies block
  * {@link DependencyHandler} of a build script. The rules can be defined in two different ways:


### PR DESCRIPTION
Add a new attribute to specify whether a component is available externally. Ensure all JVM variants declare themselves as such.

Published libraries require their dependencies are also published.

Now, depending on a non-published module from a published one fails.

This should probably be natively integrated into the Gradle publishing plugins.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
