### PR TITLE
Introduce GradleConnectorFactory

### DIFF
--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectorServices.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.internal.consumer;
 
-import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.operations.BuildOperationIdFactory;
@@ -28,6 +27,7 @@ import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
 import org.gradle.tooling.CancellationTokenSource;
+import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.internal.consumer.loader.CachingToolingImplementationLoader;
 import org.gradle.tooling.internal.consumer.loader.DefaultToolingImplementationLoader;
 import org.gradle.tooling.internal.consumer.loader.SynchronizedToolingImplementationLoader;
@@ -40,8 +40,8 @@ public class ConnectorServices {
         singletonRegistry = ConnectorServiceRegistry.create();
     }
 
-    public static DefaultGradleConnector createConnector() {
-        return singletonRegistry.getFactory(DefaultGradleConnector.class).create();
+    public static GradleConnector createConnector() {
+        return singletonRegistry.get(GradleConnectorFactory.class).createConnector();
     }
 
     public static CancellationTokenSource createCancellationTokenSource() {
@@ -71,10 +71,10 @@ public class ConnectorServices {
         }
 
         @Provides
-        protected Factory<DefaultGradleConnector> createConnectorFactory(final ConnectionFactory connectionFactory, final DistributionFactory distributionFactory) {
-            return new Factory<DefaultGradleConnector>() {
+        protected GradleConnectorFactory createConnectorFactory(final ConnectionFactory connectionFactory, final DistributionFactory distributionFactory) {
+            return new GradleConnectorFactory() {
                 @Override
-                public DefaultGradleConnector create() {
+                public GradleConnector createConnector() {
                     return new DefaultGradleConnector(connectionFactory, distributionFactory);
                 }
             };

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/GradleConnectorFactory.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/GradleConnectorFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.consumer;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.tooling.GradleConnector;
+
+@NonNullApi
+public interface GradleConnectorFactory {
+
+    GradleConnector createConnector();
+
+}

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
@@ -31,6 +31,7 @@ import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.internal.consumer.ConnectorServices
 import org.gradle.tooling.internal.consumer.DefaultGradleConnector
+import org.gradle.tooling.internal.consumer.GradleConnectorFactory
 import org.gradle.tooling.model.build.BuildEnvironment
 import org.gradle.util.GradleVersion
 import org.junit.rules.TestRule
@@ -276,7 +277,7 @@ class ToolingApi implements TestRule {
 
     private createConnector() {
         if (isolatedToolingClient != null) {
-            return isolatedToolingClient.getFactory(DefaultGradleConnector).create()
+            return isolatedToolingClient.get(GradleConnectorFactory).createConnector()
         }
         return GradleConnector.newConnector() as DefaultGradleConnector
     }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
@@ -277,7 +277,13 @@ class ToolingApi implements TestRule {
 
     private createConnector() {
         if (isolatedToolingClient != null) {
-            return isolatedToolingClient.get(GradleConnectorFactory).createConnector()
+            // This fixture can be loaded with a classloader of TAPI jar from previous Gradle releases
+            def currentVersion = GradleVersion.current().baseVersion
+            if (currentVersion <= GradleVersion.version("8.13")) {
+                return isolatedToolingClient.getFactory(GradleConnector).create()
+            } else {
+                return isolatedToolingClient.get(GradleConnectorFactory).createConnector()
+            }
         }
         return GradleConnector.newConnector() as DefaultGradleConnector
     }


### PR DESCRIPTION
Follow-up for https://github.com/gradle/gradle/pull/32806

---

BEFORE MERGING: consider introducing an indirection for the GradleConnector and related things as they are obtained by the ToolingApi fixture. While it's entirely an internal concept, we want to keep ToolingApi loadable with classpath of older Gradle version for cross-version testing.