### PR TITLE
Refine metadata of experimental Gradle API jar

### DIFF
--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
@@ -131,10 +131,7 @@ gradlePlugin {
 // For local consumption by tests - this should be unified with publish-public-libraries if possible
 configurations.create("localLibsRepositoryElements") {
     attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
-        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named("gradle-local-repository"))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EMBEDDED))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named("gradle-local-repository"))
     }
     isCanBeResolved = false
     isCanBeConsumed = true

--- a/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic-commons/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -131,10 +131,7 @@ fun publishNormalizedToLocalRepository() {
     // For local consumption by tests
     configurations.create("localLibsRepositoryElements") {
         attributes {
-            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
-            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
-            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named("gradle-local-repository"))
-            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.EMBEDDED))
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named("gradle-local-repository"))
         }
         isCanBeResolved = false
         isCanBeConsumed = true

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -77,13 +77,14 @@ fun Project.addDependenciesAndConfigurations(prefix: String) {
 
         resolver("${prefix}TestDistributionRuntimeClasspath", "gradle-bin-installation", distributionRuntimeOnly)
         resolver("${prefix}TestFullDistributionRuntimeClasspath", "gradle-bin-installation")
-        resolver("${prefix}TestLocalRepositoryPath", "gradle-local-repository", localRepository)
         resolver("${prefix}TestNormalizedDistributionPath", "gradle-normalized-distribution-zip", normalizedDistribution)
         resolver("${prefix}TestBinDistributionPath", "gradle-bin-distribution-zip", binDistribution)
         resolver("${prefix}TestAllDistributionPath", "gradle-all-distribution-zip", allDistribution)
         resolver("${prefix}TestDocsDistributionPath", "gradle-docs-distribution-zip", docsDistribution)
         resolver("${prefix}TestSrcDistributionPath", "gradle-src-distribution-zip", srcDistribution)
         resolver("${prefix}TestAgentsClasspath", LibraryElements.JAR)
+
+        localRepositoryResolver("${prefix}TestLocalRepositoryPath", localRepository)
     }
 
     // do not attempt to find projects when the plugin is applied just to generate accessors
@@ -253,6 +254,19 @@ fun Project.resolver(name: String, libraryElements: String, extends: Configurati
         attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
         attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(libraryElements))
+    }
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isVisible = false
+    if (extends != null) {
+        extendsFrom(extends)
+    }
+}
+
+private
+fun Project.localRepositoryResolver(name: String, extends: Configuration? = null) = configurations.create(name) {
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named("gradle-local-repository"))
     }
     isCanBeResolved = true
     isCanBeConsumed = false

--- a/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-jar.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-jar.gradle.kts
@@ -77,7 +77,6 @@ val gradleApiElements = configurations.consumable("gradleApiElements") {
     extendsFrom(externalApi.get())
     outgoing.artifact(task)
     configureAsApiElements(objects)
-    // TODO capabilities
 }
 
 open class SoftwareComponentFactoryProvider @Inject constructor(val factory: SoftwareComponentFactory)

--- a/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-jar.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.public-api-jar.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 import gradlebuild.basics.ClassFileContentsAttribute
-import gradlebuild.configureAsRuntimeElements
+import gradlebuild.configureAsApiElements
 import gradlebuild.configureAsRuntimeJarClasspath
 
 plugins {
@@ -76,7 +76,8 @@ val task = tasks.register<Jar>("jarGradleApi") {
 val gradleApiElements = configurations.consumable("gradleApiElements") {
     extendsFrom(externalApi.get())
     outgoing.artifact(task)
-    configureAsRuntimeElements(objects)
+    configureAsApiElements(objects)
+    // TODO capabilities
 }
 
 open class SoftwareComponentFactoryProvider @Inject constructor(val factory: SoftwareComponentFactory)

--- a/packaging/public-api/build.gradle.kts
+++ b/packaging/public-api/build.gradle.kts
@@ -73,10 +73,7 @@ val testRepoElements = configurations.consumable("testRepoElements") {
     }
     // TODO: De-duplicate this. See publish-public-libraries
     attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
-        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named("gradle-local-repository"))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.EMBEDDED))
+        attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named("gradle-local-repository"))
     }
 }
 

--- a/packaging/public-api/build.gradle.kts
+++ b/packaging/public-api/build.gradle.kts
@@ -67,6 +67,14 @@ publishing {
     }
 }
 
+configurations {
+    gradleApiElements {
+        outgoing {
+            capability("$group:${moduleIdentity.baseName.get()}-internal:$version")
+        }
+    }
+}
+
 val testRepoElements = configurations.consumable("testRepoElements") {
     outgoing.artifact(testRepoLocation) {
         builtBy( "publishMavenPublicationToTestRepository")

--- a/testing/public-api-tests/build.gradle.kts
+++ b/testing/public-api-tests/build.gradle.kts
@@ -27,10 +27,7 @@ plugins {
 val testRepo = configurations.dependencyScope("testRepo")
 val resolveTestRepo = configurations.resolvable("resolveTestRepo") {
     attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
-        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named("gradle-local-repository"))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.EMBEDDED))
+        attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named("gradle-local-repository"))
     }
     extendsFrom(testRepo.get())
 }

--- a/testing/public-api-tests/src/integTest/groovy/org/gradle/api/PublicApiIntegrationTest.groovy
+++ b/testing/public-api-tests/src/integTest/groovy/org/gradle/api/PublicApiIntegrationTest.groovy
@@ -223,7 +223,7 @@ class PublicApiIntegrationTest extends AbstractIntegrationSpec implements JavaTo
             }
 
             dependencies {
-                implementation("org.gradle.experimental:gradle-public-api:${apiJarVersion}")
+                compileOnly("org.gradle.experimental:gradle-public-api:${apiJarVersion}")
             }
 
             testing {

--- a/testing/public-api-tests/src/integTest/groovy/org/gradle/api/PublicApiIntegrationTest.groovy
+++ b/testing/public-api-tests/src/integTest/groovy/org/gradle/api/PublicApiIntegrationTest.groovy
@@ -223,7 +223,11 @@ class PublicApiIntegrationTest extends AbstractIntegrationSpec implements JavaTo
             }
 
             dependencies {
-                compileOnly("org.gradle.experimental:gradle-public-api:${apiJarVersion}")
+                compileOnly("org.gradle.experimental:gradle-public-api:${apiJarVersion}") {
+                    capabilities {
+                        requireCapability("org.gradle.experimental:gradle-public-api-internal")
+                    }
+                }
             }
 
             testing {


### PR DESCRIPTION
* Make is `java-api` and not runtime
* Add a capability

In addition, there is clean up in how we depend on a configuration that is designed to provide a local path.