### PR TITLE
FeatureSpec: Add usingSourceSet Provider overload

### DIFF
--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/plugins/FeatureSpec.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/plugins/FeatureSpec.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.plugins;
 
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -31,6 +33,14 @@ public interface FeatureSpec {
      * @param sourceSet the source set
      */
     void usingSourceSet(SourceSet sourceSet);
+
+    /**
+     * Declares the source set which this feature is built from.
+     * @param sourceSet the source set
+     * @since 9.0
+     */
+    @Incubating
+    void usingSourceSet(Provider<SourceSet> sourceSet);
 
     /**
      * Declares a capability of this feature.

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -21,6 +21,8 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.FeatureSpec;
 import org.gradle.api.plugins.jvm.internal.DefaultJvmFeature;
 import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
@@ -34,7 +36,7 @@ public class DefaultJavaFeatureSpec implements FeatureSpec {
     private final Set<Capability> capabilities = new LinkedHashSet<>(1);
     private final ProjectInternal project;
 
-    private SourceSet sourceSet;
+    private final Property<SourceSet> sourceSet;
     private boolean withJavadocJar = false;
     private boolean withSourcesJar = false;
     private boolean allowPublication = true;
@@ -42,11 +44,17 @@ public class DefaultJavaFeatureSpec implements FeatureSpec {
     public DefaultJavaFeatureSpec(String name, ProjectInternal project) {
         this.name = name;
         this.project = project;
+        this.sourceSet = project.getObjects().property(SourceSet.class);
     }
 
     @Override
     public void usingSourceSet(SourceSet sourceSet) {
-        this.sourceSet = sourceSet;
+        this.sourceSet.set(sourceSet);
+    }
+
+    @Override
+    public void usingSourceSet(Provider<SourceSet> sourceSet) {
+        this.sourceSet.set(sourceSet);
     }
 
     @Override
@@ -74,6 +82,7 @@ public class DefaultJavaFeatureSpec implements FeatureSpec {
     }
 
     public JvmFeatureInternal create() {
+        SourceSet sourceSet = this.sourceSet.getOrNull();
         if (sourceSet == null) {
             throw new InvalidUserCodeException("You must specify which source set to use for feature '" + name + "'");
         }

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -475,9 +475,9 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         commonProject.pluginManager.apply(JavaPlugin)
         commonProject.group = "group"
         commonProject.extensions.configure(JavaPluginExtension) { java ->
-            java.sourceSets.create("other")
+            var otherRegistered = java.sourceSets.register("otherRegistered")
             java.registerFeature("other") {
-                it.usingSourceSet(java.sourceSets.other)
+                it.usingSourceSet(otherRegistered)
             }
         }
         middleProject.pluginManager.apply(JavaPlugin)


### PR DESCRIPTION
Fixes #30797

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
