### PR TITLE
Implement += support for some lazy types in Groovy build scripts - take 2

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/CompoundAssignmentResultFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/CompoundAssignmentResultFileCollection.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import com.google.common.base.Preconditions;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.file.UnionFileCollection;
+import org.gradle.api.internal.provider.support.CompoundAssignmentValue;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
+
+import javax.annotation.Nullable;
+
+/**
+ * A result of applying an operator (so far only {@code +}) to ConfigurableFileCollection.
+ * Allows assigning itself back to the collection without causing circular evaluation failure if it is produced by the compound assignment operator {@code +=}.
+ */
+class CompoundAssignmentResultFileCollection extends UnionFileCollection implements CompoundAssignmentValue {
+    private boolean canBeAssignedBack;
+    @Nullable
+    private ConfigurableFileCollection owner;
+    private final FileCollectionInternal rhs;
+
+    public CompoundAssignmentResultFileCollection(TaskDependencyFactory taskDependencyFactory, DefaultConfigurableFileCollection owner, FileCollectionInternal rhs) {
+        super(taskDependencyFactory, owner, rhs);
+        this.owner = owner;
+        this.rhs = rhs;
+    }
+
+    public boolean canBeAssignedBackTo(ConfigurableFileCollection owner) {
+        return canBeAssignedBack && this.owner == owner;
+    }
+
+    public void assignToOwner() {
+        ConfigurableFileCollection theOwner = owner;
+        Preconditions.checkState(theOwner != null, "The collection is already consumed by the owner");
+        theOwner.from(rhs);
+        assignmentCompleted();
+    }
+
+    @Override
+    public void prepareForAssignment() {
+        // We are part of the compound assignment and not just some standalone (prop `+` value).
+        canBeAssignedBack = true;
+    }
+
+    @Override
+    public void assignmentCompleted() {
+        // When the expression involves a variable on the left side as opposed to a field, then this collection becomes its value.
+        // It must lose all "magical" properties towards its owner, because it may be used to set its value outside the original expression.
+        canBeAssignedBack = false;
+        // Clean up stuff we no longer need to let GC collect them.
+        owner = null;
+    }
+
+    @Override
+    public boolean shouldReplaceResultWithNull() {
+        // FileCollection supported += for a while, so changing this would be a breaking change.
+        return false;
+    }
+}

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -28,10 +28,12 @@ import org.gradle.api.internal.file.CompositeFileCollection;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
+import org.gradle.api.internal.file.UnionFileCollection;
 import org.gradle.api.internal.provider.HasConfigurableValueInternal;
 import org.gradle.api.internal.provider.PropertyHost;
 import org.gradle.api.internal.provider.ValueState;
 import org.gradle.api.internal.provider.ValueSupplier;
+import org.gradle.api.internal.provider.support.CompoundAssignmentSupport;
 import org.gradle.api.internal.provider.support.LazyGroovySupport;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -249,7 +251,10 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
 
     @Override
     public FileCollection plus(FileCollection collection) {
-        return new CompoundAssignmentResultFileCollection(taskDependencyFactory, this, (FileCollectionInternal) collection);
+        if (CompoundAssignmentSupport.isEnabled()) {
+            return new CompoundAssignmentResultFileCollection(taskDependencyFactory, this, (FileCollectionInternal) collection);
+        }
+        return new UnionFileCollection(taskDependencyFactory, this, (FileCollectionInternal) collection);
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractProviderOperatorIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractProviderOperatorIntegrationTest.groovy
@@ -41,7 +41,7 @@ abstract class AbstractProviderOperatorIntegrationTest extends AbstractIntegrati
         }
     }
 
-    private static interface Failure {
+    static interface Failure {
         void assertHasExpectedFailure(ExecutionFailure failure);
     }
 

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
@@ -16,9 +16,13 @@
 
 package org.gradle.api.provider
 
+import org.gradle.util.internal.ToBeImplemented
+
 import static org.gradle.integtests.fixtures.executer.GradleContextualExecuter.configCache
 
 class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIntegrationTest {
+    protected static final String EXPRESSION_PREFIX = "Expression value: "
+
     def "eager object properties assignment for #description"() {
         def inputDeclaration = "$inputType input"
         groovyBuildFile(inputDeclaration, inputValue, "=")
@@ -113,32 +117,39 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expressionValue)
+        }
 
         where:
-        description                              | operation | inputType                       | inputValue                                               | expectedResult
-        "Collection<T> = null"                   | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'undefined'
-        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("Cannot set the value of a property of type java.util.List using an instance of type [LMyObject;")
-        "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'
-        "Collection<T> = provider { null }"      | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'
-        "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'
-        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T"                     | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<T>"           | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T[]"                   | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> << Iterable<T>"           | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<Iterable<T>>" | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
-        "Map<K, V> = null"                       | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'undefined'
-        "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '{a=b}'
-        "Map<K, V> = provider { null }"          | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'
-        "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '{a=b}'
-        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Map<K, V>"                 | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Provider<Map<K, V>>"       | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
+        description                               | operation | inputType                       | inputValue                                               | expressionValue | expectedResult
+        "Collection<T> = null"                    | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'null'          | 'undefined'
+        "Collection<T> = T[]"                     | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | _               | unsupportedWithCause("Cannot set the value of a property of type java.util.List using an instance of type [LMyObject;")
+        "Collection<T> = Iterable<T>"             | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'           | '[a]'
+        "Collection<T> = provider { null }"       | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Collection<T> = Provider<Iterable<T>>"   | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'           | '[a]'
+        "Collection<T> += T"                      | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | 'null'          | '[a]'
+        "Collection<T> += !T"                     | "+="      | "ListProperty<MyObject>"        | '"a"'                                                    | _               | unsupportedWithCause("Cannot add an element of type String to a property of type List<MyObject>")
+        "Collection<T> << T"                      | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += provider { null }"      | "+="      | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'null'          | 'undefined'
+        "Collection<T> += Provider<T>"            | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | 'null'          | '[a]'
+        "Collection<T> += Provider<!T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { "a" }'                                       | _               | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.lang.String")
+        "Collection<T> << Provider<T>"            | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += T[]"                    | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | 'null'          | '[a]'
+        "Collection<T> << T[]"                    | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += Iterable<T>"            | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | 'null'          | '[a]'
+        "Collection<T> << Iterable<T>"            | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += Provider<Iterable<T>>"  | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | 'null'          | '[a]'
+        "Collection<T> += Provider<Iterable<!T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { ["a"] as Iterable<String> }'                 | _               | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.lang.String.")
+        "Collection<T> << Provider<Iterable<T>>"  | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | _               | unsupportedWithCause("No signature of method")
+        "Map<K, V> = null"                        | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'null'          | 'undefined'
+        "Map<K, V> = Map<K, V>"                   | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'         | '{a=b}'
+        "Map<K, V> = provider { null }"           | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Map<K, V> = Provider<Map<K, V>>"         | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'         | '{a=b}'
+        "Map<K, V> += Map<K, V>"                  | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | 'null'          | '{a=b}'
+        "Map<K, V> << Map<K, V>"                  | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | _               | unsupportedWithCause("No signature of method")
+        "Map<K, V> += Provider<Map<K, V>>"        | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | 'null'          | '{a=b}'
+        "Map<K, V> << Provider<Map<K, V>>"        | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | _               | unsupportedWithCause("No signature of method")
     }
 
     def "lazy collection variables assignment for #description"() {
@@ -147,32 +158,36 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expressionValue)
+        }
 
         where:
-        description                              | operation | inputType                       | inputValue                                               | expectedResult
-        "Collection<T> = null"                   | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'null'
-        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | '[a]'
-        "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'
-        "Collection<T> = provider { null }"      | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'
-        "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'
-        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T"                     | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<T>"           | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T[]"                   | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> << Iterable<T>"           | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<Iterable<T>>" | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
-        "Map<K, V> = null"                       | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'null'
-        "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'
-        "Map<K, V> = provider { null }"          | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'
-        "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'
-        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Map<K, V>"                 | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Provider<Map<K, V>>"       | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
+        description                              | operation | inputType                       | inputValue                                               | expressionValue | expectedResult
+        "Collection<T> = null"                   | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'null'          | 'null'
+        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | '[a]'           | '[a]'
+        "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'           | '[a]'
+        "Collection<T> = provider { null }"      | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'           | '[a]'
+        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | 'null'          | '[a]'
+        "Collection<T> << T"                     | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += provider { null }"     | "+="      | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'null'          | 'undefined'
+        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | 'null'          | '[a]'
+        "Collection<T> << Provider<T>"           | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | 'null'          | '[a]'
+        "Collection<T> << T[]"                   | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | 'null'          | '[a]'
+        "Collection<T> << Iterable<T>"           | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | _               | unsupportedWithCause("No signature of method")
+        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | 'null'          | '[a]'
+        "Collection<T> << Provider<Iterable<T>>" | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | _               | unsupportedWithCause("No signature of method")
+        "Map<K, V> = null"                       | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'null'          | 'null'
+        "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'         | '[a:b]'
+        "Map<K, V> = provider { null }"          | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'         | '[a:b]'
+        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | 'null'          | '[a:b]'
+        "Map<K, V> << Map<K, V>"                 | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | _               | unsupportedWithCause("No signature of method")
+        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | 'null'          | '[a:b]'
+        "Map<K, V> << Provider<Map<K, V>>"       | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | _               | unsupportedWithCause("No signature of method")
     }
 
     def "eager FileCollection properties assignment for #description"() {
@@ -181,6 +196,9 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expectedResult)
+        }
 
         where:
         description                        | operation | inputType        | inputValue        | expectedResult
@@ -202,6 +220,9 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expectedResult)
+        }
 
         where:
         description                        | operation | inputType                    | inputValue              | expectedResult
@@ -210,7 +231,7 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         "FileCollection = Object"          | "="       | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("Failed to cast object")
         "FileCollection = File"            | "="       | "ConfigurableFileCollection" | 'file("a.txt")'         | unsupportedWithCause("Failed to cast object")
         "FileCollection = Iterable<File>"  | "="       | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("Failed to cast object")
-        "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | unsupportedWithCause("Self-referencing ConfigurableFileCollections are not supported. Use the from() method to add to a ConfigurableFileCollection.")
+        "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | '[a.txt]'
         "FileCollection << FileCollection" | "<<"      | "ConfigurableFileCollection" | 'files("a.txt")'        | unsupportedWithCause("No signature of method")
         "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | unsupportedWithCause("Failed to cast object")
         "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("Failed to cast object")
@@ -225,6 +246,9 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expectedResult)
+        }
 
         where:
         description                        | operation | inputType                    | inputValue              | expectedType                 | expectedResult
@@ -240,6 +264,109 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'         | "List"                       | "[a.txt]"
         "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | '["a.txt"]'             | "List"                       | "[a.txt]"
         "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | "List"                       | "[a.txt]"
+    }
+
+    def "variable can be used as task input after #description"() {
+        buildFile """
+            ${groovyTypesDefinition()}
+            import static ${org.gradle.api.internal.provider.Providers.name}.changing
+
+            abstract class MyTask extends DefaultTask {
+                @Input
+                abstract $inputType getInput()
+
+                @TaskAction
+                def action() {
+                    ${groovyInputPrintRoutine(RESULT_PREFIX)}
+                }
+            }
+
+            tasks.register("myTask", MyTask) {
+                def property = $factory
+                property += $value
+                input = property
+            }
+        """
+
+        expect:
+        runAndAssert("myTask", expectedResult)
+
+        where:
+        description                                  | inputType                     | factory     | value                    | expectedResult
+        "ListProperty<T> += T"                       | "ListProperty<String>"        | listFactory | '"a"'                    | "[a]"
+        "ListProperty<T> += Collection<T>"           | "ListProperty<String>"        | listFactory | '["a"]'                  | "[a]"
+        "ListProperty<T> += Provider<T>"             | "ListProperty<String>"        | listFactory | 'provider { "a" }'       | "[a]"
+        "ListProperty<T> += Provider<Collection<T>>" | "ListProperty<String>"        | listFactory | 'provider { ["a"] }'     | "[a]"
+        "SetProperty<T> += T"                        | "SetProperty<String>"         | setFactory  | '"a"'                    | "[a]"
+        "SetProperty<T> += Collection<T>"            | "SetProperty<String>"         | setFactory  | '["a"]'                  | "[a]"
+        "SetProperty<T> += Provider<T>"              | "SetProperty<String>"         | setFactory  | 'provider { "a" }'       | "[a]"
+        "SetProperty<T> += Provider<Collection<T>>"  | "SetProperty<String>"         | setFactory  | 'provider { ["a"] }'     | "[a]"
+        "MapProperty<K,V> += Map<K,V>"               | "MapProperty<String, String>" | mapFactory  | '["a":"b"]'              | "{a=b}"
+        "MapProperty<K,V> += Provider<Map<K,V>>"     | "MapProperty<String, String>" | mapFactory  | 'provider { ["a":"b"] }' | "{a=b}"
+    }
+
+    // We need these properties to have changing values so the tests trigger CC-serialization of intermediate providers created by += implementation.
+    private static String getListFactory() { "objects.listProperty(String).value(changing {[]})" }
+
+    private static String getSetFactory() { "objects.setProperty(String).value(changing {[]})" }
+
+    private static String getMapFactory() { "objects.mapProperty(String, String).value(changing {[:]})" }
+
+    def "compound assignment preserves dependencies"() {
+        given:
+        buildFile """
+            abstract class MyTask extends DefaultTask {
+                @OutputFile abstract RegularFileProperty getOutputFile()
+
+                MyTask() {
+                    outputFile.convention(project.layout.buildDirectory.file(name + ".txt"))
+                }
+
+                @TaskAction
+                def action() {
+                    outputFile.get().asFile.text = name
+                }
+            }
+
+            def t1 = tasks.register("t1", MyTask)
+            def t2 = tasks.register("t2", MyTask)
+            def t3 = tasks.register("t3", MyTask)
+            def t4 = tasks.register("t4", MyTask)
+
+            tasks.register("echo") {
+                Closure<Provider<String>> outputAsText = { t -> t.flatMap { it.outputFile }.map { it.asFile.text.trim() }}
+
+                def lines = objects.listProperty(String)
+                lines.add(outputAsText(t1))
+                lines += outputAsText(t2)
+
+                def mapLines = objects.mapProperty(String, String)
+                mapLines.put("k3", outputAsText(t3))
+                mapLines += outputAsText(t4).map { [k4: it] }
+
+                inputs.property("lines", lines)
+                inputs.property("mapLines", mapLines)
+
+                doLast {
+                    lines.get().forEach {
+                        println("line: \$it")
+                    }
+                    mapLines.get().forEach { k, v ->
+                        println("mapLine: \$k=\$v")
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds("echo")
+
+        then:
+        result.assertTasksExecuted(":t1", ":t2", ":t3", ":t4", ":echo")
+        outputContains("line: t1")
+        outputContains("line: t2")
+        outputContains("mapLine: k3=t3")
+        outputContains("mapLine: k4=t4")
     }
 
     def "Groovy assignment for ConfigurableFileCollection doesn't resolve a Configuration"() {
@@ -301,6 +428,75 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         run("help")
     }
 
+    @ToBeImplemented
+    def "compound assignments work in plugins too"() {
+        given:
+        createDir("plugin") {
+            buildFile(file("build.gradle"), """
+                plugins {
+                    id "groovy"
+                    id "java-gradle-plugin"
+                }
+
+                dependencies {
+                    implementation gradleApi()
+                    implementation localGroovy()
+                }
+
+                gradlePlugin {
+                    plugins {
+                        pluginInGroovy {
+                            id = "org.example.plugin-in-groovy"
+                            implementationClass = "org.example.PluginInGroovy"
+                        }
+                    }
+                }
+            """)
+
+            file("src/main/groovy/org/example/PluginInGroovy.groovy") << """
+                package org.example
+
+                import org.gradle.api.Plugin
+                import org.gradle.api.Project
+                import org.gradle.api.provider.ListProperty
+
+                abstract class PluginInGroovy implements Plugin<Project> {
+                    abstract ListProperty<String> getStringList()
+
+                    @Override
+                    void apply(Project target) {
+                        stringList += ["a", "b"]
+
+                        target.tasks.register("printProperties") {
+                            def stringList = stringList
+                            doLast {
+                                println("stringList = \${stringList.get()}")
+                            }
+                        }
+                    }
+                }
+            """
+        }
+
+        settingsFile """
+            pluginManagement {
+                includeBuild("plugin")
+            }
+        """
+
+        buildFile """
+            plugins {
+                id("org.example.plugin-in-groovy")
+            }
+        """
+
+        expect:
+        fails("printProperties")
+
+        // TODO(mlopatkin): With the AST transformation applied globally this should succeed and print the property.
+        // outputContains("stringList = [a, b]")
+    }
+
     private void groovyBuildFile(String inputDeclaration, String inputValue, String operation) {
         buildFile.text = """
             ${groovyTypesDefinition()}
@@ -311,12 +507,16 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
                 @TaskAction
                 void run() {
-                    ${groovyInputPrintRoutine()}
+                    ${groovyInputPrintRoutine(RESULT_PREFIX, "input")}
                 }
             }
 
             tasks.register("myTask", MyTask) {
-                input $operation $inputValue
+                def result = (input $operation $inputValue)
+
+                doLast {
+                    ${groovyInputPrintRoutine(EXPRESSION_PREFIX, "result")}
+                }
             }
         """
     }
@@ -327,10 +527,11 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
             tasks.register("myTask") {
                 def input = $inputInitializer
-                input $operation $inputValue
+                def result = (input $operation $inputValue)
                 ${expectedType ? "assert input instanceof $expectedType" : ""}
                 doLast {
-                    ${groovyInputPrintRoutine()}
+                    ${groovyInputPrintRoutine(RESULT_PREFIX, "input")}
+                    ${groovyInputPrintRoutine(EXPRESSION_PREFIX, "result")}
                 }
             }
         """
@@ -354,21 +555,28 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         """
     }
 
-    private String groovyInputPrintRoutine() {
+    private String groovyInputPrintRoutine(String prefix = RESULT_PREFIX, String variable = "input") {
         """
-            if (input instanceof FileSystemLocationProperty) {
-                println("$RESULT_PREFIX" + input.map { it.asFile.name }.getOrElse("undefined"))
-            } else if (input instanceof File) {
-               println("$RESULT_PREFIX" + input.name)
-            } else if (input instanceof Provider) {
-                println("$RESULT_PREFIX" + input.map { it.toString() }.getOrElse("undefined"))
-            } else if (input instanceof FileCollection) {
-                println("$RESULT_PREFIX" + input.files.collect { it.name })
-            } else if (input instanceof Iterable) {
-                println("$RESULT_PREFIX" + input.collect { it instanceof File ? it.name : it })
+            if (${variable} instanceof FileSystemLocationProperty) {
+                println("$prefix" + ${variable}.map { it.asFile.name }.getOrElse("undefined"))
+            } else if (${variable} instanceof File) {
+               println("$prefix" + ${variable}.name)
+            } else if (${variable} instanceof Provider) {
+                println("$prefix" + ${variable}.map { it.toString() }.getOrElse("undefined"))
+            } else if (${variable} instanceof FileCollection) {
+                println("$prefix" + ${variable}.files.collect { it.name })
+            } else if (${variable} instanceof Iterable) {
+                println("$prefix" + ${variable}.collect { it instanceof File ? it.name : it })
+            } else if (${variable}?.getClass()?.isArray()) {
+                println("$prefix" + Arrays.toString(${variable}))
             } else {
-                println("$RESULT_PREFIX" + input.toString())
+                println("$prefix" + ${variable})
             }
         """
     }
+
+    private void assertExpression(def value) {
+        outputContains(EXPRESSION_PREFIX + value)
+    }
 }
+

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -243,7 +243,15 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     @Override
-    public void setFromAnyValue(Object object) {
+    public void setFromAnyValue(@Nullable Object object) {
+        if (object instanceof CompoundAssignmentResultProvider<?>) {
+            CompoundAssignmentResultProvider<?> compoundAssignmentResult = (CompoundAssignmentResultProvider<?>) object;
+            if (compoundAssignmentResult.canBeAssignedBackTo(this)) {
+                compoundAssignmentResult.assignToOwner();
+                return;
+            }
+        }
+
         if (object instanceof Provider) {
             set(Cast.<Provider<C>>uncheckedCast(object));
         } else {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyExtensions.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyExtensions.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import org.gradle.api.provider.HasMultipleValues;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.Cast;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.gradle.api.internal.lambdas.SerializableLambdas.bifunction;
+import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
+
+@SuppressWarnings("unused") // Groovy extension methods for ListProperty and SetProperty
+public final class CollectionPropertyExtensions {
+    private CollectionPropertyExtensions() {}
+
+    public static <T> Provider<Iterable<T>> plus(HasMultipleValues<T> lhs, Iterable<T> rhs) {
+        return plusImpl(Cast.uncheckedCast(lhs), rhs);
+    }
+
+    // Called for property += Iterable<T>
+    private static <T> Provider<Iterable<T>> plusImpl(AbstractCollectionProperty<T, ?> lhs, Iterable<T> rhs) {
+        return new CompoundAssignmentResultProvider<>(
+            Providers.internal(lhs.map(transformer(items -> Iterables.concat(items, rhs)))),
+            lhs,
+            () -> lhs.addAll(rhs)
+        );
+    }
+
+    // Called for:
+    // property += Provider<Iterable<T>>
+    // property += Provider<T>
+    public static <T> Provider<Iterable<T>> plus(HasMultipleValues<T> lhs, Provider<?> rhs) {
+        // Because of type erasure, we cannot have two overloads of this method for Provider<T> and Provider<Iterable<T>>.
+        return plusImpl(Cast.uncheckedCast(lhs), Providers.internal(rhs));
+    }
+
+    // Called for property += T[]
+    public static <T> Provider<Iterable<T>> plus(HasMultipleValues<T> lhs, T[] items) {
+        return plusImpl(Cast.uncheckedCast(lhs), Arrays.asList(items));
+    }
+
+    private static <T> Provider<Iterable<T>> plusImpl(AbstractCollectionProperty<T, ?> lhs, ProviderInternal<?> rhs) {
+        ProviderInternal<? extends Iterable<T>> safeProvider = toSafeProvider(rhs);
+        return new CompoundAssignmentResultProvider<>(
+            Providers.internal(lhs.zip(safeProvider, bifunction(Iterables::concat))),
+            lhs,
+            () -> lhs.addAll(safeProvider)
+        );
+    }
+
+    // Called for property += T
+    public static <T> Provider<Iterable<T>> plus(HasMultipleValues<T> lhs, T item) {
+        return plusImpl(Cast.uncheckedCast(lhs), item);
+    }
+
+    private static <T> Provider<Iterable<T>> plusImpl(AbstractCollectionProperty<T, ?> lhs, Object item) {
+        Preconditions.checkNotNull(item, "Cannot add a null element to a property of type %s.", lhs.getType().getSimpleName());
+        Preconditions.checkArgument(
+            lhs.getElementType().isInstance(item),
+            "Cannot add an element of type %s to a property of type %s<%s>.",
+            item.getClass().getSimpleName(),
+            lhs.getType().getSimpleName(),
+            lhs.getElementType().getSimpleName());
+        T safeItem = lhs.getElementType().cast(item);
+
+        return new CompoundAssignmentResultProvider<>(
+            Providers.internal(lhs.map(transformer(thisItems -> Iterables.concat(thisItems, Collections.singleton(safeItem))))),
+            lhs,
+            () -> lhs.add(safeItem)
+        );
+    }
+
+    private static <T> ProviderInternal<? extends Iterable<T>> toSafeProvider(Provider<?> provider) {
+        ProviderInternal<?> internal = Providers.internal(provider);
+        if (isProviderOfIterable(internal)) {
+            // This is definitely a provider of iterable, it can be used as is.
+            return Cast.uncheckedCast(internal);
+        }
+        // May still be provider of iterable, but we'll only know after it is computed.
+        return internal.map(transformer(value -> {
+            if (value instanceof Iterable) {
+                return Cast.<Iterable<T>>uncheckedCast(value);
+            }
+            return Collections.singleton(Cast.uncheckedCast(value));
+        }));
+    }
+
+    private static boolean isProviderOfIterable(ProviderInternal<?> internal) {
+        Class<?> type = internal.getType();
+        return type != null && Iterable.class.isAssignableFrom(type);
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CompoundAssignmentResultProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CompoundAssignmentResultProvider.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import com.google.common.base.Preconditions;
+import org.gradle.api.internal.provider.support.CompoundAssignmentValue;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * A result of applying an operator (so far only {@code +}) to ListProperty, MapProperty or SetProperty.
+ * Allows assigning itself back to the property without causing circular evaluation failure if it is produced by the compound assignment operator {@code +=}.
+ */
+public final class CompoundAssignmentResultProvider<T> extends AbstractMinimalProvider<T> implements CompoundAssignmentValue {
+    private final ProviderInternal<T> value;
+    private boolean canBeAssignedBack;
+    @Nullable
+    private Object owner;
+    @Nullable
+    private Runnable assignToOwnerAction;
+
+    /**
+     * Creates the result for {@code owner <OP> rhs} operation.
+     *
+     * @param value the intermediate value of the operation, used when LHS is a variable or non-Gradle enhanced property
+     * @param owner the LHS operand of the compound operation
+     * @param assignToOwnerAction the mutation of the owner
+     */
+    public CompoundAssignmentResultProvider(ProviderInternal<T> value, Object owner, Runnable assignToOwnerAction) {
+        this.value = value;
+        this.owner = owner;
+        this.assignToOwnerAction = Objects.requireNonNull(assignToOwnerAction);
+    }
+
+    public boolean canBeAssignedBackTo(Object target) {
+        // It might be that this object is used outside its originating assignment expression, in which case it is considered a normal provider.
+        return canBeAssignedBack && target == owner;
+    }
+
+    public void assignToOwner() {
+        Runnable action = assignToOwnerAction;
+        Preconditions.checkState(action != null, "The property is already consumed by the owner");
+        action.run();
+        assignmentCompleted();
+    }
+
+    @Override
+    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+        return value.calculateValue(consumer);
+    }
+
+    @Override
+    public boolean calculatePresence(ValueConsumer consumer) {
+        return value.calculatePresence(consumer);
+    }
+
+    @Override
+    public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+        return value.calculateExecutionTimeValue();
+    }
+
+    @Nullable
+    @Override
+    public Class<T> getType() {
+        return value.getType();
+    }
+
+    @Override
+    public ValueProducer getProducer() {
+        return value.getProducer();
+    }
+
+    @Override
+    protected String toStringNoReentrance() {
+        return value.toString();
+    }
+
+    @Override
+    public void prepareForAssignment() {
+        // We are part of the compound assignment and not just some standalone (prop `+` value).
+        canBeAssignedBack = true;
+    }
+
+    @Override
+    public void assignmentCompleted() {
+        // When the expression involves a variable on the left side as opposed to a field, then this provider becomes its value.
+        // It must lose all "magical" properties towards its owner, because it may be used to set its value outside the original expression.
+        canBeAssignedBack = false;
+        // Clean up stuff we no longer need to let GC collect them.
+        owner = null;
+        assignToOwnerAction = null;
+    }
+
+    @Override
+    public boolean shouldReplaceResultWithNull() {
+        // Disallow using prop += ... as a subexpression to mimic Kotlin.
+        return true;
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -145,9 +145,18 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     @SuppressWarnings("unchecked")
     public void setFromAnyValue(@Nullable Object object) {
         if (object == null || object instanceof Map<?, ?>) {
-            set((Map) object);
-        } else if (object instanceof Provider<?>) {
-            set((Provider) object);
+            set((Map<K, V>) object);
+            return;
+        }
+        if (object instanceof CompoundAssignmentResultProvider<?>) {
+            CompoundAssignmentResultProvider<?> compoundAssignmentResult = (CompoundAssignmentResultProvider<?>) object;
+            if (compoundAssignmentResult.canBeAssignedBackTo(this)) {
+                compoundAssignmentResult.assignToOwner();
+                return;
+            }
+        }
+        if (object instanceof Provider<?>) {
+            set((Provider<Map<K, V>>) object);
         } else {
             throw new IllegalArgumentException(String.format(
                 "Cannot set the value of a property of type %s using an instance of type %s.", Map.class.getName(), object.getClass().getName()));

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapPropertyExtensions.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapPropertyExtensions.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.internal.provider.support.CompoundAssignmentSupport;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 
@@ -88,6 +89,10 @@ public class MapPropertyExtensions {
     }
 
     public static <K, V> Provider<Map<K, V>> plus(MapProperty<K, V> lhs, Map<K, V> rhs) {
+        if (!CompoundAssignmentSupport.isEnabled()) {
+            throw new UnsupportedOperationException("Cannot call plus() on MapProperty");
+        }
+
         return new CompoundAssignmentResultProvider<>(
             Providers.internal(lhs.map(transformer(left -> concat(left, rhs)))),
             lhs,
@@ -96,6 +101,10 @@ public class MapPropertyExtensions {
     }
 
     public static <K, V> Provider<Map<K, V>> plus(MapProperty<K, V> lhs, Provider<? extends Map<K, V>> rhs) {
+        if (!CompoundAssignmentSupport.isEnabled()) {
+            throw new UnsupportedOperationException("Cannot call plus() on MapProperty");
+        }
+
         return new CompoundAssignmentResultProvider<>(
             Providers.internal(lhs.zip(rhs, bifunction(MapPropertyExtensions::concat))),
             lhs,

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/CompoundAssignmentSupport.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/CompoundAssignmentSupport.java
@@ -45,7 +45,13 @@ import javax.annotation.Nullable;
  */
 @SuppressWarnings("unused") // references are produced by the AST transform
 public final class CompoundAssignmentSupport {
+    public static final String FEATURE_FLAG_NAME = "org.gradle.internal.groovy-compound-assignment-enabled";
+
     private CompoundAssignmentSupport() {}
+
+    public static boolean isEnabled() {
+        return Boolean.getBoolean(FEATURE_FLAG_NAME);
+    }
 
     /**
      * Adjusts the result of the compound operation before assigning it to LHS by calling {@link CompoundAssignmentValue#prepareForAssignment()}.
@@ -61,7 +67,7 @@ public final class CompoundAssignmentSupport {
      */
     @Nullable
     public static <T> T forCompoundAssignment(@Nullable T compoundValue) {
-        if (compoundValue instanceof CompoundAssignmentValue) {
+        if (isEnabled() && compoundValue instanceof CompoundAssignmentValue) {
             ((CompoundAssignmentValue) compoundValue).prepareForAssignment();
         }
         return compoundValue;
@@ -83,7 +89,7 @@ public final class CompoundAssignmentSupport {
      */
     @Nullable
     public static <T> T finishCompoundAssignment(@Nullable T compoundValue) {
-        if (compoundValue instanceof CompoundAssignmentValue) {
+        if (isEnabled() && compoundValue instanceof CompoundAssignmentValue) {
             CompoundAssignmentValue value = (CompoundAssignmentValue) compoundValue;
             value.assignmentCompleted();
             return value.shouldReplaceResultWithNull() ? null : compoundValue;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/CompoundAssignmentSupport.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/CompoundAssignmentSupport.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.support;
+
+import javax.annotation.Nullable;
+
+/**
+ * Support for special protocol of compound assignments ({@code +=}, {@code -=}, etc.) handling in Groovy.
+ * <p>
+ * Unlike Kotlin, Groovy doesn't allow overloading the compound assignment operators.
+ * One has to rely on overloading the non-assignment part, i.e. {@code +} for {@code +=} when implementing that.
+ * For example, Groovy always treats {@code a += b} as {@code a = a + b}.
+ * <p>
+ * Gradle applies a source transformation to separate these two expressions.
+ * The compound assignment {@code LHS <OP>= RHS} is transformed into:
+ * <pre>
+ *     CompoundAssignmentSupport.finishCompoundAssignment(
+ *         LHS = CompoundAssignmentSupport.forCompoundAssignment(LHS &lt;OP&gt; RHS)
+ *     )
+ * </pre>
+ * If the result of {@code LHS <OP> RHS} implements {@link CompoundAssignmentValue}, then its lifecycle methods are invoked.
+ * {@code LHS} is reassigned with the value returned by {@link #forCompoundAssignment(Object)}.
+ * However, the result of the expression may be different if {@link #finishCompoundAssignment(Object)} replaces it.
+ * <p>
+ * <b>Important</b>: to opt into the custom protocol, this interface must be implemented by the result of the operator, not by the left-hand side operand.
+ * <p>
+ * <b>API stability:</b> this should be considered public API, changes should be binary compatible.
+ * Plugins written in Groovy may contain references to the methods of this class.
+ * <p>
+ * See {@code org.gradle.groovy.scripts.internal.CompoundAssignmentTransformer} for the actual transformation.
+ */
+@SuppressWarnings("unused") // references are produced by the AST transform
+public final class CompoundAssignmentSupport {
+    private CompoundAssignmentSupport() {}
+
+    /**
+     * Adjusts the result of the compound operation before assigning it to LHS by calling {@link CompoundAssignmentValue#prepareForAssignment()}.
+     * The returned value is assigned to LHS either directly (if it is a variable or a property of non-enhanced type), or by calling {@link LazyGroovySupport#setFromAnyValue(Object)}.
+     * <p>
+     * Because of limitations of the AST transformation, it transforms all compound assignments in code regardless of type.
+     * Thus, the value may not implement SupportsCompoundAssignment.
+     * In this case nothing happens and the value is returned unchanged.
+     *
+     * @param compoundValue the value produced by operator
+     * @param <T> the type of the value, to keep the static type checker happy
+     * @return the argument
+     */
+    @Nullable
+    public static <T> T forCompoundAssignment(@Nullable T compoundValue) {
+        if (compoundValue instanceof CompoundAssignmentValue) {
+            ((CompoundAssignmentValue) compoundValue).prepareForAssignment();
+        }
+        return compoundValue;
+    }
+
+    /**
+     * Called after assignment is completed to produce the value for the enclosing expression.
+     * Calls {@link CompoundAssignmentValue#assignmentCompleted()}.
+     * If the compound assignment was a sub-expression, this method may replace its value to {@code null}
+     * if {@link CompoundAssignmentValue#shouldReplaceResultWithNull()} is {@code false}.
+     *
+     * Because of limitations of the AST transformation, it transforms all compound assignments in code regardless of type.
+     * Thus, the value may not implement SupportsCompoundAssignment.
+     * In this case nothing happens and the value is returned unchanged.
+     *
+     * @param compoundValue the value produced by operator
+     * @param <T> the type of the value, to keep the static type checker happy
+     * @return the argument
+     */
+    @Nullable
+    public static <T> T finishCompoundAssignment(@Nullable T compoundValue) {
+        if (compoundValue instanceof CompoundAssignmentValue) {
+            CompoundAssignmentValue value = (CompoundAssignmentValue) compoundValue;
+            value.assignmentCompleted();
+            return value.shouldReplaceResultWithNull() ? null : compoundValue;
+        }
+        return compoundValue;
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/CompoundAssignmentValue.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/CompoundAssignmentValue.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.support;
+
+/**
+ * The return value of {@code a <OP> b} that supports custom protocol when used in the compound assignment operation, i.e. {@code a <OP>= b}.
+ */
+public interface CompoundAssignmentValue {
+    /**
+     * Called right before assigning this value to the target of the compound assignment.
+     */
+    void prepareForAssignment();
+
+    /**
+     * Called after this value has been assigned to the target of the compound assignment.
+     */
+    void assignmentCompleted();
+
+    /**
+     * Whether the value of the compound assignment expression should be replaced with null.
+     * This <b>DOES NOT</b> affect the value assigned to the target of the compound assignment.
+     *
+     * @return {@code true} if the compound assignment expression should return null as its value
+     */
+    boolean shouldReplaceResultWithNull();
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/LazyGroovySupport.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/LazyGroovySupport.java
@@ -20,6 +20,8 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.instantiation.generator.AsmBackedClassGenerator;
 
+import javax.annotation.Nullable;
+
 /**
  * An interface used to support lazy assignment for types like {@link Property} and {@link ConfigurableFileCollection} in Groovy DSL.
  * Call to this interface is generated via {@link AsmBackedClassGenerator}.
@@ -29,5 +31,5 @@ public interface LazyGroovySupport {
     /**
      * Sets the value from some arbitrary object. Used from the Groovy DSL.
      */
-    void setFromAnyValue(Object object);
+    void setFromAnyValue(@Nullable Object object);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/package-info.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes and interfaces that help provide syntactic sugar for Providers and Properties.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.api.internal.provider.support;

--- a/platforms/core-configuration/model-core/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/platforms/core-configuration/model-core/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -16,4 +16,4 @@
 
 moduleName=model-core
 moduleVersion=1.0
-extensionClasses=org.gradle.api.internal.provider.MapPropertyExtensions
+extensionClasses=org.gradle.api.internal.provider.MapPropertyExtensions,org.gradle.api.internal.provider.CollectionPropertyExtensions

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CompoundAssignmentPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CompoundAssignmentPropertySpec.groovy
@@ -17,12 +17,15 @@
 package org.gradle.api.internal.provider
 
 import groovy.transform.CompileStatic
+import org.gradle.api.internal.provider.support.CompoundAssignmentSupport
 import org.gradle.api.internal.provider.support.LazyGroovySupport
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.internal.evaluation.CircularEvaluationException
+import org.gradle.util.SetSystemProperties
+import org.junit.Rule
 import spock.lang.Specification
 
 @TransformCompoundAssignments
@@ -38,6 +41,9 @@ abstract class CompoundAssignmentPropertySpec<P extends Provider<?>, T extends L
     abstract def asValue(def v)
 
     abstract def addValue(P property, String v)
+
+    @Rule
+    SetSystemProperties systemProperties = new SetSystemProperties((CompoundAssignmentSupport.FEATURE_FLAG_NAME): "true")
 
     class Origin {
         protected T value = propertyImpl()

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CompoundAssignmentPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CompoundAssignmentPropertySpec.groovy
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import groovy.transform.CompileStatic
+import org.gradle.api.internal.provider.support.LazyGroovySupport
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import org.gradle.internal.evaluation.CircularEvaluationException
+import spock.lang.Specification
+
+@TransformCompoundAssignments
+abstract class CompoundAssignmentPropertySpec<P extends Provider<?>, T extends LazyGroovySupport & P> extends Specification {
+    protected PropertyHost host = Mock()
+
+    abstract T propertyImpl()
+
+    P property() { propertyImpl() }
+
+    abstract def value(String v)
+
+    abstract def asValue(def v)
+
+    abstract def addValue(P property, String v)
+
+    class Origin {
+        protected T value = propertyImpl()
+
+        P getValue() { value }
+
+        void setValue(def v) {
+            // This simulates what the AsmBackedClassGenerator does.
+            value.setFromAnyValue(v)
+        }
+    }
+
+    Origin newOrigin() { new Origin() }
+
+    def "compound operand can be applied to property"() {
+        given:
+        def lhs = new Origin()
+
+        expect:
+        (lhs.value += value("a")) == null
+        asValue(lhs.value.get()) == value("a")
+    }
+
+    def "compound operand can be applied to variable"() {
+        given:
+        def lhs = property()
+
+        expect:
+        (lhs += value("a")) == null
+        asValue(lhs.get()) == value("a")
+    }
+
+    def "updating the variable with compound operand does not change the property value"() {
+        // The in-place update magic only kicks in when LHS is a property of something.
+        // The plain assignment follows the same rule.
+        given:
+        def origin = property()
+        addValue(origin, "a")
+        def lhs = origin
+
+        when:
+        lhs += value("b")
+
+        then:
+        asValue(lhs.get()) == value("a") + value("b")
+        asValue(origin.get()) == value("a")
+    }
+
+    def "variable updated with compound operand tracks lhs updates"() {
+        given:
+        def origin = new Origin()
+        def lhs = origin.value
+
+        when:
+        lhs += value("a")
+        addValue(origin.value, "b")
+
+        then:
+        // note that lhs += "a" results in lhs + ["a"], so adding "b" to lhs effectively prepends it to the result.
+        asValue(lhs.get()) == value("b") + value("a")
+    }
+
+    def "special compound handling only applies inside the compound assignment expression"() {
+        // It is possible to snatch the result of the compound assignment and assign it back to the LHS property instance outside of += expression.
+        given:
+        def origin = new Origin()
+        def lhs = origin.value
+        lhs += value("a")
+        origin.value = lhs
+
+        when:
+        origin.value.get()
+
+        then:
+        thrown(CircularEvaluationException)
+    }
+
+    def "special compound handling does not apply to sums"() {
+        given:
+        def origin = new Origin()
+        def sum = origin.value + value("a")
+        origin.value = sum
+
+        when:
+        origin.value.get()
+
+        then:
+        thrown(CircularEvaluationException)
+    }
+
+    @TransformCompoundAssignments
+    static class CompoundAssignmentListPropertyTest extends CompoundAssignmentPropertySpec<ListProperty<String>, DefaultListProperty<String>> {
+        class ListOrigin extends Origin {
+            @Override
+            ListProperty<String> getValue() {
+                return super.getValue() as ListProperty<String>
+            }
+        }
+
+        @Override
+        ListOrigin newOrigin() { new ListOrigin() }
+
+        @Override
+        DefaultListProperty<String> propertyImpl() { new DefaultListProperty<>(host, String) }
+
+        @Override
+        def value(String v) { [v] }
+
+        @Override
+        def asValue(def result) { result as List<String> }
+
+        @Override
+        def addValue(ListProperty<String> property, String v) { property.add(v) }
+
+        // Static compilation doesn't allow us to have these tests in the parent test suite.
+        // For brevity, we're only testing these with ListProperty.
+        @CompileStatic
+        def staticCompilationWorksWithVariables() {
+            def p = property()
+
+            def v = (p += ["a"])
+            return [v, p]
+        }
+
+        def "compound assignment works with variables and static compilation"() {
+            when:
+            def (v, p) = staticCompilationWorksWithVariables()
+
+            then:
+            v == null
+            asValue(p.get()) == ["a"]
+        }
+
+        @CompileStatic
+        def staticCompilationWorksWithProperties() {
+            def origin = newOrigin()
+
+            def v = (origin.value += ["a"])
+            return [v, origin.value]
+        }
+
+        def "compound assignment works with properties and static compilation"() {
+            when:
+            def (v, p) = staticCompilationWorksWithProperties()
+
+            then:
+            v == null
+            asValue(p.get()) == ["a"]
+        }
+    }
+
+    static class CompoundAssignmentSetPropertyTest extends CompoundAssignmentPropertySpec<SetProperty<String>, DefaultSetProperty<String>> {
+        @Override
+        DefaultSetProperty<String> propertyImpl() { new DefaultSetProperty<>(host, String) }
+
+        @Override
+        def value(String v) { [v] }
+
+        @Override
+        def asValue(def result) { result as List<String> }
+
+        @Override
+        def addValue(SetProperty<String> property, String v) { property.add(v) }
+    }
+
+    static class CompoundAssignmentMapPropertyTest extends CompoundAssignmentPropertySpec<MapProperty<String, String>, DefaultMapProperty<String, String>> {
+        @Override
+        DefaultMapProperty<String, String> propertyImpl() { new DefaultMapProperty<>(host, String, String) }
+
+        @Override
+        def value(String v) { [(v): v] }
+
+        @Override
+        def asValue(def result) { result as Map<String, String> }
+
+        @Override
+        def addValue(MapProperty<String, String> property, String v) { property.put(v, v) }
+    }
+}

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CompoundAssignmentUnrelatedSpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CompoundAssignmentUnrelatedSpec.groovy
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import groovy.transform.CompileStatic
+import spock.lang.Specification
+
+/**
+ * This test verifies that the source transformation doesn't break types that do not support the custom compound assignment protocol.
+ */
+@TransformCompoundAssignments
+class CompoundAssignmentUnrelatedSpec extends Specification {
+    class Origin {
+        int intVal = 1
+        List<String> listVal = []
+    }
+
+    def "compound assignment works for integer variables"() {
+        given:
+        int i = 1
+
+        when:
+        def v = (i += 2)
+
+        then:
+        v == 3
+        i == 3
+    }
+
+    def "compound assignment works for integer properties"() {
+        given:
+        def origin = new Origin()
+
+        when:
+        def v = (origin.intVal += 2)
+
+        then:
+        v == 3
+        origin.intVal == 3
+    }
+
+    def "compound assignment works for list variables"() {
+        given:
+        def list = ["a"]
+
+        when:
+        def v = (list += ["b"])
+
+        then:
+        v == ["a", "b"]
+        list == ["a", "b"]
+        v === list
+    }
+
+    def "compound assignment works for list properties"() {
+        given:
+        def origin = new Origin()
+
+        when:
+        def v = (origin.listVal += ["a"])
+
+        then:
+        v == ["a"]
+        origin.listVal == ["a"]
+        origin.listVal === v
+    }
+
+    @CompileStatic
+    def intVarCompoundAssignment() {
+        int i = 1
+        def v = (i += 2)
+
+        return [i, v]
+    }
+
+    def "compound assignment works for integer variables with static typing"() {
+        given:
+        def (i, v) = intVarCompoundAssignment()
+
+        expect:
+        v == 3
+        i == 3
+    }
+
+    @CompileStatic
+    def intPropCompoundAssignment() {
+        def origin = new Origin()
+        def v = (origin.intVal += 2)
+        return [origin.intVal, v]
+    }
+
+    def "compound assignment works for integer properties with static typing"() {
+        given:
+        def (i, v) = intPropCompoundAssignment()
+
+        expect:
+        v == 3
+        i == 3
+    }
+
+    @CompileStatic
+    def listVarCompoundAssignment() {
+        def list = ["a"]
+        def v = (list += ["b"])
+
+        return [list, v]
+    }
+
+    def "compound assignment works for list variables with static typing"() {
+        given:
+        def (i, v) = listVarCompoundAssignment()
+
+        expect:
+        v == ["a", "b"]
+        i == ["a", "b"]
+        v === i
+    }
+
+    @CompileStatic
+    def listPropCompoundAssignment() {
+        def origin = new Origin()
+        def v = (origin.listVal += ["a"])
+        return [origin.listVal, v]
+    }
+
+    def "compound assignment works for list properties with static typing"() {
+        given:
+        def (i, v) = listPropCompoundAssignment()
+
+        expect:
+        v == ["a"]
+        i == ["a"]
+        v === i
+    }
+}

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CompoundAssignmentUnrelatedSpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CompoundAssignmentUnrelatedSpec.groovy
@@ -17,6 +17,9 @@
 package org.gradle.api.internal.provider
 
 import groovy.transform.CompileStatic
+import org.gradle.api.internal.provider.support.CompoundAssignmentSupport
+import org.gradle.util.SetSystemProperties
+import org.junit.Rule
 import spock.lang.Specification
 
 /**
@@ -28,6 +31,9 @@ class CompoundAssignmentUnrelatedSpec extends Specification {
         int intVal = 1
         List<String> listVal = []
     }
+
+    @Rule
+    SetSystemProperties systemProperties = new SetSystemProperties((CompoundAssignmentSupport.FEATURE_FLAG_NAME): "true")
 
     def "compound assignment works for integer variables"() {
         given:

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/CompoundAssignmentTransformInTest.java
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/CompoundAssignmentTransformInTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+import org.gradle.api.internal.provider.support.CompoundAssignmentValue;
+import org.gradle.groovy.scripts.internal.CompoundAssignmentTransformer;
+
+/**
+ * Applies compound operation transformer to a class or a method.
+ *
+ * @see TransformCompoundAssignments
+ * @see CompoundAssignmentValue
+ */
+@SuppressWarnings("unused")  // Applied by TransformCompoundAssignments annotation.
+@GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
+public class CompoundAssignmentTransformInTest implements ASTTransformation {
+    @Override
+    public void visit(ASTNode[] nodes, SourceUnit source) {
+        new CompoundAssignmentTransformer().call(nodes[1], source);
+    }
+}

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/TransformCompoundAssignments.java
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/TransformCompoundAssignments.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.codehaus.groovy.transform.GroovyASTTransformationClass;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Applies the compound assignment transformation to a body of a unit test class/method.
+ * Useful for testing the assignment protocol.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@GroovyASTTransformationClass("org.gradle.api.internal.provider.CompoundAssignmentTransformInTest")
+public @interface TransformCompoundAssignments {}

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScriptTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScriptTransformer.java
@@ -53,6 +53,7 @@ public class BuildScriptTransformer implements Transformer, Factory<BuildScriptD
         new StatementLabelsScriptTransformer().register(compilationUnit);
         new ModelBlockTransformer(scriptSource.getDisplayName(), scriptSource.getResource().getLocation().getURI()).register(compilationUnit);
         imperativeStatementDetectingTransformer.register(compilationUnit);
+        new CompoundAssignmentTransformer().register(compilationUnit);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/CompoundAssignmentTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/CompoundAssignmentTransformer.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts.internal;
+
+import com.google.common.collect.ImmutableMap;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.Phases;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.syntax.Token;
+import org.codehaus.groovy.syntax.Types;
+import org.gradle.api.internal.provider.support.CompoundAssignmentSupport;
+
+import java.util.Map;
+
+/**
+ * Rewrites some compound assignment expressions, like {@code +=}, in a way they can be intercepted at runtime and a custom behavior applied.
+ *
+ * @see CompoundAssignmentSupport
+ */
+public class CompoundAssignmentTransformer extends AbstractScriptTransformer {
+    @Override
+    protected int getPhase() {
+        return Phases.CANONICALIZATION;
+    }
+
+    @Override
+    public void call(SourceUnit source) throws CompilationFailedException {
+        CompoundAssignmentExpressionRewriter visitor = new CompoundAssignmentExpressionRewriter(source);
+        source.getAST().getStatementBlock().visit(visitor);
+        source.getAST().getClasses().forEach(visitor::visitClass);
+        source.getAST().getMethods().forEach(visitor::visitMethod);
+    }
+
+    /**
+     * Transforms a single AST node. This is useful for unit tests that want to apply the transform.
+     *
+     * @param node the ClassNode or the MethodNode
+     * @param source the source unit in which the AST node resides
+     * @throws CompilationFailedException if the transformation cannot be applied.
+     */
+    public void call(ASTNode node, SourceUnit source) throws CompilationFailedException {
+        CompoundAssignmentExpressionRewriter visitor = new CompoundAssignmentExpressionRewriter(source);
+        if (node instanceof ClassNode) {
+            visitor.visitClass((ClassNode) node);
+        } else if (node instanceof MethodNode) {
+            visitor.visitMethod((MethodNode) node);
+        } else {
+            throw new IllegalArgumentException("Cannot apply the transformation to node " + node + " of type " + node.getClass());
+        }
+    }
+
+    private static class CompoundAssignmentExpressionRewriter extends ClassCodeExpressionTransformer {
+        // This only includes operators we want to transform.
+        // TODO(mlopatkin): ConfigurableFileCollections support `-`, so they should probably support `-=` too.
+        private static final Map<String, Integer> COMPOUND_TO_OPERATOR = ImmutableMap.of(
+            "+=", Types.PLUS
+        );
+        private final SourceUnit sourceUnit;
+
+        public CompoundAssignmentExpressionRewriter(SourceUnit sourceUnit) {
+            this.sourceUnit = sourceUnit;
+        }
+
+        @Override
+        public Expression transform(Expression expr) {
+            Expression transformedExpr = super.transform(expr);
+            if (transformedExpr instanceof BinaryExpression) {
+                return transformBinaryExpression((BinaryExpression) transformedExpr);
+            }
+            if (transformedExpr instanceof ClosureExpression) {
+                // Closure expression contains code, but ClosureExpression.transform doesn't descend into it.
+                ClosureExpression closureExpression = (ClosureExpression) transformedExpr;
+                closureExpression.visit(this);
+            }
+            return transformedExpr;
+        }
+
+        private Expression transformBinaryExpression(BinaryExpression expr) {
+            String operation = expr.getOperation().getText();
+            Integer compoundOpType = COMPOUND_TO_OPERATOR.get(operation);
+            if (compoundOpType != null) {
+                return transformCompoundAssignment(expr, compoundOpType);
+            }
+            return expr;
+        }
+
+        /**
+         * Rewrites {@code foo <OP>= bar} into {@code CompoundAssignmentSupport.unwrapCompoundAssignment(foo = CompoundAssignmentSupport.forCompoundAssignment(foo <OP> bar))}.
+         *
+         * @param original the original compound assignment expression
+         * @param compoundOperation the added operation of assignment ({@code OP})
+         * @return the transformed expression
+         */
+        private Expression transformCompoundAssignment(BinaryExpression original, int compoundOperation) {
+            Expression lhs = original.getLeftExpression();
+            Expression rhs = original.getRightExpression();
+
+            if (!isValidDestination(lhs)) {
+                // Skip array element assignments and the likes?
+                return original;
+            }
+
+            // This transformation is not the easiest one to deal with. It aims at several goals:
+            // 1. The transformed code should preserve runtime behavior - for example, do not call `getFoo` twice when it is a property.
+            // 2. The transformed code should be expressible in plain Groovy - it should not use constructs not allowed by language, like TemporaryVariableExpression.
+            //    These are black magic and cause unwanted side effects when used with other AST transformations like Spock or even @CompileStatic.
+            //    Our attempts to use them either caused VerificationErrors or required tight coupling with Groovy compiler internals.
+            // 3. The transformed code should support static compilation.
+
+            // foo <OP>= bar -> foo = CompoundAssignmentSupport.forCompoundAssignment(foo <OP> bar)
+            BinaryExpression assignment = withSourceLocationOf(original, new BinaryExpression(
+                lhs,
+                rewriteToken(original.getOperation(), Types.ASSIGN),
+                markForAssignment(
+                    withSourceLocationOf(original, new BinaryExpression(
+                        lhs,
+                        rewriteToken(original.getOperation(), compoundOperation),
+                        rhs
+                    ))
+                )
+            ));
+
+            // foo = ... -> CompoundAssignmentSupport.finishCompoundAssignment(foo = ...)
+            return finishAssignment(assignment);
+        }
+
+        /**
+         * Builds a new token from the original, keeping the source position.
+         *
+         * @param originalOperation the original operation token
+         * @param newType the new token type
+         * @return the new token
+         */
+        private Token rewriteToken(Token originalOperation, int newType) {
+            return Token.newSymbol(newType, originalOperation.getStartLine(), originalOperation.getStartColumn());
+        }
+
+        private Expression markForAssignment(Expression expr) {
+            return callSupportMethodOn("forCompoundAssignment", expr);
+        }
+
+        private Expression finishAssignment(Expression expr) {
+            return callSupportMethodOn("finishCompoundAssignment", expr);
+        }
+
+        private Expression callSupportMethodOn(String methodName, Expression argument) {
+            return withSourceLocationOf(argument, new StaticMethodCallExpression(ClassHelper.make(CompoundAssignmentSupport.class), methodName, new ArgumentListExpression(argument)));
+        }
+
+        private static boolean isValidDestination(Expression expr) {
+            // We only rewrite compound assignments to non-primitive variables and properties.
+            if (expr instanceof VariableExpression) {
+                return !isPrimitiveVariable((VariableExpression) expr);
+            } else {
+                return expr instanceof PropertyExpression;
+            }
+        }
+
+        private static boolean isPrimitiveVariable(VariableExpression expr) {
+            return ClassHelper.isPrimitiveType(expr.getOriginType());
+        }
+
+        private static <T extends Expression> T withSourceLocationOf(Expression original, T transformed) {
+            transformed.setSourcePosition(original);
+            return transformed;
+        }
+
+        @Override
+        protected SourceUnit getSourceUnit() {
+            return sourceUnit;
+        }
+    }
+}

--- a/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
@@ -463,7 +463,6 @@ Class <org.gradle.api.internal.provider.sources.process.ProcessOutputValueSource
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleBaseExecSpec> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProviderCompatibleBaseExecSpec.java:0)
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleExecSpec> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProviderCompatibleExecSpec.java:0)
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleJavaExecSpec> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ProviderCompatibleJavaExecSpec.java:0)
-Class <org.gradle.api.internal.provider.support.LazyGroovySupport> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (LazyGroovySupport.java:0)
 Class <org.gradle.api.internal.resolve.DefaultLocalLibraryResolver> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (DefaultLocalLibraryResolver.java:0)
 Class <org.gradle.api.internal.resolve.DefaultProjectModelResolver> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (DefaultProjectModelResolver.java:0)
 Class <org.gradle.api.internal.resolve.LibraryResolutionErrorMessageBuilder> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (LibraryResolutionErrorMessageBuilder.java:0)


### PR DESCRIPTION
### += support for some lazy types in Groovy build scripts
This also introduces a limited support for `+` when a collection property is on left-hand side. Unlike Kotlin, implementing only `+=` is significantly more involved because of the Groovy overloading restrictions. Groovy only supports overloading of +, and uses it to implement +=, by basically rewriting `a += b` into `a = a + b`. A naive implementation of plus operator (e.g. `a.zip(b) { l1, l2 -> l1 + l2 }`) is likely to cause a self-referencing chain to happen. While this can also be solved upon assignment, we don't really want users to have "action-at-distance" when you can set `c = a + b`, and, a thousand lines
after, happily assign `a = c` and get some strange results. The latter should cause circular evaluation failure.

In order to support `+=`, and not arbitrary self-referencing `+` expressions, we employ an AST transformation. It rewrites `+=` expressions and adds interception point, so the sum can be adjusted to temporarily allow assigning it back to the target without causing the circular evaluation error. We've investigated several other transformations, but this one plays well with Groovy's static typing and doesn't leak too much types into the generated code.

Again, unlike Kotlin, the += is an expression in Groovy. To make both DSLs consistent, the value of += expression involving Properties is `null`. While it is still possible to write `foo = (a += b)` in Groovy, it is now rather pointless thing to do. All my attempts to give this expression some sensible value (e.g. return lhs operand or a shallow copy) faced different complicated corner cases.

The implementation for FileCollections mostly follows the implementation in the collection properties. One difference is that because it was possible to write expressions with `+=` already (for variables), we cannot apply the same null replacement without breaking compatibility.

### Feature flag
In order to be able to ship this in 8.14, a simple feature flag is added. The AST transform runs unconditionally, but all runtime behavior is gated behind the flag. I don't use `InternalFlag` intentionally because it requires `InternalOptions` to be passed around, and it is hard to obtain out-of-thin-air.

We'll remove the flag when we define the proper semantics for `+=`.

### Changes since [the previous attempt](https://github.com/gradle/gradle/pull/32287)
* There is no compound assignment stand in, `plus()` is invoked directly on the Property. If we want to support plus on providers in general, we'll have to have it anyway. There is no more `wrap(lhs)` call.
* The sum (`lhs + rhs`) then goes through the "preparation" call that allows it to be assigned back to the Property. The sum still has to be a custom type. 
* The "unwrap" call is now called `finishCompoundAssignment`, but works mostly the same. However, instead of asking the sum to give the expression value, it only allows replacing it with `null`. This is mostly to please the static checker, to make all methods return the same type.
* Added new tests for `@CompileStatic`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
