### PR TITLE
Do not emit deprecation warning when tests are discovered but not executed

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
@@ -88,9 +88,6 @@ class TestNGTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegratio
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
-            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
         succeeds "test"
 
         then:

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/TestCountLogger.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/TestCountLogger.java
@@ -39,7 +39,7 @@ public class TestCountLogger implements TestListener {
     private final Logger logger;
 
     private long totalTests;
-    private long totalDiscoveredTests;
+    private long totalDiscoveredItems;
     private long failedTests;
     private long skippedTests;
     private boolean hadFailures;
@@ -60,7 +60,7 @@ public class TestCountLogger implements TestListener {
     @Override
     public void afterTest(TestDescriptor testDescriptor, TestResult result) {
         totalTests += result.getTestCount();
-        totalDiscoveredTests += result.getTestCount();
+        totalDiscoveredItems += result.getTestCount();
         failedTests += result.getFailedTestCount();
         skippedTests += result.getSkippedTestCount();
         progressLogger.progress(summary());
@@ -117,7 +117,7 @@ public class TestCountLogger implements TestListener {
             // Only count suites that can be attributed to a discovered class such as test class suites, explicit test suites,
             // parameterized tests, test templates, dynamic tests, etc, and ignore the "test worker" and root suites.
             if (suite.getClassName() != null) {
-                totalDiscoveredTests++;
+                totalDiscoveredItems++;
             }
         }
     }
@@ -134,7 +134,7 @@ public class TestCountLogger implements TestListener {
      * Returns the total number of test methods, test suites, test classes and/or dynamic tests that were discovered before
      * or during test execution.  This does not include the "test worker" or root suites.
      */
-    public long getTotalDiscovered() {
-        return totalDiscoveredTests;
+    public long getTotalDiscoveredItems() {
+        return totalDiscoveredItems;
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/TestCountLogger.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/TestCountLogger.java
@@ -39,6 +39,7 @@ public class TestCountLogger implements TestListener {
     private final Logger logger;
 
     private long totalTests;
+    private long totalDiscoveredTests;
     private long failedTests;
     private long skippedTests;
     private boolean hadFailures;
@@ -59,6 +60,7 @@ public class TestCountLogger implements TestListener {
     @Override
     public void afterTest(TestDescriptor testDescriptor, TestResult result) {
         totalTests += result.getTestCount();
+        totalDiscoveredTests += result.getTestCount();
         failedTests += result.getFailedTestCount();
         skippedTests += result.getSkippedTestCount();
         progressLogger.progress(summary());
@@ -111,6 +113,12 @@ public class TestCountLogger implements TestListener {
             if (result.getResultType() == TestResult.ResultType.FAILURE) {
                 hadFailures = true;
             }
+        } else {
+            // Only count suites that can be attributed to a discovered class such as test class suites, explicit test suites,
+            // parameterized tests, test templates, dynamic tests, etc, and ignore the "test worker" and root suites.
+            if (suite.getClassName() != null) {
+                totalDiscoveredTests++;
+            }
         }
     }
 
@@ -120,5 +128,13 @@ public class TestCountLogger implements TestListener {
 
     public long getTotalTests() {
         return totalTests;
+    }
+
+    /**
+     * Returns the total number of test methods, test suites, test classes and/or dynamic tests that were discovered before
+     * or during test execution.  This does not include the "test worker" or root suites.
+     */
+    public long getTotalDiscovered() {
+        return totalDiscoveredTests;
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -545,7 +545,9 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
             handleTestFailures();
         } else if (testCountLogger.getTotalTests() == 0) {
             if (testsAreNotFiltered()) {
-                emitDeprecationMessage();
+                if (testCountLogger.getTotalDiscovered() == 0) {
+                    emitDeprecationMessage();
+                }
             } else if (shouldFailOnNoMatchingTests()) {
                 throw new TestExecutionException(createNoMatchingTestErrorMessage());
             }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -544,8 +544,12 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         if (testCountLogger.hadFailures()) {
             handleTestFailures();
         } else if (testCountLogger.getTotalTests() == 0) {
+            // No tests were executed, the following rules apply:
+            // - If there are no filters, and no tests or test suites were discovered, emit a deprecation warning
+            // - If there are filters and the task is configured to fail when no tests match the filters, throw an exception
+            // - Otherwise, this is fine - the task should succeed with no warnings or errors
             if (testsAreNotFiltered()) {
-                if (testCountLogger.getTotalDiscovered() == 0) {
+                if (testCountLogger.getTotalDiscoveredItems() == 0) {
                     emitDeprecationMessage();
                 }
             } else if (shouldFailOnNoMatchingTests()) {

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestCountLoggerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestCountLoggerTest.groovy
@@ -142,7 +142,7 @@ class TestCountLoggerTest extends Specification {
     }
 
     private suite(boolean root = false) {
-        [getParent: {root ? null : [:] as TestDescriptor}] as TestDescriptor
+        [getParent: {root ? null : [:] as TestDescriptor}, getClassName: {root ? null : ''}] as TestDescriptor
     }
 
     private result(boolean failed = false) {


### PR DESCRIPTION
Fixes #30315 

We now track not only the tests that execute, but also the test classes and suites that are discovered during test execution.  If we find that any matching tests suites are found, we do not emit the deprecation, even if no actual tests were executed as a result.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
