### PR TITLE
Make sure we only return Strings from getAllCompilerArgs

### DIFF
--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.api.tasks.compile
 
+import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.util.TestUtil
+import spock.lang.Issue
 import spock.lang.Specification
 
 import java.util.concurrent.atomic.AtomicReference
@@ -112,5 +114,22 @@ class CompileOptionsTest extends Specification {
 
         expect:
         compileOptions.debugOptions == debugOptions.get()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/32606")
+    def "getAllCompilerArgs() returns only Strings"() {
+        given:
+        def commandLineArgumentProvider = new CommandLineArgumentProvider() {
+            @Override
+            Iterable<String> asArguments() {
+                return ["${'make this a GString'}"]
+            }
+        }
+        compileOptions.compilerArgumentProviders.add(commandLineArgumentProvider)
+
+        expect:
+        commandLineArgumentProvider.asArguments().iterator().next() instanceof GString
+        compileOptions.allCompilerArgs.size() == 1
+        compileOptions.allCompilerArgs[0] instanceof String
     }
 }

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/compile/ForkOptionsTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/compile/ForkOptionsTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.api.tasks.compile
 
+import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.util.TestUtil
+import spock.lang.Issue
 import spock.lang.Specification
 
 class ForkOptionsTest extends Specification {
@@ -39,5 +41,22 @@ class ForkOptionsTest extends Specification {
         forkOptions.define(PROPS.collectEntries { [it, "${it}Value" as String ] })
         then:
         PROPS.each { assert forkOptions."${it}" == "${it}Value" as String }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/32606")
+    def "getAllJvmArgs() returns only String"() {
+        given:
+        def commandLineArgumentProvider = new CommandLineArgumentProvider() {
+            @Override
+            Iterable<String> asArguments() {
+                return ["${'make this a GString'}"]
+            }
+        }
+        forkOptions.jvmArgumentProviders.add(commandLineArgumentProvider)
+
+        expect:
+        commandLineArgumentProvider.asArguments().iterator().next() instanceof GString
+        forkOptions.allJvmArgs.size() == 1
+        forkOptions.allJvmArgs[0] instanceof String
     }
 }

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -391,7 +391,7 @@ public abstract class CompileOptions extends AbstractOptions {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
         builder.addAll(CollectionUtils.stringize(getCompilerArgs()));
         for (CommandLineArgumentProvider compilerArgumentProvider : getCompilerArgumentProviders()) {
-            builder.addAll(compilerArgumentProvider.asArguments());
+            builder.addAll(CollectionUtils.toStringList(compilerArgumentProvider.asArguments()));
         }
         return builder.build();
     }

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/ProviderAwareCompilerDaemonForkOptions.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/tasks/compile/ProviderAwareCompilerDaemonForkOptions.java
@@ -63,7 +63,7 @@ public class ProviderAwareCompilerDaemonForkOptions extends BaseForkOptions {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
         builder.addAll(CollectionUtils.stringize(getJvmArgs()));
         for (CommandLineArgumentProvider argumentProvider : getJvmArgumentProviders()) {
-            builder.addAll(argumentProvider.asArguments());
+            builder.addAll(CollectionUtils.toStringList(argumentProvider.asArguments()));
         }
         return builder.build();
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
@@ -238,6 +238,9 @@ public class JvmOptions {
             || extraJvmArgString.startsWith("-agentlib:jdwp");
     }
 
+    /**
+     * Adds extra JVM args and implicitly converts given arguments to just Strings
+     */
     public void jvmArgs(Iterable<?> arguments) {
         addExtraJvmArgs(arguments);
         checkDebugConfiguration(extraJvmArgs);
@@ -271,7 +274,7 @@ public class JvmOptions {
                     systemProperty(keyValue.substring(0, equalsIndex), keyValue.substring(equalsIndex + 1));
                 }
             } else {
-                extraJvmArgs.add(argument);
+                extraJvmArgs.add(argStr);
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ProcessArgumentsSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ProcessArgumentsSpec.java
@@ -19,6 +19,7 @@ package org.gradle.process.internal;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.util.internal.CollectionUtils;
 import org.gradle.util.internal.GUtil;
 
 import java.util.ArrayList;
@@ -71,7 +72,7 @@ public class ProcessArgumentsSpec {
             allArgs = new ArrayList<>(args);
         }
         for (CommandLineArgumentProvider argumentProvider : argumentProviders) {
-            Iterables.addAll(allArgs, argumentProvider.asArguments());
+            Iterables.addAll(allArgs, CollectionUtils.toStringList(argumentProvider.asArguments()));
         }
         return allArgs;
     }


### PR DESCRIPTION
fixes #32606

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
