### PR TITLE
Remove internal load-after-store flag

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIntegrationTest.groovy
@@ -409,21 +409,4 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
         configurationCache.assertNoConfigurationCache()
         outputContains("isConfigurationCacheRequested=true")
     }
-
-    def "internal load-after-store flag is deprecated"() {
-        def configurationCache = newConfigurationCacheFixture()
-
-        when:
-        executer.expectDeprecationWarning("The org.gradle.configuration-cache.internal.load-after-store system property has been deprecated." +
-            " Starting with Gradle 9.0, it will not be possible to disable load-after-store behavior of Configuration Cache." +
-            " The behavior is enabled by default. Avoid using the internal flag.")
-
-        configurationCacheRun "help", "-Dorg.gradle.configuration-cache.internal.load-after-store=$load"
-
-        then:
-        configurationCache.assertStateStored(load)
-
-        where:
-        load << [true, false]
-    }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildTreeWorkController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildTreeWorkController.kt
@@ -17,10 +17,10 @@
 package org.gradle.internal.cc.impl
 
 import org.gradle.composite.internal.BuildTreeWorkGraphController
-import org.gradle.internal.cc.impl.initialization.ConfigurationCacheStartParameter
 import org.gradle.execution.EntryTaskSelector
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.ExecutionResult
+import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeWorkController
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor
 import org.gradle.internal.buildtree.BuildTreeWorkPreparer
@@ -32,7 +32,7 @@ class ConfigurationCacheAwareBuildTreeWorkController(
     private val workGraph: BuildTreeWorkGraphController,
     private val cache: BuildTreeConfigurationCache,
     private val buildRegistry: BuildStateRegistry,
-    private val startParameter: ConfigurationCacheStartParameter,
+    private val startParameter: BuildModelParameters,
 ) : BuildTreeWorkController {
 
     override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?): ExecutionResult<Void> {
@@ -41,22 +41,32 @@ class ConfigurationCacheAwareBuildTreeWorkController(
                 addFinalization(rootBuildState, selector::postProcessExecutionPlan)
             }
         }
-        val executionResult = workGraph.withNewWorkGraph { graph ->
+        val executionResult: ExecutionResult<Void>? = workGraph.withNewWorkGraph { graph ->
             val result = cache.loadOrScheduleRequestedTasks(
                 graph = graph,
                 graphBuilder = scheduleTaskSelectorPostProcessing
             ) { workPreparer.scheduleRequestedTasks(graph, taskSelector) }
-            if (!result.wasLoadedFromCache && !result.entryDiscarded && startParameter.loadAfterStore) {
-                // Load the work graph from cache instead
+            // There are four outcomes:
+            // 1. CC miss, graph has been successfully stored. We don't try to execute the graph directly but store it first, discard, and then reload.
+            // 2. Same as (1) but we also need tooling models. The model builders can be executed after the tasks (if any) in a build action,
+            //    and these builders may access project state as well as the task state. Because of that we execute the prepared graph directly.
+            // 3. CC miss, graph has been configured but the cached state discarded without failing the build (e.g. task.notCompatibleWithCC is used).
+            //    We execute the build immediately using the prepared graph.
+            // 4. CC hit: we've loaded the cached graph. We execute the build immediately using the loaded graph.
+            if (!result.wasLoadedFromCache && !result.entryDiscarded && !startParameter.isRequiresToolingModels) {
+                // This is the first outcome of the list above.
+                // We don't want to fold the code below here so the "live" graph can be garbage collected before execution.
                 null
             } else {
                 workExecutor.execute(result.graph)
             }
         }
         if (executionResult != null) {
+            // We have executed the work graph already.
             return executionResult
         }
 
+        // Store and reload the graph for the execution.
         cache.finalizeCacheEntry()
         buildRegistry.visitBuilds { build ->
             build.beforeModelReset().rethrow()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeLifecycleControllerFactory.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeLifecycleControllerFactory.kt
@@ -26,7 +26,6 @@ import org.gradle.internal.buildtree.BuildTreeLifecycleController
 import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor
 import org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController
-import org.gradle.internal.cc.impl.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.cc.impl.services.DefaultDeferredRootBuildGradle
 import org.gradle.internal.model.StateTransitionControllerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -41,7 +40,6 @@ class ConfigurationCacheBuildTreeLifecycleControllerFactory internal constructor
     private val taskGraph: BuildTreeWorkGraphController,
     private val stateTransitionControllerFactory: StateTransitionControllerFactory,
     private val startParameter: StartParameter,
-    private val configurationCacheStartParameter: ConfigurationCacheStartParameter,
     private val buildStateRegistry: BuildStateRegistry,
     private val deferredRootBuildGradle: DefaultDeferredRootBuildGradle,
     parameterCarrierFactory: ToolingModelParameterCarrier.Factory,
@@ -81,7 +79,7 @@ class ConfigurationCacheBuildTreeLifecycleControllerFactory internal constructor
         }
 
         val workPreparer = vintageFactory.createWorkPreparer(targetBuild)
-        val workController = ConfigurationCacheAwareBuildTreeWorkController(workPreparer, workExecutor, taskGraph, cache, buildStateRegistry, configurationCacheStartParameter)
+        val workController = ConfigurationCacheAwareBuildTreeWorkController(workPreparer, workExecutor, taskGraph, cache, buildStateRegistry, buildModelParameters)
 
         val defaultModelCreator = vintageFactory.createModelCreator(targetBuild)
         val modelCreator = ConfigurationCacheAwareBuildTreeModelCreator(defaultModelCreator, cache)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -22,7 +22,6 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.initialization.layout.BuildLayout
 import org.gradle.internal.Factory
-import org.gradle.internal.buildoption.InternalFlag
 import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.cc.impl.ConfigurationCacheLoggingParameters
@@ -44,42 +43,6 @@ class ConfigurationCacheStartParameter internal constructor(
     private val modelParameters: BuildModelParameters,
     private val loggingParameters: ConfigurationCacheLoggingParameters,
 ) {
-
-    companion object {
-
-        private
-        val loadAfterStoreFlag = InternalFlag("org.gradle.configuration-cache.internal.load-after-store", true)
-
-        private
-        fun InternalOptions.loadAfterStoreRequested(): Boolean {
-            val value = getOption(loadAfterStoreFlag)
-            if (value.isExplicit) {
-                DeprecationLogger.deprecateSystemProperty(loadAfterStoreFlag.systemPropertyName)
-                    .withContext("The behavior is enabled by default.")
-                    .withAdvice("Avoid using the internal flag.")
-                    .startingWithGradle9("it will not be possible to disable load-after-store behavior of Configuration Cache")
-                    .undocumented()
-                    .nagUser()
-            }
-            return value.get()
-        }
-    }
-
-    /**
-     * On a CC miss, should we load the newly stored state in the same invocation?
-     *
-     * This provides a benefit of discarding a lot of state (e.g. project state) earlier in the build,
-     * potentially reducing the memory consumption.
-     * Another key benefit is that this eliminates discrepancies in behavior between cache hits and misses.
-     *
-     * We disable load-after-store when tooling model builders are involved.
-     * This is because the builders can be executed after the tasks (if any) in a build action,
-     * and these builders may access project state as well as the task state.
-     * Doing load-after-store would have discarded the project state and isolated the task state,
-     * providing the builders with an incomplete view of the build.
-     */
-    val loadAfterStore: Boolean by lazy { options.loadAfterStoreRequested() && !modelParameters.isRequiresToolingModels }
-
     val taskExecutionAccessPreStable: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.task-execution-access-pre-stable")
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/BuildTreeWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/BuildTreeWorkGraphController.java
@@ -19,6 +19,7 @@ package org.gradle.composite.internal;
 import org.gradle.internal.buildtree.BuildTreeWorkGraph;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.jspecify.annotations.Nullable;
 
 import java.util.function.Function;
 
@@ -36,5 +37,5 @@ public interface BuildTreeWorkGraphController {
      * Runs the given action against a new, empty work graph. This allows tasks to be run while calculating the task graph of the build tree, for example to run `buildSrc` tasks or
      * to build local plugins in an included build.
      */
-    <T> T withNewWorkGraph(Function<? super BuildTreeWorkGraph, T> action);
+    <T extends @Nullable Object> T withNewWorkGraph(Function<? super BuildTreeWorkGraph, T> action);
 }


### PR DESCRIPTION
It has been deprecated since 8.13.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
