### PR TITLE
Enable classloading strict mode for test-kit integration tests

### DIFF
--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/jvm/GradleRunnerCliGradlePropertyFileDaemonJvmIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/jvm/GradleRunnerCliGradlePropertyFileDaemonJvmIntegrationTest.groovy
@@ -26,6 +26,6 @@ class GradleRunnerCliGradlePropertyFileDaemonJvmIntegrationTest extends GradleRu
 
     @Override
     def configureRunner(GradleRunner runner, Jvm jvm) {
-        runner.withArguments("-Dorg.gradle.java.home=" + jvm.javaHome.absolutePath)
+        runner.withArguments(["-Dorg.gradle.java.home=" + jvm.javaHome.absolutePath] + runner.getArguments())
     }
 }

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/jvm/GradleRunnerToolchainDaemonJvmIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/jvm/GradleRunnerToolchainDaemonJvmIntegrationTest.groovy
@@ -31,6 +31,6 @@ class GradleRunnerToolchainDaemonJvmIntegrationTest extends GradleRunnerExplicit
 
     @Override
     def configureRunner(GradleRunner runner, Jvm jvm) {
-        runner.withArguments("-Porg.gradle.java.installations.paths=" + jvm.javaHome.canonicalPath)
+        runner.withArguments(["-Porg.gradle.java.installations.paths=" + jvm.javaHome.canonicalPath] + runner.getArguments())
     }
 }

--- a/platforms/extensibility/test-kit/src/testFixtures/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/testFixtures/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testkit.runner
 
 import groovy.transform.Sortable
+import org.gradle.api.internal.initialization.DefaultClassLoaderScope
 import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.compatibility.MultiVersionTestCategory
@@ -118,8 +119,9 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
         List<String> allArgs = arguments as List
         if (closeServices) {
             // Do not keep user home dir services open when running embedded or when using a custom user home dir
-            allArgs.add(("-D" + DefaultGradleUserHomeScopeServiceRegistry.REUSE_USER_HOME_SERVICES + "=false") as String)
+            allArgs.add("-D" + DefaultGradleUserHomeScopeServiceRegistry.REUSE_USER_HOME_SERVICES + "=false")
         }
+        allArgs.add("-D" + DefaultClassLoaderScope.STRICT_MODE_PROPERTY + "=true")
         def gradleRunner = GradleRunner.create()
             .withTestKitDir(testKitDir)
             .withProjectDir(testDirectory)
@@ -187,7 +189,7 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
     static {
         def releasedGradleVersions = new ReleasedVersionDistributions()
         def probeVersions = ["4.10.3", "5.6.4", "6.9.4", "7.6.4", "8.8"]
-        String compatibleVersion = probeVersions.find {version ->
+        String compatibleVersion = probeVersions.find { version ->
             releasedGradleVersions.getDistribution(version)?.worksWith(Jvm.current())
         }
         LOWEST_MAJOR_GRADLE_VERSION = compatibleVersion


### PR DESCRIPTION
In `gradle/gradle` integrations tests we are having Strict classloader mode set by default:
https://github.com/gradle/gradle/blob/748528426a08ddef67d4cfb64e9694b2d437bbb8/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java#L184

The "strinctess" of the mode is represented like https://github.com/gradle/gradle/blob/19795ce4158d7e2c90a6c1445dea2434bd1efbbe/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java#L112
when we try to access an unlocked classloader we fail. Without strict mode we are fine, and trying to build multiparent classloader.

Despite we can disable this behavior for an executer, we barely use it. I believe it because of the mental assumption "If we are good in Strict mode, then in lenient mode we are good as well", what is ok imo.

However, `test-kit` runners in integTests are not using Strict mode. This PR alters it and enables Strict mode unconditionally for `test-kit` runners in integTests. I think it's can be desirable because of `test-kit` able to do classpath injection when applying plugins.