### PR TITLE
Allow alternatives to ForkingTestClassProcessor

### DIFF
--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -89,7 +89,7 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
         final Factory<TestClassProcessor> forkingProcessorFactory = new Factory<TestClassProcessor>() {
             @Override
             public TestClassProcessor create() {
-                return new ForkingTestClassProcessor(workerLeaseService, workerFactory, testInstanceFactory, testExecutionSpec.getJavaForkOptions(),
+                return createTestClassProcessor(workerLeaseService, workerFactory, testInstanceFactory, testExecutionSpec.getJavaForkOptions(),
                     classpath, testFramework.getWorkerConfigurationAction(), documentationRegistry);
             }
         };
@@ -117,6 +117,26 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
         }
 
         new TestMainAction(detector, processor, testResultProcessor, workerLeaseService, clock, testExecutionSpec.getPath(), "Gradle Test Run " + testExecutionSpec.getIdentityPath()).run();
+    }
+
+    protected TestClassProcessor createTestClassProcessor(
+        WorkerLeaseService workerLeaseService,
+        WorkerProcessFactory workerProcessFactory,
+        WorkerTestClassProcessorFactory workerTestClassProcessorFactory,
+        JavaForkOptions javaForkOptions,
+        ForkedTestClasspath classpath,
+        Action<WorkerProcessBuilder> workerConfigurationAction,
+        DocumentationRegistry documentationRegistry
+    ) {
+        return new ForkingTestClassProcessor(
+            workerLeaseService,
+            workerProcessFactory,
+            workerTestClassProcessorFactory,
+            javaForkOptions,
+            classpath,
+            workerConfigurationAction,
+            documentationRegistry
+        );
     }
 
     @Override


### PR DESCRIPTION
`DefaultTestExecuter` hard-codes the use of `ForkingTestClassProcessor`. This pull request introduces a way to use alternative `TestClassProcessor`.

When running tests on `Scala.js`, forking is not an option, so [Gradle Scala.js plugin](https://github.com/dubinsky/scalajs-gradle)  needs to use a TestClassProcessor that [does not fork](https://github.com/dubinsky/scalajs-gradle/blob/master/src/main/scala/org/podval/tools/test/processor/NonForkingTestClassProcessor.scala).

Without an extension point, the only way to make this work is to [fork](https://github.com/dubinsky/scalajs-gradle/blob/master/src/main/scala/org/podval/tools/test/task/DefaultTestExecuter.scala) `DefaultTestExecuter`  class and track changes to its Gradle original in a different repository just to be able to override [one method](https://github.com/dubinsky/scalajs-gradle/blob/master/src/main/scala/org/podval/tools/test/task/TestExecuter.scala#L60) - which is sub-optimal ;)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
