### PR TITLE
Upload binary compatibility html

### DIFF
--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -52,6 +52,7 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
       - run: ./gradlew compileAll -DdisableLocalCache=true ${{ steps.determine-sys-prop-args.outputs.sys-prop-args }}
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: build-receipt.properties
           path: platforms/core-runtime/base-services/build/generated-resources/build-receipt/org/gradle/build-receipt.properties
@@ -82,6 +83,12 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
       - run: ./gradlew sanityCheck -DdisableLocalCache=true ${{ needs.build.outputs.sys-prop-args }}
+      - name: Upload Compatibility Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-compatibility-report
+          path: testing/architecture-test/build/reports/binary-compatibility/report.html
 
   unit-test:
     name: "${{ matrix.bucket.name }} (Unit Test)"


### PR DESCRIPTION
Otherwise we wouldn't be able to see the report when it fails.