### PR TITLE
Bump dependency-analysis-gradle-plugin to latest version

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
         api("org.asciidoctor:asciidoctor-gradle-jvm:4.0.2")
         api("org.jetbrains.kotlin:kotlin-gradle-plugin") { version { strictly(kotlinVersion) } }
         api(kotlin("compiler-embeddable")) { version { strictly(kotlinVersion) } }
-        api("com.autonomousapps:dependency-analysis-gradle-plugin:1.33.0")
+        api("com.autonomousapps:dependency-analysis-gradle-plugin:2.13.2")
         api("com.squareup.okio:okio:3.4.0") {
             because("Bump version brought in by dependency-analysis-gradle-plugin, to resolve CVE-2022-3635")
         }


### PR DESCRIPTION
To get rid of this deprecation warning: https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1305