### PR TITLE
Use @PathSensitive(RELATIVE) for architecture-test:test

### DIFF
--- a/testing/architecture-test/build.gradle.kts
+++ b/testing/architecture-test/build.gradle.kts
@@ -58,7 +58,7 @@ tasks {
         // Only use one fork, so freezing doesn't have concurrency issues
         maxParallelForks = 1
 
-        inputs.dir(ruleStoreDir)
+        inputs.dir(ruleStoreDir).withPathSensitivity(PathSensitivity.RELATIVE)
 
         systemProperty("org.gradle.public.api.includes", (PublicApi.includes + PublicKotlinDslApi.includes).joinToString(":"))
         systemProperty("org.gradle.public.api.excludes", (PublicApi.excludes + PublicKotlinDslApi.excludes).joinToString(":"))


### PR DESCRIPTION
Found its path sensitivity is incorrectly set as relative: https://ge.gradle.org/c/hxhyllcgaknaw/nih5bf3nqj6qy/task-inputs?expanded=WyJiZ3lwN3k3bTV1Z2h3LSQxIl0&task-text=:architecture-test:test