### PR TITLE
Annotate BuildTree-scope services (re-revert)

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
@@ -24,6 +24,8 @@ import org.gradle.api.internal.tasks.TaskExecutionAccessChecker
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
 import org.gradle.execution.ExecutionAccessChecker
 import org.gradle.execution.ExecutionAccessListener
+import org.gradle.internal.build.BuildModelControllerServices
+import org.gradle.internal.build.BuildToolingModelControllerFactory
 import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeModelControllerServices
@@ -63,8 +65,8 @@ class ConfigurationCacheServices : AbstractGradleModuleServices() {
         registration.run {
             add(BuildNameProvider::class.java)
             add(ConfigurationCacheKey::class.java)
-            add(DefaultBuildModelControllerServices::class.java)
-            add(DefaultBuildToolingModelControllerFactory::class.java)
+            add(BuildModelControllerServices::class.java, DefaultBuildModelControllerServices::class.java)
+            add(BuildToolingModelControllerFactory::class.java, DefaultBuildToolingModelControllerFactory::class.java)
             add(DeprecatedFeaturesListener::class.java)
             add(InputTrackingState::class.java)
             add(InstrumentedExecutionAccessListener::class.java)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -44,10 +44,10 @@ import org.gradle.internal.service.scopes.ServiceScope
 
 
 @ServiceScope(Scope.BuildTree::class)
+@ListenerService
 interface ConfigurationCacheProblemsListener : ExecutionAccessListener, TaskExecutionAccessListener, BuildScopeListenerRegistrationListener, ExternalProcessStartedListener
 
 
-@ListenerService
 class DefaultConfigurationCacheProblemsListener internal constructor(
     private val problems: ProblemsListener,
     private val problemFactory: ProblemFactory,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/InstrumentedExecutionAccessListenerRegistry.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/InstrumentedExecutionAccessListenerRegistry.kt
@@ -20,8 +20,11 @@ import org.gradle.internal.cc.impl.InstrumentedExecutionAccessListener
 import org.gradle.internal.classpath.InstrumentedExecutionAccess
 import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.service.scopes.ListenerService
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
 
 
+@ServiceScope(Scope.BuildTree::class)
 @ListenerService
 internal
 class InstrumentedExecutionAccessListenerRegistry(

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/ConfigurationCacheBuildTreeModelSideEffectExecutor.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/ConfigurationCacheBuildTreeModelSideEffectExecutor.kt
@@ -19,8 +19,11 @@ package org.gradle.internal.cc.impl.services
 import org.gradle.internal.cc.impl.models.BuildTreeModelSideEffectStore
 import org.gradle.internal.buildtree.BuildTreeModelSideEffect
 import org.gradle.internal.buildtree.BuildTreeModelSideEffectExecutor
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
 
 
+@ServiceScope(Scope.BuildTree::class)
 internal
 class ConfigurationCacheBuildTreeModelSideEffectExecutor : BuildTreeModelSideEffectExecutor {
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/DeferredRootBuildGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/DeferredRootBuildGradle.kt
@@ -38,6 +38,7 @@ interface DeferredRootBuildGradle {
 }
 
 
+@ServiceScope(Scope.BuildTree::class)
 internal
 class DefaultDeferredRootBuildGradle : DeferredRootBuildGradle {
 

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemFactory.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemFactory.kt
@@ -18,8 +18,10 @@ package org.gradle.internal.configuration.problems
 
 import org.gradle.internal.service.scopes.EventScope
 import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
 
 
+@ServiceScope(Scope.BuildTree::class)
 @EventScope(Scope.BuildTree::class)
 interface ProblemFactory {
     /**

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceScopeValidatorWorkarounds.java
@@ -31,6 +31,10 @@ class ServiceScopeValidatorWorkarounds {
         "org.gradle.cache.internal.ProducerGuard",
         "org.gradle.internal.typeconversion.NotationParser",
 
+        // Avoid annotating services published as public libraries
+        // build-cache-base:
+        "org.gradle.caching.internal.origin.OriginMetadataFactory",
+
         // It's supposed to be only in the Settings scope
         // However, ProjectBuilderImpl does not instantiate that scope at all, while still requiring the service
         // Because of this, it artificially puts it into the Build-scope to make it available

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterprisePluginServiceRefInternal.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterprisePluginServiceRefInternal.java
@@ -18,7 +18,10 @@ package org.gradle.internal.enterprise.impl;
 
 import org.gradle.internal.enterprise.GradleEnterprisePluginService;
 import org.gradle.internal.enterprise.GradleEnterprisePluginServiceRef;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scope.BuildTree.class)
 public interface GradleEnterprisePluginServiceRefInternal extends GradleEnterprisePluginServiceRef {
 
     void set(GradleEnterprisePluginService service);

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblems.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblems.java
@@ -17,8 +17,11 @@
 package org.gradle.api.problems.internal;
 
 import org.gradle.api.problems.Problems;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.reflect.Instantiator;
 
+@ServiceScope(Scope.BuildTree.class)
 public interface InternalProblems extends Problems {
 
     /**

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/ProblemReportCreator.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/ProblemReportCreator.java
@@ -16,9 +16,13 @@
 
 package org.gradle.api.problems.internal;
 
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 import java.io.File;
 import java.util.List;
 
+@ServiceScope(Scope.BuildTree.class)
 public interface ProblemReportCreator {
     /**
      * Stores a new problem in a temporary file that will be added to the final report when #createProblem is called.

--- a/platforms/ide/problems-api/src/main/java/org/gradle/problems/buildtree/ProblemStream.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/problems/buildtree/ProblemStream.java
@@ -17,11 +17,14 @@
 package org.gradle.problems.buildtree;
 
 import com.google.common.base.Supplier;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.problems.ProblemDiagnostics;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
+@ServiceScope(Scope.BuildTree.class)
 public interface ProblemStream {
     /**
      * Returns diagnostics based on the state of the calling thread.

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingBuilderServices.java
@@ -17,6 +17,7 @@
 package org.gradle.tooling.internal.provider.runner;
 
 import org.gradle.internal.build.event.BuildEventListenerFactory;
+import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractGradleModuleServices;
 
@@ -29,9 +30,9 @@ public class ToolingBuilderServices extends AbstractGradleModuleServices {
     @Override
     public void registerBuildTreeServices(ServiceRegistration registration) {
         registration.add(BuildControllerFactory.class);
-        registration.add(BuildModelActionRunner.class);
-        registration.add(TestExecutionRequestActionRunner.class);
-        registration.add(ClientProvidedBuildActionRunner.class);
-        registration.add(ClientProvidedPhasedActionRunner.class);
+        registration.add(BuildActionRunner.class, BuildModelActionRunner.class);
+        registration.add(BuildActionRunner.class, TestExecutionRequestActionRunner.class);
+        registration.add(BuildActionRunner.class, ClientProvidedBuildActionRunner.class);
+        registration.add(BuildActionRunner.class, ClientProvidedPhasedActionRunner.class);
     }
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetector.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetector.java
@@ -30,6 +30,8 @@ import org.gradle.cache.internal.FileContentCache;
 import org.gradle.cache.internal.FileContentCacheFactory;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.serialize.ListSerializer;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -48,6 +50,7 @@ import java.util.Map;
  * Inspects a classpath to find annotation processors contained in it. If several versions of the same annotation processor are found,
  * the first one is returned, mimicking the behavior of {@link java.util.ServiceLoader}.
  */
+@ServiceScope(Scope.BuildTree.class)
 public class AnnotationProcessorDetector {
 
     public static final String PROCESSOR_DECLARATION = "META-INF/services/javax.annotation.processing.Processor";

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
@@ -54,7 +54,9 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalVariantGraphResolveStateBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProjectLocalComponentProvider;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProjectPublicationRegistry;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentProvider;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectArtifactResolver;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublicationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VariantArtifactSetCache;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AdhocHandlingComponentResultSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
@@ -71,6 +73,7 @@ import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.filestore.ArtifactIdentifierFileStore;
 import org.gradle.api.internal.filestore.DefaultArtifactIdentifierFileStore;
 import org.gradle.api.internal.filestore.TwoStageArtifactIdentifierFileStore;
+import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.component.external.model.ModuleComponentGraphResolveStateFactory;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveStateFactory;
@@ -114,8 +117,8 @@ class DependencyManagementBuildTreeScopeServices implements ServiceRegistrationP
         registration.add(ThisBuildTreeOnlyComponentResultSerializer.class);
         registration.add(AdhocHandlingComponentResultSerializer.class);
         registration.add(ConnectionFailureRepositoryDisabler.class);
-        registration.add(DefaultProjectLocalComponentProvider.class);
-        registration.add(DefaultProjectPublicationRegistry.class);
+        registration.add(LocalComponentProvider.class, DefaultProjectLocalComponentProvider.class);
+        registration.add(ProjectPublicationRegistry.class, HoldsProjectState.class, DefaultProjectPublicationRegistry.class);
         registration.add(LocalVariantGraphResolveStateBuilder.class, DefaultLocalVariantGraphResolveStateBuilder.class);
         registration.add(ResolvedVariantCache.class);
         registration.add(VariantArtifactSetCache.class);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/capability/CapabilitySelectorSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/capability/CapabilitySelectorSerializer.java
@@ -21,9 +21,12 @@ import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.IOException;
 
+@ServiceScope(Scope.BuildTree.class)
 public class CapabilitySelectorSerializer implements Serializer<CapabilitySelector> {
 
     private static final int SPECIFIC_CAPABILITY_SELECTOR = 1;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleRepositoryCacheProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleRepositoryCacheProvider.java
@@ -15,6 +15,10 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scope.BuildTree.class)
 public class ModuleRepositoryCacheProvider {
     private final ModuleRepositoryCaches caches;
     private final ModuleRepositoryCaches inMemoryCaches;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/BuildTreeLocalComponentProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/BuildTreeLocalComponentProvider.java
@@ -17,6 +17,8 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -27,6 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>In general, you should be using {@link LocalComponentRegistry} instead of this type, as it is scoped
  * to a build and will call the appropriate method on this provider.</p>
  */
+@ServiceScope(Scope.BuildTree.class)
 @ThreadSafe
 public interface BuildTreeLocalComponentProvider {
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentCache.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentCache.java
@@ -16,6 +16,8 @@
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
 
 import java.util.function.Function;
@@ -23,6 +25,7 @@ import java.util.function.Function;
 /**
  * A cache for {@link LocalComponentGraphResolveState} instances.
  */
+@ServiceScope(Scope.BuildTree.class)
 public interface LocalComponentCache {
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentProvider.java
@@ -17,6 +17,8 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -25,6 +27,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>In general, you should be using {@link LocalComponentRegistry} instead of this type.</p>
  */
+@ServiceScope(Scope.BuildTree.class)
 @ThreadSafe
 public interface LocalComponentProvider {
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectPublicationRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectPublicationRegistry.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -30,6 +32,7 @@ import java.util.Collection;
  *
  * The information is gathered from multiple sources ({@code publishing.publications} container, etc.).
  */
+@ServiceScope(Scope.BuildTree.class)
 @ThreadSafe
 public interface ProjectPublicationRegistry {
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/AdhocHandlingComponentResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/AdhocHandlingComponentResultSerializer.java
@@ -19,11 +19,14 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * A {@link ComponentResultSerializer} that determines whether to fully serialize a component
  * depending on if it is adhoc or not.
  */
+@ServiceScope(Scope.BuildTree.class)
 public class AdhocHandlingComponentResultSerializer implements ComponentResultSerializer {
 
     private final ThisBuildTreeOnlyComponentResultSerializer thisBuildTreeOnlyComponentResultSerializer;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CompleteComponentResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CompleteComponentResultSerializer.java
@@ -38,6 +38,8 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.ListSerializer;
 import org.gradle.internal.serialize.Serializer;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -46,6 +48,7 @@ import java.util.List;
  * A {@link ComponentResultSerializer} that serializes the complete component result
  * without relying on any external state to be held between serialization and deserialization.
  */
+@ServiceScope(Scope.BuildTree.class)
 public class CompleteComponentResultSerializer implements ComponentResultSerializer {
 
     private final ComponentSelectionReasonSerializer reasonSerializer;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ThisBuildTreeOnlyComponentResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ThisBuildTreeOnlyComponentResultSerializer.java
@@ -28,6 +28,8 @@ import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.IOException;
 import java.util.List;
@@ -41,6 +43,7 @@ import java.util.List;
  * This serializer is intended for {@link ComponentGraphResolveState#isAdHoc() non-adhoc} components, as holding references
  * to adhoc components would prevent them from being garbage collected.
  */
+@ServiceScope(Scope.BuildTree.class)
 public class ThisBuildTreeOnlyComponentResultSerializer implements ComponentResultSerializer {
 
     private final Long2ObjectMap<ComponentGraphResolveState> components = Long2ObjectMaps.synchronize(new Long2ObjectOpenHashMap<>());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
@@ -23,6 +23,8 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.cache.internal.Store;
 import org.gradle.internal.concurrent.CompositeStoppable;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 
@@ -32,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@ServiceScope(Scope.BuildTree.class)
 public class ResolutionResultsStoreFactory implements Closeable {
     private final static Logger LOG = Logging.getLogger(ResolutionResultsStoreFactory.class);
     private static final int DEFAULT_MAX_SIZE = 2000000000; //2 gigs

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/composite/CompositeBuildContext.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/composite/CompositeBuildContext.java
@@ -22,9 +22,12 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.internal.Pair;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Set;
 
+@ServiceScope(Scope.BuildTree.class)
 public interface CompositeBuildContext extends DependencySubstitutionRules {
     void addAvailableModules(Set<Pair<ModuleVersionIdentifier, ProjectComponentIdentifier>> availableModules);
     void registerSubstitution(Action<DependencySubstitution> substitutions);

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/AggregateTestEventReporter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/AggregateTestEventReporter.java
@@ -24,6 +24,8 @@ import org.gradle.api.internal.tasks.testing.report.generic.MetadataRendererRegi
 import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.problems.buildtree.ProblemReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Aggregates test results from multiple test executions and generates a report at the end of the build.
  */
 @NonNullApi
+@ServiceScope(Scope.BuildTree.class)
 public class AggregateTestEventReporter implements ProblemReporter, TestExecutionResultsListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AggregateTestEventReporter.class);

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/VcsMappingFactory.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/VcsMappingFactory.java
@@ -17,7 +17,10 @@
 package org.gradle.vcs.internal;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scope.BuildTree.class)
 public interface VcsMappingFactory {
     VcsMappingInternal create(ComponentSelector selector);
 }

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/VersionControlSpecFactory.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/VersionControlSpecFactory.java
@@ -16,10 +16,13 @@
 
 package org.gradle.vcs.internal;
 
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.vcs.VersionControlSpec;
 
 import java.net.URI;
 
+@ServiceScope(Scope.BuildTree.class)
 public interface VersionControlSpecFactory {
     <T extends VersionControlSpec> T create(Class<T> specType);
 

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/resolver/VcsVersionSelectionCache.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/resolver/VcsVersionSelectionCache.java
@@ -18,6 +18,8 @@ package org.gradle.vcs.internal.resolver;
 
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.vcs.internal.VersionControlRepositoryConnection;
 import org.gradle.vcs.internal.VersionRef;
 
@@ -27,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+@ServiceScope(Scope.BuildTree.class)
 public class VcsVersionSelectionCache {
     private final Map<String, File> resolvedVersions = new ConcurrentHashMap<String, File>();
     private final Map<String, Set<VersionRef>> repositoryVersions = new ConcurrentHashMap<String, Set<VersionRef>>();

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -19,6 +19,7 @@ package org.gradle.composite.internal;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.ComponentSelectorNotationConverter;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.BuildTreeLocalComponentProvider;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.composite.CompositeBuildContext;
 import org.gradle.api.internal.project.HoldsProjectState;
@@ -48,7 +49,7 @@ public class CompositeBuildServices extends AbstractGradleModuleServices {
     @Override
     public void registerBuildTreeServices(ServiceRegistration registration) {
         registration.addProvider(new CompositeBuildTreeScopeServices());
-        registration.add(DefaultBuildTreeLocalComponentProvider.class);
+        registration.add(BuildTreeLocalComponentProvider.class, HoldsProjectState.class, DefaultBuildTreeLocalComponentProvider.class);
     }
 
     @Override
@@ -67,8 +68,8 @@ public class CompositeBuildServices extends AbstractGradleModuleServices {
         @Provides
         public void configure(ServiceRegistration serviceRegistration) {
             serviceRegistration.add(BuildStateFactory.class);
-            serviceRegistration.add(DefaultIncludedBuildFactory.class);
-            serviceRegistration.add(DefaultIncludedBuildTaskGraph.class);
+            serviceRegistration.add(IncludedBuildFactory.class, DefaultIncludedBuildFactory.class);
+            serviceRegistration.add(BuildTreeWorkGraphController.class, DefaultIncludedBuildTaskGraph.class);
         }
 
         @Provides

--- a/subprojects/core-api/src/main/java/org/gradle/internal/model/BuildTreeObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/model/BuildTreeObjectFactory.java
@@ -17,9 +17,12 @@
 package org.gradle.internal.model;
 
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * A marker interface for an ObjectFactory that is instantiated with BuildTreeScopeServices.
  */
+@ServiceScope(Scope.BuildTree.class)
 public interface BuildTreeObjectFactory extends ObjectFactory {
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/BuildType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/BuildType.java
@@ -16,6 +16,10 @@
 
 package org.gradle.api.internal;
 
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scope.BuildTree.class)
 public enum BuildType {
     TASKS,
     MODEL

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/HoldsProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/HoldsProjectState.java
@@ -23,7 +23,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * A service can implement this interface to indicate that it holds mutable project scoped state that should be discarded when
  * projects are discarded.
  */
-@ServiceScope(Scope.Build.class)
+@ServiceScope({Scope.BuildTree.class, Scope.Build.class})
 public interface HoldsProjectState {
     /**
      * Discards any project state.

--- a/subprojects/core/src/main/java/org/gradle/initialization/exception/ExceptionCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/exception/ExceptionCollector.java
@@ -16,8 +16,12 @@
 
 package org.gradle.initialization.exception;
 
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 import java.util.Collection;
 
+@ServiceScope(Scope.BuildTree.class)
 public interface ExceptionCollector {
     /**
      * Transforms the given failure into zero or more (most likely 1) failures to be reported.

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildActionModelRequirements.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildActionModelRequirements.java
@@ -19,7 +19,10 @@ package org.gradle.internal.buildtree;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.hash.Hasher;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scope.BuildTree.class)
 public interface BuildActionModelRequirements {
     /**
      * Will the action run tasks?

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildActionRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildActionRunner.java
@@ -29,7 +29,7 @@ import java.util.List;
 /**
  * Responsible for executing a {@link BuildAction} and generating the result.
  */
-@ServiceScope(Scope.Global.class)
+@ServiceScope({Scope.Global.class, Scope.BuildTree.class})
 public interface BuildActionRunner {
     /**
      * Runs the given action, returning a result that describes the build outcome and the result that should be returned to the client.

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -23,11 +23,14 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.FileCollectionObservationListener;
+import org.gradle.api.internal.initialization.BuildLogicBuildQueue;
 import org.gradle.api.internal.initialization.DefaultBuildLogicBuildQueue;
 import org.gradle.api.internal.model.DefaultObjectFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.project.DefaultProjectStateRegistry;
+import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.project.taskfactory.TaskIdentityFactory;
+import org.gradle.api.internal.provider.ConfigurationTimeBarrier;
 import org.gradle.api.internal.provider.DefaultConfigurationTimeBarrier;
 import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -42,6 +45,7 @@ import org.gradle.execution.ProjectConfigurer;
 import org.gradle.execution.TaskNameResolver;
 import org.gradle.execution.TaskPathProjectEvaluator;
 import org.gradle.execution.TaskSelector;
+import org.gradle.execution.selection.BuildTaskSelector;
 import org.gradle.execution.selection.DefaultBuildTaskSelector;
 import org.gradle.initialization.BuildOptionBuildOperationProgressEventsEmitter;
 import org.gradle.initialization.exception.DefaultExceptionAnalyser;
@@ -49,10 +53,12 @@ import org.gradle.initialization.exception.ExceptionCollector;
 import org.gradle.initialization.exception.MultipleBuildFailuresExceptionAnalyser;
 import org.gradle.initialization.exception.StackTraceSanitizingExceptionAnalyser;
 import org.gradle.internal.Factory;
+import org.gradle.internal.build.BuildLifecycleControllerFactory;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.DefaultBuildLifecycleControllerFactory;
 import org.gradle.internal.buildoption.DefaultFeatureFlags;
 import org.gradle.internal.buildoption.DefaultInternalOptions;
+import org.gradle.internal.buildoption.FeatureFlags;
 import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ListenerManager;
@@ -73,6 +79,8 @@ import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.service.scopes.GradleModuleServices;
 import org.gradle.internal.service.scopes.Scope;
+import org.gradle.problems.buildtree.ProblemDiagnosticsFactory;
+import org.gradle.problems.buildtree.ProblemReporter;
 
 import java.util.List;
 
@@ -97,19 +105,19 @@ public class BuildTreeScopeServices implements ServiceRegistrationProvider {
         registration.add(BuildInvocationScopeId.class, buildInvocationScopeId);
         registration.add(BuildTreeState.class, buildTree);
         registration.add(GradleEnterprisePluginManager.class);
-        registration.add(DefaultBuildLifecycleControllerFactory.class);
+        registration.add(BuildLifecycleControllerFactory.class, DefaultBuildLifecycleControllerFactory.class);
         registration.add(BuildOptionBuildOperationProgressEventsEmitter.class);
         registration.add(BuildInclusionCoordinator.class);
-        registration.add(DefaultProjectStateRegistry.class);
-        registration.add(DefaultConfigurationTimeBarrier.class);
-        registration.add(DeprecationsReporter.class);
-        registration.add(TaskPathProjectEvaluator.class);
-        registration.add(DefaultFeatureFlags.class);
-        registration.add(DefaultProblemDiagnosticsFactory.class);
-        registration.add(DefaultExceptionAnalyser.class);
+        registration.add(ProjectStateRegistry.class, DefaultProjectStateRegistry.class);
+        registration.add(ConfigurationTimeBarrier.class, DefaultConfigurationTimeBarrier.class);
+        registration.add(ProblemReporter.class, DeprecationsReporter.class);
+        registration.add(ProjectConfigurer.class, TaskPathProjectEvaluator.class);
+        registration.add(FeatureFlags.class, DefaultFeatureFlags.class);
+        registration.add(ProblemDiagnosticsFactory.class, DefaultProblemDiagnosticsFactory.class);
+        registration.add(ExceptionCollector.class, DefaultExceptionAnalyser.class);
         registration.add(ConfigurationCacheableIdFactory.class);
         registration.add(TaskIdentityFactory.class);
-        registration.add(DefaultBuildLogicBuildQueue.class);
+        registration.add(BuildLogicBuildQueue.class, DefaultBuildLogicBuildQueue.class);
         modelServices.applyServicesTo(registration);
     }
 
@@ -144,7 +152,7 @@ public class BuildTreeScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    protected DefaultBuildTaskSelector createBuildTaskSelector(BuildStateRegistry buildRegistry, TaskSelector taskSelector, List<BuiltInCommand> commands, InternalProblems problemsService) {
+    protected BuildTaskSelector createBuildTaskSelector(BuildStateRegistry buildRegistry, TaskSelector taskSelector, List<BuiltInCommand> commands, InternalProblems problemsService) {
         return new DefaultBuildTaskSelector(buildRegistry, taskSelector, commands, problemsService);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeState.java
@@ -37,7 +37,7 @@ public class BuildTreeState implements Closeable {
 
     public BuildTreeState(BuildInvocationScopeId buildInvocationScopeId, ServiceRegistry parent, BuildTreeModelControllerServices.Supplier modelServices) {
         services = ServiceRegistryBuilder.builder()
-            .scope(Scope.BuildTree.class)
+            .scopeStrictly(Scope.BuildTree.class)
             .displayName("build tree services")
             .parent(parent)
             .provider(new BuildTreeScopeServices(buildInvocationScopeId, this, modelServices))

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkGraphPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkGraphPreparer.java
@@ -16,9 +16,13 @@
 
 package org.gradle.internal.buildtree;
 
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 /**
  * Performs any initial setup that needs to happen to a build tree work graph prior to scheduling the requested tasks.
  */
+@ServiceScope(Scope.BuildTree.class)
 public interface BuildTreeWorkGraphPreparer {
     void prepareToScheduleTasks(BuildTreeWorkGraph.Builder workGraph);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/problems/DefaultProblemLocationAnalyzer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/problems/DefaultProblemLocationAnalyzer.java
@@ -26,6 +26,8 @@ import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.problems.failure.InternalStackTraceClassifier;
 import org.gradle.internal.problems.failure.StackFramePredicate;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.problems.Location;
 
 import javax.annotation.Nullable;
@@ -37,6 +39,7 @@ import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+@ServiceScope(Scope.BuildTree.class)
 public class DefaultProblemLocationAnalyzer implements ProblemLocationAnalyzer, ClassLoaderScopeRegistryListener, Closeable {
 
     private static final StackFramePredicate GRADLE_CODE = (frame, relevance) -> InternalStackTraceClassifier.isGradleCall(frame.getClassName());

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionServices.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.service.scopes;
 
 import org.gradle.execution.plan.DefaultPlanExecutor;
+import org.gradle.execution.plan.PlanExecutor;
 import org.gradle.internal.service.ServiceRegistration;
 
 public class ExecutionServices extends AbstractGradleModuleServices {
@@ -27,7 +28,7 @@ public class ExecutionServices extends AbstractGradleModuleServices {
 
     @Override
     public void registerBuildTreeServices(ServiceRegistration registration) {
-        registration.add(DefaultPlanExecutor.class);
+        registration.add(PlanExecutor.class, DefaultPlanExecutor.class);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/util/internal/SimpleMapInterner.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/SimpleMapInterner.java
@@ -16,11 +16,14 @@
 package org.gradle.util.internal;
 
 import com.google.common.collect.Interner;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+@ServiceScope(Scope.BuildTree.class)
 public class SimpleMapInterner implements Interner<String> {
     private final Map<String, String> internedStrings;
 

--- a/testing/architecture-test/src/changes/archunit-store/injected-services-should-have-service-scope-applied.txt
+++ b/testing/architecture-test/src/changes/archunit-store/injected-services-should-have-service-scope-applied.txt
@@ -22,7 +22,6 @@ Class <org.gradle.api.logging.LoggingManager> is not annotated with @ServiceScop
 Class <org.gradle.api.plugins.PluginManager> is not annotated with @ServiceScope in (PluginManager.java:0)
 Class <org.gradle.api.plugins.jvm.internal.JvmLanguageUtilities> is not annotated with @ServiceScope in (JvmLanguageUtilities.java:0)
 Class <org.gradle.api.plugins.jvm.internal.JvmPluginServices> is not annotated with @ServiceScope in (JvmPluginServices.java:0)
-Class <org.gradle.api.problems.internal.InternalProblems> is not annotated with @ServiceScope in (InternalProblems.java:0)
 Class <org.gradle.api.provider.ValueSourceParameters> is not annotated with @ServiceScope in (ValueSourceParameters.java:0)
 Class <org.gradle.api.services.BuildServiceParameters> is not annotated with @ServiceScope in (BuildServiceParameters.java:0)
 Class <org.gradle.api.services.BuildServiceRegistry> is not annotated with @ServiceScope in (BuildServiceRegistry.java:0)


### PR DESCRIPTION
Re-introduces https://github.com/gradle/gradle/pull/31990, which was initially [revered](https://github.com/gradle/gradle/pull/32125) on the suspicions of breaking Configuration Cache. However, the suspicions were not confirmed.