### PR TITLE
Untangle BuildOperationNotificationsFixture and rootProject callback

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixture.groovy
@@ -27,12 +27,11 @@ import org.gradle.test.fixtures.file.TestDirectoryProvider
 import java.lang.reflect.InvocationTargetException
 
 /**
- * Implicitly tests that the build emits usable build operation notifications,
- * with the listener subscribing as the root project is loaded.
- *
+ * Implicitly tests that the build emits usable build operation notifications.
+ * <p>
  * This exercises the store-and-replay behaviour of the notification dispatcher
  * that allows a listener to observe all of the notifications from the very start of the build.
- *
+ * <p>
  * This fixture reflectively exercises the details/results objects of the notifications,
  * ensuring that they are "usable".
  */
@@ -49,12 +48,18 @@ class BuildOperationNotificationsFixture {
         }
     }
 
+    /**
+     * @see org.gradle.internal.operations.notify.BuildOperationNotificationBridge
+     */
     static String injectNotificationListenerBuildLogic() {
+        // The registration of the listener must happen before the BuildOperationNotificationValve is closed preemptively
+        // The actual Develocity plugin register a listener before `projectsLoaded`.
+        // Here, we rely on the order of `projectLoaded` callback registrations.
         """
-            rootProject {
-                if(gradle.isRootBuild()) {
+            gradle.projectsLoaded {
+                if (gradle.isRootBuild()) {
                     def listener = new BuildOperationNotificationsEvaluationListener()
-                    def registrar = project.services.get($BuildOperationNotificationListenerRegistrar.name)
+                    def registrar = gradle.rootProject.services.get($BuildOperationNotificationListenerRegistrar.name)
                     registrar.register(listener)
                 }
             }


### PR DESCRIPTION
In preparation for moving root project callbacks until after the classloaders have been locked. Without this change, the fixture relies on the root project callbacks to be executed within on of the projectsLoaded callbacks.

Preparation for https://github.com/gradle/gradle/pull/32137

---

In the current setup, there is a special build operation listener that captures all operations from the beginning of the build. This is required so that the Develocity plugin which will be attached to the build later (during settings evaluation) can get all the necessary build operations, even the ones started (or finished) before it had been enabled.

However, in case the Develocity plugin is not applied, we don't want to continue delaying/bufferring all the build operations until the end of the build -- it would be a significant memory hog. Instead, the delaying listener registers a `projectsLoaded` callback to stop collecting operations, in case no listener has been registered:
https://github.com/gradle/gradle/blob/b9ba1b09d7f84c2efc69d71d4cdcf43fe6fb1a69/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationBridge.java#L94-L100

Before this change, the `BuildOperationNotificationsFixture` has been registering the listener in a `rootProject` callback. This has worked, because, as it happens, all root project actions has been executed as part of another `projectsLoaded` callback registered by `DefaultGradle`. However, as noted above, we want to move the execution of the root project callbacks later in the pipeline (in a separate PR), once the base project classloader is locked.

In order to untangle the connection between fixture and the `rootProject` callbacks, we update the fixture to use `projectsLoaded` directly instead.