### PR TITLE
Add better error reporting for concurrent property modifications

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -205,8 +205,16 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
      */
     private void addExplicitCollector(Collector<T> collector) {
         assertCanMutate();
-        CollectionSupplier<T, C> explicitValue = getExplicitValue(defaultValue);
-        setSupplier(explicitValue.plus(collector));
+        setSupplier(withAppendedValue(collector));
+    }
+
+    private CollectionSupplier<T, C> withAppendedValue(Collector<T> value) {
+        CollectionSupplier<T, C> currentValue = getExplicitValue(defaultValue);
+        try {
+            return currentValue.plus(value);
+        } catch (IllegalStateException e) {
+            throw failWithCorruptedStateException(e);
+        }
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -28,6 +28,7 @@ import org.gradle.internal.state.ModelObject;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ConcurrentModificationException;
 
 /**
  * The base implementation for all properties in Gradle.
@@ -176,6 +177,20 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
                 throw UncheckedException.throwAsUncheckedException(e);
             }
         }
+    }
+
+    /**
+     * Throws a {@link ConcurrentModificationException} with text describing data corruption because of unsafe property access.
+     *
+     * @param reason the (optional) reason indicating the detected corruption
+     * @return nothing (it throws), but you can use this method in {@code throw} statement to appease the compiler
+     */
+    protected ConcurrentModificationException failWithCorruptedStateException(@Nullable Throwable reason) {
+        throw new ConcurrentModificationException(
+            "State of " + getDisplayName().getDisplayName() + " is corrupted. " +
+                "This may be caused by unsafe concurrent modifications with parallel configuration or execution enabled.",
+            reason
+        );
     }
 
     protected abstract Value<? extends T> calculateValueFrom(EvaluationScopeContext context, S value, ValueConsumer consumer);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -232,8 +232,16 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
     private void addExplicitCollector(MapCollector<K, V> collector) {
         assertCanMutate();
-        MapSupplier<K, V> explicitValue = getExplicitValue(defaultValue);
-        setSupplier(explicitValue.plus(collector));
+        setSupplier(withAppendedValue(collector));
+    }
+
+    private MapSupplier<K, V> withAppendedValue(MapCollector<K, V> value) {
+        MapSupplier<K, V> currentValue = getExplicitValue(defaultValue);
+        try {
+            return currentValue.plus(value);
+        } catch (IllegalStateException e) {
+            throw failWithCorruptedStateException(e);
+        }
     }
 
     protected void withActualValue(Runnable action) {

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -26,6 +26,11 @@ import java.util.List;
  * You can create a {@link ListProperty} instance using factory method {@link org.gradle.api.model.ObjectFactory#listProperty(Class)}.
  * </p>
  *
+ * <p>
+ * Instances of this interface are not thread-safe for reading and writing.
+ * It is not safe to share the same ListProperty instance between different projects.
+ * </p>
+ *
  * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors.
  *
  * @param <T> the type of elements.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -30,6 +30,11 @@ import java.util.Set;
  * You can create a {@link MapProperty} instance using factory method {@link org.gradle.api.model.ObjectFactory#mapProperty(Class, Class)}.
  * </p>
  *
+ * <p>
+ * Instances of this interface are not thread-safe for reading and writing.
+ * It is not safe to share the same MapProperty instance between different projects.
+ * </p>
+ *
  * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors.
  *
  * @param <K> the type of keys.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -40,6 +40,10 @@ import javax.annotation.Nullable;
  * </p>
  *
  * <p>
+ * Instances of this interface are not thread-safe for reading and writing.
+ * It is not safe to share the same Property instance between different projects.
+ * </p>
+ * <p>
  * <b>Note:</b> This interface is not intended for implementation by build script or plugin authors.
  * </p>
  *

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -26,6 +26,11 @@ import java.util.Set;
  * You can create a {@link SetProperty} instance using factory method {@link org.gradle.api.model.ObjectFactory#setProperty(Class)}.
  * </p>
  *
+ * <p>
+ * Instances of this interface are not thread-safe for reading and writing.
+ * It is not safe to share the same SetProperty instance between different projects.
+ * </p>
+ *
  * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors.
  *
  * @param <T> the type of elements.


### PR DESCRIPTION
The internal failure message from the AppendOnceList isn't really user-friendly. The new one gives some pointers to the failure location and the reason, and the ConcurrentModificationException also serves as a hint.

It doesn't really make sense to throw CME from AppendOnceList, because from its standpoint it has nothing to do with concurrency.

Fixes #32158 

Now the error looks like:
```
* What went wrong:
Error resolving plugin [id: 'org.gradle.toolchains.foojay-resolver-convention', version: '0.9.0']
> Multiple build operations failed.
      A problem occurred configuring project ':build-logic-commons:module-identity'.
      A problem occurred configuring project ':build-logic-commons:basics'.
   > A problem occurred configuring project ':build-logic-commons:module-identity'.
      > State of property 'configurationMetrics' is corrupted. This may be caused by unprotected concurrent modifications with parallel configuration or execution enabled.
   > A problem occurred configuring project ':build-logic-commons:basics'.
      > State of property 'configurationMetrics' is corrupted. This may be caused by unprotected concurrent modifications with parallel configuration or execution enabled.
```

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
