### PR TITLE
Upgrade tested AGP versions

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,4 +1,4 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=7.3.1,7.4.2,8.0.2,8.2.2,8.3.2,8.4.2,8.5.2,8.6.1,8.7.3,8.8.0,8.9.0-beta01,8.10.0-alpha02
-nightlyBuildId=12982950
+latests=7.3.1,7.4.2,8.0.2,8.2.2,8.3.2,8.4.2,8.5.2,8.6.1,8.7.3,8.8.1,8.9.0-rc02,8.10.0-alpha05
+nightlyBuildId=13097777
 nightlyVersion=8.10.0-dev

--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -107,7 +107,7 @@ Gradle plugins written in Groovy must use Groovy 3.x for compatibility with Grad
 
 == Android
 
-Gradle is tested with Android Gradle Plugin 7.3 through 8.8.
+Gradle is tested with Android Gradle Plugin 7.3 through 8.9.
 Alpha and beta versions may or may not work.
 
 == Target Platforms


### PR DESCRIPTION
from 8.8.0 to 8.8.1
from 8.9.0-beta01 to 8.9.0-rc02
from 8.10.0-alpha02 to 8.10.0-alpha05
bumping the 8.10-dev nightly

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
