### PR TITLE
Add AssumptionTestFailure and generate JUnit XML with assumption fail…

### DIFF
--- a/platforms/jvm/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
+++ b/platforms/jvm/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
@@ -88,6 +88,7 @@ class JUnitTestClassProcessorTest extends Specification {
         then:
         1 * processor.started({it.id == 1}, {it.parentId == null})
         1 * processor.started({ it.id == 2 && it.name == "assumed" && it.className == ATestClassWithFailedTestAssumption.name }, { it.parentId == 1 })
+        1 * processor.failure(2, ATestClassWithFailedTestAssumption.failure)
         1 * processor.completed(2, { it.resultType == SKIPPED })
         1 * processor.completed(1, { it.resultType == null })
         0 * processor._

--- a/platforms/jvm/testing-jvm-infrastructure/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorData.groovy
+++ b/platforms/jvm/testing-jvm-infrastructure/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorData.groovy
@@ -21,6 +21,7 @@ import junit.framework.TestCase
 import junit.framework.TestSuite
 import org.gradle.api.tasks.testing.TestFailure
 import org.junit.After
+import org.junit.AssumptionViolatedException
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Ignore
@@ -33,8 +34,6 @@ import org.junit.runner.notification.RunNotifier
 import org.junit.runners.Parameterized
 import org.junit.runners.Suite
 import org.junit.runners.model.RunnerBuilder
-
-import static org.junit.Assume.assumeTrue
 
 public class ATestClass {
     @Test
@@ -60,9 +59,11 @@ public class ATestClassWithIgnoredMethod {
 }
 
 public class ATestClassWithFailedTestAssumption {
+    static def failure = TestFailure.fromAssumptionFailure(new AssumptionViolatedException(""))
+
     @Test
     public void assumed() {
-        assumeTrue(false)
+        throw failure.rawFailure
     }
 }
 

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/AssumptionTestFailure.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/AssumptionTestFailure.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import org.gradle.api.tasks.testing.TestFailure;
+import org.gradle.api.tasks.testing.TestFailureDetails;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+@org.gradle.api.NonNullApi
+public class AssumptionTestFailure extends TestFailure {
+
+    private final Throwable rawFailure;
+
+    public AssumptionTestFailure(Throwable rawFailure) {
+        this.rawFailure = rawFailure;
+    }
+
+    @Override
+    public List<TestFailure> getCauses() {
+        return Collections.<TestFailure>emptyList();
+    }
+
+    @Override
+    public Throwable getRawFailure() {
+        return rawFailure;
+    }
+
+    @Override
+    @Nullable
+    public TestFailureDetails getDetails() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AssumptionTestFailure that = (AssumptionTestFailure) o;
+
+        return rawFailure != null ? rawFailure.equals(that.rawFailure) : that.rawFailure == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return rawFailure != null ? rawFailure.hashCode() : 0;
+    }
+
+    public static TestFailure fromAssumptionFailure(Throwable failure) {
+        return new AssumptionTestFailure(failure);
+    }
+}

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/tasks/testing/TestFailure.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/tasks/testing/TestFailure.java
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.testing;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.internal.tasks.testing.AssumptionTestFailure;
 import org.gradle.api.internal.tasks.testing.DefaultTestFailure;
 
 import java.util.List;
@@ -104,5 +105,17 @@ public abstract class TestFailure {
      */
     public static TestFailure fromTestFrameworkFailure(Throwable failure, List<TestFailure> causes) {
         return DefaultTestFailure.fromTestFrameworkFailure(failure, causes);
+    }
+
+    /**
+     * Creates a new TestFailure instance from an assumption failure.
+     *
+     * @param failure the failure
+     * @return the new instance
+     *
+     * @since 8.14
+     */
+    public static TestFailure fromAssumptionFailure(Throwable failure) {
+        return AssumptionTestFailure.fromAssumptionFailure(failure);
     }
 }

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/tasks/testing/TestResult.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/tasks/testing/TestResult.java
@@ -67,6 +67,17 @@ public interface TestResult {
     List<Throwable> getExceptions();
 
     /**
+     * If the test failed with assumption violation exception, this will contain the exception.
+     *
+     * @return the exception, if any, logged for this test. If none, null is returned.
+     *
+     * @since 8.14
+     */
+    @Nullable
+    @Incubating
+    Throwable getAssumptionFailureException();
+
+    /**
      * Returns the time when this test started execution.
      *
      * @return The start time, in milliseconds since the epoch.

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestEventReporter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestEventReporter.java
@@ -91,12 +91,12 @@ class DefaultTestEventReporter implements TestEventReporter {
         if (!isComposite()) {
             testResultState.incrementSuccessfulCount();
         }
-        listener.completed(testDescriptor, new DefaultTestResult(TestResult.ResultType.SUCCESS, startTime, endTime.toEpochMilli(), testResultState.getTotalCount(), testResultState.getSuccessfulCount(), testResultState.getFailureCount(), Collections.emptyList()), new TestCompleteEvent(endTime.toEpochMilli(), TestResult.ResultType.SUCCESS));
+        listener.completed(testDescriptor, new DefaultTestResult(TestResult.ResultType.SUCCESS, startTime, endTime.toEpochMilli(), testResultState.getTotalCount(), testResultState.getSuccessfulCount(), testResultState.getFailureCount(), Collections.emptyList(), null), new TestCompleteEvent(endTime.toEpochMilli(), TestResult.ResultType.SUCCESS));
     }
 
     @Override
     public void skipped(Instant endTime) {
-        listener.completed(testDescriptor, new DefaultTestResult(TestResult.ResultType.SKIPPED, startTime, endTime.toEpochMilli(), testResultState.getTotalCount(), testResultState.getSuccessfulCount(), testResultState.getFailureCount(), Collections.emptyList()), new TestCompleteEvent(endTime.toEpochMilli(), TestResult.ResultType.SKIPPED));
+        listener.completed(testDescriptor, new DefaultTestResult(TestResult.ResultType.SKIPPED, startTime, endTime.toEpochMilli(), testResultState.getTotalCount(), testResultState.getSuccessfulCount(), testResultState.getFailureCount(), Collections.emptyList(), null), new TestCompleteEvent(endTime.toEpochMilli(), TestResult.ResultType.SKIPPED));
     }
 
     @Override
@@ -106,7 +106,7 @@ class DefaultTestEventReporter implements TestEventReporter {
         }
         TestFailureDetails failureDetails = new DefaultTestFailureDetails(message, Throwable.class.getName(), additionalContent, true, false, null, null, null, null);
         TestFailure testFailure = new DefaultTestFailure(new Throwable(message), failureDetails, Collections.emptyList());
-        listener.completed(testDescriptor, new DefaultTestResult(TestResult.ResultType.FAILURE, startTime, endTime.toEpochMilli(), testResultState.getTotalCount(), testResultState.getSuccessfulCount(), testResultState.getFailureCount(), Collections.singletonList(testFailure)), new TestCompleteEvent(endTime.toEpochMilli(), TestResult.ResultType.FAILURE));
+        listener.completed(testDescriptor, new DefaultTestResult(TestResult.ResultType.FAILURE, startTime, endTime.toEpochMilli(), testResultState.getTotalCount(), testResultState.getSuccessfulCount(), testResultState.getFailureCount(), Collections.singletonList(testFailure), null), new TestCompleteEvent(endTime.toEpochMilli(), TestResult.ResultType.FAILURE));
     }
 
     @Override

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
@@ -155,7 +155,7 @@ public class JUnitXmlResultWriter {
                     case SUCCESS:
                         return Collections.singleton(success(classId, execution.getId()));
                     case SKIPPED:
-                        return Collections.singleton(skipped(classId, execution.getId()));
+                        return Collections.singleton(skipped(classId, execution.getId(), execution.getAssumptionFailure()));
                     case FAILURE:
                         return failures(classId, execution, allFailed
                             ? execution == firstExecution ? FailureType.FAILURE : FailureType.RERUN_FAILURE
@@ -220,7 +220,7 @@ public class JUnitXmlResultWriter {
             case FAILURE:
                 return failures(classId, methodResult, FailureType.FAILURE);
             case SKIPPED:
-                return Collections.singleton(skipped(classId, methodResult.getId()));
+                return Collections.singleton(skipped(classId, methodResult.getId(), methodResult.getAssumptionFailure()));
             case SUCCESS:
                 return Collections.singleton(success(classId, methodResult.getId()));
             default:
@@ -299,13 +299,23 @@ public class JUnitXmlResultWriter {
 
 
     private static class TestCaseExecutionSkipped extends TestCaseExecution {
-        TestCaseExecutionSkipped(OutputProvider outputProvider, JUnitXmlResultOptions options) {
+        private final SerializableFailure assumptionFailure;
+        TestCaseExecutionSkipped(
+            OutputProvider outputProvider,
+            JUnitXmlResultOptions options,
+            SerializableFailure assumptionFailure
+        ) {
             super(outputProvider, options);
+            this.assumptionFailure = assumptionFailure;
         }
 
         @Override
         public void write(SimpleXmlWriter writer) throws IOException {
-            writer.startElement("skipped").endElement();
+            writer.startElement("skipped");
+            if (assumptionFailure != null) {
+                writer.write(assumptionFailure.getStackTrace());
+            }
+            writer.endElement();
             writeOutput(writer);
         }
     }
@@ -358,8 +368,8 @@ public class JUnitXmlResultWriter {
         return new TestCaseExecutionSuccess(outputProvider(classId, id), options);
     }
 
-    private TestCaseExecution skipped(long classId, long id) {
-        return new TestCaseExecutionSkipped(outputProvider(classId, id), options);
+    private TestCaseExecution skipped(long classId, long id, SerializableFailure assumptionFailure) {
+        return new TestCaseExecutionSkipped(outputProvider(classId, id), options, assumptionFailure);
     }
 
     private Iterable<TestCaseExecution> failures(final long classId, final TestMethodResult methodResult, final FailureType failureType) {

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestMethodResult.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestMethodResult.java
@@ -31,6 +31,8 @@ public class TestMethodResult {
     private long endTime;
     private final List<SerializableFailure> failures = new ArrayList<SerializableFailure>();
 
+    private SerializableFailure assumptionFailure = null;
+
     public TestMethodResult(long id, String name) {
         this(id, name, name);
     }
@@ -69,6 +71,11 @@ public class TestMethodResult {
         return this;
     }
 
+    public TestMethodResult setAssumptionFailure(String message, String stackTrace, String exceptionType) {
+        this.assumptionFailure = new SerializableFailure(message, stackTrace, exceptionType);
+        return this;
+    }
+
     public long getId() {
         return id;
     }
@@ -83,6 +90,10 @@ public class TestMethodResult {
 
     public List<SerializableFailure> getFailures() {
         return failures;
+    }
+
+    public SerializableFailure getAssumptionFailure() {
+        return assumptionFailure;
     }
 
     public TestResult.ResultType getResultType() {

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollector.java
@@ -82,6 +82,12 @@ public class TestReportDataCollector implements TestListener, TestOutputListener
                 }
 
                 TestMethodResult methodResult = new TestMethodResult(internalIdCounter++, suite.getName());
+
+                Throwable assumptionFailureException = result.getAssumptionFailureException();
+                if (assumptionFailureException != null) {
+                    methodResult.setAssumptionFailure(failureMessage(assumptionFailureException), stackTrace(assumptionFailureException), exceptionClassName(assumptionFailureException));
+                }
+
                 methodResult.completed(result);
                 classResult.add(methodResult);
             }
@@ -103,6 +109,12 @@ public class TestReportDataCollector implements TestListener, TestOutputListener
         for (Throwable throwable : result.getExceptions()) {
             methodResult.addFailure(failureMessage(throwable), stackTrace(throwable), exceptionClassName(throwable));
         }
+
+        Throwable assumptionFailureException = result.getAssumptionFailureException();
+        if (assumptionFailureException != null) {
+            methodResult.setAssumptionFailure(failureMessage(assumptionFailureException), stackTrace(assumptionFailureException), exceptionClassName(assumptionFailureException));
+        }
+
         TestClassResult classResult = results.get(className);
         if (classResult == null) {
             classResult = new TestClassResult(internalIdCounter++, className, classDisplayName, result.getStartTime());

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/DefaultTestResult.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/DefaultTestResult.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 public class DefaultTestResult implements TestResult, Serializable {
     private final List<TestFailure> failures;
+    private final TestFailure assumptionFailure;
     private final ResultType resultType;
     private final long startTime;
     private final long endTime;
@@ -34,10 +35,10 @@ public class DefaultTestResult implements TestResult, Serializable {
     private final long failedCount;
 
     public DefaultTestResult(TestState state) {
-        this(state.resultType, state.getStartTime(), state.getEndTime(), state.testCount, state.successfulCount, state.failedCount, state.failures);
+        this(state.resultType, state.getStartTime(), state.getEndTime(), state.testCount, state.successfulCount, state.failedCount, state.failures, state.assumptionFailure);
     }
 
-    public DefaultTestResult(ResultType resultType, long startTime, long endTime, long testCount, long successfulCount, long failedCount, List<TestFailure> failures) {
+    public DefaultTestResult(ResultType resultType, long startTime, long endTime, long testCount, long successfulCount, long failedCount, List<TestFailure> failures, TestFailure assumptionFailure) {
         this.resultType = resultType;
         this.startTime = startTime;
         this.endTime = endTime;
@@ -45,6 +46,7 @@ public class DefaultTestResult implements TestResult, Serializable {
         this.successfulCount = successfulCount;
         this.failedCount = failedCount;
         this.failures = failures;
+        this.assumptionFailure = assumptionFailure;
     }
 
     @Override
@@ -55,6 +57,11 @@ public class DefaultTestResult implements TestResult, Serializable {
     @Override
     public Throwable getException() {
         return failures.isEmpty() ? null : failures.get(0).getRawFailure();
+    }
+
+    @Override
+    public Throwable getAssumptionFailureException() {
+        return (assumptionFailure == null) ? null : assumptionFailure.getRawFailure();
     }
 
     @Override

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/StateTrackingTestResultProcessor.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/StateTrackingTestResultProcessor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.results;
 
+import org.gradle.api.internal.tasks.testing.AssumptionTestFailure;
 import org.gradle.api.internal.tasks.testing.DecoratingTestDescriptor;
 import org.gradle.api.internal.tasks.testing.TestCompleteEvent;
 import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
@@ -105,7 +106,11 @@ public class StateTrackingTestResultProcessor implements TestResultProcessor {
                     "Received a failure event for test with unknown id '%s'. Registered test ids: '%s'",
                     testId, executing.keySet()));
         }
-        testState.failures.add(testFailure);
+        if (testFailure instanceof AssumptionTestFailure) {
+            testState.assumptionFailure = testFailure;
+        } else {
+            testState.failures.add(testFailure);
+        }
     }
 
     @Override

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/TestState.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/TestState.java
@@ -32,6 +32,7 @@ public class TestState {
     private final Map<Object, TestState> executing;
     public boolean failedChild;
     public List<TestFailure> failures = new ArrayList<TestFailure>();
+    public TestFailure assumptionFailure = null;
     public long testCount;
     public long successfulCount;
     public long failedCount;

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterSpec.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterSpec.groovy
@@ -47,6 +47,7 @@ class JUnitXmlResultWriterSpec extends Specification {
         result.add(new TestMethodResult(2, "some test two", SUCCESS, 15, startTime + 30))
         result.add(new TestMethodResult(3, "some failing test", FAILURE, 10, startTime + 40).addFailure("failure message", "[stack-trace]", "ExceptionType"))
         result.add(new TestMethodResult(4, "some skipped test", SKIPPED, 10, startTime + 45))
+        result.add(new TestMethodResult(5, "some assumption failure test", SKIPPED, 10, startTime + 50).setAssumptionFailure("assumption failed", "[assumption-failure-stack-trace]", "AssumptionViolationException"))
 
         provider.writeAllOutput(1, StdOut, _) >> { args -> args[2].write("1st output message\n2nd output message\n") }
         provider.writeAllOutput(1, StdErr, _) >> { args -> args[2].write("err") }
@@ -56,9 +57,9 @@ class JUnitXmlResultWriterSpec extends Specification {
 
         then:
         new JUnitTestClassExecutionResult(xml, "com.foo.FooTest", "com.foo.FooTest", TestResultOutputAssociation.WITH_SUITE)
-            .assertTestCount(4, 1, 1, 0)
+            .assertTestCount(5, 2, 1, 0)
             .assertTestFailed("some failing test", equalTo('failure message'))
-            .assertTestsSkipped("some skipped test")
+            .assertTestsSkipped("some skipped test", "some assumption failure test")
             .assertTestsExecuted("some test", "some test two", "some failing test")
             .assertStdout(equalTo("""1st output message
 2nd output message
@@ -67,7 +68,7 @@ class JUnitXmlResultWriterSpec extends Specification {
 
         and:
         xml == """<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="com.foo.FooTest" tests="4" skipped="1" failures="1" errors="0" timestamp="2012-11-19T17:09:28.049Z" hostname="localhost" time="0.045">
+<testsuite name="com.foo.FooTest" tests="5" skipped="2" failures="1" errors="0" timestamp="2012-11-19T17:09:28.049Z" hostname="localhost" time="0.05">
   <properties/>
   <testcase name="some test" classname="com.foo.FooTest" time="0.015"/>
   <testcase name="some test two" classname="com.foo.FooTest" time="0.015"/>
@@ -76,6 +77,9 @@ class JUnitXmlResultWriterSpec extends Specification {
   </testcase>
   <testcase name="some skipped test" classname="com.foo.FooTest" time="0.01">
     <skipped/>
+  </testcase>
+  <testcase name="some assumption failure test" classname="com.foo.FooTest" time="0.01">
+    <skipped>[assumption-failure-stack-trace]</skipped>
   </testcase>
   <system-out><![CDATA[1st output message
 2nd output message
@@ -91,7 +95,7 @@ class JUnitXmlResultWriterSpec extends Specification {
 
         and:
         TestClassResult result = new TestClassResult(1, "com.foo.FooTest", startTime)
-        result.add(new TestMethodResult(1, "some test").completed(new DefaultTestResult(SUCCESS, startTime + 100, startTime + 300, 1, 1, 0, emptyList())))
+        result.add(new TestMethodResult(1, "some test").completed(new DefaultTestResult(SUCCESS, startTime + 100, startTime + 300, 1, 1, 0, emptyList(), null)))
         _ * provider.writeAllOutput(_, _, _)
 
         when:

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestClassResultSpec.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestClassResultSpec.groovy
@@ -17,7 +17,9 @@
 package org.gradle.api.internal.tasks.testing.junit.result
 
 import org.gradle.api.internal.tasks.testing.results.DefaultTestResult
+import org.gradle.api.tasks.testing.TestFailure
 import org.gradle.api.tasks.testing.TestResult
+import org.junit.AssumptionViolatedException
 import spock.lang.Specification
 
 class TestClassResultSpec extends Specification {
@@ -27,13 +29,14 @@ class TestClassResultSpec extends Specification {
         assert result.duration == 0
 
         when:
-        result.add(new TestMethodResult(1, "foo").completed(new DefaultTestResult(TestResult.ResultType.SUCCESS, 100, 200, 1, 1, 0, [])))
-        result.add(new TestMethodResult(2, "fail").completed(new DefaultTestResult(TestResult.ResultType.FAILURE, 250, 300, 1, 0, 1, [new RuntimeException("bar")])))
-        result.add(new TestMethodResult(3, "fail2").completed(new DefaultTestResult(TestResult.ResultType.FAILURE, 300, 450, 1, 0, 1, [new RuntimeException("foo")])))
-
+        result.add(new TestMethodResult(1, "foo").completed(new DefaultTestResult(TestResult.ResultType.SUCCESS, 100, 200, 1, 1, 0, [], null)))
+        result.add(new TestMethodResult(2, "fail").completed(new DefaultTestResult(TestResult.ResultType.FAILURE, 250, 300, 1, 0, 1, [new RuntimeException("bar")], null)))
+        result.add(new TestMethodResult(3, "fail2").completed(new DefaultTestResult(TestResult.ResultType.FAILURE, 300, 450, 1, 0, 1, [new RuntimeException("foo")], null)))
+        result.add(new TestMethodResult(4, "skip1").completed(new DefaultTestResult(TestResult.ResultType.SKIPPED, 500, 550, 1, 0, 0, [], null)))
+        result.add(new TestMethodResult(5, "skip2").completed(new DefaultTestResult(TestResult.ResultType.SKIPPED, 600, 650, 1, 0, 0, [], TestFailure.fromAssumptionFailure(new AssumptionViolatedException("")))))
         then:
         result.failuresCount == 2
-        result.testsCount == 3
-        result.duration == 350
+        result.testsCount == 5
+        result.duration == 550
     }
 }

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollectorSpec.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollectorSpec.groovy
@@ -18,7 +18,9 @@ package org.gradle.api.internal.tasks.testing.junit.result
 
 import org.gradle.api.internal.tasks.testing.*
 import org.gradle.api.internal.tasks.testing.results.DefaultTestResult
+import org.gradle.api.tasks.testing.TestFailure
 import org.gradle.internal.serialize.PlaceholderException
+import org.junit.AssumptionViolatedException
 import spock.lang.Issue
 import spock.lang.Specification
 
@@ -26,6 +28,7 @@ import static java.util.Arrays.asList
 import static org.gradle.api.tasks.testing.TestOutputEvent.Destination.StdErr
 import static org.gradle.api.tasks.testing.TestOutputEvent.Destination.StdOut
 import static org.gradle.api.tasks.testing.TestResult.ResultType.FAILURE
+import static org.gradle.api.tasks.testing.TestResult.ResultType.SKIPPED
 import static org.gradle.api.tasks.testing.TestResult.ResultType.SUCCESS
 
 class TestReportDataCollectorSpec extends Specification {
@@ -37,10 +40,13 @@ class TestReportDataCollectorSpec extends Specification {
         def root = new DefaultTestSuiteDescriptor("1", "Suite")
         def clazz = new DecoratingTestDescriptor(new DefaultTestClassDescriptor("1.1", "FooTest"), root)
         def test1 = new DecoratingTestDescriptor(new DefaultTestDescriptor("1.1.1", "FooTest", "testMethod"), clazz)
-        def result1 = new DefaultTestResult(SUCCESS, 100, 200, 1, 1, 0, [])
+        def result1 = new DefaultTestResult(SUCCESS, 100, 200, 1, 1, 0, [], null)
 
         def test2 = new DecoratingTestDescriptor(new DefaultTestDescriptor("1.1.2", "FooTest", "testMethod2"), clazz)
-        def result2 = new DefaultTestResult(FAILURE, 250, 300, 1, 0, 1, asList(org.gradle.api.tasks.testing.TestFailure.fromTestFrameworkFailure(new RuntimeException("Boo!"))))
+        def result2 = new DefaultTestResult(FAILURE, 250, 300, 1, 0, 1, asList(TestFailure.fromTestFrameworkFailure(new RuntimeException("Boo!"))), null)
+
+        def test3 = new DecoratingTestDescriptor(new DefaultTestDescriptor("1.1.3", "FooTest", "testMethod3"), clazz)
+        def result3 = new DefaultTestResult(SKIPPED, 350, 400, 1, 0, 0, [], TestFailure.fromAssumptionFailure(new AssumptionViolatedException("Assumption violeted!")))
 
         when:
         //simulating TestNG, where we don't receive beforeSuite for classes
@@ -48,23 +54,26 @@ class TestReportDataCollectorSpec extends Specification {
 
         collector.beforeTest(test1)
         collector.beforeTest(test2)
+        collector.beforeTest(test3)
 
         collector.afterTest(test1, result1)
         collector.afterTest(test2, result2)
+        collector.afterTest(test3, result3)
 
-        collector.afterSuite(root, new DefaultTestResult(FAILURE, 0, 500, 2, 1, 1, []))
+        collector.afterSuite(root, new DefaultTestResult(FAILURE, 0, 500, 2, 1, 1, [], null))
 
         then:
         results.size() == 1
         def fooTest = results.values().toList().first()
         fooTest.className == 'FooTest'
         fooTest.startTime == 100
-        fooTest.testsCount == 2
+        fooTest.testsCount == 3
         fooTest.failuresCount == 1
-        fooTest.duration == 200
-        fooTest.results.size() == 2
+        fooTest.duration == 300
+        fooTest.results.size() == 3
         fooTest.results.find { it.name == 'testMethod' && it.endTime == 200 && it.duration == 100 }
         fooTest.results.find { it.name == 'testMethod2' && it.endTime == 300 && it.duration == 50 }
+        fooTest.results.find { it.name == 'testMethod3' && it.endTime == 400 && it.duration == 50 }
     }
 
     def "writes test outputs for interleaved tests"() {
@@ -105,7 +114,7 @@ class TestReportDataCollectorSpec extends Specification {
     def "writes test outputs for failed suite"() {
         def suite = new DefaultTestSuiteDescriptor("1", "Suite")
         def failure = org.gradle.api.tasks.testing.TestFailure.fromTestFrameworkFailure(new RuntimeException("failure"))
-        def result = new DefaultTestResult(FAILURE, 0, 0, 0, 0, 0, [failure])
+        def result = new DefaultTestResult(FAILURE, 0, 0, 0, 0, 0, [failure], null)
 
         when:
         collector.beforeSuite(suite)
@@ -121,7 +130,7 @@ class TestReportDataCollectorSpec extends Specification {
         def test = new DefaultTestDescriptor("1.1.1", "FooTest", "testMethod")
         def failure1 = org.gradle.api.tasks.testing.TestFailure.fromTestFrameworkFailure(new RuntimeException("failure1"))
         def failure2 = org.gradle.api.tasks.testing.TestFailure.fromTestFrameworkFailure(new IOException("failure2"))
-        def result = new DefaultTestResult(SUCCESS, 0, 0, 1, 0, 1, [failure1, failure2])
+        def result = new DefaultTestResult(SUCCESS, 0, 0, 1, 0, 1, [failure1, failure2], null)
 
         when:
         collector.beforeTest(test)
@@ -138,10 +147,26 @@ class TestReportDataCollectorSpec extends Specification {
         failures[1].stackTrace.startsWith(failure2.rawFailure.toString())
     }
 
+    def "collects assumption failure for test"() {
+        def test = new DefaultTestDescriptor("1.1.1", "FooTest", "testMethod")
+        def assumptionFailure = TestFailure.fromAssumptionFailure(new AssumptionViolatedException("assumption"))
+        def result = new DefaultTestResult(SKIPPED, 0, 0, 1, 0, 0, [], assumptionFailure)
+
+        when:
+        collector.beforeTest(test)
+        collector.afterTest(test, result)
+
+        then:
+        def failure = results["FooTest"].results[0].assumptionFailure
+        failure.exceptionType == AssumptionViolatedException.name
+        failure.message == assumptionFailure.rawFailure.toString()
+        failure.stackTrace.startsWith(assumptionFailure.rawFailure.toString())
+    }
+
     def "handle PlaceholderExceptions for test failures"() {
         def test = new DefaultTestDescriptor("1.1.1", "FooTest", "testMethod")
         def failure = org.gradle.api.tasks.testing.TestFailure.fromTestFrameworkFailure(new PlaceholderException("OriginalClassName", "failure2", null, "toString()", null, null))
-        def result = new DefaultTestResult(SUCCESS, 0, 0, 1, 0, 1, [failure])
+        def result = new DefaultTestResult(SUCCESS, 0, 0, 1, 0, 1, [failure], null)
 
         when:
         collector.beforeTest(test)
@@ -164,7 +189,7 @@ class TestReportDataCollectorSpec extends Specification {
                 throw failure2.rawFailure
             }
         })
-        def result = new DefaultTestResult(SUCCESS, 0, 0, 1, 0, 1, [failure1])
+        def result = new DefaultTestResult(SUCCESS, 0, 0, 1, 0, 1, [failure1], null)
 
         when:
         collector.beforeTest(test)
@@ -186,7 +211,7 @@ class TestReportDataCollectorSpec extends Specification {
                 throw failure2.rawFailure
             }
         })
-        def result = new DefaultTestResult(SUCCESS, 0, 0, 1, 0, 1, [failure1])
+        def result = new DefaultTestResult(SUCCESS, 0, 0, 1, 0, 1, [failure1], null)
 
         when:
         collector.beforeTest(test)
@@ -207,8 +232,8 @@ class TestReportDataCollectorSpec extends Specification {
         //simulating a scenario with suite failing badly enough so that no tests are executed
         collector.beforeSuite(root)
         collector.beforeSuite(testWorker)
-        collector.afterSuite(testWorker, new DefaultTestResult(FAILURE, 50, 450, 2, 1, 1, [org.gradle.api.tasks.testing.TestFailure.fromTestFrameworkFailure(new RuntimeException("Boo!"))]))
-        collector.afterSuite(root, new DefaultTestResult(FAILURE, 0, 500, 2, 1, 1, []))
+        collector.afterSuite(testWorker, new DefaultTestResult(FAILURE, 50, 450, 2, 1, 1, [org.gradle.api.tasks.testing.TestFailure.fromTestFrameworkFailure(new RuntimeException("Boo!"))], null))
+        collector.afterSuite(root, new DefaultTestResult(FAILURE, 0, 500, 2, 1, 1, [], null))
 
         then:
         results.size() == 1
@@ -229,7 +254,7 @@ class TestReportDataCollectorSpec extends Specification {
         when:
         collector.beforeTest(test)
         collector.onOutput(test, new DefaultTestOutputEvent(1, StdOut, "suite-out"))
-        collector.afterTest(test, new DefaultTestResult(SUCCESS, 100, 200, 1, 1, 0, asList()))
+        collector.afterTest(test, new DefaultTestResult(SUCCESS, 100, 200, 1, 1, 0, asList(), null))
 
         then:
         results.get("FooTest").startTime == 100

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestEventLoggerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestEventLoggerTest.groovy
@@ -48,9 +48,10 @@ class SimpleTestEventLoggerTest extends Specification {
         def logger = new SimpleTestEventLogger(textOutputFactory)
 
         def descriptor = new DefaultTestDescriptor(0, "Class", "method", "Class", "method()")
-        def result = new DefaultTestResult(TestResult.ResultType.FAILURE, 0, 0, 0, 0, 0, [new DefaultTestFailure(null, new DefaultTestFailureDetails("message", "Exception", "stack", true, false, null, null, null, null), [])])
+        def result = new DefaultTestResult(TestResult.ResultType.FAILURE, 0, 0, 0, 0, 0, [new DefaultTestFailure(null, new DefaultTestFailureDetails("message", "Exception", "stack", true, false, null, null, null, null), [])], null)
         def complete = new TestCompleteEvent(0, TestResult.ResultType.FAILURE)
 
+        when:
         when:
         logger.completed(descriptor, result, complete)
         then:
@@ -67,7 +68,7 @@ method() {failure}FAILED{normal}
         def logger = new SimpleTestEventLogger(textOutputFactory)
 
         def descriptor = new DefaultTestDescriptor(0, "Class", "method", "Class", "method()")
-        def result = new DefaultTestResult(TestResult.ResultType.FAILURE, 0, 0, 0, 0, 0, [new DefaultTestFailure(null, new DefaultTestFailureDetails("message", "TestFrameworkException", "stack", false, false, null, null, null, null), [])])
+        def result = new DefaultTestResult(TestResult.ResultType.FAILURE, 0, 0, 0, 0, 0, [new DefaultTestFailure(null, new DefaultTestFailureDetails("message", "TestFrameworkException", "stack", false, false, null, null, null, null), [])], null)
         def complete = new TestCompleteEvent(0, TestResult.ResultType.FAILURE)
 
         when:
@@ -86,7 +87,7 @@ method() {failure}FAILED{normal}
         def logger = new SimpleTestEventLogger(textOutputFactory)
 
         def descriptor = new DefaultTestDescriptor(0, "Class", "method", "Class", "method()")
-        def result = new DefaultTestResult(TestResult.ResultType.FAILURE, 0, 0, 0, 0, 0, [new DefaultTestFailure(null, new DefaultTestFailureDetails("message", "TestFrameworkException", "stack", false, true, "expected", "actual", null, null), [])])
+        def result = new DefaultTestResult(TestResult.ResultType.FAILURE, 0, 0, 0, 0, 0, [new DefaultTestFailure(null, new DefaultTestFailureDetails("message", "TestFrameworkException", "stack", false, true, "expected", "actual", null, null), [])], null)
         def complete = new TestCompleteEvent(0, TestResult.ResultType.FAILURE)
 
         when:
@@ -106,7 +107,7 @@ method() {failure}FAILED{normal}
         def logger = new SimpleTestEventLogger(textOutputFactory)
 
         def descriptor = new DefaultTestSuiteDescriptor(0, "Root")
-        def result = new DefaultTestResult(TestResult.ResultType.FAILURE, 0, 0, totalCount, successes, failures, [])
+        def result = new DefaultTestResult(TestResult.ResultType.FAILURE, 0, 0, totalCount, successes, failures, [], null)
         def complete = new TestCompleteEvent(0, TestResult.ResultType.FAILURE)
 
         when:
@@ -132,7 +133,7 @@ method() {failure}FAILED{normal}
 
         def parent = new DefaultTestSuiteDescriptor(0, "Root")
         def descriptor = new DecoratingTestDescriptor(new DefaultTestSuiteDescriptor(1, "Child"), parent)
-        def result = new DefaultTestResult(TestResult.ResultType.FAILURE, 0, 0, 1, 0, 1, [])
+        def result = new DefaultTestResult(TestResult.ResultType.FAILURE, 0, 0, 1, 0, 1, [], null)
         def complete = new TestCompleteEvent(0, TestResult.ResultType.FAILURE)
 
         when:
@@ -146,7 +147,7 @@ method() {failure}FAILED{normal}
         def logger = new SimpleTestEventLogger(textOutputFactory)
 
         def descriptor = new DefaultTestDescriptor(0, "Class", "method", "Class", "method()")
-        def result = new DefaultTestResult(TestResult.ResultType.SKIPPED, 0, 0, 0, 0, 0, [])
+        def result = new DefaultTestResult(TestResult.ResultType.SKIPPED, 0, 0, 0, 0, 0, [], null)
         def complete = new TestCompleteEvent(0, TestResult.ResultType.SKIPPED)
 
         when:
@@ -160,7 +161,7 @@ method() {failure}FAILED{normal}
         def logger = new SimpleTestEventLogger(textOutputFactory)
 
         def descriptor = new DefaultTestDescriptor(0, "Class", "method", "Class", "method()")
-        def result = new DefaultTestResult(TestResult.ResultType.SUCCESS, 0, 0, 0, 0, 0, [])
+        def result = new DefaultTestResult(TestResult.ResultType.SUCCESS, 0, 0, 0, 0, 0, [], null)
         def complete = new TestCompleteEvent(0, TestResult.ResultType.SUCCESS)
 
         when:

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestWorkerProgressListenerTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/TestWorkerProgressListenerTest.groovy
@@ -185,7 +185,7 @@ class TestWorkerProgressListenerTest extends Specification {
     }
 
     static TestResult createTestResult() {
-        new DefaultTestResult(TestResult.ResultType.SUCCESS, new Date().time, new Date().time, 2L, 2L, 0L, [])
+        new DefaultTestResult(TestResult.ResultType.SUCCESS, new Date().time, new Date().time, 2L, 2L, 0L, [], null)
     }
 
     static TestCompleteEvent createTestCompleteEvent() {

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/results/DefaultTestResultTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/results/DefaultTestResultTest.groovy
@@ -20,7 +20,9 @@ package org.gradle.api.internal.tasks.testing.results;
 import org.gradle.api.internal.tasks.testing.DefaultTestDescriptor
 import org.gradle.api.internal.tasks.testing.TestCompleteEvent
 import org.gradle.api.internal.tasks.testing.TestStartEvent
+import org.gradle.api.tasks.testing.TestFailure
 import org.gradle.api.tasks.testing.TestResult.ResultType
+import org.junit.AssumptionViolatedException
 import spock.lang.Specification
 
 public class DefaultTestResultTest extends Specification {
@@ -31,6 +33,8 @@ public class DefaultTestResultTest extends Specification {
         state.completed(new TestCompleteEvent(200L, ResultType.SKIPPED))
 
         when:
+        def assumptionFailureException = new AssumptionViolatedException("")
+        state.assumptionFailure = TestFailure.fromAssumptionFailure(assumptionFailureException)
         def result = new DefaultTestResult(state)
 
         then:
@@ -41,5 +45,18 @@ public class DefaultTestResultTest extends Specification {
         result.testCount == state.testCount
         result.successfulTestCount == state.successfulCount
         result.failedTestCount == state.failedCount
+        result.assumptionFailureException == state.assumptionFailure.getRawFailure()
+    }
+
+    def "return null for unset assumption failure"() {
+        expect:
+        def state = new TestState(new DefaultTestDescriptor("12", "FooTest", "shouldWork"), new TestStartEvent(100L), new HashMap());
+        state.completed(new TestCompleteEvent(200L, ResultType.SKIPPED))
+
+        when:
+        def result = new DefaultTestResult(state)
+
+        then:
+        result.assumptionFailureException == null
     }
 }

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/results/StateTrackingTestResultProcessorTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/results/StateTrackingTestResultProcessorTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.testing.TestFailure
 import org.gradle.api.tasks.testing.TestOutputEvent
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.api.tasks.testing.TestResult.ResultType
+import org.junit.AssumptionViolatedException
 import spock.lang.Issue
 import spock.lang.Specification
 
@@ -84,6 +85,27 @@ class StateTrackingTestResultProcessorTest extends Specification {
         1 * listener.completed({ it.descriptor == test },
                 { it.successfulTestCount == 0 && it.testCount == 1 && it.failedTestCount == 1 && it.exception.is(failure.rawFailure) },
                 completeEvent
+        )
+        0 * _
+    }
+
+    void createsAResultForATestWithAssumptionFailure() {
+        given:
+        def failure = TestFailure.fromAssumptionFailure(new AssumptionViolatedException(""))
+        def test = new DefaultTestDescriptor("15", "Foo", "bar");
+        def startEvent = new TestStartEvent(100L)
+        def completeEvent = new TestCompleteEvent(200L, ResultType.SKIPPED)
+
+        when:
+        adapter.started(test, startEvent)
+        adapter.failure('15', failure)
+        adapter.completed('15', completeEvent)
+
+        then:
+        1 * listener.started(_, _)
+        1 * listener.completed({ it.descriptor == test },
+            { it.successfulTestCount == 0 && it.testCount == 1 && it.failedTestCount == 0 && it.skippedTestCount == 1 && it.assumptionFailureException.is(failure.rawFailure) },
+            completeEvent
         )
         0 * _
     }

--- a/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/BuildableTestResultsProvider.groovy
+++ b/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/BuildableTestResultsProvider.groovy
@@ -131,6 +131,8 @@ class BuildableTestResultsProvider implements TestResultsProvider {
         long duration
         List<SerializableFailure> failures = []
 
+        SerializableFailure assumptionFailure = null
+
         TestResult.ResultType resultType = TestResult.ResultType.SUCCESS
 
         private final List<BuildableOutputEvent> outputEvents
@@ -145,6 +147,11 @@ class BuildableTestResultsProvider implements TestResultsProvider {
         void failure(String message, String stackTrace) {
             failures.add(new SerializableFailure(message, stackTrace, "ExceptionType"))
             resultType = TestResult.ResultType.FAILURE
+        }
+
+        void assumptionFailure(String message, String stackTrace) {
+            assumptionFailure = new SerializableFailure(message, stackTrace, "ExceptionType")
+            resultType = TestResult.ResultType.SKIPPED
         }
 
         void ignore() {

--- a/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/SimpleTestResult.groovy
+++ b/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/SimpleTestResult.groovy
@@ -23,6 +23,7 @@ class SimpleTestResult implements TestResult {
     TestResult.ResultType resultType = TestResult.ResultType.SUCCESS
     List<Throwable> exceptions = []
     Throwable exception = exceptions[0]
+    Throwable assumptionFailureException = null
     List<TestFailure> failures
     long startTime = 0
     long endTime = startTime + 100


### PR DESCRIPTION
Fixes #5511

### Context
Right now, when a JUnit test encounters an assumption violation exception, the XML report indicates the test is skipped with a <skipped> tag but with no further information - the same way it reports a test with the @Ignore annotation. Therefore, for the downstream processes that use the report, it is impossible to differentiate between the assumption failure tests and the @Ignore tests. 
