### PR TITLE
Remove deprecated `buidlFile` usage

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -573,7 +573,6 @@ performanceTest.registerTestProject("largeNativeBuild", RemoteProject) {
 }
 
 performanceTest.registerTestProject("largeNativeBuildPrebuilt", GradleBuild) {
-    buildFile = file("$largeNativeBuild.outputDirectory/prebuilt/util/build.gradle")
     dir = file("$largeNativeBuild.outputDirectory/prebuilt/util")
     tasks = ['build']
 }


### PR DESCRIPTION
To get rid of deprecation warning like [this](https://ge.gradle.org/s/5do3hukvxitui/deprecations?expanded=WyIyNyIsIjM0Il0&expanded-stacktrace=WyIyOSJd#27).