### PR TITLE
Set testFailure=true for failure conditions

### DIFF
--- a/.teamcity/src/main/kotlin/common/CommonExtensions.kt
+++ b/.teamcity/src/main/kotlin/common/CommonExtensions.kt
@@ -159,7 +159,7 @@ fun BuildType.applyDefaultSettings(
         if (this@applyDefaultSettings.type != BuildTypeSettings.Type.COMPOSITE) {
             executionTimeoutMin = timeout
         }
-        testFailure = false
+        testFailure = true
         supportTestRetry = true
         add {
             failOnText {


### PR DESCRIPTION
See thread https://gradle.slack.com/archives/CBSJ2GUTV/p1741300442400979.

In short, we expect to see the build turns red if there are new test failures, but with `testFailure=false`, TeamCity doesn't consider the build failing if there are test failures.