### PR TITLE
Annotate Project-scope dependency management services

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ArtifactPublicationServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ArtifactPublicationServices.java
@@ -16,7 +16,10 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scope.Project.class)
 public interface ArtifactPublicationServices {
     RepositoryHandler createRepositoryHandler();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/BaseRepositoryFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/BaseRepositoryFactory.java
@@ -19,10 +19,13 @@ import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Factory for {@link org.gradle.api.artifacts.repositories.ArtifactRepository} implementations.
  */
+@ServiceScope(Scope.Project.class)
 public interface BaseRepositoryFactory {
 
     String PLUGIN_PORTAL_DEFAULT_URL = "https://plugins.gradle.org/m2";

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessorFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentMetadataProcessorFactory.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 /**
  * A factory for {@link ComponentMetadataProcessor}.
  * <p>
@@ -25,6 +28,7 @@ package org.gradle.api.internal.artifacts;
  * <p>
  * The {@link MetadataResolutionContext} enables a {@link ComponentMetadataProcessor} to execute with the proper context.
  */
+@ServiceScope(Scope.Project.class)
 public interface ComponentMetadataProcessorFactory {
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentModuleMetadataHandlerInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentModuleMetadataHandlerInternal.java
@@ -18,10 +18,13 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.internal.artifacts.dsl.ImmutableModuleReplacements;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Internal counterpart to {@link ComponentModuleMetadataHandler}.
  */
+@ServiceScope(Scope.Project.class)
 public interface ComponentModuleMetadataHandlerInternal extends ComponentModuleMetadataHandler {
 
     ImmutableModuleReplacements getModuleReplacements();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentSelectorConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ComponentSelectorConverter.java
@@ -18,12 +18,15 @@ package org.gradle.api.internal.artifacts;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Adapts the new `ComponentSelector` types to legacy types.
  * Note that for `ProjectComponentSelector` this requires looking up the target project in order
  * to determine the project coordinates.
  */
+@ServiceScope(Scope.Project.class)
 public interface ComponentSelectorConverter {
     ModuleIdentifier getModule(ComponentSelector selector);
     ModuleVersionSelector getSelector(ComponentSelector selector);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ConfigurationResolver.java
@@ -20,6 +20,8 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformUpstreamDependenciesResolver;
 import org.gradle.internal.model.CalculatedValue;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.List;
 
@@ -30,6 +32,7 @@ import java.util.List;
  * in the sense that resolution failures in most cases will not cause exceptions
  * to be thrown. Instead, recoverable failures are packaged in the result type.
  */
+@ServiceScope(Scope.Project.class)
 public interface ConfigurationResolver {
     /**
      * Traverses enough of the graph to calculate the build dependencies of the given configuration. All failures are packaged in the result.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -65,6 +65,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionS
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.FileStoreAndIndexProvider;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultLocalComponentRegistry;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DependencyGraphResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder;
@@ -90,6 +91,7 @@ import org.gradle.api.internal.artifacts.transform.TransformExecutionResult.Tran
 import org.gradle.api.internal.artifacts.transform.TransformInvocationFactory;
 import org.gradle.api.internal.artifacts.transform.TransformParameterScheme;
 import org.gradle.api.internal.artifacts.transform.TransformRegistrationFactory;
+import org.gradle.api.internal.artifacts.transform.TransformedVariantFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
@@ -273,16 +275,16 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         void configure(ServiceRegistration registration) {
-            registration.add(DefaultTransformedVariantFactory.class);
+            registration.add(TransformedVariantFactory.class, DefaultTransformedVariantFactory.class);
             registration.add(DefaultRootComponentMetadataBuilder.Factory.class);
             registration.add(ResolveExceptionMapper.class);
             registration.add(ResolutionStrategyFactory.class);
-            registration.add(DefaultLocalComponentRegistry.class);
+            registration.add(LocalComponentRegistry.class, DefaultLocalComponentRegistry.class);
             registration.add(ProjectDependencyResolver.class);
             registration.add(ConsumerProvidedVariantFinder.class);
             registration.add(DefaultConfigurationFactory.class);
-            registration.add(DefaultComponentSelectorConverter.class);
-            registration.add(DefaultArtifactResolutionQueryFactory.class);
+            registration.add(ComponentSelectorConverter.class, DefaultComponentSelectorConverter.class);
+            registration.add(ArtifactResolutionQueryFactory.class, DefaultArtifactResolutionQueryFactory.class);
             registration.add(DependencyGraphResolver.class);
             registration.add(DependencyGraphBuilder.class);
             registration.add(AttributeDescriberRegistry.class);
@@ -557,7 +559,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyConstraintFactory, objects, platformSupport);
         }
 
-        @Provides
+        @Provides({ComponentMetadataHandler.class, ComponentMetadataHandlerInternal.class})
         DefaultComponentMetadataHandler createComponentMetadataHandler(
             Instantiator instantiator,
             ImmutableModuleIdentifierFactory moduleIdentifierFactory,
@@ -575,7 +577,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         @Provides
-        DefaultComponentModuleMetadataHandler createComponentModuleMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
+        ComponentModuleMetadataHandlerInternal createComponentModuleMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
             return instantiator.newInstance(DefaultComponentModuleMetadataHandler.class, moduleIdentifierFactory);
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/GlobalDependencyResolutionRules.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/GlobalDependencyResolutionRules.java
@@ -20,11 +20,14 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencySubstitution;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.internal.Actions;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.internal.CollectionUtils;
 
 import javax.inject.Inject;
 import java.util.List;
 
+@ServiceScope(Scope.Project.class)
 public class GlobalDependencyResolutionRules {
     private final DependencySubstitutionRules compositeRule;
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/RepositoriesSupplier.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/RepositoriesSupplier.java
@@ -16,9 +16,12 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.List;
 import java.util.function.Supplier;
 
+@ServiceScope(Scope.Project.class)
 public interface RepositoriesSupplier extends Supplier<List<ResolutionAwareRepository>> {
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveExceptionMapper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveExceptionMapper.java
@@ -23,6 +23,8 @@ import org.gradle.api.internal.artifacts.ivyservice.TypedResolveException;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.resolve.ModuleVersionNotFoundException;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -32,6 +34,7 @@ import java.util.List;
 /**
  * Adds additional context to exceptions thrown during resolution.
  */
+@ServiceScope(Scope.Project.class)
 public class ResolveExceptionMapper {
 
     private final DomainObjectContext domainObjectContext;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/VariantTransformRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/VariantTransformRegistry.java
@@ -20,12 +20,15 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.artifacts.transform.TransformSpec;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Set;
 
 /**
  * A registry for artifact transforms.
  */
+@ServiceScope(Scope.Project.class)
 public interface VariantTransformRegistry {
     /**
      * Register an artifact transform.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationContainerInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationContainerInternal.java
@@ -17,7 +17,10 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.UnknownConfigurationException;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scope.Project.class)
 public interface ConfigurationContainerInternal extends RoleBasedConfigurationContainerInternal, ConfigurationsProvider {
     @Override
     ConfigurationInternal getByName(String name) throws UnknownConfigurationException;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
@@ -40,6 +40,8 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.model.CalculatedValueFactory;
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.work.WorkerThreadRegistry;
 
@@ -49,6 +51,7 @@ import javax.inject.Inject;
 /**
  * Factory for creating {@link org.gradle.api.artifacts.Configuration} instances.
  */
+@ServiceScope(Scope.Project.class)
 @ThreadSafe
 public class DefaultConfigurationFactory {
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyFactory.java
@@ -37,6 +37,8 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.vcs.internal.VcsResolver;
 
@@ -45,6 +47,7 @@ import javax.inject.Inject;
 /**
  * Creates fully initialized {@link ResolutionStrategyInternal} instances.
  */
+@ServiceScope(Scope.Project.class)
 public class ResolutionStrategyFactory implements Factory<ResolutionStrategyInternal> {
 
     private final BuildState currentBuild;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataHandlerInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataHandlerInternal.java
@@ -21,9 +21,12 @@ import org.gradle.api.internal.artifacts.MetadataResolutionContext;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.management.DependencyResolutionManagementInternal;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.function.Consumer;
 
+@ServiceScope(Scope.Project.class)
 public interface ComponentMetadataHandlerInternal {
     ComponentMetadataProcessor createComponentMetadataProcessor(MetadataResolutionContext resolutionContext);
     void setVariantDerivationStrategy(VariantDerivationStrategy strategy);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationParserFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/PublishArtifactNotationParserFactory.java
@@ -32,6 +32,8 @@ import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.internal.Factory;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.typeconversion.MapKey;
 import org.gradle.internal.typeconversion.MapNotationConverter;
 import org.gradle.internal.typeconversion.NotationParser;
@@ -40,6 +42,7 @@ import org.gradle.internal.typeconversion.TypedNotationConverter;
 
 import java.io.File;
 
+@ServiceScope(Scope.Project.class)
 public class PublishArtifactNotationParserFactory implements Factory<NotationParser<Object, ConfigurablePublishArtifact>> {
     private final Instantiator instantiator;
     private final DependencyMetaDataProvider metaDataProvider;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -22,12 +22,15 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Set;
 
 /**
  * Provides dependency locking support for dependency resolution.
  */
+@ServiceScope(Scope.Project.class)
 public interface DependencyLockingProvider {
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
@@ -106,6 +106,8 @@ import org.gradle.internal.model.CalculatedValue;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resolve.resolver.ResolvedVariantCache;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
@@ -127,6 +129,7 @@ import java.util.Set;
  *     </li>
  * </ul>
  */
+@ServiceScope(Scope.Project.class)
 public class ResolutionExecutor {
 
     private static final Spec<DependencyMetadata> IS_LOCAL_EDGE = element -> element.getSelector() instanceof ProjectComponentSelector;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -37,6 +37,8 @@ import org.gradle.internal.component.local.model.LocalVariantGraphResolveState;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.model.ModelContainer;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -247,6 +249,7 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
         }
     }
 
+    @ServiceScope(Scope.Project.class)
     public static class Factory {
         private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
         private final LocalComponentGraphResolveStateFactory localResolveStateFactory;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentRegistry.java
@@ -17,6 +17,8 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -25,6 +27,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * These components may be produced within the same project, another project in the same multi-project build,
  * or in another build within a composite.
  */
+@ServiceScope(Scope.Project.class)
 @ThreadSafe
 public interface LocalComponentRegistry {
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphResolver.java
@@ -47,6 +47,8 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -56,6 +58,7 @@ import static org.gradle.api.internal.artifacts.ivyservice.dependencysubstitutio
 /**
  * Resolves a dependency graph and visits it. Essentially, this class is a {@link DependencyGraphBuilder} executor.
  */
+@ServiceScope(Scope.Project.class)
 public class DependencyGraphResolver {
     private final DependencyMetadataFactory dependencyMetadataFactory;
     private final VersionComparator versionComparator;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -62,6 +62,8 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,6 +79,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+@ServiceScope(Scope.Project.class)
 public class DependencyGraphBuilder {
 
     static final Spec<EdgeState> ENDORSE_STRICT_VERSIONS_DEPENDENCY_SPEC = dependencyState -> dependencyState.getDependencyState().getDependency().isEndorsingStrictVersions();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/ArtifactResolutionQueryFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/ArtifactResolutionQueryFactory.java
@@ -16,7 +16,10 @@
 package org.gradle.api.internal.artifacts.query;
 
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scope.Project.class)
 public interface ArtifactResolutionQueryFactory {
     ArtifactResolutionQuery createArtifactResolutionQuery();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultUrlArtifactRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultUrlArtifactRepository.java
@@ -21,6 +21,8 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.repositories.UrlArtifactRepository;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.deprecation.Documentation;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.verifier.HttpRedirectVerifier;
 import org.gradle.internal.verifier.HttpRedirectVerifierFactory;
 
@@ -123,6 +125,7 @@ public class DefaultUrlArtifactRepository implements UrlArtifactRepository {
             );
     }
 
+    @ServiceScope(Scope.Project.class)
     public static class Factory {
         private final FileResolver fileResolver;
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -27,6 +27,8 @@ import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.api.internal.attributes.matching.AttributeMatcher;
 import org.gradle.internal.collections.ImmutableFilteredList;
 import org.gradle.internal.lazy.Lazy;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import java.util.function.BiFunction;
  * Caches the results, as often the same request is made for many components in a
  * dependency graph.
  */
+@ServiceScope(Scope.Project.class)
 public class ConsumerProvidedVariantFinder {
     private final VariantTransformRegistry variantTransforms;
     private final AttributesFactory attributesFactory;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/MutableTransformWorkspaceServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/MutableTransformWorkspaceServices.java
@@ -21,7 +21,10 @@ import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.workspace.MutableWorkspaceProvider;
 import org.gradle.internal.file.ReservedFileSystemLocation;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scope.Project.class)
 public interface MutableTransformWorkspaceServices extends ReservedFileSystemLocation {
     MutableWorkspaceProvider getWorkspaceProvider();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformInvocationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformInvocationFactory.java
@@ -20,10 +20,13 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.internal.Deferrable;
 import org.gradle.internal.Try;
 import org.gradle.internal.execution.InputFingerprinter;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.File;
 
+@ServiceScope(Scope.Project.class)
 @ThreadSafe
 public interface TransformInvocationFactory {
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformRegistrationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformRegistrationFactory.java
@@ -20,9 +20,12 @@ import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.internal.artifacts.TransformRegistration;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 
+@ServiceScope(Scope.Project.class)
 public interface TransformRegistrationFactory {
     TransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends TransformAction<?>> implementation, @Nullable TransformParameters parameterObject);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedVariantFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedVariantFactory.java
@@ -19,7 +19,10 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scope.Project.class)
 public interface TransformedVariantFactory {
     ResolvedArtifactSet transformedExternalArtifacts(
         ComponentIdentifier componentIdentifier,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/ArtifactTypeRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/ArtifactTypeRegistry.java
@@ -24,9 +24,12 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.inject.Inject;
 
+@ServiceScope(Scope.Project.class)
 public class ArtifactTypeRegistry {
 
     private final Instantiator instantiator;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributesSchemaInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributesSchemaInternal.java
@@ -18,10 +18,13 @@ package org.gradle.api.internal.attributes;
 
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Map;
 import java.util.Set;
 
+@ServiceScope(Scope.Project.class)
 public interface AttributesSchemaInternal extends AttributesSchema {
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphVariantSelector.java
@@ -34,6 +34,8 @@ import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -50,6 +52,7 @@ import java.util.Set;
  * to allow the caller to handle failures in a consistent way - all matching failures should be reported via
  * calls to that instance.
  */
+@ServiceScope(Scope.Project.class)
 public class GraphVariantSelector {
 
     private final AttributeSchemaServices attributeSchemaServices;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionFailureHandler.java
@@ -57,6 +57,8 @@ import org.gradle.internal.component.resolution.failure.type.NoCompatibleVariant
 import org.gradle.internal.component.resolution.failure.type.NoVariantsWithMatchingCapabilitiesFailure;
 import org.gradle.internal.component.resolution.failure.type.UnknownArtifactSelectionFailure;
 import org.gradle.internal.instantiation.InstanceGenerator;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -83,6 +85,7 @@ import java.util.stream.Stream;
  * @implNote The methods for reporting failures via this class are ordered to match the stages of the variant selection process and
  * within those stages alphabetically, with names aligned with the failure type hierarchy.  This makes it much easier to navigate.
  */
+@ServiceScope(Scope.Project.class)
 public class ResolutionFailureHandler {
     public static final String DEFAULT_MESSAGE_PREFIX = "Review the variant matching algorithm at ";
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/transform/TransformedVariantConverter.java
@@ -21,6 +21,8 @@ import org.gradle.api.Action;
 import org.gradle.api.internal.artifacts.transform.Transform;
 import org.gradle.api.internal.artifacts.transform.TransformStep;
 import org.gradle.api.internal.artifacts.transform.TransformedVariant;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Collection;
 
@@ -30,6 +32,7 @@ import java.util.Collection;
  * <p>
  * See the {@link org.gradle.internal.component.resolution.failure.transform package javadoc} for why.
  */
+@ServiceScope(Scope.Project.class)
 public final class TransformedVariantConverter {
     public ImmutableList<TransformationChainData> convert(Collection<TransformedVariant> transformedVariants) {
         ImmutableList.Builder<TransformationChainData> builder = ImmutableList.builder();

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ComponentMetadataHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ComponentMetadataHandler.java
@@ -22,6 +22,8 @@ import org.gradle.api.ActionConfiguration;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ComponentMetadataRule;
 import org.gradle.internal.HasInternalProtocol;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Allows the build to provide rules that modify the metadata of depended-on software components.
@@ -61,6 +63,7 @@ import org.gradle.internal.HasInternalProtocol;
  * @since 1.8
  */
 @HasInternalProtocol
+@ServiceScope(Scope.Project.class)
 public interface ComponentMetadataHandler {
     /**
      * Adds a rule action that may modify the metadata of any resolved software component.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
@@ -19,6 +19,8 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderConvertible;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * <p>A {@code DependencyConstraintHandler} is used to declare dependency constraints.</p>
@@ -74,6 +76,7 @@ import org.gradle.api.provider.ProviderConvertible;
  *
  * @since 4.5
  */
+@ServiceScope(Scope.Project.class)
 public interface DependencyConstraintHandler {
     /**
      * Adds a dependency constraint to the given configuration.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -30,6 +30,8 @@ import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderConvertible;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -276,6 +278,7 @@ import java.util.Map;
  * not available. Client modules are represented using a {@link org.gradle.api.artifacts.ClientModule}.
  *
  */
+@ServiceScope(Scope.Project.class)
 public interface DependencyHandler extends ExtensionAware {
     /**
      * Adds a dependency to the given configuration.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
@@ -19,12 +19,15 @@ package org.gradle.api.artifacts.dsl;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * A {@code DependencyLockingHandler} manages the behaviour and configuration of dependency locking.
  *
  * @since 4.8
  */
+@ServiceScope(Scope.Project.class)
 public interface DependencyLockingHandler {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -28,6 +28,8 @@ import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.declarative.dsl.model.annotations.Adding;
 import org.gradle.internal.HasInternalProtocol;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Map;
 
@@ -35,6 +37,7 @@ import java.util.Map;
  * A {@code RepositoryHandler} manages a set of repositories, allowing repositories to be defined and queried.
  */
 @HasInternalProtocol
+@ServiceScope(Scope.Project.class)
 public interface RepositoryHandler extends ArtifactRepositoryContainer {
 
     /**

--- a/testing/architecture-test/src/changes/archunit-store/injected-services-should-have-service-scope-applied.txt
+++ b/testing/architecture-test/src/changes/archunit-store/injected-services-should-have-service-scope-applied.txt
@@ -1,8 +1,5 @@
 Class <org.gradle.api.Project> is not annotated with @ServiceScope in (Project.java:0)
 Class <org.gradle.api.artifacts.dsl.DependencyFactory> is not annotated with @ServiceScope in (DependencyFactory.java:0)
-Class <org.gradle.api.artifacts.dsl.DependencyHandler> is not annotated with @ServiceScope in (DependencyHandler.java:0)
-Class <org.gradle.api.artifacts.dsl.DependencyLockingHandler> is not annotated with @ServiceScope in (DependencyLockingHandler.java:0)
-Class <org.gradle.api.artifacts.dsl.RepositoryHandler> is not annotated with @ServiceScope in (RepositoryHandler.java:0)
 Class <org.gradle.api.artifacts.transform.TransformParameters> is not annotated with @ServiceScope in (TransformParameters.java:0)
 Class <org.gradle.api.cache.CacheConfigurations> is not annotated with @ServiceScope in (CacheConfigurations.java:0)
 Class <org.gradle.api.component.SoftwareComponentContainer> is not annotated with @ServiceScope in (SoftwareComponentContainer.java:0)


### PR DESCRIPTION
A step toward making the Project service scope strictly annotated, as most of the other scopes already are.

Since this scope has too many non-annotated services, this will be addressed in a series of PRs.