### PR TITLE
Make GradlePluginDevelopmentExtension follow more idiomatic patterns

### DIFF
--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/GradlePluginDevelopmentExtension.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/GradlePluginDevelopmentExtension.java
@@ -25,6 +25,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 
 import java.util.Arrays;
@@ -131,7 +132,7 @@ public abstract class GradlePluginDevelopmentExtension {
      *
      * @return the plugin source set
      */
-    @ToBeReplacedByLazyProperty
+    @NotToBeReplacedByLazyProperty(because="this property will be made non-configurable")
     public SourceSet getPluginSourceSet() {
         return pluginSourceSet;
     }
@@ -141,7 +142,7 @@ public abstract class GradlePluginDevelopmentExtension {
      *
      * @return the test source sets
      */
-    @ToBeReplacedByLazyProperty
+    @NotToBeReplacedByLazyProperty(because="this property will be replaced by another API")
     public Set<SourceSet> getTestSourceSets() {
         return testSourceSets;
     }

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/GradlePluginDevelopmentExtension.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/GradlePluginDevelopmentExtension.java
@@ -60,23 +60,13 @@ import java.util.Set;
  * @since 2.13
  */
 public abstract class GradlePluginDevelopmentExtension {
-
-    private final Property<String> website;
-
-    private final Property<String> vcsUrl;
-
     private final SourceSetContainer testSourceSets;
     private SourceSet pluginSourceSet;
     private boolean automatedPublishing = true;
 
-    private final NamedDomainObjectContainer<PluginDeclaration> plugins;
-
     public GradlePluginDevelopmentExtension(Project project, SourceSet pluginSourceSet, SourceSet testSourceSet) {
-        this.plugins = project.container(PluginDeclaration.class);
         this.pluginSourceSet = pluginSourceSet;
         this.testSourceSets = project.getObjects().newInstance(DefaultSourceSetContainer.class);
-        this.website = project.getObjects().property(String.class);
-        this.vcsUrl = project.getObjects().property(String.class);
         testSourceSets(testSourceSet);
     }
 
@@ -88,11 +78,8 @@ public abstract class GradlePluginDevelopmentExtension {
             .withUpgradeGuideSection(8, "deprecated_plugin_development_methods")
             .nagUser();
 
-        this.plugins = project.container(PluginDeclaration.class);
         this.pluginSourceSet = pluginSourceSet;
         this.testSourceSets = project.getObjects().newInstance(DefaultSourceSetContainer.class);
-        this.website = project.getObjects().property(String.class);
-        this.vcsUrl = project.getObjects().property(String.class);
         testSourceSets(testSourceSets);
     }
 
@@ -164,27 +151,21 @@ public abstract class GradlePluginDevelopmentExtension {
      *
      * @since 7.6
      */
-    public Property<String> getWebsite() {
-        return website;
-    }
+    public abstract Property<String> getWebsite();
 
     /**
      * Returns the property holding the URL for the plugin's VCS repository.
      *
      * @since 7.6
      */
-    public Property<String> getVcsUrl() {
-        return vcsUrl;
-    }
+    public abstract Property<String> getVcsUrl();
 
     /**
      * Returns the declared plugins.
      *
      * @return the declared plugins, never null
      */
-    public NamedDomainObjectContainer<PluginDeclaration> getPlugins() {
-        return plugins;
-    }
+    public abstract NamedDomainObjectContainer<PluginDeclaration> getPlugins();
 
     /**
      * Configures the declared plugins.
@@ -192,7 +173,7 @@ public abstract class GradlePluginDevelopmentExtension {
      * @param action the configuration action to invoke on the plugins
      */
     public void plugins(Action<? super NamedDomainObjectContainer<PluginDeclaration>> action) {
-        action.execute(plugins);
+        action.execute(getPlugins());
     }
 
     /**

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,3 +1,28 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.plugin.devel.GradlePluginDevelopmentExtension",
+            "member": "Method org.gradle.plugin.devel.GradlePluginDevelopmentExtension.getPlugins()",
+            "acceptation": "auto-generated as managed properties",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugin.devel.GradlePluginDevelopmentExtension",
+            "member": "Method org.gradle.plugin.devel.GradlePluginDevelopmentExtension.getVcsUrl()",
+            "acceptation": "auto-generated as managed properties",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugin.devel.GradlePluginDevelopmentExtension",
+            "member": "Method org.gradle.plugin.devel.GradlePluginDevelopmentExtension.getWebsite()",
+            "acceptation": "auto-generated as managed properties",
+            "changes": [
+                "Method is now abstract"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This also fixes an issue with elements of the plugins container not
having the proper decoration.
### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
