### PR TITLE
Add Java 23 back on macOS

### DIFF
--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -89,6 +89,7 @@ enum class Os(
                         DefaultJvm(JvmVersion.JAVA_11, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_17, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_21, JvmVendor.OPENJDK),
+                        DefaultJvm(JvmVersion.JAVA_23, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_24, JvmVendor.OPENJDK),
                     )
 


### PR DESCRIPTION
Because it's still used in some builds. Example: https://ge.gradle.org/s/fofgjjisg73w6