### PR TITLE
Prevent selecting the root node as a variant

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/ToolingApiSpec.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/fixtures/ToolingApiSpec.groovy
@@ -106,15 +106,23 @@ trait ToolingApiSpec {
         addModelImplementation("buildSrc")
 
         addModelBuilderImplementation("buildSrc", """
-            def message = "project \${project.path} classpath = \${project.configurations.implementation.files.size()}"
+            def message = "project \${project.path} classpath = \${project.configurations.runtimeClasspath.files.size()}"
             return new MyModel(message)
         """)
 
         addBuilderRegisteringPluginImplementation("buildSrc", "MyModelBuilder", """
-            def implementation = project.configurations.create("implementation")
-            implementation.attributes.attribute(${Attribute.name}.of("thing", String), "custom")
-            def artifact = project.layout.buildDirectory.file("out.txt")
-            implementation.outgoing.artifact(artifact)
+            def implementation = project.configurations.dependencyScope("implementation")
+            def runtimeClasspath = project.configurations.resolvable("runtimeClasspath") {
+                extendsFrom(implementation.get())
+                attributes.attribute(${Attribute.name}.of("thing", String), "custom")
+            }
+            def runtimeElements = project.configurations.consumable("runtimeElements") {
+                extendsFrom(implementation.get())
+                attributes.attribute(${Attribute.name}.of("thing", String), "custom")
+
+                def artifact = project.layout.buildDirectory.file("out.txt")
+                outgoing.artifact(artifact)
+            }
         """)
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -522,7 +522,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
         }
     }
 
-    // TODO #9591: This does not reflect desired behavior. The recursive is a detached configuration, which
+    // TODO #9591: This does not reflect desired behavior. The recursive copy is a detached configuration, which
     // effectively replaces the root component, preventing the consumable configuration from being selected.
     @Issue('GRADLE-3280')
     def "cannot resolve recursive copy of configuration with cyclic project dependencies"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -522,8 +522,10 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
         }
     }
 
+    // TODO #9591: This does not reflect desired behavior. The recursive is a detached configuration, which
+    // effectively replaces the root component, preventing the consumable configuration from being selected.
     @Issue('GRADLE-3280')
-    def "can resolve recursive copy of configuration with cyclic project dependencies"() {
+    def "cannot resolve recursive copy of configuration with cyclic project dependencies"() {
         given:
         settingsFile << "include 'a', 'b', 'c'"
         def common = """
@@ -583,12 +585,14 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
         """
 
         expect:
-        succeeds ':a:assertCanResolve'
+        succeeds(":a:assertCanResolve")
 
-        and:
+        when:
         executer.expectDocumentedDeprecationWarning("The resCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
-        executer.expectDocumentedDeprecationWarning("While resolving configuration 'resCopy', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
-        succeeds ':a:assertCanResolveRecursiveCopy'
+        fails(":a:assertCanResolveRecursiveCopy")
+
+        then:
+        failure.assertHasCause("Cannot select root node 'resCopy' as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them.")
     }
 
     // this test is largely covered by other tests, but does ensure that there is nothing special about

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
@@ -103,7 +103,7 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
-    def "configuration can resolve itself"() {
+    def "configuration cannot resolve itself"() {
         buildFile << """
             configurations {
                 conf {
@@ -128,13 +128,14 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("While resolving configuration 'conf', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
+        when:
+        fails("resolve")
 
-        expect:
-        succeeds("resolve")
+        then:
+        failure.assertHasCause("Cannot select root node 'conf' as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them.")
     }
 
-    def "configuration can resolve itself and reselect artifacts"() {
+    def "configuration cannot resolve itself and reselect artifacts"() {
         buildFile << """
             configurations {
                 conf {
@@ -172,10 +173,11 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("While resolving configuration 'conf', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
+        when:
+        fails("resolve")
 
-        expect:
-        succeeds("resolve")
+        then:
+        failure.assertHasCause("Cannot select root node 'conf' as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them.")
     }
 
     def "resolvable configuration and consumable configuration from same project live in same resolved component"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
@@ -135,51 +135,6 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Cannot select root node 'conf' as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them.")
     }
 
-    def "configuration cannot resolve itself and reselect artifacts"() {
-        buildFile << """
-            configurations {
-                conf {
-                    outgoing {
-                        artifact file("foo.txt")
-                    }
-                    attributes {
-                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "foo"))
-                    }
-                }
-                other {
-                    outgoing {
-                        artifact file("bar.txt")
-                    }
-                    attributes {
-                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "bar"))
-                    }
-                }
-            }
-
-            dependencies {
-                conf project
-            }
-
-            task resolve {
-                def files = configurations.conf.incoming.artifactView {
-                    withVariantReselection()
-                    attributes {
-                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "bar"))
-                    }
-                }.files
-                doLast {
-                    assert files*.name == ["bar.txt"]
-                }
-            }
-        """
-
-        when:
-        fails("resolve")
-
-        then:
-        failure.assertHasCause("Cannot select root node 'conf' as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them.")
-    }
-
     def "resolvable configuration and consumable configuration from same project live in same resolved component"() {
         buildFile << """
             configurations {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveStateBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalVariantGraphResolveStateBuilder.java
@@ -56,6 +56,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
@@ -89,16 +90,39 @@ public class DefaultLocalVariantGraphResolveStateBuilder implements LocalVariant
         ModelContainer<?> model,
         CalculatedValueContainerFactory calculatedValueContainerFactory
     ) {
-        // Starting in Gradle 9.0, the logic for creating the root variant and for creating a
-        // consumable variant will differ, as the root variant should not have artifacts.
-        // However, until then, since the root variant can still be consumed, it must have artifacts.
-        return doCreateVariantState(
-            configuration,
-            componentId,
+        finalize(configuration, "resolved");
+
+        ImmutableAttributes attributes = configuration.getAttributes().asImmutable();
+        CalculatedValue<DefaultLocalVariantGraphResolveState.VariantDependencyMetadata> dependencies = getConfigurationDependencyState(
+            configuration.asDescribable(),
+            configuration.getHierarchy(),
+            attributes,
             dependencyCache,
             model,
+            calculatedValueContainerFactory
+        );
+
+        // TODO: The root node should have no capabilities, as it has no artifacts.
+        // However, changing this prevents conflicts between code being compiled and its
+        // dependencies from being detected during compilation -- though this also
+        // can lead to some false positives.
+        ImmutableCapabilities capabilities = ImmutableCapabilities.of(Configurations.collectCapabilities(configuration, new HashSet<>(), new HashSet<>()));
+        LocalVariantGraphResolveMetadata metadata = new DefaultLocalVariantGraphResolveMetadata(
+            configuration.getName(),
+            configuration.isTransitive(),
+            attributes,
+            capabilities,
+            false
+        );
+
+        return new DefaultLocalVariantGraphResolveState(
+            idGenerator.nextVariantId(),
+            componentId,
+            metadata,
+            idGenerator,
             calculatedValueContainerFactory,
-            "resolved"
+            dependencies,
+            Collections.emptySet()
         );
     }
 
@@ -110,29 +134,7 @@ public class DefaultLocalVariantGraphResolveStateBuilder implements LocalVariant
         ModelContainer<?> model,
         CalculatedValueContainerFactory calculatedValueContainerFactory
     ) {
-        return doCreateVariantState(
-            configuration,
-            componentId,
-            dependencyCache,
-            model,
-            calculatedValueContainerFactory,
-            "consumed as a variant"
-        );
-    }
-
-    private DefaultLocalVariantGraphResolveState doCreateVariantState(
-        ConfigurationInternal configuration,
-        ComponentIdentifier componentId,
-        DependencyCache dependencyCache,
-        ModelContainer<?> model,
-        CalculatedValueContainerFactory calculatedValueContainerFactory,
-        String observationReason
-    ) {
-        // Perform any final mutating actions for this configuration and its parents.
-        // Then, lock this configuration and its parents from mutation.
-        // After we observe a configuration (by building its metadata), its state should not change.
-        configuration.runDependencyActions();
-        configuration.markAsObserved(observationReason);
+        finalize(configuration, "consumed as a variant");
 
         String configurationName = configuration.getName();
         ComponentConfigurationIdentifier configurationIdentifier = new ComponentConfigurationIdentifier(componentId, configurationName);
@@ -156,13 +158,14 @@ public class DefaultLocalVariantGraphResolveStateBuilder implements LocalVariant
             }
         });
 
-        // Collect all dependencies and excludes in hierarchy.
-        // After running the dependency actions and preventing from mutation above, we know the
-        // hierarchy will not change anymore and all configurations in the hierarchy
-        // will no longer be mutated.
-        Set<Configuration> hierarchy = configuration.getHierarchy();
-        CalculatedValue<DefaultLocalVariantGraphResolveState.VariantDependencyMetadata> dependencies =
-            getConfigurationDependencyState(configuration.asDescribable(), hierarchy, attributes, dependencyCache, model, calculatedValueContainerFactory);
+        CalculatedValue<DefaultLocalVariantGraphResolveState.VariantDependencyMetadata> dependencies = getConfigurationDependencyState(
+            configuration.asDescribable(),
+            configuration.getHierarchy(),
+            attributes,
+            dependencyCache,
+            model,
+            calculatedValueContainerFactory
+        );
 
         LocalVariantGraphResolveMetadata metadata = new DefaultLocalVariantGraphResolveMetadata(
             configurationName,
@@ -181,6 +184,19 @@ public class DefaultLocalVariantGraphResolveStateBuilder implements LocalVariant
             dependencies,
             artifactSets.build()
         );
+    }
+
+    /**
+     * Perform any final mutating actions for this configuration and its parents.
+     * Then, lock this configuration and its parents from mutation.
+     * After we observe a configuration (by building its metadata), its state should not change.
+     */
+    private static void finalize(ConfigurationInternal configuration, String reason) {
+        // Perform any final mutating actions for this configuration and its parents.
+        // Then, lock this configuration and its parents from mutation.
+        // After we observe a configuration (by building its metadata), its state should not change.
+        configuration.runDependencyActions();
+        configuration.markAsObserved(reason);
     }
 
     private static CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> getVariantArtifacts(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -56,7 +56,6 @@ import org.gradle.internal.component.model.GraphVariantSelector;
 import org.gradle.internal.component.model.VariantGraphResolveMetadata;
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.resolution.failure.exception.AbstractResolutionFailureException;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.operations.BuildOperationConstraint;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -435,22 +434,6 @@ public class DependencyGraphBuilder {
             } else if (module.isVirtualPlatform()) {
                 attachMultipleForceOnPlatformFailureToEdges(module);
             }
-        }
-
-        if (resolveState.getRoot().wasIncomingEdgeAdded()) {
-            String rootNodeName = resolveState.getRoot().getMetadata().getName();
-            DeprecationLogger.deprecate(
-                    String.format(
-                        "While resolving configuration '%s', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. " +
-                            "Depending on the resolved configuration in this manner",
-                        rootNodeName
-                    ))
-                .withProblemIdDisplayName("Configurations should not act as both a resolution root and a variant simultaneously.")
-                .withProblemId("configurations-acting-as-both-root-and-variant")
-                .withAdvice("Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them.")
-                .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(8, "depending_on_root_configuration")
-                .nagUser();
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RootNode.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RootNode.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.local.model.LocalVariantGraphResolveMetadata;
@@ -30,8 +31,6 @@ import java.util.Set;
 class RootNode extends NodeState implements RootGraphNode {
     private final ResolveOptimizations resolveOptimizations;
     private final List<? extends DependencyMetadata> syntheticDependencies;
-
-    boolean incomingEdgeWasAdded = false;
 
     RootNode(long resultId, ComponentState moduleRevision, ResolveState resolveState, List<? extends DependencyMetadata> syntheticDependencies, VariantGraphResolveState root) {
         super(resultId, moduleRevision, resolveState, root, false);
@@ -51,17 +50,11 @@ class RootNode extends NodeState implements RootGraphNode {
 
     @Override
     void addIncomingEdge(EdgeState dependencyEdge) {
-        super.addIncomingEdge(dependencyEdge);
-        incomingEdgeWasAdded = true;
-
-        // TODO: We read `incomingEdgeWasAdded` at the end of graph resolution.
-        // If this method is ever called, we trigger a deprecation warning.
-        // In Gradle 9.0, we should fail here immediately if someone tries to
-        // add an incoming edge to a root node.
-    }
-
-    public boolean wasIncomingEdgeAdded() {
-        return incomingEdgeWasAdded;
+        throw new InvalidUserCodeException(
+            "Cannot select root node '" + getMetadata().getName() + "' as a variant. " +
+                "Configurations should not act as both a resolution root and a variant simultaneously. " +
+                "Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them."
+        );
     }
 
     @Override

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -103,7 +103,6 @@ class KnownProblemIds {
         'deprecation:plugin': ['Plugin has been deprecated.'],
         'deprecation:plugin-script': ['Plugin script has been deprecated.'],
         'deprecation:the-detachedconfiguration-configuration-has-been-deprecated-for-consumption': ['The detachedConfiguration1 configuration has been deprecated for consumption.'],
-        'deprecation:configurations-acting-as-both-root-and-variant': ['Configurations should not act as both a resolution root and a variant simultaneously.'],
         'deprecation:properties-should-be-assigned-using-the-propname-value-syntax-setting-a-property-via-the-gradle-generated-propname-value-or-propname-value-syntax-in-groovy-dsl': ['Properties should be assigned using the \'propName = value\' syntax. Setting a property via the Gradle-generated \'propName value\' or \'propName(value)\' syntax in Groovy DSL has been deprecated.'],
         'deprecation:repository-jcenter': ['The RepositoryHandler.jcenter() method has been deprecated.'],
         'task-selection:no-matches': ['No matches', 'cannot locate task'],


### PR DESCRIPTION
The root node represents the configuration being resolved, and therefore it is not intended to be selected as a variant.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
