### PR TITLE
Explicitly enable toolchain download in JavaApplicationInitSoakTest

### DIFF
--- a/testing/soak/src/integTest/groovy/org/gradle/buildinit/JavaApplicationInitSoakTest.groovy
+++ b/testing/soak/src/integTest/groovy/org/gradle/buildinit/JavaApplicationInitSoakTest.groovy
@@ -31,8 +31,7 @@ class JavaApplicationInitSoakTest extends AbstractIntegrationSpec {
         succeeds('init', '--type', 'java-application', '--dsl', 'groovy')
 
         and:
-        executer.withArgument("-Porg.gradle.java.installations.auto-detect=false")
-        executer.withArgument("-Porg.gradle.java.installations.auto-download=true")
+        executer.withToolchainDownloadEnabled()
         succeeds('run')
 
         then:


### PR DESCRIPTION
By default, `AbstractGradleExecuter` has `disableToolchainDownload=true` and `disableToolchainDetection=true`, which results a weird param list for `JavaApplicationInitSoakTest`:

```
cmd.exe [/d, /c, "gradle ... -Porg.gradle.java.installations.auto-download=false -Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.auto-download=true ...]
```

I.e. `org.gradle.java.installations.auto-detect=false` is duplicate, while `Porg.gradle.java.installations.auto-download=false` and `Porg.gradle.java.installations.auto-download=true` are conflicting.

This PR explicitly enables  toolchain downloading. It's part of soak test so it only runs once per day.