### PR TITLE
Add "Use Cacheability Annotations" Best Practice

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
@@ -83,7 +83,7 @@ Remember that only tasks that produce reproducible and relocatable output should
 === Explanation
 
 Annotating a task type will ensure that _each task instance_ of that type is properly understood by Gradle to be cacheable (or not cacheable).
-This removes the need to remember to configure each of the task instances separately in buildscripts.
+This removes the need to remember to configure each of the task instances separately in build scripts.
 Using the annotations also _documents_ the intended cacheability of the task type within its own source, appearing in Javadoc and making the task's behavior clear to other developers without requiring them to inspect each task instance's configuration.
 It is also slightly more efficient than running a test at configuration time to determine cacheability.
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
@@ -73,7 +73,7 @@ Gradle can use this information to optimize task scheduling.
 [[use_cacheability_annotations]]
 == Favor Cacheability Annotations Over Cache Control Methods
 
-The link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#cacheIf(org.gradle.api.specs.Spec)[`cacheIf`] and link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#doNotCacheIf(java.lang.String,org.gradle.api.specs.Spec)[`doNotCacheIf`] methods should only be used in situations when the cacheability of a task can vary between different task instances, or can not be determined until the task is configured by Gradle.
+The link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#cacheIf(org.gradle.api.specs.Spec)[`cacheIf`] and link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#doNotCacheIf(java.lang.String,org.gradle.api.specs.Spec)[`doNotCacheIf`] methods should only be used in situations where the cacheability of a task varies between different task instances or cannot be determined until the task is configured by Gradle.
 
 Once you have decided to make a task <<build_cache.adoc#build_cache,cacheable>>, you should instead favor annotating the task class itself with the link:{javadocPath}/org/gradle/api/tasks/CacheableTask.html[`@CacheableTask`] annotation for any task that is meant to _always_ be cacheable.
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
@@ -78,7 +78,7 @@ The link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#cacheIf(org.gradle.
 You should instead favor annotating the task class itself with the link:{javadocPath}/org/gradle/api/tasks/CacheableTask.html[`@CacheableTask`] annotation for any task that is meant to _always_ be cacheable.
 Likewise, the link:{javadocPath}/org/gradle/work/DisableCachingByDefault.html[`@DisableCachingByDefault`] should be used to always disable caching for all instances of a task type.
 
-Remember that only tasks that produce reproducible and relocatable output should be marked as `@Cacheable`.
+Remember that only tasks that produce reproducible and relocatable output should be marked as `@CacheableTask`.
 
 === Explanation
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
@@ -75,7 +75,7 @@ Gradle can use this information to optimize task scheduling.
 
 The link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#cacheIf(org.gradle.api.specs.Spec)[`cacheIf`] and link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#doNotCacheIf(java.lang.String,org.gradle.api.specs.Spec)[`doNotCacheIf`] methods should only be used in situations when the cacheability of a task can vary between different task instances, or can not be determined until the task is configured by Gradle.
 
-You should instead favor annotating the task class itself with the link:{javadocPath}/org/gradle/api/tasks/CacheableTask.html[`@CacheableTask`] annotation for any task that is meant to _always_ be cacheable.
+Once you have decided to make a task <<build_cache.adoc,cacheable>>, you should instead favor annotating the task class itself with the link:{javadocPath}/org/gradle/api/tasks/CacheableTask.html[`@CacheableTask`] annotation for any task that is meant to _always_ be cacheable.
 Likewise, the link:{javadocPath}/org/gradle/work/DisableCachingByDefault.html[`@DisableCachingByDefault`] should be used to always disable caching for all instances of a task type.
 
 Remember that only tasks that produce reproducible and relocatable output should be marked as `@CacheableTask`.

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
@@ -75,8 +75,10 @@ Gradle can use this information to optimize task scheduling.
 
 The link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#cacheIf(org.gradle.api.specs.Spec)[`cacheIf`] and link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#doNotCacheIf(java.lang.String,org.gradle.api.specs.Spec)[`doNotCacheIf`] methods should only be used in situations when the cacheability of a task can vary between different task instances, or can not be determined until the task is configured by Gradle.
 
-Once you have decided to make a task <<build_cache.adoc,cacheable>>, you should instead favor annotating the task class itself with the link:{javadocPath}/org/gradle/api/tasks/CacheableTask.html[`@CacheableTask`] annotation for any task that is meant to _always_ be cacheable.
+Once you have decided to make a task <<build_cache.adoc#build_cache,cacheable>>, you should instead favor annotating the task class itself with the link:{javadocPath}/org/gradle/api/tasks/CacheableTask.html[`@CacheableTask`] annotation for any task that is meant to _always_ be cacheable.
+
 Likewise, the link:{javadocPath}/org/gradle/work/DisableCachingByDefault.html[`@DisableCachingByDefault`] should be used to always disable caching for all instances of a task type.
+This annotation allows you to provide an explanation for why caching is disabled, which is useful for documenting the behavior of the task type.
 
 Remember that only tasks that produce reproducible and relocatable output should be marked as `@CacheableTask`.
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
@@ -15,6 +15,7 @@
 [[best_practices_for_tasks]]
 = Best Practices for Tasks
 
+[[avoid_depends_on]]
 == Avoid DependsOn
 
 The task link:{javadocPath}/org/gradle/api/DefaultTask.html#setDependsOn(java.lang.Iterable)[dependsOn] method should only be used for <<organizing_tasks.adoc#sec:lifecycle_tasks,lifecycle tasks>> (tasks without task actions).
@@ -68,3 +69,55 @@ Gradle can use this information to optimize task scheduling.
 
 === Tags
 `#tasks`, `#inputs-and-outputs`, `#up-to-date-checking`
+
+[[use_cacheability_annotations]]
+== Favor Cacheability Annotations Over Cache Control Methods
+
+The link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#cacheIf(org.gradle.api.specs.Spec)[`cacheIf`] and link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#doNotCacheIf(java.lang.String,org.gradle.api.specs.Spec)[`doNotCacheIf`] methods should only be used in situations when the cacheability of a task can vary between different task instances, or can not be determined until the task is configured by Gradle.
+
+You should instead favor annotating the task class itself with the link:{javadocPath}/org/gradle/api/tasks/CacheableTask.html[`@CacheableTask`] annotation for any task that is meant to _always_ be cacheable.
+Likewise, the link:{javadocPath}/org/gradle/work/DisableCachingByDefault.html[`@DisableCachingByDefault`] should be used to always disable caching for all instances of a task type.
+
+Remember that only tasks that produce reproducible and relocatable output should be marked as `@Cacheable`.
+
+=== Explanation
+
+Annotating a task type will ensure that _each task instance_ of that type is properly understood by Gradle to be cacheable (or not cacheable).
+This removes the need to remember to configure each of the task instances separately in buildscripts.
+Using the annotations also _documents_ the intended cacheability of the task type within its own source, appearing in Javadoc and making the task's behavior clear to other developers without requiring them to inspect each task instance's configuration.
+It is also slightly more efficient than running a test at configuration time to determine cacheability.
+
+=== Example
+
+==== Don't Do This
+
+If we want to reuse the output of a task, we shouldn't do this:
+
+====
+include::sample[dir="snippets/bestPractices/useCacheabilityAnnotations/kotlin",files="build.gradle.kts[tags=avoid-this]"]
+include::sample[dir="snippets/bestPractices/useCacheabilityAnnotations/groovy",files="build.gradle[tags=avoid-this]"]
+====
+
+<1> *Define a Task*: The `BadCalculatorTask` type is deterministic and produces relocatable output, but is not annotated.
+<2> *Mark the Task Instance as Cacheable*: This example shows how to mark a specific task instance as cacheable.
+<3> *Forget to Mark a Task Instance as Cacheable*: Unfortunately, the `addBad2` instance of the `BadCalculatorTask` type is not marked as cacheable, so it will not be cached, despite behaving the same as `addBad1`.
+
+==== Do This Instead
+
+As this task meets the criteria from cacheability (we can imagine doing a much more complex calculation in the `@TaskAction` would benefit from automatic work avoidance via caching), we should mark the _task type itself_ as cacheable like this:
+
+====
+include::sample[dir="snippets/bestPractices/useCacheabilityAnnotations/kotlin",files="build.gradle.kts[tags=do-this]"]
+include::sample[dir="snippets/bestPractices/useCacheabilityAnnotations/groovy",files="build.gradle[tags=do-this]"]
+====
+
+<1> *Annotate the Task Type*: Applying the `@CacheableTask` to a task type informs Gradle that instances of this task should _always_ be cached.
+<2> *Nothing Else Needs To Be Done*: When we register task instances, nothing else needs to be done - Gradle knows to cache them.
+
+=== References
+<<more_about_tasks.adoc#sec:caching_tasks,Caching Tasks>>
+<<build_cache.adoc#sec:task_output_caching_details,Cacheable Tasks>>
+<<build_cache_concepts.adoc#non_cacheable_tasks,Non-cacheable Tasks>>
+
+=== Tags
+`#tasks`, `#caching`

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
@@ -104,7 +104,7 @@ include::sample[dir="snippets/bestPractices/useCacheabilityAnnotations/groovy",f
 
 ==== Do This Instead
 
-As this task meets the criteria from cacheability (we can imagine doing a much more complex calculation in the `@TaskAction` would benefit from automatic work avoidance via caching), we should mark the _task type itself_ as cacheable like this:
+As this task meets the criteria for cacheability (we can imagine a more complex calculation in the `@TaskAction` that would benefit from automatic work avoidance via caching), we should mark the _task type itself_ as cacheable like this:
 
 ====
 include::sample[dir="snippets/bestPractices/useCacheabilityAnnotations/kotlin",files="build.gradle.kts[tags=do-this]"]

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
@@ -41,7 +41,7 @@ include::sample[dir="snippets/bestPractices/avoidDependsOn/groovy",files="build.
 
 ==== Don't Do This
 
-If we want to translate the greeting in the `message.txt` file using another task, we could do this:
+If you want to translate the greeting in the `message.txt` file using another task, you could do this:
 
 ====
 include::sample[dir="snippets/bestPractices/avoidDependsOn/kotlin",files="build.gradle.kts[tags=avoid-this]"]
@@ -53,7 +53,7 @@ include::sample[dir="snippets/bestPractices/avoidDependsOn/groovy",files="build.
 
 ==== Do This Instead
 
-Instead, we should explicitly wire task inputs and outputs like this:
+Instead, you should explicitly wire task inputs and outputs like this:
 
 ====
 include::sample[dir="snippets/bestPractices/avoidDependsOn/kotlin",files="build.gradle.kts[tags=do-this]"]
@@ -93,7 +93,7 @@ It is also slightly more efficient than running a test at configuration time to 
 
 ==== Don't Do This
 
-If we want to reuse the output of a task, we shouldn't do this:
+If you want to reuse the output of a task, you shouldn't do this:
 
 ====
 include::sample[dir="snippets/bestPractices/useCacheabilityAnnotations/kotlin",files="build.gradle.kts[tags=avoid-this]"]
@@ -106,7 +106,7 @@ include::sample[dir="snippets/bestPractices/useCacheabilityAnnotations/groovy",f
 
 ==== Do This Instead
 
-As this task meets the criteria for cacheability (we can imagine a more complex calculation in the `@TaskAction` that would benefit from automatic work avoidance via caching), we should mark the _task type itself_ as cacheable like this:
+As this task meets the criteria for cacheability (we can imagine a more complex calculation in the `@TaskAction` that would benefit from automatic work avoidance via caching), you should mark the _task type itself_ as cacheable like this:
 
 ====
 include::sample[dir="snippets/bestPractices/useCacheabilityAnnotations/kotlin",files="build.gradle.kts[tags=do-this]"]

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/tags_reference.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/tags_reference.adoc
@@ -3,6 +3,10 @@
 
 Here you can find a brief explanation of all the tags used in the best practices documentation.
 
+`#caching`
+
+Items that are related to using Gradle's various caching mechanisms, such as <<build_cache.adoc#sec:task_output_caching,caching tasks>>.
+
 `#inputs-and-outputs`
 
 Items that are related to Gradle <<writing_tasks.adoc#task_inputs_and_outputs,task inputs and outputs>>, the annotations used to declare them, and their proper use.

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/build-cache/build_cache_concepts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/build-cache/build_cache_concepts.adoc
@@ -174,6 +174,7 @@ These tasks can safely reuse each other's outputs.
 
 As <<build_cache_use_cases.adoc#share_results_between_ci_builds,discussed previously>>, you can use Develocity to diagnose the source build of these unexpected cache-hits.
 
+[[non_cacheable_tasks]]
 == Non-cacheable tasks
 
 You've seen quite a bit about cacheable tasks, which implies there are non-cacheable ones, too. If caching task outputs is as awesome as it sounds, why not cache every task?

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/groovy/build.gradle
@@ -1,0 +1,69 @@
+// tag::avoid-this[]
+tasks.register("clean", Delete) {
+    delete layout.buildDirectory
+}
+
+abstract class BadCalculatorTask extends DefaultTask {
+    @Input
+    abstract Property<Integer> getFirst()
+
+    @Input
+    abstract Property<Integer> getSecond()
+
+    @OutputFile
+    abstract RegularFileProperty getOutputFile()
+
+    @TaskAction
+    void run() {
+        def result = first.get() + second.get()
+        logger.lifecycle("Result: " + result)
+        outputFile.get().asFile.write(result.toString())
+    }
+}
+
+tasks.register("addBad1", BadCalculatorTask) {
+    first = 10
+    second = 25
+    outputFile = layout.buildDirectory.file("badOutput.txt")
+    outputs.cacheIf { true }
+}
+
+tasks.register("addBad2", BadCalculatorTask) {
+    first = 3
+    second = 7
+    outputFile = layout.buildDirectory.file("badOutput2.txt")
+}
+// end::avoid-this[]
+
+// tag::do-this[]
+@CacheableTask // <1>
+abstract class GoodCalculatorTask extends DefaultTask {
+    @Input
+    abstract Property<Integer> getFirst()
+
+    @Input
+    abstract Property<Integer> getSecond()
+
+    @OutputFile
+    abstract RegularFileProperty getOutputFile()
+
+    @TaskAction
+    void run() {
+        def result = first.get() + second.get()
+        logger.lifecycle("Result: " + result)
+        outputFile.get().asFile.write(result.toString())
+    }
+}
+
+tasks.register("addGood1", GoodCalculatorTask) {
+    first = 10
+    second = 25
+    outputFile = layout.buildDirectory.file("goodOutput.txt")
+}
+
+tasks.register("addGood2", GoodCalculatorTask) { // <2>
+    first = 3
+    second = 7
+    outputFile = layout.buildDirectory.file("goodOutput2.txt")
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/groovy/gradle.properties
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/groovy/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/groovy/gradle.properties
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/groovy/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.caching=true

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "use-cacheability-annotations"

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/kotlin/build.gradle.kts
@@ -1,0 +1,69 @@
+// tag::avoid-this[]
+tasks.register<Delete>("clean") {
+    delete(layout.buildDirectory)
+}
+
+abstract class BadCalculatorTask : DefaultTask() { // <1>
+    @get:Input
+    abstract val first: Property<Int>
+
+    @get:Input
+    abstract val second: Property<Int>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        val result = (first.get() + second.get()).toString()
+        logger.lifecycle("Result: " + result)
+        outputFile.get().asFile.writeText(result)
+    }
+}
+
+tasks.register<BadCalculatorTask>("addBad1") {
+    first.set(10)
+    second.set(25)
+    outputFile.set(layout.buildDirectory.file("badOutput.txt"))
+    outputs.cacheIf { true } // <2>
+}
+
+tasks.register<BadCalculatorTask>("addBad2") { // <3>
+    first.set(3)
+    second.set(7)
+    outputFile.set(layout.buildDirectory.file("badOutput2.txt"))
+}
+// end::avoid-this[]
+
+// tag::do-this[]
+@CacheableTask // <1>
+abstract class GoodCalculatorTask : DefaultTask() {
+    @get:Input
+    abstract val first: Property<Int>
+
+    @get:Input
+    abstract val second: Property<Int>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        val result = (first.get() + second.get()).toString()
+        logger.lifecycle("Result: " + result)
+        outputFile.get().asFile.writeText(result)
+    }
+}
+
+tasks.register<GoodCalculatorTask>("addGood1") { // <2>
+    first.set(10)
+    second.set(25)
+    outputFile.set(layout.buildDirectory.file("goodOutput.txt"))
+}
+
+tasks.register<GoodCalculatorTask>("addGood2") {
+    first.set(3)
+    second.set(7)
+    outputFile.set(layout.buildDirectory.file("goodOutput2.txt"))
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/kotlin/build.gradle.kts
@@ -22,16 +22,16 @@ abstract class BadCalculatorTask : DefaultTask() { // <1>
 }
 
 tasks.register<BadCalculatorTask>("addBad1") {
-    first.set(10)
-    second.set(25)
-    outputFile.set(layout.buildDirectory.file("badOutput.txt"))
+    first = 10
+    second = 25
+    outputFile = layout.buildDirectory.file("badOutput.txt")
     outputs.cacheIf { true } // <2>
 }
 
 tasks.register<BadCalculatorTask>("addBad2") { // <3>
-    first.set(3)
-    second.set(7)
-    outputFile.set(layout.buildDirectory.file("badOutput2.txt"))
+    first = 3
+    second = 7
+    outputFile = layout.buildDirectory.file("badOutput2.txt")
 }
 // end::avoid-this[]
 
@@ -56,14 +56,14 @@ abstract class GoodCalculatorTask : DefaultTask() {
 }
 
 tasks.register<GoodCalculatorTask>("addGood1") { // <2>
-    first.set(10)
-    second.set(25)
-    outputFile.set(layout.buildDirectory.file("goodOutput.txt"))
+    first = 10
+    second = 25
+    outputFile = layout.buildDirectory.file("goodOutput.txt")
 }
 
 tasks.register<GoodCalculatorTask>("addGood2") {
-    first.set(3)
-    second.set(7)
-    outputFile.set(layout.buildDirectory.file("goodOutput2.txt"))
+    first = 3
+    second = 7
+    outputFile = layout.buildDirectory.file("goodOutput2.txt")
 }
 // end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/kotlin/build.gradle.kts
@@ -15,9 +15,9 @@ abstract class BadCalculatorTask : DefaultTask() { // <1>
 
     @TaskAction
     fun run() {
-        val result = (first.get() + second.get()).toString()
-        logger.lifecycle("Result: " + result)
-        outputFile.get().asFile.writeText(result)
+        val result = first.get() + second.get()
+        logger.lifecycle("Result: $result")
+        outputFile.get().asFile.writeText(result.toString())
     }
 }
 
@@ -49,9 +49,9 @@ abstract class GoodCalculatorTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        val result = (first.get() + second.get()).toString()
-        logger.lifecycle("Result: " + result)
-        outputFile.get().asFile.writeText(result)
+        val result = first.get() + second.get()
+        logger.lifecycle("Result: $result")
+        outputFile.get().asFile.writeText(result.toString())
     }
 }
 

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/kotlin/gradle.properties
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/kotlin/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "use-cacheability-annotations"

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.bad.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.bad.out
@@ -1,0 +1,9 @@
+
+> Task :addBad1
+Result: 35
+
+> Task :addBad2
+Result: 10
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.bad.secondRun.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.bad.secondRun.out
@@ -1,0 +1,7 @@
+> Task :addBad1 FROM-CACHE
+
+> Task :addBad2
+Result: 10
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 1 executed, 1 from cache

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.good.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.good.out
@@ -1,0 +1,9 @@
+
+> Task :addGood1
+Result: 35
+
+> Task :addGood2
+Result: 10
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.good.secondRun.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.good.secondRun.out
@@ -1,0 +1,5 @@
+> Task :addGood1 FROM-CACHE
+> Task :addGood2 FROM-CACHE
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 from cache

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.sample.conf
@@ -3,25 +3,31 @@ commands: [{
     args: addBad1 addBad2
     expected-output-file: useCacheabilityAnnotations.bad.out
     allow-disordered-output: true
+    flags: --build-cache
 }, {
      executable: gradle
      args: clean
+    flags: --build-cache
 }, {
     executable: gradle
     args: addBad1 addBad2
     expected-output-file: useCacheabilityAnnotations.bad.secondRun.out
     allow-disordered-output: true
+    flags: --build-cache
 }, {
     executable: gradle
     args: addGood1 addGood2
     expected-output-file: useCacheabilityAnnotations.good.out
     allow-disordered-output: true
+    flags: --build-cache
 }, {
     executable: gradle
     args: clean
+    flags: --build-cache
 }, {
     executable: gradle
     args: addGood1 addGood2
     expected-output-file: useCacheabilityAnnotations.good.secondRun.out
     allow-disordered-output: true
+    flags: --build-cache
 }]

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.sample.conf
@@ -2,6 +2,7 @@ commands: [{
     executable: gradle
     args: addBad1 addBad2
     expected-output-file: useCacheabilityAnnotations.bad.out
+    allow-disordered-output: true
 }, {
      executable: gradle
      args: clean
@@ -9,10 +10,12 @@ commands: [{
     executable: gradle
     args: addBad1 addBad2
     expected-output-file: useCacheabilityAnnotations.bad.secondRun.out
+    allow-disordered-output: true
 }, {
     executable: gradle
     args: addGood1 addGood2
     expected-output-file: useCacheabilityAnnotations.good.out
+    allow-disordered-output: true
 }, {
     executable: gradle
     args: clean
@@ -20,4 +23,5 @@ commands: [{
     executable: gradle
     args: addGood1 addGood2
     expected-output-file: useCacheabilityAnnotations.good.secondRun.out
+    allow-disordered-output: true
 }]

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.sample.conf
@@ -3,6 +3,7 @@ commands: [{
     args: addBad1 addBad2
     expected-output-file: useCacheabilityAnnotations.bad.out
     allow-disordered-output: true
+    allow-additional-output: true
     flags: --build-cache
 }, {
      executable: gradle
@@ -13,12 +14,14 @@ commands: [{
     args: addBad1 addBad2
     expected-output-file: useCacheabilityAnnotations.bad.secondRun.out
     allow-disordered-output: true
+    allow-additional-output: true
     flags: --build-cache
 }, {
     executable: gradle
     args: addGood1 addGood2
     expected-output-file: useCacheabilityAnnotations.good.out
     allow-disordered-output: true
+    allow-additional-output: true
     flags: --build-cache
 }, {
     executable: gradle
@@ -29,5 +32,6 @@ commands: [{
     args: addGood1 addGood2
     expected-output-file: useCacheabilityAnnotations.good.secondRun.out
     allow-disordered-output: true
+    allow-additional-output: true
     flags: --build-cache
 }]

--- a/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useCacheabilityAnnotations/tests/useCacheabilityAnnotations.sample.conf
@@ -1,0 +1,23 @@
+commands: [{
+    executable: gradle
+    args: addBad1 addBad2
+    expected-output-file: useCacheabilityAnnotations.bad.out
+}, {
+     executable: gradle
+     args: clean
+}, {
+    executable: gradle
+    args: addBad1 addBad2
+    expected-output-file: useCacheabilityAnnotations.bad.secondRun.out
+}, {
+    executable: gradle
+    args: addGood1 addGood2
+    expected-output-file: useCacheabilityAnnotations.good.out
+}, {
+    executable: gradle
+    args: clean
+}, {
+    executable: gradle
+    args: addGood1 addGood2
+    expected-output-file: useCacheabilityAnnotations.good.secondRun.out
+}]


### PR DESCRIPTION
Continues the work started in #32570 by adding a new best practice to the catalog.

Run: `./gradlew serveDocs -PquickDocs` and navigate to `http://127.0.0.1:8000/userguide/bp_tasks.html#use_cacheability_annotations` to view this.

Use: `./gradlew :docs:docsTest --tests "*snippet-best-practices-use-cacheability-annotations*` to run the samples.