### PR TITLE
Mark WatchedDirectoriesFileSystemWatchingIntegrationTest as flaky for now

### DIFF
--- a/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/platforms/core-execution/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.watch
 
 import com.google.common.collect.ImmutableSet
+import org.gradle.test.fixtures.Flaky
 import org.gradle.testdistribution.LocalOnly
 import org.apache.commons.io.FileUtils
 import org.gradle.cache.GlobalCacheLocations
@@ -33,6 +34,7 @@ import org.junit.Rule
 import spock.lang.Issue
 
 @LocalOnly
+@Flaky(because = "https://github.com/gradle/gradle-private/issues/4642")
 class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSystemWatchingIntegrationTest {
     @Rule
     public final RepositoryHttpServer server = new RepositoryHttpServer(temporaryFolder)


### PR DESCRIPTION
While we're investigating https://github.com/gradle/gradle-private/issues/4642
