### PR TITLE
Improve DCL performance

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/integTest/groovy/org/gradle/internal/declarativedsl/ErrorHandlingOnReflectiveCallsSpec.groovy
+++ b/platforms/core-configuration/declarative-dsl-core/src/integTest/groovy/org/gradle/internal/declarativedsl/ErrorHandlingOnReflectiveCallsSpec.groovy
@@ -206,7 +206,7 @@ class ErrorHandlingOnReflectiveCallsSpec extends AbstractIntegrationSpec {
 
 
         then:
-        failureCauseContains("Failed disambiguating between following functions (matches 0):")
+        failureCauseContains("Failed disambiguating between following functions (matches 2):")
         failureCauseContains("fun com.example.restricted.Extension.access(org.gradle.api.Action<com.example.restricted.Extension.Access>): kotlin.Unit")
         failureCauseContains("fun com.example.restricted.Extension.access((com.example.restricted.Extension.Access) -> kotlin.Unit): kotlin.Unit")
     }

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/FunctionExtractor.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/FunctionExtractor.kt
@@ -125,10 +125,11 @@ class DefaultFunctionExtractor(
                 param != function.instanceParameter && run {
                     // is value parameter, not a configuring block:
                     val isNotLastParameter = index != fnParams.lastIndex
-                    val isNotConfigureLambda = configureLambdas.getTypeConfiguredByLambda(param.type)?.let { typeConfiguredByLambda ->
-                        param.parameterTypeToRefOrError(host) { typeConfiguredByLambda } != maybeConfigureTypeRef
-                    } ?: true
-                    isNotLastParameter || isNotConfigureLambda
+                    isNotLastParameter || run isNotAConfigureLambda@{
+                        configureLambdas.getTypeConfiguredByLambda(param.type)?.let { typeConfiguredByLambda ->
+                            param.parameterTypeToRefOrError(host) { typeConfiguredByLambda } != maybeConfigureTypeRef
+                        } ?: true
+                    }
                 }
             }
             .map { fnParam -> dataParameter(host, function, fnParam, returnClassifier, semanticsFromSignature, preIndex) }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectInterpretationSequenceStep.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectInterpretationSequenceStep.kt
@@ -31,7 +31,7 @@ internal
 fun projectInterpretationSequenceStep(
     softwareTypeRegistry: SoftwareTypeRegistry,
 ) = SimpleInterpretationSequenceStepWithConversion(
-    "project",
+    PROJECT_INTERPRETATION_SEQUENCE_STEP_KEY,
     features = setOf(
         ApplyModelDefaults(),
         UnsupportedSyntaxFeatureCheck.feature,
@@ -40,3 +40,5 @@ fun projectInterpretationSequenceStep(
 ) {
     projectEvaluationSchema(softwareTypeRegistry)
 }
+
+internal const val PROJECT_INTERPRETATION_SEQUENCE_STEP_KEY = "project"

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
@@ -73,9 +73,10 @@ object BuildServices : ServiceRegistrationProvider {
     @Provides
     fun createDeclarativeModelDefaultsHandler(
         softwareTypeRegistry: SoftwareTypeRegistry,
+        interpretationSchemaBuilder: InterpretationSchemaBuilder,
         objectFactory: ObjectFactory
     ): ModelDefaultsHandler {
-        return objectFactory.newInstance(DeclarativeModelDefaultsHandler::class.java, softwareTypeRegistry)
+        return objectFactory.newInstance(DeclarativeModelDefaultsHandler::class.java, softwareTypeRegistry, interpretationSchemaBuilder)
     }
 
     private


### PR DESCRIPTION
Attempts to fix the performance regression introduced by the changes in the DCL runtime function resolution.

* Delay expensive disambiguation as much as possible in DCL runtime.
* Avoid producing a duplicate project schema for defaults application; reuse the one from the evaluator.