### PR TITLE
Support += in Groovy build scripts

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -595,6 +595,13 @@
     "crossVersionTests": false
   },
   {
+    "name": "groovy-support",
+    "path": "platforms/core-configuration/groovy-support",
+    "unitTests": true,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
     "name": "guava-serialization-codecs",
     "path": "platforms/core-configuration/guava-serialization-codecs",
     "unitTests": false,

--- a/platforms/core-configuration/file-collections/build.gradle.kts
+++ b/platforms/core-configuration/file-collections/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     testImplementation(projects.snapshots)
     testImplementation(testFixtures(projects.core))
     testImplementation(testFixtures(projects.coreApi))
+    testImplementation(testFixtures(projects.groovySupport))
     testImplementation(testFixtures(projects.modelCore))
     testImplementation(testFixtures(projects.modelReflect))
     testImplementation(libs.groovyDateUtil)

--- a/platforms/core-configuration/file-collections/build.gradle.kts
+++ b/platforms/core-configuration/file-collections/build.gradle.kts
@@ -18,8 +18,9 @@ dependencies {
     api(libs.inject)
     api(libs.jspecify)
 
-    implementation(projects.io)
     implementation(projects.baseServicesGroovy)
+    implementation(projects.groovySupport)
+    implementation(projects.io)
 
     implementation(libs.slf4jApi)
     implementation(libs.commonsIo)

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ConfigurableFileCollectionCompoundAssignmentStandIn.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ConfigurableFileCollectionCompoundAssignmentStandIn.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
+
+/**
+ * This class acts as a replacement to call {@code +} on when evaluating {@code ConfigurableFileCollection += <RHS>} expressions in Groovy code.
+ *
+ * <b>This is a hidden public API</b>. Compiling Groovy code that depends on Gradle API may end up emitting references to methods of this class.
+ */
+public final class ConfigurableFileCollectionCompoundAssignmentStandIn {
+    private final DefaultConfigurableFileCollection lhs;
+    private final TaskDependencyFactory taskDependencyFactory;
+
+    ConfigurableFileCollectionCompoundAssignmentStandIn(DefaultConfigurableFileCollection lhs, TaskDependencyFactory taskDependencyFactory) {
+        this.lhs = lhs;
+        this.taskDependencyFactory = taskDependencyFactory;
+    }
+
+    public FileCollection plus(FileCollection rhs) {
+        return new FileCollectionCompoundAssignmentResult(taskDependencyFactory, lhs, (FileCollectionInternal) rhs);
+    }
+}

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.file.collections;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Action;
@@ -200,11 +201,21 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     }
 
     @Override
-    public void setFromAnyValue(Object object) {
+    public void setFromAnyValue(@Nullable Object object) {
+        Preconditions.checkNotNull(object, "Can't assign null value to %s", getDisplayName());
+
+        if (object instanceof FileCollectionCompoundAssignmentResult) {
+            FileCollectionCompoundAssignmentResult compoundAssignmentResult = (FileCollectionCompoundAssignmentResult) object;
+            if (compoundAssignmentResult.isOwnedBy(this)) {
+                compoundAssignmentResult.assignToOwner();
+                return;
+            }
+        }
+
         // Currently we support just FileCollection for Groovy assign, so first try to cast to FileCollection
         FileCollectionInternal fileCollection = Cast.castNullable(FileCollectionInternal.class, Cast.castNullable(FileCollection.class, object));
 
-        // Don't allow a += b or a = (a + b), this is not support
+        // Don't allow a = (a + b), this is not supported yet
         fileCollection.visitStructure(new FileCollectionStructureVisitor() {
             @Override
             public boolean startVisit(FileCollectionInternal.Source source, FileCollectionInternal fileCollection) {
@@ -830,5 +841,14 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
             }
             return this;
         }
+    }
+
+    /**
+     * Returns a stand-in that defines operations for Groovy's {@code <OP>=} expression.
+     *
+     * @return the stand-in to call the operation on
+     */
+    public ConfigurableFileCollectionCompoundAssignmentStandIn forCompoundAssignment() {
+       return new ConfigurableFileCollectionCompoundAssignmentStandIn(this, taskDependencyFactory);
     }
 }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileCollectionCompoundAssignmentResult.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileCollectionCompoundAssignmentResult.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import com.google.common.base.Preconditions;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.file.UnionFileCollection;
+import org.gradle.api.internal.groovy.support.CompoundAssignmentResult;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A helper class to implement an intermediate result of a compound assignment operation, like "+=".
+ * It is then assigned to the left-hand side operand. When the LHS is a ConfigurableFileCollection-typed property of some Gradle-enhanced object, then the assignment action is invoked.
+ */
+final class FileCollectionCompoundAssignmentResult extends UnionFileCollection implements CompoundAssignmentResult {
+    @Nullable
+    private ConfigurableFileCollection owner;
+    private final FileCollectionInternal rhs;
+
+    public FileCollectionCompoundAssignmentResult(TaskDependencyFactory taskDependencyFactory, DefaultConfigurableFileCollection owner, FileCollectionInternal rhs) {
+        super(taskDependencyFactory, owner, rhs);
+        this.owner = owner;
+        this.rhs = rhs;
+    }
+
+    public boolean isOwnedBy(ConfigurableFileCollection owner) {
+        return this.owner == owner;
+    }
+
+    public void assignToOwner() {
+        ConfigurableFileCollection theOwner = owner;
+        owner = null;
+        Preconditions.checkState(theOwner != null, "The collection is already consumed by the owner");
+        theOwner.from(rhs);
+    }
+
+    @Override
+    public void assignmentComplete() {
+        // When the expression involves a variable on the left side as opposed to a field, then this collection becomes its value.
+        // It must lose all "magical" properties towards its owner, because it may be used to set its value outside the original expression.
+        owner = null;
+    }
+
+    @Override
+    public boolean shouldDiscardResult() {
+        // Unlike the Property, we cannot discard the += value without losing backward compatibility.
+        return false;
+    }
+}

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileCollectionExtensions.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileCollectionExtensions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
+
+/**
+ * Groovy extension functions for {@link FileCollection} and {@link ConfigurableFileCollection}.
+ */
+@SuppressWarnings("unused") // registered as Groovy extension in ExtensionModule
+public final class FileCollectionExtensions {
+    private FileCollectionExtensions() {}
+
+    /**
+     * Creates a stand-in for {@link ConfigurableFileCollection} to be used as a left-hand side operand of {@code +=}.
+     * <p>
+     * The AST transformer knows the name of this method.
+     *
+     * @param lhs the configurable file collection
+     * @return the stand-in object to call {@code plus} on
+     * @see org.gradle.api.internal.groovy.support.CompoundAssignmentTransformer
+     */
+    public static ConfigurableFileCollectionCompoundAssignmentStandIn forCompoundAssignment(ConfigurableFileCollection lhs) {
+        return ((DefaultConfigurableFileCollection) lhs).forCompoundAssignment();
+    }
+}

--- a/platforms/core-configuration/file-collections/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/platforms/core-configuration/file-collections/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,0 +1,19 @@
+#
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+moduleName=file-collections
+moduleVersion=1.0
+extensionClasses=org.gradle.api.internal.file.collections.FileCollectionExtensions

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileCollectionExtensionsApiTest.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileCollectionExtensionsApiTest.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.groovy.support.CompoundAssignmentBinaryCompatibilityFixture
+import spock.lang.Specification
+
+class FileCollectionExtensionsApiTest extends Specification implements CompoundAssignmentBinaryCompatibilityFixture {
+    // This class verifies binary compatibility of non-public API used by Groovy static compilation.
+    // String are used intentionally to catch unexpected change to class name that breaks binary compatibility.
+    private static final String EXTENSION_CLASS = "org.gradle.api.internal.file.collections.FileCollectionExtensions"
+    private static final String STAND_IN_CLASS = "org.gradle.api.internal.file.collections.ConfigurableFileCollectionCompoundAssignmentStandIn"
+
+    def "extension class has expected api"() {
+        given:
+        def extensionClass = Class.forName(EXTENSION_CLASS)
+        def standInClass = Class.forName(STAND_IN_CLASS)
+
+        expect:
+        assertHasForCompoundAssignmentMethod(extensionClass, ConfigurableFileCollection, standInClass)
+    }
+
+    def "stand-in class defines operators"() {
+        given:
+        def standInClass = Class.forName(STAND_IN_CLASS)
+
+        expect:
+        assertHasOperator(standInClass, OP_PLUS, FileCollection, FileCollection)
+    }
+}

--- a/platforms/core-configuration/groovy-support/build.gradle.kts
+++ b/platforms/core-configuration/groovy-support/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    id("gradlebuild.distribution.api-java")
+}
+
+description = "Groovy specific enhancements to Gradle APIs"
+
+dependencies {
+    api(projects.baseServicesGroovy)
+
+    api(libs.groovy)
+    api(libs.jspecify)
+
+    implementation(libs.guava)
+
+    testImplementation(projects.modelCore)
+}

--- a/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/CompoundAssignmentExtensions.java
+++ b/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/CompoundAssignmentExtensions.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.groovy.support;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * This class provides catch-all support for {@code <OP>=} overloading.
+ * <p>
+ * <b>This is a hidden public API</b>. Compiling Groovy code that depends on Gradle API may end up emitting references to methods of this class.
+ */
+@SuppressWarnings("unused") // registered as Groovy extension in ExtensionModule
+public final class CompoundAssignmentExtensions {
+    private CompoundAssignmentExtensions() {}
+
+    /**
+     * No-op implementation, returns the argument.
+     * This method is called when the compound assignment expression should use the default Groovy logic.
+     * Classes must provide their own extension method with the exact signature to participate in the custom overloading protocol.
+     * <p>
+     * The AST transformer knows the name of this method.
+     *
+     * @param lhs the original argument
+     * @param <T> the type of the argument, used to please the static type checker
+     * @return the given argument
+     */
+    @Nullable
+    public static <T> T forCompoundAssignment(@Nullable T lhs) {
+        return lhs;
+    }
+
+    /**
+     * Converts the sum produced by {@code <OP>=} expression to the result of this expression. Implementations may replace the return value with {@code null}.
+     * <p>
+     * The AST transformer knows the name of this method.
+     *
+     * @param result the result, may not implement the custom protocol
+     * @param <T> the type of the expression
+     * @return the result for the {@code <OP>=} expression
+     */
+    @Nullable
+    public static <T> T toAssignmentResult(@Nullable T result) {
+        if (result instanceof CompoundAssignmentResult) {
+            CompoundAssignmentResult assignmentResult = (CompoundAssignmentResult) result;
+            assignmentResult.assignmentComplete();
+            if (assignmentResult.shouldDiscardResult()) {
+                return null;
+            }
+        }
+        return result;
+    }
+}

--- a/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/CompoundAssignmentResult.java
+++ b/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/CompoundAssignmentResult.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.groovy.support;
+
+/**
+ * Custom protocol for the value of the compound assignment expression {@code a <OP>= b}.
+ */
+public interface CompoundAssignmentResult {
+    /**
+     * Called when the assignment expression has been calculated. Implementation should discard any affinity towards its origin.
+     */
+    void assignmentComplete();
+
+    /**
+     * If {@code true} then the result of the {@code <OP>=} expression is replaced with {@code null}.
+     * Note that this replaces the value of the whole {@code a <OP>= b}, it doesn't affect what will be stored in {@code a} (which will be this object if {@code a} is a variable).
+     *
+     * @return {@code true} if the result should be replaced.
+     */
+    boolean shouldDiscardResult();
+}

--- a/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/CompoundAssignmentTransformer.java
+++ b/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/CompoundAssignmentTransformer.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.groovy.support;
+
+import com.google.common.collect.ImmutableMap;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.Phases;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.syntax.Token;
+import org.codehaus.groovy.syntax.Types;
+import org.gradle.groovy.scripts.internal.AbstractScriptTransformer;
+
+import java.util.Map;
+
+/**
+ * Rewrites some compound assignment expressions, like {@code +=} to help runtime distinguish them from operator calls {@code +}.
+ * <p>
+ * See the package documentation for the complete description.
+ */
+public class CompoundAssignmentTransformer extends AbstractScriptTransformer {
+    @Override
+    protected int getPhase() {
+        return Phases.CANONICALIZATION;
+    }
+
+    @Override
+    public void call(SourceUnit source) throws CompilationFailedException {
+        CompoundAssignmentExpressionRewriter visitor = new CompoundAssignmentExpressionRewriter(source);
+        source.getAST().getStatementBlock().visit(visitor);
+        source.getAST().getClasses().forEach(visitor::visitClass);
+        source.getAST().getMethods().forEach(visitor::visitMethod);
+    }
+
+    /**
+     * Transforms a single AST node. This is useful for unit tests that want to apply the transform.
+     *
+     * @param node the ClassNode or the MethodNode
+     * @param source the source unit in which the AST node resides
+     * @throws CompilationFailedException if the transformation cannot be applied.
+     */
+    public static void call(ASTNode node, SourceUnit source) throws CompilationFailedException {
+        CompoundAssignmentExpressionRewriter visitor = new CompoundAssignmentExpressionRewriter(source);
+        if (node instanceof ClassNode) {
+            visitor.visitClass((ClassNode) node);
+        } else if (node instanceof MethodNode) {
+            visitor.visitMethod((MethodNode) node);
+        } else {
+            throw new IllegalArgumentException("Cannot apply the transformation to node " + node + " of type " + node.getClass());
+        }
+    }
+
+    private static class CompoundAssignmentExpressionRewriter extends ClassCodeExpressionTransformer {
+        // This only includes operators we want to transform.
+        // TODO(mlopatkin): ConfigurableFileCollections support `-`, so they should probably support `-=` too.
+        private static final Map<String, Integer> COMPOUND_TO_OPERATOR = ImmutableMap.of(
+            "+=", Types.PLUS
+        );
+        private final SourceUnit sourceUnit;
+
+        public CompoundAssignmentExpressionRewriter(SourceUnit sourceUnit) {
+            this.sourceUnit = sourceUnit;
+        }
+
+        @Override
+        public Expression transform(Expression expr) {
+            Expression transformedExpr = super.transform(expr);
+            if (transformedExpr instanceof BinaryExpression) {
+                return transformBinaryExpression((BinaryExpression) transformedExpr);
+            }
+            if (transformedExpr instanceof ClosureExpression) {
+                // Closure expression contains code, but ClosureExpression.transform doesn't descend into it.
+                ClosureExpression closureExpression = (ClosureExpression) transformedExpr;
+                closureExpression.visit(this);
+            }
+            return transformedExpr;
+        }
+
+        private Expression transformBinaryExpression(BinaryExpression expr) {
+            String operation = expr.getOperation().getText();
+            Integer compoundOpType = COMPOUND_TO_OPERATOR.get(operation);
+            if (compoundOpType != null) {
+                return transformCompoundAssignment(expr, compoundOpType);
+            }
+            return expr;
+        }
+
+        /**
+         * Rewrites {@code foo <OP>= bar} into {@code (foo = foo.forCompoundAssignment() <OP> (bar)).toAssignmentResult()}.
+         *
+         * @param original the original compound assignment expression
+         * @param compoundOperation the added operation of assignment ({@code OP})
+         * @return the transformed expression
+         */
+        private Expression transformCompoundAssignment(BinaryExpression original, int compoundOperation) {
+            Expression lhs = original.getLeftExpression();
+            Expression rhs = original.getRightExpression();
+
+            if (!isValidDestination(lhs)) {
+                // Skip array element assignments and the likes?
+                return original;
+            }
+
+            // Rewriting `foo <OP>= bar` into `foo = foo.forCompoundAssignment() <OP> (bar)`.
+            BinaryExpression assignment = withSourceLocationOf(original, new BinaryExpression(
+                lhs,
+                rewriteToken(original.getOperation(), Types.ASSIGN),
+                withSourceLocationOf(original, new BinaryExpression(
+                    applyForCompoundAssignment(lhs),
+                    rewriteToken(original.getOperation(), compoundOperation),
+                    rhs
+                ))
+            ));
+            // Final rewrite: unwrap the result
+            return withSourceLocationOf(original, applyToAssignmentResult(assignment));
+        }
+
+        /**
+         * Builds a new token from the original, keeping the source position.
+         *
+         * @param originalOperation the original operation token
+         * @param newType the new token type
+         * @return the new token
+         */
+        private Token rewriteToken(Token originalOperation, int newType) {
+            return Token.newSymbol(newType, originalOperation.getStartLine(), originalOperation.getStartColumn());
+        }
+
+        /**
+         * @see CompoundAssignmentExtensions#forCompoundAssignment(Object)
+         */
+        private Expression applyForCompoundAssignment(Expression receiver) {
+            return callSupportMethodOn(receiver, "forCompoundAssignment");
+        }
+
+        /**
+         * @see CompoundAssignmentExtensions#toAssignmentResult(Object)
+         */
+        private Expression applyToAssignmentResult(Expression receiver) {
+            return callSupportMethodOn(receiver, "toAssignmentResult");
+        }
+
+        private Expression callSupportMethodOn(Expression receiver, String methodName) {
+            return withSourceLocationOf(receiver, new MethodCallExpression(
+                receiver,
+                methodName,
+                MethodCallExpression.NO_ARGUMENTS)
+            );
+        }
+
+        private static boolean isValidDestination(Expression expr) {
+            // We only rewrite compound assignments to non-primitive variables and properties.
+            if (expr instanceof VariableExpression) {
+                return !isPrimitiveVariable((VariableExpression) expr);
+            } else {
+                return expr instanceof PropertyExpression;
+            }
+        }
+
+        private static boolean isPrimitiveVariable(VariableExpression expr) {
+            return ClassHelper.isPrimitiveType(expr.getOriginType());
+        }
+
+        private static <T extends Expression> T withSourceLocationOf(Expression original, T transformed) {
+            transformed.setSourcePosition(original);
+            return transformed;
+        }
+
+        @Override
+        protected SourceUnit getSourceUnit() {
+            return sourceUnit;
+        }
+    }
+}

--- a/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/CompoundAssignmentTransformer.java
+++ b/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/CompoundAssignmentTransformer.java
@@ -43,6 +43,9 @@ import java.util.Map;
  * See the package documentation for the complete description.
  */
 public class CompoundAssignmentTransformer extends AbstractScriptTransformer {
+    static final String FOR_COMPOUND_ASSIGNMENT_METHOD_NAME = "forCompoundAssignment";
+    static final String TO_ASSIGNMENT_RESULT_METHOD_NAME = "toAssignmentResult";
+
     @Override
     protected int getPhase() {
         return Phases.CANONICALIZATION;
@@ -127,7 +130,7 @@ public class CompoundAssignmentTransformer extends AbstractScriptTransformer {
 
             // Rewriting `foo <OP>= bar` into `foo = foo.forCompoundAssignment() <OP> (bar)`.
             BinaryExpression assignment = withSourceLocationOf(original, new BinaryExpression(
-                lhs,
+                ExpressionUtils.copyExpression(lhs), // Sharing the same node in different branches may cause other transforms to overwrite their metadata.
                 rewriteToken(original.getOperation(), Types.ASSIGN),
                 withSourceLocationOf(original, new BinaryExpression(
                     applyForCompoundAssignment(lhs),
@@ -154,14 +157,14 @@ public class CompoundAssignmentTransformer extends AbstractScriptTransformer {
          * @see CompoundAssignmentExtensions#forCompoundAssignment(Object)
          */
         private Expression applyForCompoundAssignment(Expression receiver) {
-            return callSupportMethodOn(receiver, "forCompoundAssignment");
+            return callSupportMethodOn(receiver, FOR_COMPOUND_ASSIGNMENT_METHOD_NAME);
         }
 
         /**
          * @see CompoundAssignmentExtensions#toAssignmentResult(Object)
          */
         private Expression applyToAssignmentResult(Expression receiver) {
-            return callSupportMethodOn(receiver, "toAssignmentResult");
+            return callSupportMethodOn(receiver, TO_ASSIGNMENT_RESULT_METHOD_NAME);
         }
 
         private Expression callSupportMethodOn(Expression receiver, String methodName) {

--- a/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/ExpressionUtils.java
+++ b/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/ExpressionUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.groovy.support;
+
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.ExpressionTransformer;
+
+final class ExpressionUtils {
+    private ExpressionUtils() {}
+
+    private static final ExpressionTransformer COPY_TRANSFORMER = new ExpressionTransformer() {
+        @Override
+        public Expression transform(Expression expression) {
+            return expression.transformExpression(this);
+        }
+    };
+
+    /**
+     * Creates a deep-ish copy of the expression. This method relies on traverse capabilities of {@link Expression#transformExpression(ExpressionTransformer)}.
+     *
+     * @param expression the expression to copy
+     * @param <T> the type of the expression
+     * @return the deep copy of the expression
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends Expression> T copyExpression(T expression) {
+        return (T) expression.transformExpression(COPY_TRANSFORMER);
+    }
+}

--- a/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/package-info.java
+++ b/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/package-info.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Groovy-specific enhancements to various Gradle model types.
+ *
+ * <h2>Compound assignment support</h2>
+ * <h3>Implementation overview</h3>
+ * <p>
+ * Groovy supports multiple compound assignment operators (like {@code +=}, {@code -=}) for common types like List out of the box.
+ * However, unlike Kotlin, from the point of view of operator overloading,
+ * the compound assignment is not really an operator of its own, but a combination of assignment and the standalone operator.
+ * So, in order to support {@code +=} for your type, you need to define {@code plus()} method, which will also give support of {@code +}.
+ * <p>
+ * For some Gradle types, we want to support {@code +=} in a special way, which isn't compatible with common Groovy behavior.
+ * In particular, we want to emulate Groovy properties with {@code Property} type.
+ * For that we need to overload {@code +=} in a special way, to distinguish it from a standalone {@code +} use.
+ * In other words, {@code a += b} should work but {@code a = a + b} shouldn't.
+ * <p>
+ * We do this by utilizing an AST transformation.
+ * The source code of the transformation is in {@link org.gradle.api.internal.groovy.support.CompoundAssignmentTransformer}.
+ * It also relies on a number of extension methods, support classes and interfaces that your type has to provide.
+ * <p>
+ * Compound assignments can be used in two different contexts:
+ * <ul>
+ *     <li>
+ *         Updating a variable:
+ *         <pre>
+ *  def foo = objects.listProperty(String)
+ *  foo += ["a"]
+ *         </pre>
+ *         In this case, {@code foo} <b>reference</b> is updated with a (processed) result of {@code foo + ["a"]} expression.
+ *         It is not possible to intercept and handle the assignment part.
+ *     </li>
+ *     <li>
+ *         Updating a property of a Gradle-managed class:
+ *         <pre>
+ *  abstract class Bar {
+ *      abstract ListProperty&lt;String&gt; getFoo()
+ *  }
+ *  def bar = objects.newInstance(Bar)
+ *  bar.foo += ["a"]
+ *         </pre>
+ *         In this case, Gradle generates a synthetic setter that invokes {@code bar.foo.setFromAnyValue(bar.foo + ["a"])}.
+ *         No references are being reassigned.
+ *     </li>
+ * </ul>
+ * In both cases, source transformation kicks in and allows the implementation of {@code foo} to replace itself with something that knows how to handle {@code +} even if the {@code foo} itself cannot.
+ *
+ * <h3>How to override compound assignment for your type</h3>
+ * <p>
+ * Suppose you want to support {@code +=} expression for your type. You need too:
+ * <ol>
+ *     <li>
+ *         Define a class that will represent the sum. It must be useful on its own, because that is what will be assigned to the LHS variable.
+ *         This class must implement {@link org.gradle.api.internal.groovy.support.CompoundAssignmentResult} interface.
+ *     </li>
+ *     <li>
+ *         If the class you enhancing implements {@code LazyGroovySupport} then you can add custom assignment handling in the {@code setFromAnyValue} method,
+ *         by checking if the argument is of the type defined in the previous step. And if it doesn't then why do you bother with this stuff?
+ *         For example, instead of assigning its value as a whole, you can append its RHS side to the state of the class.
+ *         Do not rely on type alone, these sums may become detached from its original producer when created as part of a variable:
+ *         {@code def foo = bar.foo; foo += ["baz"]; bar.foo = foo }
+ *         <p>
+ *         A general recommendation is to also detach the sum implementation from the producer when {@code assignmentComplete} method is called:
+ *         it means that the object is out of scope of the original {@code +=} expression.
+ *     </li>
+ *     <li>
+ *         Define a <b>public</b> stand-in class that will handle {@code plus} operations.
+ *         You need an overload for each right-hand-side operand type. These methods should return sum instances defined in step (1).
+ *         The return type doesn't have to be the sum type, it can be its public supertype. The return type doesn't have to implement {@code Result}.
+ *     </li>
+ *     <li>
+ *         Define a <a href="https://blog.mrhaki.com/2013/01/groovy-goodness-adding-extra-methods.html">public Groovy extension method</a> named {@code forCompoundAssignment}
+ *         that accepts a <b>public</b> type of your class (e.g. {@code MapProperty} for {@code DefaultMapProperty} type) and returns a stand-in.
+ *     </li>
+ * </ol>
+ * Note that the extension method and the stand-in type and its methods become <b>public APIs</b> and must follow binary compatibility policy,
+ * though they aren't visible to the users. Compiled Groovy code may include references to these types and methods, especially if static compilation is used.
+ *
+ * <h3>Testing notes</h3>
+ * You may need to clean {@code intTestHomeDir/} in the root project for your integration tests to pick up new type definitions.
+ */
+@org.jspecify.annotations.NullMarked
+package org.gradle.api.internal.groovy.support;

--- a/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/package-info.java
+++ b/platforms/core-configuration/groovy-support/src/main/java/org/gradle/api/internal/groovy/support/package-info.java
@@ -93,6 +93,10 @@
  *
  * <h3>Testing notes</h3>
  * You may need to clean {@code intTestHomeDir/} in the root project for your integration tests to pick up new type definitions.
+ * <p>
+ * Extension methods and stand-ins are not covered by existing public API checks.
+ * So far we're using manual tests that verify class names and method signatures through Reflection API.
+ * See {@code CompoundAssignmentBinaryCompatibilityFixture} for extra information.
  */
 @org.jspecify.annotations.NullMarked
 package org.gradle.api.internal.groovy.support;

--- a/platforms/core-configuration/groovy-support/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/platforms/core-configuration/groovy-support/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,0 +1,19 @@
+#
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+moduleName=groovy-support
+moduleVersion=1.0
+extensionClasses=org.gradle.api.internal.groovy.support.CompoundAssignmentExtensions

--- a/platforms/core-configuration/groovy-support/src/test/groovy/org/gradle/api/internal/groovy/support/CompoundAssignmentPropertySpec.groovy
+++ b/platforms/core-configuration/groovy-support/src/test/groovy/org/gradle/api/internal/groovy/support/CompoundAssignmentPropertySpec.groovy
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.groovy.support
+
+import groovy.transform.CompileStatic
+import org.gradle.api.internal.provider.DefaultListProperty
+import org.gradle.api.internal.provider.DefaultMapProperty
+import org.gradle.api.internal.provider.DefaultSetProperty
+import org.gradle.api.internal.provider.PropertyHost
+import org.gradle.api.internal.provider.support.LazyGroovySupport
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import org.gradle.internal.evaluation.CircularEvaluationException
+import spock.lang.Specification
+
+@TransformCompoundAssignments
+abstract class CompoundAssignmentPropertySpec<P extends Provider<?>, T extends LazyGroovySupport & P> extends Specification {
+    protected PropertyHost host = Mock()
+
+    abstract T propertyImpl()
+
+    P property() { propertyImpl() }
+
+    abstract def value(String v)
+
+    abstract def asValue(def v)
+
+    abstract def addValue(P property, String v)
+
+    class Origin {
+        protected T value = propertyImpl()
+
+        P getValue() { value }
+
+        void setValue(def v) {
+            // This simulates what the AsmBackedClassGenerator does.
+            value.setFromAnyValue(v)
+        }
+    }
+
+    Origin newOrigin() { new Origin() }
+
+    def "compound operand can be applied to property"() {
+        given:
+        def lhs = new Origin()
+
+        expect:
+        (lhs.value += value("a")) == null
+        asValue(lhs.value.get()) == value("a")
+    }
+
+    def "compound operand can be applied to variable"() {
+        given:
+        def lhs = property()
+
+        expect:
+        (lhs += value("a")) == null
+        asValue(lhs.get()) == value("a")
+    }
+
+    def "updating the variable with compound operand does not change the property value"() {
+        // The in-place update magic only kicks in when LHS is a property of something.
+        // The plain assignment follows the same rule.
+        given:
+        def origin = property()
+        addValue(origin, "a")
+        def lhs = origin
+
+        when:
+        lhs += value("b")
+
+        then:
+        asValue(lhs.get()) == value("a") + value("b")
+        asValue(origin.get()) == value("a")
+    }
+
+    def "variable updated with compound operand tracks lhs updates"() {
+        given:
+        def origin = new Origin()
+        def lhs = origin.value
+
+        when:
+        lhs += value("a")
+        addValue(origin.value, "b")
+
+        then:
+        // note that lhs += "a" results in lhs + ["a"], so adding "b" to lhs effectively prepends it to the result.
+        asValue(lhs.get()) == value("b") + value("a")
+    }
+
+    def "special compound handling only applies inside the compound assignment expression"() {
+        // It is possible to snatch the result of the compound assignment and assign it back to the LHS property instance outside of += expression.
+        given:
+        def origin = new Origin()
+        def lhs = origin.value
+        lhs += value("a")
+        origin.value = lhs
+
+        when:
+        origin.value.get()
+
+        then:
+        thrown(CircularEvaluationException)
+    }
+
+    @TransformCompoundAssignments
+    static class CompoundAssignmentListPropertyTest extends CompoundAssignmentPropertySpec<ListProperty<String>, DefaultListProperty<String>> {
+        class ListOrigin extends Origin {
+            @Override
+            ListProperty<String> getValue() {
+                return super.getValue() as ListProperty<String>
+            }
+        }
+
+        @Override
+        ListOrigin newOrigin() { new ListOrigin() }
+
+        @Override
+        DefaultListProperty<String> propertyImpl() { new DefaultListProperty<>(host, String) }
+
+        @Override
+        def value(String v) { [v] }
+
+        @Override
+        def asValue(def result) { result as List<String> }
+
+        @Override
+        def addValue(ListProperty<String> property, String v) { property.add(v) }
+
+        @CompileStatic
+        def staticCompilationWorksWithVariables() {
+            def p = property()
+
+            def v = (p += ["a"])
+            return [v, p]
+        }
+
+        def "compound assignment works with variables and static compilation"() {
+            when:
+            def (v, p) = staticCompilationWorksWithVariables()
+
+            then:
+            v == null
+            asValue(p.get()) == ["a"]
+        }
+
+        @CompileStatic
+        def staticCompilationWorksWithProperties() {
+            def origin = newOrigin()
+
+            def v = (origin.value += ["a"])
+            return [v, origin.value]
+        }
+
+        def "compound assignment works with properties and static compilation"() {
+            when:
+            def (v, p) = staticCompilationWorksWithProperties()
+
+            then:
+            v == null
+            asValue(p.get()) == ["a"]
+        }
+    }
+
+    @TransformCompoundAssignments
+    static class CompoundAssignmentSetPropertyTest extends CompoundAssignmentPropertySpec<SetProperty<String>, DefaultSetProperty<String>> {
+        class SetOrigin extends Origin {
+            @Override
+            SetProperty<String> getValue() {
+                return super.getValue() as SetProperty<String>
+            }
+        }
+
+        @Override
+        SetOrigin newOrigin() { new SetOrigin() }
+
+        @Override
+        DefaultSetProperty<String> propertyImpl() { new DefaultSetProperty<>(host, String) }
+
+        @Override
+        def value(String v) { [v] }
+
+        @Override
+        def asValue(def result) { result as List<String> }
+
+        @Override
+        def addValue(SetProperty<String> property, String v) { property.add(v) }
+
+        @CompileStatic
+        def staticCompilationWorksWithVariables() {
+            def p = property()
+
+            def v = (p += ["a"])
+            return [v, p]
+        }
+
+        def "compound assignment works with variables and static compilation"() {
+            when:
+            def (v, p) = staticCompilationWorksWithVariables()
+
+            then:
+            v == null
+            asValue(p.get()) == ["a"]
+        }
+
+        @CompileStatic
+        def staticCompilationWorksWithProperties() {
+            def origin = newOrigin()
+
+            def v = (origin.value += ["a"])
+            return [v, origin.value]
+        }
+
+        def "compound assignment works with properties and static compilation"() {
+            when:
+            def (v, p) = staticCompilationWorksWithProperties()
+
+            then:
+            v == null
+            asValue(p.get()) == ["a"]
+        }
+    }
+
+    @TransformCompoundAssignments
+    static class CompoundAssignmentMapPropertyTest extends CompoundAssignmentPropertySpec<MapProperty<String, String>, DefaultMapProperty<String, String>> {
+        class MapOrigin extends Origin {
+            @Override
+            MapProperty<String, String> getValue() {
+                return super.getValue() as MapProperty<String, String>
+            }
+        }
+
+        @Override
+        MapOrigin newOrigin() { new MapOrigin() }
+
+        @Override
+        DefaultMapProperty<String, String> propertyImpl() { new DefaultMapProperty<>(host, String, String) }
+
+        @Override
+        def value(String v) { [(v): v] }
+
+        @Override
+        def asValue(def result) { result as Map<String, String> }
+
+        @Override
+        def addValue(MapProperty<String, String> property, String v) { property.put(v, v) }
+
+        @CompileStatic
+        def staticCompilationWorksWithVariables() {
+            def p = property()
+
+            def v = (p += [a:"a"])
+            return [v, p]
+        }
+
+        def "compound assignment works with variables and static compilation"() {
+            when:
+            def (v, p) = staticCompilationWorksWithVariables()
+
+            then:
+            v == null
+            asValue(p.get()) == [a:"a"]
+        }
+
+        @CompileStatic
+        def staticCompilationWorksWithProperties() {
+            def origin = newOrigin()
+
+            def v = (origin.value += [a:"a"])
+            return [v, origin.value]
+        }
+
+        def "compound assignment works with properties and static compilation"() {
+            when:
+            def (v, p) = staticCompilationWorksWithProperties()
+
+            then:
+            v == null
+            asValue(p.get()) == [a:"a"]
+        }
+    }
+}

--- a/platforms/core-configuration/groovy-support/src/test/groovy/org/gradle/api/internal/groovy/support/CompoundAssignmentUnrelatedSpec.groovy
+++ b/platforms/core-configuration/groovy-support/src/test/groovy/org/gradle/api/internal/groovy/support/CompoundAssignmentUnrelatedSpec.groovy
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.groovy.support
+
+import groovy.transform.CompileStatic
+import spock.lang.Specification
+
+/**
+ * This test verifies that the source transformation doesn't break types that do not support the custom compound assignment protocol.
+ */
+@TransformCompoundAssignments
+class CompoundAssignmentUnrelatedSpec extends Specification {
+    class Origin {
+        int intVal = 1
+        List<String> listVal = []
+    }
+
+    def "compound assignment works for integer variables"() {
+        given:
+        int i = 1
+
+        when:
+        def v = (i += 2)
+
+        then:
+        v == 3
+        i == 3
+    }
+
+    def "compound assignment works for integer properties"() {
+        given:
+        def origin = new Origin()
+
+        when:
+        def v = (origin.intVal += 2)
+
+        then:
+        v == 3
+        origin.intVal == 3
+    }
+
+    def "compound assignment works for list variables"() {
+        given:
+        def list = ["a"]
+
+        when:
+        def v = (list += ["b"])
+
+        then:
+        v == ["a", "b"]
+        list == ["a", "b"]
+        v === list
+    }
+
+    def "compound assignment works for list properties"() {
+        given:
+        def origin = new Origin()
+
+        when:
+        def v = (origin.listVal += ["a"])
+
+        then:
+        v == ["a"]
+        origin.listVal == ["a"]
+        origin.listVal === v
+    }
+
+    @CompileStatic
+    def intVarCompoundAssignment() {
+        int i = 1
+        def v = (i += 2)
+
+        return [i, v]
+    }
+
+    def "compound assignment works for integer variables with static typing"() {
+        given:
+        def (i, v) = intVarCompoundAssignment()
+
+        expect:
+        v == 3
+        i == 3
+    }
+
+    @CompileStatic
+    def intPropCompoundAssignment() {
+        def origin = new Origin()
+        def v = (origin.intVal += 2)
+        return [origin.intVal, v]
+    }
+
+    def "compound assignment works for integer properties with static typing"() {
+        given:
+        def (i, v) = intPropCompoundAssignment()
+
+        expect:
+        v == 3
+        i == 3
+    }
+
+    @CompileStatic
+    def listVarCompoundAssignment() {
+        def list = ["a"]
+        def v = (list += ["b"])
+
+        return [list, v]
+    }
+
+    def "compound assignment works for list variables with static typing"() {
+        given:
+        def (i, v) = listVarCompoundAssignment()
+
+        expect:
+        v == ["a", "b"]
+        i == ["a", "b"]
+        v === i
+    }
+
+    @CompileStatic
+    def listPropCompoundAssignment() {
+        def origin = new Origin()
+        def v = (origin.listVal += ["a"])
+        return [origin.listVal, v]
+    }
+
+    def "compound assignment works for list properties with static typing"() {
+        given:
+        def (i, v) = listPropCompoundAssignment()
+
+        expect:
+        v == ["a"]
+        i == ["a"]
+        v === i
+    }
+}

--- a/platforms/core-configuration/groovy-support/src/test/groovy/org/gradle/api/internal/groovy/support/ExtensionsApiStabilityTest.groovy
+++ b/platforms/core-configuration/groovy-support/src/test/groovy/org/gradle/api/internal/groovy/support/ExtensionsApiStabilityTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.groovy.support
+
+import spock.lang.Specification
+
+class ExtensionsApiStabilityTest extends Specification implements CompoundAssignmentBinaryCompatibilityFixture {
+    // This class verifies binary compatibility of non-public API used by Groovy static compilation.
+    // String are used intentionally to catch unexpected change to class name that breaks binary compatibility.
+    private static final String EXTENSION_CLASS_NAME = "org.gradle.api.internal.groovy.support.CompoundAssignmentExtensions"
+
+    def "compound assignment extensions are defined for Object"() {
+        given:
+        def extensionsClass = Class.forName(EXTENSION_CLASS_NAME)
+
+        expect:
+        assertHasForCompoundAssignmentMethod(extensionsClass, Object, Object)
+        assertHasToAssignmentResultMethod(extensionsClass, Object, Object)
+    }
+}

--- a/platforms/core-configuration/groovy-support/src/testFixtures/groovy/org/gradle/api/internal/groovy/support/CompoundAssignmentBinaryCompatibilityFixture.groovy
+++ b/platforms/core-configuration/groovy-support/src/testFixtures/groovy/org/gradle/api/internal/groovy/support/CompoundAssignmentBinaryCompatibilityFixture.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.groovy.support
+
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+/**
+ * Helper to test binary compatibility of compound assignment helper classes.
+ */
+trait CompoundAssignmentBinaryCompatibilityFixture {
+    static final String OP_PLUS = "plus"
+
+    void assertHasForCompoundAssignmentMethod(Class<?> extensionClass, Class<?> receiverType, Class<?> returnType) {
+        assertHasExtensionMethod(extensionClass, CompoundAssignmentTransformer.FOR_COMPOUND_ASSIGNMENT_METHOD_NAME, receiverType, returnType)
+    }
+
+    void assertHasToAssignmentResultMethod(Class<?> extensionClass, Class<?> receiverType, Class<?> returnType) {
+        assertHasExtensionMethod(extensionClass, CompoundAssignmentTransformer.TO_ASSIGNMENT_RESULT_METHOD_NAME, receiverType, returnType)
+    }
+
+    void assertHasExtensionMethod(Class<?> extensionClass, String methodName, Class<?> receiverType, Class<?> returnType) {
+        Method method
+        try {
+            method = extensionClass.getDeclaredMethod(methodName, receiverType)
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException(
+                "Could not find public static method ${returnType.name} ${extensionClass.name}.${methodName}(${receiverType.name})`", e)
+        }
+
+        assert isStatic(method)
+        assert isPublic(method)
+        assert method.returnType == returnType
+    }
+
+    void assertHasOperator(Class<?> receiverType, String operatorMethod, Class<?> rhsType, Class<?> returnType) {
+        Method method
+        try {
+            method = receiverType.getDeclaredMethod(operatorMethod, rhsType)
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException(
+                "Could not find operator public method ${returnType.name} ${receiverType.name}.${operatorMethod}(${rhsType.name})`", e)
+        }
+
+        assert !isStatic(method)
+        assert isPublic(method)
+        assert method.returnType == returnType
+    }
+
+    private boolean isStatic(Method method) {
+        return (method.modifiers & Modifier.STATIC) != 0
+    }
+
+    private boolean isPublic(Method method) {
+        return (method.modifiers & Modifier.PUBLIC) != 0
+    }
+}

--- a/platforms/core-configuration/groovy-support/src/testFixtures/java/org/gradle/api/internal/groovy/support/CompoundAssignmentTransformInTest.java
+++ b/platforms/core-configuration/groovy-support/src/testFixtures/java/org/gradle/api/internal/groovy/support/CompoundAssignmentTransformInTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.groovy.support;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+
+/**
+ * Applies compound operation transformer to a class or a method.
+ *
+ * @see TransformCompoundAssignments
+ * @see CompoundAssignmentTransformer
+ */
+@SuppressWarnings("unused")  // Applied by TransformCompoundAssignments annotation.
+@GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
+public class CompoundAssignmentTransformInTest implements ASTTransformation {
+    @Override
+    public void visit(ASTNode[] nodes, SourceUnit source) {
+        CompoundAssignmentTransformer.call(nodes[1], source);
+    }
+}

--- a/platforms/core-configuration/groovy-support/src/testFixtures/java/org/gradle/api/internal/groovy/support/TransformCompoundAssignments.java
+++ b/platforms/core-configuration/groovy-support/src/testFixtures/java/org/gradle/api/internal/groovy/support/TransformCompoundAssignments.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.groovy.support;
+
+import org.codehaus.groovy.transform.GroovyASTTransformationClass;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Applies the compound assignment transformation to a body of a unit test class/method.
+ * Useful for testing the assignment protocol.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@GroovyASTTransformationClass("org.gradle.api.internal.groovy.support.CompoundAssignmentTransformInTest")
+public @interface TransformCompoundAssignments {}

--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     testImplementation(projects.native)
     testImplementation(projects.resources)
     testImplementation(testFixtures(projects.coreApi))
+    testImplementation(testFixtures(projects.groovySupport))
     testImplementation(testFixtures(projects.languageGroovy))
     testImplementation(testFixtures(projects.modelReflect))
 

--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(projects.baseServicesGroovy)
     implementation(projects.baseAsm)
     implementation(projects.classloaders)
+    implementation(projects.groovySupport)
     implementation(projects.logging)
     implementation(projects.problemsApi)
     implementation(projects.serviceProvider)

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractProviderOperatorIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractProviderOperatorIntegrationTest.groovy
@@ -41,7 +41,7 @@ abstract class AbstractProviderOperatorIntegrationTest extends AbstractIntegrati
         }
     }
 
-    private static interface Failure {
+    static interface Failure {
         void assertHasExpectedFailure(ExecutionFailure failure);
     }
 

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/GroovyPropertyAssignmentIntegrationTest.groovy
@@ -22,6 +22,8 @@ import org.gradle.util.internal.ToBeImplemented
 import static org.gradle.integtests.fixtures.executer.GradleContextualExecuter.configCache
 
 class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIntegrationTest {
+    protected static final String EXPRESSION_PREFIX = "Expression value: "
+
     def "eager object properties assignment for #description"() {
         def inputDeclaration = "$inputType input"
         groovyBuildFile(inputDeclaration, inputValue, "=")
@@ -136,32 +138,39 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expressionValue)
+        }
 
         where:
-        description                              | operation | inputType                       | inputValue                                               | expectedResult
-        "Collection<T> = null"                   | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'undefined'
-        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("Cannot set the value of a property of type java.util.List using an instance of type [LMyObject;")
-        "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'
-        "Collection<T> = provider { null }"      | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'
-        "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'
-        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T"                     | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | '[a]'
-        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<T>"           | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | '[a]'
-        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T[]"                   | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("Cannot cast object")
-        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> << Iterable<T>"           | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.util.ArrayList")
-        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<Iterable<T>>" | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.util.ArrayList")
-        "Map<K, V> = null"                       | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'undefined'
-        "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '{a=b}'
-        "Map<K, V> = provider { null }"          | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'
-        "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '{a=b}'
-        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Map<K, V>"                 | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '{a=b}'
-        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Provider<Map<K, V>>"       | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '{a=b}'
+        description                               | operation | inputType                       | inputValue                                               | expressionValue | expectedResult
+        "Collection<T> = null"                    | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'null'          | 'undefined'
+        "Collection<T> = T[]"                     | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | _               | unsupportedWithCause("Cannot set the value of a property of type java.util.List using an instance of type [LMyObject;")
+        "Collection<T> = Iterable<T>"             | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'           | '[a]'
+        "Collection<T> = provider { null }"       | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Collection<T> = Provider<Iterable<T>>"   | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'           | '[a]'
+        "Collection<T> += T"                      | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | 'null'          | '[a]'
+        "Collection<T> += !T"                     | "+="      | "ListProperty<MyObject>"        | '"a"'                                                    | _               | unsupportedWithCause("Cannot add an element of type String to a property of type List<MyObject>")
+        "Collection<T> << T"                      | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | '[a]'           | '[a]'
+        "Collection<T> += provider { null }"      | "+="      | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'null'          | 'undefined'
+        "Collection<T> += Provider<T>"            | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | 'null'          | '[a]'
+        "Collection<T> += Provider<!T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { "a" }'                                       | _               | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.lang.String")
+        "Collection<T> << Provider<T>"            | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | '[a]'           | '[a]'
+        "Collection<T> += T[]"                    | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | 'null'          | '[a]'
+        "Collection<T> << T[]"                    | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | _               | unsupportedWithCause("Cannot cast object")
+        "Collection<T> += Iterable<T>"            | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | 'null'          | '[a]'
+        "Collection<T> << Iterable<T>"            | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | _               | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.util.ArrayList")
+        "Collection<T> += Provider<Iterable<T>>"  | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | 'null'          | '[a]'
+        "Collection<T> += Provider<Iterable<!T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { ["a"] as Iterable<String> }'                 | _               | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.lang.String.")
+        "Collection<T> << Provider<Iterable<T>>"  | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | _               | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.util.ArrayList")
+        "Map<K, V> = null"                        | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'null'          | 'undefined'
+        "Map<K, V> = Map<K, V>"                   | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'         | '{a=b}'
+        "Map<K, V> = provider { null }"           | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Map<K, V> = Provider<Map<K, V>>"         | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'         | '{a=b}'
+        "Map<K, V> += Map<K, V>"                  | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | 'null'          | '{a=b}'
+        "Map<K, V> << Map<K, V>"                  | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '{a=b}'         | '{a=b}'
+        "Map<K, V> += Provider<Map<K, V>>"        | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | 'null'          | '{a=b}'
+        "Map<K, V> << Provider<Map<K, V>>"        | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '{a=b}'         | '{a=b}'
     }
 
     def "lazy collection variables assignment for #description"() {
@@ -170,32 +179,36 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expressionValue)
+        }
 
         where:
-        description                              | operation | inputType                       | inputValue                                               | expectedResult
-        "Collection<T> = null"                   | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'null'
-        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | '[a]'
-        "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'
-        "Collection<T> = provider { null }"      | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'
-        "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'
-        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T"                     | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | '[a]'
-        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<T>"           | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | '[a]'
-        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("No signature of method")
-        "Collection<T> << T[]"                   | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | unsupportedWithCause("Cannot cast object")
-        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("No signature of method")
-        "Collection<T> << Iterable<T>"           | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.util.ArrayList")
-        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("No signature of method")
-        "Collection<T> << Provider<Iterable<T>>" | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.util.ArrayList")
-        "Map<K, V> = null"                       | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'null'
-        "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'
-        "Map<K, V> = provider { null }"          | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'
-        "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'
-        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Map<K, V>"                 | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '{a=b}'
-        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | unsupportedWithCause("No signature of method")
-        "Map<K, V> << Provider<Map<K, V>>"       | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '{a=b}'
+        description                              | operation | inputType                       | inputValue                                               | expressionValue | expectedResult
+        "Collection<T> = null"                   | "="       | "ListProperty<MyObject>"        | 'null'                                                   | 'null'          | 'null'
+        "Collection<T> = T[]"                    | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | '[a]'           | '[a]'
+        "Collection<T> = Iterable<T>"            | "="       | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | '[a]'           | '[a]'
+        "Collection<T> = provider { null }"      | "="       | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Collection<T> = Provider<Iterable<T>>"  | "="       | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | '[a]'           | '[a]'
+        "Collection<T> += T"                     | "+="      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | 'null'          | '[a]'
+        "Collection<T> << T"                     | "<<"      | "ListProperty<MyObject>"        | 'new MyObject("a")'                                      | '[a]'           | '[a]'
+        "Collection<T> += provider { null }"     | "+="      | "ListProperty<MyObject>"        | 'provider { null }'                                      | 'null'          | 'undefined'
+        "Collection<T> += Provider<T>"           | "+="      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | 'null'          | '[a]'
+        "Collection<T> << Provider<T>"           | "<<"      | "ListProperty<MyObject>"        | 'provider { new MyObject("a") }'                         | '[a]'           | '[a]'
+        "Collection<T> += T[]"                   | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | 'null'          | '[a]'
+        "Collection<T> << T[]"                   | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as MyObject[]'                      | _               | unsupportedWithCause("Cannot cast object")
+        "Collection<T> += Iterable<T>"           | "+="      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | 'null'          | '[a]'
+        "Collection<T> << Iterable<T>"           | "<<"      | "ListProperty<MyObject>"        | '[new MyObject("a")] as Iterable<MyObject>'              | _               | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.util.ArrayList")
+        "Collection<T> += Provider<Iterable<T>>" | "+="      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | 'null'          | '[a]'
+        "Collection<T> << Provider<Iterable<T>>" | "<<"      | "ListProperty<MyObject>"        | 'provider { [new MyObject("a")] as Iterable<MyObject> }' | _               | unsupportedWithCause("Cannot get the value of a property of type java.util.List with element type MyObject as the source value contains an element of type java.util.ArrayList")
+        "Map<K, V> = null"                       | "="       | "MapProperty<String, MyObject>" | 'null'                                                   | 'null'          | 'null'
+        "Map<K, V> = Map<K, V>"                  | "="       | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '[a:b]'         | '[a:b]'
+        "Map<K, V> = provider { null }"          | "="       | "MapProperty<String, MyObject>" | 'provider { null }'                                      | 'undefined'     | 'undefined'
+        "Map<K, V> = Provider<Map<K, V>>"        | "="       | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '[a:b]'         | '[a:b]'
+        "Map<K, V> += Map<K, V>"                 | "+="      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | 'null'          | '[a:b]'
+        "Map<K, V> << Map<K, V>"                 | "<<"      | "MapProperty<String, MyObject>" | '["a": new MyObject("b")]'                               | '{a=b}'         | '{a=b}'
+        "Map<K, V> += Provider<Map<K, V>>"       | "+="      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | 'null'          | '[a:b]'
+        "Map<K, V> << Provider<Map<K, V>>"       | "<<"      | "MapProperty<String, MyObject>" | 'provider { ["a": new MyObject("b")] }'                  | '{a=b}'         | '{a=b}'
     }
 
     def "eager FileCollection properties assignment for #description"() {
@@ -204,6 +217,9 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expectedResult)
+        }
 
         where:
         description                        | operation | inputType        | inputValue        | expectedResult
@@ -213,10 +229,10 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         "FileCollection = Iterable<File>"  | "="       | "FileCollection" | '[file("a.txt")]' | unsupportedWithCause("Cannot cast object")
         "FileCollection += FileCollection" | "+="      | "FileCollection" | 'files("a.txt")'  | '[a.txt]'
         "FileCollection << FileCollection" | "<<"      | "FileCollection" | 'files("a.txt")'  | unsupportedWithCause("No signature of method")
-        "FileCollection += Object"         | "+="      | "FileCollection" | '"a.txt"'         | unsupportedWithCause("Cannot cast object")
-        "FileCollection += File"           | "+="      | "FileCollection" | 'file("a.txt")'   | unsupportedWithCause("Cannot cast object")
-        "FileCollection += Iterable<?>"    | "+="      | "FileCollection" | '["a.txt"]'       | unsupportedWithCause("Cannot cast object")
-        "FileCollection += Iterable<File>" | "+="      | "FileCollection" | '[file("a.txt")]' | unsupportedWithCause("Cannot cast object")
+        "FileCollection += Object"         | "+="      | "FileCollection" | '"a.txt"'         | unsupportedWithCause("No signature of method")
+        "FileCollection += File"           | "+="      | "FileCollection" | 'file("a.txt")'   | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<?>"    | "+="      | "FileCollection" | '["a.txt"]'       | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<File>" | "+="      | "FileCollection" | '[file("a.txt")]' | unsupportedWithCause("No signature of method")
     }
 
     def "lazy FileCollection properties assignment for #description"() {
@@ -225,6 +241,9 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expectedResult)
+        }
 
         where:
         description                        | operation | inputType                    | inputValue              | expectedResult
@@ -233,13 +252,13 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         "FileCollection = Object"          | "="       | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("Failed to cast object")
         "FileCollection = File"            | "="       | "ConfigurableFileCollection" | 'file("a.txt")'         | unsupportedWithCause("Failed to cast object")
         "FileCollection = Iterable<File>"  | "="       | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("Failed to cast object")
-        "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | unsupportedWithCause("Self-referencing ConfigurableFileCollections are not supported. Use the from() method to add to a ConfigurableFileCollection.")
+        "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | '[a.txt]'
         "FileCollection << FileCollection" | "<<"      | "ConfigurableFileCollection" | 'files("a.txt")'        | unsupportedWithCause("No signature of method")
-        "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | unsupportedWithCause("Failed to cast object")
-        "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("Failed to cast object")
-        "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'         | unsupportedWithCause("Failed to cast object")
-        "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | '["a.txt"]'             | unsupportedWithCause("Failed to cast object")
-        "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("Failed to cast object")
+        "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | unsupportedWithCause("No signature of method")
+        "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("No signature of method")
+        "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'         | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | '["a.txt"]'             | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("No signature of method")
     }
 
     @ToBeImplemented("Needs a fix for -= cycle detection")
@@ -261,6 +280,9 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
         expect:
         runAndAssert("myTask", expectedResult)
+        if (expectedResult !instanceof Failure) {
+            assertExpression(expectedResult)
+        }
 
         where:
         description                        | operation | inputType                    | inputValue              | expectedType                 | expectedResult
@@ -271,11 +293,114 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         "FileCollection = Iterable<File>"  | "="       | "ConfigurableFileCollection" | '[file("a.txt")]'       | "List"                       | "[a.txt]"
         "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | "FileCollection"             | "[a.txt]"
         "FileCollection << FileCollection" | "<<"      | "ConfigurableFileCollection" | 'files("a.txt")'        | ""                           | unsupportedWithCause("No signature of method")
-        "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | "List"                       | "[a.txt]"
-        "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | "List"                       | "[a.txt]"
-        "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'         | "List"                       | "[a.txt]"
-        "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | '["a.txt"]'             | "List"                       | "[a.txt]"
-        "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | "List"                       | "[a.txt]"
+        "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | "List"                       | unsupportedWithCause("No signature of method")
+        "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | "List"                       | unsupportedWithCause("No signature of method")
+        "FileCollection += File"           | "+="      | "ConfigurableFileCollection" | 'file("a.txt")'         | "List"                       | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<?>"    | "+="      | "ConfigurableFileCollection" | '["a.txt"]'             | "List"                       | unsupportedWithCause("No signature of method")
+        "FileCollection += Iterable<File>" | "+="      | "ConfigurableFileCollection" | '[file("a.txt")]'       | "List"                       | unsupportedWithCause("No signature of method")
+    }
+
+    def "variable can be used as task input after #description"() {
+        buildFile """
+            ${groovyTypesDefinition()}
+            import static ${org.gradle.api.internal.provider.Providers.name}.changing
+
+            abstract class MyTask extends DefaultTask {
+                @Input
+                abstract $inputType getInput()
+
+                @TaskAction
+                def action() {
+                    ${groovyInputPrintRoutine(RESULT_PREFIX)}
+                }
+            }
+
+            tasks.register("myTask", MyTask) {
+                def property = $factory
+                property += $value
+                input = property
+            }
+        """
+
+        expect:
+        runAndAssert("myTask", expectedResult)
+
+        where:
+        description                                  | inputType                     | factory     | value                    | expectedResult
+        "ListProperty<T> += T"                       | "ListProperty<String>"        | listFactory | '"a"'                    | "[a]"
+        "ListProperty<T> += Collection<T>"           | "ListProperty<String>"        | listFactory | '["a"]'                  | "[a]"
+        "ListProperty<T> += Provider<T>"             | "ListProperty<String>"        | listFactory | 'provider { "a" }'       | "[a]"
+        "ListProperty<T> += Provider<Collection<T>>" | "ListProperty<String>"        | listFactory | 'provider { ["a"] }'     | "[a]"
+        "SetProperty<T> += T"                        | "SetProperty<String>"         | setFactory  | '"a"'                    | "[a]"
+        "SetProperty<T> += Collection<T>"            | "SetProperty<String>"         | setFactory  | '["a"]'                  | "[a]"
+        "SetProperty<T> += Provider<T>"              | "SetProperty<String>"         | setFactory  | 'provider { "a" }'       | "[a]"
+        "SetProperty<T> += Provider<Collection<T>>"  | "SetProperty<String>"         | setFactory  | 'provider { ["a"] }'     | "[a]"
+        "MapProperty<K,V> += Map<K,V>"               | "MapProperty<String, String>" | mapFactory  | '["a":"b"]'              | "{a=b}"
+        "MapProperty<K,V> += Provider<Map<K,V>>"     | "MapProperty<String, String>" | mapFactory  | 'provider { ["a":"b"] }' | "{a=b}"
+    }
+
+    // We need these properties to have changing values so the tests trigger CC-serialization of intermediate providers created by += implementation.
+    private static String getListFactory() { "objects.listProperty(String).value(changing {[]})" }
+
+    private static String getSetFactory() { "objects.setProperty(String).value(changing {[]})" }
+
+    private static String getMapFactory() { "objects.mapProperty(String, String).value(changing {[:]})" }
+
+    def "compound assignment preserves dependencies"() {
+        given:
+        buildFile """
+            abstract class MyTask extends DefaultTask {
+                @OutputFile abstract RegularFileProperty getOutputFile()
+
+                MyTask() {
+                    outputFile.convention(project.layout.buildDirectory.file(name + ".txt"))
+                }
+
+                @TaskAction
+                def action() {
+                    outputFile.get().asFile.text = name
+                }
+            }
+
+            def t1 = tasks.register("t1", MyTask)
+            def t2 = tasks.register("t2", MyTask)
+            def t3 = tasks.register("t3", MyTask)
+            def t4 = tasks.register("t4", MyTask)
+
+            tasks.register("echo") {
+                Closure<Provider<String>> outputAsText = { t -> t.flatMap { it.outputFile }.map { it.asFile.text.trim() }}
+
+                def lines = objects.listProperty(String)
+                lines.add(outputAsText(t1))
+                lines += outputAsText(t2)
+
+                def mapLines = objects.mapProperty(String, String)
+                mapLines.put("k3", outputAsText(t3))
+                mapLines += outputAsText(t4).map { [k4: it] }
+
+                inputs.property("lines", lines)
+                inputs.property("mapLines", mapLines)
+
+                doLast {
+                    lines.get().forEach {
+                        println("line: \$it")
+                    }
+                    mapLines.get().forEach { k, v ->
+                        println("mapLine: \$k=\$v")
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds("echo")
+
+        then:
+        result.assertTasksExecuted(":t1", ":t2", ":t3", ":t4", ":echo")
+        outputContains("line: t1")
+        outputContains("line: t2")
+        outputContains("mapLine: k3=t3")
+        outputContains("mapLine: k4=t4")
     }
 
     def "Groovy assignment for ConfigurableFileCollection doesn't resolve a Configuration"() {
@@ -337,6 +462,75 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         run("help")
     }
 
+    @ToBeImplemented
+    def "compound assignments work in plugins too"() {
+        given:
+        createDir("plugin") {
+            buildFile(file("build.gradle"), """
+                plugins {
+                    id "groovy"
+                    id "java-gradle-plugin"
+                }
+
+                dependencies {
+                    implementation gradleApi()
+                    implementation localGroovy()
+                }
+
+                gradlePlugin {
+                    plugins {
+                        pluginInGroovy {
+                            id = "org.example.plugin-in-groovy"
+                            implementationClass = "org.example.PluginInGroovy"
+                        }
+                    }
+                }
+            """)
+
+            file("src/main/groovy/org/example/PluginInGroovy.groovy") << """
+                package org.example
+
+                import org.gradle.api.Plugin
+                import org.gradle.api.Project
+                import org.gradle.api.provider.ListProperty
+
+                abstract class PluginInGroovy implements Plugin<Project> {
+                    abstract ListProperty<String> getStringList()
+
+                    @Override
+                    void apply(Project target) {
+                        stringList += ["a", "b"]
+
+                        target.tasks.register("printProperties") {
+                            def stringList = stringList
+                            doLast {
+                                println("stringList = \${stringList.get()}")
+                            }
+                        }
+                    }
+                }
+            """
+        }
+
+        settingsFile """
+            pluginManagement {
+                includeBuild("plugin")
+            }
+        """
+
+        buildFile """
+            plugins {
+                id("org.example.plugin-in-groovy")
+            }
+        """
+
+        expect:
+        fails("printProperties")
+
+        // TODO(mlopatkin): With the AST transformation applied globally this should succeed and print the property.
+        // outputContains("stringList = [a, b]")
+    }
+
     private void groovyBuildFile(String inputDeclaration, String inputValue, String operation) {
         buildFile.text = """
             ${groovyTypesDefinition()}
@@ -347,12 +541,16 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
                 @TaskAction
                 void run() {
-                    ${groovyInputPrintRoutine()}
+                    ${groovyInputPrintRoutine(RESULT_PREFIX, "input")}
                 }
             }
 
             tasks.register("myTask", MyTask) {
-                input $operation $inputValue
+                def result = (input $operation $inputValue)
+
+                doLast {
+                    ${groovyInputPrintRoutine(EXPRESSION_PREFIX, "result")}
+                }
             }
         """
     }
@@ -363,10 +561,11 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
 
             tasks.register("myTask") {
                 def input = $inputInitializer
-                input $operation $inputValue
+                def result = (input $operation $inputValue)
                 ${expectedType ? "assert input instanceof $expectedType" : ""}
                 doLast {
-                    ${groovyInputPrintRoutine()}
+                    ${groovyInputPrintRoutine(RESULT_PREFIX, "input")}
+                    ${groovyInputPrintRoutine(EXPRESSION_PREFIX, "result")}
                 }
             }
         """
@@ -390,21 +589,27 @@ class GroovyPropertyAssignmentIntegrationTest extends AbstractProviderOperatorIn
         """
     }
 
-    private String groovyInputPrintRoutine() {
+    private String groovyInputPrintRoutine(String prefix = RESULT_PREFIX, String variable = "input") {
         """
-            if (input instanceof FileSystemLocationProperty) {
-                println("$RESULT_PREFIX" + input.map { it.asFile.name }.getOrElse("undefined"))
-            } else if (input instanceof File) {
-               println("$RESULT_PREFIX" + input.name)
-            } else if (input instanceof Provider) {
-                println("$RESULT_PREFIX" + input.map { it.toString() }.getOrElse("undefined"))
-            } else if (input instanceof FileCollection) {
-                println("$RESULT_PREFIX" + input.files.collect { it.name })
-            } else if (input instanceof Iterable) {
-                println("$RESULT_PREFIX" + input.collect { it instanceof File ? it.name : it })
+            if (${variable} instanceof FileSystemLocationProperty) {
+                println("$prefix" + ${variable}.map { it.asFile.name }.getOrElse("undefined"))
+            } else if (${variable} instanceof File) {
+               println("$prefix" + ${variable}.name)
+            } else if (${variable} instanceof Provider) {
+                println("$prefix" + ${variable}.map { it.toString() }.getOrElse("undefined"))
+            } else if (${variable} instanceof FileCollection) {
+                println("$prefix" + ${variable}.files.collect { it.name })
+            } else if (${variable} instanceof Iterable) {
+                println("$prefix" + ${variable}.collect { it instanceof File ? it.name : it })
+            } else if (${variable}?.getClass()?.isArray()) {
+                println("$prefix" + Arrays.toString(${variable}))
             } else {
-                println("$RESULT_PREFIX" + input.toString())
+                println("$prefix" + ${variable})
             }
         """
+    }
+
+    private void assertExpression(def value) {
+        outputContains(EXPRESSION_PREFIX + value)
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyCompoundAssignmentResult.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyCompoundAssignmentResult.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import com.google.common.base.Preconditions;
+import org.gradle.api.internal.groovy.support.CompoundAssignmentResult;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * A helper class to implement an intermediate result of a compound assignment operation, like "+=".
+ * It is then assigned to the left-hand side operand. When the LHS is a Property-typed property of some Gradle-enhanced object, then the assignment action is invoked.
+ */
+final class CollectionPropertyCompoundAssignmentResult<T> extends AbstractMinimalProvider<T> implements CompoundAssignmentResult {
+    private final ProviderInternal<T> value;
+    private @Nullable Object owner;
+    private @Nullable Runnable assignToOwnerAction;
+
+    /**
+     * Creates the result for {@code owner <OP> rhs} operation.
+     *
+     * @param value the intermediate value of the operation, used when LHS is a variable or non-Gradle enhanced property
+     * @param owner the LHS operand of the compound operation
+     * @param assignToOwnerAction the mutation of the owner
+     */
+    public CollectionPropertyCompoundAssignmentResult(ProviderInternal<T> value, Object owner, Runnable assignToOwnerAction) {
+        this.value = value;
+        this.owner = owner;
+        this.assignToOwnerAction = Objects.requireNonNull(assignToOwnerAction);
+    }
+
+    public boolean isOwnedBy(Object target) {
+        // It might be that this object escaped its origin expression, in which case it is considered a normal provider.
+        return target == owner;
+    }
+
+    public void assignToOwner() {
+        Runnable action = assignToOwnerAction;
+        Preconditions.checkState(action != null, "The property is already consumed by the owner");
+        detach();
+        action.run();
+    }
+
+    private void detach() {
+        owner = null;
+        assignToOwnerAction = null;
+    }
+
+    @Override
+    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+        return value.calculateValue(consumer);
+    }
+
+    @Override
+    public boolean calculatePresence(ValueConsumer consumer) {
+        return value.calculatePresence(consumer);
+    }
+
+    @Override
+    public ExecutionTimeValue<? extends T> calculateExecutionTimeValue() {
+        return value.calculateExecutionTimeValue();
+    }
+
+    @Nullable
+    @Override
+    public Class<T> getType() {
+        return value.getType();
+    }
+
+    @Override
+    public ValueProducer getProducer() {
+        return value.getProducer();
+    }
+
+    @Override
+    protected String toStringNoReentrance() {
+        return value.toString();
+    }
+
+    @Override
+    public void assignmentComplete() {
+        // When the expression involves a variable on the left side as opposed to a field, then this provider becomes its value.
+        // It must lose all "magical" properties towards its owner, because it may be used to set its value outside the original expression.
+        detach();
+    }
+
+    @Override
+    public boolean shouldDiscardResult() {
+        // We don't support using foo += bar as a subexpression for properties.
+        return true;
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyCompoundAssignmentStandIn.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyCompoundAssignmentStandIn.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import org.gradle.api.provider.HasMultipleValues;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.Cast;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.gradle.api.internal.lambdas.SerializableLambdas.bifunction;
+import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
+
+/**
+ * This class acts as a replacement to call {@code +} on when evaluating {@code AbstractCollectionProperty += <RHS>} expressions in Groovy code.
+ *
+ * <b>This is a hidden public API</b>. Compiling Groovy code that depends on Gradle API may end up emitting references to methods of this class.
+ * @see CollectionPropertyCompoundAssignmentResult
+ */
+public final class CollectionPropertyCompoundAssignmentStandIn<T> {
+    private final AbstractCollectionProperty<T, ?> lhs;
+
+    CollectionPropertyCompoundAssignmentStandIn(HasMultipleValues<T> lhs) {
+        this.lhs = Cast.uncheckedCast(lhs);
+    }
+
+    // Called for property += Iterable<T>
+    public Provider<Iterable<T>> plus(Iterable<T> rhs) {
+        return plusImpl(rhs);
+    }
+
+    // Called for property += T[]
+    public Provider<Iterable<T>> plus(T[] items) {
+        return plusImpl(Arrays.asList(items));
+    }
+
+    private Provider<Iterable<T>> plusImpl(Iterable<T> rhs) {
+        return new CollectionPropertyCompoundAssignmentResult<>(
+            Providers.internal(lhs.map(transformer(items -> Iterables.concat(items, rhs)))),
+            lhs,
+            () -> lhs.addAll(rhs)
+        );
+    }
+
+    // Called for:
+    // property += Provider<Iterable<T>>
+    // property += Provider<T>
+    public Provider<Iterable<T>> plus(Provider<?> rhs) {
+        // Because of type erasure, we cannot have two overloads of this method for Provider<T> and Provider<Iterable<T>>.
+        return plusImpl(Providers.internal(rhs));
+    }
+
+    private Provider<Iterable<T>> plusImpl(ProviderInternal<?> rhs) {
+        ProviderInternal<? extends Iterable<T>> safeProvider = toSafeProvider(rhs);
+        return new CollectionPropertyCompoundAssignmentResult<>(
+            Providers.internal(lhs.zip(safeProvider, bifunction(Iterables::concat))),
+            lhs,
+            () -> lhs.addAll(safeProvider)
+        );
+    }
+
+    // Called for property += T
+    public Provider<Iterable<T>> plus(T item) {
+        return plusImpl(item);
+    }
+
+    private Provider<Iterable<T>> plusImpl(Object item) {
+        Preconditions.checkNotNull(item, "Cannot add a null element to a property of type %s.", lhs.getType().getSimpleName());
+        Preconditions.checkArgument(
+            lhs.getElementType().isInstance(item),
+            "Cannot add an element of type %s to a property of type %s<%s>.",
+            item.getClass().getSimpleName(),
+            lhs.getType().getSimpleName(),
+            lhs.getElementType().getSimpleName());
+        T safeItem = lhs.getElementType().cast(item);
+
+        return new CollectionPropertyCompoundAssignmentResult<>(
+            Providers.internal(lhs.map(transformer(thisItems -> Iterables.concat(thisItems, Collections.singleton(safeItem))))),
+            lhs,
+            () -> lhs.add(safeItem)
+        );
+    }
+
+    private static <T> ProviderInternal<? extends Iterable<T>> toSafeProvider(Provider<?> provider) {
+        ProviderInternal<?> internal = Providers.internal(provider);
+        if (isProviderOfIterable(internal)) {
+            // This is definitely a provider of iterable, it can be used as is.
+            return Cast.uncheckedCast(internal);
+        }
+        // May still be provider of iterable, but we'll only know after it is computed.
+        return internal.map(transformer(value -> {
+            if (value instanceof Iterable) {
+                return Cast.<Iterable<T>>uncheckedCast(value);
+            }
+            return Collections.singleton(Cast.uncheckedCast(value));
+        }));
+    }
+
+    private static boolean isProviderOfIterable(ProviderInternal<?> internal) {
+        Class<?> type = internal.getType();
+        return type != null && Iterable.class.isAssignableFrom(type);
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyExtensions.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyExtensions.java
@@ -17,7 +17,9 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.provider.HasMultipleValues;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
 
 @SuppressWarnings("unused") // registered as Groovy extension in ExtensionModule
 public final class CollectionPropertyExtensions {
@@ -50,5 +52,19 @@ public final class CollectionPropertyExtensions {
     public static <T> HasMultipleValues<T> leftShift(HasMultipleValues<T> self, Provider<? extends T> provider) {
         self.add(provider);
         return self;
+    }
+
+    /**
+     * Creates a stand-in for {@link ListProperty} or {@link SetProperty} to be used as a left-hand side operand of {@code +=}.
+     * <p>
+     * The AST transformer knows the name of this method.
+     *
+     * @param lhs the property
+     * @param <T> the type of property elements, to help the static type checker
+     * @return the stand-in object to call {@code plus} on
+     * @see org.gradle.api.internal.groovy.support.CompoundAssignmentTransformer
+     */
+    public static <T> CollectionPropertyCompoundAssignmentStandIn<T> forCompoundAssignment(HasMultipleValues<T> lhs) {
+        return ((AbstractCollectionProperty<T, ?>) lhs).forCompoundAssignment();
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -145,9 +145,18 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
     @SuppressWarnings("unchecked")
     public void setFromAnyValue(@Nullable Object object) {
         if (object == null || object instanceof Map<?, ?>) {
-            set((Map) object);
-        } else if (object instanceof Provider<?>) {
-            set((Provider) object);
+            set((Map<K, V>) object);
+            return;
+        }
+        if (object instanceof CollectionPropertyCompoundAssignmentResult<?>) {
+            CollectionPropertyCompoundAssignmentResult<?> compoundAssignmentResult = (CollectionPropertyCompoundAssignmentResult<?>) object;
+            if (compoundAssignmentResult.isOwnedBy(this)) {
+                compoundAssignmentResult.assignToOwner();
+                return;
+            }
+        }
+        if (object instanceof Provider<?>) {
+            set((Provider<Map<K, V>>) object);
         } else {
             throw new IllegalArgumentException(String.format(
                 "Cannot set the value of a property of type %s using an instance of type %s.", Map.class.getName(), object.getClass().getName()));
@@ -685,5 +694,14 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         public String toString() {
             return entries.toString();
         }
+    }
+
+    /**
+     * Returns a stand-in that defines operations for Groovy's {@code <OP>=} expression.
+     *
+     * @return the stand-in to call the operation on
+     */
+    public MapPropertyCompoundAssignmentStandIn<K, V> forCompoundAssignment() {
+        return new MapPropertyCompoundAssignmentStandIn<>(this);
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapPropertyCompoundAssignmentStandIn.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapPropertyCompoundAssignmentStandIn.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.gradle.api.internal.groovy.support.CompoundAssignmentTransformer;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Provider;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.gradle.api.internal.lambdas.SerializableLambdas.bifunction;
+import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
+
+/**
+ * This class acts as a replacement to call {@code +} on when evaluating {@code DefaultMapProperty += <RHS>} expressions in Groovy code.
+ *
+ * <b>This is a hidden public API</b>. Compiling Groovy code that depends on Gradle API may end up emitting references to methods of this class.
+ *
+ * @see CompoundAssignmentTransformer
+ */
+public final class MapPropertyCompoundAssignmentStandIn<K, V> {
+    private final MapProperty<K, V> lhs;
+
+    MapPropertyCompoundAssignmentStandIn(MapProperty<K, V> lhs) {
+        this.lhs = lhs;
+    }
+
+    // Called for property += Map<K,V>
+    public Provider<Map<K, V>> plus(Map<K, V> rhs) {
+        return new CollectionPropertyCompoundAssignmentResult<>(
+            Providers.internal(lhs.map(transformer(left -> concat(left, rhs)))),
+            lhs,
+            () -> lhs.putAll(rhs)
+        );
+    }
+
+    // Called for property += Provider<Map<K,V>>
+    public Provider<Map<K, V>> plus(Provider<? extends Map<K, V>> rhs) {
+        return new CollectionPropertyCompoundAssignmentResult<>(
+            Providers.internal(lhs.zip(rhs, bifunction(MapPropertyCompoundAssignmentStandIn::concat))),
+            lhs,
+            () -> lhs.putAll(rhs)
+        );
+    }
+
+    private static <K, V> Map<K, V> concat(Map<? extends K, ? extends V> left, Map<? extends K, ? extends V> right) {
+        Map<K, V> result = new LinkedHashMap<>(left);
+        result.putAll(right);
+        return result;
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapPropertyExtensions.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapPropertyExtensions.java
@@ -112,4 +112,19 @@ public final class MapPropertyExtensions {
         self.putAll(provider);
         return self;
     }
+
+    /**
+     * Creates a stand-in of {@link MapProperty} to be used as a left-hand side operand of {@code +=}.
+     * <p>
+     * The AST transformer knows the name of this method.
+     *
+     * @param lhs the property
+     * @param <K> the type of map keys, to help the static type checker
+     * @param <V> the type of map values, to help the static type checker
+     * @return the stand-in object to call {@code plus} on
+     * @see org.gradle.api.internal.groovy.support.CompoundAssignmentTransformer
+     */
+    public static <K, V> MapPropertyCompoundAssignmentStandIn<K, V> forCompoundAssignment(MapProperty<K, V> lhs) {
+        return ((DefaultMapProperty<K, V>) lhs).forCompoundAssignment();
+    }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/LazyGroovySupport.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/LazyGroovySupport.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider.support;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.instantiation.generator.AsmBackedClassGenerator;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An interface used to support lazy assignment for types like {@link Property} and {@link ConfigurableFileCollection} in Groovy DSL.
@@ -29,5 +30,5 @@ public interface LazyGroovySupport {
     /**
      * Sets the value from some arbitrary object. Used from the Groovy DSL.
      */
-    void setFromAnyValue(Object object);
+    void setFromAnyValue(@Nullable Object object);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/package-info.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/support/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes and interfaces that help provide syntactic sugar for Providers and Properties.
+ */
+@org.jspecify.annotations.NullMarked
+package org.gradle.api.internal.provider.support;

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/PropertyExtensionsApiTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/PropertyExtensionsApiTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+
+import org.gradle.api.internal.groovy.support.CompoundAssignmentBinaryCompatibilityFixture
+import org.gradle.api.provider.HasMultipleValues
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
+import spock.lang.Specification
+
+class PropertyExtensionsApiTest extends Specification implements CompoundAssignmentBinaryCompatibilityFixture {
+    // This class verifies binary compatibility of non-public API used by Groovy static compilation
+    // String are used intentionally to catch unexpected change to class name that breaks binary compatibility.
+    private static final String COLLECTION_EXTENSION_CLASS = "org.gradle.api.internal.provider.CollectionPropertyExtensions"
+    private static final String COLLECTION_STAND_IN_CLASS = "org.gradle.api.internal.provider.CollectionPropertyCompoundAssignmentStandIn"
+    private static final String MAP_EXTENSION_CLASS = "org.gradle.api.internal.provider.MapPropertyExtensions"
+    private static final String MAP_STAND_IN_CLASS = "org.gradle.api.internal.provider.MapPropertyCompoundAssignmentStandIn"
+
+    def "extension class for HasMultipleValues has expected api"() {
+        given:
+        def extensionClass = Class.forName(COLLECTION_EXTENSION_CLASS)
+        def standInClass = Class.forName(COLLECTION_STAND_IN_CLASS)
+
+        expect:
+        assertHasForCompoundAssignmentMethod(extensionClass, HasMultipleValues, standInClass)
+    }
+
+    def "stand-in class for HasMultipleValues defines operators"() {
+        given:
+        def standInClass = Class.forName(COLLECTION_STAND_IN_CLASS)
+
+        expect:
+        assertHasOperator(standInClass, OP_PLUS, Iterable, Provider)
+        assertHasOperator(standInClass, OP_PLUS, Object[], Provider)
+        assertHasOperator(standInClass, OP_PLUS, Provider, Provider)
+        assertHasOperator(standInClass, OP_PLUS, Object, Provider)
+    }
+
+    def "extension class for MapProperty has expected api"() {
+        given:
+        def extensionClass = Class.forName(MAP_EXTENSION_CLASS)
+        def standInClass = Class.forName(MAP_STAND_IN_CLASS)
+
+        expect:
+        assertHasForCompoundAssignmentMethod(extensionClass, MapProperty, standInClass)
+    }
+
+    def "stand-in class for MapProperty defines operators"() {
+        given:
+        def standInClass = Class.forName(MAP_STAND_IN_CLASS)
+
+        expect:
+        assertHasOperator(standInClass, OP_PLUS, Map, Provider)
+        assertHasOperator(standInClass, OP_PLUS, Provider, Provider)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -133,6 +133,7 @@ val core = platform("core") {
         subproject("file-operations")
         subproject("flow-services")
         subproject("graph-serialization")
+        subproject("groovy-support")
         subproject("guava-serialization-codecs")
         subproject("input-tracking")
         subproject("kotlin-dsl")

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -126,6 +126,7 @@ dependencies {
     api(libs.nativePlatform)
 
     implementation(projects.buildOperationsTrace)
+    implementation(projects.groovySupport)
     implementation(projects.io)
     implementation(projects.inputTracking)
     implementation(projects.modelGroovy)

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScriptTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScriptTransformer.java
@@ -17,6 +17,7 @@ package org.gradle.groovy.scripts.internal;
 
 import org.codehaus.groovy.ast.stmt.Statement;
 import org.codehaus.groovy.control.CompilationUnit;
+import org.gradle.api.internal.groovy.support.CompoundAssignmentTransformer;
 import org.gradle.api.specs.Spec;
 import org.gradle.configuration.ScriptTarget;
 import org.gradle.groovy.scripts.ScriptSource;
@@ -53,6 +54,7 @@ public class BuildScriptTransformer implements Transformer, Factory<BuildScriptD
         new StatementLabelsScriptTransformer().register(compilationUnit);
         new ModelBlockTransformer(scriptSource.getDisplayName(), scriptSource.getResource().getLocation().getURI()).register(compilationUnit);
         imperativeStatementDetectingTransformer.register(compilationUnit);
+        new CompoundAssignmentTransformer().register(compilationUnit);
     }
 
     @Override

--- a/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/internal-api-nullability.txt
@@ -463,7 +463,6 @@ Class <org.gradle.api.internal.provider.sources.process.ProcessOutputValueSource
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleBaseExecSpec> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (ProviderCompatibleBaseExecSpec.java:0)
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleExecSpec> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (ProviderCompatibleExecSpec.java:0)
 Class <org.gradle.api.internal.provider.sources.process.ProviderCompatibleJavaExecSpec> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (ProviderCompatibleJavaExecSpec.java:0)
-Class <org.gradle.api.internal.provider.support.LazyGroovySupport> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (LazyGroovySupport.java:0)
 Class <org.gradle.api.internal.resolve.DefaultLocalLibraryResolver> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (DefaultLocalLibraryResolver.java:0)
 Class <org.gradle.api.internal.resolve.DefaultProjectModelResolver> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (DefaultProjectModelResolver.java:0)
 Class <org.gradle.api.internal.resolve.LibraryResolutionErrorMessageBuilder> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (LibraryResolutionErrorMessageBuilder.java:0)

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -88,6 +88,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
         "functional",
         "gradle-cli",
         "gradle-cli-main",
+        "groovy-support",
         "hashing",
         "input-tracking",
         "installation-beacon",


### PR DESCRIPTION
This builds on top of the #32287 (which cannot be reopened), changes to it are in the last two commits.

Summary of changes:
- extract base support classes into a separate module `groovy-support`
- support Groovy static compilation with type check
- move Groovy support into separate files where possible

For the static types to work we can no longer get away with just `DefaultXxx` implementing some interface, all types has to be publicly available.

Fixes #23637 