### PR TITLE
Move incubating to the specific methods in `configurations`

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationContainerExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationContainerExtensions.kt
@@ -15,9 +15,6 @@
  */
 
 
-@file:Incubating
-
-
 package org.gradle.kotlin.dsl
 
 import org.gradle.api.Action
@@ -40,7 +37,6 @@ import org.gradle.api.artifacts.ResolvableConfiguration
  * @since 8.4
  */
 @Suppress("nothing_to_inline")
-@Incubating
 inline operator fun ConfigurationContainer.invoke(
     configuration: Action<ConfigurationContainerScope>
 ): ConfigurationContainer = apply {
@@ -66,21 +62,27 @@ private constructor(
     override fun detachedConfiguration(vararg dependencies: Dependency): Configuration =
         delegate.detachedConfiguration(*dependencies)
 
+    @Incubating
     override fun resolvable(name: String): NamedDomainObjectProvider<ResolvableConfiguration> =
         delegate.resolvable(name)
 
+    @Incubating
     override fun resolvable(name: String, action: Action<in ResolvableConfiguration>): NamedDomainObjectProvider<ResolvableConfiguration> =
         delegate.resolvable(name, action)
 
+    @Incubating
     override fun consumable(name: String): NamedDomainObjectProvider<ConsumableConfiguration> =
         delegate.consumable(name)
 
+    @Incubating
     override fun consumable(name: String, action: Action<in ConsumableConfiguration>): NamedDomainObjectProvider<ConsumableConfiguration> =
         delegate.consumable(name, action)
 
+    @Incubating
     override fun dependencyScope(name: String): NamedDomainObjectProvider<DependencyScopeConfiguration> =
         delegate.dependencyScope(name)
 
+    @Incubating
     override fun dependencyScope(name: String, action: Action<in DependencyScopeConfiguration>): NamedDomainObjectProvider<DependencyScopeConfiguration> =
         delegate.dependencyScope(name, action)
 }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/32196

### Context
Only some of this is incubating, the `invoke` and scope class should not be marked as such since `ConfigurationContainer` is not.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
