### PR TITLE
Fix documentation link in Artifact Transform report

### DIFF
--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ArtifactTransformsReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ArtifactTransformsReportTaskIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.util.GradleVersion
  * Integration tests for the {@link ArtifactTransformsReportTask}.
  */
 class ArtifactTransformsReportTaskIntegrationTest extends AbstractIntegrationSpec {
-    private static final String CACHEABILITY_NUDGE = "Some artifact transforms are not cacheable.  This can have negative performance impacts.  See more documentation here: https://docs.gradle.org/${GradleVersion.current().version}/userguide/artifact_transforms.html#artifact_transforms_with_caching."
+    private static final String CACHEABILITY_NUDGE = "Some artifact transforms are not cacheable.  This can have negative performance impacts.  See more documentation here: https://docs.gradle.org/${GradleVersion.current().version}/userguide/artifact_transforms.html#caching-transforms."
 
     def setup() {
         settingsFile << """

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ArtifactTransformsReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ArtifactTransformsReportTaskIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.util.GradleVersion
  * Integration tests for the {@link ArtifactTransformsReportTask}.
  */
 class ArtifactTransformsReportTaskIntegrationTest extends AbstractIntegrationSpec {
-    private static final String CACHEABILITY_NUDGE = "Some artifact transforms are not cacheable.  This can have negative performance impacts.  See more documentation here: https://docs.gradle.org/${GradleVersion.current().version}/userguide/artifact_transforms.html#caching-transforms."
+    private static final String CACHEABILITY_NUDGE = "Some artifact transforms are not cacheable.  This can have negative performance impacts.  See more documentation here: https://docs.gradle.org/${GradleVersion.current().version}/userguide/artifact_transforms.html#sec:caching-transforms."
 
     def setup() {
         settingsFile << """

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/artifact/transforms/renderer/ConsoleArtifactTransformReportRenderer.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/artifact/transforms/renderer/ConsoleArtifactTransformReportRenderer.java
@@ -110,7 +110,7 @@ public final class ConsoleArtifactTransformReportRenderer extends AbstractArtifa
     private void writeSuggestions(List<ReportArtifactTransform> transforms) {
         output.style(StyledTextOutput.Style.Info);
         if (transforms.stream().anyMatch(t -> !t.isCacheable())) {
-            output.println("Some artifact transforms are not cacheable.  This can have negative performance impacts.  See more documentation here: " + documentationRegistry.getDocumentationFor("artifact_transforms", "artifact_transforms_with_caching") + ".");
+            output.println("Some artifact transforms are not cacheable.  This can have negative performance impacts.  See more documentation here: " + documentationRegistry.getDocumentationFor("artifact_transforms", "caching-transforms") + ".");
         }
     }
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/artifact/transforms/renderer/ConsoleArtifactTransformReportRenderer.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/artifact/transforms/renderer/ConsoleArtifactTransformReportRenderer.java
@@ -110,7 +110,7 @@ public final class ConsoleArtifactTransformReportRenderer extends AbstractArtifa
     private void writeSuggestions(List<ReportArtifactTransform> transforms) {
         output.style(StyledTextOutput.Style.Info);
         if (transforms.stream().anyMatch(t -> !t.isCacheable())) {
-            output.println("Some artifact transforms are not cacheable.  This can have negative performance impacts.  See more documentation here: " + documentationRegistry.getDocumentationFor("artifact_transforms", "caching-transforms") + ".");
+            output.println("Some artifact transforms are not cacheable.  This can have negative performance impacts.  See more documentation here: " + documentationRegistry.getDocumentationFor("artifact_transforms", "sec:caching-transforms") + ".");
         }
     }
 


### PR DESCRIPTION
The documentation link: 

```
Some artifact transforms are not cacheable.  This can have negative performance impacts.  See more documentation here: https://docs.gradle.org/8.14-20250303050000+0000/userguide/artifact_transforms.html#caching-transforms.
```

used to link to a missing section.  Now it links to the proper section on the page.