### PR TITLE
Do not realize attribute values on attribute container keySet call

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/BuildableBackedProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/BuildableBackedProvider.java
@@ -91,6 +91,11 @@ public class BuildableBackedProvider<B extends Buildable & TaskDependencyContain
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        return Value.ofNullable(valueFactory.create());
+        T value = valueFactory.create();
+        if (value == null) {
+            // AbstractProviderWithValue expects the factory to always return a non-null value
+            throw new NullPointerException("Value factory must not return null");
+        }
+        return Value.of(value);
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderWithValue.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderWithValue.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.evaluation.EvaluationScopeContext;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+/**
+ * Avoids executing the supplier (which may have side effects) when determining whether the
+ * provider is present. The value supplier that backs this provider must always return
+ * a non-null value.
+ */
+public class DefaultProviderWithValue<T> extends AbstractProviderWithValue<T> {
+
+    private final Class<T> type;
+    private final Supplier<T> supplier;
+
+    public DefaultProviderWithValue(Class<T> type, Supplier<T> supplier) {
+        this.type = type;
+        this.supplier = supplier;
+    }
+
+    @Override
+    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+        try (EvaluationScopeContext ignored = openScope()) {
+            T value = supplier.get();
+            if (value == null) {
+                // AbstractProviderWithValue expects the factory to always return a non-null value
+                throw new NullPointerException("Value factory must not return null");
+            }
+            return Value.of(value);
+        } catch (Exception e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    @Nullable
+    @Override
+    public Class<T> getType() {
+        return type;
+    }
+
+}

--- a/platforms/jvm/plugins-java-base/build.gradle.kts
+++ b/platforms/jvm/plugins-java-base/build.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
 
     implementation(projects.fileCollections)
     implementation(projects.fileOperations)
-    implementation(projects.functional)
     implementation(projects.jvmServices)
     implementation(projects.logging)
     implementation(projects.platformBase)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport
 import org.gradle.api.internal.provider.DefaultProperty
 import org.gradle.api.internal.provider.DefaultProvider
+import org.gradle.api.internal.provider.DefaultProviderWithValue
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.Property
@@ -410,5 +411,27 @@ final class DefaultMutableAttributeContainerTest extends BaseAttributeContainerT
         then:
         def e = thrown(IllegalStateException)
         e.message == "Cannot have two attributes with the same name but different types. This container has an attribute named 'flavor' of type 'java.lang.Boolean' and another attribute of type 'java.lang.String'"
+    }
+
+    def "calling keySet does not realize lazy attributes when they are guaranteed to have a value"() {
+        def container = createContainer()
+        def testAttribute = Attribute.of("test", String)
+        container.attributeProvider(testAttribute, new DefaultProviderWithValue<>(String.class, () -> {
+            throw new RuntimeException("Foooooooo")
+        }))
+
+        when:
+        def keys = container.keySet()
+
+        then:
+        keys.size() == 1
+        keys.contains(testAttribute)
+
+        when:
+        container.getAttribute(testAttribute)
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message == "Foooooooo"
     }
 }


### PR DESCRIPTION
Realizing the provider for TargetJvmVersion attribute causes the toolchain to be downloaded and probed. This locks in the value of the provider configuring the toolchain version. We wrap this provider in a DefaultProviderWithValue, which ensures we only realize the provider when getting the value and not when isPresent is called.

We update the mutable attribute container to use the keySet property on MapProperty to avoid getting the value of the providers when only the key set is required.

This fixes a bug in Spring integration, where they called keySet, without observing the values, effectively locking in the toolchain version, even if they did not intend to read the toolchain attribute value.

Fixes bug introduced in https://github.com/gradle/gradle/pull/31707

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
