### PR TITLE
Report problems for build failures to Build Scans

### DIFF
--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/BuildCompletionNotifyingBuildActionRunner.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/BuildCompletionNotifyingBuildActionRunner.java
@@ -21,6 +21,11 @@ import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.invocation.BuildAction;
+import org.gradle.internal.problems.failure.Failure;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * An {@link BuildActionRunner} that notifies the GE plugin manager that the build has completed.
@@ -50,6 +55,23 @@ public class BuildCompletionNotifyingBuildActionRunner implements BuildActionRun
     }
 
     private void notifyEnterprisePluginManager(Result result) {
-        gradleEnterprisePluginManager.buildFinished(result.getBuildFailure());
+        List<Failure> unwrappedBuildFailure = unwrapBuildFailure(result.getBuildFailure(), result.getRichBuildFailure());
+        gradleEnterprisePluginManager.buildFinished(result.getBuildFailure(), unwrappedBuildFailure);
+    }
+
+    private static List<Failure> unwrapBuildFailure(@Nullable Throwable buildFailure, @Nullable Failure richBuildFailure) {
+        if (buildFailure != null && richBuildFailure == null) {
+            // There was a problem with the build that could not be translated to a Failure
+            return null;
+        }
+        if (richBuildFailure == null) {
+            // No build failure, empty list
+            return Collections.emptyList();
+        }
+        return richBuildFailure.getCauses().size() > 1
+            // Multiple build failures -- extract the causes
+            ? richBuildFailure.getCauses()
+            // Single build failure
+            : Collections.singletonList(richBuildFailure);
     }
 }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/DefaultFailure.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/problems/failure/DefaultFailure.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.problems.failure;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.problems.internal.InternalProblem;
 
 import java.util.List;
 
@@ -27,13 +28,15 @@ class DefaultFailure implements Failure {
     private final List<StackTraceRelevance> frameRelevance;
     private final List<Failure> suppressed;
     private final List<Failure> causes;
+    private final List<InternalProblem> problems;
 
     public DefaultFailure(
         Throwable original,
         List<StackTraceElement> stackTrace,
         List<StackTraceRelevance> frameRelevance,
         List<Failure> suppressed,
-        List<Failure> causes
+        List<Failure> causes,
+        List<InternalProblem> problems
     ) {
         if (stackTrace.size() != frameRelevance.size()) {
             throw new IllegalArgumentException("stackTrace and frameRelevance must have the same size.");
@@ -44,6 +47,7 @@ class DefaultFailure implements Failure {
         this.frameRelevance = ImmutableList.copyOf(frameRelevance);
         this.suppressed = ImmutableList.copyOf(suppressed);
         this.causes = ImmutableList.copyOf(causes);
+        this.problems = ImmutableList.copyOf(problems);
     }
 
     @Override
@@ -54,6 +58,11 @@ class DefaultFailure implements Failure {
     @Override
     public String getHeader() {
         return original.toString();
+    }
+
+    @Override
+    public String getMessage() {
+        return original.getMessage();
     }
 
     @Override
@@ -74,6 +83,16 @@ class DefaultFailure implements Failure {
     @Override
     public List<Failure> getCauses() {
         return causes;
+    }
+
+    @Override
+    public List<InternalProblem> getProblems() {
+        return problems;
+    }
+
+    @Override
+    public Throwable getOriginal() {
+        return original;
     }
 
     @Override

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/problems/failure/DefaultFailureFactoryTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/problems/failure/DefaultFailureFactoryTest.groovy
@@ -16,13 +16,14 @@
 
 package org.gradle.internal.problems.failure
 
+import org.gradle.api.problems.internal.ProblemLocator
 import org.gradle.internal.failure.SimulatedJavaException
 import spock.lang.Specification
 
 class DefaultFailureFactoryTest extends Specification {
 
     def "creates failure from a throwable with circular references"() {
-        def factory = new DefaultFailureFactory(StackTraceClassifier.USER_CODE)
+        def factory = new DefaultFailureFactory(StackTraceClassifier.USER_CODE, ProblemLocator.EMPTY_LOCATOR)
 
         def e0 = SimulatedJavaException.simulateDeeperException()
         def e = new RuntimeException("BOOM", e0)

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/problems/Failure.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/problems/Failure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,26 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.enterprise.core;
-
-import org.gradle.internal.problems.failure.Failure;
+package org.gradle.operations.problems;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
 
-public interface GradleEnterprisePluginAdapter {
+public interface Failure {
 
-    boolean shouldSaveToConfigurationCache();
+    String getClassName();
 
-    void onLoadFromConfigurationCache();
+    @Nullable
+    String getMessage();
 
-    void buildFinished(@Nullable Throwable buildFailure, @Nullable List<Failure> richBuildFailures);
+    Map<String, String> getMetadata();
 
+    List<StackTraceElement> getStackTrace();
+
+    List<String> getClassLevelAnnotations();
+
+    List<Failure> getCauses();
+
+    List<Problem> getProblems();
 }

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/problems/Problem.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/problems/Problem.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.operations.problems;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * A problem from the problems API.
+ *
+ * @since 8.14
+ */
+public interface Problem {
+    /**
+     * The problem definition, i.e. the data that is independent of the usage.
+     *
+     * @since 8.14
+     */
+    ProblemDefinition getDefinition();
+
+    /**
+     * The severity of the problem.
+     *
+     * @since 8.14
+     */
+    ProblemSeverity getSeverity();
+
+    /**
+     * Declares a short, but usage-dependent message for this problem.
+     *
+     * @return the contextual label, or {@code null} if not specified. Then the display name from the definition should be used.
+     * @since 8.14
+     */
+    @Nullable
+    String getContextualLabel();
+
+    /**
+     * Returns solutions and advice that contain context-sensitive data, e.g. the message contains references to variables, locations, etc.
+     *
+     * @since 8.14
+     */
+    List<String> getSolutions();
+
+    /**
+     * A long description detailing the problem.
+     * <p>
+     * Details can elaborate on the problem, and provide more information about the problem.
+     * They can be multiple lines long, but should not detail solutions; for that, use {@link #getSolutions()}.
+     * <p>
+     * {@code null} if no details have been specified.
+     *
+     * @since 8.14
+     */
+    @Nullable
+    String getDetails();
+
+    /**
+     * Returns the locations where the problem originated.
+     * <p>
+     * Might be empty if the origin is not known.
+     *
+     * @since 8.14
+     */
+    List<ProblemLocation> getOriginLocations();
+
+    /**
+     * Returns additional locations, which can help to understand the problem further.
+     * <p>
+     * For example, if a problem was emitted during task execution, the task path will be available in this list.
+     * <p>
+     * Might be empty if there is no meaningful contextual information.
+     *
+     * @since 8.14
+     */
+    List<ProblemLocation> getContextualLocations();
+}

--- a/platforms/enterprise/enterprise/build.gradle.kts
+++ b/platforms/enterprise/enterprise/build.gradle.kts
@@ -13,6 +13,7 @@ errorprone {
 dependencies {
     api(projects.baseServices)
     api(projects.buildOperations)
+    api(projects.enterpriseOperations)
     api(projects.configurationCache)
     api(projects.core)
     api(projects.coreApi)

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginEndOfBuildListener.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginEndOfBuildListener.java
@@ -16,7 +16,10 @@
 
 package org.gradle.internal.enterprise;
 
+import org.gradle.operations.problems.Failure;
+
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * Used to signal the end of build to the plugin.
@@ -31,6 +34,18 @@ public interface GradleEnterprisePluginEndOfBuildListener {
     interface BuildResult {
         @Nullable
         Throwable getFailure();
+
+        /**
+         * The build failure in a more structured form.
+         * <p>
+         * The non-empty list of failures if the build did fail.
+         * An empty list if the build didn't fail.
+         * {@code null} if the build failure could not be converted to a structured form. Use {@link #getFailure()} in this case.
+         *
+         * @since 8.14
+         */
+        @Nullable
+        List<Failure> getFailures();
     }
 
     void buildFinished(BuildResult buildResult);

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginAdapter.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginAdapter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.enterprise.impl;
 
+import org.gradle.api.problems.internal.DevelocityProblem;
 import org.gradle.internal.enterprise.GradleEnterprisePluginBuildState;
 import org.gradle.internal.enterprise.GradleEnterprisePluginConfig;
 import org.gradle.internal.enterprise.GradleEnterprisePluginEndOfBuildListener;
@@ -24,15 +25,26 @@ import org.gradle.internal.enterprise.GradleEnterprisePluginService;
 import org.gradle.internal.enterprise.GradleEnterprisePluginServiceFactory;
 import org.gradle.internal.enterprise.GradleEnterprisePluginServiceRef;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginAdapter;
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
+import org.gradle.internal.enterprise.exceptions.ExceptionMetadataHelper;
 import org.gradle.internal.operations.notify.BuildOperationNotificationListenerRegistrar;
+import org.gradle.operations.problems.Failure;
+import org.gradle.operations.problems.Problem;
 
 import javax.annotation.Nullable;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Captures the state to recreate the {@link GradleEnterprisePluginService} instance.
  * <p>
  * The adapter is created on check-in in {@link DefaultGradleEnterprisePluginCheckInService} via {@link DefaultGradleEnterprisePluginAdapterFactory}.
- * Then the adapter is stored on the {@link org.gradle.internal.enterprise.core.GradleEnterprisePluginManager}.
+ * Then the adapter is stored on the {@link GradleEnterprisePluginManager}.
  * <p>
  * There is some custom logic to store the adapter from the manager in the configuration cache and restore it afterward.
  * The pluginServices need to be recreated when loading from the configuration cache.
@@ -88,12 +100,12 @@ public class DefaultGradleEnterprisePluginAdapter implements GradleEnterprisePlu
     }
 
     @Override
-    public void buildFinished(@Nullable Throwable buildFailure) {
+    public void buildFinished(@Nullable Throwable buildFailure, List<org.gradle.internal.problems.failure.Failure> buildFailures) {
         // Ensure that all tasks are complete prior to the buildFinished callback.
         backgroundJobExecutors.shutdown();
 
         if (pluginService != null) {
-            pluginService.getEndOfBuildListener().buildFinished(new DefaultDevelocityPluginResult(buildFailure));
+            pluginService.getEndOfBuildListener().buildFinished(new DefaultDevelocityPluginResult(buildFailure, buildFailures));
         }
     }
 
@@ -104,10 +116,14 @@ public class DefaultGradleEnterprisePluginAdapter implements GradleEnterprisePlu
     }
 
     private static class DefaultDevelocityPluginResult implements GradleEnterprisePluginEndOfBuildListener.BuildResult {
+        @Nullable
         private final Throwable buildFailure;
+        @Nullable
+        private final List<org.gradle.internal.problems.failure.Failure> buildFailures;
 
-        public DefaultDevelocityPluginResult(@Nullable Throwable buildFailure) {
+        public DefaultDevelocityPluginResult(@Nullable Throwable buildFailure, @Nullable List<org.gradle.internal.problems.failure.Failure> buildFailures) {
             this.buildFailure = buildFailure;
+            this.buildFailures = buildFailures;
         }
 
         @Nullable
@@ -115,5 +131,74 @@ public class DefaultGradleEnterprisePluginAdapter implements GradleEnterprisePlu
         public Throwable getFailure() {
             return buildFailure;
         }
+
+        @Nullable
+        @Override
+        public List<Failure> getFailures() {
+            return buildFailures != null
+                ? buildFailures.stream()
+                .map(DevelocityBuildFailure::new)
+                .collect(Collectors.toList())
+                : null;
+        }
+
     }
+
+    private static class DevelocityBuildFailure implements Failure {
+
+        private final org.gradle.internal.problems.failure.Failure failure;
+
+        public DevelocityBuildFailure(org.gradle.internal.problems.failure.Failure failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public String getClassName() {
+            return failure.getExceptionType().getName();
+        }
+
+        @Nullable
+        @Override
+        public String getMessage() {
+            return failure.getHeader();
+        }
+
+        @Override
+        public Map<String, String> getMetadata() {
+            return ExceptionMetadataHelper.getMetadata(failure.getOriginal());
+        }
+
+        @Override
+        public List<StackTraceElement> getStackTrace() {
+            return failure.getStackTrace();
+        }
+
+        @Override
+        public List<String> getClassLevelAnnotations() {
+            return getClassLevelAnnotations(failure.getExceptionType());
+        }
+
+        @Override
+        public List<Failure> getCauses() {
+            return failure.getCauses().stream()
+                .map(DevelocityBuildFailure::new)
+                .collect(Collectors.toList());
+        }
+
+        @Override
+        public List<Problem> getProblems() {
+            return failure.getProblems().stream()
+                .map(DevelocityProblem::new)
+                .collect(Collectors.toList());
+        }
+
+        private static List<String> getClassLevelAnnotations(Class<?> cls) {
+            Set<String> anns = new HashSet<>();
+            for (Annotation a : cls.getAnnotations()) {
+                anns.add(a.annotationType().getName());
+            }
+            return new ArrayList<>(anns);
+        }
+    }
+
 }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/LegacyGradleEnterprisePluginCheckInService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/LegacyGradleEnterprisePluginCheckInService.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginAdapter;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
+import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.scan.config.BuildScanConfig;
 import org.gradle.internal.scan.config.BuildScanConfigProvider;
 import org.gradle.internal.scan.config.BuildScanPluginMetadata;
@@ -32,6 +33,7 @@ import org.gradle.util.internal.VersionNumber;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import java.util.List;
 
 @ServiceScope(Scope.Build.class)
 public class LegacyGradleEnterprisePluginCheckInService implements BuildScanConfigProvider, BuildScanEndOfBuildNotifier {
@@ -206,7 +208,7 @@ public class LegacyGradleEnterprisePluginCheckInService implements BuildScanConf
         }
 
         @Override
-        public void buildFinished(@Nullable Throwable buildFailure) {
+        public void buildFinished(@Nullable Throwable buildFailure, @Nullable List<Failure> richBuildFailures) {
             if (listener != null) {
                 listener.execute(new BuildResult() {
                     @Nullable

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemProgressDetails.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemProgressDetails.java
@@ -16,26 +16,21 @@
 
 package org.gradle.api.problems.internal;
 
-import com.google.common.collect.ImmutableList;
-import org.gradle.operations.problems.DocumentationLink;
-import org.gradle.operations.problems.FileLocation;
-import org.gradle.operations.problems.LineInFileLocation;
-import org.gradle.operations.problems.OffsetInFileLocation;
 import org.gradle.operations.problems.ProblemDefinition;
-import org.gradle.operations.problems.ProblemGroup;
 import org.gradle.operations.problems.ProblemLocation;
 import org.gradle.operations.problems.ProblemSeverity;
 import org.gradle.operations.problems.ProblemUsageProgressDetails;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
 public class DefaultProblemProgressDetails implements ProblemProgressDetails, ProblemUsageProgressDetails {
     private final InternalProblem problem;
+    private final DevelocityProblem develocityProblem;
 
     public DefaultProblemProgressDetails(InternalProblem problem) {
         this.problem = problem;
+        this.develocityProblem = new DevelocityProblem(problem);
     }
 
     public InternalProblem getProblem() {
@@ -44,286 +39,44 @@ public class DefaultProblemProgressDetails implements ProblemProgressDetails, Pr
 
     @Override
     public ProblemDefinition getDefinition() {
-        return new DevelocityProblemDefinition(problem.getDefinition());
+        return develocityProblem.getDefinition();
     }
 
     @Override
     public ProblemSeverity getSeverity() {
-        switch (problem.getDefinition().getSeverity()) {
-            case ADVICE:
-                return ProblemSeverity.ADVICE;
-            case WARNING:
-                return ProblemSeverity.WARNING;
-            case ERROR:
-                return ProblemSeverity.ERROR;
-            default:
-                throw new IllegalArgumentException("Unknown severity: " + problem.getDefinition().getSeverity());
-        }
+        return develocityProblem.getSeverity();
     }
 
     @Nullable
     @Override
     public String getContextualLabel() {
-        return problem.getContextualLabel();
+        return develocityProblem.getContextualLabel();
     }
 
     @Override
     public List<String> getSolutions() {
-        return problem.getSolutions();
+        return develocityProblem.getSolutions();
     }
 
     @Nullable
     @Override
     public String getDetails() {
-        return problem.getDetails();
+        return develocityProblem.getDetails();
     }
 
     @Override
     public List<ProblemLocation> getOriginLocations() {
-        return convertProblemLocations(problem.getOriginLocations());
+        return develocityProblem.getOriginLocations();
     }
 
     @Override
     public List<ProblemLocation> getContextualLocations() {
-        return convertProblemLocations(problem.getContextualLocations());
-    }
-
-    @Nonnull
-    private ImmutableList<ProblemLocation> convertProblemLocations(List<org.gradle.api.problems.ProblemLocation> locations) {
-        ImmutableList.Builder<ProblemLocation> builder = ImmutableList.builder();
-        for (org.gradle.api.problems.ProblemLocation location : locations) {
-            ProblemLocation develocityLocation = convertToLocation(location);
-            if (develocityLocation != null) {
-                builder.add(develocityLocation);
-            }
-        }
-        return builder.build();
-    }
-
-    @Nullable
-    private static ProblemLocation convertToLocation(final org.gradle.api.problems.ProblemLocation location) {
-        if (location instanceof org.gradle.api.problems.FileLocation) {
-            return convertToDevelocityFileLocation(location);
-        } else if (location instanceof TaskLocation) {
-            // The Develocity plugin will infer the task location from the build operation hierarchy - no need to send this contextual information
-            return null;
-        } else if (location instanceof org.gradle.api.problems.internal.PluginIdLocation) {
-            return new DevelocityPluginIdLocation((PluginIdLocation) location);
-        } else if (location instanceof org.gradle.api.problems.internal.StackTraceLocation) {
-            return new DevelocityStackTraceLocation((StackTraceLocation) location);
-        }
-        throw new IllegalArgumentException("Unknown location type: " + location.getClass() + ", location: '" + location + "'");
-    }
-
-    @Nonnull
-    private static FileLocation convertToDevelocityFileLocation(org.gradle.api.problems.ProblemLocation location) {
-        if (location instanceof org.gradle.api.problems.LineInFileLocation) {
-            return new DevelocityLineInFileLocation((org.gradle.api.problems.LineInFileLocation) location);
-        } else if (location instanceof org.gradle.api.problems.OffsetInFileLocation) {
-            return new DevelocityOffsetInFileLocation((org.gradle.api.problems.OffsetInFileLocation) location);
-        } else {
-            return new DevelocityFileLocation((org.gradle.api.problems.FileLocation) location);
-        }
+        return develocityProblem.getContextualLocations();
     }
 
     @Nullable
     @Override
     public Throwable getFailure() {
         return problem.getException() == null ? null : problem.getException();
-    }
-
-    private static class DevelocityProblemDefinition implements ProblemDefinition {
-        private final org.gradle.api.problems.ProblemDefinition definition;
-
-        public DevelocityProblemDefinition(org.gradle.api.problems.ProblemDefinition definition) {
-            this.definition = definition;
-        }
-
-        @Override
-        public String getName() {
-            return definition.getId().getName();
-        }
-
-        @Override
-        public String getDisplayName() {
-            return definition.getId().getDisplayName();
-        }
-
-        @Override
-        public ProblemGroup getGroup() {
-            return new DevelocityProblemGroup(definition.getId().getGroup());
-        }
-
-        @Nullable
-        @Override
-        public DocumentationLink getDocumentationLink() {
-            InternalDocLink documentationLink = (InternalDocLink) definition.getDocumentationLink();
-            return documentationLink == null ? null : new DevelocityDocumentationLink(documentationLink);
-        }
-
-        private static class DevelocityProblemGroup implements ProblemGroup {
-            private final org.gradle.api.problems.ProblemGroup currentGroup;
-
-            public DevelocityProblemGroup(org.gradle.api.problems.ProblemGroup currentGroup) {
-                this.currentGroup = currentGroup;
-            }
-
-            @Override
-            public String getName() {
-                return currentGroup.getName();
-            }
-
-            @Override
-            public String getDisplayName() {
-                return currentGroup.getDisplayName();
-            }
-
-            @Nullable
-            @Override
-            public ProblemGroup getParent() {
-                org.gradle.api.problems.ProblemGroup parent = currentGroup.getParent();
-                return parent == null ? null : new DevelocityProblemGroup(parent);
-            }
-        }
-
-        private static class DevelocityDocumentationLink implements DocumentationLink {
-            private final InternalDocLink documentationLink;
-
-            public DevelocityDocumentationLink(InternalDocLink documentationLink) {
-                this.documentationLink = documentationLink;
-            }
-
-            @Override
-            public String getUrl() {
-                return documentationLink.getUrl();
-            }
-        }
-    }
-
-    private static class DevelocityFileLocation implements FileLocation {
-
-        private final org.gradle.api.problems.FileLocation location;
-
-        public DevelocityFileLocation(org.gradle.api.problems.FileLocation location) {
-            this.location = location;
-        }
-
-        @Override
-        public String getPath() {
-            return location.getPath();
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "file '" + getPath() + "'";
-        }
-    }
-
-    private static class DevelocityLineInFileLocation extends DevelocityFileLocation implements LineInFileLocation {
-        private final org.gradle.api.problems.LineInFileLocation lineInFileLocation;
-
-        public DevelocityLineInFileLocation(org.gradle.api.problems.LineInFileLocation lineInFileLocation) {
-            super(lineInFileLocation);
-            this.lineInFileLocation = lineInFileLocation;
-        }
-
-        @Override
-        public int getLine() {
-            return lineInFileLocation.getLine();
-        }
-
-        @Nullable
-        @Override
-        public Integer getColumn() {
-            return lineInFileLocation.getColumn() <= 0 ? null : lineInFileLocation.getColumn();
-        }
-
-        @Nullable
-        @Override
-        public Integer getLength() {
-            return lineInFileLocation.getLength() <= 0 ? null : lineInFileLocation.getLength();
-        }
-
-        @Override
-        public String getDisplayName() {
-            String location = getPath() + ":" + getLine();
-            if (getColumn() != null) {
-                location += ":" + getColumn();
-            }
-            if (getLength() != null) {
-                location += ":" + getLength();
-            }
-            return "file '" + location + "'";
-        }
-    }
-
-    private static class DevelocityStackTraceLocation implements org.gradle.operations.problems.StackTraceLocation {
-        private final org.gradle.api.problems.internal.StackTraceLocation stackTraceLocation;
-
-        public DevelocityStackTraceLocation(org.gradle.api.problems.internal.StackTraceLocation stackTraceLocation) {
-            this.stackTraceLocation = stackTraceLocation;
-        }
-
-        @Nullable
-        @Override
-        public FileLocation getFileLocation() {
-            return stackTraceLocation.getFileLocation() == null
-                ? null
-                : convertToDevelocityFileLocation(stackTraceLocation.getFileLocation());
-        }
-
-        @Override
-        public List<StackTraceElement> getStackTrace() {
-            return stackTraceLocation.getStackTrace();
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "stack trace location " + stackTraceLocation.getFileLocation();
-        }
-    }
-
-    private static class DevelocityOffsetInFileLocation extends DevelocityFileLocation implements OffsetInFileLocation {
-
-        private final org.gradle.api.problems.OffsetInFileLocation offsetInFileLocation;
-
-        public DevelocityOffsetInFileLocation(org.gradle.api.problems.OffsetInFileLocation offsetInFileLocation) {
-            super(offsetInFileLocation);
-            this.offsetInFileLocation = offsetInFileLocation;
-        }
-
-        @Override
-        public int getOffset() {
-            return offsetInFileLocation.getOffset();
-        }
-
-        @Override
-        public int getLength() {
-            return offsetInFileLocation.getLength();
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "offset in file '" + getPath() + ":" + getOffset() + ":" + getLength() + "'";
-        }
-    }
-
-    private static class DevelocityPluginIdLocation implements org.gradle.operations.problems.PluginIdLocation {
-
-        private final PluginIdLocation pluginId;
-
-        public DevelocityPluginIdLocation(PluginIdLocation pluginId) {
-            this.pluginId = pluginId;
-        }
-
-        @Override
-        public String getPluginId() {
-            return pluginId.getPluginId();
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "plugin '" + pluginId.getPluginId() + "'";
-        }
     }
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DevelocityProblem.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DevelocityProblem.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems.internal;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.operations.problems.DocumentationLink;
+import org.gradle.operations.problems.FileLocation;
+import org.gradle.operations.problems.LineInFileLocation;
+import org.gradle.operations.problems.OffsetInFileLocation;
+import org.gradle.operations.problems.Problem;
+import org.gradle.operations.problems.ProblemDefinition;
+import org.gradle.operations.problems.ProblemGroup;
+import org.gradle.operations.problems.ProblemLocation;
+import org.gradle.operations.problems.ProblemSeverity;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class DevelocityProblem implements Problem {
+    private final InternalProblem problem;
+
+    public DevelocityProblem(InternalProblem problem) {
+        this.problem = problem;
+    }
+
+    @Override
+    public ProblemDefinition getDefinition() {
+        return new DevelocityProblemDefinition(problem.getDefinition());
+    }
+
+    @Override
+    public ProblemSeverity getSeverity() {
+        switch (problem.getDefinition().getSeverity()) {
+            case ADVICE:
+                return ProblemSeverity.ADVICE;
+            case WARNING:
+                return ProblemSeverity.WARNING;
+            case ERROR:
+                return ProblemSeverity.ERROR;
+            default:
+                throw new IllegalArgumentException("Unknown severity: " + problem.getDefinition().getSeverity());
+        }
+    }
+
+    @Nullable
+    @Override
+    public String getContextualLabel() {
+        return problem.getContextualLabel();
+    }
+
+    @Override
+    public List<String> getSolutions() {
+        return problem.getSolutions();
+    }
+
+    @Nullable
+    @Override
+    public String getDetails() {
+        return problem.getDetails();
+    }
+
+    @Override
+    public List<ProblemLocation> getOriginLocations() {
+        return convertProblemLocations(problem.getOriginLocations());
+    }
+
+    @Override
+    public List<ProblemLocation> getContextualLocations() {
+        return convertProblemLocations(problem.getContextualLocations());
+    }
+
+    @Nonnull
+    private ImmutableList<ProblemLocation> convertProblemLocations(List<org.gradle.api.problems.ProblemLocation> locations) {
+        ImmutableList.Builder<ProblemLocation> builder = ImmutableList.builder();
+        for (org.gradle.api.problems.ProblemLocation location : locations) {
+            ProblemLocation develocityLocation = convertToLocation(location);
+            if (develocityLocation != null) {
+                builder.add(develocityLocation);
+            }
+        }
+        return builder.build();
+    }
+
+    @Nullable
+    private static ProblemLocation convertToLocation(final org.gradle.api.problems.ProblemLocation location) {
+        if (location instanceof org.gradle.api.problems.FileLocation) {
+            return convertToDevelocityFileLocation(location);
+        } else if (location instanceof TaskLocation) {
+            // The Develocity plugin will infer the task location from the build operation hierarchy - no need to send this contextual information
+            return null;
+        } else if (location instanceof org.gradle.api.problems.internal.PluginIdLocation) {
+            return new DevelocityPluginIdLocation((PluginIdLocation) location);
+        } else if (location instanceof org.gradle.api.problems.internal.StackTraceLocation) {
+            return new DevelocityStackTraceLocation((StackTraceLocation) location);
+        }
+        throw new IllegalArgumentException("Unknown location type: " + location.getClass() + ", location: '" + location + "'");
+    }
+
+    @Nonnull
+    private static FileLocation convertToDevelocityFileLocation(org.gradle.api.problems.ProblemLocation location) {
+        if (location instanceof org.gradle.api.problems.LineInFileLocation) {
+            return new DevelocityLineInFileLocation((org.gradle.api.problems.LineInFileLocation) location);
+        } else if (location instanceof org.gradle.api.problems.OffsetInFileLocation) {
+            return new DevelocityOffsetInFileLocation((org.gradle.api.problems.OffsetInFileLocation) location);
+        } else {
+            return new DevelocityFileLocation((org.gradle.api.problems.FileLocation) location);
+        }
+    }
+
+    private static class DevelocityProblemDefinition implements ProblemDefinition {
+        private final org.gradle.api.problems.ProblemDefinition definition;
+
+        public DevelocityProblemDefinition(org.gradle.api.problems.ProblemDefinition definition) {
+            this.definition = definition;
+        }
+
+        @Override
+        public String getName() {
+            return definition.getId().getName();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return definition.getId().getDisplayName();
+        }
+
+        @Override
+        public ProblemGroup getGroup() {
+            return new DevelocityProblemDefinition.DevelocityProblemGroup(definition.getId().getGroup());
+        }
+
+        @Nullable
+        @Override
+        public DocumentationLink getDocumentationLink() {
+            InternalDocLink documentationLink = (InternalDocLink) definition.getDocumentationLink();
+            return documentationLink == null ? null : new DevelocityProblemDefinition.DevelocityDocumentationLink(documentationLink);
+        }
+
+        private static class DevelocityProblemGroup implements ProblemGroup {
+            private final org.gradle.api.problems.ProblemGroup currentGroup;
+
+            public DevelocityProblemGroup(org.gradle.api.problems.ProblemGroup currentGroup) {
+                this.currentGroup = currentGroup;
+            }
+
+            @Override
+            public String getName() {
+                return currentGroup.getName();
+            }
+
+            @Override
+            public String getDisplayName() {
+                return currentGroup.getDisplayName();
+            }
+
+            @Nullable
+            @Override
+            public ProblemGroup getParent() {
+                org.gradle.api.problems.ProblemGroup parent = currentGroup.getParent();
+                return parent == null ? null : new DevelocityProblemDefinition.DevelocityProblemGroup(parent);
+            }
+        }
+
+        private static class DevelocityDocumentationLink implements DocumentationLink {
+            private final InternalDocLink documentationLink;
+
+            public DevelocityDocumentationLink(InternalDocLink documentationLink) {
+                this.documentationLink = documentationLink;
+            }
+
+            @Override
+            public String getUrl() {
+                return documentationLink.getUrl();
+            }
+        }
+    }
+
+    private static class DevelocityFileLocation implements FileLocation {
+
+        private final org.gradle.api.problems.FileLocation location;
+
+        public DevelocityFileLocation(org.gradle.api.problems.FileLocation location) {
+            this.location = location;
+        }
+
+        @Override
+        public String getPath() {
+            return location.getPath();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "file '" + getPath() + "'";
+        }
+    }
+
+    private static class DevelocityLineInFileLocation extends DevelocityFileLocation implements LineInFileLocation {
+        private final org.gradle.api.problems.LineInFileLocation lineInFileLocation;
+
+        public DevelocityLineInFileLocation(org.gradle.api.problems.LineInFileLocation lineInFileLocation) {
+            super(lineInFileLocation);
+            this.lineInFileLocation = lineInFileLocation;
+        }
+
+        @Override
+        public int getLine() {
+            return lineInFileLocation.getLine();
+        }
+
+        @Nullable
+        @Override
+        public Integer getColumn() {
+            return lineInFileLocation.getColumn() <= 0 ? null : lineInFileLocation.getColumn();
+        }
+
+        @Nullable
+        @Override
+        public Integer getLength() {
+            return lineInFileLocation.getLength() <= 0 ? null : lineInFileLocation.getLength();
+        }
+
+        @Override
+        public String getDisplayName() {
+            String location = getPath() + ":" + getLine();
+            if (getColumn() != null) {
+                location += ":" + getColumn();
+            }
+            if (getLength() != null) {
+                location += ":" + getLength();
+            }
+            return "file '" + location + "'";
+        }
+    }
+
+    private static class DevelocityStackTraceLocation implements org.gradle.operations.problems.StackTraceLocation {
+        private final org.gradle.api.problems.internal.StackTraceLocation stackTraceLocation;
+
+        public DevelocityStackTraceLocation(org.gradle.api.problems.internal.StackTraceLocation stackTraceLocation) {
+            this.stackTraceLocation = stackTraceLocation;
+        }
+
+        @Nullable
+        @Override
+        public FileLocation getFileLocation() {
+            return stackTraceLocation.getFileLocation() == null
+                ? null
+                : convertToDevelocityFileLocation(stackTraceLocation.getFileLocation());
+        }
+
+        @Override
+        public List<StackTraceElement> getStackTrace() {
+            return stackTraceLocation.getStackTrace();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "stack trace location " + stackTraceLocation.getFileLocation();
+        }
+    }
+
+    private static class DevelocityOffsetInFileLocation extends DevelocityFileLocation implements OffsetInFileLocation {
+
+        private final org.gradle.api.problems.OffsetInFileLocation offsetInFileLocation;
+
+        public DevelocityOffsetInFileLocation(org.gradle.api.problems.OffsetInFileLocation offsetInFileLocation) {
+            super(offsetInFileLocation);
+            this.offsetInFileLocation = offsetInFileLocation;
+        }
+
+        @Override
+        public int getOffset() {
+            return offsetInFileLocation.getOffset();
+        }
+
+        @Override
+        public int getLength() {
+            return offsetInFileLocation.getLength();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "offset in file '" + getPath() + ":" + getOffset() + ":" + getLength() + "'";
+        }
+    }
+
+    private static class DevelocityPluginIdLocation implements org.gradle.operations.problems.PluginIdLocation {
+
+        private final PluginIdLocation pluginId;
+
+        public DevelocityPluginIdLocation(PluginIdLocation pluginId) {
+            this.pluginId = pluginId;
+        }
+
+        @Override
+        public String getPluginId() {
+            return pluginId.getPluginId();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "plugin '" + pluginId.getPluginId() + "'";
+        }
+    }
+}

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/ProblemLocator.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/ProblemLocator.java
@@ -17,7 +17,15 @@
 package org.gradle.api.problems.internal;
 
 import java.util.Collection;
+import java.util.Collections;
 
 public interface ProblemLocator {
+    ProblemLocator EMPTY_LOCATOR = new ProblemLocator() {
+        @Override
+        public Collection<InternalProblem> findAll(Throwable t) {
+            return Collections.emptyList();
+        }
+    };
+
     Collection<InternalProblem> findAll(Throwable t);
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/failure/Failure.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/internal/problems/failure/Failure.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.problems.failure;
 
+import org.gradle.api.problems.internal.InternalProblem;
+
 import java.util.List;
 
 /**
@@ -37,6 +39,11 @@ public interface Failure {
      * @see Throwable#toString()
      */
     String getHeader();
+
+    /**
+     * The message of the original exception.
+     */
+    String getMessage();
 
     /**
      * Stack frames from the original exception.
@@ -61,8 +68,17 @@ public interface Failure {
     List<Failure> getCauses();
 
     /**
+     * The problems associated to the failure.
+     */
+    List<InternalProblem> getProblems();
+
+    /**
      * Returns the index of the first matching frame in the stack trace, or {@code -1} if not found.
      */
     int indexOfStackFrame(int start, StackFramePredicate predicate);
 
+    /**
+     * The original exception.
+     */
+    Throwable getOriginal();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildActionRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildActionRunner.java
@@ -18,6 +18,7 @@ package org.gradle.internal.buildtree;
 
 import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.internal.invocation.BuildAction;
+import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -47,14 +48,22 @@ public interface BuildActionRunner {
         private final boolean hasResult;
         private final Object result;
         private final Throwable buildFailure;
+        private final Failure richBuildFailure;
         private final Throwable clientFailure;
-        private static final Result NOTHING = new Result(false, null, null, null);
-        private static final Result NULL = new Result(true, null, null, null);
+        private static final Result NOTHING = new Result(false, null, null, null, null);
+        private static final Result NULL = new Result(true, null, null, null, null);
 
-        private Result(boolean hasResult, @Nullable Object result, @Nullable Throwable buildFailure, @Nullable Throwable clientFailure) {
+        private Result(
+            boolean hasResult,
+            @Nullable Object result,
+            @Nullable Throwable buildFailure,
+            @Nullable Failure richBuildFailure,
+            @Nullable Throwable clientFailure
+        ) {
             this.hasResult = hasResult;
             this.result = result;
             this.buildFailure = buildFailure;
+            this.richBuildFailure = richBuildFailure;
             this.clientFailure = clientFailure;
         }
 
@@ -66,15 +75,19 @@ public interface BuildActionRunner {
             if (result == null) {
                 return NULL;
             }
-            return new Result(true, result, null, null);
+            return new Result(true, result, null, null, null);
         }
 
         public static Result failed(Throwable buildFailure) {
-            return new Result(true, null, buildFailure, buildFailure);
+            return new Result(true, null, buildFailure, null, buildFailure);
+        }
+
+        public static Result failed(Throwable buildFailure, Failure richBuildFailure) {
+            return new Result(true, null, buildFailure, richBuildFailure, buildFailure);
         }
 
         public static Result failed(Throwable buildFailure, RuntimeException clientFailure) {
-            return new Result(true, null, buildFailure, clientFailure);
+            return new Result(true, null, buildFailure, null, clientFailure);
         }
 
         /**
@@ -98,6 +111,16 @@ public interface BuildActionRunner {
         @Nullable
         public Throwable getBuildFailure() {
             return buildFailure;
+        }
+
+        /**
+         * Returns a preprocessed failure that was reported in the build outcome.
+         * <p>
+         * {@code null} when there is no failure, or when the build failure hasn't been converted, yet, or when the failure happened after converting the build failure.
+         */
+        @Nullable
+        public Failure getRichBuildFailure() {
+            return richBuildFailure;
         }
 
         /**
@@ -130,6 +153,11 @@ public interface BuildActionRunner {
             } else {
                 return failed(new MultipleBuildFailures(newFailures));
             }
+        }
+
+        public Result withFailure(Failure richBuildFailure) {
+            assert buildFailure != null;
+            return failed(buildFailure, richBuildFailure);
         }
 
         /**

--- a/subprojects/core/src/main/java/org/gradle/internal/enterprise/core/GradleEnterprisePluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/enterprise/core/GradleEnterprisePluginManager.java
@@ -21,6 +21,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.InternalBuildAdapter;
+import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.slf4j.Logger;
@@ -28,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 
 @ServiceScope(Scope.BuildTree.class)
 public class GradleEnterprisePluginManager {
@@ -71,9 +73,9 @@ public class GradleEnterprisePluginManager {
         return adapter != null;
     }
 
-    public void buildFinished(@Nullable Throwable buildFailure) {
+    public void buildFinished(@Nullable Throwable buildFailure, @Nullable List<Failure> richBuildFailures) {
         if (adapter != null) {
-            adapter.buildFinished(buildFailure);
+            adapter.buildFinished(buildFailure, richBuildFailures);
         }
     }
 


### PR DESCRIPTION
We report the problems associated to a build failure to Build Scan in `GradleEnterprisePluginEndOfBuildListener`. We will also try to use the same internal failure for console reporting and reporting to the TAPI, so we don't need to do the work to associate a failure to problems multiple times and the reporting is consistent.