### PR TITLE
Fix smoke-test test dir is marked as production code

### DIFF
--- a/testing/smoke-test/build.gradle.kts
+++ b/testing/smoke-test/build.gradle.kts
@@ -176,7 +176,7 @@ plugins.withType<IdeaPlugin>().configureEach {
     val smokeTestCompileClasspath: Configuration by configurations
     val smokeTestRuntimeClasspath: Configuration by configurations
     model.module {
-        testSources.from(smokeTestSourceSet.groovy.srcDirs)
+        testSources.from(smokeTestSourceSet.java.srcDirs, smokeTestSourceSet.groovy.srcDirs)
         testResources.from(smokeTestSourceSet.resources.srcDirs)
         scopes["TEST"]!!["plus"]!!.add(smokeTestCompileClasspath)
         scopes["TEST"]!!["plus"]!!.add(smokeTestRuntimeClasspath)


### PR DESCRIPTION
Improves https://github.com/gradle/gradle-private/issues/4627

![image](https://github.com/user-attachments/assets/f192c39a-a4d1-4459-92d0-c484eae852fd)
