### PR TITLE
Fix broken link in 'Modifying Dependency Metadata'

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/dep-man/dependency-management/component_metadata_rules.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/dependency-management/component_metadata_rules.adoc
@@ -112,7 +112,7 @@ Additionally, several component-level properties can be changed:
 
 - **Component Attributes**: The only <<sec:custom-status-scheme,meaningful attribute>> here is `org.gradle.status`.
 - **Status Scheme**: Influence how the `org.gradle.status` attribute is interpreted during version selection.
-- **BelongsTo Property**: Used for <component_capabilities.adoc#sec:declaring-capabilities-external-modules,version alignment>> via virtual platforms.
+- **BelongsTo Property**: Used for <<component_capabilities.adoc#sec:declaring-capabilities-external-modules,version alignment>> via virtual platforms.
 
 The format of a module's metadata affects how it maps to the variant-centric representation:
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
- #32858

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Fixes a malformed AsciiDoc link in the BelongsTo Property section of the Modifying Dependency Metadata documentation.
The link was missing an opening angle bracket (<), causing it to render incorrectly.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
