### PR TITLE
Add environment variable JAVA_HOME toolchain installation supplier

### DIFF
--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainIntegrationTest.groovy
@@ -71,6 +71,22 @@ class DaemonToolchainIntegrationTest extends AbstractIntegrationSpec implements 
         assertDaemonUsedJvm(otherJvm)
     }
 
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given criteria matching JAVA_HOME environment variable and disabled auto-detection When executing any task Then daemon jvm was set up with expected configuration"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        def otherMetadata = AvailableJavaHomes.getJvmInstallationMetadata(otherJvm)
+        writeJvmCriteria(otherJvm.javaVersion, otherMetadata.vendor.knownVendor.name())
+        captureJavaHome()
+
+        executer.withJavaHome(Jvm.current().javaHome.absolutePath)
+            .withEnvironmentVarsIncludingJavaHome([JAVA_HOME: otherJvm.javaHome.absolutePath])
+
+        expect:
+        succeeds("help")
+        assertDaemonUsedJvm(otherJvm)
+    }
+
     def "Given daemon toolchain criteria with version that doesn't match installed ones When executing any task Then fails with the expected message"() {
         given:
         // Java 10 is not available

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.tooling.GradleConnectionException
 import org.junit.Assume
+import spock.lang.Ignore
 
 // 8.8 did not support configuring the set of available Java homes or disabling auto-detection
 @TargetGradleVersion(">=8.9")
@@ -58,6 +59,27 @@ class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements
         when:
         withConnection {
             it.newBuild().forTasks("help").run()
+        }
+
+        then:
+        assertDaemonUsedJvm(otherJvm.javaHome)
+    }
+
+    @Ignore("https://github.com/gradle/gradle/issues/32969")
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given criteria matching JAVA_HOME environment variable and disabled auto-detection When executing any task Then daemon jvm was set up with expected configuration"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        writeJvmCriteria(otherJvm.javaVersion.majorVersion)
+        captureJavaHome()
+
+        when:
+        withConnection {
+            it.newBuild()
+                .setEnvironmentVariables(["JAVA_HOME": otherJvm.javaHome.absolutePath])
+                .forTasks("help").withArguments(
+                "-Dorg.gradle.java.installations.auto-detect=false",
+            ).run()
         }
 
         then:

--- a/platforms/jvm/jvm-services/src/integTest/groovy/org/gradle/jvm/toolchain/JavaInstallationRegistryIntegrationTest.groovy
+++ b/platforms/jvm/jvm-services/src/integTest/groovy/org/gradle/jvm/toolchain/JavaInstallationRegistryIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.jvm.toolchain
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
@@ -96,6 +97,41 @@ class JavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
         outputContains("Directory '${new File("/unknown/env").absolutePath}' (environment variable 'JDK1') used for java installations does not exist")
         outputContains(firstJavaHome)
         outputContains(secondJavaHome)
+    }
+
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "installation registry is populated by JAVA_HOME environment variable"() {
+        def currentJvm = Jvm.current().javaHome.absolutePath
+        def otherJvm = AvailableJavaHomes.differentVersion.javaHome.absolutePath
+
+        buildFile << """
+            import org.gradle.internal.jvm.inspection.JavaInstallationRegistry;
+
+            abstract class ShowPlugin implements Plugin<Project> {
+                @Inject
+                abstract JavaInstallationRegistry getRegistry()
+
+                void apply(Project project) {
+                    project.tasks.register("show") {
+                       registry.listInstallations().each { println it.location }
+                    }
+                }
+            }
+
+            apply plugin: ShowPlugin
+        """
+
+        when:
+        result = executer
+            .withArguments("-Dorg.gradle.java.home=$currentJvm", "--info")
+            .withEnvironmentVarsIncludingJavaHome([JAVA_HOME: otherJvm])
+            .withTasks("show")
+            .requireIsolatedDaemons()
+            .run()
+
+        then:
+        outputContains(currentJvm)
+        outputContains(otherJvm)
     }
 
     def "relative file paths are resolved relative to root dir"() {

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJavaInstallationRegistry.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJavaInstallationRegistry.java
@@ -30,6 +30,7 @@ import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.internal.AutoInstalledInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.CurrentInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.EnvironmentVariableJavaHomeInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.EnvironmentVariableListInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.InstallationLocation;
 import org.gradle.jvm.toolchain.internal.InstallationSupplier;
@@ -119,6 +120,7 @@ public class DefaultJavaInstallationRegistry implements JavaInstallationRegistry
     private static List<InstallationSupplier> builtInSuppliers(ToolchainConfiguration toolchainConfiguration, FileResolver fileResolver, JdkCacheDirectory jdkCacheDirectory) {
         List<InstallationSupplier> allSuppliers = new ArrayList<>();
         allSuppliers.add(new EnvironmentVariableListInstallationSupplier(toolchainConfiguration, fileResolver, System.getenv()));
+        allSuppliers.add(new EnvironmentVariableJavaHomeInstallationSupplier(System.getenv()));
         allSuppliers.add(new LocationListInstallationSupplier(toolchainConfiguration, fileResolver));
         allSuppliers.add(new CurrentInstallationSupplier());
         allSuppliers.add(new AutoInstalledInstallationSupplier(toolchainConfiguration, jdkCacheDirectory));

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/EnvironmentVariableJavaHomeInstallationSupplier.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/EnvironmentVariableJavaHomeInstallationSupplier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal;
+
+import org.jspecify.annotations.Nullable;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public class EnvironmentVariableJavaHomeInstallationSupplier implements InstallationSupplier {
+
+    private final @Nullable String javaHomePath;
+
+    public EnvironmentVariableJavaHomeInstallationSupplier(Map<String, String> environment) {
+        this.javaHomePath = environment.get("JAVA_HOME");
+    }
+
+    @Override
+    public String getSourceName() {
+        return "environment variable 'JAVA_HOME'";
+    }
+
+    @Override
+    public Set<InstallationLocation> get() {
+        if (javaHomePath == null || javaHomePath.isEmpty()) {
+            return Collections.emptySet();
+        }
+        File javaHome = new File(javaHomePath);
+        InstallationLocation installationLocation = InstallationLocation.userDefined(javaHome, getSourceName());
+        return Collections.singleton(installationLocation);
+    }
+}

--- a/platforms/jvm/jvm-services/src/test/groovy/org/gradle/jvm/toolchain/internal/EnvironmentVariableJavaHomeInstallationSupplierTest.groovy
+++ b/platforms/jvm/jvm-services/src/test/groovy/org/gradle/jvm/toolchain/internal/EnvironmentVariableJavaHomeInstallationSupplierTest.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+class EnvironmentVariableJavaHomeInstallationSupplierTest extends Specification {
+
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+
+    def "supplies no installations for not defined or empty JAVA_HOME property"() {
+        when:
+        def supplier = new EnvironmentVariableJavaHomeInstallationSupplier(environment)
+        def directories = supplier.get()
+
+        then:
+        directories.isEmpty()
+
+        where:
+        environment << [[:], [JAVA_HOME: ''], [OTHER: 'other']]
+    }
+
+    def "supplies installation for JAVA_HOME property"() {
+        given:
+        def jdk8 = tmpDir.createDir("jdk8")
+        def environment = [JAVA_HOME: jdk8.absolutePath]
+
+        when:
+        def supplier = new EnvironmentVariableJavaHomeInstallationSupplier(environment)
+        def directories = supplier.get()
+
+        then:
+        directories.size() == 1
+        directories[0].location == jdk8
+        directories[0].source == "environment variable 'JAVA_HOME'"
+    }
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -348,7 +348,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         }
         executer.withTasks(tasks);
         executer.withArguments(args);
-        executer.withEnvironmentVars(environmentVars);
+        executer.withEnvironmentVarsIncludingJavaHome(environmentVars);
         executer.usingExecutable(executable);
         if (quiet) {
             executer.withQuietLogging();
@@ -782,6 +782,11 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     @Override
     public final GradleExecuter withEnvironmentVars(Map<String, ?> environment) {
         Preconditions.checkArgument(!environment.containsKey("JAVA_HOME"), "Cannot provide JAVA_HOME to withEnvironmentVars, use withJavaHome instead");
+        return withEnvironmentVarsIncludingJavaHome(environment);
+    }
+
+    @Override
+    public GradleExecuter withEnvironmentVarsIncludingJavaHome(Map<String, ?> environment) {
         environmentVars.clear();
         for (Map.Entry<String, ?> entry : environment.entrySet()) {
             environmentVars.put(entry.getKey(), entry.getValue().toString());

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -85,6 +85,16 @@ public interface GradleExecuter extends Stoppable {
      */
     GradleExecuter withEnvironmentVars(Map<String, ?> environment);
 
+    /**
+     * Sets the additional environment variables to use when executing the build, allowing to pass JAVA_HOME as well.
+     * <p>
+     * The provided environment is added to the environment variables of this process, so it is only possible to add new variables or modify values of existing ones.
+     * Not propagating a variable of this process to the executed build at all is not supported.
+     * <p>
+     * Setting "JAVA_HOME" this way is not supported.
+     */
+    GradleExecuter withEnvironmentVarsIncludingJavaHome(Map<String, ?> environment);
+
     GradleExecuter usingInitScript(File initScript);
 
     /**

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -127,8 +127,9 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
         final String value = toJvmArgsString(invocation.launcherJvmArgs);
         environmentVars.put(jvmOptsEnvVar, value);
 
-        // Always set JAVA_HOME, so the daemon process runs on the configured JVM
-        environmentVars.put("JAVA_HOME", getJavaHome());
+        if (!environmentVars.containsKey("JAVA_HOME")) {
+            environmentVars.put("JAVA_HOME", getJavaHome());
+        }
     }
 
     @Override


### PR DESCRIPTION
#### Context

Expose a new toolchain installation supplier to resolve `JAVA_HOME` environment variable since this might be different than the JVM of the launcher process resolved by existing `CurrentInstallationSupplier`. This will help to align much better CLI and IDE `auto-detection` mechanism to avoid having different resolutions. More details can be found on the related bug  https://github.com/gradle/gradle/issues/32444.

##### Overview 

- The `EnvironmentVariableJavaHomeInstallationSupplier` is always discovered by the `auto-detection` mechanism and cannot be ignored, similar to `EnvironmentVariableListInstallationSupplierTest` given that is a user definition
- Adapt [AbstractGradleExecuter.java](https://github.com/gradle/gradle/pull/32948/files#diff-2eaa747880856381cf7196d0ca007af4e53a10e59ce89ea7372a073f7b203cf3) to allow execute tests with `org.gradle.java.home` parameter but also with defined `JAVA_HOME` at the same time

#### Tests
- [EnvironmentVariableJavaHomeInstallationSupplierTest.groovy](https://github.com/gradle/gradle/pull/32948/files#diff-83e42c4c84bfd37543d58dbcc0eb9c2a46f3539bc72ac8a8186aa94e615df9a8)
- [JavaInstallationRegistryIntegrationTest.groovy](https://github.com/gradle/gradle/pull/32948/files#diff-0fcb413e60de9db02d84373335b5869f0f19103a52fe7a97cadfc7579f62ba0e)
- [DaemonToolchainCrossVersionTest.groovy](https://github.com/gradle/gradle/pull/32948/files#diff-86c7b3ad2aaf456e2918c03efe4d3a1ca13d8869db4637920cb5eff01a942d6f)
- [DaemonToolchainIntegrationTest.groovy](https://github.com/gradle/gradle/pull/32948/files#diff-5fa2369a230dc8cf0eccd8bed69a095a9150ad2dcf6fc54379e8ec8c0440924c)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.