### PR TITLE
Fixed mixed up JavaDoc

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/VerificationType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/VerificationType.java
@@ -37,12 +37,12 @@ public interface VerificationType extends Named {
     String MAIN_SOURCES = "main-sources";
 
     /**
-     * Binary results of running tests containing pass/fail information
+     * Binary test coverage data gathered by JaCoCo
      */
     String JACOCO_RESULTS = "jacoco-coverage";
 
     /**
-     * Binary test coverage data gathered by JaCoCo
+     * Binary results of running tests containing pass/fail information
      */
     String TEST_RESULTS = "test-results";
 }


### PR DESCRIPTION
### Context
The JavaDoc for those two constants seems to have been mixed up.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
