### PR TITLE
Publish :classloaders module as library

### DIFF
--- a/platforms/core-runtime/classloaders/build.gradle.kts
+++ b/platforms/core-runtime/classloaders/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
 
     api(libs.jsr305)
 
-    implementation(projects.baseAsm)
     implementation(projects.concurrent)
     implementation(projects.io)
 

--- a/platforms/core-runtime/classloaders/build.gradle.kts
+++ b/platforms/core-runtime/classloaders/build.gradle.kts
@@ -16,6 +16,8 @@
 
 plugins {
     id("gradlebuild.distribution.implementation-java")
+    // TODO Make :serialization not depend on this and then we can unpublish this library
+    id("gradlebuild.publish-public-libraries")
 }
 
 description = "Tools to handle classloaders"

--- a/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/TransformReplacer.java
+++ b/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/TransformReplacer.java
@@ -21,7 +21,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.internal.classpath.TransformedClassPath;
 import org.gradle.internal.io.StreamByteBuffer;
-import org.gradle.model.internal.asm.AsmConstants;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -207,10 +206,9 @@ public class TransformReplacer implements Closeable {
                 jarFile = JarCompat.open(transformedJarPath);
                 if (jarFile.isMultiRelease() && !isTransformed(jarFile.getJarFile())) {
                     throw new GradleException(String.format(
-                        "Cannot load multi-release JAR '%s' because it cannot be fully instrumented for Java %d by this version of Gradle. Please use a supported Java version (<=%d).",
+                        "Cannot load multi-release JAR '%s' because it cannot be fully instrumented for Java %d by this version of Gradle. Please use a supported Java version.",
                         originalPath.getAbsolutePath(),
-                        jarFile.javaRuntimeVersionUsed(),
-                        AsmConstants.MAX_SUPPORTED_JAVA_VERSION));
+                        jarFile.javaRuntimeVersionUsed()));
                 }
             }
             return jarFile.getJarFile();


### PR DESCRIPTION
Recently a dependency on `:base-services` was added from `:serialization` to be able to serialize additional payloads for problems. This broke the published library contract, as `:serialization` is a published library and now it depended on a non-published library (`:base-services`).

To fix this we introduced `:classloaders`, see:

- #32430 

However, that PR did not remove the dependency from `:serialization`, and now that project still depends on a couple of non-published projects: `:classloaders` and `:base-asm`. We could publish these two subprojects, or we could try to remove the dependency.

This PR is a quick-fix that published `:classloaders`. We should revisit this and remove the dependency in `:serialization` and un-publish `:classloaders` for a proper fix.

A proper fix is drafted in this PR:

- https://github.com/gradle/gradle/pull/32466

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
