### PR TITLE
Add support for MapProperty indexed access/assignment in Kotlin

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PropertyExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PropertyExtensions.kt
@@ -194,6 +194,45 @@ operator fun <K : Any, V : Any> MapProperty<K, V>.plusAssign(value: Pair<K, V>) 
     this.put(value.first, value.second)
 }
 
+/**
+ * Returns a provider that resolves to the value of the mapping of the given key. It will have no value
+ * if the property has no value, or if it does not contain a mapping for the key.
+ *
+ * @see MapProperty.getting
+ * @since 9.0
+ */
+@Incubating
+operator fun <K : Any, V : Any> MapProperty<K, V>.get(key: K): Provider<V> {
+    return this.getting(key)
+}
+
+/**
+ * Adds a map entry to the property value.
+ *
+ * @param key the key
+ * @param value the value
+ *
+ * @see MapProperty.put
+ * @since 9.0
+ */
+@Incubating
+operator fun <K : Any, V : Any> MapProperty<K, V>.set(key: K, value: V) {
+    this.put(key, value)
+}
+
+/**
+ * Adds a map entry to the property value.
+ *
+ * @param key the key
+ * @param providerOfValue the provider of the value
+ *
+ * @see MapProperty.put
+ * @since 9.0
+ */
+@Incubating
+operator fun <K : Any, V : Any> MapProperty<K, V>.set(key: K, providerOfValue: Provider<out V>) {
+    this.put(key, providerOfValue)
+}
 
 /**
  * Adds a map entry to the property value.

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/CollectionPropertyExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/CollectionPropertyExtensionsTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
+import org.junit.Test
+import kotlin.test.assertSame
+
+class CollectionPropertyExtensionsTest {
+
+    @Test
+    fun `adding value to list invokes add(T)`() {
+        val list = mock<ListProperty<String>>()
+
+        list += "foo"
+
+        verify(list).add("foo")
+    }
+
+    @Test
+    fun `adding collection to list invokes add(Collection of T)`() {
+        val list = mock<ListProperty<String>>()
+        val rawList = mock<List<String>>()
+
+        list += rawList
+
+        verify(list).addAll(rawList)
+    }
+
+    @Test
+    fun `adding provider of collection invokes addAll(Provider of list of T)`() {
+        val list = mock<ListProperty<String>>()
+        val provider = mock<Provider<List<String>>>()
+
+        list += provider
+
+        verify(list).addAll(provider)
+    }
+
+    @Test
+    fun `map indexed assignment using provider invokes put`() {
+        val map = mock<MapProperty<String, Int>>()
+        val valueProvider = mock<Provider<Int>>()
+
+        map["a"] = valueProvider
+
+        verify(map).put("a", valueProvider)
+    }
+
+    @Test
+    fun `map indexed assignment using provider of subtype`() {
+        val map = mock<MapProperty<String, Number>>()
+        val valueProvider = mock<Provider<Int>>()
+
+        map["a"] = valueProvider
+
+        verify(map).put("a", valueProvider)
+    }
+
+    @Test
+    fun `map indexed assignment invokes put`() {
+        val map = mock<MapProperty<String, Int>>()
+
+        map["a"] = 10
+
+        verify(map).put("a", 10)
+    }
+
+    @Test
+    fun `map indexed access invokes getting`() {
+        val map = mock<MapProperty<String, Int>>()
+        val providerOfInt = mock<Provider<Int>>()
+
+        whenever(map.getting("a")).thenReturn(providerOfInt)
+
+        val result = map["a"]
+
+        verify(map).getting("a")
+        assertSame(providerOfInt, result)
+    }
+
+
+}

--- a/testing/architecture-test/src/changes/accepted-changes/propertyExtension-accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/propertyExtension-accepted-public-api-changes.json
@@ -2,6 +2,14 @@
     "acceptedApiChanges": [
         {
             "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.get(org.gradle.api.provider.MapProperty,java.lang.Object)",
+            "acceptation": "New indexed access API",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
             "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssign(org.gradle.api.provider.HasMultipleValues,java.lang.Object)",
             "acceptation": "New += API",
             "changes": [
@@ -44,6 +52,22 @@
             "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
             "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssignElementsProvider(org.gradle.api.provider.MapProperty,org.gradle.api.provider.Provider)",
             "acceptation": "New += API",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.set(org.gradle.api.provider.MapProperty,java.lang.Object,java.lang.Object)",
+            "acceptation": "New indexed assignment API",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.set(org.gradle.api.provider.MapProperty,java.lang.Object,org.gradle.api.provider.Provider)",
+            "acceptation": "New indexed assignment API",
             "changes": [
                 "Method added to public class"
             ]


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Issue: #29402

Only adds indexed access/assignment for `MapProperty`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
