### PR TITLE
Fail early on null displayname

### DIFF
--- a/platforms/ide/problems/src/main/kotlin/org/gradle/problems/internal/impl/DefaultProblemsReportCreator.kt
+++ b/platforms/ide/problems/src/main/kotlin/org/gradle/problems/internal/impl/DefaultProblemsReportCreator.kt
@@ -96,12 +96,13 @@ class DefaultProblemsReportCreator(
     }
 }
 
+@Suppress("USELESS_ELVIS")
 fun JsonWriter.problemId(id: ProblemId) {
     property("problemId") {
         val list = generateSequence(id.group) { it.parent }.toList() + listOf(ProblemGroup.create(id.name, id.displayName))
         jsonObjectList(list) { group ->
-            property("name", group.name)
-            property("displayName", group.displayName)
+            property("name", group.name ?: "<no name provided>")
+            property("displayName", group.displayName ?: "<no display name provided>")
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/32573

Defensive fix for the issue, we can follow up once we are able to pin point the `null` origin. But as it stands now, this avoids failing builds because of the html problem report.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
