### PR TITLE
Fix failing PackageListGeneratorIntegrationTest

### DIFF
--- a/build-logic-commons/basics/build.gradle.kts
+++ b/build-logic-commons/basics/build.gradle.kts
@@ -29,3 +29,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.2")
 }
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/build-logic-commons/basics/src/test/kotlin/gradlebuild/basics/tasks/PackageListGeneratorIntegrationTest.kt
+++ b/build-logic-commons/basics/src/test/kotlin/gradlebuild/basics/tasks/PackageListGeneratorIntegrationTest.kt
@@ -111,6 +111,7 @@ class PackageListGeneratorIntegrationTest {
         touchFile(directory.resolve("com/acme/internal/FooInternal.class"))
         touchFile(directory.resolve("com/foo/internal/FooInternal.class"))
         touchFile(directory.resolve("javax/servlet/http/HttpServletRequest.class"))
+        touchFile(directory.resolve("org/gradle/fileevents/FileEvent.class"))
 
         return sequenceOf(directory)
     }


### PR DESCRIPTION
Noticed a [deprecation warning](https://ge.gradle.org/s/2fdsl4mb3rqrk/deprecations?expanded=WyIyNiJd#22) that `PackageListGeneratorIntegrationTest` is not run at all. Enabled it via `useJUnitPlatform()`.

The test assert to see `org/gradle/fileevents` in the result, but didn't set up input for that package. 