### PR TITLE
Deprecate addCandidate in preparation for removal in 9.0

### DIFF
--- a/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -130,7 +130,7 @@ public abstract class EarPlugin implements Plugin<Project> {
                 deploymentDescriptor.setDescription(project.getDescription());
             }
         }
-        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(new LazyPublishArtifact(ear, ((ProjectInternal) project).getFileResolver(), taskDependencyFactory));
+        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidateInternal(new LazyPublishArtifact(ear, ((ProjectInternal) project).getFileResolver(), taskDependencyFactory));
     }
 
     private void wireEarTaskConventions(Project project, final EarPluginConvention earConvention) {

--- a/platforms/jvm/plugins-java/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/platforms/jvm/plugins-java/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -267,7 +267,7 @@ public abstract class JavaPlugin implements Plugin<Project> {
 
         // Build the main jar when running `assemble`.
         DefaultArtifactPublicationSet publicationSet = project.getExtensions().getByType(DefaultArtifactPublicationSet.class);
-        publicationSet.addCandidate(javaComponent.getMainFeature().getRuntimeElementsConfiguration().getArtifacts().iterator().next());
+        publicationSet.addCandidateInternal(javaComponent.getMainFeature().getRuntimeElementsConfiguration().getArtifacts().iterator().next());
 
         BuildOutputCleanupRegistry buildOutputCleanupRegistry = projectInternal.getServices().get(BuildOutputCleanupRegistry.class);
         configureSourceSets(buildOutputCleanupRegistry, sourceSets);

--- a/platforms/jvm/war/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/platforms/jvm/war/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -96,7 +96,7 @@ public abstract class WarPlugin implements Plugin<Project> {
         });
 
         PublishArtifact warArtifact = new LazyPublishArtifact(war, ((ProjectInternal) project).getFileResolver(), ((ProjectInternal) project).getTaskDependencyFactory());
-        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(warArtifact);
+        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidateInternal(warArtifact);
         configureConfigurations(((ProjectInternal) project).getConfigurations(), mainFeature);
         configureComponent(project, warArtifact);
     }

--- a/platforms/software/platform-base/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
+++ b/platforms/software/platform-base/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.provider.AbstractMinimalProvider;
 import org.gradle.api.internal.provider.ChangingValue;
 import org.gradle.api.internal.provider.ChangingValueHandler;
 import org.gradle.api.internal.provider.CollectionProviderInternal;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -55,7 +56,24 @@ public abstract class DefaultArtifactPublicationSet {
         configurations.getByName(aggregateArtifactsConfName).getArtifacts().addAllLater(defaultArtifactProvider);
     }
 
+    /**
+     * This interface will be removed in Gradle 9.  We output a deprecation warning in order to warn any external users of this fact.
+     * Please use {@link #addCandidateInternal(PublishArtifact)} instead for any internal usages of this method.
+     */
+    @Deprecated
     public void addCandidate(PublishArtifact artifact) {
+        DeprecationLogger.deprecateInternalApi("DefaultArtifactPublicationSet.addCandidate(PublishArtifact)")
+            .withAdvice("Add the artifact as a direct dependency of the assemble task instead.")
+            .willBeRemovedInGradle9()
+            .undocumented()
+            .nagUser();
+        addCandidateInternal(artifact);
+    }
+
+    /**
+     * Temporary method for internal use that avoids emitting a deprecation warning.
+     */
+    public void addCandidateInternal(PublishArtifact artifact) {
         defaultArtifactProvider.addArtifact(artifact);
     }
 

--- a/platforms/software/plugins-distribution/src/main/java/org/gradle/api/distribution/plugins/DistributionBasePlugin.java
+++ b/platforms/software/plugins-distribution/src/main/java/org/gradle/api/distribution/plugins/DistributionBasePlugin.java
@@ -125,8 +125,8 @@ public abstract class DistributionBasePlugin implements Plugin<Project> {
         addAssembleTask(project, dist, assembleTaskName, zipTask, tarTask);
 
         // Build zips and tars by default when running the build-wide assemble task.
-        defaultArtifactPublicationSet.addCandidate(new LazyPublishArtifact(zipTask, project.getFileResolver(), project.getTaskDependencyFactory()));
-        defaultArtifactPublicationSet.addCandidate(new LazyPublishArtifact(tarTask, project.getFileResolver(), project.getTaskDependencyFactory()));
+        defaultArtifactPublicationSet.addCandidateInternal(new LazyPublishArtifact(zipTask, project.getFileResolver(), project.getTaskDependencyFactory()));
+        defaultArtifactPublicationSet.addCandidateInternal(new LazyPublishArtifact(tarTask, project.getFileResolver(), project.getTaskDependencyFactory()));
     }
 
     /**


### PR DESCRIPTION
This is an internal class, but we know at least one plugin makes use of it.  This is just throwing a deprecation warning as a courtesy before we remove this method in 9.0.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
