### PR TITLE
Remove already resolved TODO

### DIFF
--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
@@ -58,7 +58,7 @@ public class DefaultTypeValidationContext extends ProblemRecordingTypeValidation
 
     @Override
     protected void recordProblem(InternalProblem problem) {
-        if (onlyAffectsCacheableWork(problem.getDefinition().getId()) && !reportCacheabilityProblems) { // TODO (donat) is already fixed on master
+        if (onlyAffectsCacheableWork(problem.getDefinition().getId()) && !reportCacheabilityProblems) {
             return;
         }
         problems.add(problem);


### PR DESCRIPTION
The comment refers to a really old WIP change to restore the condition in the 'if' statement. We fixed the condition but we accidentally kept the comment. See:

https://github.com/gradle/gradle/commit/56f3af62eb39bc2d45c6b08b235bdd452815fda6#diff-47ed4b29666096701d85db7b4e0fdc147c6aa2bd8ed05c07d8f61d69ac2984a8R60

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle-private/issues/4640

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
