### PR TITLE
Store `java.io.File` in CC state in a prefixed-tree form for optimizing space

### DIFF
--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("gradlebuild.distribution.implementation-kotlin")
     id("gradlebuild.kotlin-dsl-sam-with-receiver")
     id("gradlebuild.kotlin-experimental-contracts")
+    id("gradlebuild.jmh")
 }
 
 description = "Configuration cache implementation"

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
@@ -64,7 +64,7 @@ class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractConfigura
         def confCacheDir = file("./app/.gradle/configuration-cache")
         confCacheDir.isDirectory()
         def confCacheFiles = confCacheDir.allDescendants().findAll { it != 'configuration-cache.lock' && it != 'gc.properties' }
-        confCacheFiles.size() == 13 // header, candidates file, 2 * fingerprint, build strings file, root build state file, root build shared objects file, included build state file, included build shared objects file, 2 * project state file, 2 * owner-less node state files
+        confCacheFiles.size() == 14 // header, files storage, candidates file, 2 * fingerprint, build strings file, root build state file, root build shared objects file, included build state file, included build shared objects file, 2 * project state file, 2 * owner-less node state files
         if (!OperatingSystem.current().isWindows()) {
             confCacheFiles.forEach {
                 assert confCacheDir.file(it).mode == 384

--- a/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/serialize/graph/FilePrefixedTreeCompressionBenchmark.kt
+++ b/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/serialize/graph/FilePrefixedTreeCompressionBenchmark.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.graph
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+
+@Fork(1)
+@Warmup(iterations = 1)
+@Measurement(iterations = 10)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+open class FilePrefixedTreeCompressionBenchmark {
+
+    private var treeToCompress: FilePrefixedTree = FilePrefixedTree()
+    private lateinit var fileTree: Path
+
+    @Setup(Level.Trial)
+    fun setup() {
+        fileTree = Files.createTempDirectory("tree")
+        generateFileTree(fileTree, 7, 7) // 137257 nodes
+        Files.walk(fileTree).forEach { treeToCompress.insert(it.toFile()) }
+    }
+
+    @Setup(Level.Trial)
+    fun tearDown() {
+        fileTree.toFile().deleteRecursively()
+    }
+
+    // avgt   10  11.551 ± 0.110  ms/op
+    @Benchmark
+    fun prefixedTreeCompress(bh: Blackhole) {
+        bh.consume(treeToCompress.compress())
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/serialize/graph/FilePrefixedTreeInsertionBenchmark.kt
+++ b/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/serialize/graph/FilePrefixedTreeInsertionBenchmark.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.graph
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import java.util.stream.Collectors
+
+@Fork(1)
+@Warmup(iterations = 1)
+@Measurement(iterations = 10)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+open class FilePrefixedTreeInsertionBenchmark {
+
+    private lateinit var filesToInsert: List<File>
+    private lateinit var fileTree: Path
+
+    @Setup(Level.Trial)
+    fun setup() {
+        fileTree = Files.createTempDirectory("tree")
+        generateFileTree(fileTree, 7, 7) // 137257 nodes
+        filesToInsert = Files.walk(fileTree).map { it.toFile() }.collect(Collectors.toList())
+    }
+
+    @Setup(Level.Trial)
+    fun tearDown() {
+        fileTree.toFile().deleteRecursively()
+    }
+
+    // avgt   10  104.991 ± 0.719  ms/op
+    @Benchmark
+    @Threads(4)
+    fun prefixedTreeInsert(bh: Blackhole) {
+        val prefixedTree = FilePrefixedTree()
+        filesToInsert.forEach { bh.consume(prefixedTree.insert(it)) }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/serialize/graph/FileTreeGeneration.kt
+++ b/platforms/core-configuration/configuration-cache/src/jmh/kotlin/org/gradle/internal/serialize/graph/FileTreeGeneration.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.graph
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal fun generateFileTree(root: Path, depth: Int, width: Int) {
+    if (depth == 0) return
+    Files.createDirectories(root)
+
+    for (i in 1..width) {
+        val sub = root.resolve("sub_$i")
+        generateFileTree(sub, depth - 1, width)
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -184,7 +184,6 @@ class ConfigurationCacheState(
         graphBuilder: BuildTreeWorkGraphBuilder?,
         loadAfterStore: Boolean
     ): Pair<String, BuildTreeWorkGraph.FinalizedGraph> {
-
         val originBuildInvocationId = readBuildInvocationId()
         val builds = readRootBuild()
         require(readInt() == 0x1ecac8e) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -94,6 +94,8 @@ class ConfigurationCacheStartParameter internal constructor(
      */
     val isParallelLoad = options.getInternalFlag("org.gradle.configuration-cache.internal.parallel-load", true)
 
+    val isOptimizingFiles = options.getInternalFlag("org.gradle.configuration-cache.internal.optimize-files", true)
+
     val gradleProperties: Map<String, Any?>
         get() = startParameter.projectProperties
             .filterKeys { !Workarounds.isIgnoredStartParameterProperty(it) }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassPathEncodingExtensions.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassPathEncodingExtensions.kt
@@ -21,9 +21,7 @@ import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.classpath.TransformedClassPath
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.graph.WriteContext
-import org.gradle.internal.serialize.graph.readFile
 import org.gradle.internal.serialize.graph.writeCollection
-import org.gradle.internal.serialize.graph.writeFile
 
 
 internal

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/Codecs.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/Codecs.kt
@@ -178,7 +178,7 @@ class Codecs(
     transformStepNodeFactory: TransformStepNodeFactory,
     val parallelStore: Boolean = true,
     val parallelLoad: Boolean = true,
-    problems: InternalProblems
+    problems: InternalProblems,
 ) {
     private
     val userTypesBindings: Bindings

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultFileCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultFileCodec.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.serialize
+
+import org.gradle.internal.serialize.graph.CloseableReadContext
+import org.gradle.internal.serialize.graph.CloseableWriteContext
+import org.gradle.internal.serialize.graph.FileDecoder
+import org.gradle.internal.serialize.graph.FileEncoder
+import org.gradle.internal.serialize.graph.FilePrefixedTree
+import org.gradle.internal.serialize.graph.FilePrefixedTree.Node
+import org.gradle.internal.serialize.graph.ReadContext
+import org.gradle.internal.serialize.graph.WriteContext
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.concurrent.thread
+
+private const val EOF = (-1).toByte()
+private const val NODE_FINAL_START = 1.toByte()
+private const val NODE_INTERMEDIATE_START = 2.toByte()
+private const val NODE_END = 3.toByte()
+
+class DefaultFileEncoder(
+    private val globalContext: CloseableWriteContext,
+    private val prefixedTree: FilePrefixedTree
+) : FileEncoder {
+
+    override fun writeFile(writeContext: WriteContext, file: File) {
+        writeContext.writeSmallInt(prefixedTree.insert(file))
+    }
+
+    override fun close() {
+        globalContext.use {
+            it.writePrefixedTreeNode(prefixedTree.compress(), null)
+            it.writeByte(EOF)
+        }
+    }
+
+    private fun WriteContext.writePrefixedTreeNode(node: Node, parent: Node?) {
+        val nodeHeader =
+            if (node.isFinal) NODE_FINAL_START
+            else NODE_INTERMEDIATE_START
+
+        writeByte(nodeHeader)
+        writeSmallInt(node.index - (parent?.index ?: 0)) // delta encoding
+        writeString(node.segment)
+        node.children.values.forEach { child ->
+            writePrefixedTreeNode(child, node)
+        }
+        writeByte(NODE_END)
+    }
+}
+
+class DefaultFileDecoder(
+    private val globalContext: CloseableReadContext,
+) : FileDecoder {
+
+    private
+    class FutureFile {
+
+        private
+        val latch = CountDownLatch(1)
+
+        private
+        var file: File? = null
+
+        fun complete(file: File) {
+            this.file = file
+            latch.countDown()
+        }
+
+        fun get(): File {
+            if (!latch.await(1, TimeUnit.MINUTES)) {
+                throw TimeoutException("Timeout while waiting for file")
+            }
+            return file!!
+        }
+    }
+
+    private val files = ConcurrentHashMap<Int, Any>()
+
+    @Suppress("LoopWithTooManyJumpStatements")
+    private
+    val reader = thread(isDaemon = true) {
+        val segments = HashMap<Int, String>()
+        val stack = ArrayDeque<Int>()
+
+        globalContext.use { context ->
+            while (true) {
+                val nodeHeader = context.readByte()
+                if (nodeHeader == EOF) break
+
+                if (nodeHeader == NODE_END) {
+                    stack.removeLastOrNull() ?: break
+                    continue
+                }
+
+                val deltaId = context.readSmallInt()
+                val segment = context.readString()
+                val parent = stack.lastOrNull()
+                val isFinal = nodeHeader == NODE_FINAL_START
+                val id = deltaId + (parent ?: 0)
+
+                val path = parent?.let {
+                    val parentSegment = segments[it]
+                    if (parentSegment.isNullOrEmpty()) segment else "$parentSegment${File.separatorChar}$segment"
+                } ?: segment
+
+                segments[id] = path
+
+                if (isFinal) {
+                    files.compute(id) { _, value ->
+                        val file = File(path)
+                        when (value) {
+                            is FutureFile -> value.complete(file)
+                            else -> require(value == null)
+                        }
+                        file
+                    }
+                }
+
+                stack.addLast(id)
+            }
+        }
+    }
+
+    override fun readFile(readContext: ReadContext): File =
+        when (val file = files.computeIfAbsent(readContext.readSmallInt()) { FutureFile() }) {
+            is FutureFile -> file.get()
+            is File -> file
+            else -> error("$file is unsupported")
+        }
+
+    override fun close() {
+        reader.join(TimeUnit.MINUTES.toMillis(1))
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/FilePrefixedTreeTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/FilePrefixedTreeTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.internal.serialize.graph.FilePrefixedTree
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class FilePrefixedTreeTest {
+
+    @Test
+    fun `can create prefixed tree of inserted files`() {
+        val prefixedTree = FilePrefixedTree()
+        prefixedTree.insert(File("org/example/foo/Foo"))
+        prefixedTree.insert(File("org/example/bar")) // insert a dir
+        prefixedTree.insert(File("org/example/bar/Bar"))
+        prefixedTree.insert(File("org/example/bar/Bar1"))
+
+        val expectedTree =
+            root(
+                intermediateNode(
+                    "org", 1,
+                    intermediateNode(
+                        "example", 2,
+                        intermediateNode(
+                            "foo", 3,
+                            finalNode(
+                                "Foo", 4
+                            )
+                        ),
+                        finalNode(
+                            "bar", 5,
+                            finalNode(
+                                "Bar", 6
+                            ),
+                            finalNode(
+                                "Bar1", 7
+                            )
+                        )
+                    )
+                )
+            )
+
+        assertEquals(expectedTree, prefixedTree.root)
+    }
+
+    @Test
+    fun `absolute paths and relative paths in the same tree are supported`() {
+        val prefixedTree = FilePrefixedTree()
+        prefixedTree.insert(File("org/example/Foo"))
+        prefixedTree.insert(File("/org/example/bar/Bar"))
+
+        val expectedTree =
+            root(
+                intermediateNode(
+                    "org", 1,
+                    intermediateNode(
+                        "example", 2,
+                        finalNode(
+                            "Foo", 3
+                        )
+                    )
+                ),
+                intermediateNode(
+                    "/", 4,
+                    intermediateNode(
+                        "org", 5,
+                        intermediateNode(
+                            "example", 6,
+                            intermediateNode(
+                                "bar", 7,
+                                finalNode(
+                                    "Bar", 8
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+        assertEquals(expectedTree, prefixedTree.root)
+    }
+
+    @Test
+    fun `tree is compressable`() {
+        val prefixedTree = FilePrefixedTree()
+        prefixedTree.insert(File("/org/example/company/foo/Foo"))
+        prefixedTree.insert(File("/org/example/company/bar/Bar"))
+        prefixedTree.insert(File("/org/example/company/bar/Bar1"))
+        prefixedTree.insert(File("org/example/company/bar"))
+        prefixedTree.insert(File("org/example/company/bar/Bar2"))
+        prefixedTree.insert(File("/org/example/company/baz/Baz"))
+
+        val expectedCompressedTree =
+            root(
+                finalNode(
+                    "org/example/company/bar", 13,
+                    finalNode(
+                        "Bar2", 14
+                    )
+                ),
+                intermediateNode(
+                    "/org/example/company", 4,
+                    finalNode("baz/Baz", 16),
+                    intermediateNode(
+                        "bar", 7,
+                        finalNode(
+                            "Bar1", 9
+                        ),
+                        finalNode(
+                            "Bar", 8
+                        ),
+                    ),
+                    finalNode(
+                        "foo/Foo", 6
+                    )
+                )
+            )
+
+        assertEquals(expectedCompressedTree, prefixedTree.compress())
+    }
+
+    @Test
+    fun `indexes are preserved after compression`() {
+        val prefixedTree = FilePrefixedTree()
+        val fooIndex = prefixedTree.insert(File("org/example/foo/Foo"))
+        val barIndex = prefixedTree.insert(File("org/example/bar/Bar"))
+
+        val indexes = FilePrefixedTree.buildIndexes(prefixedTree.compress())
+
+        assertEquals(File("org/example/foo/Foo"), indexes[fooIndex])
+        assertEquals(File("org/example/bar/Bar"), indexes[barIndex])
+    }
+
+    @Test
+    fun `returns the same index for the same file`() {
+        val prefixedTree = FilePrefixedTree()
+
+        val foo1Index = prefixedTree.insert(File("org/example/foo/Foo"))
+        val foo2Index = prefixedTree.insert(File("org/example/foo/Foo"))
+
+        assertEquals(foo1Index, foo2Index)
+    }
+
+    private fun node(isFinal: Boolean, index: Int, segment: String, vararg children: FilePrefixedTree.Node) =
+        FilePrefixedTree.Node(isFinal, index, segment, children.associateBy { it.segment }.toMutableMap())
+
+    private fun finalNode(segment: String, index: Int, vararg children: FilePrefixedTree.Node) =
+        node(true, index, segment, *children)
+
+    private fun intermediateNode(segment: String, index: Int, vararg children: FilePrefixedTree.Node) =
+        node(false, index, segment, *children)
+
+    private fun root(vararg children: FilePrefixedTree.Node) =
+        intermediateNode("", 0, *children)
+}

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -339,6 +339,10 @@ class ConfigurationCacheFingerprintCheckerTest {
             values.add(value)
         }
 
+        override fun writeFile(file: File) {
+            values.add(file)
+        }
+
         override val tracer: Tracer?
             get() = null
 
@@ -448,6 +452,8 @@ class ConfigurationCacheFingerprintCheckerTest {
         override fun readSmallInt(): Int = next()
 
         override suspend fun read(): Any? = next()
+
+        override fun readFile(): File = next()
 
         override suspend fun <T : Any> readSharedObject(decode: suspend ReadContext.() -> T): T = next()
 

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ConfigurableFileTreeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ConfigurableFileTreeCodec.kt
@@ -24,9 +24,7 @@ import org.gradle.internal.file.PathToFileResolver
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
-import org.gradle.internal.serialize.graph.readFile
 import org.gradle.internal.serialize.graph.readNonNull
-import org.gradle.internal.serialize.graph.writeFile
 
 
 class ConfigurableFileTreeCodec(

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/FileCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/FileCodecs.kt
@@ -22,8 +22,6 @@ import org.gradle.api.internal.file.FileFactory
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
-import org.gradle.internal.serialize.graph.readFile
-import org.gradle.internal.serialize.graph.writeFile
 
 
 class DirectoryCodec(private val fileFactory: FileFactory) : Codec<Directory> {

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/PathToFileResolverCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/PathToFileResolverCodec.kt
@@ -28,8 +28,6 @@ import org.gradle.internal.serialize.graph.decodeBean
 import org.gradle.internal.serialize.graph.decodePreservingSharedIdentity
 import org.gradle.internal.serialize.graph.encodeBean
 import org.gradle.internal.serialize.graph.encodePreservingSharedIdentityOf
-import org.gradle.internal.serialize.graph.readFile
-import org.gradle.internal.serialize.graph.writeFile
 
 
 class PathToFileResolverCodec(

--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/DefaultResolvableArtifactCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/DefaultResolvableArtifactCodec.kt
@@ -20,14 +20,12 @@ import org.gradle.api.internal.artifacts.DefaultResolvableArtifact
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentIdentifierSerializer
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.IvyArtifactNameSerializer
 import org.gradle.api.internal.tasks.TaskDependencyContainer
-import org.gradle.internal.serialize.graph.Codec
-import org.gradle.internal.serialize.graph.ReadContext
-import org.gradle.internal.serialize.graph.WriteContext
-import org.gradle.internal.serialize.graph.readFile
-import org.gradle.internal.serialize.graph.writeFile
 import org.gradle.internal.Describables
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
 import org.gradle.internal.model.CalculatedValueContainerFactory
+import org.gradle.internal.serialize.graph.Codec
+import org.gradle.internal.serialize.graph.ReadContext
+import org.gradle.internal.serialize.graph.WriteContext
 
 
 class DefaultResolvableArtifactCodec(
@@ -50,6 +48,13 @@ class DefaultResolvableArtifactCodec(
         val artifactName = IvyArtifactNameSerializer.INSTANCE.read(this)
         val componentId = componentIdSerializer.read(this)
         val artifactId = ComponentFileArtifactIdentifier(componentId, file.name)
-        return DefaultResolvableArtifact(null, artifactName, artifactId, TaskDependencyContainer.EMPTY, calculatedValueContainerFactory.create(Describables.of(artifactId), file), calculatedValueContainerFactory)
+        return DefaultResolvableArtifact(
+            null,
+            artifactName,
+            artifactId,
+            TaskDependencyContainer.EMPTY,
+            calculatedValueContainerFactory.create(Describables.of(artifactId), file),
+            calculatedValueContainerFactory
+        )
     }
 }

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -60,7 +60,7 @@ interface WriteContext : MutableIsolateContext, Encoder {
 
     suspend fun write(value: Any?)
 
-    suspend fun <T: Any> writeSharedObject(value: T, encode: suspend WriteContext.(T) -> Unit)
+    suspend fun <T : Any> writeSharedObject(value: T, encode: suspend WriteContext.(T) -> Unit)
 
     fun writeClass(type: Class<*>)
 
@@ -109,7 +109,7 @@ interface ReadContext : IsolateContext, MutableIsolateContext, Decoder {
 
     suspend fun read(): Any?
 
-    suspend fun <T: Any> readSharedObject(decode: suspend ReadContext.() -> T): T
+    suspend fun <T : Any> readSharedObject(decode: suspend ReadContext.() -> T): T
 
     fun readClass(): Class<*>
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Combinators.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Combinators.kt
@@ -18,11 +18,9 @@ package org.gradle.internal.serialize.graph
 
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.extensions.stdlib.useToRun
-import org.gradle.internal.serialize.BaseSerializerFactory
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.Serializer
-import java.io.File
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import kotlin.coroutines.Continuation
@@ -226,15 +224,6 @@ suspend fun <K, V, T : MutableMap<K, V>> ReadContext.readMapEntriesInto(items: T
         items[key] = value
     }
 }
-
-
-fun Encoder.writeFile(file: File) {
-    BaseSerializerFactory.FILE_SERIALIZER.write(this, file)
-}
-
-
-fun Decoder.readFile(): File =
-    BaseSerializerFactory.FILE_SERIALIZER.read(this)
 
 
 fun WriteContext.writeStrings(strings: Collection<String>) {

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/FilePrefixedTree.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/FilePrefixedTree.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.graph
+
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * An implementation of <a href="https://en.wikipedia.org/wiki/Trie">Prefix tree</a> for files.
+ * <p>
+ * The tree can be compressed. The compressing factor is totally depends on the structure of the tree.
+ */
+class FilePrefixedTree {
+
+    private var currentIndex = AtomicInteger(1)
+
+    val root = Node(false, 0, "")
+
+    /**
+     * Inserts a file path into the tree, creating necessary nodes if they do not exist.
+     * Insertion is thread-safe.
+     *
+     * @return the index of the final node representing the file.
+     * If the path already exists, returns the existing index.
+     */
+    fun insert(file: File): Int {
+        val segmentBuilder = StringBuilder()
+        var current = root
+
+        for (char in file.path) {
+            if (char == File.separatorChar) {
+                val childSegment = segmentBuilder.ifEmpty { /* leading separator for absolute file */ File.separator }.toString()
+                current = current.children.computeIfAbsent(childSegment) { Node(false, currentIndex.getAndIncrement(), childSegment) }
+                segmentBuilder.clear()
+                continue
+            }
+            segmentBuilder.append(char)
+        }
+
+        if (segmentBuilder.isNotEmpty()) {
+            val childSegment = segmentBuilder.toString()
+            current = current.children.computeIfAbsent(childSegment) { Node(false, currentIndex.getAndIncrement(), childSegment) }
+        }
+
+        current.isFinal = true
+        return current.index
+    }
+
+    /**
+     * Compresses the current tree following the <a href="http://en.wikipedia.org/wiki/Radix_tree">Radix tree</a> idea.
+     * <p>
+     * Tree should be compressed only after all insertions are completed.
+     * @return a new tree, which is a compressed version of the current one.
+     */
+    fun compress(): Node = compressFrom(root)
+
+    private fun compressFrom(node: Node): Node {
+        if (node.isFinal) {
+            return node.copy(children = node.children.compress())
+        }
+
+        val segmentsToCompress = mutableListOf<String>()
+        var current = node
+
+        while (current.children.size == 1) {
+            segmentsToCompress.add(current.segment)
+            current = current.singleChild
+            if (current.isFinal) break
+        }
+
+        segmentsToCompress.add(current.segment)
+        return Node(current.isFinal, current.index, segmentsToCompress.compressPath(), current.children.compress())
+    }
+
+    private fun List<String>.compressPath(): String {
+        val segments = dropWhile { it.isEmpty() }
+        val isAbsolute = segments.firstOrNull() == File.separator
+        return if (isAbsolute) {
+            File.separator + segments.dropWhile { it == File.separator }.joinToString(File.separator)
+        } else {
+            segments.joinToString(File.separator)
+        }
+    }
+
+    private fun Map<String, Node>.compress() = ConcurrentHashMap(values.map(::compressFrom).associateBy { it.segment })
+
+
+    data class Node(
+        @Volatile var isFinal: Boolean,
+        val index: Int,
+        val segment: String,
+        val children: MutableMap<String, Node> = ConcurrentHashMap()
+    ) {
+        val singleChild
+            get() = children.entries.single().value
+
+    }
+
+    companion object {
+        /**
+         * The only efficient way to perform a lookup in the tree.
+         * <p>
+         * Indexes are built by performing a depth-first search (DFS) through the entire tree,
+         * creating a mapping between each index and its corresponding item.
+         */
+        fun buildIndexes(root: Node): Map<Int, File> {
+            val indexes = mutableMapOf<Int, File>()
+            buildIndexFor(root, mutableListOf(), indexes)
+            return indexes
+        }
+
+        private fun buildIndexFor(node: Node, segments: MutableList<String>, indexes: MutableMap<Int, File>) {
+            segments.add(node.segment)
+            indexes[node.index] = File(segments.joinToString(File.separator))
+            for (child in node.children.values) {
+                buildIndexFor(child, segments, indexes)
+            }
+            segments.removeAt(segments.size - 1) // backtrack
+        }
+    }
+}

--- a/platforms/core-configuration/isolated-action-services/src/test/kotlin/org/gradle/internal/isolate/actions/services/IsolatedActionCodecsFactoryTest.kt
+++ b/platforms/core-configuration/isolated-action-services/src/test/kotlin/org/gradle/internal/isolate/actions/services/IsolatedActionCodecsFactoryTest.kt
@@ -199,6 +199,6 @@ class IsolatedActionCodecsFactoryTest {
             javaSerializationEncodingLookup = JavaSerializationEncodingLookup(),
             propertyFactory = propertyFactory(),
             fileFactory = TestFiles.fileFactory(),
-            filePropertyFactory = TestFiles.filePropertyFactory()
+            filePropertyFactory = TestFiles.filePropertyFactory(),
         )
 }

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/AbstractDecoder.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/AbstractDecoder.java
@@ -19,6 +19,7 @@ package org.gradle.internal.serialize;
 import org.jspecify.annotations.Nullable;
 
 import java.io.EOFException;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -88,6 +89,11 @@ public abstract class AbstractDecoder implements Decoder {
         if (remaining > 0) {
             throw new EOFException();
         }
+    }
+
+    @Override
+    public File readFile() throws EOFException, IOException {
+        return new File(readString());
     }
 
     @Override

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/AbstractEncoder.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/AbstractEncoder.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.serialize;
 
 import org.jspecify.annotations.Nullable;
-
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -81,6 +81,11 @@ public abstract class AbstractEncoder implements Encoder {
             writeBoolean(true);
             writeString(value.toString());
         }
+    }
+
+    @Override
+    public void writeFile(File file) throws IOException {
+        writeString(file.getPath());
     }
 
     private class EncoderStream extends OutputStream {

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
@@ -138,12 +138,12 @@ public class BaseSerializerFactory {
     private static class FileSerializer extends AbstractSerializer<File> {
         @Override
         public File read(Decoder decoder) throws Exception {
-            return new File(decoder.readString());
+            return decoder.readFile();
         }
 
         @Override
         public void write(Encoder encoder, File value) throws Exception {
-            encoder.writeString(value.getPath());
+            encoder.writeFile(value);
         }
     }
 

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/Decoder.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/Decoder.java
@@ -19,6 +19,7 @@ package org.gradle.internal.serialize;
 import org.jspecify.annotations.Nullable;
 
 import java.io.EOFException;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -143,6 +144,13 @@ public interface Decoder {
      * @throws EOFException when the end of the byte stream is reached before the byte array was fully read.
      */
     byte[] readBinary() throws EOFException, IOException;
+
+    /**
+     * Reads a file.
+     *
+     * @throws EOFException when the end of the byte stream is reached before the file can be fully read.
+     */
+    File readFile() throws EOFException, IOException;
 
     /**
      * Skips the given number of bytes. Can skip over any byte values that were written using one of the raw byte methods on {@link Encoder}.

--- a/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/Encoder.java
+++ b/platforms/core-runtime/serialization/src/main/java/org/gradle/internal/serialize/Encoder.java
@@ -18,6 +18,7 @@ package org.gradle.internal.serialize;
 
 import org.jspecify.annotations.Nullable;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -125,6 +126,11 @@ public interface Encoder {
      * Writes a nullable string value.
      */
     void writeNullableString(@Nullable CharSequence value) throws IOException;
+
+    /**
+     * Writes a file.
+     */
+    void writeFile(File file) throws IOException;
 
     interface EncodeAction<T> {
         void write(T target) throws Exception;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/StringDeduplicatingDecoder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/StringDeduplicatingDecoder.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.Closeable;
 import java.io.EOFException;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -117,6 +118,11 @@ class StringDeduplicatingDecoder implements Decoder, Closeable {
     @Override
     public byte[] readBinary() throws EOFException, IOException {
         return delegate.readBinary();
+    }
+
+    @Override
+    public File readFile() throws EOFException, IOException {
+        return delegate.readFile();
     }
 
     @Override


### PR DESCRIPTION
Currently we store `java.io.File` in CC state as a `String` of file's path. It's rather wasteful because of the files nature - paths contain many repeated segments because the file system is a tree.

This PR suggests to store `java.io.File` in a shape of [prefixed tree](https://en.wikipedia.org/wiki/Trie). By doing this, we effectively store each path segment only once, and we have to store additional metadata for each node that representing a segment. 

Consider an example:
We store `com/example/org/Foo` and `com/example/org/Bar`. For avoiding to store extra metadata for 5 nodes we could safely "compress" `com/example/org` in a single node, and store only `com/example/org`, `Foo` and `Bar` with corresponding metadata in CC state. This idea is commonly named [compressed tree or radix tree](https://en.wikipedia.org/wiki/Radix_tree).

So, `java.io.File` that we store in a CC entry are becoming indexes(`smallInt`) of the node in the tree, and additionally we store the tree in a separate file `.files.work.bin`.

This thing is all about performance, so I've added a couple of JMH microbenchmarks, which are allowed me to get 50% of runtime improvement for `FilePrefixedTree#insert`.

Speaking about macrobenchmarks we have:
- All performance tests are green, without any significant improvement
- CC entry size for `perf-android-large-2` reduced `288Mb -> 260Mb`, what is ~10%
- Memory wasn't measured but I'd expect some minor improvements because of the map [here](https://github.com/gradle/gradle/pull/32767/files#diff-f5f14be426028058835c145459fcd2a931ecdc0fc853f9eb070a5e35431516f4R96)

Whereas ~10% of the disc usage isn't really much, it can be multiplied when use multiple entries for key.
