### PR TITLE
Provide task-output dependency info in AntlrPlugin

### DIFF
--- a/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -19,7 +19,6 @@ package org.gradle.api.plugins.antlr;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.DefaultSourceSet;
@@ -29,6 +28,7 @@ import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.antlr.internal.DefaultAntlrSourceDirectorySet;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskProvider;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -82,28 +82,23 @@ public abstract class AntlrPlugin implements Plugin<Project> {
                     //    naming conventions via call to sourceSet.getTaskName()
                     final String taskName = sourceSet.getTaskName("generate", "GrammarSource");
 
-                    // 3) Set up the Antlr output directory (adding to javac inputs!)
+                    // 3) Set up the Antlr output directory
                     final String outputDirectoryName = project.getBuildDir() + "/generated-src/antlr/" + sourceSet.getName();
                     final File outputDirectory = new File(outputDirectoryName);
-                    sourceSet.getJava().srcDir(outputDirectory);
 
-                    project.getTasks().register(taskName, AntlrTask.class, new Action<AntlrTask>() {
+                    // 4) Register a source-generating task, and
+                    TaskProvider<AntlrTask> antlrTask = project.getTasks().register(taskName, AntlrTask.class, new Action<AntlrTask>() {
                         @Override
                         public void execute(AntlrTask antlrTask) {
                             antlrTask.setDescription("Processes the " + sourceSet.getName() + " Antlr grammars.");
-                            // 4) set up convention mapping for default sources (allows user to not have to specify)
+                            // 4.1) set up convention mapping for default sources (allows user to not have to specify)
                             antlrTask.setSource(antlrSourceSet);
                             antlrTask.setOutputDirectory(outputDirectory);
                         }
                     });
 
-                    // 5) register fact that antlr should be run before compiling
-                    project.getTasks().named(sourceSet.getCompileJavaTaskName(), new Action<Task>() {
-                        @Override
-                        public void execute(Task task) {
-                            task.dependsOn(taskName);
-                        }
-                    });
+                    // 5) Add that task's outputs to the Java source set
+                    sourceSet.getJava().srcDir(antlrTask.map(t -> t.getOutputDirectory()));
                 }
             });
     }

--- a/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -98,7 +98,7 @@ public abstract class AntlrPlugin implements Plugin<Project> {
                     });
 
                     // 5) Add that task's outputs to the Java source set
-                    sourceSet.getJava().srcDir(antlrTask.map(t -> t.getOutputDirectory()));
+                    sourceSet.getJava().srcDir(antlrTask);
                 }
             });
     }

--- a/platforms/software/antlr/src/test/groovy/org/gradle/api/plugins/antlr/AntlrPluginTest.groovy
+++ b/platforms/software/antlr/src/test/groovy/org/gradle/api/plugins/antlr/AntlrPluginTest.groovy
@@ -93,4 +93,19 @@ class AntlrPluginTest extends AbstractProjectBuilderSpec {
         def main = project.sourceSets.main
         main.extensions.extensionsSchema.find { it.name == 'antlr' }.publicType == typeOf(AntlrSourceDirectorySet)
     }
+
+    def 'adds task dependency to sourcesJar'() {
+        when:
+        project.pluginManager.apply(AntlrPlugin)
+
+        and:
+        project.java {
+            withSourcesJar()
+        }
+
+        then:
+        def generateGrammarSource = project.tasks.generateGrammarSource
+        def sourcesJar = project.tasks.sourcesJar
+        sourcesJar.taskDependencies.getDependencies(null).contains(generateGrammarSource)
+    }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

Adds and propagates task dependency information in the ANTLR plugin, ensuring that codegen runs before Java compilation tasks, and also that any tasks using Java source sets as input have an explicit dependency on the corresponding `AntlrTask`.

Fixes #19555 
Fixes #25885 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

The benefit of this change is that consumers of this plugin will no longer need to manually add explicit `dependsOn` links between Javadoc, Dokka, Kotlin, etc tasks and `generateGrammarSource` tasks.  Examples:
- https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/shadowed/antlr/build.gradle.kts#L89
- https://github.com/microsoft/thrifty/blob/master/thrifty-schema/build.gradle#L46

Today, the `AntlrPlugin` will configure an `AntlrTask` for each Java source-set by doing the following steps in order (leaving a bunch of other stuff out, of course):
1. Determine an output directory path (a `java.io.File`)
2. Add this output directory file to the source set using `ss.srcDir(outputDirectory)`
3. Register an antlr task, and set its output directory to `outputDirectory`
4. Ensure that the antlr task runs before the java compile task using `task.dependsOn(antlrTaskName)`

This works and has worked well enough for getting sources generated and consumed by Java compile tasks, but note that there is no dependency propagation between `AntlrTask` and Java-compile tasks.  This means that other tasks making use of Java source sets (like Javadoc, Dokka, source-jar tasks, and similar) end up with an implicit dependency on the `AntlrTask`.  Most people end up manually adding `dependsOn` statements to work around the resulting build error.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
