### PR TITLE
Box primitive varargs when passed to generic type parameter in DCL

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeRuntimeFunction.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/DeclarativeRuntimeFunction.kt
@@ -21,6 +21,8 @@ import org.gradle.internal.declarativedsl.InstanceAndPublicType
 import org.gradle.internal.declarativedsl.schemaBuilder.ConfigureLambdaHandler
 import java.lang.reflect.InvocationTargetException
 import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.KTypeParameter
 import kotlin.reflect.jvm.jvmErasure
 
 
@@ -45,9 +47,43 @@ class ReflectionFunction(private val kFunction: KFunction<*>, private val config
         val params = FunctionBinding.convertBinding(kFunction, receiver, binding, hasLambda, configureLambdaHandler)
             ?: error("signature of $kFunction does not match the arguments: $binding")
         val captor = params.valueCaptor
-        val returnedValue = kFunction.callBy(params.map)
+        val returnedValue = kFunction.callBy(adaptVarargs(params.map))
         val returnedPublicType = kFunction.returnType.jvmErasure
         val capturedValue = captor?.value ?: InstanceAndPublicType.NULL
         return DeclarativeRuntimeFunction.InvocationResult(InstanceAndPublicType.of(returnedValue, returnedPublicType), capturedValue)
+    }
+
+    /**
+     * The DCL type inference makes no difference between primitive and boxed arrays, and when the inferred parameter type is a "vararg of ints", it
+     * will always be the primitive array, e.g. [IntArray].
+     * However, the type might have been inferred that way because the generic type specification had a type parameter substitution like
+     * T := [Int].
+     * In that case, the JVM method is generic and expects an object-typed [Array], so we need to convert the
+     * argument array back from unboxed primitives to boxed values.
+     */
+    private fun adaptVarargs(bindingMap: Map<KParameter, Any?>): Map<KParameter, Any?> {
+        fun isVarargWithGenericTypeArgument(kParameter: KParameter) =
+            kParameter.isVararg && kParameter.type.arguments.singleOrNull()?.type?.classifier is KTypeParameter
+
+        if (bindingMap.keys.none(::isVarargWithGenericTypeArgument))
+            return bindingMap
+
+        fun adaptVarargValueArrayToGenerics(valueArray: Any?) = when (valueArray) {
+            is IntArray -> valueArray.toTypedArray()
+            is ShortArray -> valueArray.toTypedArray()
+            is ByteArray -> valueArray.toTypedArray()
+            is LongArray -> valueArray.toTypedArray()
+            is BooleanArray -> valueArray.toTypedArray()
+            is CharArray -> valueArray.toTypedArray()
+            is FloatArray -> valueArray.toTypedArray()
+            is DoubleArray -> valueArray.toTypedArray()
+            else -> valueArray
+        }
+
+        return bindingMap.mapValues {
+            if (isVarargWithGenericTypeArgument(it.key))
+                adaptVarargValueArrayToGenerics(it.value)
+            else it.value
+        }
     }
 }

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/VarargMappingToJvmTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/mappingToJvm/VarargMappingToJvmTest.kt
@@ -28,12 +28,14 @@ class VarargMappingToJvmTest {
     fun `varargs with primitive type get properly converted`() {
         val code = """
             ints = myInts(1, 2, 3)
+            moreInts = myGenericValues(1, 2, 3, 4)
             longs = myLongs(1L, 2L, 3L)
             booleans = myBooleans(true, false, true)
         """.trimIndent()
 
         val receiver = runtimeInstanceFromResult(schema, schema.resolve(code), kotlinFunctionAsConfigureLambda, RuntimeCustomAccessors.none, ::MyTypeWithVarargs)
         assertEquals(listOf(1, 2, 3), receiver.ints)
+        assertEquals(listOf(1, 2, 3, 4), receiver.moreInts)
         assertEquals(listOf(1L, 2L, 3L), receiver.longs)
         assertEquals(listOf(true, false, true), receiver.booleans)
     }
@@ -77,11 +79,18 @@ class VarargMappingToJvmTest {
         @Restricted
         fun myBooleans(vararg booleans: Boolean): List<Boolean> = booleans.toList()
 
+        @Suppress("unused")
+        @Restricted
+        fun <T> myGenericValues(vararg values: T): List<T> = values.toList()
+
         @get:Restricted
         var strings: List<String> = emptyList()
 
         @get:Restricted
         var ints: List<Int> = emptyList()
+
+        @get:Restricted
+        var moreInts: List<Int> = emptyList()
 
         @get:Restricted
         var longs: List<Long> = emptyList()

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDslProjectBuildFileIntegrationSpec.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDslProjectBuildFileIntegrationSpec.groovy
@@ -101,7 +101,7 @@ secondaryAccess { three, true, true}"""
             defaults {
                 restricted {
                     arguments = listOf("one")
-                    flags = listOf("foo", "bar")
+                    flags = listOf(1, 2)
                 }
             }
         """
@@ -109,7 +109,7 @@ secondaryAccess { three, true, true}"""
         file("build.gradle.dcl") << """
             restricted {
                 arguments += listOf("two", "three")
-                flags += listOf("baz")
+                flags += listOf(3)
             }
         """
 
@@ -118,7 +118,7 @@ secondaryAccess { three, true, true}"""
 
         then:
         outputContains("arguments = [one, two, three]")
-        outputContains("flags = [foo, bar, baz]")
+        outputContains("flags = [1, 2, 3]")
 
         where:
         language | _
@@ -262,14 +262,14 @@ secondaryAccess { three, true, true}"""
             @Restricted
             public abstract ListProperty<String> getArguments();
 
-            private List<String> flags = new ArrayList<>();
+            private List<Integer> flags = new ArrayList<>();
 
-            @Restricted // TODO: test a primitive-typed list as well (has issues currently)
-            public List<String> getFlags() {
+            @Restricted
+            public List<Integer> getFlags() {
                 return flags;
             }
 
-            public void setFlags(List<String> flags) {
+            public void setFlags(List<Integer> flags) {
                 this.flags = flags;
             }
 
@@ -363,8 +363,8 @@ secondaryAccess { three, true, true}"""
             @get:Restricted
             abstract val arguments: ListProperty<String>
 
-            @get:Restricted // TODO: test a primitive-typed list as well (has issues currently)
-            var flags: List<String> = emptyList()
+            @get:Restricted
+            var flags: List<Int> = emptyList()
 
             @Configuring
             fun primaryAccess(configure: Access.() -> Unit) {


### PR DESCRIPTION
The DCL type inference makes no difference between primitive and boxed arrays, and when the inferred parameter type is a "vararg of ints", it will always be the primitive array at runtime, e.g. `IntArray`.


However, the type might have been inferred that way because the generic type specialization had a type parameter substitution like `T := Int`. 

In that case, the JVM method is generic and expects an object-typed `Array<Any>`, so we need to convert the argument array back from unboxed primitives to boxed values.
    