### PR TITLE
Forbid publishing Maven component with different artifact name

### DIFF
--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
@@ -415,7 +415,7 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         }
     }
 
-    def "publishing a dependency to with name different than the artifactId is deprecated"() {
+    def "cannot publish a dependency to with name different than the artifactId"() {
         given:
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
@@ -452,22 +452,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("Publishing a dependency with an artifact name different from the dependency's artifactId. This behavior has been deprecated. This will fail with an error in Gradle 9.0. This functionality is only supported by Ivy repositories. Declare a dependency with artifactId 'notfoo' instead of 'foo'. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#publishing_artifact_name_different_from_artifact_id_maven")
-        succeeds "publish"
+        fails "publish"
 
         then:
-        repoModule.assertPublished()
-        repoModule.assertApiDependencies()
-        repoModule.parsedPom.scope("runtime") {
-            def deps = dependencies.values()
-            assert deps.size() == 1
-            def dep = deps[0]
-            assert dep.groupId == "org"
-            assert dep.artifactId == "notfoo"
-            assert dep.version == "1.0"
-            assert dep.classifier == null
-            assert dep.type == null
-        }
+        failure.assertHasCause("Cannot publish a dependency with an artifact name different from the dependency's artifactId. This functionality is only supported by Ivy repositories. Declare a dependency with artifactId 'notfoo' instead of 'foo'.")
     }
 
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenComponentParser.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenComponentParser.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import org.gradle.api.GradleException;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExcludeRule;
@@ -56,7 +57,6 @@ import org.gradle.api.publish.maven.internal.dependencies.MavenDependency;
 import org.gradle.api.publish.maven.internal.dependencies.MavenPomDependencies;
 import org.gradle.api.publish.maven.internal.dependencies.VersionRangeMapper;
 import org.gradle.api.publish.maven.internal.validation.MavenPublicationErrorChecker;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.jspecify.annotations.Nullable;
 
@@ -322,27 +322,19 @@ public class MavenComponentParser {
             }
 
             // If the dependency has artifacts, only map the coordinates to component-level precision.
-            // This is so we match the Gradle behavior where an explicit artifact on a dependency
+            // This is so we match the dependency-management behavior where an explicit artifact on a dependency
             // that would otherwise map to different coordinates resolves to the declared coordinates.
             ResolvedCoordinates coordinates = resolveDependency(dependency, false);
             for (DependencyArtifact artifact : dependency.getArtifacts()) {
-                ResolvedCoordinates artifactCoordinates = coordinates;
                 if (!artifact.getName().equals(dependency.getName())) {
-                    DeprecationLogger.deprecateBehaviour("Publishing a dependency with an artifact name different from the dependency's artifactId.")
-                        .withContext("This functionality is only supported by Ivy repositories.")
-                        .withAdvice(String.format("Declare a dependency with artifactId '%s' instead of '%s'.", artifact.getName(), dependency.getName()))
-                        .willBecomeAnErrorInGradle9()
-                        .withUpgradeGuideSection(8, "publishing_artifact_name_different_from_artifact_id_maven")
-                        .nagUser();
-
-                    artifactCoordinates = ResolvedCoordinates.create(
-                        coordinates.getGroup(),
-                        artifact.getName(),
-                        coordinates.getVersion()
+                    throw new InvalidUserCodeException(
+                        "Cannot publish a dependency with an artifact name different from the dependency's artifactId. " +
+                            "This functionality is only supported by Ivy repositories. " +
+                            String.format("Declare a dependency with artifactId '%s' instead of '%s'.", artifact.getName(), dependency.getName())
                     );
                 }
 
-                collector.accept(newDependency(artifactCoordinates, artifact.getType(), artifact.getClassifier(), scope, allExcludeRules, optional));
+                collector.accept(newDependency(coordinates, artifact.getType(), artifact.getClassifier(), scope, allExcludeRules, optional));
             }
         }
 


### PR DESCRIPTION
This is only supported by Ivy

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
