### PR TITLE
Add a partial signature to generated classes

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -59,6 +59,7 @@ import org.gradle.internal.state.Managed;
 import org.gradle.internal.state.ModelObject;
 import org.gradle.internal.state.OwnerAware;
 import org.gradle.model.internal.asm.AsmClassGenerator;
+import org.gradle.model.internal.asm.AsmClassGeneratorUtils;
 import org.gradle.model.internal.asm.BytecodeFragment;
 import org.gradle.model.internal.asm.ClassGeneratorSuffixRegistry;
 import org.gradle.model.internal.asm.ClassVisitorScope;
@@ -635,7 +636,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
             includeNotInheritedAnnotations();
 
-            visit(V1_8, ACC_PUBLIC | ACC_SYNTHETIC, generatedType.getInternalName(), null,
+            visit(V1_8, ACC_PUBLIC | ACC_SYNTHETIC, generatedType.getInternalName(), AsmClassGeneratorUtils.encodeTypeVariablesAsSignature(type),
                 superclass.getInternalName(), interfaceTypes.toArray(EMPTY_STRINGS));
 
             generateInitMethod();

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -81,6 +81,7 @@ import java.lang.annotation.Target;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -1191,6 +1192,15 @@ public class AsmBackedClassGeneratorTest {
         }));
         assertEquals("[1]", bean.getProp2().get());
         assertEquals("[2]", bean.getProp2().get());
+    }
+
+    @Test
+    public void generatesMethodWithRetrievableSignature() throws Exception {
+        InterfaceWithTypeParameter<?> genericInterface = newInstance(InterfaceWithTypeParameter.class);
+        assertTrue(genericInterface instanceof GeneratedSubclass);
+        Method genericMethod = genericInterface.getClass().getDeclaredMethod("getThing");
+        Type returnType = genericMethod.getGenericReturnType();
+        assertTrue(returnType instanceof TypeVariable<?>);
     }
 
     public static class Bean {

--- a/platforms/core-runtime/base-asm/src/main/java/org/gradle/model/internal/asm/AsmClassGeneratorUtils.java
+++ b/platforms/core-runtime/base-asm/src/main/java/org/gradle/model/internal/asm/AsmClassGeneratorUtils.java
@@ -16,7 +16,11 @@
 
 package org.gradle.model.internal.asm;
 
+import org.objectweb.asm.signature.SignatureVisitor;
+import org.objectweb.asm.signature.SignatureWriter;
+
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
@@ -28,6 +32,64 @@ import java.lang.reflect.WildcardType;
 import static org.objectweb.asm.Type.getType;
 
 public class AsmClassGeneratorUtils {
+    private static final String OBJECT_INTERNAL_NAME = Object.class.getName().replace('.', '/');
+
+    /**
+     * Take the type variables defined by {@code javaClass} and encode them into a signature string,
+     * appropriate for use as the signature of a subclass.
+     *
+     * <p>
+     * This allows us to refer to the same type variables in our method signatures without generating undefined type variables that are
+     * <a href="https://bugs.openjdk.org/browse/JDK-8337302">an error in JDK 24</a>.
+     * </p>
+     *
+     * @param javaClass the Java class to take the type variables from
+     */
+    @Nullable
+    public static String encodeTypeVariablesAsSignature(Class<?> javaClass) {
+        TypeVariable<? extends Class<?>>[] typeParameters = javaClass.getTypeParameters();
+        if (typeParameters.length == 0) {
+            return null;
+        }
+
+        SignatureWriter writer = new SignatureWriter();
+        copyTypeVariables(writer, typeParameters);
+
+        // Pass the variables to the supertype as well, for some amount of correctness
+        addSuperTypeGenericInfo(javaClass, writer, typeParameters);
+
+        return writer.toString();
+    }
+
+    private static void copyTypeVariables(SignatureWriter writer, TypeVariable<? extends Class<?>>[] typeParameters) {
+        for (TypeVariable<? extends Class<?>> typeParameter : typeParameters) {
+            writer.visitFormalTypeParameter(typeParameter.getName());
+            // For now, not copying the bounds as that is expensive and complex; and we probably don't need to be fully accurate here.
+            // We must still specify _some_ bound due to what I believe to be a bug in the signature parser of the JVM.
+            // Specifically, it requires <T:Ljava/lang/Object;> instead of just <T:> which is legal according to https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-4.html#jvms-4.7.9.1
+            SignatureVisitor typeParameterBoundWriter = writer.visitClassBound();
+            typeParameterBoundWriter.visitClassType(OBJECT_INTERNAL_NAME);
+            typeParameterBoundWriter.visitEnd();
+        }
+    }
+
+    private static void addSuperTypeGenericInfo(Class<?> type, SignatureWriter writer, TypeVariable<? extends Class<?>>[] typeParameters) {
+        SignatureVisitor superVisitor;
+        if (type.isInterface()) {
+            // We must visit the superclass first
+            SignatureVisitor superclassVisitor = writer.visitSuperclass();
+            superclassVisitor.visitClassType(OBJECT_INTERNAL_NAME);
+            superclassVisitor.visitEnd();
+            superVisitor = writer.visitInterface();
+        } else {
+            superVisitor = writer.visitSuperclass();
+        }
+        superVisitor.visitClassType(getType(type).getInternalName());
+        for (TypeVariable<? extends Class<?>> typeParameter : typeParameters) {
+            superVisitor.visitTypeArgument('=').visitTypeVariable(typeParameter.getName());
+        }
+        superVisitor.visitEnd();
+    }
 
     /**
      * Generates the signature for the given constructor, optionally adding a `name` parameter before all other parameters.


### PR DESCRIPTION
This works around an issue introduced by
https://bugs.openjdk.org/browse/JDK-8337302 which requires us to define the class-level type-variables so that method signatures can resolve them

### Context
Part of Java 24 work for #32576 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
