### PR TITLE
Update test-retry plugin used in smoke tests to 1.6.2

### DIFF
--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -126,7 +126,7 @@ abstract class AbstractSmokeTest extends Specification {
         static protobufTools = "4.29.3"
 
         // https://plugins.gradle.org/plugin/org.gradle.test-retry
-        static testRetryPlugin = "1.6.1"
+        static testRetryPlugin = "1.6.2"
 
         // https://plugins.gradle.org/plugin/io.freefair.aspectj
         static aspectj = "8.12"


### PR DESCRIPTION
Since it fixes some incompatibilities with Provider EAP branch.

