### PR TITLE
Replace generic Factory with dedicated interfaces for internal services

### DIFF
--- a/platforms/core-execution/worker-main/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/platforms/core-execution/worker-main/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -24,6 +24,7 @@ import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.event.ScopedListenerManager;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
@@ -179,7 +180,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
     }
 
     LoggingManagerInternal createLoggingManager(ServiceRegistry loggingServiceRegistry) {
-        LoggingManagerInternal loggingManagerInternal = loggingServiceRegistry.newInstance(LoggingManagerInternal.class);
+        LoggingManagerInternal loggingManagerInternal = loggingServiceRegistry.get(LoggingManagerFactory.class).createLoggingManager();
         loggingManagerInternal.captureSystemSources();
         return loggingManagerInternal;
     }

--- a/platforms/core-runtime/daemon-server/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
+++ b/platforms/core-runtime/daemon-server/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
@@ -23,6 +23,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.instrumentation.agent.AgentInitializer;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
@@ -113,7 +114,7 @@ public class DaemonMain extends EntryPoint {
         NativeServices.initializeOnDaemon(gradleHomeDir, NativeServicesMode.fromSystemProperties());
         DaemonServerConfiguration parameters = new DefaultDaemonServerConfiguration(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, singleUse, priority, startupOpts, nativeServicesMode);
         ServiceRegistry loggingRegistry = LoggingServiceRegistry.newCommandLineProcessLogging();
-        LoggingManagerInternal loggingManager = loggingRegistry.newInstance(LoggingManagerInternal.class);
+        LoggingManagerInternal loggingManager = loggingRegistry.get(LoggingManagerFactory.class).createLoggingManager();
 
         DaemonProcessState daemonProcessState = new DaemonProcessState(parameters, loggingRegistry, loggingManager, DefaultClassPath.of(additionalClassPath));
         ServiceRegistry daemonServices = daemonProcessState.getServices();

--- a/platforms/core-runtime/gradle-cli/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
+++ b/platforms/core-runtime/gradle-cli/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
@@ -36,6 +36,7 @@ import org.gradle.internal.buildevents.BuildExceptionReporter;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.logging.DefaultLoggingConfiguration;
 import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
@@ -470,7 +471,7 @@ public class DefaultCommandLineActionFactory implements CommandLineActionFactory
                 // Ignore, deal with this problem later
             }
 
-            LoggingManagerInternal loggingManager = loggingServices.getFactory(LoggingManagerInternal.class).create();
+            LoggingManagerInternal loggingManager = loggingServices.get(LoggingManagerFactory.class).createLoggingManager();
             loggingManager.setLevelInternal(loggingConfiguration.getLogLevel());
             loggingManager.start();
             try {

--- a/platforms/core-runtime/gradle-cli/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
+++ b/platforms/core-runtime/gradle-cli/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
@@ -20,8 +20,8 @@ import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.cli.CommandLineParser
 import org.gradle.initialization.layout.BuildLayoutFactory
 import org.gradle.internal.Actions
-import org.gradle.internal.Factory
 import org.gradle.internal.jvm.Jvm
+import org.gradle.internal.logging.LoggingManagerFactory
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.logging.console.GlobalUserInputReceiver
 import org.gradle.internal.logging.events.OutputEventListener
@@ -60,7 +60,9 @@ class BuildActionsFactoryTest extends Specification {
     ServiceRegistry basicServices
 
     def setup() {
-        def factoryLoggingManager = Mock(Factory) { _ * create() >> Mock(LoggingManagerInternal) }
+        def factoryLoggingManager = Mock(LoggingManagerFactory) {
+            _ * createLoggingManager() >> Mock(LoggingManagerInternal)
+        }
         loggingServices = ServiceRegistryBuilder.builder()
             .provider { registration ->
                 registration.add(OutputEventListener, Mock(OutputEventListener))
@@ -68,7 +70,7 @@ class BuildActionsFactoryTest extends Specification {
                 registration.add(StyledTextOutputFactory, Mock(StyledTextOutputFactory))
                 registration.addProvider(new ServiceRegistrationProvider() {
                     @Provides
-                    Factory<LoggingManagerInternal> createFactory() {
+                    LoggingManagerFactory createFactory() {
                         return factoryLoggingManager
                     }
                 })

--- a/platforms/core-runtime/gradle-cli/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
+++ b/platforms/core-runtime/gradle-cli/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
@@ -19,8 +19,8 @@ import org.apache.tools.ant.Main
 import org.gradle.api.Action
 import org.gradle.cli.CommandLineArgumentException
 import org.gradle.cli.CommandLineParser
-import org.gradle.internal.Factory
 import org.gradle.internal.jvm.Jvm
+import org.gradle.internal.logging.LoggingManagerFactory
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.logging.events.OutputEventListener
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
@@ -73,9 +73,9 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         ProgressLoggerFactory progressLoggerFactory = Mock()
         _ * loggingServices.get(ProgressLoggerFactory) >> progressLoggerFactory
         _ * loggingServices.get(OutputEventListener) >> Mock(OutputEventListener)
-        Factory<LoggingManagerInternal> loggingManagerFactory = Mock()
-        _ * loggingServices.getFactory(LoggingManagerInternal) >> loggingManagerFactory
-        _ * loggingManagerFactory.create() >> loggingManager
+        LoggingManagerFactory loggingManagerFactory = Mock()
+        _ * loggingServices.get(LoggingManagerFactory) >> loggingManagerFactory
+        _ * loggingManagerFactory.createLoggingManager() >> loggingManager
         StyledTextOutputFactory textOutputFactory = Mock()
         _ * loggingServices.get(StyledTextOutputFactory) >> textOutputFactory
         StyledTextOutput textOutput = new StreamingStyledTextOutput(outputs.stdErrPrintStream)
@@ -136,8 +136,8 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         outputs.stdErr.contains('--some-option')
 
         and:
-        1 * actionFactory1.configureCommandLineParser(!null) >> {CommandLineParser parser -> parser.option('some-option')}
-        1 * executionListener.onFailure({it instanceof CommandLineArgumentException})
+        1 * actionFactory1.configureCommandLineParser(!null) >> { CommandLineParser parser -> parser.option('some-option') }
+        1 * executionListener.onFailure({ it instanceof CommandLineArgumentException })
         0 * executionListener._
 
         where:
@@ -162,7 +162,7 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         outputs.stdErr.contains('--some-option')
 
         and:
-        1 * actionFactory1.configureCommandLineParser(!null) >> {CommandLineParser parser -> parser.option('some-option')}
+        1 * actionFactory1.configureCommandLineParser(!null) >> { CommandLineParser parser -> parser.option('some-option') }
         1 * actionFactory1.createAction(!null, !null, !null) >> { throw failure }
         1 * executionListener.onFailure(failure)
         0 * executionListener._
@@ -180,8 +180,8 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         outputs.stdErr.contains('--some-option')
 
         and:
-        1 * actionFactory1.configureCommandLineParser(!null) >> {CommandLineParser parser -> parser.option('some-option')}
-        1 * executionListener.onFailure({it instanceof CommandLineArgumentException})
+        1 * actionFactory1.configureCommandLineParser(!null) >> { CommandLineParser parser -> parser.option('some-option') }
+        1 * executionListener.onFailure({ it instanceof CommandLineArgumentException })
         0 * executionListener._
     }
 
@@ -216,7 +216,7 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         outputs.stdOut.contains('--some-option')
 
         and:
-        1 * actionFactory1.configureCommandLineParser(!null) >> {CommandLineParser parser -> parser.option('some-option')}
+        1 * actionFactory1.configureCommandLineParser(!null) >> { CommandLineParser parser -> parser.option('some-option') }
         0 * executionListener._
 
         where:
@@ -288,7 +288,7 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         outputs.stdOut.contains(EXPECTED_VERSION_TEXT)
 
         and:
-        1 * actionFactory1.configureCommandLineParser(!null) >> {CommandLineParser parser -> parser.option('some-option')}
+        1 * actionFactory1.configureCommandLineParser(!null) >> { CommandLineParser parser -> parser.option('some-option') }
         0 * actionFactory1.createAction(_, _)
         1 * loggingManager.start()
         0 * executionListener._

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/ForegroundDaemonAction.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/ForegroundDaemonAction.java
@@ -18,6 +18,7 @@ package org.gradle.launcher.daemon.bootstrap;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.instrumentation.agent.AgentInitializer;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.daemon.configuration.DaemonServerConfiguration;
@@ -41,7 +42,7 @@ public class ForegroundDaemonAction implements Runnable {
 
     @Override
     public void run() {
-        LoggingManagerInternal loggingManager = loggingRegistry.newInstance(LoggingManagerInternal.class);
+        LoggingManagerInternal loggingManager = loggingRegistry.get(LoggingManagerFactory.class).createLoggingManager();
         loggingManager.start();
 
         DaemonProcessState daemonProcessState = new DaemonProcessState(configuration, loggingRegistry, loggingManager, DefaultClassPath.of());

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -35,6 +35,7 @@ import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.daemon.client.execution.ClientBuildRequestContext;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.console.GlobalUserInputReceiver;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
@@ -151,7 +152,7 @@ public class ProviderConnection {
         this.consumerVersion = consumerVersion;
         LogLevel providerLogLevel = parameters.getVerboseLogging() ? LogLevel.DEBUG : LogLevel.INFO;
         LOGGER.debug("Configuring logging to level: {}", providerLogLevel);
-        LoggingManagerInternal loggingManager = sharedServices.newInstance(LoggingManagerInternal.class);
+        LoggingManagerInternal loggingManager = sharedServices.get(LoggingManagerFactory.class).createLoggingManager();
         loggingManager.setLevelInternal(providerLogLevel);
         loggingManager.start();
     }
@@ -310,12 +311,12 @@ public class ProviderConnection {
         }
         CompositeStoppable stoppable = new CompositeStoppable();
         if (Boolean.TRUE.equals(operationParameters.isEmbedded())) {
-            loggingManager = sharedServices.getFactory(LoggingManagerInternal.class).create();
+            loggingManager = sharedServices.get(LoggingManagerFactory.class).createLoggingManager();
             loggingManager.captureSystemSources();
             executor = new RunInProcess(new SystemPropertySetterExecuter(new ForwardStdInToThisProcess(userInputReceiver, userInputReader, standardInput, embeddedExecutor)));
         } else {
             ServiceRegistry requestSpecificLogging = LoggingServiceRegistry.newNestedLogging();
-            loggingManager = requestSpecificLogging.getFactory(LoggingManagerInternal.class).create();
+            loggingManager = requestSpecificLogging.get(LoggingManagerFactory.class).createLoggingManager();
             ServiceRegistry clientServices = daemonClientFactory.createBuildClientServices(requestSpecificLogging, params.daemonParams, params.requestContext, standardInput, Optional.ofNullable(operationParameters.getBuildProgressListener()));
             stoppable.add(clientServices);
             stoppable.add(requestSpecificLogging);

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/LoggingManagerFactory.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/LoggingManagerFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging;
+
+import org.gradle.api.NonNullApi;
+
+@NonNullApi
+public interface LoggingManagerFactory {
+
+    LoggingManagerInternal getRoot();
+
+    LoggingManagerInternal createLoggingManager();
+
+}

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManagerFactory.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManagerFactory.java
@@ -16,12 +16,12 @@
 
 package org.gradle.internal.logging.services;
 
-import org.gradle.internal.Factory;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.config.LoggingRouter;
 import org.gradle.internal.logging.config.LoggingSourceSystem;
 
-public class DefaultLoggingManagerFactory implements Factory<LoggingManagerInternal> {
+public class DefaultLoggingManagerFactory implements LoggingManagerFactory {
     private final LoggingSourceSystem slfLoggingSystem;
     private final LoggingSourceSystem javaUtilLoggingSystem;
     private final LoggingSourceSystem stdOutLoggingSystem;
@@ -39,12 +39,13 @@ public class DefaultLoggingManagerFactory implements Factory<LoggingManagerInter
         rootManager = newManager();
     }
 
+    @Override
     public LoggingManagerInternal getRoot() {
         return rootManager;
     }
 
     @Override
-    public LoggingManagerInternal create() {
+    public LoggingManagerInternal createLoggingManager() {
         if (!created) {
             created = true;
             return getRoot();

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/services/LoggingServiceRegistry.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.logging.services;
 
 import org.gradle.api.logging.LogLevel;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.config.LoggingSourceSystem;
 import org.gradle.internal.logging.config.LoggingSystemAdapter;
@@ -79,7 +80,7 @@ public abstract class LoggingServiceRegistry implements ServiceRegistrationProvi
      */
     public static ServiceRegistry newCommandLineProcessLogging() {
         ServiceRegistry loggingServices = createCommandLineLogging();
-        LoggingManagerInternal rootLoggingManager = loggingServices.get(DefaultLoggingManagerFactory.class).getRoot();
+        LoggingManagerInternal rootLoggingManager = loggingServices.get(LoggingManagerFactory.class).getRoot();
         rootLoggingManager.captureSystemSources();
         rootLoggingManager.attachSystemOutAndErr();
         return loggingServices;
@@ -145,7 +146,7 @@ public abstract class LoggingServiceRegistry implements ServiceRegistrationProvi
     }
 
     @Provides
-    protected DefaultLoggingManagerFactory createLoggingManagerFactory(Clock clock) {
+    protected LoggingManagerFactory createLoggingManagerFactory(Clock clock) {
         OutputEventListener outputEventBroadcaster = outputEventListenerManager.getBroadcaster();
 
         LoggingSourceSystem stdout = new DefaultStdOutLoggingSystem(getStdoutListener(), clock);
@@ -189,7 +190,7 @@ public abstract class LoggingServiceRegistry implements ServiceRegistrationProvi
 
         @Provides
         @Override
-        protected DefaultLoggingManagerFactory createLoggingManagerFactory(Clock clock) {
+        protected LoggingManagerFactory createLoggingManagerFactory(Clock clock) {
             // Don't configure anything
             return new DefaultLoggingManagerFactory(
                 renderer,

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/services/LoggingServiceRegistryTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/logging/services/LoggingServiceRegistryTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.StandardOutputListener
 import org.gradle.internal.SystemProperties
 import org.gradle.internal.logging.ConfigureLogging
-import org.gradle.internal.logging.LoggingManagerInternal
+import org.gradle.internal.logging.LoggingManagerFactory
 import org.gradle.internal.logging.TestOutputEventListener
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.util.internal.RedirectStdOutAndErr
@@ -44,7 +44,7 @@ class LoggingServiceRegistryTest extends Specification {
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
 
         expect:
-        def factory = registry.getFactory(LoggingManagerInternal.class)
+        def factory = registry.get(LoggingManagerFactory)
         factory instanceof DefaultLoggingManagerFactory
     }
 
@@ -63,7 +63,7 @@ class LoggingServiceRegistryTest extends Specification {
         def logger = LoggerFactory.getLogger("category")
 
         when:
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         logger.warn("before")
 
         then:
@@ -85,7 +85,7 @@ class LoggingServiceRegistryTest extends Specification {
         given:
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
         def logger = LoggerFactory.getLogger("category")
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
 
@@ -120,7 +120,7 @@ class LoggingServiceRegistryTest extends Specification {
         given:
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
         def logger = Logger.getLogger("category")
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
 
@@ -154,7 +154,7 @@ class LoggingServiceRegistryTest extends Specification {
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
         def rootLogger = Logger.getLogger("")
         def logger = Logger.getLogger("category")
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
 
         when:
         rootLogger.level = Level.OFF
@@ -184,7 +184,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         when:
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
 
         then:
         System.out == outputs.stdOutPrintStream
@@ -226,7 +226,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         given:
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.captureStandardError(LogLevel.WARN)
         loggingManager.captureStandardOutput(LogLevel.INFO)
         loggingManager.levelInternal = LogLevel.INFO
@@ -236,7 +236,7 @@ class LoggingServiceRegistryTest extends Specification {
         loggingManager.start()
 
         when:
-        def nestedManager = registry.newInstance(LoggingManagerInternal)
+        def nestedManager = registry.get(LoggingManagerFactory).createLoggingManager()
         nestedManager.captureStandardError(LogLevel.INFO)
         nestedManager.captureStandardOutput(LogLevel.DEBUG)
         nestedManager.start()
@@ -268,7 +268,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         given:
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
@@ -310,7 +310,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         when:
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
 
         then:
         System.out == outputs.stdOutPrintStream
@@ -336,7 +336,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         given:
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
 
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
@@ -364,7 +364,7 @@ class LoggingServiceRegistryTest extends Specification {
         given:
         def logger = LoggerFactory.getLogger("category")
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
 
         when:
         logger.warn("before")
@@ -389,7 +389,7 @@ class LoggingServiceRegistryTest extends Specification {
         given:
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
         def logger = LoggerFactory.getLogger("category")
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         def listener = Mock(StandardOutputListener)
 
         when:
@@ -414,7 +414,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         given:
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
@@ -443,7 +443,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         given:
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
@@ -470,7 +470,7 @@ class LoggingServiceRegistryTest extends Specification {
         given:
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
         def logger = Logger.getLogger("category")
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
@@ -513,7 +513,7 @@ class LoggingServiceRegistryTest extends Specification {
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
         def rootLogger = Logger.getLogger("")
         def logger = Logger.getLogger("category")
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
 
         when:
         rootLogger.level = Level.OFF
@@ -542,7 +542,7 @@ class LoggingServiceRegistryTest extends Specification {
     def doesNotConsumeFromSystemOutAndErrWhenEmbedded() {
         when:
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.levelInternal = LogLevel.INFO
         loggingManager.start()
 
@@ -556,7 +556,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         when:
         def registry = LoggingServiceRegistry.newEmbeddableLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.addStandardErrorListener(listener)
@@ -598,7 +598,7 @@ class LoggingServiceRegistryTest extends Specification {
         given:
         def registry = LoggingServiceRegistry.newNestedLogging()
         def logger = LoggerFactory.getLogger("category")
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         def listener = Mock(StandardOutputListener)
 
         when:
@@ -617,7 +617,7 @@ class LoggingServiceRegistryTest extends Specification {
     def doesNotConsumeJavaUtilLoggingWhenNested() {
         given:
         def registry = LoggingServiceRegistry.newNestedLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.levelInternal = LogLevel.WARN
         loggingManager.start()
         def logger = Logger.getLogger("category")
@@ -634,7 +634,7 @@ class LoggingServiceRegistryTest extends Specification {
     def doesNotConsumeFromSystemOutputAndErrorWhenNested() {
         when:
         def registry = LoggingServiceRegistry.newNestedLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.levelInternal = LogLevel.WARN
         loggingManager.start()
 
@@ -648,7 +648,7 @@ class LoggingServiceRegistryTest extends Specification {
 
         when:
         def registry = LoggingServiceRegistry.newNestedLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.start()

--- a/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
+++ b/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
@@ -17,9 +17,9 @@ package org.gradle.testfixtures.internal;
 
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.internal.CacheFactory;
-import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.instrumentation.agent.AgentStatus;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
@@ -42,8 +42,8 @@ public class TestGlobalScopeServices extends GlobalScopeServices {
     }
 
     @Provides
-    LoggingManagerInternal createLoggingManager(Factory<LoggingManagerInternal> loggingManagerFactory) {
-        return loggingManagerFactory.create();
+    LoggingManagerInternal createLoggingManager(LoggingManagerFactory loggingManagerFactory) {
+        return loggingManagerFactory.createLoggingManager();
     }
 
     @Provides

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilderTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.catalog.problems.VersionCatalogErrorMessages
 import org.gradle.api.internal.catalog.problems.VersionCatalogProblemId
 import org.gradle.api.internal.catalog.problems.VersionCatalogProblemTestFor
 import org.gradle.api.logging.StandardOutputListener
-import org.gradle.internal.logging.LoggingManagerInternal
+import org.gradle.internal.logging.LoggingManagerFactory
 import org.gradle.internal.logging.services.LoggingServiceRegistry
 
 class DefaultVersionCatalogBuilderTest extends AbstractVersionCatalogTest implements VersionCatalogErrorMessages {
@@ -162,7 +162,7 @@ class DefaultVersionCatalogBuilderTest extends AbstractVersionCatalogTest implem
     def "warns if multiple entries use the same alias"() {
         StandardOutputListener listener = Mock()
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.start()
@@ -182,7 +182,7 @@ class DefaultVersionCatalogBuilderTest extends AbstractVersionCatalogTest implem
     def "warns if multiple entries use the same bundle name"() {
         StandardOutputListener listener = Mock()
         def registry = LoggingServiceRegistry.newCommandLineProcessLogging()
-        def loggingManager = registry.newInstance(LoggingManagerInternal)
+        def loggingManager = registry.get(LoggingManagerFactory).createLoggingManager()
         loggingManager.enableUserStandardOutputListeners()
         loggingManager.addStandardOutputListener(listener)
         loggingManager.start()

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
@@ -38,10 +38,10 @@ import org.gradle.internal.instrumentation.agent.AgentStatus
 import org.gradle.internal.jvm.inspection.CachingJvmMetadataDetector
 import org.gradle.internal.jvm.inspection.DefaultJvmMetadataDetector
 import org.gradle.internal.jvm.inspection.DefaultJvmVersionDetector
+import org.gradle.internal.logging.LoggingManagerFactory
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.logging.TestOutputEventListener
 import org.gradle.internal.logging.events.OutputEventListener
-import org.gradle.internal.logging.services.DefaultLoggingManagerFactory
 import org.gradle.internal.logging.services.LoggingServiceRegistry
 import org.gradle.internal.operations.CurrentBuildOperationRef
 import org.gradle.internal.operations.DefaultBuildOperationRef
@@ -160,7 +160,7 @@ abstract class AbstractWorkerProcessIntegrationSpec extends Specification {
     }
 
     static LoggingManagerInternal loggingManager(LogLevel logLevel) {
-        def loggingManager = LoggingServiceRegistry.newEmbeddableLogging().get(DefaultLoggingManagerFactory).create()
+        def loggingManager = LoggingServiceRegistry.newEmbeddableLogging().get(LoggingManagerFactory).createLoggingManager()
         loggingManager.setLevelInternal(logLevel)
         return loggingManager
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -72,6 +72,7 @@ import org.gradle.internal.extensibility.ExtensibleDynamicObject;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger;
@@ -560,7 +561,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private LoggingManagerInternal loggingManager() {
         if (loggingManager == null) {
-            loggingManager = services.getFactory(org.gradle.internal.logging.LoggingManagerInternal.class).create();
+            loggingManager = services.get(LoggingManagerFactory.class).createLoggingManager();
         }
         return loggingManager;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/AntBuilderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/AntBuilderFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project;
+
+import org.gradle.api.AntBuilder;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scope.Project.class)
+public interface AntBuilderFactory {
+
+    AntBuilder createAntBuilder();
+
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultAntBuilderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultAntBuilderFactory.java
@@ -15,16 +15,14 @@
  */
 package org.gradle.api.internal.project;
 
-import org.gradle.api.AntBuilder;
 import org.gradle.api.Project;
 import org.gradle.api.internal.project.ant.AntLoggingAdapter;
 import org.gradle.api.internal.project.ant.AntLoggingAdapterFactory;
-import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.CompositeStoppable;
 
 import java.io.Closeable;
 
-public class DefaultAntBuilderFactory implements Factory<AntBuilder>, Closeable {
+public class DefaultAntBuilderFactory implements AntBuilderFactory, Closeable {
     private final Project project;
     private final AntLoggingAdapterFactory loggingAdapterFactory;
     private final CompositeStoppable stoppable = new CompositeStoppable();
@@ -35,7 +33,7 @@ public class DefaultAntBuilderFactory implements Factory<AntBuilder>, Closeable 
     }
 
     @Override
-    public DefaultAntBuilder create() {
+    public DefaultAntBuilder createAntBuilder() {
         AntLoggingAdapter loggingAdapter = loggingAdapterFactory.create();
         DefaultAntBuilder antBuilder = new DefaultAntBuilder(project, loggingAdapter);
         antBuilder.getProject().setBaseDir(project.getProjectDir());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -190,7 +190,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     private final ProjectStateInternal state;
 
-    private Factory<AntBuilder> antBuilderFactory;
+    private AntBuilderFactory antBuilderFactory;
 
     private AntBuilder ant;
 
@@ -799,7 +799,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @Override
     public AntBuilder createAntBuilder() {
         onMutableStateAccess();
-        return getAntBuilderFactory().create();
+        return getAntBuilderFactory().createAntBuilder();
     }
 
     /**
@@ -1093,9 +1093,9 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         return getFileOperations().delete(action);
     }
 
-    public Factory<AntBuilder> getAntBuilderFactory() {
+    public AntBuilderFactory getAntBuilderFactory() {
         if (antBuilderFactory == null) {
-            antBuilderFactory = services.getFactory(AntBuilder.class);
+            antBuilderFactory = services.get(AntBuilderFactory.class);
         }
         return antBuilderFactory;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
@@ -19,9 +19,8 @@ package org.gradle.api.internal.project;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.initialization.DefaultProjectDescriptor;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.Factory;
 import org.gradle.internal.build.BuildState;
-import org.gradle.internal.logging.LoggingManagerInternal;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.model.StateTransitionController;
 import org.gradle.internal.model.StateTransitionControllerFactory;
 import org.gradle.internal.service.CloseableServiceRegistry;
@@ -72,7 +71,7 @@ public class ProjectLifecycleController implements Closeable {
             ProjectState parent = owner.getBuildParent();
             ProjectInternal parentModel = parent == null ? null : parent.getMutableModel();
             ServiceRegistryFactory serviceRegistryFactory = domainObject -> {
-                final Factory<LoggingManagerInternal> loggingManagerFactory = buildServices.getFactory(LoggingManagerInternal.class);
+                LoggingManagerFactory loggingManagerFactory = buildServices.get(LoggingManagerFactory.class);
                 projectScopeServices = ProjectScopeServices.create(buildServices, (ProjectInternal) domainObject, loggingManagerFactory);
                 return projectScopeServices;
             };

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultScriptPluginFactory.java
@@ -31,7 +31,7 @@ import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.groovy.scripts.internal.BuildScriptData;
 import org.gradle.groovy.scripts.internal.CompileOperation;
 import org.gradle.internal.Actions;
-import org.gradle.internal.Factory;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.service.CloseableServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
@@ -45,14 +45,14 @@ import org.gradle.plugin.use.internal.PluginsAwareScript;
 public class DefaultScriptPluginFactory implements ScriptPluginFactory {
     private final ServiceRegistry scriptServices;
     private final ScriptCompilerFactory scriptCompilerFactory;
-    private final Factory<LoggingManagerInternal> loggingFactoryManager;
+    private final LoggingManagerFactory loggingFactoryManager;
     private final PluginHandler pluginHandler;
     private final PluginRequestApplicator pluginRequestApplicator;
     private final CompileOperationFactory compileOperationFactory;
     private ScriptPluginFactory scriptPluginFactory;
 
     public DefaultScriptPluginFactory(
-        ServiceRegistry scriptServices, ScriptCompilerFactory scriptCompilerFactory, Factory<LoggingManagerInternal> loggingFactoryManager,
+        ServiceRegistry scriptServices, ScriptCompilerFactory scriptCompilerFactory, LoggingManagerFactory loggingFactoryManager,
         PluginHandler pluginHandler, PluginRequestApplicator pluginRequestApplicator,
         CompileOperationFactory compileOperationFactory
     ) {
@@ -102,7 +102,7 @@ public class DefaultScriptPluginFactory implements ScriptPluginFactory {
                 .provider(registration -> {
                     registration.add(ScriptPluginFactory.class, scriptPluginFactory);
                     registration.add(ClassLoaderScope.class, baseScope);
-                    registration.add(LoggingManagerInternal.class, loggingFactoryManager.create());
+                    registration.add(LoggingManagerInternal.class, loggingFactoryManager.createLoggingManager());
                     registration.add(ScriptHandler.class, scriptHandler);
                 })
                 .build();

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -163,7 +163,6 @@ import org.gradle.initialization.properties.DefaultProjectPropertiesLoader;
 import org.gradle.initialization.properties.DefaultSystemPropertiesInstaller;
 import org.gradle.initialization.properties.ProjectPropertiesLoader;
 import org.gradle.initialization.properties.SystemPropertiesInstaller;
-import org.gradle.internal.Factory;
 import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.actor.internal.DefaultActorFactory;
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
@@ -206,7 +205,7 @@ import org.gradle.internal.instrumentation.reporting.PropertyUpgradeReportConfig
 import org.gradle.internal.invocation.DefaultBuildInvocationDetails;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.jvm.JavaModuleDetector;
-import org.gradle.internal.logging.LoggingManagerInternal;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.management.ToolchainManagementInternal;
 import org.gradle.internal.model.CalculatedValueFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
@@ -546,7 +545,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         InstantiatorFactory instantiatorFactory,
         ServiceRegistry buildScopedServices,
         ScriptCompilerFactory scriptCompilerFactory,
-        Factory<LoggingManagerInternal> loggingManagerFactory,
+        LoggingManagerFactory loggingManagerFactory,
         PluginHandler pluginHandler,
         PluginRequestApplicator pluginRequestApplicator,
         CompileOperationFactory compileOperationFactory,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -63,7 +63,6 @@ import org.gradle.initialization.FlatClassLoaderRegistry;
 import org.gradle.initialization.JdkToolsInitializer;
 import org.gradle.initialization.LegacyTypesSupport;
 import org.gradle.initialization.layout.BuildLayoutFactory;
-import org.gradle.internal.Factory;
 import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.ExecutorFactory;
@@ -81,6 +80,7 @@ import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.instantiation.generator.DefaultInstantiatorFactory;
 import org.gradle.internal.instrumentation.agent.AgentInitializer;
 import org.gradle.internal.instrumentation.agent.AgentStatus;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
@@ -330,8 +330,8 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
     }
 
     @Provides
-    LoggingManagerInternal createLoggingManager(Factory<LoggingManagerInternal> loggingManagerFactory) {
-        return loggingManagerFactory.create();
+    LoggingManagerInternal createLoggingManager(LoggingManagerFactory loggingManagerFactory) {
+        return loggingManagerFactory.createLoggingManager();
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.service.scopes;
 
-import org.gradle.api.AntBuilder;
 import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.initialization.SharedModelDefaults;
@@ -49,6 +48,7 @@ import org.gradle.api.internal.plugins.PluginRegistry;
 import org.gradle.api.internal.plugins.PluginTarget;
 import org.gradle.api.internal.plugins.PluginTargetType;
 import org.gradle.api.internal.plugins.RuleBasedPluginTarget;
+import org.gradle.api.internal.project.AntBuilderFactory;
 import org.gradle.api.internal.project.CrossProjectConfigurator;
 import org.gradle.api.internal.project.CrossProjectModelAccess;
 import org.gradle.api.internal.project.DefaultAntBuilderFactory;
@@ -78,7 +78,6 @@ import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.configuration.project.DefaultProjectConfigurationActionContainer;
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
 import org.gradle.initialization.layout.BuildLayout;
-import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.PathToFileResolver;
@@ -214,7 +213,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    protected Factory<AntBuilder> createAntBuilderFactory() {
+    protected AntBuilderFactory createAntBuilderFactory() {
         return new DefaultAntBuilderFactory(project, new DefaultAntLoggingAdapterFactory());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -84,6 +84,7 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.jvm.JavaModuleDetector;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationRunner;
@@ -124,7 +125,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
     public static CloseableServiceRegistry create(
         ServiceRegistry buildServices,
         ProjectInternal project,
-        Factory<LoggingManagerInternal> loggingManagerInternalFactory
+        LoggingManagerFactory loggingManagerInternalFactory
     ) {
         return ServiceRegistryBuilder.builder()
             .scopeStrictly(Scope.Project.class)
@@ -136,10 +137,10 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
     }
 
     private final ProjectInternal project;
-    private final Factory<LoggingManagerInternal> loggingManagerInternalFactory;
+    private final LoggingManagerFactory loggingManagerInternalFactory;
 
 
-    public ProjectScopeServices(ProjectInternal project, Factory<LoggingManagerInternal> loggingManagerInternalFactory) {
+    public ProjectScopeServices(ProjectInternal project, LoggingManagerFactory loggingManagerInternalFactory) {
         this.project = project;
         this.loggingManagerInternalFactory = loggingManagerInternalFactory;
     }
@@ -176,7 +177,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected LoggingManagerInternal createLoggingManager() {
-        return loggingManagerInternalFactory.create();
+        return loggingManagerInternalFactory.createLoggingManager();
     }
 
     @Provides

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultAntBuilderFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultAntBuilderFactoryTest.groovy
@@ -31,7 +31,7 @@ public class DefaultAntBuilderFactoryTest extends AbstractProjectBuilderSpec {
 
     public void "can create AntBuilder"() {
         when:
-        def ant = factory.create()
+        def ant = factory.createAntBuilder()
 
         then:
         ant != null
@@ -40,7 +40,7 @@ public class DefaultAntBuilderFactoryTest extends AbstractProjectBuilderSpec {
 
     public void "sets base directory of Ant project"() {
         when:
-        def ant = factory.create()
+        def ant = factory.createAntBuilder()
 
         then:
         ant.project.baseDir == project.projectDir

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -41,7 +41,6 @@ import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.util.internal.PatternSets
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator
-import org.gradle.internal.Factory
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.management.DependencyResolutionManagementInternal
@@ -270,11 +269,8 @@ class DefaultProjectSpec extends Specification {
         serviceRegistry.add(SoftwareFeatureApplicator, Stub(SoftwareFeatureApplicator))
 
         def antBuilder = Mock(AntBuilder)
-        serviceRegistry.addProvider(new ServiceRegistrationProvider() {
-            @Provides
-            Factory<AntBuilder> createAntBuilder() {
-                return () -> antBuilder
-            }
+        serviceRegistry.add(AntBuilderFactory, Mock(AntBuilderFactory) {
+            createAntBuilder() >> antBuilder
         })
 
         serviceRegistry.addProvider(new ServiceRegistrationProvider() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -80,7 +80,6 @@ import org.gradle.groovy.scripts.EmptyScript
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.initialization.ClassLoaderScopeRegistryListener
 import org.gradle.internal.Actions
-import org.gradle.internal.Factory
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.management.DependencyResolutionManagementInternal
@@ -138,7 +137,7 @@ class DefaultProjectTest extends Specification {
     ServiceRegistry serviceRegistryMock
     ServiceRegistryFactory projectServiceRegistryFactoryMock
     TaskContainerInternal taskContainerMock = Stub(TaskContainerInternal)
-    Factory<AntBuilder> antBuilderFactoryMock = Stub(Factory)
+    AntBuilderFactory antBuilderFactoryMock = Stub(AntBuilderFactory)
     AntBuilder testAntBuilder
 
     RoleBasedConfigurationContainerInternal configurationContainerMock = Stub(RoleBasedConfigurationContainerInternal)
@@ -185,7 +184,7 @@ class DefaultProjectTest extends Specification {
 
         testAntBuilder = new DefaultAntBuilder(null, antLoggingAdapter)
 
-        antBuilderFactoryMock.create() >> testAntBuilder
+        antBuilderFactoryMock.createAntBuilder() >> testAntBuilder
         script.getDisplayName() >> '[build file]'
         script.getClassName() >> 'scriptClass'
         script.getResource() >> new StringTextResource("", "")
@@ -215,7 +214,7 @@ class DefaultProjectTest extends Specification {
         serviceRegistryMock.get((Type) InputNormalizationHandlerInternal) >> inputNormalizationHandler
         serviceRegistryMock.get(ProjectEvaluator) >> projectEvaluator
         serviceRegistryMock.get(DynamicLookupRoutine) >> new DefaultDynamicLookupRoutine()
-        serviceRegistryMock.getFactory(AntBuilder) >> antBuilderFactoryMock
+        serviceRegistryMock.get(AntBuilderFactory) >> antBuilderFactoryMock
         serviceRegistryMock.get((Type) ScriptHandlerInternal) >> scriptHandlerMock
         serviceRegistryMock.get((Type) LoggingManagerInternal) >> loggingManagerMock
         serviceRegistryMock.get(FileResolver) >> fileResolver

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
@@ -33,10 +33,10 @@ import org.gradle.groovy.scripts.ScriptRunner
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.groovy.scripts.internal.BuildScriptData
 import org.gradle.groovy.scripts.internal.NoDataCompileOperation
-import org.gradle.internal.Factory
 import org.gradle.internal.classloader.ClasspathHasher
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.hash.TestHashCodes
+import org.gradle.internal.logging.LoggingManagerFactory
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
@@ -58,7 +58,7 @@ class DefaultScriptPluginFactoryTest extends Specification {
     def pluginRequestApplicator = Mock(PluginRequestApplicator)
     def scriptHandler = Mock(ScriptHandlerInternal)
     def classPathScriptRunner = Mock(ScriptRunner)
-    def loggingManagerFactory = Mock(Factory) as Factory<LoggingManagerInternal>
+    def loggingManagerFactory = Mock(LoggingManagerFactory)
     def loggingManager = Mock(LoggingManagerInternal)
     def documentationRegistry = Mock(DocumentationRegistry)
     def classpathHasher = Mock(ClasspathHasher)
@@ -95,7 +95,7 @@ class DefaultScriptPluginFactoryTest extends Specification {
         configurer.apply(target)
 
         then:
-        1 * loggingManagerFactory.create() >> loggingManager
+        1 * loggingManagerFactory.createLoggingManager() >> loggingManager
         1 * scriptCompilerFactory.createCompiler(scriptSource) >> scriptCompiler
         1 * scriptCompiler.compile(DefaultScript, target, baseScope, _ as NoDataCompileOperation, _) >> classPathScriptRunner
         1 * classPathScriptRunner.run(target, _ as ServiceRegistry)
@@ -117,7 +117,7 @@ class DefaultScriptPluginFactoryTest extends Specification {
         configurer.apply(target)
 
         then:
-        1 * loggingManagerFactory.create() >> loggingManager
+        1 * loggingManagerFactory.createLoggingManager() >> loggingManager
         1 * scriptCompilerFactory.createCompiler(scriptSource) >> scriptCompiler
         1 * scriptCompiler.compile(ProjectScript, target, baseScope, _ as NoDataCompileOperation, _) >> classPathScriptRunner
         1 * classPathScriptRunner.run(target, _ as ServiceRegistry)
@@ -143,7 +143,7 @@ class DefaultScriptPluginFactoryTest extends Specification {
         configurer.apply(target)
 
         then:
-        1 * loggingManagerFactory.create() >> loggingManager
+        1 * loggingManagerFactory.createLoggingManager() >> loggingManager
         1 * scriptCompilerFactory.createCompiler(scriptSource) >> scriptCompiler
         1 * scriptCompiler.compile(ProjectScript, target, baseScope, _ as NoDataCompileOperation, _) >> classPathScriptRunner
         1 * classPathScriptRunner.run(target, _ as ServiceRegistry)
@@ -168,7 +168,7 @@ class DefaultScriptPluginFactoryTest extends Specification {
         configurer.apply(target)
 
         then:
-        1 * loggingManagerFactory.create() >> loggingManager
+        1 * loggingManagerFactory.createLoggingManager() >> loggingManager
         1 * scriptCompilerFactory.createCompiler(scriptSource) >> scriptCompiler
         1 * scriptCompiler.compile(ProjectScript, target, baseScope, _ as NoDataCompileOperation, _) >> classPathScriptRunner
         1 * classPathScriptRunner.run(target, _ as ServiceRegistry)
@@ -193,7 +193,7 @@ class DefaultScriptPluginFactoryTest extends Specification {
         configurer.apply(target)
 
         then:
-        1 * loggingManagerFactory.create() >> loggingManager
+        1 * loggingManagerFactory.createLoggingManager() >> loggingManager
         1 * scriptCompilerFactory.createCompiler(scriptSource) >> scriptCompiler
         1 * scriptCompiler.compile(ProjectScript, target, baseScope, _ as NoDataCompileOperation, _) >> classPathScriptRunner
         1 * classPathScriptRunner.run(target, _ as ServiceRegistry)
@@ -217,7 +217,7 @@ class DefaultScriptPluginFactoryTest extends Specification {
         configurer.apply(target)
 
         then:
-        1 * loggingManagerFactory.create() >> loggingManager
+        1 * loggingManagerFactory.createLoggingManager() >> loggingManager
         1 * scriptCompilerFactory.createCompiler(scriptSource) >> scriptCompiler
         1 * scriptCompiler.compile(ProjectScript, target, baseScope, _ as NoDataCompileOperation, _) >> classPathScriptRunner
         1 * classPathScriptRunner.run(target, _ as ServiceRegistry)
@@ -239,7 +239,7 @@ class DefaultScriptPluginFactoryTest extends Specification {
         configurer.apply(target)
 
         then:
-        1 * loggingManagerFactory.create() >> loggingManager
+        1 * loggingManagerFactory.createLoggingManager() >> loggingManager
         1 * scriptCompilerFactory.createCompiler(scriptSource) >> scriptCompiler
         1 * scriptCompiler.compile(DefaultScript, target, baseScope, _ as NoDataCompileOperation, _) >> classPathScriptRunner
         1 * classPathScriptRunner.run(target, _ as ServiceRegistry)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -47,8 +47,8 @@ import org.gradle.internal.jvm.inspection.CachingJvmMetadataDetector;
 import org.gradle.internal.jvm.inspection.DefaultJvmMetadataDetector;
 import org.gradle.internal.jvm.inspection.DefaultJvmVersionDetector;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
-import org.gradle.internal.logging.services.DefaultLoggingManagerFactory;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.console.TestOverrideConsoleDetector;
 import org.gradle.internal.nativeintegration.services.NativeServices;
@@ -425,10 +425,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
             executer.withGradleVersionOverride(gradleVersionOverride);
         }
 
-        if (debug.isEnabled()){
+        if (debug.isEnabled()) {
             executer.startBuildProcessInDebugger(opts -> debug.copyTo(opts));
         }
-        if (debugLauncher.isEnabled()){
+        if (debugLauncher.isEnabled()) {
             executer.startLauncherInDebugger(opts -> debugLauncher.copyTo(opts));
         }
 
@@ -1664,7 +1664,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
     private static ServiceRegistry newCommandLineProcessLogging() {
         ServiceRegistry loggingServices = LoggingServiceRegistry.newEmbeddableLogging();
-        LoggingManagerInternal rootLoggingManager = loggingServices.get(DefaultLoggingManagerFactory.class).getRoot();
+        LoggingManagerInternal rootLoggingManager = loggingServices.get(LoggingManagerFactory.class).getRoot();
         rootLoggingManager.attachSystemOutAndErr();
         return loggingServices;
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -51,6 +51,7 @@ import org.gradle.internal.instrumentation.agent.AgentInitializer;
 import org.gradle.internal.instrumentation.agent.AgentUtils;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.internal.os.OperatingSystem;
@@ -122,7 +123,7 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
     public static final TestFile COMMON_TMP = new TestFile(new File("build/tmp"));
 
     static {
-        LoggingManagerInternal loggingManager = GLOBAL_SERVICES.getFactory(LoggingManagerInternal.class).create();
+        LoggingManagerInternal loggingManager = GLOBAL_SERVICES.get(LoggingManagerFactory.class).createLoggingManager();
         loggingManager.start();
 
         GLOBAL_SERVICES.get(AgentInitializer.class).maybeConfigureInstrumentationAgent();
@@ -350,7 +351,7 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
     }
 
     private LoggingManagerInternal createLoggingManager(StartParameter startParameter, OutputStream outputStream, OutputStream errorStream) {
-        LoggingManagerInternal loggingManager = GLOBAL_SERVICES.getFactory(LoggingManagerInternal.class).create();
+        LoggingManagerInternal loggingManager = GLOBAL_SERVICES.get(LoggingManagerFactory.class).createLoggingManager();
         loggingManager.captureSystemSources();
 
         ConsoleOutput consoleOutput = startParameter.getConsoleOutput();


### PR DESCRIPTION
Follow-up for https://github.com/gradle/gradle/pull/32792

Reduces the use of generic `Factory` implementations as services. After this change, there is a single usage of this API left -- `Factory<DefaultGradleConnector>`. All other Gradle services are using dedicated factories.

This PR specifically converts:
- `Factory<LoggingManagerInternal>` to `LoggingManagerFactory`
- `Factory<AntBuilder>` to `AntBuilderFactory`

Getting rid of the use of the generic factories would allow us to either simplify our overly complex `ServiceRegistry` implementation or repurpose the factory concept for something else, withing incurring additional complexity.

---

We leave changing `Factory<DefaultGradleConnector>`, because it has implications for our cross-version testing of the tooling API, so better done separately as this PR is mostly mechanical.