### PR TITLE
Restore 8.11 attribute container behavior

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenAttributesFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenAttributesFactory.java
@@ -85,7 +85,7 @@ public class DefaultMavenAttributesFactory implements MavenAttributesFactory {
     }
 
     @Override
-    public ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes) {
+    public ImmutableAttributes fromMap(Map<Attribute<?>, Isolatable<?>> attributes) {
         return delegate.fromMap(attributes);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributesFactory.java
@@ -61,7 +61,7 @@ public interface AttributesFactory {
      * @param attributes the attribute values the result should contain
      * @return immutable instance containing only the specified attributes
      */
-    ImmutableAttributes fromMap(Map<Attribute<?>, ?> attributes);
+    ImmutableAttributes fromMap(Map<Attribute<?>, Isolatable<?>> attributes);
 
     /**
      * Adds the given attribute to the given container. Note: the container _should not_ contain the given attribute.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -18,6 +18,9 @@ package org.gradle.api.internal.attributes
 
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.HasAttributes
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.Usage
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport
 import org.gradle.api.internal.provider.DefaultProperty
 import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.api.internal.provider.PropertyHost
@@ -388,5 +391,33 @@ class DefaultMutableAttributeContainerTest extends Specification {
         for (Attribute<?> attribute : container.keySet()) {
             container.getAttribute(attribute)
         }
+    }
+
+    def "can add deprecated usage then add libraryelements and convert to immutable"() {
+        def container = mutable()
+
+        when:
+        container.attribute(Usage.USAGE_ATTRIBUTE, TestUtil.objectInstantiator().named(Usage, JavaEcosystemSupport.DEPRECATED_JAVA_API_JARS))
+        container.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, TestUtil.objectInstantiator().named(LibraryElements, "aar"))
+
+        then:
+        def immutable = container.asImmutable()
+        immutable.keySet().size() == 2
+        immutable.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
+        immutable.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).name == "aar"
+    }
+
+    def "can add libraryelements then add deprecated usage and convert to immutable"() {
+        def container = mutable()
+
+        when:
+        container.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, TestUtil.objectInstantiator().named(LibraryElements, "aar"))
+        container.attribute(Usage.USAGE_ATTRIBUTE, TestUtil.objectInstantiator().named(Usage, JavaEcosystemSupport.DEPRECATED_JAVA_API_JARS))
+
+        then:
+        def immutable = container.asImmutable()
+        immutable.keySet().size() == 2
+        immutable.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
+        immutable.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).name == "jar"
     }
 }


### PR DESCRIPTION
When Gradle detects deprecated Usage attribute values, like java-api-jars, it splits the configured value from Usage=java-api-jars to Usage=java-api and LibraryElements=jar.

If the user specifies their own LibraryElements value, the later value wins. Setting Usage to a deprecated value after setting LibraryElements will overwrite the prior LibraryElements value.

In 8.12, this behavior changed to an undesired behavior. This commit restores the prior behavior. The original change in behavior was likely introduced in https://github.com/gradle/gradle/pull/30667

The change in behavior affected KMP android targets, as KMP continues to use the deprecated Usage values. Related KMP issue: http://youtrack.jetbrains.com/issue/KT-36004/Update-org.gradle.usage-attribute-rules-to-support-the-JAVAAPI-and-JAVARUNTIME-value

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
