### PR TITLE
Add StackTraceLocation for problems API

### DIFF
--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/problems/StackTraceLocation.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/problems/StackTraceLocation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.operations.problems;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * A stack trace for the location of a problem.
+ * <p>
+ * For example, the stacktrace of a direct deprecation warning.
+ *
+ * @since 8.14
+ */
+public interface StackTraceLocation extends ProblemLocation {
+
+    /**
+     * The source file location inferred from the stacktrace.
+     * <p>
+     * Most of the time, this is a location in a build file.
+     * {@code null} if the source file location could not be inferred.
+     *
+     * @since 8.14
+     */
+    @Nullable
+    FileLocation getFileLocation();
+
+    /**
+     * The stack trace elements that lead to the problem.
+     *
+     * @since 8.14
+     */
+    List<StackTraceElement> getStackTrace();
+
+}

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsApiBuildOperationIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsApiBuildOperationIntegrationTest.groovy
@@ -61,7 +61,7 @@ class ProblemsApiBuildOperationIntegrationTest extends AbstractIntegrationSpec {
             details == null
             originLocations.empty
             contextualLocations.size() == 1
-            with(contextualLocations[0]) {
+            with(contextualLocations[0].fileLocation) {
                 path == this.buildFile.absolutePath
                 line == 13
                 column == null
@@ -102,10 +102,13 @@ class ProblemsApiBuildOperationIntegrationTest extends AbstractIntegrationSpec {
             details == null
             originLocations.size() == 1
             with(originLocations[0]) {
-                path == this.buildFile.absolutePath
-                line == 13
-                column == null
-                length == null
+                with(fileLocation) {
+                    path == this.buildFile.absolutePath
+                    line == 13
+                    column == null
+                    length == null
+                }
+                stackTrace.find() { it.className == 'ProblemReportingTask' && it.methodName == 'run' }
             }
             contextualLocations.empty
             failure == null
@@ -246,10 +249,12 @@ class ProblemsApiBuildOperationIntegrationTest extends AbstractIntegrationSpec {
             originLocations.empty
             contextualLocations.size() == 1
             with(contextualLocations[0]) {
-                path == this.file('included/sub1/build.gradle').absolutePath
-                line == 13
-                column == null
-                length == null
+                with(fileLocation) {
+                    path == this.file('included/sub1/build.gradle').absolutePath
+                    line == 13
+                    column == null
+                    length == null
+                }
             }
             failure == null
         }

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.problems
 
+import org.gradle.api.problems.internal.StackTraceLocation
 import org.gradle.api.problems.internal.TaskLocation
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
@@ -47,7 +48,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             definition.id.fqid == 'generic:type'
             definition.id.displayName == 'label'
-            with(oneLocation(LineInFileLocation)) {
+            with(oneLocation(StackTraceLocation).fileLocation) {
                 length == -1
                 column == -1
                 line == 13
@@ -97,11 +98,13 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 path == buildFile.absolutePath
             }
             contextualLocations.size() == 1
-            with(contextualLocations[0] as LineInFileLocation) {
-                length == -1
-                column == -1
-                line == 10
-                path == buildFile.absolutePath
+            with(contextualLocations[0] as StackTraceLocation) {
+                with(fileLocation as LineInFileLocation) {
+                    length == -1
+                    column == -1
+                    line == 10
+                    path == buildFile.absolutePath
+                }
             }
         }
     }
@@ -123,11 +126,14 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             definition.id.fqid == 'generic:type'
             definition.id.displayName == 'label'
-            with(oneLocation(LineInFileLocation)) {
-                length == -1
-                column == -1
-                line == 13
-                path == buildFile.absolutePath
+            with(oneLocation(StackTraceLocation)) {
+                with(fileLocation as LineInFileLocation) {
+                    length == -1
+                    column == -1
+                    line == 13
+                    path == buildFile.absolutePath
+                }
+                stackTrace.find { it.className == 'ProblemReportingTask' && it.methodName == 'run' }
             }
         }
 
@@ -170,7 +176,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 length == 2
             }
             contextualLocations.size() == 2
-            with(contextualLocations[0] as LineInFileLocation) {
+            with((contextualLocations[0] as StackTraceLocation).fileLocation as LineInFileLocation) {
                 length == -1
                 column == -1
                 line == 13
@@ -204,7 +210,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 path == 'test-location'
             }
             contextualLocations.size() == 2
-            with(contextualLocations.get(0) as LineInFileLocation) {
+            with((contextualLocations.get(0) as StackTraceLocation).fileLocation as LineInFileLocation) {
                 length == -1
                 column == -1
                 line == 13
@@ -326,7 +332,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             definition.id.fqid == 'problems-api:unsupported-additional-data'
             definition.id.displayName == 'Unsupported additional data type'
-            with(oneLocation(LineInFileLocation)) {
+            with(oneLocation(StackTraceLocation).fileLocation as LineInFileLocation) {
                 length == -1
                 column == -1
                 line == 13

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
@@ -133,7 +133,9 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
         ProblemDiagnostics problemDiagnostics = problemStream.forCurrentCaller(exceptionForProblemInstantiation);
         Location loc = problemDiagnostics.getLocation();
         if (loc != null) {
-            addFileLocationTo(locations, getFileLocation(loc));
+            FileLocation fileLocation = getFileLocation(loc);
+            locations.remove(fileLocation);
+            locations.add(new DefaultStackTraceLocation(fileLocation, problemDiagnostics.getStack()));
         }
         PluginIdLocation pluginIdLocation = getDefaultPluginIdLocation(problemDiagnostics);
         if (pluginIdLocation != null) {
@@ -141,6 +143,7 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
         }
     }
 
+    @Nullable
     private static PluginIdLocation getDefaultPluginIdLocation(ProblemDiagnostics problemDiagnostics) {
         UserCodeSource source = problemDiagnostics.getSource();
         if (source == null) {

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultStackTraceLocation.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultStackTraceLocation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems.internal;
+
+import org.gradle.api.problems.FileLocation;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class DefaultStackTraceLocation implements StackTraceLocation {
+
+    private final FileLocation location;
+    private final List<StackTraceElement> stackTrace;
+
+    public DefaultStackTraceLocation(@Nullable FileLocation location, List<StackTraceElement> stackTrace) {
+        this.location = location;
+        this.stackTrace = stackTrace;
+    }
+
+    @Nullable
+    @Override
+    public FileLocation getFileLocation() {
+        return location;
+    }
+
+    @Override
+    public List<StackTraceElement> getStackTrace() {
+        return stackTrace;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DefaultStackTraceLocation that = (DefaultStackTraceLocation) o;
+        return (location == null ? that.location == null : location.equals(that.location)) && stackTrace.equals(that.stackTrace);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = location != null ? location.hashCode() : 0;
+        result = 31 * result + stackTrace.hashCode();
+        return result;
+    }
+}

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/StackTraceLocation.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/StackTraceLocation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems.internal;
+
+import org.gradle.api.problems.FileLocation;
+import org.gradle.api.problems.ProblemLocation;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * A stack trace for the location of a problem.
+ * <p>
+ * For example, the stacktrace of a direct deprecation warning.
+ */
+public interface StackTraceLocation extends ProblemLocation {
+
+    /**
+     * The source file location inferred from the stacktrace.
+     * <p>
+     * Most of the time, this is a location in a build file.
+     * {@code null} if the source file location could not be inferred.
+     */
+    @Nullable
+    FileLocation getFileLocation();
+
+    /**
+     * The stack trace elements that lead to the problem.
+     */
+    List<StackTraceElement> getStackTrace();
+}

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProblemsProgressEventUtils.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProblemsProgressEventUtils.java
@@ -34,6 +34,7 @@ import org.gradle.api.problems.internal.GeneralData;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.PluginIdLocation;
 import org.gradle.api.problems.internal.ProblemSummaryData;
+import org.gradle.api.problems.internal.StackTraceLocation;
 import org.gradle.api.problems.internal.TaskLocation;
 import org.gradle.api.problems.internal.TypeValidationData;
 import org.gradle.api.problems.internal.TypedAdditionalData;
@@ -177,26 +178,31 @@ public class ProblemsProgressEventUtils {
     }
 
     private static List<InternalLocation> toInternalLocations(List<ProblemLocation> locations) {
-        return locations.stream().map(location -> {
-            if (location instanceof LineInFileLocation) {
-                LineInFileLocation fileLocation = (LineInFileLocation) location;
-                return new org.gradle.internal.build.event.types.DefaultLineInFileLocation(fileLocation.getPath(), fileLocation.getLine(), fileLocation.getColumn(), fileLocation.getLength());
-            } else if (location instanceof OffsetInFileLocation) {
-                OffsetInFileLocation fileLocation = (OffsetInFileLocation) location;
-                return new org.gradle.internal.build.event.types.DefaultOffsetInFileLocation(fileLocation.getPath(), fileLocation.getOffset(), fileLocation.getLength());
-            } else if (location instanceof FileLocation) { // generic class must be after the subclasses in the if-elseif chain.
-                FileLocation fileLocation = (FileLocation) location;
-                return new org.gradle.internal.build.event.types.DefaultFileLocation(fileLocation.getPath());
-            } else if (location instanceof PluginIdLocation) {
-                PluginIdLocation pluginLocation = (PluginIdLocation) location;
-                return new org.gradle.internal.build.event.types.DefaultPluginIdLocation(pluginLocation.getPluginId());
-            } else if (location instanceof TaskLocation) {
-                TaskLocation taskLocation = (TaskLocation) location;
-                return new org.gradle.internal.build.event.types.DefaultTaskPathLocation(taskLocation.getBuildTreePath());
-            } else {
-                throw new RuntimeException("No mapping defined for " + location.getClass().getName());
-            }
-        }).collect(toImmutableList());
+        return locations.stream()
+            .filter(location -> !(location instanceof StackTraceLocation && ((StackTraceLocation) location).getFileLocation() == null))
+            .map(location -> location instanceof StackTraceLocation
+                ? ((StackTraceLocation) location).getFileLocation()
+                : location)
+            .map(location -> {
+                if (location instanceof LineInFileLocation) {
+                    LineInFileLocation fileLocation = (LineInFileLocation) location;
+                    return new org.gradle.internal.build.event.types.DefaultLineInFileLocation(fileLocation.getPath(), fileLocation.getLine(), fileLocation.getColumn(), fileLocation.getLength());
+                } else if (location instanceof OffsetInFileLocation) {
+                    OffsetInFileLocation fileLocation = (OffsetInFileLocation) location;
+                    return new org.gradle.internal.build.event.types.DefaultOffsetInFileLocation(fileLocation.getPath(), fileLocation.getOffset(), fileLocation.getLength());
+                } else if (location instanceof FileLocation) { // generic class must be after the subclasses in the if-elseif chain.
+                    FileLocation fileLocation = (FileLocation) location;
+                    return new org.gradle.internal.build.event.types.DefaultFileLocation(fileLocation.getPath());
+                } else if (location instanceof PluginIdLocation) {
+                    PluginIdLocation pluginLocation = (PluginIdLocation) location;
+                    return new org.gradle.internal.build.event.types.DefaultPluginIdLocation(pluginLocation.getPluginId());
+                } else if (location instanceof TaskLocation) {
+                    TaskLocation taskLocation = (TaskLocation) location;
+                    return new org.gradle.internal.build.event.types.DefaultTaskPathLocation(taskLocation.getBuildTreePath());
+                } else {
+                    throw new RuntimeException("No mapping defined for " + location.getClass().getName());
+                }
+            }).collect(toImmutableList());
     }
 
     @Nullable

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/ReceivedProblem.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.problems.internal.InternalDocLink
 import org.gradle.api.problems.internal.InternalProblem
 import org.gradle.api.problems.internal.InternalProblemBuilder
 import org.gradle.api.problems.internal.PluginIdLocation
+import org.gradle.api.problems.internal.StackTraceLocation
 import org.gradle.api.problems.internal.TaskLocation
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.tooling.internal.provider.serialization.PayloadSerializer
@@ -65,21 +66,27 @@ class ReceivedProblem implements InternalProblem {
     private static List<ProblemLocation> fromList(List<Object> locations) {
         List<ProblemLocation> result = []
         locations.each { location ->
-            if (location['pluginId'] != null) {
-                result += new ReceivedPluginIdLocation(location as Map<String, Object>)
-            } else if (location['line'] != null) {
-                result += new ReceivedLineInFileLocation(location as Map<String, Object>)
-            } else if (location['offset'] != null) {
-                result += new ReceivedOffsetInFileLocation(location as Map<String, Object>)
-            } else if (location['path'] != null) {
-                result += new ReceivedFileLocation(location as Map<String, Object>)
-            } else if (location['buildTreePath'] != null) {
-                result += new ReceivedTaskLocation(location as Map<String, Object>)
-            } else {
-                result += new ReceivedFileLocation(location as Map<String, Object>)
-            }
+            result += fromLocation(location)
         }
         result
+    }
+
+    private static ProblemLocation fromLocation(location) {
+        if (location['pluginId'] != null) {
+            return new ReceivedPluginIdLocation(location as Map<String, Object>)
+        } else if (location['line'] != null) {
+            return new ReceivedLineInFileLocation(location as Map<String, Object>)
+        } else if (location['offset'] != null) {
+            return new ReceivedOffsetInFileLocation(location as Map<String, Object>)
+        } else if (location['path'] != null) {
+            return new ReceivedFileLocation(location as Map<String, Object>)
+        } else if (location['buildTreePath'] != null) {
+            return new ReceivedTaskLocation(location as Map<String, Object>)
+        } else if (location['stackTrace'] != null) {
+            return new ReceivedStackTraceLocation(location as Map<String, Object>)
+        } else {
+            return new ReceivedFileLocation(location as Map<String, Object>)
+        }
     }
 
     long getOperationId() {
@@ -358,6 +365,19 @@ class ReceivedProblem implements InternalProblem {
         @Override
         int getLength() {
             length
+        }
+    }
+
+    static class ReceivedStackTraceLocation implements StackTraceLocation {
+        final List<StackTraceElement> stackTrace
+        final FileLocation fileLocation
+
+        ReceivedStackTraceLocation(Map<String, Object> location) {
+            def fileLocationJson = location['fileLocation']
+            this.fileLocation = fileLocationJson == null ? null : fromLocation(fileLocationJson) as FileLocation
+            this.stackTrace = location.stackTrace.collect {
+                new StackTraceElement(it['className'] as String, it['methodName'] as String, it['fileName'] as String, it['lineNumber'] as int)
+            }
         }
     }
 


### PR DESCRIPTION
This location is currently internal. For the TAPI, we use the file location from the stacktrace location as before. We introduce the corresponding location for consumption by scans directly.

This PR doesn't map the stack trace location from the worker API, yet, since the worker API doesn't produce stacktrace locations.
