### PR TITLE
Replace overridden accessors for upgraded properties

### DIFF
--- a/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/jvmbytecode/JvmBytecodeCallInterceptor.java
+++ b/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/jvmbytecode/JvmBytecodeCallInterceptor.java
@@ -32,7 +32,7 @@ public interface JvmBytecodeCallInterceptor extends FilterableBytecodeIntercepto
      * Potentially replace the whole method with a new one.
      */
     @Nullable
-    MethodVisitorScope visitReplacementMethod(MethodVisitorScope mv, int access, String name, String descriptor, String signature, String[] exceptions, Supplier<MethodNode> asNode);
+    ReplacementMethodBuilder findReplacementMethod(String className, int access, String name, String descriptor, String signature, String[] exceptions, Supplier<MethodNode> asNode);
 
     boolean visitMethodInsn(
             MethodVisitorScope mv,

--- a/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/jvmbytecode/JvmBytecodeCallInterceptor.java
+++ b/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/jvmbytecode/JvmBytecodeCallInterceptor.java
@@ -27,6 +27,13 @@ import javax.annotation.Nullable;
 import java.util.function.Supplier;
 
 public interface JvmBytecodeCallInterceptor extends FilterableBytecodeInterceptor {
+
+    /**
+     * Potentially replace the whole method with a new one.
+     */
+    @Nullable
+    MethodVisitorScope visitReplacementMethod(MethodVisitorScope mv, int access, String name, String descriptor, String signature, String[] exceptions, Supplier<MethodNode> asNode);
+
     boolean visitMethodInsn(
             MethodVisitorScope mv,
             String className,

--- a/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/jvmbytecode/JvmBytecodeCallInterceptor.java
+++ b/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/jvmbytecode/JvmBytecodeCallInterceptor.java
@@ -32,9 +32,11 @@ public interface JvmBytecodeCallInterceptor extends FilterableBytecodeIntercepto
      * Potentially replace the whole method with a new one.
      */
     @Nullable
-    ReplacementMethodBuilder findReplacementMethod(String className, int access, String name, String descriptor, String signature, String[] exceptions, Supplier<MethodNode> asNode);
+    default ReplacementMethodBuilder findReplacementMethod(String className, int access, String name, String descriptor, String signature, String[] exceptions, Supplier<MethodNode> asNode) {
+        return null;
+    }
 
-    boolean visitMethodInsn(
+    default boolean visitMethodInsn(
             MethodVisitorScope mv,
             String className,
             int opcode,
@@ -43,10 +45,14 @@ public interface JvmBytecodeCallInterceptor extends FilterableBytecodeIntercepto
             String descriptor,
             boolean isInterface,
             Supplier<MethodNode> readMethodNode
-    );
+    ) {
+        return false;
+    }
 
     @Nullable
-    BridgeMethodBuilder findBridgeMethodBuilder(String className, int tag, String owner, String name, String descriptor);
+    default BridgeMethodBuilder findBridgeMethodBuilder(String className, int tag, String owner, String name, String descriptor) {
+        return null;
+    }
 
     interface Factory extends FilterableBytecodeInterceptorFactory {
         JvmBytecodeCallInterceptor create(InstrumentationMetadata metadata, BytecodeInterceptorFilter interceptorFilter);

--- a/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/jvmbytecode/ReplacementMethodBuilder.java
+++ b/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/jvmbytecode/ReplacementMethodBuilder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.api.jvmbytecode;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+
+/**
+ * A generator for a replacement method.
+ */
+public interface ReplacementMethodBuilder {
+    MethodVisitor buildReplacementMethod(ClassVisitor cv);
+}

--- a/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/jvmbytecode/SuperReplacementMethodBuilder.java
+++ b/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/jvmbytecode/SuperReplacementMethodBuilder.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.instrumentation.extensions.property;
+package org.gradle.internal.instrumentation.api.jvmbytecode;
 
-import org.gradle.internal.instrumentation.api.jvmbytecode.ReplacementMethodBuilder;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
@@ -32,14 +31,14 @@ import static org.objectweb.asm.Opcodes.ARETURN;
 import static org.objectweb.asm.Opcodes.ASM9;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 
-public class PropertyUpgradeSuperGetterReplacementMethodBuilder implements ReplacementMethodBuilder {
+public class SuperReplacementMethodBuilder implements ReplacementMethodBuilder {
 
     private final String name;
     private final String superclassName;
     private final String replacementDescriptor;
     private final List<AnnotationData> annotations = new ArrayList<>();
 
-    public PropertyUpgradeSuperGetterReplacementMethodBuilder(String name, String superclassName, String replacementDescriptor) {
+    public SuperReplacementMethodBuilder(String superclassName, String name, String replacementDescriptor) {
         this.name = name;
         this.superclassName = superclassName;
         this.replacementDescriptor = replacementDescriptor;

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -652,7 +652,8 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         if (accessor.accessorType == AccessorType.GETTER) {
             // TODO Use a better class name here
             extras.add(new PropertyUpgradeGetterOverrideRequestExtra(
-               interceptorsClassName + "_GetterOverride"
+                interceptorsClassName + "_GetterOverride",
+                methodDescriptor
             ));
         }
         return extras;

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -649,6 +649,12 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
             binaryCompatibility,
             accessor.bridgedMethod
         ));
+        if (accessor.accessorType == AccessorType.GETTER) {
+            // TODO Use a better class name here
+            extras.add(new PropertyUpgradeGetterOverrideRequestExtra(
+               interceptorsClassName + "_GetterOverride"
+            ));
+        }
         return extras;
     }
 

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeGetterOverrideRequestExtra.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeGetterOverrideRequestExtra.java
@@ -20,14 +20,20 @@ import org.gradle.internal.instrumentation.model.RequestExtra;
 
 class PropertyUpgradeGetterOverrideRequestExtra implements RequestExtra {
     private final String implementationClassName;
+    private final String methodDescriptor;
 
     public PropertyUpgradeGetterOverrideRequestExtra(
-        String implementationClassName
+        String implementationClassName, String methodDescriptor
     ) {
         this.implementationClassName = implementationClassName;
+        this.methodDescriptor = methodDescriptor;
     }
 
     public String getImplementationClassName() {
         return implementationClassName;
+    }
+
+    public String getMethodDescriptor() {
+        return methodDescriptor;
     }
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeGetterOverrideRequestExtra.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeGetterOverrideRequestExtra.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.instrumentation.api.jvmbytecode;
+package org.gradle.internal.instrumentation.extensions.property;
 
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.MethodVisitor;
+import org.gradle.internal.instrumentation.model.RequestExtra;
 
-/**
- * A generator for a replacement method.
- */
-public interface ReplacementMethodBuilder {
-    MethodVisitor createCapturingVisitor();
-    void generateReplacementMethod(ClassVisitor cv);
+class PropertyUpgradeGetterOverrideRequestExtra implements RequestExtra {
+    private final String implementationClassName;
+
+    public PropertyUpgradeGetterOverrideRequestExtra(
+        String implementationClassName
+    ) {
+        this.implementationClassName = implementationClassName;
+    }
+
+    public String getImplementationClassName() {
+        return implementationClassName;
+    }
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeReplaceSuperGettersCodeGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeReplaceSuperGettersCodeGenerator.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.extensions.property;
+
+import com.squareup.javapoet.ArrayTypeName;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeSpec;
+import org.gradle.internal.instrumentation.api.jvmbytecode.JvmBytecodeCallInterceptor;
+import org.gradle.internal.instrumentation.api.jvmbytecode.ReplacementMethodBuilder;
+import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorType;
+import org.gradle.internal.instrumentation.model.CallInterceptionRequest;
+import org.gradle.internal.instrumentation.model.CallableOwnerInfo;
+import org.gradle.internal.instrumentation.model.RequestExtra;
+import org.gradle.internal.instrumentation.processor.codegen.HasFailures.FailureInfo;
+import org.gradle.internal.instrumentation.processor.codegen.jvmbytecode.JvmInterceptorGenerator;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.MethodNode;
+
+import javax.lang.model.element.Modifier;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.GENERATED_ANNOTATION;
+
+/**
+ * Generates a single bytecode rewriter class for replacing super-call getters.
+ */
+public class PropertyUpgradeReplaceSuperGettersCodeGenerator extends JvmInterceptorGenerator {
+
+    @Override
+    protected String classNameForRequest(CallInterceptionRequest request) {
+        return request.getRequestExtras().getByType(PropertyUpgradeGetterOverrideRequestExtra.class)
+            .map(PropertyUpgradeGetterOverrideRequestExtra::getImplementationClassName)
+            .orElse(null);
+    }
+
+    @Override
+    protected Consumer<TypeSpec.Builder> classContentForClass(
+        String className,
+        List<CallInterceptionRequest> requestsClassGroup,
+        Consumer<? super CallInterceptionRequest> onProcessedRequest,
+        Consumer<? super FailureInfo> onFailure
+    ) {
+        // TODO Move much of this to super-type?
+        BytecodeInterceptorType interceptorType = requestsClassGroup.get(0).getRequestExtras().getByType(RequestExtra.InterceptJvmCalls.class)
+            .map(RequestExtra.InterceptJvmCalls::getInterceptionType)
+            .orElseThrow(() -> new IllegalStateException(RequestExtra.InterceptJvmCalls.class.getSimpleName() + " should be present at this stage!"));
+
+        Map<Type, FieldSpec> typeFieldByOwner = generateFieldsForImplementationOwners(requestsClassGroup);
+
+        Map<CallableOwnerInfo, List<CallInterceptionRequest>> requestsByOwner = requestsClassGroup.stream().collect(
+            Collectors.groupingBy(it -> it.getInterceptedCallable().getOwner(), LinkedHashMap::new, Collectors.toList())
+        );
+
+        MethodSpec.Builder visitReplacementMethodBuilder = getVisitReplacementMethodBuilder();
+        generateVisitReplacementMethodCode(visitReplacementMethodBuilder, typeFieldByOwner, requestsByOwner, onProcessedRequest, onFailure);
+
+        TypeSpec factoryClass = generateFactoryClass(className, interceptorType);
+
+        return builder ->
+            builder.addMethod(constructor)
+                .addAnnotation(GENERATED_ANNOTATION.asClassName())
+                .addModifiers(Modifier.PUBLIC)
+                .addSuperinterface(ClassName.get(JvmBytecodeCallInterceptor.class))
+                .addSuperinterface(ClassName.get(interceptorType.getInterceptorMarkerInterface()))
+                .addField(METADATA_FIELD)
+                .addField(CONTEXT_FIELD)
+                .addMethod(visitReplacementMethodBuilder.build())
+                .addType(factoryClass);
+    }
+
+    @SuppressWarnings("unused")
+    private static void generateVisitReplacementMethodCode(
+        MethodSpec.Builder method,
+        Map<Type, FieldSpec> typeFieldByOwner,
+        Map<CallableOwnerInfo, List<CallInterceptionRequest>> requestsByOwner,
+        Consumer<? super CallInterceptionRequest> onProcessedRequest,
+        Consumer<? super FailureInfo> onFailure
+    ) {
+        CodeBlock.Builder code = CodeBlock.builder();
+        requestsByOwner.forEach((owner, requests) -> generateCodeForOwner(
+            owner,
+            typeFieldByOwner,
+            requests,
+            code,
+            // TODO Avoid adding '&& true'
+            callable -> CodeBlock.of("true"),
+            PropertyUpgradeReplaceSuperGettersCodeGenerator::generateReplacementMethod,
+            null,
+            onProcessedRequest,
+            onFailure));
+        code.addStatement("return null");
+        method.addCode(code.build());
+    }
+
+    private static MethodSpec.Builder getVisitReplacementMethodBuilder() {
+        return MethodSpec.methodBuilder("findReplacementMethod")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ReplacementMethodBuilder.class)
+            .addParameter(String.class, "owner")
+            .addParameter(int.class, "access")
+            .addParameter(String.class, "name")
+            .addParameter(String.class, "descriptor")
+            .addParameter(String.class, "signature")
+            .addParameter(ArrayTypeName.of(String.class), "exceptions")
+            .addParameter(ParameterizedTypeName.get(Supplier.class, MethodNode.class), "readMethodNode");
+    }
+
+    private static void generateReplacementMethod(CallInterceptionRequest request, FieldSpec ownerTypeField, CodeBlock.Builder code) {
+        code.addStatement("return null");
+    }
+}

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeReplaceSuperGettersCodeGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeReplaceSuperGettersCodeGenerator.java
@@ -25,6 +25,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 import org.gradle.internal.instrumentation.api.jvmbytecode.JvmBytecodeCallInterceptor;
 import org.gradle.internal.instrumentation.api.jvmbytecode.ReplacementMethodBuilder;
+import org.gradle.internal.instrumentation.api.jvmbytecode.SuperReplacementMethodBuilder;
 import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorType;
 import org.gradle.internal.instrumentation.model.CallInterceptionRequest;
 import org.gradle.internal.instrumentation.model.CallableOwnerInfo;
@@ -129,7 +130,13 @@ public class PropertyUpgradeReplaceSuperGettersCodeGenerator extends JvmIntercep
             .addParameter(ParameterizedTypeName.get(Supplier.class, MethodNode.class), "readMethodNode");
     }
 
-    private static void generateReplacementMethod(CallInterceptionRequest request, FieldSpec ownerTypeField, CodeBlock.Builder code) {
-        code.addStatement("return null");
+    private static void generateReplacementMethod(CallInterceptionRequest request, FieldSpec ownerTypeField, CodeBlock.Builder method) {
+        PropertyUpgradeGetterOverrideRequestExtra extra = request.getRequestExtras().getByType(PropertyUpgradeGetterOverrideRequestExtra.class)
+            .orElseThrow(() -> new IllegalStateException("PropertyUpgradeGetterOverrideRequestExtra should be present at this stage!"));
+        method.addStatement(
+            "return new $1T(owner, name, \"$2N\")",
+            SuperReplacementMethodBuilder.class,
+            extra.getMethodDescriptor()
+        );
     }
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeSuperGetterReplacementMethodBuilder.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeSuperGetterReplacementMethodBuilder.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.extensions.property;
+
+import org.gradle.internal.instrumentation.api.jvmbytecode.ReplacementMethodBuilder;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.ASM9;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+
+public class PropertyUpgradeSuperGetterReplacementMethodBuilder implements ReplacementMethodBuilder {
+
+    private final String name;
+    private final String superclassName;
+    private final String replacementDescriptor;
+    private final List<AnnotationData> annotations = new ArrayList<>();
+
+    public PropertyUpgradeSuperGetterReplacementMethodBuilder(String name, String superclassName, String replacementDescriptor) {
+        this.name = name;
+        this.superclassName = superclassName;
+        this.replacementDescriptor = replacementDescriptor;
+    }
+
+    @Override
+    public MethodVisitor createCapturingVisitor() {
+        // TODO Check if existing method only does super-call and nothing else
+        return new MethodVisitor(ASM9) {
+            @Override
+            public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+                AnnotationData annotationData = new AnnotationData(descriptor, visible);
+                annotations.add(annotationData);
+                return new AnnotationCollector(annotationData);
+            }
+        };
+    }
+
+    @Override
+    public void generateReplacementMethod(ClassVisitor cv) {
+        // TODO Should we include a signature?
+        MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, name, replacementDescriptor, null, null);
+        mv.visitCode();
+
+        // Load "this"
+        mv.visitVarInsn(ALOAD, 0);
+
+        // Call to super
+        mv.visitMethodInsn(INVOKESPECIAL, superclassName,
+            name, replacementDescriptor, false);
+
+        // Return the result
+        mv.visitInsn(ARETURN);
+
+        // Copy annotations
+        for (AnnotationData annotation : annotations) {
+            AnnotationVisitor av = mv.visitAnnotation(annotation.desc, annotation.visible);
+            annotation.values.forEach(av::visit);
+            av.visitEnd();
+        }
+
+        // Set max stack and locals
+        mv.visitMaxs(1, 1);
+        mv.visitEnd();
+    }
+
+    private static class AnnotationData {
+        private final String desc;
+        private final boolean visible;
+        private final Map<String, Object> values = new LinkedHashMap<>();
+
+        public AnnotationData(String desc, boolean visible) {
+            this.desc = desc;
+            this.visible = visible;
+        }
+    }
+
+    private static class AnnotationCollector extends AnnotationVisitor {
+        private final AnnotationData annotationData;
+
+        public AnnotationCollector(AnnotationData annotationData) {
+            super(ASM9);
+            this.annotationData = annotationData;
+        }
+
+        @Override
+        public void visit(String name, Object value) {
+            annotationData.values.put(name, value);
+        }
+    }
+}

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/ConfigurationCacheInstrumentationProcessor.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/ConfigurationCacheInstrumentationProcessor.java
@@ -18,14 +18,15 @@ package org.gradle.internal.instrumentation.processor;
 
 import org.gradle.internal.instrumentation.api.annotations.InterceptGroovyCalls;
 import org.gradle.internal.instrumentation.api.annotations.InterceptJvmCalls;
+import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 import org.gradle.internal.instrumentation.api.annotations.SpecificGroovyCallInterceptors;
 import org.gradle.internal.instrumentation.api.annotations.SpecificJvmCallInterceptors;
-import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.VisitForInstrumentation;
+import org.gradle.internal.instrumentation.extensions.property.InstrumentedPropertiesResourceGenerator;
 import org.gradle.internal.instrumentation.extensions.property.PropertyUpgradeAnnotatedMethodReader;
 import org.gradle.internal.instrumentation.extensions.property.PropertyUpgradeClassSourceGenerator;
-import org.gradle.internal.instrumentation.extensions.property.InstrumentedPropertiesResourceGenerator;
+import org.gradle.internal.instrumentation.extensions.property.PropertyUpgradeReplaceSuperGettersCodeGenerator;
 import org.gradle.internal.instrumentation.extensions.types.InstrumentedTypesResourceGenerator;
 import org.gradle.internal.instrumentation.model.RequestExtra;
 import org.gradle.internal.instrumentation.processor.codegen.groovy.InterceptGroovyCallsGenerator;
@@ -88,6 +89,7 @@ public class ConfigurationCacheInstrumentationProcessor extends AbstractInstrume
 
             // Properties upgrade extensions
             new PropertyUpgradeAnnotatedMethodReader(processingEnv),
+            (CodeGeneratorContributor) PropertyUpgradeReplaceSuperGettersCodeGenerator::new,
             (CodeGeneratorContributor) PropertyUpgradeClassSourceGenerator::new,
             // Generate resource with instrumented properties
             (ResourceGeneratorContributor) InstrumentedPropertiesResourceGenerator::new,

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/JvmInterceptorGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/JvmInterceptorGenerator.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instrumentation.processor.codegen.jvmbytecode;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import org.gradle.internal.instrumentation.api.annotations.CallableKind;
+import org.gradle.internal.instrumentation.api.annotations.ParameterKind;
+import org.gradle.internal.instrumentation.api.jvmbytecode.JvmBytecodeCallInterceptor;
+import org.gradle.internal.instrumentation.api.metadata.InstrumentationMetadata;
+import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorFilter;
+import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorType;
+import org.gradle.internal.instrumentation.model.CallInterceptionRequest;
+import org.gradle.internal.instrumentation.model.CallableInfo;
+import org.gradle.internal.instrumentation.model.CallableKindInfo;
+import org.gradle.internal.instrumentation.model.CallableOwnerInfo;
+import org.gradle.internal.instrumentation.model.ParameterInfo;
+import org.gradle.internal.instrumentation.model.ParameterKindInfo;
+import org.gradle.internal.instrumentation.processor.codegen.HasFailures;
+import org.gradle.internal.instrumentation.processor.codegen.JavadocUtils;
+import org.gradle.internal.instrumentation.processor.codegen.RequestGroupingInstrumentationClassSourceGenerator;
+import org.gradle.internal.instrumentation.util.NameUtil;
+import org.objectweb.asm.Type;
+
+import javax.annotation.Nullable;
+import javax.lang.model.element.Modifier;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public abstract class JvmInterceptorGenerator extends RequestGroupingInstrumentationClassSourceGenerator {
+    /**
+     * Emits the code that generates interceptor method invocation.
+     */
+    @FunctionalInterface
+    protected interface InvocationGenerator {
+        void generate(CallInterceptionRequest request, FieldSpec implTypeField, CodeBlock.Builder code);
+    }
+
+    /**
+     * Creates the code block that checks if the invocation operation should be intercepted.
+     */
+    @FunctionalInterface
+    protected interface InvocationMatcher {
+        CodeBlock generate(CallableInfo info);
+    }
+
+    protected static final FieldSpec METADATA_FIELD =
+        FieldSpec.builder(InstrumentationMetadata.class, "metadata", Modifier.PRIVATE, Modifier.FINAL).build();
+
+    protected static final FieldSpec CONTEXT_FIELD =
+        FieldSpec.builder(BytecodeInterceptorFilter.class, "context", Modifier.PRIVATE, Modifier.FINAL).build();
+
+    protected final MethodSpec constructor = MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE)
+        .addParameter(InstrumentationMetadata.class, "metadata")
+        .addParameter(BytecodeInterceptorFilter.class, "context")
+        .addStatement("this.$N = metadata", InterceptJvmCallsGenerator.METADATA_FIELD)
+        .addStatement("this.$N = context", InterceptJvmCallsGenerator.CONTEXT_FIELD)
+        .build();
+
+    protected static TypeSpec generateFactoryClass(String className, BytecodeInterceptorType interceptorType) {
+        MethodSpec method = MethodSpec.methodBuilder("create")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(JvmBytecodeCallInterceptor.class)
+            .addParameter(InstrumentationMetadata.class, "metadata")
+            .addParameter(BytecodeInterceptorFilter.class, "context")
+            .addStatement("return new $L($N, $N)", className, "metadata", "context")
+            .addAnnotation(Override.class)
+            .build();
+        return TypeSpec.classBuilder("Factory")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addSuperinterface(ClassName.get(JvmBytecodeCallInterceptor.Factory.class))
+            .addSuperinterface(ClassName.get(interceptorType.getInterceptorFactoryMarkerInterface()))
+            .addMethod(method)
+            .build();
+    }
+
+    protected static Map<Type, FieldSpec> generateFieldsForImplementationOwners(Collection<CallInterceptionRequest> interceptionRequests) {
+        Set<String> knownSimpleNames = new HashSet<>();
+        return interceptionRequests.stream().map(it -> it.getImplementationInfo().getOwner()).distinct()
+            .collect(Collectors.toMap(Function.identity(), implementationType -> {
+                ClassName implementationClassName = NameUtil.getClassName(implementationType.getClassName());
+                String fieldTypeName = knownSimpleNames.add(implementationClassName.simpleName()) ?
+                    implementationClassName.simpleName() :
+                    implementationClassName.reflectionName();
+                String fullFieldName = NameUtil.camelToUpperUnderscoreCase(fieldTypeName) + "_TYPE";
+                return FieldSpec.builder(String.class, fullFieldName, Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                    .initializer("$S", implementationClassName.reflectionName().replace(".", "/"))
+                    .build();
+            }, (u, v) -> u, LinkedHashMap::new));
+    }
+
+    protected static void generateCodeForOwner(
+        CallableOwnerInfo owner,
+        Map<Type, FieldSpec> implTypeFields,
+        List<CallInterceptionRequest> requestsForOwner,
+        CodeBlock.Builder code,
+        InvocationMatcher invocationMatcher,
+        InvocationGenerator interceptStandard,
+        @Nullable InvocationGenerator interceptKotlinDefault,
+        Consumer<? super CallInterceptionRequest> onProcessedRequest,
+        Consumer<? super HasFailures.FailureInfo> onFailure
+    ) {
+        if (owner.isInterceptSubtypes()) {
+            code.beginControlFlow("if ($N.isInstanceOf(owner, $S))", METADATA_FIELD, owner.getType().getInternalName());
+        } else {
+            code.beginControlFlow("if (owner.equals($S))", owner.getType().getInternalName());
+        }
+        for (CallInterceptionRequest request : requestsForOwner) {
+            CodeBlock.Builder nested = CodeBlock.builder();
+            try {
+                generateCodeForRequest(
+                    request,
+                    implTypeFields.get(request.getImplementationInfo().getOwner()),
+                    nested,
+                    invocationMatcher,
+                    interceptStandard,
+                    interceptKotlinDefault
+                );
+            } catch (Failure failure) {
+                onFailure.accept(new HasFailures.FailureInfo(request, failure.reason));
+            }
+            onProcessedRequest.accept(request);
+            code.add(nested.build());
+        }
+        code.endControlFlow();
+    }
+
+    protected static void generateCodeForRequest(
+        CallInterceptionRequest request,
+        FieldSpec implTypeField,
+        CodeBlock.Builder code,
+        InvocationMatcher invocationMatcher,
+        InvocationGenerator interceptStandard,
+        @Nullable InvocationGenerator interceptKotlinDefault
+    ) {
+        String callableName = request.getInterceptedCallable().getCallableName();
+        CallableInfo interceptedCallable = request.getInterceptedCallable();
+        String interceptedCallableDescriptor = standardCallableDescriptor(interceptedCallable);
+        validateSignature(interceptedCallable);
+
+        CodeBlock matchInvocationOperation = invocationMatcher.generate(interceptedCallable);
+
+        documentInterceptorGeneratedCode(request, code);
+        matchAndInterceptStandardCallableSignature(
+            request,
+            implTypeField,
+            code,
+            callableName,
+            interceptedCallableDescriptor,
+            matchInvocationOperation,
+            interceptStandard
+        );
+
+        if (interceptKotlinDefault != null && interceptedCallable.hasKotlinDefaultMaskParam()) {
+            matchAndInterceptKotlinDefaultSignature(
+                request,
+                implTypeField,
+                code,
+                callableName,
+                interceptedCallable,
+                matchInvocationOperation,
+                interceptKotlinDefault
+            );
+        }
+    }
+
+    protected static void matchAndInterceptStandardCallableSignature(
+        CallInterceptionRequest request,
+        FieldSpec implTypeField,
+        CodeBlock.Builder code,
+        String callableName,
+        String callableDescriptor,
+        CodeBlock matchOpcodeExpression,
+        InvocationGenerator invocationGenerator
+    ) {
+        code.beginControlFlow("if (name.equals($S) && descriptor.equals($S) && $L)", callableName, callableDescriptor, matchOpcodeExpression);
+        invocationGenerator.generate(request, implTypeField, code);
+        code.endControlFlow();
+    }
+
+    private static void matchAndInterceptKotlinDefaultSignature(
+        CallInterceptionRequest request,
+        FieldSpec ownerTypeField,
+        CodeBlock.Builder code,
+        String callableName,
+        CallableInfo interceptedCallable,
+        CodeBlock matchOpcodeExpression,
+        InvocationGenerator invocationGenerator
+    ) {
+        code.add("// Additionally intercept the signature with the Kotlin default mask and marker:\n");
+        String callableDescriptorKotlinDefault = kotlinDefaultFunctionDescriptor(interceptedCallable);
+        String defaultMethodName = callableName + "$default";
+        code.beginControlFlow("if (name.equals($S) && descriptor.equals($S) && $L)", defaultMethodName, callableDescriptorKotlinDefault, matchOpcodeExpression);
+        invocationGenerator.generate(request, ownerTypeField, code);
+        code.endControlFlow();
+    }
+
+    private static void documentInterceptorGeneratedCode(CallInterceptionRequest request, CodeBlock.Builder code) {
+        code.add("/** \n * Intercepting $L: $L\n", JavadocUtils.callableKindForJavadoc(request), JavadocUtils.interceptedCallableLink(request));
+        code.add(" * Intercepted by $L\n*/\n", JavadocUtils.interceptorImplementationLink(request));
+    }
+
+    private static void validateSignature(CallableInfo callable) {
+        if (callable.getKind() == CallableKindInfo.GROOVY_PROPERTY_GETTER || callable.getKind() == CallableKindInfo.GROOVY_PROPERTY_SETTER) {
+            throw new Failure("Groovy property access cannot be intercepted in JVM calls");
+        }
+
+        boolean hasInjectVisitorContext = callable.hasInjectVisitorContextParam();
+        if (hasInjectVisitorContext) {
+            ParameterInfo lastParameter = callable.getParameters().get(callable.getParameters().size() - 1);
+            if (lastParameter.getKind() != ParameterKindInfo.INJECT_VISITOR_CONTEXT) {
+                throw new Failure("The interceptor's @" + ParameterKind.InjectVisitorContext.class.getSimpleName() + " parameter should be last parameter");
+            }
+            if (!lastParameter.getParameterType().getClassName().equals(BytecodeInterceptorFilter.class.getName())) {
+                throw new Failure("The interceptor's @" + ParameterKind.InjectVisitorContext.class.getSimpleName() + " parameter should be of type " + BytecodeInterceptorFilter.class.getName() + " but was " + lastParameter.getParameterType().getClassName());
+            }
+            if (callable.getParameters().stream().filter(it -> it.getKind() == ParameterKindInfo.INJECT_VISITOR_CONTEXT).count() > 1) {
+                throw new Failure("An interceptor may not have more than one @" + ParameterKind.InjectVisitorContext.class.getSimpleName() + " parameter");
+            }
+        }
+
+        boolean hasCallerClassName = callable.hasCallerClassNameParam();
+        if (hasCallerClassName) {
+            int expectedIndex = hasInjectVisitorContext ? callable.getParameters().size() - 2 : callable.getParameters().size() - 1;
+            if (callable.getParameters().get(expectedIndex).getKind() != ParameterKindInfo.CALLER_CLASS_NAME) {
+                throw new Failure("The interceptor's @" + ParameterKind.CallerClassName.class.getSimpleName() + " parameter should be last or just before @" + ParameterKind.InjectVisitorContext.class.getSimpleName() + " if that parameter is present");
+            }
+            if (callable.getParameters().stream().filter(it -> it.getKind() == ParameterKindInfo.CALLER_CLASS_NAME).count() > 1) {
+                throw new Failure("An interceptor may not have more than one @" + ParameterKind.CallerClassName.class.getSimpleName() + " parameter");
+            }
+        }
+
+        if (callable.hasKotlinDefaultMaskParam()) {
+            // TODO support @AfterConstructor with Kotlin default mask? Kotlin constructors have a special DefaultConstructorMarker as the last argument
+            if (callable.getKind() != CallableKindInfo.STATIC_METHOD && callable.getKind() != CallableKindInfo.INSTANCE_METHOD) {
+                throw new Failure(
+                    "Only @" + CallableKind.StaticMethod.class.getSimpleName() + " or @" + CallableKind.InstanceMethod.class.getSimpleName() + " can use Kotlin default parameters"
+                );
+            }
+
+            int expectedKotlinDefaultMaskIndex = callable.getParameters().size() - (hasCallerClassName ? 2 : 1);
+            if (callable.getParameters().get(expectedKotlinDefaultMaskIndex).getKind() != ParameterKindInfo.KOTLIN_DEFAULT_MASK) {
+                throw new Failure(
+                    "@" + ParameterKind.KotlinDefaultMask.class.getSimpleName() + " should be the last parameter of may be followed only by @" + ParameterKind.CallerClassName.class.getSimpleName()
+                );
+            }
+        }
+
+        if (callable.getOwner().isInterceptSubtypes() && !callable.getOwner().getType().getInternalName().startsWith("org/gradle")) {
+            throw new Failure("Intercepting inherited methods is supported only for Gradle types for now, but type was: " + callable.getOwner().getType().getInternalName());
+        }
+    }
+
+    private static String standardCallableDescriptor(CallableInfo callableInfo) {
+        Type[] parameterTypes = callableInfo.getParameters().stream()
+            .filter(it -> it.getKind().isSourceParameter())
+            .map(ParameterInfo::getParameterType).toArray(Type[]::new);
+        Type returnType = callableInfo.getReturnType().getType();
+        return Type.getMethodDescriptor(returnType, parameterTypes);
+    }
+
+    private static String kotlinDefaultFunctionDescriptor(CallableInfo callableInfo) {
+        if (callableInfo.getKind() != CallableKindInfo.INSTANCE_METHOD && callableInfo.getKind() != CallableKindInfo.STATIC_METHOD) {
+            throw new UnsupportedOperationException("Kotlin default parameters are not yet supported for " + callableInfo.getKind());
+        }
+
+        String standardDescriptor = standardCallableDescriptor(callableInfo);
+        Type returnType = Type.getReturnType(standardDescriptor);
+        Type[] argumentTypes = Type.getArgumentTypes(standardDescriptor);
+        Type[] argumentTypesWithDefault = Stream.concat(
+            Arrays.stream(argumentTypes),
+            Stream.of(Type.getType(int.class), Type.getType(Object.class))
+        ).toArray(Type[]::new);
+        return Type.getMethodDescriptor(returnType, argumentTypesWithDefault);
+    }
+
+    protected static class Failure extends RuntimeException {
+        public final String reason;
+
+        public Failure(String reason) {
+            this.reason = reason;
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/transforms/AdhocInterceptors.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/transforms/AdhocInterceptors.java
@@ -21,6 +21,7 @@ import org.gradle.internal.classpath.Instrumented;
 import org.gradle.internal.instrumentation.api.jvmbytecode.BridgeMethodBuilder;
 import org.gradle.internal.instrumentation.api.jvmbytecode.DefaultBridgeMethodBuilder;
 import org.gradle.internal.instrumentation.api.jvmbytecode.JvmBytecodeCallInterceptor;
+import org.gradle.internal.instrumentation.api.jvmbytecode.ReplacementMethodBuilder;
 import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorType;
 import org.gradle.model.internal.asm.MethodVisitorScope;
 import org.objectweb.asm.Opcodes;
@@ -133,7 +134,7 @@ public class AdhocInterceptors implements JvmBytecodeCallInterceptor {
 
     @Nullable
     @Override
-    public MethodVisitorScope visitReplacementMethod(MethodVisitorScope mv, int access, String name, String descriptor, String signature, String[] exceptions, Supplier<MethodNode> asNode) {
+    public ReplacementMethodBuilder findReplacementMethod(String className, int access, String name, String descriptor, String signature, String[] exceptions, Supplier<MethodNode> asNode) {
         return null;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/transforms/AdhocInterceptors.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/transforms/AdhocInterceptors.java
@@ -18,8 +18,8 @@ package org.gradle.internal.classpath.transforms;
 
 import org.codehaus.groovy.runtime.ProcessGroovyMethods;
 import org.gradle.internal.classpath.Instrumented;
-import org.gradle.internal.instrumentation.api.jvmbytecode.DefaultBridgeMethodBuilder;
 import org.gradle.internal.instrumentation.api.jvmbytecode.BridgeMethodBuilder;
+import org.gradle.internal.instrumentation.api.jvmbytecode.DefaultBridgeMethodBuilder;
 import org.gradle.internal.instrumentation.api.jvmbytecode.JvmBytecodeCallInterceptor;
 import org.gradle.internal.instrumentation.api.types.BytecodeInterceptorType;
 import org.gradle.model.internal.asm.MethodVisitorScope;
@@ -130,6 +130,12 @@ public class AdhocInterceptors implements JvmBytecodeCallInterceptor {
     // ProcessGroovyMethods.execute(List, List, File) -> execute(List, List, File, String)
     private static final String RETURN_PROCESS_FROM_LIST_LIST_FILE = getMethodDescriptor(PROCESS_TYPE, LIST_TYPE, LIST_TYPE, FILE_TYPE);
     private static final String RETURN_PROCESS_FROM_LIST_LIST_FILE_STRING = getMethodDescriptor(PROCESS_TYPE, LIST_TYPE, LIST_TYPE, FILE_TYPE, STRING_TYPE);
+
+    @Nullable
+    @Override
+    public MethodVisitorScope visitReplacementMethod(MethodVisitorScope mv, int access, String name, String descriptor, String signature, String[] exceptions, Supplier<MethodNode> asNode) {
+        return null;
+    }
 
     @Override
     public boolean visitMethodInsn(MethodVisitorScope mv, String className, int opcode, String owner, String name, String descriptor, boolean isInterface, Supplier<MethodNode> readMethodNode) {


### PR DESCRIPTION
## TODO

- [ ] Make sure the new generated interceptor is used
- [ ] Test the thing
- [ ] Make it work for Groovy (if we feasibly can)
- [ ] Figure out how to better organize the generated code; now we create a separate generated class per subproject just for the method replacements.
- [ ] Extract more of `PropertyUpgradeReplaceSuperGettersCodeGenerator` / `InterceptJvmCallsGenerator` to the new super-class
- [ ] Check if the overriding method we want to replace is actually super-only
- [ ] Figure out if we need to generate the overriding method with a generic signature or if a raw override is fine.
- [ ] Do not use `&& true` to hide the check for opcodes where we don't need them

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
