### PR TITLE
Add capability and spec config for native image

### DIFF
--- a/platforms/core-runtime/build-configuration/src/integTest/groovy/org/gradle/interal/buildconfiguration/tasks/UpdateDaemonJvmIntegrationTest.groovy
+++ b/platforms/core-runtime/build-configuration/src/integTest/groovy/org/gradle/interal/buildconfiguration/tasks/UpdateDaemonJvmIntegrationTest.groovy
@@ -323,7 +323,7 @@ tasks.named("updateDaemonJvm") {
         then:
         // TODO The description is different with CC on
 //        failureDescriptionContains("Execution failed for task ':updateDaemonJvm'")
-        failureHasCause("Toolchain resolvers did not return download URLs providing a JDK matching {languageVersion=20, vendor=vendor matching('FOO'), implementation=vendor-specific} for any of the requested platforms")
+        failureHasCause("Toolchain resolvers did not return download URLs providing a JDK matching {languageVersion=20, vendor=vendor matching('FOO'), implementation=vendor-specific, nativeImageCapable=false} for any of the requested platforms")
     }
 
     def "configuring the languageVersion will use that value for the generate properties file"() {

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainDownloadIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainDownloadIntegrationTest.groovy
@@ -48,7 +48,7 @@ class DaemonToolchainDownloadIntegrationTest extends AbstractIntegrationSpec imp
             .runWithFailure()
 
         then:
-        failure.assertHasDescription("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific}. " +
+        failure.assertHasDescription("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. " +
                 "Toolchain auto-provisioning is not enabled.")
             .assertHasResolutions(
                 DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection and auto-provisioning at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
@@ -68,7 +68,7 @@ class DaemonToolchainDownloadIntegrationTest extends AbstractIntegrationSpec imp
             .runWithFailure()
 
         then:
-        failure.assertHasDescription("Unable to download toolchain matching the requirements ({languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific}) " +
+        failure.assertHasDescription("Unable to download toolchain matching the requirements ({languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}) " +
             "from 'http://insecure-server.com', due to: Attempting to download java toolchain from an insecure URI http://insecure-server.com. This is not supported, use a secure URI instead")
     }
 
@@ -84,7 +84,7 @@ class DaemonToolchainDownloadIntegrationTest extends AbstractIntegrationSpec imp
             .runWithFailure()
 
         then:
-        failure.assertHasDescription("Unable to download toolchain matching the requirements ({languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific}) from 'https://server.com/v=^10'")
+        failure.assertHasDescription("Unable to download toolchain matching the requirements ({languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}) from 'https://server.com/v=^10'")
             .assertHasResolutions(
                 DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection and auto-provisioning at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
                 DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain repositories at https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories."),
@@ -104,7 +104,7 @@ class DaemonToolchainDownloadIntegrationTest extends AbstractIntegrationSpec imp
             .runWithFailure()
 
         then:
-        failure.assertHasDescription("Unable to download toolchain matching the requirements ({languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific}) from 'invalid-url'")
+        failure.assertHasDescription("Unable to download toolchain matching the requirements ({languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}) from 'invalid-url'")
     }
 
     @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
@@ -129,8 +129,8 @@ class DaemonToolchainDownloadIntegrationTest extends AbstractIntegrationSpec imp
         jdkRepository.stop()
 
         then:
-        failure.assertHasDescription("Unable to download toolchain matching the requirements ({languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific}) from '$uri', " +
-            "due to: Toolchain provisioned from '$uri' doesn't satisfy the specification: {languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific}")
+        failure.assertHasDescription("Unable to download toolchain matching the requirements ({languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}) from '$uri', " +
+            "due to: Toolchain provisioned from '$uri' doesn't satisfy the specification: {languageVersion=${javaVersion.majorVersion}, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}")
     }
 
     @Requires(value = [IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable, IntegTestPreconditions.NotNoDaemonExecutor])

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainIntegrationTest.groovy
@@ -80,7 +80,7 @@ class DaemonToolchainIntegrationTest extends AbstractIntegrationSpec implements 
 
         expect:
         fails("help")
-        failure.assertHasDescription("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=10, vendor=any vendor, implementation=vendor-specific}")
+        failure.assertHasDescription("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=10, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}")
     }
 
     def "Given daemon toolchain criteria with version and vendor that doesn't match installed ones When executing any task Then fails with the expected message"() {
@@ -93,6 +93,6 @@ class DaemonToolchainIntegrationTest extends AbstractIntegrationSpec implements 
 
         expect:
         fails("help")
-        failure.assertHasDescription("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=10, vendor=IBM, implementation=vendor-specific}")
+        failure.assertHasDescription("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=10, vendor=IBM, implementation=vendor-specific, nativeImageCapable=false}")
     }
 }

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainInvalidCriteriaIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainInvalidCriteriaIntegrationTest.groovy
@@ -62,7 +62,7 @@ class DaemonToolchainInvalidCriteriaIntegrationTest extends AbstractIntegrationS
         fails 'help'
 
         then:
-        failureDescriptionContains("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=17, vendor=vendor matching('unexpectedVendor'), implementation=vendor-specific}.")
+        failureDescriptionContains("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=17, vendor=vendor matching('unexpectedVendor'), implementation=vendor-specific, nativeImageCapable=false}.")
     }
 
     @NotYetImplemented

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -212,6 +212,23 @@ interface SomeDataView {
 }
 ```
 
+### GraalVM Native Image selection for toolchains
+
+Gradle's [toolchain support](userguide/toolchains.html) allows provisioning and selection of JDK versions required for building projects (compiling code, running tests, etc) and running Gradle itself.
+
+With this release, the selection criteria have been expanded to include [GraalVM Native Image](https://www.graalvm.org/reference-manual/native-image/) capability selection:
+
+```kotlin
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+        nativeImageCapable = true
+    }
+}
+```
+
+See [the documentation](userguide/toolchains.html#sec:native_image) for details.
+
 ### Configuration Cache improvements
 
 #### Integrity Check mode

--- a/platforms/documentation/docs/src/docs/userguide/platforms/jvm/toolchains.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/platforms/jvm/toolchains.adoc
@@ -78,6 +78,19 @@ include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradl
 include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-matching-vendor]"]
 ====
 
+[[sec:native_image]]
+=== Selecting toolchains that support GraalVM native image
+
+If your project needs a toolchain with https://www.graalvm.org/latest/reference-manual/native-image/[GraalVM Native Image capability], you can configure the spec to request it:
+
+====
+include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-native-image]"]
+include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-native-image]"]
+====
+
+Leaving that value unconfigured or set to `false` will not restrict the toolchain selection based on the Native Image capability.
+That means that a Native Image capable JDK can be selected if it matches the other criteria.
+
 === Selecting toolchains by virtual machine implementation
 
 If your project requires a specific implementation, you can filter based on the implementation as well.

--- a/platforms/documentation/docs/src/snippets/java/toolchain-filters/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-filters/groovy/build.gradle
@@ -35,4 +35,13 @@ java {
     }
 }
 // end::toolchain-matching-implementation[]
+} else if (testToolchain == "nativeImage") {
+// tag::toolchain-native-image[]
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+        nativeImageCapable = true
+    }
+}
+// end::toolchain-native-image[]
 }

--- a/platforms/documentation/docs/src/snippets/java/toolchain-filters/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-filters/kotlin/build.gradle.kts
@@ -36,4 +36,13 @@ java {
     }
 }
 // end::toolchain-matching-implementation[]
+} else if (testToolchain == "nativeImage") {
+// tag::toolchain-native-image[]
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+        nativeImageCapable = true
+    }
+}
+// end::toolchain-native-image[]
 }

--- a/platforms/documentation/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithCC.out
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithCC.out
@@ -1,4 +1,4 @@
 Could not determine the dependencies of task ':compileJava'.
 > Could not resolve all dependencies for configuration ':compileClasspath'.
    > Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
-      > Cannot find a Java installation on your machine (%OS_ARCH%) matching: {languageVersion=11, vendor=vendor matching('customString'), implementation=vendor-specific}. Toolchain auto-provisioning is not enabled.
+      > Cannot find a Java installation on your machine (%OS_ARCH%) matching: {languageVersion=11, vendor=vendor matching('customString'), implementation=vendor-specific, nativeImageCapable=false}. Toolchain auto-provisioning is not enabled.

--- a/platforms/documentation/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithoutCC.out
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithoutCC.out
@@ -1,4 +1,4 @@
 Could not determine the dependencies of task ':compileJava'.
 > Could not resolve all dependencies for configuration ':compileClasspath'.
    > Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
-      > Cannot find a Java installation on your machine (%OS_ARCH%) matching: {languageVersion=11, vendor=vendor matching('customString'), implementation=vendor-specific}. Toolchain auto-provisioning is not enabled.
+      > Cannot find a Java installation on your machine (%OS_ARCH%) matching: {languageVersion=11, vendor=vendor matching('customString'), implementation=vendor-specific, nativeImageCapable=false}. Toolchain auto-provisioning is not enabled.

--- a/platforms/documentation/docs/src/snippets/java/toolchain-filters/tests/sanityCheck.sample.conf
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-filters/tests/sanityCheck.sample.conf
@@ -7,4 +7,7 @@ commands:[{
 }, {
     executable: gradle
     args: "tasks -DtestToolchain=matchingImplementation"
+}, {
+    executable: gradle
+    args: "tasks -DtestToolchain=nativeImage"
 }]

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/ToolchainsParallelActionExecutionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/ToolchainsParallelActionExecutionCrossVersionSpec.groovy
@@ -85,7 +85,9 @@ class ToolchainsParallelActionExecutionCrossVersionSpec extends ToolingApiSpecif
         def e = thrown(BuildActionFailureException)
         def root = rootCause(e)
         def message = 'No locally installed toolchains match'
-        if (targetVersion >= GradleVersion.version("8.13")) {
+        if (targetVersion >= GradleVersion.version("8.14")) {
+            message = "Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. No matching toolchain could be found in the configured toolchain download repositories."
+        } else if (targetVersion >= GradleVersion.version("8.13")) {
             message = "Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=any vendor, implementation=vendor-specific}. No matching toolchain could be found in the configured toolchain download repositories."
         } else if (targetVersion >= GradleVersion.version("8.8")) {
             message = 'No matching toolchain could be found in the locally installed toolchains'

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JavaInstallationCapability.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JavaInstallationCapability.java
@@ -41,7 +41,11 @@ public enum JavaInstallationCapability {
     /**
      * The installation uses the J9 virtual machine. This is only present for IBM J9 JVMs.
      */
-    J9_VIRTUAL_MACHINE;
+    J9_VIRTUAL_MACHINE,
+    /**
+     * The installation provides the `native-image` binary. This is present for Graal VM compatible installations.
+     */
+    NATIVE_IMAGE;
 
     /**
      * All capabilities needed by our uses of a JDK. When something "is JDK", it has all of these.
@@ -58,6 +62,8 @@ public enum JavaInstallationCapability {
                 return "executable 'jar'";
             case J9_VIRTUAL_MACHINE:
                 return "J9 virtual machine";
+            case NATIVE_IMAGE:
+                return "executable 'native-image'";
             default:
                 throw new IllegalStateException("Unknown capability: " + this);
         }

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
@@ -256,6 +256,9 @@ public interface JvmInstallationMetadata {
             if (getToolByExecutable("jar").exists()) {
                 capabilities.add(JavaInstallationCapability.JAR_TOOL);
             }
+            if (getToolByExecutable("native-image").exists()) {
+                capabilities.add(JavaInstallationCapability.NATIVE_IMAGE);
+            }
             boolean isJ9vm = jvmName.contains("J9");
             if (isJ9vm) {
                 capabilities.add(JavaInstallationCapability.J9_VIRTUAL_MACHINE);

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -306,7 +306,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec implem
             .runWithFailure()
 
         then:
-        failure.assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=any vendor, implementation=vendor-specific}. " +
+        failure.assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. " +
                 "Toolchain auto-provisioning is not enabled.")
             .assertHasResolutions(
                 DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection and auto-provisioning at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
@@ -377,7 +377,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec implem
         fails("compileJava")
 
         then:
-        failure.assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=$version, vendor=Amazon Corretto, implementation=vendor-specific}. " +
+        failure.assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=$version, vendor=Amazon Corretto, implementation=vendor-specific, nativeImageCapable=false}. " +
                 "Toolchain auto-provisioning is not enabled.")
             .assertHasResolutions(
                 DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection and auto-provisioning at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
@@ -404,7 +404,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec implem
         withInstallations(jre).fails("compileJava")
 
         then:
-        failure.assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=${jre.javaVersionMajor}, vendor=any vendor, implementation=vendor-specific}. " +
+        failure.assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=${jre.javaVersionMajor}, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. " +
                 "Toolchain auto-provisioning is not enabled")
             .assertHasResolutions(
                 DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection and auto-provisioning at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
@@ -206,7 +206,7 @@ class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec implements
         withInstallations(jre).fails("javadoc")
 
         then:
-        failure.assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=${jre.javaVersionMajor}, vendor=any vendor, implementation=vendor-specific}. " +
+        failure.assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=${jre.javaVersionMajor}, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. " +
                 "Toolchain auto-provisioning is not enabled.")
             .assertHasResolutions(
                 DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection and auto-provisioning at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -62,7 +62,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec imple
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=14, vendor=Eclipse Temurin, implementation=J9}. " +
+               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=14, vendor=Eclipse Temurin, implementation=J9, nativeImageCapable=false}. " +
                     "No matching toolchain could be found in the configured toolchain download repositories.")
                .assertHasResolutions(
                    DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection and auto-provisioning at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
@@ -101,7 +101,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec imple
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=14, vendor=any vendor, implementation=vendor-specific}. " +
+               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=14, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. " +
                    "Toolchain auto-provisioning is not enabled.")
                .assertHasResolutions(
                    DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection and auto-provisioning at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
@@ -137,9 +137,9 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec imple
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=any vendor, implementation=vendor-specific}. " +
+               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. " +
                    "Some toolchain resolvers had provisioning failures: custom (Unable to download toolchain matching the requirements " +
-                   "({languageVersion=99, vendor=any vendor, implementation=vendor-specific}) from 'http://exoticJavaToolchain.com/java-99', " +
+                   "({languageVersion=99, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}) from 'http://exoticJavaToolchain.com/java-99', " +
                    "due to: Attempting to download java toolchain from an insecure URI http://exoticJavaToolchain.com/java-99. This is not supported, use a secure URI instead.).")
     }
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiAuthenticationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiAuthenticationIntegrationTest.groovy
@@ -76,9 +76,9 @@ class JavaToolchainDownloadSpiAuthenticationIntegrationTest extends AbstractInte
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
                .assertHasCause("Could not resolve all dependencies for configuration ':compileClasspath'.")
                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific}. " +
+               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific, nativeImageCapable=false}. " +
                     "Some toolchain resolvers had provisioning failures: custom (Unable to download toolchain matching the requirements " +
-                    "({languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific}) from '$archiveUri', " +
+                    "({languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific, nativeImageCapable=false}) from '$archiveUri', " +
                     "due to: Unpacked JDK archive does not contain a Java home: " + temporaryFolder.testDirectory.file("user-home", ".tmp", "jdks", "toolchain"))
     }
 
@@ -132,9 +132,9 @@ class JavaToolchainDownloadSpiAuthenticationIntegrationTest extends AbstractInte
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
             .assertHasCause("Could not resolve all dependencies for configuration ':compileClasspath'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-            .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific}. " +
+            .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific, nativeImageCapable=false}. " +
                 "Some toolchain resolvers had provisioning failures: custom (Unable to download toolchain matching the requirements " +
-                "({languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific}) from '$archiveUri', " +
+                "({languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific, nativeImageCapable=false}) from '$archiveUri', " +
                 "due to: Unpacked JDK archive does not contain a Java home: " + temporaryFolder.testDirectory.file("user-home", ".tmp", "jdks", "toolchain"))
     }
 }

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiIntegrationTest.groovy
@@ -66,9 +66,9 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific}. " +
+               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific, nativeImageCapable=false}. " +
                    "Some toolchain resolvers had provisioning failures: custom (Unable to download toolchain matching the requirements " +
-                   "({languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific}) from 'https://exoticJavaToolchain.com/java-99', " +
+                   "({languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific, nativeImageCapable=false}) from 'https://exoticJavaToolchain.com/java-99', " +
                    "due to: Could not HEAD 'https://exoticJavaToolchain.com/java-99'.).")
     }
 
@@ -107,9 +107,9 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=11, vendor=any vendor, implementation=vendor-specific}. " +
-                   "Some toolchain resolvers had provisioning failures: custom (Unable to download toolchain matching the requirements ({languageVersion=11, vendor=any vendor, implementation=vendor-specific}) " +
-                   "from '$uri', due to: Toolchain provisioned from '$uri' doesn't satisfy the specification: {languageVersion=11, vendor=any vendor, implementation=vendor-specific} and must have the executable 'javac', the executable 'javadoc', and the executable 'jar'.)")
+               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=11, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. " +
+                   "Some toolchain resolvers had provisioning failures: custom (Unable to download toolchain matching the requirements ({languageVersion=11, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}) " +
+                   "from '$uri', due to: Toolchain provisioned from '$uri' doesn't satisfy the specification: {languageVersion=11, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false} and must have the executable 'javac', the executable 'javadoc', and the executable 'jar'.)")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/30409")
@@ -200,9 +200,9 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific}. " +
+               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific, nativeImageCapable=false}. " +
                    "Some toolchain resolvers had provisioning failures: custom (Unable to download toolchain matching the requirements " +
-                   "({languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific}) from 'https://exoticJavaToolchain.com/java-99', " +
+                   "({languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific, nativeImageCapable=false}) from 'https://exoticJavaToolchain.com/java-99', " +
                    "due to: Could not HEAD 'https://exoticJavaToolchain.com/java-99'.).")
     }
 
@@ -479,7 +479,7 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=any vendor, implementation=vendor-specific}. " +
+               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. " +
                    "Toolchain download repositories have not been configured.")
                .assertHasResolutions(
                    DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection and auto-provisioning at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
@@ -552,11 +552,11 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractIntegrationSpec {
         where:
         logLevel | test
         "warn"   | { ExecutionResult r -> r.assertOutputContains("Some toolchain resolvers had internal failures: failsOnResolve (Ooops!). " +
-            "Some toolchain resolvers had provisioning failures: failsOnProvision (Unable to download toolchain matching the requirements ({languageVersion=11, vendor=any vendor, implementation=vendor-specific}) from 'http://exoticJavaToolchain.com/java-11', due to: Attempting to download java toolchain from an insecure URI http://exoticJavaToolchain.com/java-11. This is not supported, use a secure URI instead.). Switch logging level to DEBUG (--debug) for further information.")
+            "Some toolchain resolvers had provisioning failures: failsOnProvision (Unable to download toolchain matching the requirements ({languageVersion=11, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}) from 'http://exoticJavaToolchain.com/java-11', due to: Attempting to download java toolchain from an insecure URI http://exoticJavaToolchain.com/java-11. This is not supported, use a secure URI instead.). Switch logging level to DEBUG (--debug) for further information.")
         }
-        "debug"  | { ExecutionResult r -> r.assertOutputContains("Some toolchain resolvers had internal failures: failsOnResolve (Ooops!). Some toolchain resolvers had provisioning failures: failsOnProvision (Unable to download toolchain matching the requirements ({languageVersion=11, vendor=any vendor, implementation=vendor-specific}) from 'http://exoticJavaToolchain.com/java-11', due to: Attempting to download java toolchain from an insecure URI http://exoticJavaToolchain.com/java-11. This is not supported, use a secure URI instead.)")
+        "debug"  | { ExecutionResult r -> r.assertOutputContains("Some toolchain resolvers had internal failures: failsOnResolve (Ooops!). Some toolchain resolvers had provisioning failures: failsOnProvision (Unable to download toolchain matching the requirements ({languageVersion=11, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}) from 'http://exoticJavaToolchain.com/java-11', due to: Attempting to download java toolchain from an insecure URI http://exoticJavaToolchain.com/java-11. This is not supported, use a secure URI instead.)")
             .assertOutputContains("Suppressed: java.lang.Exception: Ooops!")
-            .assertOutputContains("Suppressed: org.gradle.jvm.toolchain.internal.install.exceptions.ToolchainDownloadException: Unable to download toolchain matching the requirements ({languageVersion=11, vendor=any vendor, implementation=vendor-specific}) from 'http://exoticJavaToolchain.com/java-11', due to: Attempting to download java toolchain from an insecure URI http://exoticJavaToolchain.com/java-11. This is not supported, use a secure URI instead.")
+            .assertOutputContains("Suppressed: org.gradle.jvm.toolchain.internal.install.exceptions.ToolchainDownloadException: Unable to download toolchain matching the requirements ({languageVersion=11, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}) from 'http://exoticJavaToolchain.com/java-11', due to: Attempting to download java toolchain from an insecure URI http://exoticJavaToolchain.com/java-11. This is not supported, use a secure URI instead.")
         }
     }
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiKotlinIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiKotlinIntegrationTest.groovy
@@ -60,9 +60,9 @@ class JavaToolchainDownloadSpiKotlinIntegrationTest extends AbstractIntegrationS
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific}. " +
+               .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific, nativeImageCapable=false}. " +
                    "Some toolchain resolvers had provisioning failures: custom (Unable to download toolchain matching the requirements " +
-                   "({languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific}) from 'https://exoticJavaToolchain.com/java-99', " +
+                   "({languageVersion=99, vendor=vendor matching('exotic'), implementation=vendor-specific, nativeImageCapable=false}) from 'https://exoticJavaToolchain.com/java-99', " +
                    "due to: Could not HEAD 'https://exoticJavaToolchain.com/java-99'.).")
     }
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
@@ -193,7 +193,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
         fails ':build'
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-            .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=11, vendor=IBM, implementation=J9}. " +
+            .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=11, vendor=IBM, implementation=J9, nativeImageCapable=false}. " +
                 "Toolchain auto-provisioning is not enabled.")
     }
 
@@ -215,7 +215,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
         fails ':build'
         failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-            .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=11, vendor=IBM, implementation=J9}. " +
+            .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=11, vendor=IBM, implementation=J9, nativeImageCapable=false}. " +
                 "Toolchain auto-provisioning is not enabled.")
     }
 }

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
@@ -18,6 +18,7 @@ package org.gradle.jvm.toolchain;
 
 import com.google.common.base.MoreObjects;
 import org.gradle.api.Describable;
+import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -74,6 +75,14 @@ public interface JavaToolchainSpec extends Describable {
      */
     Property<JvmImplementation> getImplementation();
 
+    /**
+     * Indicates if the toolchain should be native-image capable.
+     *
+     * @since 8.14
+     */
+    @Incubating
+    Property<Boolean> getNativeImageCapable();
+
     @Override
     default String getDisplayName() {
         final MoreObjects.ToStringHelper builder = MoreObjects.toStringHelper("");
@@ -81,6 +90,7 @@ public interface JavaToolchainSpec extends Describable {
         builder.add("languageVersion", getLanguageVersion().map(JavaLanguageVersion::toString).getOrElse("unspecified"));
         builder.add("vendor", getVendor().map(JvmVendorSpec::toString).getOrNull());
         builder.add("implementation", getImplementation().map(JvmImplementation::toString).getOrNull());
+        builder.add("nativeImageCapable", getNativeImageCapable().getOrElse(false));
         return builder.toString();
     }
 

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -32,16 +32,19 @@ public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
     private final Property<JavaLanguageVersion> version;
     private final Property<JvmVendorSpec> vendor;
     private final Property<JvmImplementation> implementation;
+    private final Property<Boolean> nativeImageCapable;
 
     public static class Key implements JavaToolchainSpecInternal.Key {
         private final JavaLanguageVersion languageVersion;
         private final JvmVendorSpec vendor;
         private final JvmImplementation implementation;
+        private final boolean nativeImageCapable;
 
-        public Key(@Nullable JavaLanguageVersion languageVersion, @Nullable JvmVendorSpec vendor, @Nullable JvmImplementation implementation) {
+        public Key(@Nullable JavaLanguageVersion languageVersion, @Nullable JvmVendorSpec vendor, @Nullable JvmImplementation implementation, boolean nativeImageCapable) {
             this.languageVersion = languageVersion;
             this.vendor = vendor;
             this.implementation = implementation;
+            this.nativeImageCapable = nativeImageCapable;
         }
 
         @Override
@@ -55,12 +58,13 @@ public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
             Key that = (Key) o;
             return Objects.equals(languageVersion, that.languageVersion)
                 && Objects.equals(vendor, that.vendor)
-                && Objects.equals(implementation, that.implementation);
+                && Objects.equals(implementation, that.implementation)
+                && nativeImageCapable == that.nativeImageCapable;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(languageVersion, vendor, implementation);
+            return Objects.hash(languageVersion, vendor, implementation, nativeImageCapable);
         }
 
         @Override
@@ -69,6 +73,7 @@ public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
                 "languageVersion=" + languageVersion +
                 ", vendor=" + vendor +
                 ", implementation=" + implementation +
+                ", nativeImageCapable=" + nativeImageCapable +
                 '}';
         }
     }
@@ -78,6 +83,7 @@ public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
         version = propertyFactory.property(JavaLanguageVersion.class);
         vendor = propertyFactory.property(JvmVendorSpec.class);
         implementation = propertyFactory.property(JvmImplementation.class);
+        nativeImageCapable = propertyFactory.property(Boolean.class);
 
         getVendor().convention(getConventionVendor());
         getImplementation().convention(getConventionImplementation());
@@ -99,8 +105,13 @@ public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
     }
 
     @Override
+    public Property<Boolean> getNativeImageCapable() {
+        return nativeImageCapable;
+    }
+
+    @Override
     public JavaToolchainSpecInternal.Key toKey() {
-        return new Key(getLanguageVersion().getOrNull(), getVendor().getOrNull(), getImplementation().getOrNull());
+        return new Key(getLanguageVersion().getOrNull(), getVendor().getOrNull(), getImplementation().getOrNull(), nativeImageCapable.getOrElse(false));
     }
 
     @Override

--- a/platforms/jvm/toolchains-jvm-shared/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultToolchainSpecTest.groovy
+++ b/platforms/jvm/toolchains-jvm-shared/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultToolchainSpecTest.groovy
@@ -32,15 +32,16 @@ class DefaultToolchainSpecTest extends Specification {
     def "spec key implements equals"() {
         given:
         def spec11 = createSpec()
-        def spec12 = createSpec()
         def spec11Vendor1 = createSpec()
         def spec11Vendor2 = createSpec()
         def spec11Impl1 = createSpec()
         def spec11Impl2 = createSpec()
+        def spec12 = createSpec()
+        def spec21 = createSpec()
+        def spec21Native = createSpec()
 
         when:
         spec11.languageVersion.set(JavaLanguageVersion.of(11))
-        spec12.languageVersion.set(JavaLanguageVersion.of(12))
         spec11Vendor1.languageVersion.set(JavaLanguageVersion.of(11))
         spec11Vendor1.vendor.set(JvmVendorSpec.AMAZON)
         spec11Vendor2.languageVersion.set(JavaLanguageVersion.of(11))
@@ -52,6 +53,10 @@ class DefaultToolchainSpecTest extends Specification {
 
         spec12.languageVersion.set(JavaLanguageVersion.of(12))
 
+        spec21.languageVersion.set(JavaLanguageVersion.of(21))
+        spec21Native.languageVersion.set(JavaLanguageVersion.of(21))
+        spec21Native.nativeImageCapable.set(true)
+
         then:
         Matchers.strictlyEquals(spec11.toKey(), spec11.toKey())
         Matchers.strictlyEquals(spec11.toKey(), spec11Impl1.toKey())
@@ -61,5 +66,7 @@ class DefaultToolchainSpecTest extends Specification {
         Matchers.strictlyEquals(spec11Impl1.toKey(), spec11Impl1.toKey())
         !Matchers.strictlyEquals(spec11Impl1.toKey(), spec11Impl2.toKey())
         !Matchers.strictlyEquals(spec11Vendor1.toKey(), spec11Vendor2.toKey())
+        Matchers.strictlyEquals(spec21Native.toKey(), spec21Native.toKey())
+        !Matchers.strictlyEquals(spec21.toKey(), spec21Native.toKey())
     }
 }

--- a/platforms/jvm/toolchains-jvm-shared/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/platforms/jvm/toolchains-jvm-shared/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -41,6 +41,8 @@ import java.util.function.Function
 import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
 import static org.gradle.internal.jvm.inspection.JavaInstallationCapability.JAVADOC_TOOL
 import static org.gradle.internal.jvm.inspection.JavaInstallationCapability.JAVA_COMPILER
+import static org.gradle.internal.jvm.inspection.JavaInstallationCapability.JDK_CAPABILITIES
+import static org.gradle.internal.jvm.inspection.JavaInstallationCapability.NATIVE_IMAGE
 
 class JavaToolchainQueryServiceTest extends Specification {
 
@@ -155,7 +157,7 @@ class JavaToolchainQueryServiceTest extends Specification {
 
     def "uses jdk if requested via capabilities = #capabilities"() {
         given:
-        def queryService = setupInstallations(["8.0.jre", "8.0.242.jre.hs-adpt", "7.9.jre", "7.7.jre", "14.0.2+12.jre", "8.0.1.jdk"])
+        def queryService = setupInstallations(["8.0.jre", "8.0.242.jre.hs-adpt", "7.9.jre", "7.7.jre", "14.0.2+12.jre", "8.0.1.jdk.native", "21.0.6-native"])
 
         when:
         def filter = createSpec()
@@ -164,19 +166,20 @@ class JavaToolchainQueryServiceTest extends Specification {
 
         then:
         toolchain.languageVersion == JavaLanguageVersion.of(8)
-        toolchain.getInstallationPath().toString() == systemSpecificAbsolutePath("/path/8.0.1.jdk")
+        toolchain.getInstallationPath().toString() == systemSpecificAbsolutePath("/path/8.0.1.jdk.native")
 
         where:
         capabilities << [
             EnumSet.of(JAVA_COMPILER),
             EnumSet.of(JAVADOC_TOOL),
-            JavaInstallationCapability.JDK_CAPABILITIES
+            JDK_CAPABILITIES,
+            EnumSet.of(NATIVE_IMAGE)
         ]
     }
 
     def "fails when no jdk is present and requested capabilities = #capabilities"() {
         given:
-        def queryService = setupInstallations(["8.0.jre", "8.0.242.jre", "7.9.jre", "7.7.jre", "14.0.2+12.jre"])
+        def queryService = setupInstallations(["8.0.jre", "8.0.242.jre", "7.9.jre", "7.7.jre", "14.0.2+12.jre", "21.0.6-native"])
 
         when:
         def filter = createSpec()
@@ -186,14 +189,15 @@ class JavaToolchainQueryServiceTest extends Specification {
 
         then:
         def e = thrown(ToolchainProvisioningException)
-        e.message == "Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=8, vendor=any vendor, implementation=vendor-specific}. " +
+        e.message == "Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=8, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. " +
                 "Toolchain auto-provisioning is not enabled."
 
         where:
         capabilities << [
             EnumSet.of(JAVA_COMPILER),
             EnumSet.of(JAVADOC_TOOL),
-            JavaInstallationCapability.JDK_CAPABILITIES
+            JDK_CAPABILITIES,
+            EnumSet.of(NATIVE_IMAGE)
         ]
     }
 
@@ -223,7 +227,7 @@ class JavaToolchainQueryServiceTest extends Specification {
 
         then:
         def e = thrown(ToolchainProvisioningException)
-        e.message == "Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=12, vendor=any vendor, implementation=vendor-specific}. " +
+        e.message == "Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=12, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. " +
             "Toolchain auto-provisioning is not enabled."
     }
 
@@ -474,9 +478,13 @@ class JavaToolchainQueryServiceTest extends Specification {
             jvmName = "J9"
         }
 
-        def additionalCapabilities = location.name.contains("jdk")
-            ? JavaInstallationCapability.JDK_CAPABILITIES
-            : Collections.<JavaInstallationCapability> emptySet()
+        def additionalCapabilities= EnumSet.noneOf(JavaInstallationCapability)
+        if (location.name.contains("jdk")) {
+            additionalCapabilities.addAll(JDK_CAPABILITIES)
+        }
+        if (location.name.contains("native")) {
+            additionalCapabilities.add(NATIVE_IMAGE)
+        }
 
         new JvmMetadataWithAddedCapabilities(
             JvmInstallationMetadata.from(


### PR DESCRIPTION
This enables a toolchains spec to indicate that a JVM with native image capability is required.

In order to provide auto-provisioning, changes are required in the Foojay plugin.
