### PR TITLE
Separate MergeReleaseIntoMaster from NightlySnapshot

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -84,7 +84,7 @@
                     <format>kotlin</format>
                     <dstDir>target/generated-configs</dstDir>
                     <contextParameters>
-                        <Branch>${dslContextParameter.branch}</Branch>
+                        <branch>${dslContextParameter.branch}</branch>
                     </contextParameters>
                 </configuration>
             </plugin>

--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -45,9 +45,15 @@ data class VersionedSettingsBranch(
 
         private const val EXPERIMENTAL_BRANCH = "experimental"
 
+        // master branch of gradle/gradle-promote
+        private const val GRADLE_PROMOTE_MASTER_VCS_ROOT_ID = "Gradle_GradlePromoteMaster"
+
+        // experimental branch of gradle/gradle-promote
+        private const val GRADLE_PROMOTE_EXPERIMENTAL_VCS_ROOT_ID = "Gradle_GradlePromoteExperimental"
+
         private val OLD_RELEASE_PATTERN = "release(\\d+)x".toRegex()
 
-        fun fromDslContext(): VersionedSettingsBranch = VersionedSettingsBranch(DslContext.getParameter("Branch", "placeholder"))
+        fun fromDslContext(): VersionedSettingsBranch = VersionedSettingsBranch(DslContext.getParameter("branch"))
 
         private fun determineNightlyPromotionTriggerHour(branchName: String) =
             when (branchName) {
@@ -76,6 +82,8 @@ data class VersionedSettingsBranch(
         get() = branchName == EXPERIMENTAL_BRANCH
 
     fun vcsRootId() = DslContext.settingsRoot.id.toString()
+
+    fun gradlePromoteVcsRootId() = if (isExperimental) GRADLE_PROMOTE_EXPERIMENTAL_VCS_ROOT_ID else GRADLE_PROMOTE_MASTER_VCS_ROOT_ID
 
     fun promoteNightlyTaskName() = nightlyTaskName("promote")
 

--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -18,6 +18,7 @@ package promotion
 
 import common.BuildToolBuildJvm
 import common.Os
+import common.VersionedSettingsBranch
 import common.paramsForBuildToolBuild
 import common.requiresNotEc2Agent
 import common.requiresOs
@@ -26,12 +27,11 @@ import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.CheckoutMode
 
 abstract class BasePromotionBuildType(
-    vcsRootId: String,
     cleanCheckout: Boolean = true,
 ) : BuildType() {
     init {
         vcs {
-            root(AbsoluteId(vcsRootId))
+            root(AbsoluteId(VersionedSettingsBranch.fromDslContext().gradlePromoteVcsRootId()))
 
             checkoutMode = CheckoutMode.ON_AGENT
             this.cleanCheckout = cleanCheckout

--- a/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
@@ -21,7 +21,6 @@ import common.promotionBuildParameters
 import jetbrains.buildServer.configs.kotlin.BuildSteps
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.RelativeId
-import vcsroots.gradlePromotionMaster
 
 abstract class BasePublishGradleDistribution(
     // The branch to be promoted
@@ -31,9 +30,8 @@ abstract class BasePublishGradleDistribution(
     val gitUserName: String = "bot-teamcity",
     val gitUserEmail: String = "bot-teamcity@gradle.com",
     val extraParameters: String = "",
-    vcsRootId: String = gradlePromotionMaster,
     cleanCheckout: Boolean = true,
-) : BasePromotionBuildType(vcsRootId, cleanCheckout) {
+) : BasePromotionBuildType(cleanCheckout) {
     init {
         artifactRules =
             """
@@ -81,5 +79,9 @@ fun BuildSteps.buildStep(
         tasks = "$prepTask $stepTask"
         gradleParams =
             promotionBuildParameters(RelativeId("Check_Stage_${triggerName}_Trigger"), extraParameters, gitUserName, gitUserEmail)
+
+        conditions {
+            doesNotEqual("skip.promote", "true")
+        }
     }
 }

--- a/.teamcity/src/main/kotlin/promotion/MergeReleaseIntoMaster.kt
+++ b/.teamcity/src/main/kotlin/promotion/MergeReleaseIntoMaster.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promotion
+
+import common.VersionedSettingsBranch
+import common.gradleWrapper
+import jetbrains.buildServer.configs.kotlin.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
+
+object MergeReleaseIntoMaster : BasePromotionBuildType() {
+    init {
+        id("Promotion_MergeReleaseIntoMaster")
+        name = "Merge Release into Master"
+        description = "Merge Release into Master"
+
+        steps {
+            gradleWrapper {
+                name = "Merge Release into Master"
+                tasks =
+                    listOf(
+                        "updateReleaseVersionsOnMaster",
+                        "gitMergeReleaseToMaster",
+                        "createPreTestCommitPullRequestMergeReleaseIntoMaster",
+                        "-PtriggeredBy=\"%teamcity.build.triggeredBy%\"",
+                    ).joinToString(" ")
+                useGradleWrapper = true
+            }
+        }
+
+        triggers {
+            finishBuildTrigger {
+                buildType = "Gradle_${VersionedSettingsBranch.fromDslContext().branchName.uppercase()}_${NIGHTLY_SNAPSHOT_BUILD_ID}"
+                successfulOnly = true
+                branchFilter = "+:*"
+            }
+        }
+
+        dependencies {
+            dependency(
+                AbsoluteId("Gradle_${VersionedSettingsBranch.fromDslContext().branchName.uppercase()}_${NIGHTLY_SNAPSHOT_BUILD_ID}"),
+            ) {
+                artifacts {
+                    buildRule = lastSuccessful()
+                    artifactRules = "version-info.properties => ./"
+                }
+            }
+        }
+    }
+}

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -33,6 +33,7 @@ class PromotionProject(
         } else {
             buildType(PublishReleaseCandidate(branch))
             buildType(PublishFinalRelease(branch))
+            buildType(MergeReleaseIntoMaster)
         }
 
         if (branch.isRelease || branch.isExperimental) {

--- a/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
@@ -18,7 +18,6 @@ package promotion
 
 import jetbrains.buildServer.configs.kotlin.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.RelativeId
-import vcsroots.gradlePromotionBranches
 
 object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistributionFullBuild(
     promotedBranch = "%branch.qualifier%",
@@ -26,7 +25,6 @@ object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistributionFullBui
     prepTask = "prepSnapshot",
     promoteTask = "promoteSnapshot",
     extraParameters = "-PpromotedBranch=%branch.qualifier%",
-    vcsRootId = gradlePromotionBranches,
 ) {
     init {
         id("Promotion_PublishBranchSnapshotFromQuickFeedback")

--- a/.teamcity/src/main/kotlin/promotion/PublishGradleDistributionFullBuild.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishGradleDistributionFullBuild.kt
@@ -16,8 +16,6 @@
 
 package promotion
 
-import vcsroots.gradlePromotionMaster
-
 abstract class PublishGradleDistributionFullBuild(
     // The branch to be promoted
     promotedBranch: String,
@@ -27,8 +25,7 @@ abstract class PublishGradleDistributionFullBuild(
     gitUserName: String = "bot-teamcity",
     gitUserEmail: String = "bot-teamcity@gradle.com",
     extraParameters: String = "",
-    vcsRootId: String = gradlePromotionMaster,
-) : BasePublishGradleDistribution(promotedBranch, prepTask, triggerName, gitUserName, gitUserEmail, extraParameters, vcsRootId) {
+) : BasePublishGradleDistribution(promotedBranch, prepTask, triggerName, gitUserName, gitUserEmail, extraParameters) {
     init {
         steps {
             if (prepTask != null) {

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlyDocumentation.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlyDocumentation.kt
@@ -19,7 +19,6 @@ package promotion
 import common.VersionedSettingsBranch
 import jetbrains.buildServer.configs.kotlin.triggers.schedule
 import model.StageName
-import vcsroots.gradlePromotionBranches
 
 class PublishNightlyDocumentation(
     branch: VersionedSettingsBranch,
@@ -27,7 +26,6 @@ class PublishNightlyDocumentation(
         promotedBranch = branch.branchName,
         promoteTask = "publishBranchDocs",
         triggerName = StageName.PULL_REQUEST_FEEDBACK.uuid,
-        vcsRootId = gradlePromotionBranches,
     ) {
     init {
         id("Promotion_NightlyDocumentation")

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
@@ -19,7 +19,8 @@ package promotion
 import common.VersionedSettingsBranch
 import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
 import jetbrains.buildServer.configs.kotlin.triggers.schedule
-import vcsroots.gradlePromotionBranches
+
+const val NIGHTLY_SNAPSHOT_BUILD_ID = "Promotion_Nightly"
 
 class PublishNightlySnapshot(
     branch: VersionedSettingsBranch,
@@ -28,12 +29,12 @@ class PublishNightlySnapshot(
         prepTask = branch.prepNightlyTaskName(),
         promoteTask = branch.promoteNightlyTaskName(),
         triggerName = "ReadyforNightly",
-        vcsRootId = gradlePromotionBranches,
     ) {
     init {
-        id("Promotion_Nightly")
+        id(NIGHTLY_SNAPSHOT_BUILD_ID)
         name = "Nightly Snapshot"
-        description = "Promotes the latest successful changes on '${branch.branchName}' from Ready for Nightly as a new nightly snapshot"
+        description =
+            "Promotes the latest successful changes on '${branch.branchName}' from Ready for Nightly as a new nightly snapshot"
 
         triggers {
             branch.nightlyPromotionTriggerHour?.let { triggerHour ->
@@ -56,8 +57,14 @@ class PublishNightlySnapshot(
                     // https://www.jetbrains.com/help/teamcity/2022.04/configuring-schedule-triggers.html#general-syntax-1
                     // We want it to be triggered only when there're pending changes in the specific vcs root, i.e. GradleMaster/GradleRelease
                     triggerRules = "+:root=${VersionedSettingsBranch.fromDslContext().vcsRootId()}:."
-                    // The promotion itself will be triggered on gradle-promote's master branch
-                    branchFilter = "+:master"
+                    branchFilter =
+                        if (VersionedSettingsBranch.fromDslContext().isExperimental) {
+                            // The promotion itself will be triggered on gradle-promote's master branch
+                            "+:master"
+                        } else {
+                            // The promotion itself will be triggered on gradle-promote's experimental branch
+                            "+:experimental"
+                        }
                 }
             }
         }

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedback.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedback.kt
@@ -17,7 +17,6 @@
 package promotion
 
 import common.VersionedSettingsBranch
-import vcsroots.gradlePromotionBranches
 
 class PublishNightlySnapshotFromQuickFeedback(
     branch: VersionedSettingsBranch,
@@ -26,7 +25,6 @@ class PublishNightlySnapshotFromQuickFeedback(
         prepTask = branch.prepNightlyTaskName(),
         promoteTask = branch.promoteNightlyTaskName(),
         triggerName = "QuickFeedback",
-        vcsRootId = gradlePromotionBranches,
     ) {
     init {
         id("Promotion_SnapshotFromQuickFeedback")

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepCheckReady.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepCheckReady.kt
@@ -17,7 +17,6 @@
 package promotion
 
 import common.VersionedSettingsBranch
-import vcsroots.gradlePromotionBranches
 
 class PublishNightlySnapshotFromQuickFeedbackStepCheckReady(
     branch: VersionedSettingsBranch,
@@ -25,7 +24,6 @@ class PublishNightlySnapshotFromQuickFeedbackStepCheckReady(
         promotedBranch = branch.branchName,
         prepTask = branch.prepNightlyTaskName(),
         triggerName = "QuickFeedback",
-        vcsRootId = gradlePromotionBranches,
         cleanCheckout = false,
     ) {
     init {

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepPromote.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepPromote.kt
@@ -17,7 +17,6 @@
 package promotion
 
 import common.VersionedSettingsBranch
-import vcsroots.gradlePromotionBranches
 
 class PublishNightlySnapshotFromQuickFeedbackStepPromote(
     branch: VersionedSettingsBranch,
@@ -25,7 +24,6 @@ class PublishNightlySnapshotFromQuickFeedbackStepPromote(
         promotedBranch = branch.branchName,
         prepTask = branch.prepNightlyTaskName(),
         triggerName = "QuickFeedback",
-        vcsRootId = gradlePromotionBranches,
         cleanCheckout = false,
     ) {
     init {

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepUpload.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepUpload.kt
@@ -17,7 +17,6 @@
 package promotion
 
 import common.VersionedSettingsBranch
-import vcsroots.gradlePromotionBranches
 
 class PublishNightlySnapshotFromQuickFeedbackStepUpload(
     branch: VersionedSettingsBranch,
@@ -25,7 +24,6 @@ class PublishNightlySnapshotFromQuickFeedbackStepUpload(
         promotedBranch = branch.branchName,
         prepTask = branch.prepNightlyTaskName(),
         triggerName = "QuickFeedback",
-        vcsRootId = gradlePromotionBranches,
     ) {
     init {
         id("Promotion_SnapshotFromQuickFeedbackStepUpload")

--- a/.teamcity/src/main/kotlin/promotion/SanityCheck.kt
+++ b/.teamcity/src/main/kotlin/promotion/SanityCheck.kt
@@ -6,7 +6,6 @@ import common.gradleWrapper
 import common.requiresOs
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.triggers.vcs
-import vcsroots.gradlePromotionMaster
 import vcsroots.useAbsoluteVcs
 
 // Gradle_Master_Promotion_SanityCheck
@@ -15,7 +14,7 @@ object SanityCheck : BuildType({
     name = "SanityCheck"
     description = "Sanity check for promotion project"
 
-    vcs.useAbsoluteVcs(gradlePromotionMaster)
+    vcs.useAbsoluteVcs(VersionedSettingsBranch.fromDslContext().gradlePromoteVcsRootId())
 
     steps {
         gradleWrapper {

--- a/.teamcity/src/main/kotlin/promotion/StartReleaseCycle.kt
+++ b/.teamcity/src/main/kotlin/promotion/StartReleaseCycle.kt
@@ -20,9 +20,8 @@ import common.gradleWrapper
 import common.promotionBuildParameters
 import jetbrains.buildServer.configs.kotlin.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.RelativeId
-import vcsroots.gradlePromotionMaster
 
-object StartReleaseCycle : BasePromotionBuildType(vcsRootId = gradlePromotionMaster) {
+object StartReleaseCycle : BasePromotionBuildType() {
     init {
         id("Promotion_StartReleaseCycle")
         name = "Start Release Cycle"

--- a/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
+++ b/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
@@ -21,9 +21,8 @@ import common.VersionedSettingsBranch
 import common.gradleWrapper
 import jetbrains.buildServer.configs.kotlin.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.triggers.vcs
-import vcsroots.gradlePromotionBranches
 
-object StartReleaseCycleTest : BasePromotionBuildType(vcsRootId = gradlePromotionBranches, cleanCheckout = false) {
+object StartReleaseCycleTest : BasePromotionBuildType(cleanCheckout = false) {
     init {
         id("Promotion_AllBranchesStartReleaseCycleTest")
         name = "Start Release Cycle Test"

--- a/.teamcity/src/main/kotlin/vcsroots/VcsRoots.kt
+++ b/.teamcity/src/main/kotlin/vcsroots/VcsRoots.kt
@@ -4,9 +4,6 @@ import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.CheckoutMode
 import jetbrains.buildServer.configs.kotlin.VcsSettings
 
-val gradlePromotionMaster = "Gradle_GradlePromoteMaster"
-val gradlePromotionBranches = "Gradle_GradlePromoteBranches"
-
 fun VcsSettings.useAbsoluteVcs(absoluteId: String) {
     root(AbsoluteId(absoluteId))
 

--- a/.teamcity/src/test/kotlin/PromotionProjectTests.kt
+++ b/.teamcity/src/test/kotlin/PromotionProjectTests.kt
@@ -61,7 +61,7 @@ class PromotionProjectTests {
         val model = setupModelFor("release")
 
         assertEquals("Promotion", model.name)
-        assertEquals(11, model.buildTypes.size)
+        assertEquals(12, model.buildTypes.size)
         assertEquals(
             listOf(
                 "SanityCheck",
@@ -74,6 +74,7 @@ class PromotionProjectTests {
                 "Release - Milestone",
                 "Release - Release Candidate",
                 "Release - Final",
+                "Merge Release into Master",
                 "Nightly Documentation",
             ),
             model.buildTypes.map { it.name },


### PR DESCRIPTION
Also see https://github.com/gradle/gradle-promote/pull/217/files

This PR fixes two issues:

### Makes MergeReleaseIntoMaster a separate build

Closes https://github.com/gradle/gradle-promote/issues/214

We used to merge `release` into `master` in `PublishNightlySnapshot` build. This has some problems: if a version is released, no more nightly version is published. Thus `release` is no longer merged into `master`. This PR creates a separate build configuration `MergeReleaseIntoMaster`, which could be triggered in the following way:

- Triggered manually. It simply merge `release` into `master` then create a MQ build.
- Triggered by `PublishNightlySnapshot` finishing event. When this happens, an artifact dependency is used to resolve the newly published nightly version and timestamp, so that we update the nightly version then merge `release` into `master`.

### Creates a new VCS root for `experimental` branch in `gradle/gradle-promote`

In the past, all promotion builds ran on `master` branch of `gradle-promote` repo. This makes it extremely hard to make changes to it - we had to merge to `master` to test it. In this PR we add another VCS root for `experimental` branch of `gradle-promote`, i.e.:

1. `GradleMaster` and `GradleRelease` pipelines use `GRADLE_PROMOTE_MASTER_VCS_ROOT_ID`.
2. `GradleExperimental` pipeline uses `GRADLE_PROMOTE_EXPERIMENTAL_VCS_ROOT_ID`.

In this way we can easily test changes on `experimental` branch of `gradle/gradle` and `gradle/gradle-promote`.