### PR TITLE
Add native-image toolchain criteria to daemon JVM

### DIFF
--- a/platforms/core-runtime/build-configuration/src/main/java/org/gradle/buildconfiguration/tasks/UpdateDaemonJvm.java
+++ b/platforms/core-runtime/build-configuration/src/main/java/org/gradle/buildconfiguration/tasks/UpdateDaemonJvm.java
@@ -102,6 +102,7 @@ public abstract class UpdateDaemonJvm extends DefaultTask {
             getPropertiesFile().get().getAsFile(),
             getLanguageVersion().get(),
             jvmVendorCriteria,
+            getNativeImageCapable().getOrElse(false),
             getToolchainDownloadUrls().get()
         );
     }
@@ -200,6 +201,17 @@ public abstract class UpdateDaemonJvm extends DefaultTask {
     public List<String> getAvailableVendors() {
         return Arrays.stream(JvmVendor.KnownJvmVendor.values()).filter(e -> e!=JvmVendor.KnownJvmVendor.UNKNOWN).map(Enum::name).collect(Collectors.toList());
     }
+
+    /**
+     * Indicates it the native-image capability is required.
+     *
+     * @since 8.14
+     */
+    @Input
+    @Optional
+    @Incubating
+    @Option(option = "native-image-capable", description = "Indicates if the native-image capability is required.")
+    public abstract Property<Boolean> getNativeImageCapable();
 
     /**
      * The set of {@link BuildPlatform} for which download links should be generated.

--- a/platforms/core-runtime/build-configuration/src/main/java/org/gradle/internal/buildconfiguration/tasks/DaemonJvmPropertiesAccessor.java
+++ b/platforms/core-runtime/build-configuration/src/main/java/org/gradle/internal/buildconfiguration/tasks/DaemonJvmPropertiesAccessor.java
@@ -60,6 +60,10 @@ public class DaemonJvmPropertiesAccessor {
         }
     }
 
+    public boolean getNativeImageCapable() {
+        return Boolean.parseBoolean(properties.get(DaemonJvmPropertiesDefaults.TOOLCHAIN_NATIVE_IMAGE_CAPABLE_PROPERTY));
+    }
+
     public Map<BuildPlatform, String> getToolchainDownloadUrls() {
         return properties.entrySet().stream()
             .filter(entry -> entry.getKey().startsWith(DaemonJvmPropertiesDefaults.TOOLCHAIN_URL_PROPERTY_PREFIX))

--- a/platforms/core-runtime/build-configuration/src/main/java/org/gradle/internal/buildconfiguration/tasks/DaemonJvmPropertiesModifier.java
+++ b/platforms/core-runtime/build-configuration/src/main/java/org/gradle/internal/buildconfiguration/tasks/DaemonJvmPropertiesModifier.java
@@ -45,6 +45,7 @@ public class DaemonJvmPropertiesModifier {
         File propertiesFile,
         JavaLanguageVersion toolchainVersion,
         @Nullable String toolchainVendor,
+        boolean nativeImageCapable,
         Map<BuildPlatform, URI> downloadUrlsByPlatform
     ) {
         validateToolchainVersion(toolchainVersion);
@@ -53,6 +54,9 @@ public class DaemonJvmPropertiesModifier {
         daemonJvmProperties.put(DaemonJvmPropertiesDefaults.TOOLCHAIN_VERSION_PROPERTY, toolchainVersion.toString());
         if (toolchainVendor != null) {
             daemonJvmProperties.put(DaemonJvmPropertiesDefaults.TOOLCHAIN_VENDOR_PROPERTY, toolchainVendor);
+        }
+        if (nativeImageCapable) {
+            daemonJvmProperties.put(DaemonJvmPropertiesDefaults.TOOLCHAIN_NATIVE_IMAGE_CAPABLE_PROPERTY, "true");
         }
 
         downloadUrlsByPlatform.forEach((buildPlatform, uri) -> {

--- a/platforms/core-runtime/build-configuration/src/test/groovy/org/gradle/internal/buildconfiguration/DaemonJvmPropertiesAccessorTest.groovy
+++ b/platforms/core-runtime/build-configuration/src/test/groovy/org/gradle/internal/buildconfiguration/DaemonJvmPropertiesAccessorTest.groovy
@@ -34,6 +34,7 @@ class DaemonJvmPropertiesAccessorTest extends Specification {
         def properties = [
             "toolchainVersion": "12",
             "toolchainVendor": "BELLSOFT",
+            "toolchainNativeImageCapable": "true",
             "toolchainUrl.FREE_BSD.X86_64": "https://server?os=FREE_BSD&architecture=X86_64",
             "toolchainUrl.FREE_BSD.AARCH64": "https://server?os=FREE_BSD&architecture=AARCH64",
             "toolchainUrl.LINUX.X86_64": "https://server?os=LINUX&architecture=X86_64",
@@ -54,6 +55,7 @@ class DaemonJvmPropertiesAccessorTest extends Specification {
         then:
         propertiesAccessor.version == JavaLanguageVersion.of(12)
         propertiesAccessor.vendor == JvmVendorSpec.BELLSOFT
+        propertiesAccessor.nativeImageCapable
         def expectedDownloadUrlsBySupportedBuildPlatform = Stream.of(Architecture.X86_64, Architecture.AARCH64).flatMap(arch ->
             Stream.of(OperatingSystem.values()).map(os -> BuildPlatformFactory.of(arch, os)))
             .collect(Collectors.toSet()).collectEntries { buildPlatform ->

--- a/platforms/core-runtime/build-configuration/src/test/groovy/org/gradle/internal/buildconfiguration/DaemonJvmPropertiesModifierTest.groovy
+++ b/platforms/core-runtime/build-configuration/src/test/groovy/org/gradle/internal/buildconfiguration/DaemonJvmPropertiesModifierTest.groovy
@@ -37,14 +37,15 @@ class DaemonJvmPropertiesModifierTest extends Specification {
         given:
         def propertiesModifier = new DaemonJvmPropertiesModifier()
         when:
-        propertiesModifier.updateJvmCriteria(daemonJvmPropertiesFile, JavaLanguageVersion.of(11), "IBM",
-            [(createBuildPlatform(Architecture.AARCH64, OperatingSystem.LINUX)): new URI("https://server/whatever1"),
-             (createBuildPlatform(Architecture.X86_64, OperatingSystem.MAC_OS)): new URI("https://server/whatever2"),
-             (createBuildPlatform(Architecture.X86_64, OperatingSystem.WINDOWS)): new URI("https://server/whatever3")])
+        propertiesModifier.updateJvmCriteria(daemonJvmPropertiesFile, JavaLanguageVersion.of(11), "IBM", true,
+                [(createBuildPlatform(Architecture.AARCH64, OperatingSystem.LINUX)): new URI("https://server/whatever1"),
+                 (createBuildPlatform(Architecture.X86_64, OperatingSystem.MAC_OS)): new URI("https://server/whatever2"),
+                 (createBuildPlatform(Architecture.X86_64, OperatingSystem.WINDOWS)): new URI("https://server/whatever3")])
         then:
         def props = daemonJvmPropertiesFile.properties
         props[DaemonJvmPropertiesDefaults.TOOLCHAIN_VERSION_PROPERTY] == "11"
         props[DaemonJvmPropertiesDefaults.TOOLCHAIN_VENDOR_PROPERTY] == "IBM"
+        props[DaemonJvmPropertiesDefaults.TOOLCHAIN_NATIVE_IMAGE_CAPABLE_PROPERTY] == "true"
         props[String.format(DaemonJvmPropertiesDefaults.TOOLCHAIN_URL_PROPERTY_FORMAT, OperatingSystem.LINUX, Architecture.AARCH64)] == "https://server/whatever1"
         props[String.format(DaemonJvmPropertiesDefaults.TOOLCHAIN_URL_PROPERTY_FORMAT, OperatingSystem.MAC_OS, Architecture.X86_64)] == "https://server/whatever2"
         props[String.format(DaemonJvmPropertiesDefaults.TOOLCHAIN_URL_PROPERTY_FORMAT, OperatingSystem.WINDOWS, Architecture.X86_64)] == "https://server/whatever3"
@@ -55,18 +56,19 @@ class DaemonJvmPropertiesModifierTest extends Specification {
         given:
         def propertiesModifier = new DaemonJvmPropertiesModifier()
         when:
-        propertiesModifier.updateJvmCriteria(daemonJvmPropertiesFile, JavaLanguageVersion.of(11), null, [:])
+        propertiesModifier.updateJvmCriteria(daemonJvmPropertiesFile, JavaLanguageVersion.of(11), null, false, [:])
         then:
         def props = daemonJvmPropertiesFile.properties
         props[DaemonJvmPropertiesDefaults.TOOLCHAIN_VERSION_PROPERTY] == "11"
         props[DaemonJvmPropertiesDefaults.TOOLCHAIN_VENDOR_PROPERTY] == null
+        props[DaemonJvmPropertiesDefaults.TOOLCHAIN_NATIVE_IMAGE_CAPABLE_PROPERTY] == null
     }
 
     def "writes only java version when no other properties are given"() {
         given:
         def propertiesModifier = new DaemonJvmPropertiesModifier()
         when:
-        propertiesModifier.updateJvmCriteria(daemonJvmPropertiesFile, JavaLanguageVersion.of(11), null, [:])
+        propertiesModifier.updateJvmCriteria(daemonJvmPropertiesFile, JavaLanguageVersion.of(11), null, false, [:])
         then:
         def props = daemonJvmPropertiesFile.properties
         props[DaemonJvmPropertiesDefaults.TOOLCHAIN_VERSION_PROPERTY] == "11"
@@ -82,7 +84,7 @@ class DaemonJvmPropertiesModifierTest extends Specification {
             ${DaemonJvmPropertiesDefaults.TOOLCHAIN_IMPLEMENTATION_PROPERTY}=vendor-specific
         """
         when:
-        propertiesModifier.updateJvmCriteria(daemonJvmPropertiesFile, JavaLanguageVersion.of(15), null, [:])
+        propertiesModifier.updateJvmCriteria(daemonJvmPropertiesFile, JavaLanguageVersion.of(15), null, false, [:])
         then:
         def props = daemonJvmPropertiesFile.properties
         props[DaemonJvmPropertiesDefaults.TOOLCHAIN_VERSION_PROPERTY] == "15"
@@ -99,7 +101,7 @@ class DaemonJvmPropertiesModifierTest extends Specification {
             ${DaemonJvmPropertiesDefaults.TOOLCHAIN_VERSION_PROPERTY}=15
         """
         when:
-        propertiesModifier.updateJvmCriteria(daemonJvmPropertiesFile, JavaLanguageVersion.of(11), "IBM", [:])
+        propertiesModifier.updateJvmCriteria(daemonJvmPropertiesFile, JavaLanguageVersion.of(11), "IBM", false, [:])
         then:
         def props = daemonJvmPropertiesFile.properties
         props.size() == 2

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
@@ -216,6 +216,9 @@ public class DefaultDaemonStarter implements DaemonStarter {
         toolchainSpec.getLanguageVersion().value(JavaLanguageVersion.of(daemonJvmCriteria.getJavaVersion().asInt()));
         toolchainSpec.getVendor().value(daemonJvmCriteria.getVendorSpec());
         toolchainSpec.getImplementation().convention(JvmImplementation.VENDOR_SPECIFIC);
+        if (daemonJvmCriteria.isNativeImageCapable()) {
+            toolchainSpec.getNativeImageCapable().set(true);
+        }
         return toolchainSpec;
     }
 

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -131,7 +131,7 @@ public class DaemonParameters {
         JavaLanguageVersion requestedVersion = daemonJvmAccessor.getVersion();
         if (requestedVersion != null) {
             JvmVendorSpec requestedJavaVendor = daemonJvmAccessor.getVendor();
-            this.requestedJvmCriteria = new DaemonJvmCriteria.Spec(requestedVersion, requestedJavaVendor, JvmImplementation.VENDOR_SPECIFIC);
+            this.requestedJvmCriteria = new DaemonJvmCriteria.Spec(requestedVersion, requestedJavaVendor, JvmImplementation.VENDOR_SPECIFIC, daemonJvmAccessor.getNativeImageCapable());
             this.toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider(daemonJvmAccessor.getToolchainDownloadUrls());
         }
     }

--- a/platforms/core-runtime/client-services/src/test/groovy/org/gradle/launcher/daemon/configuration/DaemonParametersTest.groovy
+++ b/platforms/core-runtime/client-services/src/test/groovy/org/gradle/launcher/daemon/configuration/DaemonParametersTest.groovy
@@ -47,7 +47,7 @@ class DaemonParametersTest extends Specification {
     def "does not apply defaults when jvmargs already specified"() {
         when:
         parameters.setJvmArgs(["-Xmx17m"])
-        parameters.requestedJvmCriteria = new DaemonJvmCriteria.Spec(JavaLanguageVersion.of(8), null, null)
+        parameters.requestedJvmCriteria = new DaemonJvmCriteria.Spec(JavaLanguageVersion.of(8), null, null, false)
 
         then:
         parameters.effectiveJvmArgs.containsAll(["-Xmx17m"])
@@ -56,7 +56,7 @@ class DaemonParametersTest extends Specification {
 
     def "can apply defaults for Java 8 and later"() {
         when:
-        parameters.requestedJvmCriteria = new DaemonJvmCriteria.Spec(JavaLanguageVersion.of(9), null, null)
+        parameters.requestedJvmCriteria = new DaemonJvmCriteria.Spec(JavaLanguageVersion.of(9), null, null, false)
 
         then:
         parameters.effectiveJvmArgs.containsAll(DaemonParameters.DEFAULT_JVM_ARGS)
@@ -76,7 +76,7 @@ class DaemonParametersTest extends Specification {
     def "debug mode is persisted when defaults are applied"() {
         when:
         parameters.setDebug(true)
-        parameters.requestedJvmCriteria = new DaemonJvmCriteria.Spec(jvmDefault, null, null)
+        parameters.requestedJvmCriteria = new DaemonJvmCriteria.Spec(jvmDefault, null, null, false)
 
         then:
         parameters.effectiveJvmArgs.contains("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")

--- a/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/internal/buildconfiguration/DaemonJvmPropertiesDefaults.java
+++ b/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/internal/buildconfiguration/DaemonJvmPropertiesDefaults.java
@@ -24,4 +24,5 @@ public class DaemonJvmPropertiesDefaults {
     public static final String TOOLCHAIN_IMPLEMENTATION_PROPERTY = "toolchainImplementation";
     public static final String TOOLCHAIN_URL_PROPERTY_PREFIX = "toolchainUrl";
     public static final String TOOLCHAIN_URL_PROPERTY_FORMAT = TOOLCHAIN_URL_PROPERTY_PREFIX + ".%s.%s";
+    public static final String TOOLCHAIN_NATIVE_IMAGE_CAPABLE_PROPERTY = "toolchainNativeImageCapable";
 }

--- a/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonJvmCriteria.java
+++ b/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonJvmCriteria.java
@@ -113,11 +113,13 @@ public interface DaemonJvmCriteria {
         private final JavaLanguageVersion javaVersion;
         private final JvmVendorSpec vendorSpec;
         private final JvmImplementation jvmImplementation;
+        private final boolean nativeImageCapable;
 
-        public Spec(JavaLanguageVersion javaVersion, JvmVendorSpec vendorSpec, JvmImplementation jvmImplementation) {
+        public Spec(JavaLanguageVersion javaVersion, JvmVendorSpec vendorSpec, JvmImplementation jvmImplementation, boolean nativeImageCapable) {
             this.javaVersion = javaVersion;
             this.vendorSpec = vendorSpec;
             this.jvmImplementation = jvmImplementation;
+            this.nativeImageCapable = nativeImageCapable;
         }
 
         public JavaLanguageVersion getJavaVersion() {
@@ -151,7 +153,11 @@ public interface DaemonJvmCriteria {
 
         @Override
         public String toString() {
-            return String.format("Compatible with Java %s, %s (from %s)", getJavaVersion(), getVendorSpec(), DaemonJvmPropertiesDefaults.DAEMON_JVM_PROPERTIES_FILE);
+            return String.format("Compatible with Java %s, %s, nativeImageCapable=%s (from %s)", getJavaVersion(), getVendorSpec(), isNativeImageCapable(), DaemonJvmPropertiesDefaults.DAEMON_JVM_PROPERTIES_FILE);
+        }
+
+        public boolean isNativeImageCapable() {
+            return nativeImageCapable;
         }
     }
 }

--- a/platforms/core-runtime/daemon-protocol/src/test/groovy/org/gradle/launcher/daemon/context/DaemonCompatibilitySpecSpec.groovy
+++ b/platforms/core-runtime/daemon-protocol/src/test/groovy/org/gradle/launcher/daemon/context/DaemonCompatibilitySpecSpec.groovy
@@ -82,7 +82,7 @@ class DaemonCompatibilitySpecSpec extends Specification {
     }
 
     def "contexts with different jvm criteria are incompatible"() {
-        clientWants(new DaemonJvmCriteria.Spec(JavaLanguageVersion.of(11), JvmVendorSpec.ADOPTIUM, JvmImplementation.VENDOR_SPECIFIC))
+        clientWants(new DaemonJvmCriteria.Spec(JavaLanguageVersion.of(11), JvmVendorSpec.ADOPTIUM, JvmImplementation.VENDOR_SPECIFIC, false))
 
         candidate.javaVersion >> JavaLanguageVersion.of(15)
 

--- a/platforms/core-runtime/gradle-cli/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
+++ b/platforms/core-runtime/gradle-cli/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
@@ -177,7 +177,7 @@ class BuildActionsFactoryTest extends Specification {
     }
 
     private DaemonRequestContext createDaemonRequest(Collection<String> daemonOpts = []) {
-        def request = new DaemonRequestContext(new DaemonJvmCriteria.Spec(JavaLanguageVersion.current(), null, null), daemonOpts, false, NativeServices.NativeServicesMode.NOT_SET, DaemonPriority.NORMAL)
+        def request = new DaemonRequestContext(new DaemonJvmCriteria.Spec(JavaLanguageVersion.current(), null, null, false), daemonOpts, false, NativeServices.NativeServicesMode.NOT_SET, DaemonPriority.NORMAL)
         request
     }
 

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineOutputIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineOutputIntegrationTest.groovy
@@ -57,6 +57,6 @@ class CommandLineOutputIntegrationTest extends AbstractIntegrationSpec implement
         succeeds("--version")
 
         then:
-        outputContains("Daemon JVM:    Compatible with Java 17, any vendor (from gradle/gradle-daemon-jvm.properties)")
+        outputContains("Daemon JVM:    Compatible with Java 17, any vendor, nativeImageCapable=false (from gradle/gradle-daemon-jvm.properties)")
     }
 }

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -229,6 +229,8 @@ java {
 
 See [the documentation](userguide/toolchains.html#sec:native_image) for details.
 
+Note that this feature is available as well for [the daemon toolchain](userguide/gradle_daemon.html#sec:native_image).
+
 ### Configuration Cache improvements
 
 #### Integrity Check mode

--- a/platforms/documentation/docs/src/docs/userguide/reference/gradle_daemon.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/gradle_daemon.adoc
@@ -325,6 +325,18 @@ You can view the list of recognized vendors by running `./gradlew help --task up
 If the specified vendor is not one of the recognized equivalents, Gradle will match it exactly.
 For example, "MyCustomJVM" would require an exact match of the vendor name.
 
+[[sec:native_image]]
+==== Requesting a native-image capable JDK
+
+Both the CLI options and the task configuration allow to request a JDK that is `native-image` capable.
+
+[source, bash]
+----
+$ ./gradlew updateDaemonJvm --jvm-version=17 --native-image-capable
+----
+
+See the <<toolchains.adoc#sec:native_image,toolchain documentation section>> for more information.
+
 [[sec:detect_provision]]
 === Auto-detection and auto-provisioning
 


### PR DESCRIPTION
This allows users to configure the Gradle Daemon to run with a native-image capable JDK.

Fixes #32613