### PR TITLE
Update to Guava 33.4.6, revert size change for dist

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
         // Java Libraries
         api("com.github.javaparser:javaparser-core:$javaParserVersion")
         api("com.github.javaparser:javaparser-symbol-solver-core:$javaParserVersion")
-        api("com.google.guava:guava:33.4.5-jre")
+        api("com.google.guava:guava:33.4.6-jre")
         api("com.google.errorprone:error_prone_annotations:2.5.1")
         api("com.google.code.gson:gson:2.8.9")
         api("com.nhaarman:mockito-kotlin:1.6.0")

--- a/build-logic/java-api-extractor/build.gradle.kts
+++ b/build-logic/java-api-extractor/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     //      The error can be reproduced in production code by running an integration test
     //      that uses Kotlin DSL, like ManagedPropertyJavaInterOpIntegrationTest.
     implementation("org.ow2.asm:asm:9.7.1")
-    implementation("com.google.guava:guava:33.4.5-jre") {
+    implementation("com.google.guava:guava:33.4.6-jre") {
         isTransitive = false
     }
 }

--- a/packaging/distributions-dependencies/build.gradle.kts
+++ b/packaging/distributions-dependencies/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
         api(libs.develocityTestAnnotation) { version { strictly("2.0.1") }}
         api(libs.gcs)                   { version { strictly("v1-rev20220705-1.32.1") }}
         api(libs.googleApiClient)       { version { strictly("1.34.0"); because("our GCS version requires 1.34.0") }}
-        api(libs.guava)                 { version { strictly("33.4.5-jre"); because("our Google API Client version requires at least 31.1-jre, 33.4.5 removes usage of Unsafe")  }}
+        api(libs.guava)                 { version { strictly("33.4.6-jre"); because("our Google API Client version requires at least 31.1-jre, 33.4.5 removes usage of Unsafe")  }}
         api(libs.googleHttpClientGson)  { version { strictly("1.42.2"); because("our Google API Client version requires 1.42.2")  }}
         api(libs.googleHttpClientApacheV2) { version { strictly("1.42.2"); because("our Google API Client version requires 1.42.2")  }}
         api(libs.googleHttpClient)      { version { strictly("1.42.2"); because("our Google API Client version requires 1.42.2") }}

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -46,9 +46,9 @@ The `Settings.getDefaults()` incubating method introduced in 8.10 has been remov
 Use`Settings.defaults(Action<SharedModelDefaults>)` method, taking a lambda, instead.
 The change is driven by the need to interpret such default values in the scope of individual projects and not at Settings level.
 
-==== Upgrade to Guava 33.4.5
+==== Upgrade to Guava 33.4.6
 
-Guava was updated from 32.1.2 to 33.4.5, which deprecates some core features like `Charsets` or `Ints.compare`.
+Guava was updated from 32.1.2 to 33.4.6, which deprecates some core features like `Charsets`.
 See https://github.com/google/guava/releases for details.
 
 === Deprecations

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 227 * 1024 * 1024
+        return 225 * 1024 * 1024
     }
 
     @Requires(UnitTestPreconditions.StableGroovy) // cannot link to public javadocs of Groovy snapshots like https://docs.groovy-lang.org/docs/groovy-4.0.5-SNAPSHOT/html/gapi/


### PR DESCRIPTION
### Context
This fixes a small mistake by Guava which doubled the JAR size. https://github.com/google/guava/commit/40485b93ce2252de5ffa7ee956f6b76f9df4e8ab

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
