### PR TITLE
Update JaCoCo to 0.8.13

### DIFF
--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -695,12 +695,6 @@ tasks.named<Test>("docsTest") {
             excludeTestsMatching("org.gradle.docs.samples.*.snippet-code-quality-code-quality*")
         }
 
-        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_24)) {
-            // JaCoCo doesn't yet support Java 24 (need 0.8.13)
-            excludeTestsMatching("org.gradle.docs.samples.*.jvm-multi-project-with-code-coverage*")
-            excludeTestsMatching("org.gradle.docs.samples.*.snippet-testing-jacoco*")
-        }
-
         if (OperatingSystem.current().isMacOsX && System.getProperty("os.arch") == "aarch64") {
             excludeTestsMatching("org.gradle.docs.samples.*.snippet-native*.sample")
             excludeTestsMatching("org.gradle.docs.samples.*.snippet-swift*.sample")

--- a/platforms/documentation/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
+++ b/platforms/documentation/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
@@ -26,7 +26,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>0.8.11</literal></td>
+                <td><literal>0.8.13</literal></td>
             </tr>
             <tr>
                 <td>reportsDirectory</td>

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -64,6 +64,10 @@ Groovy has been updated to https://groovy-lang.org/changelogs/changelog-3.0.24.h
 
 Since the previous version was 3.0.22, this includes changes for https://groovy-lang.org/changelogs/changelog-3.0.23.html[Groovy 3.0.23] as well.
 
+==== Upgrade to JaCoCo 0.8.13
+
+JaCoCo has been updated to https://www.jacoco.org/jacoco/trunk/doc/changes.html[0.8.13].
+
 === Deprecations
 
 [[null-attribute-lookup]]

--- a/platforms/documentation/docs/src/snippets/testing/jacoco-quickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/testing/jacoco-quickstart/groovy/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 // tag::jacoco-configuration[]
 jacoco {
-    toolVersion = "0.8.12"
+    toolVersion = "0.8.13"
     reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
 }
 // end::jacoco-configuration[]

--- a/platforms/documentation/docs/src/snippets/testing/jacoco-quickstart/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/testing/jacoco-quickstart/kotlin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 // tag::jacoco-configuration[]
 jacoco {
-    toolVersion = "0.8.12"
+    toolVersion = "0.8.13"
     reportsDirectory = layout.buildDirectory.dir("customJacocoReportDir")
 }
 // end::jacoco-configuration[]

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -68,7 +68,7 @@ public abstract class JacocoPlugin implements Plugin<Project> {
      *
      * @since 3.4
      */
-    public static final String DEFAULT_JACOCO_VERSION = "0.8.12";
+    public static final String DEFAULT_JACOCO_VERSION = "0.8.13";
     public static final String AGENT_CONFIGURATION_NAME = "jacocoAgent";
     public static final String ANT_CONFIGURATION_NAME = "jacocoAnt";
     public static final String PLUGIN_EXTENSION_NAME = "jacoco";

--- a/platforms/jvm/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
+++ b/platforms/jvm/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
@@ -48,6 +48,8 @@ class JacocoAgentJarTest extends Specification {
         '0.8.9'               | true
         '0.8.10'              | true
         '0.8.11'              | true
+        '0.8.12'              | true
+        '0.8.13'              | true
     }
 
     def "versions >= 0.7.6 support include no location classes #version -> #incNoLocationClassesSupport"() {
@@ -73,5 +75,7 @@ class JacocoAgentJarTest extends Specification {
         '0.8.9'               | true
         '0.8.10'              | true
         '0.8.11'              | true
+        '0.8.12'              | true
+        '0.8.13'              | true
     }
 }

--- a/platforms/jvm/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
+++ b/platforms/jvm/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
@@ -34,21 +34,11 @@ class JacocoAgentJarTest extends Specification {
         jacocoAgentJar.supportsJmx() == jmxSupport
 
         where:
+        // Keep one of each minor version
         version               | jmxSupport
         '0.5.10.201208310627' | false
-        '0.6.0.201210061924'  | false
         '0.6.2.201302030002'  | true
-        '0.7.1.201405082137'  | true
-        '0.7.6.201602180812'  | true
         '0.7.8'               | true
-        '0.8.5'               | true
-        '0.8.6'               | true
-        '0.8.7'               | true
-        '0.8.8'               | true
-        '0.8.9'               | true
-        '0.8.10'              | true
-        '0.8.11'              | true
-        '0.8.12'              | true
         '0.8.13'              | true
     }
 
@@ -61,21 +51,11 @@ class JacocoAgentJarTest extends Specification {
         jacocoAgentJar.supportsInclNoLocationClasses() == incNoLocationClassesSupport
 
         where:
+        // Keep one of each minor version
         version               | incNoLocationClassesSupport
         '0.5.10.201208310627' | false
-        '0.6.0.201210061924'  | false
         '0.6.2.201302030002'  | false
-        '0.7.1.201405082137'  | false
-        '0.7.6.201602180812'  | true
         '0.7.8'               | true
-        '0.8.5'               | true
-        '0.8.6'               | true
-        '0.8.7'               | true
-        '0.8.8'               | true
-        '0.8.9'               | true
-        '0.8.10'              | true
-        '0.8.11'              | true
-        '0.8.12'              | true
         '0.8.13'              | true
     }
 }

--- a/platforms/jvm/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
+++ b/platforms/jvm/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
@@ -24,7 +24,7 @@ final class JacocoCoverage {
 
     private JacocoCoverage() {}
 
-    private static final String[] ALL = [JacocoPlugin.DEFAULT_JACOCO_VERSION, '0.7.1.201405082137', '0.7.6.201602180812', '0.8.3'].asImmutable()
+    private static final String[] ALL = [JacocoPlugin.DEFAULT_JACOCO_VERSION, '0.7.6.201602180812'].asImmutable()
     // Order matters here, as we want to test the latest version first
     // Relies on Groovy keeping the order of the keys in a map literal
     private static final Map<JavaVersion, JacocoVersion> JDK_CUTOFFS = [


### PR DESCRIPTION
### Context
Allows an additional third-party tool to work out of the box with Java 24.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
