### PR TITLE
Resolve relative paths with `Providers.exec`

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -64,11 +64,6 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
     }
 
     @Override
-    public FilePropertyFactory forChildScope(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
-        return new DefaultFilePropertyFactory(host, fileResolver, fileCollectionFactory);
-    }
-
-    @Override
     public Directory dir(File dir) {
         dir = fileResolver.resolve(dir);
         return new FixedDirectory(dir, fileResolver.newResolver(dir), fileCollectionFactory);

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -64,6 +64,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
     }
 
     @Override
+    public FilePropertyFactory forChildScope(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
+        return new DefaultFilePropertyFactory(host, fileResolver, fileCollectionFactory);
+    }
+
+    @Override
     public Directory dir(File dir) {
         dir = fileResolver.resolve(dir);
         return new FixedDirectory(dir, fileResolver.newResolver(dir), fileCollectionFactory);

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
@@ -39,7 +39,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
-@ServiceScope({Scope.Global.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
+@ServiceScope({Scope.Global.class, Scope.BuildSession.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
 public interface FileCollectionFactory {
     /**
      * Creates a copy of this factory that uses the given resolver to convert various types to File instances.

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
@@ -21,7 +21,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope({Scope.Global.class, Scope.BuildTree.class, Scope.Project.class})
+@ServiceScope({Scope.Global.class, Scope.BuildSession.class, Scope.Project.class})
 public interface FilePropertyFactory {
     DirectoryProperty newDirectoryProperty();
 

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
@@ -21,9 +21,14 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope({Scope.Global.class, Scope.Project.class})
+@ServiceScope({Scope.Global.class, Scope.BuildTree.class, Scope.Project.class})
 public interface FilePropertyFactory {
     DirectoryProperty newDirectoryProperty();
 
     RegularFileProperty newFileProperty();
+
+    /**
+     * Creates a copy of this factory that uses the given resolver and fileCollectionFactory.
+     */
+    FilePropertyFactory forChildScope(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory);
 }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
@@ -27,8 +27,4 @@ public interface FilePropertyFactory {
 
     RegularFileProperty newFileProperty();
 
-    /**
-     * Creates a copy of this factory that uses the given resolver and fileCollectionFactory.
-     */
-    FilePropertyFactory forChildScope(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSourceProviderFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueSourceProviderFactory.java
@@ -34,7 +34,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @since 6.1
  */
-@ServiceScope(Scope.Build.class)
+@ServiceScope({Scope.Build.class, Scope.Project.class})
 public interface ValueSourceProviderFactory {
 
     <T, P extends ValueSourceParameters> Provider<T> createProviderOf(

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ExecSpecFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ExecSpecFactory.java
@@ -28,7 +28,7 @@ import org.gradle.process.JavaExecSpec;
  *
  * These instances will not be exposed to the user code directly, so there is no need of decoration.
  */
-@ServiceScope(Scope.Build.class)
+@ServiceScope({Scope.Build.class, Scope.Project.class})
 public interface ExecSpecFactory {
     ExecSpec newExecSpec();
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProcessOutputProviderFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProcessOutputProviderFactory.java
@@ -23,7 +23,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.process.ExecSpec;
 import org.gradle.process.JavaExecSpec;
 
-@ServiceScope(Scope.Build.class)
+@ServiceScope({Scope.Build.class, Scope.Project.class})
 public class ProcessOutputProviderFactory {
     private final Instantiator instantiator;
     private final ExecSpecFactory execSpecFactory;

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleExecSpecTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleExecSpecTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider.sources.process
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.process.internal.DefaultExecSpec
+import org.gradle.util.TestUtil
 
 class ProviderCompatibleExecSpecTest extends ProviderCompatibleBaseExecSpecTestBase {
     def "spec sets commandLine on parameters"() {
@@ -35,6 +36,6 @@ class ProviderCompatibleExecSpecTest extends ProviderCompatibleBaseExecSpecTestB
 
     @Override
     protected ProviderCompatibleExecSpec createSpecUnderTest() {
-        return new ProviderCompatibleExecSpec(new DefaultExecSpec(TestFiles.pathToFileResolver(tmpDir.testDirectory)))
+        return new ProviderCompatibleExecSpec(new DefaultExecSpec(TestUtil.objectFactory(tmpDir.testDirectory), TestFiles.pathToFileResolver(tmpDir.testDirectory)))
     }
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleJavaExecSpecTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleJavaExecSpecTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider.sources.process
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.process.JavaExecSpec
+import org.gradle.process.internal.DefaultExecSpecFactory
 
 class ProviderCompatibleJavaExecSpecTest extends ProviderCompatibleBaseExecSpecTestBase {
     def "spec sets commandLine on parameters"() {
@@ -35,7 +36,7 @@ class ProviderCompatibleJavaExecSpecTest extends ProviderCompatibleBaseExecSpecT
 
     @Override
     protected ProviderCompatibleJavaExecSpec createSpecUnderTest() {
-        def spec = new ProviderCompatibleJavaExecSpec(TestFiles.execFactory(tmpDir.testDirectory).newJavaExecAction())
+        def spec = new ProviderCompatibleJavaExecSpec(new DefaultExecSpecFactory(TestFiles.execFactory(tmpDir.testDirectory)).newJavaExecSpec())
         spec.mainClass.set("org.example.Main")  // This is mandatory to operate on the JavaExecSpec implementation
         return spec
     }

--- a/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -53,6 +53,7 @@ import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.CloseableServiceRegistry;
+import org.gradle.internal.service.PrivateService;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.service.ServiceRegistry;
@@ -224,6 +225,7 @@ public class WorkerDaemonServer implements RequestHandler<TransportableActionExe
         }
 
         @Provides
+        @PrivateService
         ExecFactory createExecFactory(
             FileResolver fileResolver,
             FileCollectionFactory fileCollectionFactory,

--- a/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -53,7 +53,6 @@ import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.CloseableServiceRegistry;
-import org.gradle.internal.service.PrivateService;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.service.ServiceRegistry;
@@ -225,7 +224,6 @@ public class WorkerDaemonServer implements RequestHandler<TransportableActionExe
         }
 
         @Provides
-        @PrivateService
         ExecFactory createExecFactory(
             FileResolver fileResolver,
             FileCollectionFactory fileCollectionFactory,

--- a/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -64,6 +64,7 @@ import org.gradle.internal.service.scopes.WorkerSharedUserHomeScopeServices;
 import org.gradle.internal.snapshot.impl.IsolatableSerializerRegistry;
 import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.process.internal.DefaultExecActionFactory;
+import org.gradle.process.internal.DefaultExecActionFactory.JavaModuleDetectorSupplier;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.process.internal.worker.RequestHandler;
 import org.gradle.process.internal.worker.request.RequestArgumentSerializers;
@@ -240,7 +241,8 @@ public class WorkerDaemonServer implements RequestHandler<TransportableActionExe
                 executorFactory,
                 temporaryFileProvider,
                 buildCancellationToken,
-                objectFactory
+                objectFactory,
+                JavaModuleDetectorSupplier.NO_JAVA_MODULE_DETECTOR
             );
         }
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -984,7 +984,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         given:
         settingsFile << "include 'a'"
         testDirectory.file("a/build/test/folder").mkdirs()
-        buildFile("a/build.gradle", """
+        file("a/build.gradle") << """
             import org.gradle.api.provider.*
 
             abstract class GreetValueSource implements ValueSource<String, ValueSourceParameters.None> {
@@ -1012,7 +1012,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
             tasks.register("run", MyTask) {
                 greeting = greetValueSource
             }
-        """)
+        """
 
         when:
         run("run")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -937,7 +937,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         "settings.gradle" | "javaexec" | javaExecSpec("it")               | "."
     }
 
-    def "providers.#method in build.gradle resolves relative path correctly"() {
+    def "providers.#method in a non-root build.gradle resolves relative path correctly"() {
         settingsFile << "include 'a'"
         testDirectory.file("a").mkdirs()
         testDirectory.file("$subfolder/build/test/folder").mkdirs()
@@ -966,9 +966,9 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
         succeeds("run")
 
         then:
-        testDirectory.file("$subfolder/build/test/folder/output.txt").exists()
-        testDirectory.file("$subfolder/build/test/folder/output.txt").text.contains(
-            "user.dir=${testDirectory.file("$subfolder/build/test/folder").absolutePath}"
+        testDirectory.file("a/build/test/folder/output.txt").exists()
+        testDirectory.file("a/build/test/folder/output.txt").text.contains(
+            "user.dir=${testDirectory.file("a/build/test/folder").absolutePath}"
         )
 
         where:

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -51,7 +51,7 @@ import java.util.Set;
  *
  * @since 4.0
  */
-@ServiceScope({Scope.Global.class, Scope.BuildTree.class, Scope.Project.class})
+@ServiceScope({Scope.Global.class, Scope.BuildSession.class, Scope.BuildTree.class, Scope.Project.class})
 public interface ObjectFactory {
     /**
      * Creates a simple immutable {@link Named} object of the given type and name.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -44,7 +44,7 @@ import java.util.function.BiFunction;
  * @since 4.0
  */
 @NonExtensible
-@ServiceScope(Scope.Build.class)
+@ServiceScope({Scope.Build.class, Scope.Project.class})
 public interface ProviderFactory {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -19,6 +19,7 @@ package org.gradle.internal.buildtree;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
+import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
@@ -34,6 +35,7 @@ import org.gradle.api.internal.project.taskfactory.TaskIdentityFactory;
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier;
 import org.gradle.api.internal.provider.DefaultConfigurationTimeBarrier;
 import org.gradle.api.internal.provider.PropertyFactory;
+import org.gradle.api.internal.provider.PropertyHost;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
@@ -197,8 +199,8 @@ public class BuildTreeScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    protected FilePropertyFactory createFilePropertyFactory(FilePropertyFactory parent, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
-        return parent.forChildScope(fileResolver, fileCollectionFactory);
+    protected FilePropertyFactory createFilePropertyFactory(PropertyHost host, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
+        return new DefaultFilePropertyFactory(host, fileResolver, fileCollectionFactory);
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.FileCollectionObservationListener;
+import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.initialization.BuildLogicBuildQueue;
 import org.gradle.api.internal.initialization.DefaultBuildLogicBuildQueue;
 import org.gradle.api.internal.model.DefaultObjectFactory;
@@ -63,6 +64,7 @@ import org.gradle.internal.buildoption.DefaultFeatureFlags;
 import org.gradle.internal.buildoption.DefaultInternalOptions;
 import org.gradle.internal.buildoption.FeatureFlags;
 import org.gradle.internal.buildoption.InternalOptions;
+import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.event.ScopedListenerManager;
@@ -85,6 +87,7 @@ import org.gradle.internal.service.scopes.GradleModuleServices;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.problems.buildtree.ProblemDiagnosticsFactory;
 import org.gradle.problems.buildtree.ProblemReporter;
+import org.gradle.process.internal.DefaultExecActionFactory;
 import org.gradle.process.internal.ExecFactory;
 
 import java.util.List;
@@ -145,23 +148,26 @@ public class BuildTreeScopeServices implements ServiceRegistrationProvider {
     }
 
     @Provides
-    protected ExecFactory decorateExecFactory(
-        ExecFactory execFactory,
+    protected ExecFactory createExecFactory(
         FileResolver fileResolver,
         FileCollectionFactory fileCollectionFactory,
         Instantiator instantiator,
         BuildCancellationToken buildCancellationToken,
+        ExecutorFactory executorFactory,
+        TemporaryFileProvider temporaryFileProvider,
         ObjectFactory objectFactory,
         JavaModuleDetector javaModuleDetector
     ) {
-        return execFactory.forContext()
-            .withFileResolver(fileResolver)
-            .withFileCollectionFactory(fileCollectionFactory)
-            .withInstantiator(instantiator)
-            .withBuildCancellationToken(buildCancellationToken)
-            .withObjectFactory(objectFactory)
-            .withJavaModuleDetector(javaModuleDetector)
-            .build();
+        return DefaultExecActionFactory.of(
+            fileResolver,
+            fileCollectionFactory,
+            instantiator,
+            executorFactory,
+            temporaryFileProvider,
+            buildCancellationToken,
+            objectFactory,
+            javaModuleDetector
+        );
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -434,7 +434,8 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         GradleProperties gradleProperties,
         ExecFactory execFactory,
         ListenerManager listenerManager,
-        CalculatedValueFactory calculatedValueFactory
+        CalculatedValueFactory calculatedValueFactory,
+        ObjectFactory objectFactory
     ) {
         return new DefaultValueSourceProviderFactory(
             listenerManager,
@@ -442,7 +443,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
             isolatableFactory,
             gradleProperties,
             calculatedValueFactory,
-            new DefaultExecOperations(execFactory.forContext().withoutExternalProcessStartedListener().build()),
+            objectFactory.newInstance(DefaultExecOperations.class, execFactory.forContext().withoutExternalProcessStartedListener().build()),
             services
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreBuildSessionServices.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.BuildSessionScopeFileTimeStampInspector;
 import org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache;
 import org.gradle.api.internal.changedetection.state.FileHasherStatistics;
-import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.archive.DecompressionCoordinator;
@@ -36,7 +35,6 @@ import org.gradle.cache.internal.scopes.DefaultBuildTreeScopedCacheBuilderFactor
 import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory;
 import org.gradle.deployment.internal.DefaultDeploymentRegistry;
 import org.gradle.deployment.internal.PendingChangesManager;
-import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildRequestMetaData;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.initialization.layout.BuildLayout;
@@ -49,7 +47,6 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.DefaultChecksumService;
-import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.model.InMemoryCacheFactory;
 import org.gradle.internal.model.StateTransitionControllerFactory;
@@ -57,7 +54,6 @@ import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.problems.DefaultProblemLocationAnalyzer;
 import org.gradle.internal.problems.ProblemLocationAnalyzer;
-import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.scopeids.PersistentScopeIdLoader;
 import org.gradle.internal.scopeids.ScopeIdsServices;
 import org.gradle.internal.scopeids.id.UserScopeId;
@@ -69,7 +65,6 @@ import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.AsyncWorkTracker;
 import org.gradle.internal.work.DefaultAsyncWorkTracker;
-import org.gradle.process.internal.ExecFactory;
 
 import java.io.File;
 
@@ -153,26 +148,6 @@ public class CoreBuildSessionServices implements ServiceRegistrationProvider {
     BuildStartedTime createBuildStartedTime(Clock clock, BuildRequestMetaData buildRequestMetaData) {
         long currentTime = clock.getCurrentTime();
         return BuildStartedTime.startingAt(Math.min(currentTime, buildRequestMetaData.getStartTime()));
-    }
-
-    @Provides
-    protected ExecFactory decorateExecFactory(
-        ExecFactory execFactory,
-        FileResolver fileResolver,
-        FileCollectionFactory fileCollectionFactory,
-        Instantiator instantiator,
-        BuildCancellationToken buildCancellationToken,
-        ObjectFactory objectFactory,
-        JavaModuleDetector javaModuleDetector
-    ) {
-        return execFactory.forContext()
-            .withFileResolver(fileResolver)
-            .withFileCollectionFactory(fileCollectionFactory)
-            .withInstantiator(instantiator)
-            .withBuildCancellationToken(buildCancellationToken)
-            .withObjectFactory(objectFactory)
-            .withJavaModuleDetector(javaModuleDetector)
-            .build();
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -31,9 +31,7 @@ import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FilePropertyFactory;
-import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
-import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.model.DefaultObjectFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.provider.PropertyFactory;
@@ -55,7 +53,6 @@ import org.gradle.execution.DefaultWorkValidationWarningRecorder;
 import org.gradle.execution.WorkValidationWarningReporter;
 import org.gradle.groovy.scripts.internal.DefaultScriptSourceHasher;
 import org.gradle.groovy.scripts.internal.ScriptSourceHasher;
-import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.initialization.DefaultClassLoaderRegistry;
 import org.gradle.initialization.DefaultJdkToolsInitializer;
@@ -90,7 +87,6 @@ import org.gradle.internal.operations.DefaultBuildOperationProgressEventEmitter;
 import org.gradle.internal.problems.failure.DefaultFailureFactory;
 import org.gradle.internal.problems.failure.FailureFactory;
 import org.gradle.internal.reflect.DirectInstantiator;
-import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
 import org.gradle.internal.scripts.DefaultScriptFileResolverListeners;
 import org.gradle.internal.scripts.ScriptFileResolvedListener;
@@ -116,8 +112,6 @@ import org.gradle.model.internal.manage.schema.extract.ModelSchemaAspectExtracti
 import org.gradle.model.internal.manage.schema.extract.ModelSchemaAspectExtractor;
 import org.gradle.model.internal.manage.schema.extract.ModelSchemaExtractionStrategy;
 import org.gradle.model.internal.manage.schema.extract.ModelSchemaExtractor;
-import org.gradle.process.internal.DefaultExecActionFactory;
-import org.gradle.process.internal.ExecFactory;
 import org.gradle.process.internal.health.memory.DefaultJvmMemoryInfo;
 import org.gradle.process.internal.health.memory.DefaultMemoryManager;
 import org.gradle.process.internal.health.memory.DefaultOsMemoryInfo;
@@ -293,27 +287,6 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
             taskDependencyFactory,
             fileCollectionFactory,
             domainObjectCollectionFactory);
-    }
-
-    @Provides
-    ExecFactory createExecFactory(
-        FileResolver fileResolver,
-        FileCollectionFactory fileCollectionFactory,
-        Instantiator instantiator,
-        ObjectFactory objectFactory,
-        ExecutorFactory executorFactory,
-        TemporaryFileProvider temporaryFileProvider,
-        BuildCancellationToken buildCancellationToken
-    ) {
-        return DefaultExecActionFactory.of(
-            fileResolver,
-            fileCollectionFactory,
-            instantiator,
-            executorFactory,
-            temporaryFileProvider,
-            buildCancellationToken,
-            objectFactory
-        );
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -204,9 +204,6 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         return new DefaultGlobalCacheLocations(globalCaches);
     }
 
-    /**
-     * It's a @PrivateService since we don't want this service to accidentally be used in child scopes with incorrect FileResolver and ObjectFactory.
-     */
     @Provides
     protected ExecFactory createExecFactory(
         FileResolver fileResolver,
@@ -215,7 +212,8 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         BuildCancellationToken buildCancellationToken,
         ExecutorFactory executorFactory,
         TemporaryFileProvider temporaryFileProvider,
-        ObjectFactory objectFactory
+        ObjectFactory objectFactory,
+        JavaModuleDetector javaModuleDetector
     ) {
         return DefaultExecActionFactory.of(
             fileResolver,
@@ -224,7 +222,8 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
             executorFactory,
             temporaryFileProvider,
             buildCancellationToken,
-            objectFactory
+            objectFactory,
+            () -> javaModuleDetector
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -88,7 +88,6 @@ import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.remote.MessagingServer;
-import org.gradle.internal.service.PrivateService;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
@@ -209,7 +208,6 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
      * It's a @PrivateService since we don't want this service to accidentally be used in child scopes with incorrect FileResolver and ObjectFactory.
      */
     @Provides
-    @PrivateService
     protected ExecFactory createExecFactory(
         FileResolver fileResolver,
         FileCollectionFactory fileCollectionFactory,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -61,7 +61,11 @@ import org.gradle.api.internal.project.ant.DefaultAntLoggingAdapterFactory;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
 import org.gradle.api.internal.project.taskfactory.TaskIdentityFactory;
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator;
+import org.gradle.api.internal.provider.DefaultProviderFactory;
 import org.gradle.api.internal.provider.PropertyHost;
+import org.gradle.api.internal.provider.ValueSourceProviderFactory;
+import org.gradle.api.internal.provider.sources.process.ExecSpecFactory;
+import org.gradle.api.internal.provider.sources.process.ProcessOutputProviderFactory;
 import org.gradle.api.internal.resources.ApiTextResourceAdapter;
 import org.gradle.api.internal.resources.DefaultResourceHandler;
 import org.gradle.api.internal.tasks.DefaultTaskContainerFactory;
@@ -73,6 +77,7 @@ import org.gradle.api.internal.tasks.TaskStatistics;
 import org.gradle.api.internal.tasks.properties.TaskScheme;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.InternalProblems;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.util.internal.PatternSetFactory;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.configuration.project.DefaultProjectConfigurationActionContainer;
@@ -109,6 +114,8 @@ import org.gradle.normalization.internal.RuntimeClasspathNormalizationInternal;
 import org.gradle.plugin.software.internal.ModelDefaultsHandler;
 import org.gradle.plugin.software.internal.PluginScheme;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
+import org.gradle.process.internal.DefaultExecSpecFactory;
+import org.gradle.process.internal.ExecActionFactory;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry;
 import org.jspecify.annotations.Nullable;
@@ -205,6 +212,27 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
             .withJavaModuleDetector(javaModuleDetector)
             .withExternalProcessStartedListener(listenerManager.getBroadcaster(ExternalProcessStartedListener.class))
             .build();
+    }
+
+    @Provides
+    protected ExecSpecFactory createExecSpecFactory(ExecActionFactory execActionFactory) {
+        return new DefaultExecSpecFactory(execActionFactory);
+    }
+
+    @Provides
+    protected ProcessOutputProviderFactory createProcessOutputProviderFactory(Instantiator instantiator, ExecSpecFactory execSpecFactory) {
+        return new ProcessOutputProviderFactory(instantiator, execSpecFactory);
+    }
+
+    @Provides
+    protected ProviderFactory createProviderFactory(
+        Instantiator instantiator,
+        ValueSourceProviderFactory valueSourceProviderFactory,
+        ProcessOutputProviderFactory processOutputProviderFactory,
+        ListenerManager listenerManager,
+        ObjectFactory objectFactory
+    ) {
+        return instantiator.newInstance(DefaultProviderFactory.class, valueSourceProviderFactory, processOutputProviderFactory, listenerManager, objectFactory);
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -61,7 +61,9 @@ import org.gradle.api.internal.project.ant.DefaultAntLoggingAdapterFactory;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
 import org.gradle.api.internal.project.taskfactory.TaskIdentityFactory;
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator;
+import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.api.internal.provider.DefaultProviderFactory;
+import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory;
 import org.gradle.api.internal.provider.PropertyHost;
 import org.gradle.api.internal.provider.ValueSourceProviderFactory;
 import org.gradle.api.internal.provider.sources.process.ExecSpecFactory;
@@ -87,9 +89,11 @@ import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.logging.LoggingManagerFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
+import org.gradle.internal.model.CalculatedValueFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.reflect.Instantiator;
@@ -114,6 +118,7 @@ import org.gradle.normalization.internal.RuntimeClasspathNormalizationInternal;
 import org.gradle.plugin.software.internal.ModelDefaultsHandler;
 import org.gradle.plugin.software.internal.PluginScheme;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
+import org.gradle.process.internal.DefaultExecOperations;
 import org.gradle.process.internal.DefaultExecSpecFactory;
 import org.gradle.process.internal.ExecActionFactory;
 import org.gradle.process.internal.ExecFactory;
@@ -222,6 +227,28 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
     @Provides
     protected ProcessOutputProviderFactory createProcessOutputProviderFactory(Instantiator instantiator, ExecSpecFactory execSpecFactory) {
         return new ProcessOutputProviderFactory(instantiator, execSpecFactory);
+    }
+
+    @Provides
+    protected ValueSourceProviderFactory createValueSourceProviderFactory(
+        InstantiatorFactory instantiatorFactory,
+        IsolatableFactory isolatableFactory,
+        ServiceRegistry services,
+        GradleProperties gradleProperties,
+        ExecFactory execFactory,
+        ListenerManager listenerManager,
+        CalculatedValueFactory calculatedValueFactory,
+        ObjectFactory objectFactory
+    ) {
+        return new DefaultValueSourceProviderFactory(
+            listenerManager,
+            instantiatorFactory,
+            isolatableFactory,
+            gradleProperties,
+            calculatedValueFactory,
+            objectFactory.newInstance(DefaultExecOperations.class, execFactory.forContext().withoutExternalProcessStartedListener().build()),
+            services
+        );
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -38,6 +38,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
 import org.gradle.process.JavaExecSpec;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.Executor;
@@ -87,29 +88,8 @@ public class DefaultExecActionFactory implements ExecFactory {
         ExecutorFactory executorFactory,
         TemporaryFileProvider temporaryFileProvider,
         BuildCancellationToken buildCancellationToken,
-        ObjectFactory objectFactory
-    ) {
-        return DefaultExecActionFactory.of(
-            fileResolver,
-            fileCollectionFactory,
-            instantiator,
-            executorFactory,
-            temporaryFileProvider,
-            buildCancellationToken,
-            objectFactory,
-            null
-        );
-    }
-
-    public static DefaultExecActionFactory of(
-        FileResolver fileResolver,
-        FileCollectionFactory fileCollectionFactory,
-        Instantiator instantiator,
-        ExecutorFactory executorFactory,
-        TemporaryFileProvider temporaryFileProvider,
-        BuildCancellationToken buildCancellationToken,
         ObjectFactory objectFactory,
-        @Nullable JavaModuleDetector javaModuleDetector
+        JavaModuleDetectorSupplier javaModuleDetectorSupplier
     ) {
         return new DefaultExecActionFactory(
             fileResolver,
@@ -119,7 +99,7 @@ public class DefaultExecActionFactory implements ExecFactory {
             temporaryFileProvider,
             buildCancellationToken,
             objectFactory,
-            javaModuleDetector,
+            javaModuleDetectorSupplier.get(),
             null
         );
     }
@@ -342,5 +322,17 @@ public class DefaultExecActionFactory implements ExecFactory {
                 externalProcessStartedListener
             );
         }
+    }
+
+    /**
+     * A supplier of {@link JavaModuleDetector}. Used to not add dependency to jvm-services and {@link JavaModuleDetector} in daemon-server-workers.
+     */
+    @NullMarked
+    @FunctionalInterface
+    public interface JavaModuleDetectorSupplier {
+        JavaModuleDetectorSupplier NO_JAVA_MODULE_DETECTOR = () -> null;
+
+        @Nullable
+        JavaModuleDetector get();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -89,6 +89,28 @@ public class DefaultExecActionFactory implements ExecFactory {
         BuildCancellationToken buildCancellationToken,
         ObjectFactory objectFactory
     ) {
+        return DefaultExecActionFactory.of(
+            fileResolver,
+            fileCollectionFactory,
+            instantiator,
+            executorFactory,
+            temporaryFileProvider,
+            buildCancellationToken,
+            objectFactory,
+            null
+        );
+    }
+
+    public static DefaultExecActionFactory of(
+        FileResolver fileResolver,
+        FileCollectionFactory fileCollectionFactory,
+        Instantiator instantiator,
+        ExecutorFactory executorFactory,
+        TemporaryFileProvider temporaryFileProvider,
+        BuildCancellationToken buildCancellationToken,
+        ObjectFactory objectFactory,
+        @Nullable JavaModuleDetector javaModuleDetector
+    ) {
         return new DefaultExecActionFactory(
             fileResolver,
             fileCollectionFactory,
@@ -97,7 +119,7 @@ public class DefaultExecActionFactory implements ExecFactory {
             temporaryFileProvider,
             buildCancellationToken,
             objectFactory,
-            null,
+            javaModuleDetector,
             null
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecOperations.java
@@ -23,11 +23,13 @@ import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
 import org.gradle.process.JavaExecSpec;
 
+import javax.inject.Inject;
 
 public class DefaultExecOperations implements ExecOperations {
 
     private final ProcessOperations processOperations;
 
+    @Inject
     public DefaultExecOperations(ProcessOperations processOperations) {
         this.processOperations = processOperations;
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpec.java
@@ -16,6 +16,7 @@
 
 package org.gradle.process.internal;
 
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.process.BaseExecSpec;
 import org.gradle.process.CommandLineArgumentProvider;
@@ -34,8 +35,8 @@ public class DefaultExecSpec extends DefaultProcessForkOptions implements ExecSp
     private final ProcessArgumentsSpec argumentsSpec = new ProcessArgumentsSpec(this);
 
     @Inject
-    public DefaultExecSpec(PathToFileResolver resolver) {
-        super(resolver);
+    public DefaultExecSpec(ObjectFactory objectFactory, PathToFileResolver resolver) {
+        super(objectFactory, resolver);
     }
 
     public void copyTo(ExecSpec targetSpec) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -45,7 +45,7 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
         PathToFileResolver resolver,
         FileCollectionFactory fileCollectionFactory
     ) {
-        super(resolver);
+        super(objectFactory, resolver);
         this.fileCollectionFactory = fileCollectionFactory;
         this.debugOptions = objectFactory.newInstance(DefaultJavaDebugOptions.class, objectFactory);
         this.options = new JvmOptions(fileCollectionFactory, new JavaDebugOptionsBackedSpec(debugOptions));

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory;
-import org.gradle.api.internal.lambdas.SerializableLambdas;
 import org.gradle.api.internal.provider.PropertyHost;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
@@ -40,6 +39,8 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
+
 public class DefaultProcessForkOptions implements ProcessForkOptions {
     protected final PathToFileResolver resolver;
     private Object executable;
@@ -47,7 +48,10 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
     private Map<String, Object> environment;
 
     /**
-     * Don't use it! Kept for KGP binary compatibility, will be removed in Gradle 10.
+     * Don't use it! Kept for KGP binary compatibility for version <= 2.1.20.
+     * See: <a href="https://github.com/JetBrains/kotlin/blob/658a2010b15a22583f9841e1a2d4bddf1baac612/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt#L158">KotlinJsTest.kt#L158</a>.
+     *
+     * We can remove it once we stop supporting that version.
      */
     @Deprecated
     public DefaultProcessForkOptions(PathToFileResolver resolver) {
@@ -99,7 +103,7 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
         if (dir instanceof DirectoryProperty) {
             workingDir.set((DirectoryProperty) dir);
         } else if (dir instanceof Provider) {
-            workingDir.fileProvider(((Provider<?>) dir).map(SerializableLambdas.transformer(file -> {
+            workingDir.fileProvider(((Provider<?>) dir).map(transformer(file -> {
                 if (file instanceof FileSystemLocation) {
                     return ((Directory) file).getAsFile();
                 } else if (file instanceof File) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
@@ -38,9 +38,7 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
 
     public DefaultProcessForkOptions(ObjectFactory objectFactory, PathToFileResolver resolver) {
         this.resolver = resolver;
-        // TODO: Gradle 9.0 we should just use defaultWorkingDir.fileProvider(Providers.of(new File("."))) here,
-        //  but it seems ObjectFactory.directoryProperty() doesn't have the right fileResolver set up in some cases
-        DirectoryProperty defaultWorkingDir = objectFactory.directoryProperty().fileProvider(Providers.changing(() -> new File(".")));
+        DirectoryProperty defaultWorkingDir = objectFactory.directoryProperty().fileProvider(Providers.of(new File(".")));
         this.workingDir = objectFactory.directoryProperty().convention(defaultWorkingDir);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
@@ -16,6 +16,13 @@
 package org.gradle.process.internal;
 
 import com.google.common.collect.Maps;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.internal.lambdas.SerializableLambdas;
+import org.gradle.api.internal.provider.Providers;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Provider;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.process.ProcessForkOptions;
 
@@ -26,11 +33,15 @@ import java.util.Map;
 public class DefaultProcessForkOptions implements ProcessForkOptions {
     protected final PathToFileResolver resolver;
     private Object executable;
-    private File workingDir;
+    private final DirectoryProperty workingDir;
     private Map<String, Object> environment;
 
-    public DefaultProcessForkOptions(PathToFileResolver resolver) {
+    public DefaultProcessForkOptions(ObjectFactory objectFactory, PathToFileResolver resolver) {
         this.resolver = resolver;
+        // TODO: Gradle 9.0 we should just use defaultWorkingDir.fileProvider(Providers.of(new File("."))) here,
+        //  but it seems ObjectFactory.directoryProperty() doesn't have the right fileResolver set up in some cases
+        DirectoryProperty defaultWorkingDir = objectFactory.directoryProperty().fileProvider(Providers.changing(() -> new File(".")));
+        this.workingDir = objectFactory.directoryProperty().convention(defaultWorkingDir);
     }
 
     @Override
@@ -56,20 +67,33 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
 
     @Override
     public File getWorkingDir() {
-        if (workingDir == null) {
-            workingDir = resolver.resolve(".");
-        }
-        return workingDir;
+        return workingDir.getAsFile().get();
     }
 
     @Override
     public void setWorkingDir(File dir) {
-        this.workingDir = resolver.resolve(dir);
+        this.workingDir.set(dir);
     }
 
     @Override
     public void setWorkingDir(Object dir) {
-        this.workingDir = resolver.resolve(dir);
+        if (dir instanceof DirectoryProperty) {
+            workingDir.set((DirectoryProperty) dir);
+        } else if (dir instanceof Provider) {
+            workingDir.fileProvider(((Provider<?>) dir).map(SerializableLambdas.transformer(file -> {
+                if (file instanceof FileSystemLocation) {
+                    return ((Directory) file).getAsFile();
+                } else if (file instanceof File) {
+                    return (File) file;
+                } else {
+                    return resolver.resolve(file);
+                }
+            })));
+        } else if (dir instanceof File) {
+            workingDir.set((File) dir);
+        } else {
+            workingDir.set(resolver.resolve(dir));
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
@@ -48,7 +48,7 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
     private Map<String, Object> environment;
 
     /**
-     * Don't use it! Kept for KGP binary compatibility for version <= 2.1.20.
+     * Don't use it! Kept for KGP binary compatibility for version lower than 2.1.20.
      * See: <a href="https://github.com/JetBrains/kotlin/blob/658a2010b15a22583f9841e1a2d4bddf1baac612/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/js/testing/KotlinJsTest.kt#L158">KotlinJsTest.kt#L158</a>.
      *
      * We can remove it once we stop supporting that version.

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecActionFactory.java
@@ -19,7 +19,7 @@ package org.gradle.process.internal;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope({Scope.UserHome.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
+@ServiceScope({Scope.UserHome.class, Scope.BuildSession.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
 public interface ExecActionFactory {
     /**
      * Creates an {@link ExecAction} that is not decorated. Use this when the action is not made visible to the DSL.

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecActionFactory.java
@@ -19,7 +19,7 @@ package org.gradle.process.internal;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope({Scope.UserHome.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
 public interface ExecActionFactory {
     /**
      * Creates an {@link ExecAction} that is not decorated. Use this when the action is not made visible to the DSL.

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
@@ -31,7 +31,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * Manages forking/spawning processes.
  */
 @SuppressWarnings("deprecation")
-@ServiceScope({Scope.Global.class, Scope.UserHome.class, Scope.BuildSession.class, Scope.Build.class, Scope.Project.class})
+@ServiceScope({Scope.Global.class, Scope.UserHome.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
 public interface ExecFactory extends ExecActionFactory, ExecHandleFactory, JavaExecHandleFactory, JavaForkOptionsFactory, ProcessOperations {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
@@ -31,7 +31,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * Manages forking/spawning processes.
  */
 @SuppressWarnings("deprecation")
-@ServiceScope({Scope.Global.class, Scope.UserHome.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
+@ServiceScope({Scope.UserHome.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
 public interface ExecFactory extends ExecActionFactory, ExecHandleFactory, JavaExecHandleFactory, JavaForkOptionsFactory, ProcessOperations {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
@@ -31,7 +31,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * Manages forking/spawning processes.
  */
 @SuppressWarnings("deprecation")
-@ServiceScope({Scope.UserHome.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
+@ServiceScope({Scope.UserHome.class, Scope.BuildSession.class, Scope.BuildTree.class, Scope.Build.class, Scope.Project.class})
 public interface ExecFactory extends ExecActionFactory, ExecHandleFactory, JavaExecHandleFactory, JavaForkOptionsFactory, ProcessOperations {
 
     /**

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultProcessForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultProcessForkOptionsTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.api.internal.tasks.util
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.process.ProcessForkOptions
 import org.gradle.process.internal.DefaultProcessForkOptions
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class DefaultProcessForkOptionsTest extends Specification {
@@ -25,7 +27,7 @@ class DefaultProcessForkOptionsTest extends Specification {
     def resolver = Mock(FileResolver.class) {
         resolve(".") >> baseDir
     }
-    def options = new DefaultProcessForkOptions(resolver)
+    def options = new DefaultProcessForkOptions(TestUtil.objectFactory(new TestFile(baseDir)), resolver)
 
     def defaultValues() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
@@ -28,6 +28,8 @@ import org.gradle.test.preconditions.UnitTestPreconditions
 import org.gradle.util.TestUtil
 import org.junit.Rule
 
+import static org.gradle.process.internal.DefaultExecActionFactory.JavaModuleDetectorSupplier
+
 class DefaultExecActionFactoryTest extends ConcurrentSpec {
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
@@ -41,7 +43,8 @@ class DefaultExecActionFactoryTest extends ConcurrentSpec {
         executorFactory,
         TestFiles.tmpDirTemporaryFileProvider(tmpDir.createDir("tmp")),
         new DefaultBuildCancellationToken(),
-        TestUtil.objectFactory()
+        TestUtil.objectFactory(),
+        JavaModuleDetectorSupplier.NO_JAVA_MODULE_DETECTOR
     )
 
     def javaexec() {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -251,7 +251,7 @@ public class TestFiles {
             .withFileResolver(resolver(baseDir))
             .withFileCollectionFactory(fileCollectionFactory(baseDir))
             .withInstantiator(TestUtil.instantiatorFactory().inject())
-            .withObjectFactory(objectFactory())
+            .withObjectFactory(objectFactory(baseDir))
             .build();
     }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -52,6 +52,7 @@ import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy;
 import org.gradle.process.internal.ClientExecHandleBuilderFactory;
 import org.gradle.process.internal.DefaultClientExecHandleBuilderFactory;
 import org.gradle.process.internal.DefaultExecActionFactory;
+import org.gradle.process.internal.DefaultExecActionFactory.JavaModuleDetectorSupplier;
 import org.gradle.process.internal.ExecActionFactory;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.process.internal.JavaExecHandleFactory;
@@ -242,7 +243,8 @@ public class TestFiles {
             new DefaultExecutorFactory(),
             NativeServicesTestFixture.getInstance().get(TemporaryFileProvider.class),
             new DefaultBuildCancellationToken(),
-            objectFactory()
+            objectFactory(),
+            JavaModuleDetectorSupplier.NO_JAVA_MODULE_DETECTOR
         );
     }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestJavaMain.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestJavaMain.java
@@ -58,9 +58,10 @@ public class TestJavaMain {
     }
 
     private static void appendMap(StringBuilder output, Map<?, ?> items, String prefix) {
-        items.entrySet().stream().filter(e -> String.valueOf(e.getKey()).startsWith(prefix)).sorted(comparingByStringifiedKey()).forEach(e -> {
-            output.append(String.format("   %s=%s\n", e.getKey(), e.getValue()));
-        });
+        items.entrySet().stream()
+            .filter(e -> String.valueOf(e.getKey()).startsWith(prefix))
+            .sorted(comparingByStringifiedKey())
+            .forEach(e -> output.append(String.format("   %s=%s\n", e.getKey(), e.getValue())));
     }
 
     private static Comparator<Map.Entry<?, ?>> comparingByStringifiedKey() {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestJavaMain.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestJavaMain.java
@@ -17,7 +17,10 @@
 package org.gradle.process;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Comparator;
 import java.util.Map;
 
@@ -34,21 +37,29 @@ public class TestJavaMain {
     }
 
     public static void main(String[] args) {
+        StringBuilder output = new StringBuilder();
         if (args.length > 0) {
-            System.out.println("ARGUMENTS: " + String.join(" ", args));
+            output.append("ARGUMENTS: ").append(String.join(" ", args)).append("\n");
         }
-        System.out.println("ENVIRONMENT:");
-        printMap(System.getenv(), "TEST_");
+        output.append("ENVIRONMENT:\n");
+        appendMap(output, System.getenv(), "TEST_");
 
-        System.out.println("PROPERTIES:");
-        printMap(System.getProperties(), "test.");
+        output.append("PROPERTIES:\n");
+        appendMap(output, System.getProperties(), "test.");
 
-        System.out.println("user.dir=" + System.getProperty("user.dir"));
+        output.append("user.dir=").append(System.getProperty("user.dir")).append("\n");
+        System.out.println(output);
+
+        try {
+            Files.write(new File(System.getProperty("user.dir"), "output.txt").toPath(), output.toString().getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    private static void printMap(Map<?, ?> items, String prefix) {
+    private static void appendMap(StringBuilder output, Map<?, ?> items, String prefix) {
         items.entrySet().stream().filter(e -> String.valueOf(e.getKey()).startsWith(prefix)).sorted(comparingByStringifiedKey()).forEach(e -> {
-            System.out.printf("   %s=%s\n", e.getKey(), e.getValue());
+            output.append(String.format("   %s=%s\n", e.getKey(), e.getValue()));
         });
     }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -156,7 +156,7 @@ class TestUtil {
         return services().get(TestProblems)
     }
 
-    static ObjectFactory objectFactory(TestFile baseDir) {
+    static ObjectFactory objectFactory(File baseDir) {
         def fileResolver = TestFiles.resolver(baseDir)
         def fileCollectionFactory = TestFiles.fileCollectionFactory(baseDir)
         return createServices(fileResolver, fileCollectionFactory).get(ObjectFactory)

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -79,7 +79,6 @@ import org.gradle.internal.service.scopes.CrossBuildSessionParameters
 import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.internal.work.DefaultWorkerLimits
 import org.gradle.test.fixtures.file.TestDirectoryProvider
-import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testfixtures.internal.NativeServicesTestFixture


### PR DESCRIPTION
This PR does:
1. Backs `ProcessForkOptions.workingDir` with DirectoryProperty
2. Fixes an issue with `Providers.exec` where relative paths are not resolved

I did 1. so the implementation is closer to Provider API branch implementation.

For 2. I migrated bunch of services to different scope, e.g.:
1. `ProviderFactory`, `ExecSpecFactory` and `ProcessOutputProviderFactory` are now also Project scoped
2.  `FileCollectionFactory` and `FilePropertyFactory` are now created in `BuildTree` scope next to `ObjectFactory` so they get the right `FileResolver`
3. `ExecFactory` is now BuildTree scoped instead of BuildSession scoped so it gets injected ObjectFactory with `FileCollectionFactory` and `FilePropertyFactory` with the right `FileResolver`

Fixes https://github.com/gradle/gradle/issues/32018