### PR TITLE
Fix nightly snapshot build trigger rule

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
@@ -57,14 +57,7 @@ class PublishNightlySnapshot(
                     // https://www.jetbrains.com/help/teamcity/2022.04/configuring-schedule-triggers.html#general-syntax-1
                     // We want it to be triggered only when there're pending changes in the specific vcs root, i.e. GradleMaster/GradleRelease
                     triggerRules = "+:root=${VersionedSettingsBranch.fromDslContext().vcsRootId()}:."
-                    branchFilter =
-                        if (VersionedSettingsBranch.fromDslContext().isExperimental) {
-                            // The promotion itself will be triggered on gradle-promote's master branch
-                            "+:master"
-                        } else {
-                            // The promotion itself will be triggered on gradle-promote's experimental branch
-                            "+:experimental"
-                        }
+                    branchFilter = "+:${VersionedSettingsBranch.fromDslContext().branchName}"
                 }
             }
         }


### PR DESCRIPTION
An issue was introduced in https://github.com/gradle/gradle/pull/32761: we should monitor `release` branch for `Gradle_Release_Promotion_Nightly` job.