### PR TITLE
#31659 Add support for relative java installation paths for Daemon toolchain

### DIFF
--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
@@ -19,6 +19,7 @@ package org.gradle.launcher.daemon.toolchain;
 import net.rubygrapefruit.platform.SystemInfo;
 import net.rubygrapefruit.platform.WindowsRegistry;
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.file.BaseDirFileResolver;
 import org.gradle.api.internal.file.DefaultFileOperations;
 import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -37,6 +38,7 @@ import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.scopes.ScopedCacheBuilderFactory;
+import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.Deleter;
@@ -113,7 +115,6 @@ public class DaemonClientToolchainServices implements ServiceRegistrationProvide
         FileLockManager fileLockManager,
         ClientExecHandleBuilderFactory execHandleFactory,
         GradleUserHomeTemporaryFileProvider gradleUserHomeTemporaryFileProvider,
-        FileResolver fileResolver,
         PropertyHost propertyHost,
         FileCollectionFactory fileCollectionFactory,
         DirectoryFileTreeFactory directoryFileTreeFactory,
@@ -135,6 +136,8 @@ public class DaemonClientToolchainServices implements ServiceRegistrationProvide
             installationSuppliers.add(new OsXInstallationSupplier(os, new DefaultOsXJavaHomeCommand(execHandleFactory)));
             installationSuppliers.add(new WindowsInstallationSupplier(windowsRegistry, os));
 
+            BuildLayoutParameters buildLayoutParameters = new BuildLayoutParameters();
+            FileResolver fileResolver = new BaseDirFileResolver(buildLayoutParameters.getCurrentDir());
             CurrentBuildPlatform currentBuildPlatform = new CurrentBuildPlatform(systemInfo, os);
             DefaultFilePropertyFactory filePropertyFactory = new DefaultFilePropertyFactory(propertyHost, fileResolver, fileCollectionFactory);
             DecompressionCoordinator decompressionCoordinator = new DefaultDecompressionCoordinator(scopedCacheBuilderFactory);

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainIntegrationTest.groovy
@@ -70,6 +70,25 @@ class DaemonToolchainIntegrationTest extends AbstractIntegrationSpec implements 
         assertDaemonUsedJvm(otherJvm)
     }
 
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given installation with relative path to project and disabled auto-detection When executing any task Then daemon jvm was set up with the relative path toolchain"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        def otherMetadata = AvailableJavaHomes.getJvmInstallationMetadata(otherJvm)
+        writeJvmCriteria(otherJvm.javaVersion, otherMetadata.vendor.knownVendor.name())
+        captureJavaHome()
+
+        def relativePathOtherJvmInstallation = testDirectory.relativePath(otherJvm.javaHome)
+        executer.withArguments([
+            "-Porg.gradle.java.installations.auto-detect=false",
+            "-Porg.gradle.java.installations.paths=" + relativePathOtherJvmInstallation
+        ])
+
+        expect:
+        succeeds("help")
+        assertDaemonUsedJvm(otherJvm)
+    }
+
     def "Given daemon toolchain criteria with version that doesn't match installed ones When executing any task Then fails with the expected message"() {
         given:
         // Java 10 is not available

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
@@ -62,6 +62,26 @@ class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements
         assertDaemonUsedJvm(otherJvm.javaHome)
     }
 
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given installation with relative path to project and disabled auto-detection When executing any task Then daemon jvm was set up with the relative path toolchain"() {
+        given:
+        def otherJvm = AvailableJavaHomes.getJdk11()
+        def relativePathOtherJvmInstallation = projectDir.relativePath(otherJvm.javaHome)
+        writeJvmCriteria(otherJvm.javaVersion.majorVersion)
+        withInstallations(file(relativePathOtherJvmInstallation))
+        captureJavaHome()
+
+        when:
+        withConnection {
+            it.newBuild().forTasks("help").withArguments(
+                "-Dorg.gradle.java.installations.auto-detect=false",
+            ).run()
+        }
+
+        then:
+        assertDaemonUsedJvm(otherJvm.javaHome)
+    }
+
     @Requires(IntegTestPreconditions.Java11HomeAvailable)
     def "Given daemon toolchain criteria that doesn't match installed ones When executing any task Then fails with the expected message"() {
         given:


### PR DESCRIPTION
### Context
This was reported on https://github.com/gradle/gradle/issues/31659 and in addition represents a misalignment between `Daemon toolchain` and `tasks/project toolchain` where the last one already supports relative paths, while for Daemon toolchain fails with the following exception message: 
```
java.lang.UnsupportedOperationException: Cannot convert relative path ../jdk/jdk17/linux to an absolute file.
```

For  `Daemon toolchain` the `DaemonClientToolchainServices` end up instantiating  `LocationListInstallationSupplier` using the provided `FileResolver` being `IdentityFileResolver` class this is because on Launcher context most of the services aren't available. However, the `IdentityFileResolver` doesn't support relative paths and instead `BaseDirFileResolver` should be used instead which requires the `baseDir` to resolve the relative path. To obtain project dirctory from the launcher context the `BuildLayoutParameters.currentDir` is used being this aligned with how project `gradle-daemon-jvm.properties`  are read as a criteria for the Daemon JVM.

NOTE: All of this aligns with the task/project toolchain behavior for custom toolchain when `org.gradle.java.installations.paths` is defined under `GRADLE_HOME` instead of the project.  
 - Absolute path: ✅
 - Relative path to the project: ✅
 - Relative path to GRADLE_HOME: ❌ 

#### Tests
- [DaemonToolchainIntegrationTest.groovy](https://github.com/gradle/gradle/pull/32869/files#diff-5fa2369a230dc8cf0eccd8bed69a095a9150ad2dcf6fc54379e8ec8c0440924c)
- [DaemonToolchainCrossVersionTest.groovy](https://github.com/gradle/gradle/pull/32869/files#diff-86c7b3ad2aaf456e2918c03efe4d3a1ca13d8869db4637920cb5eff01a942d6f)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.
