### PR TITLE
Add todo and a test for flow action depending on task with late binding

### DIFF
--- a/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/FlowParametersInstantiator.kt
+++ b/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/FlowParametersInstantiator.kt
@@ -49,6 +49,7 @@ class FlowParametersInstantiator(
     fun <P : FlowParameters> newInstance(parametersType: Class<P>, configure: (P) -> Unit): P {
         return instantiator.newInstance(parametersType).also {
             configure(it)
+            // TODO(mlopatkin) this doesn't prevent late binding to a task output (e.g. there can be a Property in the chain that is set later).
             validate(parametersType, it)
         }
     }


### PR DESCRIPTION
We only detect that task is used as a flow action input when the chain is ready after configuring. However, a user can add the task into the mix later. In that case, there is no validation and the failure can be cryptic.
