### PR TITLE
Remove ProjectComponentSelector.getBuildName

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
@@ -18,7 +18,6 @@ package org.gradle.internal.component.local.model;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
-import org.gradle.api.internal.artifacts.capability.SpecificCapabilitySelector;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
@@ -26,9 +25,9 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ProjectComponentIdentifierInternal;
 import org.gradle.api.internal.artifacts.capability.DefaultSpecificCapabilitySelector;
+import org.gradle.api.internal.artifacts.capability.SpecificCapabilitySelector;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.project.ProjectIdentity;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.util.Path;
 
 import java.util.List;
@@ -76,17 +75,6 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
     @Override
     public String getBuildPath() {
         return projectIdentity.getBuildIdentifier().getBuildPath();
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public String getBuildName() {
-        DeprecationLogger.deprecateMethod(ProjectComponentSelector.class, "getBuildName()")
-            .withAdvice("Use getBuildPath() to get a unique identifier for the build.")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "build_identifier_name_and_current_deprecation")
-            .nagUser();
-        return DeprecationLogger.whileDisabled(() -> projectIdentity.getBuildIdentifier().getName());
     }
 
     @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
@@ -128,8 +128,9 @@ class ComponentSelectorParsersTest extends Specification {
         then:
         v.size() == 1
         v[0] instanceof ProjectComponentSelector
-        v[0].projectPath == ":bar"
-        v[0].buildName == "build"
+        def selector = v[0] as ProjectComponentSelector
+        selector.projectPath == ":bar"
+        selector.buildPath == ":build"
     }
 
     def "fails for unknown types"() {

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
@@ -187,7 +187,6 @@ Required by:
                 assert selectors[1].displayName == 'org.test:${dependencyName}:1.2'
                 assert selectors[2].displayName == 'project :${buildName}:a'
                 assert selectors[2].buildPath == ':${buildName}'
-                assert selectors[2].buildName == '${buildName}'
                 assert selectors[2].projectPath == ':a'
             }
         """
@@ -196,7 +195,6 @@ Required by:
             executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
             executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
         }
-        executer.expectDocumentedDeprecationWarning("The ProjectComponentSelector.getBuildName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
 
         expect:
         succeeds(":assemble")

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
@@ -152,7 +152,6 @@ Required by:
                 assert selectors[0].displayName == 'org.test:${dependencyName}:1.2'
                 assert selectors[1].displayName == 'project :${buildName}:a'
                 assert selectors[1].buildPath == ':${buildName}'
-                assert selectors[1].buildName == '${buildName}'
                 assert selectors[1].projectPath == ':a'
             }
         """
@@ -161,7 +160,6 @@ Required by:
             executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
             executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
         }
-        executer.expectDocumentedDeprecationWarning("The ProjectComponentSelector.getBuildName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
 
         expect:
         succeeds(":assemble")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
@@ -169,7 +169,6 @@ Required by:
                 assert selectors.size() == 1
                 assert selectors[0].displayName == 'project :buildB:buildSrc:a'
                 assert selectors[0].buildPath == ':buildB:buildSrc'
-                assert selectors[0].buildName == 'buildSrc'
                 assert selectors[0].projectPath == ':a'
             }
         """
@@ -178,7 +177,6 @@ Required by:
             executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
             executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
         }
-        executer.expectDocumentedDeprecationWarning("The ProjectComponentSelector.getBuildName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
 
         expect:
         execute(buildA, ":assemble")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
@@ -176,7 +176,6 @@ Required by:
                 assert selectors.size() == 1
                 assert selectors[0].displayName == 'project :${buildName}:b1'
                 assert selectors[0].buildPath == ':${buildName}'
-                assert selectors[0].buildName == '${buildName}'
                 assert selectors[0].projectPath == ':b1'
             }
         """
@@ -185,7 +184,6 @@ Required by:
             executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
             executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
         }
-        executer.expectDocumentedDeprecationWarning("The ProjectComponentSelector.getBuildName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
 
         expect:
         execute(buildA, ":assemble")

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ProjectComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ProjectComponentSelector.java
@@ -34,15 +34,6 @@ public interface ProjectComponentSelector extends ComponentSelector {
     String getBuildPath();
 
     /**
-     * The name of the build to select a project from.
-     *
-     * @return The build name
-     * @deprecated Use {@link #getBuildPath()} instead.
-     */
-    @Deprecated
-    String getBuildName();
-
-    /**
      * The path of the project to select the component from.
      *
      * @return Project path

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
@@ -188,7 +188,6 @@ Required by:
                 assert selectors.size() == 1
                 assert selectors[0].displayName == 'project :buildSrc:a'
                 assert selectors[0].buildPath == ':buildSrc'
-                assert selectors[0].buildName == 'buildSrc'
                 assert selectors[0].projectPath == ':a'
             }
         """
@@ -197,7 +196,6 @@ Required by:
             executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
             executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
         }
-        executer.expectDocumentedDeprecationWarning("The ProjectComponentSelector.getBuildName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
 
         expect:
         succeeds()

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,6 +1,14 @@
 {
     "acceptedApiChanges": [
         {
+            "type": "org.gradle.api.artifacts.component.ProjectComponentSelector",
+            "member": "Method org.gradle.api.artifacts.component.ProjectComponentSelector.getBuildName()",
+            "acceptation": "Deprecated in 8.x",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
             "type": "org.gradle.api.file.RelativePath",
             "member": "Method org.gradle.api.file.RelativePath.getParent()",
             "acceptation": "Method can return null values",


### PR DESCRIPTION
Use ProjectComponentSelector.getBuildPath instead

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
