### PR TITLE
Fix flaky AndroidPluginsSmokeTest

### DIFF
--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -128,7 +128,11 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
 
         when: 'up-to-date build'
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.projectDir, IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
-        result = runner.build()
+        result = runner
+            .deprecations(AndroidDeprecations) {
+                maybeExpectIsPropertyDeprecationWarnings()
+            }
+            .build()
 
         then:
         result.task(':app:compileDebugJavaWithJavac').outcome == TaskOutcome.UP_TO_DATE


### PR DESCRIPTION
`AndroidPluginSmokeTest` is very flaky: https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.smoketests.AndroidPluginsSmokeTest&tests.sortField=FLAKY

The problem is that some deprecations appear in the second execution intermittently, so we add a `maybeExpectIsPropertyDeprecationWarnings`.