### PR TITLE
Forbid Ivy from consuming non-consumable variants

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyResolveIntegrationTest.groovy
@@ -391,7 +391,7 @@ dependencies {
         }
     }
 
-    def "consuming non-consumable project configuration when substituted as a transitive dependency is deprecated"() {
+    def "consuming non-consumable project configuration when substituted as a transitive dependency fails"() {
         file("included/settings.gradle") << """
             rootProject.name = "transitive"
         """
@@ -440,8 +440,11 @@ dependencies {
             }
         """
 
-        expect:
-        executer.expectDocumentedDeprecationWarning("Consuming non-consumable variants from from an ivy component. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#consuming_non_consumable_variants_from_ivy_component")
-        succeeds("resolve")
+        when:
+        fails("resolve")
+
+        then:
+        failure.assertHasCause("Could not resolve org:transitive:1.0")
+        failure.assertHasErrorOutput("No variants exist.")
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyMetadata.java
@@ -16,14 +16,11 @@
 
 package org.gradle.internal.component.external.model.ivy;
 
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.internal.component.external.model.ExternalModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
-import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
-import org.gradle.internal.component.local.model.LocalVariantGraphResolveState;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
@@ -31,7 +28,6 @@ import org.gradle.internal.component.model.GraphVariantSelectionResult;
 import org.gradle.internal.component.model.GraphVariantSelector;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantGraphResolveState;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
@@ -84,37 +80,8 @@ public class IvyDependencyMetadata extends ExternalModuleDependencyMetadata {
 
         // We have already verified that the target component does not support attribute matching,
         // so if it is not an ivy component, use the standard legacy selection mechanism.
-
-        // TODO: We check hasLegacyVariant so we can fall-back to the deprecated behavior in case the legacy variant
-        // is present but non-consumable. Once we remove the deprecation, we can avoid this check and allow
-        // selectLegacyVariant to throw an exception if there is no legacy variant.
-        boolean hasLegacyVariant = targetComponentState.getCandidatesForGraphVariantSelection().getLegacyVariant() != null;
-        if (hasLegacyVariant) {
-            VariantGraphResolveState selected = variantSelector.selectLegacyVariant(consumerAttributes, targetComponentState, consumerSchema, variantSelector.getFailureHandler());
-            return new GraphVariantSelectionResult(Collections.singletonList(selected), false);
-        }
-
-        // Perhaps the legacy variant is present, but comes from a non-consumable configuration.
-        if (targetComponentState instanceof LocalComponentGraphResolveState) {
-            LocalComponentGraphResolveState localComponent = (LocalComponentGraphResolveState) targetComponentState;
-
-            // getConfigurationLegacy is a legacy mechanism and does _not_ check if the target variant comes from a consumable configuration
-            @SuppressWarnings("deprecation")
-            LocalVariantGraphResolveState legacyVariant = localComponent.getConfigurationLegacy(Dependency.DEFAULT_CONFIGURATION);
-            if (legacyVariant != null) {
-                // The legacy variant is present, but comes from a non-consumable configuration.
-
-                DeprecationLogger.deprecateBehaviour("Consuming non-consumable variants from from an ivy component.")
-                    .willBecomeAnErrorInGradle9()
-                    .withUpgradeGuideSection(8, "consuming_non_consumable_variants_from_ivy_component")
-                    .nagUser();
-
-                return new GraphVariantSelectionResult(Collections.singletonList(legacyVariant), false);
-            }
-        }
-
-        // The variant was not present, even after checking for a legacy non-consumable version. We can fail now.
-        throw variantSelector.getFailureHandler().configurationDoesNotExistFailure(targetComponentState, configuration.getName());
+        VariantGraphResolveState selected = variantSelector.selectLegacyVariant(consumerAttributes, targetComponentState, consumerSchema, variantSelector.getFailureHandler());
+        return new GraphVariantSelectionResult(Collections.singletonList(selected), false);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
@@ -37,7 +37,6 @@ import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.model.CalculatedValue;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.model.InMemoryCacheFactory;
-import org.gradle.internal.model.InMemoryLoadingCache;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -61,9 +60,6 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
     private final CalculatedValueContainerFactory calculatedValueContainerFactory;
     private final InMemoryCacheFactory cacheFactory;
     private final ComponentIdentifier overrideComponentId;
-
-    // The graph resolve state for variants selected by name
-    private final InMemoryLoadingCache<String, LocalVariantGraphResolveState> variants;
 
     // The variants to use for variant selection during graph resolution
     private final AtomicReference<CalculatedValue<LocalComponentGraphSelectionCandidates>> graphSelectionCandidates = new AtomicReference<>();
@@ -91,7 +87,6 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
         this.overrideComponentId = overrideComponentId;
 
         // Mutable state
-        this.variants = cacheFactory.createCalculatedValueCache(Describables.of("variants"), this::doCreateLegacyConfiguration);
         initCalculatedValues();
     }
 
@@ -100,7 +95,6 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
         // TODO: This is not really thread-safe.
         //       We should atomically clear all the different fields at once.
         //       Or better yet, we should not allow reevaluation of the state.
-        variants.invalidate();
         variantFactory.invalidate();
         initCalculatedValues();
     }
@@ -217,24 +211,6 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
                 null
             ))
             .collect(Collectors.toList());
-    }
-
-    @Nullable
-    @Override
-    @Deprecated
-    public LocalVariantGraphResolveState getConfigurationLegacy(String configurationName) {
-        return variants.get(configurationName);
-    }
-
-    private @Nullable LocalVariantGraphResolveState doCreateLegacyConfiguration(String n) {
-        LocalVariantGraphResolveState variant = variantFactory.getVariantByConfigurationName(n);
-        if (variant == null) {
-            return null;
-        }
-        if (overrideComponentId != null) {
-            return variant.copyWithComponentId(overrideComponentId);
-        }
-        return variant;
     }
 
     private static class LocalComponentArtifactResolveMetadata implements ComponentArtifactResolveMetadata {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveState.java
@@ -34,22 +34,6 @@ import java.util.List;
 @ThreadSafe
 public interface LocalComponentGraphResolveState extends ComponentGraphResolveState {
 
-    /**
-     * Get a variant derived from the configuration with the given name, or null if no such
-     * variant exists.
-     *
-     * This method should only be used to fetch the root variant of a resolution. There are plans
-     * to migrate away from this method for that purpose.
-     *
-     * TODO: This is a legacy mechanism, and does not verify that the named configuration is
-     * consumable. Prefer {@link LocalComponentGraphSelectionCandidates#getVariantByConfigurationName(String)}.
-     *
-     * <strong>Do not use this method, as it will be removed in Gradle 9.0.</strong>
-     */
-    @Nullable
-    @Deprecated
-    LocalVariantGraphResolveState getConfigurationLegacy(String configurationName);
-
     ModuleVersionIdentifier getModuleVersionId();
 
     @Override
@@ -95,4 +79,5 @@ public interface LocalComponentGraphResolveState extends ComponentGraphResolveSt
         VariantGraphResolveState getVariantByConfigurationName(String name);
 
     }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactory.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.component.local.model;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
 import org.gradle.api.internal.artifacts.configurations.VariantIdentityUniquenessVerifier;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultLocalVariantGraphResolveStateBuilder;
@@ -31,7 +30,6 @@ import org.gradle.internal.model.InMemoryCacheFactory;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Set;
@@ -157,6 +155,7 @@ public class LocalComponentGraphResolveStateFactory {
      * states as its data source.
      */
     private static class RealizedListVariantFactory implements LocalVariantGraphResolveStateFactory {
+
         private final List<? extends LocalVariantGraphResolveState> variants;
 
         public RealizedListVariantFactory(List<? extends LocalVariantGraphResolveState> variants) {
@@ -173,13 +172,6 @@ public class LocalComponentGraphResolveStateFactory {
         @Override
         public void invalidate() {}
 
-        @Override
-        public LocalVariantGraphResolveState getVariantByConfigurationName(String name) {
-            return variants.stream()
-                .filter(variant -> name.equals(variant.getMetadata().getConfigurationName()))
-                .findFirst()
-                .orElse(null);
-        }
     }
 
     /**
@@ -214,7 +206,15 @@ public class LocalComponentGraphResolveStateFactory {
             model.applyToMutableState(p -> {
                 VariantIdentityUniquenessVerifier.buildReport(configurationsProvider).assertNoConflicts();
                 configurationsProvider.visitConsumable(configuration -> {
-                    visitor.accept(createVariantState(configuration));
+                    LocalVariantGraphResolveState variantState = stateBuilder.createConsumableVariantState(
+                        configuration,
+                        componentId,
+                        cache,
+                        model,
+                        calculatedValueContainerFactory
+                    );
+
+                    visitor.accept(variantState);
                 });
             });
         }
@@ -224,27 +224,5 @@ public class LocalComponentGraphResolveStateFactory {
             cache.invalidate();
         }
 
-        @Nullable
-        @Override
-        public LocalVariantGraphResolveState getVariantByConfigurationName(String name) {
-            return model.fromMutableState(p -> {
-                ConfigurationInternal configuration = configurationsProvider.findByName(name);
-                if (configuration == null) {
-                    return null;
-                }
-
-                return createVariantState(configuration);
-            });
-        }
-
-        private LocalVariantGraphResolveState createVariantState(ConfigurationInternal configuration) {
-            return stateBuilder.createConsumableVariantState(
-                configuration,
-                componentId,
-                cache,
-                model,
-                calculatedValueContainerFactory
-            );
-        }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantGraphResolveStateFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantGraphResolveStateFactory.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.component.local.model;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.function.Consumer;
 
 /**
@@ -39,13 +37,5 @@ public interface LocalVariantGraphResolveStateFactory {
      * Invalidates any caching used for producing variant state.
      */
     void invalidate();
-
-    /**
-     * Produces a variant state instance from the configuration with the given {@code name}.
-     *
-     * @return Null if the variant with the given configuration name does not exist.
-     */
-    @Nullable
-    LocalVariantGraphResolveState getVariantByConfigurationName(String name);
 
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/LocalComponentGraphResolveStateFactoryTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.ConfigurationVariant
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ExternalModuleDependency
-import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.PublishArtifact
@@ -283,28 +282,6 @@ class LocalComponentGraphResolveStateFactoryTest extends AbstractProjectBuilderS
         config2.prepareForArtifactResolution().artifactVariants.find { it.name == "conf2-variant2" }.artifacts.size() == 2
     }
 
-    def "files attached to configuration and its children"() {
-        def files1 = Stub(FileCollectionDependency)
-        def files2 = Stub(FileCollectionDependency)
-        def files3 = Stub(FileCollectionDependency)
-
-        given:
-        def conf1 = dependencyScope("conf1")
-        def conf2 = dependencyScope("conf2")
-        def conf3 = dependencyScope("conf3", [conf1, conf2])
-        resolvable("child1", [conf3])
-        resolvable("child2", [conf1])
-
-        and:
-        conf1.getDependencies().add(files1)
-        conf2.getDependencies().add(files2)
-        conf3.getDependencies().add(files3)
-
-        expect:
-        state.getConfigurationLegacy("child1").files*.source == [files1, files2, files3]
-        state.getConfigurationLegacy("child2").files*.source == [files1]
-    }
-
     def "dependency is attached to configuration and its children"() {
         def dependency1 = Mock(ExternalModuleDependency)
         def dependency2 = Mock(ExternalModuleDependency)
@@ -350,12 +327,6 @@ class LocalComponentGraphResolveStateFactoryTest extends AbstractProjectBuilderS
 
     ConfigurationInternal consumable(String name, List<ConfigurationInternal> extendsFrom = []) {
         project.configurations.consumable(name) { conf ->
-            extendsFrom.each { conf.extendsFrom(it) }
-        }.get() as ConfigurationInternal
-    }
-
-    ConfigurationInternal resolvable(String name, List<ConfigurationInternal> extendsFrom = []) {
-        project.configurations.resolvable(name) { conf ->
             extendsFrom.each { conf.extendsFrom(it) }
         }.get() as ConfigurationInternal
     }


### PR DESCRIPTION
There was an edge case that in some cases allowed Ivy components to select non-consumable variants. This forbids that case, while also removing some legacy logic for getting variants by name

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
