### PR TITLE
Make build-logic:test skip-able

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/BuildLogicTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/BuildLogicTest.kt
@@ -1,0 +1,36 @@
+package configurations
+
+import common.Os
+import common.buildScanTagParam
+import common.getBuildScanCustomValueParam
+import model.CIBuildModel
+import model.Stage
+
+class BuildLogicTest(
+    model: CIBuildModel,
+    stage: Stage,
+) : OsAwareBaseGradleBuildType(os = Os.LINUX, stage = stage, init = {
+        id(buildTypeId(model))
+        name = "Build-logic test"
+        description = "Run :build-logic:test"
+
+        features {
+            publishBuildStatusToGithub(model)
+        }
+
+        applyDefaults(
+            model,
+            this,
+            ":build-logic:test -PskipBuildLogicTests=false",
+            extraParameters =
+                listOf(
+                    stage.getBuildScanCustomValueParam(),
+                    buildScanTagParam("BuildLogitTest"),
+                    "-Porg.gradle.java.installations.auto-download=false",
+                ).joinToString(" "),
+        )
+    }) {
+    companion object {
+        fun buildTypeId(model: CIBuildModel) = "${model.projectId}_BuildLogicTest"
+    }
+}

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -11,6 +11,7 @@ import common.VersionedSettingsBranch
 import common.toCamelCase
 import common.toCapitalized
 import configurations.BuildDistributions
+import configurations.BuildLogicTest
 import configurations.CheckLinks
 import configurations.CheckTeamCityKotlinDSL
 import configurations.CompileAll
@@ -118,6 +119,7 @@ data class CIBuildModel(
                     listOf(
                         SpecificBuild.CompileAll,
                         SpecificBuild.SanityCheck,
+                        SpecificBuild.BuildLogicTest,
                     ),
                 functionalTests =
                     listOf(
@@ -652,6 +654,12 @@ enum class SpecificBuild {
             model: CIBuildModel,
             stage: Stage,
         ): OsAwareBaseGradleBuildType = SanityCheck(model, stage)
+    },
+    BuildLogicTest {
+        override fun create(
+            model: CIBuildModel,
+            stage: Stage,
+        ): OsAwareBaseGradleBuildType = BuildLogicTest(model, stage)
     },
     BuildDistributions {
         override fun create(

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -54,6 +54,7 @@ import gradlebuild.basics.BuildParams.PREDICTIVE_TEST_SELECTION_ENABLED
 import gradlebuild.basics.BuildParams.RERUN_ALL_TESTS
 import gradlebuild.basics.BuildParams.RUN_ANDROID_STUDIO_IN_HEADLESS_MODE
 import gradlebuild.basics.BuildParams.RUN_BROKEN_CONFIGURATION_CACHE_DOCS_TESTS
+import gradlebuild.basics.BuildParams.SKIP_BUILD_LOGIC_TESTS
 import gradlebuild.basics.BuildParams.STUDIO_HOME
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_DOGFOODING_TAG
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_ENABLED
@@ -121,6 +122,7 @@ object BuildParams {
     const val PERFORMANCE_DEPENDENCY_BUILD_IDS = "org.gradle.performance.dependencyBuildIds"
     const val PERFORMANCE_MAX_PROJECTS = "maxProjects"
     const val RERUN_ALL_TESTS = "rerunAllTests"
+    const val SKIP_BUILD_LOGIC_TESTS = "skipBuildLogicTests"
     const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
     const val TEST_DISTRIBUTION_DOGFOODING_TAG = "testDistributionDogfoodingTag"
     const val TEST_DISTRIBUTION_ENABLED = "enableTestDistribution"
@@ -171,7 +173,6 @@ fun Project.selectStringProperties(vararg propertyNames: String): Map<String, St
             propertyName to propertyValue
         }
     }.toMap()
-
 
 /**
  * Creates a [Provider] that returns `true` when this [Provider] has a value
@@ -278,6 +279,8 @@ val Project.flakyTestStrategy: FlakyTestStrategy
 val Project.ignoreIncomingBuildReceipt: Provider<Boolean>
     get() = gradleProperty(BUILD_IGNORE_INCOMING_BUILD_RECEIPT).presence()
 
+val Project.skipBuildLogicTests: Boolean
+    get() = gradleProperty(SKIP_BUILD_LOGIC_TESTS).getOrElse("true") == "true"
 
 val Project.performanceDependencyBuildIds: Provider<String>
     get() = gradleProperty(PERFORMANCE_DEPENDENCY_BUILD_IDS).orElse("")

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import gradlebuild.basics.skipBuildLogicTests
 
 plugins {
     id("java-library")
@@ -53,5 +54,6 @@ tasks.validatePlugins {
 }
 
 tasks.withType<Test>().configureEach {
+    enabled = !skipBuildLogicTests
     useJUnitPlatform()
 }

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
@@ -23,6 +23,7 @@ import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.hamcrest.Matcher
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
+import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -41,28 +42,28 @@ abstract class AbstractBinaryCompatibilityTest {
         get() = tmpDir.root
 
     internal
-    fun checkBinaryCompatibleKotlin(v1: String = "", v2: String, block: CheckResult.() -> Unit = {}): CheckResult =
+    fun checkBinaryCompatibleKotlin(@Language("kotlin") v1: String = "", @Language("kotlin") v2: String, block: CheckResult.() -> Unit = {}): CheckResult =
         runKotlinBinaryCompatibilityCheck(v1, v2) {
             assertBinaryCompatible()
             block()
         }
 
     internal
-    fun checkNotBinaryCompatibleKotlin(v1: String = "", v2: String, block: CheckResult.() -> Unit = {}): CheckResult =
+    fun checkNotBinaryCompatibleKotlin(@Language("kotlin") v1: String = "", @Language("kotlin") v2: String, block: CheckResult.() -> Unit = {}): CheckResult =
         runKotlinBinaryCompatibilityCheck(v1, v2) {
             assertNotBinaryCompatible()
             block()
         }
 
     internal
-    fun checkBinaryCompatibleJava(v1: String = "", v2: String, block: CheckResult.() -> Unit = {}): CheckResult =
+    fun checkBinaryCompatibleJava(@Language("java") v1: String = "", @Language("java") v2: String, block: CheckResult.() -> Unit = {}): CheckResult =
         runJavaBinaryCompatibilityCheck(v1, v2) {
             assertBinaryCompatible()
             block()
         }
 
     internal
-    fun checkNotBinaryCompatibleJava(v1: String = "", v2: String, block: CheckResult.() -> Unit = {}): CheckResult =
+    fun checkNotBinaryCompatibleJava(@Language("java") v1: String = "", @Language("java") v2: String, block: CheckResult.() -> Unit = {}): CheckResult =
         runJavaBinaryCompatibilityCheck(v1, v2) {
             assertNotBinaryCompatible()
             block()
@@ -107,7 +108,7 @@ abstract class AbstractBinaryCompatibilityTest {
     fun runKotlinBinaryCompatibilityCheck(v1: String, v2: String, block: CheckResult.() -> Unit = {}): CheckResult =
         runBinaryCompatibilityCheck(
             v1 = {
-                withFile(
+                withKotlinFile(
                     "kotlin/com/example/Source.kt",
                     """
                     package com.example
@@ -119,7 +120,7 @@ abstract class AbstractBinaryCompatibilityTest {
                 )
             },
             v2 = {
-                withFile(
+                withKotlinFile(
                     "kotlin/com/example/Source.kt",
                     """
                     package com.example
@@ -137,7 +138,7 @@ abstract class AbstractBinaryCompatibilityTest {
     fun runJavaBinaryCompatibilityCheck(v1: String, v2: String, block: CheckResult.() -> Unit = {}): CheckResult =
         runBinaryCompatibilityCheck(
             v1 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Source.java",
                     """
                     package com.example;
@@ -149,7 +150,7 @@ abstract class AbstractBinaryCompatibilityTest {
                 )
             },
             v2 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Source.java",
                     """
                     package com.example;
@@ -442,6 +443,15 @@ abstract class AbstractBinaryCompatibilityTest {
             parentFile.mkdirs()
             writeText(text.trimIndent())
         }
+
+    protected
+    fun File.withKotlinFile(path: String, @Language("kotlin") text: String): File = withFile(path, text)
+
+    protected
+    fun File.withJavaFile(path: String, @Language("java") text: String): File = withFile(path, text)
+
+    protected
+    fun File.withJsonFile(path: String, @Language("json") text: String): File = withFile(path, text)
 
     private
     fun File.withUniqueDirectory(prefixPath: String): File =

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AlphabeticalAcceptedApiChangesTaskIntegrationTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AlphabeticalAcceptedApiChangesTaskIntegrationTest.kt
@@ -80,6 +80,7 @@ class AlphabeticalAcceptedApiChangesTaskIntegrationTest : AbstractAcceptedApiCha
             """.trimIndent()
         )
 
+        //language=JSON
         secondAcceptedApiChangesFile.writeText(
             """
                 {
@@ -153,6 +154,7 @@ class AlphabeticalAcceptedApiChangesTaskIntegrationTest : AbstractAcceptedApiCha
             """.trimIndent()
         )
 
+        //language=JSON
         secondAcceptedApiChangesFile.writeText(
             """
                 {

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/KotlinInternalFilteringTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/KotlinInternalFilteringTest.kt
@@ -16,6 +16,7 @@
 
 package gradlebuild.binarycompatibility
 
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 
@@ -24,6 +25,7 @@ import org.junit.Test
  */
 class KotlinInternalFilteringTest : AbstractBinaryCompatibilityTest() {
 
+    @Language("kotlin")
     private
     val internalMembers = """
 
@@ -46,6 +48,7 @@ class KotlinInternalFilteringTest : AbstractBinaryCompatibilityTest() {
 
     """
 
+    @Language("kotlin")
     private
     val publicMembers = """
 
@@ -68,6 +71,7 @@ class KotlinInternalFilteringTest : AbstractBinaryCompatibilityTest() {
 
     """
 
+    @Language("kotlin")
     private
     val existingSource = """
 
@@ -83,6 +87,7 @@ class KotlinInternalFilteringTest : AbstractBinaryCompatibilityTest() {
         typealias ExistingTypeAlias = String
     """
 
+    @Language("kotlin")
     private
     val internalSource = """
 
@@ -132,6 +137,7 @@ class KotlinInternalFilteringTest : AbstractBinaryCompatibilityTest() {
         }
     """
 
+    @Language("kotlin")
     private
     val publicSource = """
 

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/SinceAndIncubatingRulesKotlinTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/SinceAndIncubatingRulesKotlinTest.kt
@@ -16,11 +16,13 @@
 
 package gradlebuild.binarycompatibility
 
+import org.intellij.lang.annotations.Language
 import org.junit.Test
 
 
 class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
 
+    @Language("kotlin")
     private
     val publicKotlinMembers = """
 
@@ -67,6 +69,7 @@ class SinceAndIncubatingRulesKotlinTest : AbstractBinaryCompatibilityTest() {
 
     """
 
+    @Language("kotlin")
     private
     val annotatedKotlinMembers = """
 

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/SortAcceptedApiChangesTaskIntegrationTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/SortAcceptedApiChangesTaskIntegrationTest.kt
@@ -83,6 +83,7 @@ class SortAcceptedApiChangesTaskIntegrationTest : AbstractAcceptedApiChangesMain
             """.trimIndent()
         )
 
+        //language=JSON
         secondAcceptedApiChangesFile.writeText(
             """
                 {
@@ -117,6 +118,7 @@ class SortAcceptedApiChangesTaskIntegrationTest : AbstractAcceptedApiChangesMain
         val finalVerifyResult = run(":verifyAcceptedApiChangesOrdering").build()
         assertEquals(TaskOutcome.SUCCESS, finalVerifyResult.task(":verifyAcceptedApiChangesOrdering")!!.outcome)
 
+        //language=JSON
         val expectedFirstJson = loadChangesJson(
             """
                 {
@@ -172,6 +174,7 @@ class SortAcceptedApiChangesTaskIntegrationTest : AbstractAcceptedApiChangesMain
                     ]
                 }
             """)
+        //language=JSON
         val expectedSecondJson = loadChangesJson(
             """
                 {

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/UpgradedPropertiesChangesTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/UpgradedPropertiesChangesTest.kt
@@ -25,7 +25,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
     fun `should report binary incompatibility for upgraded property without any metadata`() {
         checkNotBinaryCompatible(
             v1 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -41,7 +41,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                 )
             },
             v2 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -65,7 +65,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
     fun `should automatically accept binary incompatibilities for upgraded properties`() {
         checkBinaryCompatible(
             v1 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/TaskInterface.java",
                     """
                         package com.example;
@@ -76,7 +76,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -92,7 +92,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                 )
             },
             v2 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -103,7 +103,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJavaFile(
                     "java/com/example/TaskInterface.java",
                     """
                         package com.example;
@@ -114,7 +114,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJsonFile(
                     "resources/upgraded-properties.json",
                     """
                         [{
@@ -165,7 +165,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
     fun `should automatically accept binary incompatibilities for boolean upgraded properties`() {
         checkBinaryCompatible(
             v1 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -179,7 +179,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJavaFile(
                     "java/com/example/TaskInterface.java",
                     """
                         package com.example;
@@ -192,7 +192,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                 )
             },
             v2 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -206,7 +206,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJavaFile(
                     "java/com/example/TaskInterface.java",
                     """
                         package com.example;
@@ -220,7 +220,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJsonFile(
                     "resources/upgraded-properties.json",
                     """
                         [{
@@ -281,7 +281,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
     fun `should report an error if newly added method with different name does not have @since`() {
         checkNotBinaryCompatible(
             v1 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -295,7 +295,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                 )
             },
             v2 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -306,7 +306,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJsonFile(
                     "resources/upgraded-properties.json",
                     """
                         [{
@@ -336,7 +336,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
     fun `should fail if some method was upgraded but it was not actually changed`() {
         checkBinaryCompatibleFailsWithoutReport(
             v1 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -352,7 +352,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                 )
             },
             v2 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -365,7 +365,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJsonFile(
                     "resources/upgraded-properties.json",
                     """
                         [{
@@ -395,7 +395,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
     fun `should not fail if some method was upgraded and not removed but marked as kept`() {
         checkBinaryCompatible(
             v1 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -411,7 +411,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                 )
             },
             v2 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -424,7 +424,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJsonFile(
                     "resources/upgraded-properties.json",
                     """
                         [{
@@ -457,7 +457,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
     fun `should not fail if some method was upgraded and removed but marked as kept`() {
         checkBinaryCompatible(
             v1 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -473,7 +473,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                 )
             },
             v2 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -486,7 +486,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJsonFile(
                     "resources/upgraded-properties.json",
                     """
                         [{
@@ -519,7 +519,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
     fun `should accept upgraded property that used different name`() {
         checkBinaryCompatible(
             v1 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -535,7 +535,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                 )
             },
             v2 = {
-                withFile(
+                withJavaFile(
                     "java/com/example/Task.java",
                     """
                         package com.example;
@@ -549,7 +549,7 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
+                withJsonFile(
                     "resources/upgraded-properties.json",
                     """
                         [{

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -9,6 +9,10 @@ tasks.register("check") {
     dependsOn(subprojects.map { "${it.name}:check" })
 }
 
+tasks.register("test") {
+    dependsOn(subprojects.map { "${it.name}:test" })
+}
+
 val clean by tasks.registering {
     val buildLogicPropertiesFile = layout.projectDirectory.file("gradle.properties")
     val rootPropertiesFile = layout.projectDirectory.file("../gradle.properties")


### PR DESCRIPTION
### Context

Closes https://github.com/gradle/gradle-private/issues/4624

In the past, `SanityCheck` includes `build-logic:test`, which is very expensive because we run quite some "integration tests" (run Gradle builds via Test Kit):

- `AbstractBinaryCompatibilityTest` and subclasses.
- `TestFilesCleanupServiceTest`.

They take more than 3m on my local machine. Because some developers do run `sanityCheck` locally, this is harming dev productivitly.

This PR separate `build-logic:test` to a dedicate TeamCity build, and will only be enabled via `-PskipBuildLogicTests=false`. By default (local and CI sanity check), the tests won't run.