### PR TITLE
cobexer/merge release to master

### DIFF
--- a/.teamcity/jdks.yaml
+++ b/.teamcity/jdks.yaml
@@ -43,13 +43,6 @@ jdks:
     version: "jdk-21.0.6+7"
     sha256: "a2650fba422283fbed20d936ce5d2a52906a5414ec17b2f7676dddb87201dbae"
   - params:
-      - "linux.java23.openjdk.64bit"
-    os: "linux"
-    arch: "amd64"
-    vendor: "temurin"
-    version: "jdk-23.0.2+7"
-    sha256: "870ac8c05c6fe563e7a3878a47d0234b83c050e83651d2c47e8b822ec74512dd"
-  - params:
       - "linux.java24.openjdk.aarch64"
     os: "linux"
     arch: "aarch64"
@@ -124,13 +117,6 @@ jdks:
     version: "jdk-21.0.6+7"
     sha256: "897c8eebb0f85a99ccecbd482ebae9a45d88c19d6077054f6529ebab49b6d259"
   - params:
-      - "windows.java23.openjdk.64bit"
-    os: "windows"
-    arch: "amd64"
-    vendor: "temurin"
-    version: "jdk-23.0.2+7"
-    sha256: "2171b4660d3e1056fb4a5f4b7e515fff986b8e7e0cf06c9f3e1f79d435ec7d18"
-  - params:
       - "windows.java24.openjdk.64bit"
     os: "windows"
     arch: "amd64"
@@ -194,13 +180,6 @@ jdks:
     vendor: "temurin"
     version: "jdk-21.0.6+7"
     sha256: "4ef4083919126a3d93e603284b405c7493905497485a92b375f5d6c3e8f7e8f2"
-  - params:
-      - "macos.java23.openjdk.aarch64"
-    os: "macos"
-    arch: "aarch64"
-    vendor: "temurin"
-    version: "jdk-23.0.2+7"
-    sha256: "749993e751f085c7ae713140066a90800075e4aeedfac50a5ed0c5457131c5a0"
   - params:
       - "macos.java24.openjdk.amd64"
     os: "macos"

--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -23,6 +23,6 @@ enum class JvmCategory(
     MIN_VERSION(JvmVendor.ORACLE, JvmVersion.JAVA_8),
     MIN_VERSION_WINDOWS_MAC(JvmVendor.OPENJDK, JvmVersion.JAVA_8),
     MAX_LTS_VERSION(JvmVendor.OPENJDK, JvmVersion.JAVA_21),
-    MAX_VERSION(JvmVendor.OPENJDK, JvmVersion.JAVA_23),
+    MAX_VERSION(JvmVendor.OPENJDK, JvmVersion.JAVA_24),
     SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.OPENJDK, JvmVersion.JAVA_17),
 }

--- a/.teamcity/src/main/kotlin/common/JvmVersion.kt
+++ b/.teamcity/src/main/kotlin/common/JvmVersion.kt
@@ -24,7 +24,6 @@ enum class JvmVersion(
     JAVA_11(11),
     JAVA_17(17),
     JAVA_21(21),
-    JAVA_23(23),
     JAVA_24(24),
     ;
 

--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -79,7 +79,6 @@ enum class Os(
                         DefaultJvm(JvmVersion.JAVA_11, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_17, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_21, JvmVendor.OPENJDK),
-                        DefaultJvm(JvmVersion.JAVA_23, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_24, JvmVendor.OPENJDK),
                     )
 
@@ -89,7 +88,6 @@ enum class Os(
                         DefaultJvm(JvmVersion.JAVA_11, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_17, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_21, JvmVendor.OPENJDK),
-                        DefaultJvm(JvmVersion.JAVA_23, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_24, JvmVendor.OPENJDK),
                     )
 
@@ -99,7 +97,6 @@ enum class Os(
                         DefaultJvm(JvmVersion.JAVA_11, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_17, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_21, JvmVendor.OPENJDK),
-                        DefaultJvm(JvmVersion.JAVA_23, JvmVendor.OPENJDK),
                         DefaultJvm(JvmVersion.JAVA_24, JvmVendor.OPENJDK),
                     )
             }.joinToString(",") { javaHome(it, this, arch) }

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -169,7 +169,6 @@ class ApplyDefaultConfigurationTest {
                 "%linux.java11.openjdk.64bit%",
                 "%linux.java17.openjdk.64bit%",
                 "%linux.java21.openjdk.64bit%",
-                "%linux.java23.openjdk.64bit%",
                 "%linux.java24.openjdk.64bit%",
             )
         val windowsPaths =
@@ -178,7 +177,6 @@ class ApplyDefaultConfigurationTest {
                 "%windows.java11.openjdk.64bit%",
                 "%windows.java17.openjdk.64bit%",
                 "%windows.java21.openjdk.64bit%",
-                "%windows.java23.openjdk.64bit%",
                 "%windows.java24.openjdk.64bit%",
             )
         val expectedInstallationPaths = (if (os == Os.WINDOWS) windowsPaths else linuxPaths).joinToString(",")

--- a/.teamcity/src/test/kotlin/BuildScanTagUtilsTest.kt
+++ b/.teamcity/src/test/kotlin/BuildScanTagUtilsTest.kt
@@ -46,8 +46,8 @@ class BuildScanTagUtilsTest {
     @Test
     fun `test functional test project tags`() {
         assertEquals(
-            "QuickJava23AdoptiumLinuxAmd64",
-            TestCoverage(1, TestType.QUICK, Os.LINUX, JvmVersion.JAVA_23, JvmVendor.OPENJDK).asBuildScanCustomValue(),
+            "QuickJava24AdoptiumLinuxAmd64",
+            TestCoverage(1, TestType.QUICK, Os.LINUX, JvmVersion.JAVA_24, JvmVendor.OPENJDK).asBuildScanCustomValue(),
         )
     }
 }

--- a/.teamcity/src/test/kotlin/BuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/BuildTypeTest.kt
@@ -52,7 +52,6 @@ class BuildTypeTest {
                 "%linux.java11.openjdk.64bit%",
                 "%linux.java17.openjdk.64bit%",
                 "%linux.java21.openjdk.64bit%",
-                "%linux.java23.openjdk.64bit%",
                 "%linux.java24.openjdk.64bit%",
             )
         val expectedInstallationPaths = linuxPaths.joinToString(",")
@@ -86,7 +85,7 @@ class BuildTypeTest {
                 "TestFunctionalTest",
                 "Test Functional Test",
                 "Test Functional Test",
-                TestCoverage(4, TestType.PLATFORM, Os.WINDOWS, JvmVersion.JAVA_23, JvmVendor.OPENJDK),
+                TestCoverage(4, TestType.PLATFORM, Os.WINDOWS, JvmVersion.JAVA_24, JvmVendor.OPENJDK),
                 buildModel.stages[2],
             )
 
@@ -96,7 +95,6 @@ class BuildTypeTest {
                 "%windows.java11.openjdk.64bit%",
                 "%windows.java17.openjdk.64bit%",
                 "%windows.java21.openjdk.64bit%",
-                "%windows.java23.openjdk.64bit%",
                 "%windows.java24.openjdk.64bit%",
             )
         val expectedInstallationPaths = windowsPaths.joinToString(",")
@@ -109,14 +107,14 @@ class BuildTypeTest {
                 "-s",
                 "%additional.gradle.parameters%",
                 "--continue",
-                "-DbuildScan.PartOf=PlatformJava23AdoptiumWindowsAmd64,PullRequestFeedback,ReadyforNightly,ReadyforRelease",
-                "-PtestJavaVersion=23",
+                "-DbuildScan.PartOf=PlatformJava24AdoptiumWindowsAmd64,PullRequestFeedback,ReadyforNightly,ReadyforRelease",
+                "-PtestJavaVersion=24",
                 "-PtestJavaVendor=openjdk",
                 "-Dscan.tag.FunctionalTest",
                 "-Dscan.value.coverageOs=windows",
                 "-Dscan.value.coverageArch=amd64",
                 "-Dscan.value.coverageJvmVendor=openjdk",
-                "-Dscan.value.coverageJvmVersion=java23",
+                "-Dscan.value.coverageJvmVersion=java24",
                 "-PflakyTests=exclude",
                 "-Dscan.tag.Check",
                 "-PteamCityBuildId=%teamcity.build.id%",

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -79,7 +79,6 @@ class PerformanceTestBuildTypeTest {
                 "%linux.java11.openjdk.64bit%",
                 "%linux.java17.openjdk.64bit%",
                 "%linux.java21.openjdk.64bit%",
-                "%linux.java23.openjdk.64bit%",
                 "%linux.java24.openjdk.64bit%",
             )
         val expectedInstallationPaths = linuxPaths.joinToString(",")
@@ -154,7 +153,6 @@ class PerformanceTestBuildTypeTest {
                 "%windows.java11.openjdk.64bit%",
                 "%windows.java17.openjdk.64bit%",
                 "%windows.java21.openjdk.64bit%",
-                "%windows.java23.openjdk.64bit%",
                 "%windows.java24.openjdk.64bit%",
             )
         val expectedInstallationPaths = windowsPaths.joinToString(",")

--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -20,7 +20,7 @@ import gradlebuild.modules.model.License
 
 abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
 
-    val groovyVersion = if (isBundleGroovy4) "4.0.22" else "3.0.22"
+    val groovyVersion = if (isBundleGroovy4) "4.0.26" else "3.0.24"
     val groovyGroup = if (isBundleGroovy4) "org.apache.groovy" else "org.codehaus.groovy"
 
     val configurationCacheReportVersion = "1.25"

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -338,7 +338,8 @@ fun Test.configureJvmForTest() {
             // Temporary workaround for smoke tests until we have the new API (`forDaemonProcesses`) available normally.
             val clazz = org.gradle.internal.jvm.JpmsConfiguration::class.java
             val jpmsArgs = try {
-                clazz.getDeclaredField("GRADLE_DAEMON_JPMS_ARGS").get(null)
+                val non24CompatibleArgs = clazz.getDeclaredField("GRADLE_DAEMON_JPMS_ARGS").get(null) as List<*>
+                non24CompatibleArgs + (if (jvmVersionForTest().canCompileOrRun(24)) listOf("--enable-native-access=ALL-UNNAMED") else emptyList<String>())
             } catch (ignored: NoSuchFieldException) {
                 clazz.getMethod("forDaemonProcesses", Int::class.java, Boolean::class.java).invoke(null, jvmVersionForTest().asInt(), true)
             }

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -287,6 +287,7 @@
             <trusting group="xmlunit"/>
             <trusting group="^org[.]apache($|([.].*))" regex="true"/>
          </trusted-key>
+         <trusted-key id="9C60C6B3A5A9DF8FEDD299D65BE0BA8CB80602AE" group="org.apache.ivy"/>
          <trusted-key id="CF17E92C9FFA55316B5DB83901D734EE5EE9C3F8" group="org.eclipse.sisu"/>
          <trusted-key id="CF4B3A3F53BEF9A2CE2CBFB895962C5E716C39AA" group="com.autonomousapps"/>
          <trusted-key id="D40633BFD9FDB773C896E9025DFB46C505B694FE" group="com.github.bbottema"/>

--- a/packaging/distributions-dependencies/build.gradle.kts
+++ b/packaging/distributions-dependencies/build.gradle.kts
@@ -104,7 +104,7 @@ dependencies {
         api(libs.hikariCP)              { version { strictly("4.0.3"); because("5.x requires Java 11+") }}
         api(libs.httpcore)              { version { strictly("4.4.14") }}
         api(libs.inject)                { version { strictly("1") }}
-        api(libs.ivy)                   { version { strictly("2.5.2") }}
+        api(libs.ivy)                   { version { strictly("2.5.3") }}
         api(libs.jacksonAnnotations)    { version { strictly(jacksonVersion) }}
         api(libs.jacksonCore)           { version { strictly(jacksonVersion) }}
         api(libs.jacksonDatabind)       { version { strictly(jacksonVersion) }}

--- a/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi813PlusCrossVersionTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi813PlusCrossVersionTest.groovy
@@ -85,7 +85,13 @@ class ConfigurationCacheProblemsTapi813PlusCrossVersionTest extends ToolingApiSp
             definition.id.group.name == "configuration-cache"
             definition.severity == Severity.ERROR
             (originLocations[0] as LineInFileLocation).path == "build file 'build.gradle'" // FIXME: the path should not contain a prefix nor extra quotes
-            ((targetVersion.baseVersion >= GradleVersion.version("8.14") ? contextualLocations[0] : originLocations[1]) as LineInFileLocation).path == buildFileLocation(buildFile, targetVersion)
+            if (targetVersion.baseVersion < GradleVersion.version("8.14")) {
+                originLocations.size() == 2
+                (originLocations[1] as LineInFileLocation).path == buildFileLocation(buildFile, targetVersion)
+            }
+            else {
+                originLocations.size() == 1
+            }
             additionalData instanceof DefaultAdditionalData
             additionalData.asMap.isEmpty()
         }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
@@ -16,9 +16,8 @@
 
 package org.gradle.internal.cc.impl
 
-import org.gradle.api.problems.LineInFileLocation
+
 import org.gradle.api.problems.Severity
-import org.gradle.api.problems.internal.StackTraceLocation
 
 class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCacheIntegrationTest {
 
@@ -57,11 +56,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
             originLocations.size() == 1
             originLocations[0].path == "build file 'build.gradle'"
             originLocations[0].line == 2
-            contextualLocations.size() == 1
-            with((contextualLocations[0] as StackTraceLocation).fileLocation as LineInFileLocation) {
-                path == buildFile.absolutePath
-                line == 2
-            }
+            contextualLocations.empty
             additionalData.asMap.trace == "build file 'build.gradle': line 2"
         }
 
@@ -76,11 +71,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
             definition.documentationLink.url.endsWith("/userguide/configuration_cache.html#config_cache:requirements:build_listeners")
             originLocations[0].path == "build file 'build.gradle'"
             originLocations[0].line == 2
-            contextualLocations.size() == 1
-            with((contextualLocations[0] as StackTraceLocation).fileLocation as LineInFileLocation) {
-                path == buildFile.absolutePath
-                line == 2
-            }
+            contextualLocations.empty
             additionalData.asMap.trace == "build file 'build.gradle': line 2"
 
         }

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorProblemsApiIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorProblemsApiIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.workers.internal
 
 import com.google.common.collect.Iterables
 import org.gradle.api.problems.Severity
+import org.gradle.api.problems.internal.StackTraceLocation
 import org.gradle.api.problems.internal.TaskLocation
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
@@ -40,16 +41,16 @@ class WorkerExecutorProblemsApiIntegrationTest extends AbstractIntegrationSpec {
                 implementation(gradleApi())
             }
         """
-        file('buildSrc/src/main/java/org/gradle/test/ProblemsWorkerTaskParameter.java') << """
-            package org.gradle.test;
+        file('buildSrc/src/main/java/org/someorg/test/ProblemsWorkerTaskParameter.java') << """
+            package org.someorg.test;
 
             import org.gradle.workers.WorkParameters;
 
             public interface ProblemsWorkerTaskParameter extends WorkParameters { }
         """
 
-        file('buildSrc/src/main/java/org/gradle/test/SomeOtherData.java') << """
-            package org.gradle.test;
+        file('buildSrc/src/main/java/org/someorg/test/SomeOtherData.java') << """
+            package org.someorg.test;
 
             public interface SomeOtherData {
                 String getOtherName();
@@ -57,8 +58,8 @@ class WorkerExecutorProblemsApiIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        file('buildSrc/src/main/java/org/gradle/test/SomeData.java') << """
-            package org.gradle.test;
+        file('buildSrc/src/main/java/org/someorg/test/SomeData.java') << """
+            package org.someorg.test;
 
             import org.gradle.api.problems.AdditionalData;
             import org.gradle.api.provider.Property;
@@ -77,8 +78,8 @@ class WorkerExecutorProblemsApiIntegrationTest extends AbstractIntegrationSpec {
                   void setOtherData(SomeOtherData otherData);
             }
         """
-        file('buildSrc/src/main/java/org/gradle/test/ProblemWorkerTask.java') << """
-            package org.gradle.test;
+        file('buildSrc/src/main/java/org/someorg/test/ProblemWorkerTask.java') << """
+            package org.someorg.test;
 
             import java.io.File;
             import java.io.FileWriter;
@@ -139,7 +140,7 @@ class WorkerExecutorProblemsApiIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             import javax.inject.Inject
-            import org.gradle.test.ProblemWorkerTask
+            import org.someorg.test.ProblemWorkerTask
 
 
             abstract class ProblemTask extends DefaultTask {
@@ -163,39 +164,62 @@ class WorkerExecutorProblemsApiIntegrationTest extends AbstractIntegrationSpec {
             operationId == Long.parseLong(buildOperationIdFile.text)
             exception.message == "Exception message"
             exception.stacktrace.contains("Caused by: java.lang.Exception: Wrapped cause")
-            contextualLocations.size() == 1
-            (contextualLocations[0] as TaskLocation).buildTreePath == ":reportProblem"
-        }
-
-        def problem = Iterables.getOnlyElement(filteredProblemDetails(buildOperationsFixture))
-        with(problem) {
-            with(definition) {
-                name == 'type'
-                displayName == 'label'
-                with(group) {
-                    displayName == 'Generic'
-                    name == 'generic'
-                    parent == null
-                }
-                documentationLink == null
-            }
-            severity == Severity.WARNING.name()
+            definition.id.name == 'type'
+            definition.id.displayName == 'label'
+            definition.id.group.displayName == 'Generic'
+            definition.id.group.name == 'generic'
+            definition.id.group.parent == null
+            definition.documentationLink == null
+            definition.severity == Severity.WARNING
             contextualLabel == null
             solutions == []
             details == null
-            contextualLocations.empty
-            if (isolationMode == "'${WorkerExecutorFixture.IsolationMode.PROCESS_ISOLATION.method}'") {
-                // TODO: Should have the stack location for all isolation modes
-                assert originLocations.empty
-            } else {
-                assert originLocations.size() == 1
-                with(originLocations[0]) {
+            contextualLocations.size() == 1
+            (contextualLocations[0] as TaskLocation).buildTreePath == ":reportProblem"
+            operationId == Long.parseLong(buildOperationIdFile.text)
+            exception.message == "Exception message"
+            exception.stacktrace.contains("Caused by: java.lang.Exception: Wrapped cause")
+
+            if (isolationMode != "'${WorkerExecutorFixture.IsolationMode.PROCESS_ISOLATION.method}'") {
+                with(originLocations[0] as StackTraceLocation) {
                     // TODO: Should have the file location for all isolation modes
                     fileLocation == null
-                    stackTrace.find { it.className == 'org.gradle.test.ProblemWorkerTask' && it.methodName == 'execute' && it.fileName == 'ProblemWorkerTask.java' }
+                    stackTrace.find { it.className == 'org.someorg.test.ProblemWorkerTask' && it.methodName == 'execute' && it.fileName == 'ProblemWorkerTask.java' }
                 }
             }
-            failure != null
+
+            //This is here to test the values returned by the org.gradle.api.problems.internal.DefaultProblemProgressDetails.getOriginLocations
+            // and org.gradle.api.problems.internal.DefaultProblemProgressDetails.getContextualLocations.
+            def problem = Iterables.getOnlyElement(filteredProblemDetails(buildOperationsFixture))
+            with(problem) {
+                with(definition) {
+                    name == 'type'
+                    displayName == 'label'
+                    with(group) {
+                        displayName == 'Generic'
+                        name == 'generic'
+                        parent == null
+                    }
+                    documentationLink == null
+                }
+                severity == Severity.WARNING.name()
+                contextualLabel == null
+                solutions == []
+                details == null
+                contextualLocations.empty
+                if (isolationMode == "'${WorkerExecutorFixture.IsolationMode.PROCESS_ISOLATION.method}'") {
+                    // TODO: Should have the stack location for all isolation modes
+                    assert originLocations.empty
+                } else {
+                    assert originLocations.size() == 1
+                    with(originLocations[0]) {
+                        // TODO: Should have the file location for all isolation modes
+                        fileLocation == null
+                        stackTrace.find { it.className == 'org.someorg.test.ProblemWorkerTask' && it.methodName == 'execute' && it.fileName == 'ProblemWorkerTask.java' }
+                    }
+                }
+                failure != null
+            }
         }
 
         where:
@@ -205,7 +229,7 @@ class WorkerExecutorProblemsApiIntegrationTest extends AbstractIntegrationSpec {
     static Collection<Map<String, ?>> filteredProblemDetails(BuildOperationsFixture buildOperations) {
         List<Map<String, ?>> details = buildOperations.progress(ProblemUsageProgressDetails).details
         details
-            .findAll { it.definition.name != 'executing-gradle-on-jvm-versions-and-lower'}
+            .findAll { it.definition.name != 'executing-gradle-on-jvm-versions-and-lower' }
     }
 
 }

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
@@ -45,7 +45,7 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
         file('build.gradle') << """
             def inputArguments = java.lang.management.ManagementFactory.runtimeMXBean.inputArguments
             assert inputArguments.contains('-Xmx1024m')
-            assert inputArguments.count { !it.startsWith('--add-opens=') && !it.startsWith('--add-exports') && !it.startsWith('-D') && !it.startsWith('-javaagent:') } == 1
+            assert inputArguments.count { !it.startsWith('--add-opens=') && !it.startsWith('--add-exports=') && !it.startsWith('--enable-native-access=') && !it.startsWith('-D') && !it.startsWith('-javaagent:') } == 1
         """
 
         when:

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -696,6 +696,12 @@ tasks.named<Test>("docsTest") {
             excludeTestsMatching("org.gradle.docs.samples.*.snippet-code-quality-code-quality*")
         }
 
+        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_24)) {
+            // JaCoCo doesn't yet support Java 24 (need 0.8.13)
+            excludeTestsMatching("org.gradle.docs.samples.*.jvm-multi-project-with-code-coverage*")
+            excludeTestsMatching("org.gradle.docs.samples.*.snippet-testing-jacoco*")
+        }
+
         if (OperatingSystem.current().isMacOsX && System.getProperty("os.arch") == "aarch64") {
             excludeTestsMatching("org.gradle.docs.samples.*.snippet-native*.sample")
             excludeTestsMatching("org.gradle.docs.samples.*.snippet-swift*.sample")

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_general.adoc
@@ -15,4 +15,45 @@
 [[best_practices_general]]
 = General Gradle Best Practices
 
-Add content here.
+[[use_the_plugins_block]]
+== Apply Plugins Using the `plugins` Block
+
+You should always use the `plugins` block to <<plugin_basics.adoc#applying_plugins,apply plugins>> in your build scripts.
+
+=== Explanation
+
+The `plugins` block is the preferred way to apply plugins in Gradle.
+The plugins API allows Gradle to better manage the loading of plugins and it is both more concise and less error-prone than adding dependencies to the buildscript's classpath explicitly in order to use the `apply` method.
+
+It allows Gradle to optimize the loading and reuse of plugin classes and helps inform tools about the potential properties and values in extensions the plugins will add to the build script.
+It is constrained to be idempotent (produce the same result every time) and side effect-free (safe for Gradle to execute at any time).
+
+=== Example
+
+==== Don't Do This
+
+====
+include::sample[dir="snippets/bestPractices/usePluginsBlock/kotlin/avoid-this",files="build.gradle.kts[tags=avoid-this]"]
+include::sample[dir="snippets/bestPractices/usePluginsBlock/groovy/avoid-this",files="build.gradle[tags=avoid-this]"]
+====
+
+<1> *Declare a Repository*: To use the legacy plugin application syntax, you need to explicitly tell Gradle where to find a plugin.
+<2> *Declare a Plugin Dependency*: To use the legacy plugin application syntax with third-party plugins, you need to explicitly tell Gradle the full coordinates of the plugin.
+<3> *Apply a Core Plugin*: This is very similar using either method.
+<4> *Apply a Third-Party Plugin*: The syntax is the same as for core Gradle plugins, but the version is not present at the point of application in your buildscript.
+
+==== Do This Instead
+
+====
+include::sample[dir="snippets/bestPractices/usePluginsBlock/kotlin/do-this",files="build.gradle.kts[tags=do-this]"]
+include::sample[dir="snippets/bestPractices/usePluginsBlock/groovy/do-this",files="build.gradle[tags=do-this]"]
+====
+
+<1> *Apply a Core Plugin*: This is very similar using either method.
+<2> *Apply a Third-Party Plugin*: You specify the version using method chaining in the `plugins` block itself.
+
+=== References
+<<plugins.adoc#sec:using_plugins,Using Plugins>>
+
+=== Tags
+`#structuring-builds`

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/tags_reference.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/tags_reference.adoc
@@ -11,9 +11,16 @@ Items that are related to using Gradle's various caching mechanisms, such as <<b
 
 Items that are related to Gradle <<writing_tasks.adoc#task_inputs_and_outputs,task inputs and outputs>>, the annotations used to declare them, and their proper use.
 
+`#plugins`
+Items that explain the proper way to <<custom_plugins.adoc#custom_plugins,write plugins>> in Gradle, and common footguns involved in plugin authoring.
+
 `#tasks`
 
-Practices that explain the proper way to <<writing_tasks.adoc#sec:sample_task,write tasks>> in Gradle, and common footguns involved in task authoring.
+Items that explain the proper way to <<writing_tasks.adoc#sec:sample_task,write tasks>> in Gradle, and common footguns involved in task authoring.
+
+`#structuring-builds`
+
+Items that explain the proper way to structure maintainable builds in Gradle.
 
 `#up-to-date-checking`
 

--- a/platforms/documentation/docs/src/docs/userguide/platforms/jvm/toolchains.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/platforms/jvm/toolchains.adoc
@@ -33,101 +33,223 @@ You can also control the JVM used to run Gradle itself using the <<gradle_daemon
 [[sec:consuming]]
 == Toolchains for projects
 
-You can define what toolchain to use for a project by stating the Java language version in the `java` extension block:
+Gradle provides multiple ways to configure the Java version used for compiling and running your project.
+
+The five primary mechanisms are:
+
+1. *<<#sec:java-toolchains,Java toolchains>>*
+2. *<<#sec:release-flag-toolchain,The `--release` flag>>*
+3. *<<#sec:source-target-toolchain,Source and Target compatibility>>*
+4. *<<#sec:java-home-toolchain,Environment variables (`JAVA_HOME`)>>*
+5. *<<#sec:ide-settings-toolchain,IDE settings>>*
+
+These settings are **not mutually exclusive**, and advanced users may need to combine them in specific scenarios.
+
+[[sec:java-toolchains]]
+=== 1. Java toolchains
+
+To configure a toolchain for your project, declare the desired Java language version in the `java` extension block:
 
 ====
 include::sample[dir="snippets/java/toolchain-basic/kotlin",files="build.gradle.kts[tags=toolchain]"]
 include::sample[dir="snippets/java/toolchain-basic/groovy",files="build.gradle[tags=toolchain]"]
 ====
 
-Executing the build (e.g. using `gradle check`) will now handle several things for you and others running your build:
+The `java` block is flexible and supports additional configuration options.
+You can learn more in <<sec:using-java-toolchains>>.
 
-1. Gradle configures all compile, test and javadoc tasks to use the defined toolchain.
-2. Gradle detects <<#sec:auto_detection,locally installed toolchains>>.
-3. Gradle chooses a toolchain matching the requirements (any Java 17 toolchain for the example above).
-4. If no matching toolchain is found, Gradle can automatically download a matching one based on the configured <<#sub:download_repositories,toolchain download repositories>>.
+[[sec:release-flag-toolchain]]
+=== 2. The `--release` flag
 
-[NOTE]
-====
-Toolchain support is available in the Java plugins and for the tasks they define.
-
-For the Groovy plugin, compilation is supported but not yet Groovydoc generation.
-For the Scala plugin, compilation and Scaladoc generation are supported.
-====
-
-[[sec:vendors]]
-=== Selecting toolchains by vendor
-
-In case your build has specific requirements from the used JRE/JDK, you may want to define the vendor for the toolchain as well.
-link:{javadocPath}/org/gradle/jvm/toolchain/JvmVendorSpec.html[`JvmVendorSpec`] has a list of well-known JVM vendors recognized by Gradle.
-The advantage is that Gradle can handle any inconsistencies across JDK versions in how exactly the JVM encodes the vendor information.
+For strict cross-compilation, the `--release` flag is recommended instead of `sourceCompatibility` and `targetCompatibility`:
 
 ====
-include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-known-vendor]"]
-include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-known-vendor]"]
+[.multi-language-sample]
+=====
+[source,kotlin]
+----
+tasks.withType<JavaCompile>().configureEach {
+    options.release = 8
+}
+----
+=====
+[.multi-language-sample]
+=====
+[source,groovy]
+----
+tasks.withType(JavaCompile).configureEach {
+    options.release = 8
+}
+----
+=====
 ====
 
-If the vendor you want to target is not a known vendor, you can still restrict the toolchain to those matching the `java.vendor` system property of the available toolchains.
+This flag prevents accidental use of newer APIs that are not available in the specified version.
+However, it does not control which JDK is used—only how the compiler treats source code.
 
-The following snippet uses filtering to include a subset of available toolchains.
-This example only includes toolchains whose `java.vendor` property contains the given match string.
-The matching is done in a case-insensitive manner.
+This method can be combined with toolchains **if you need both a specific JDK and strict cross-compilation**.
 
-====
-include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-matching-vendor]"]
-include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-matching-vendor]"]
-====
+[[sec:source-target-toolchain]]
+=== 3. Source and Target compatibility
 
-[[sec:native_image]]
-=== Selecting toolchains that support GraalVM native image
-
-If your project needs a toolchain with https://www.graalvm.org/latest/reference-manual/native-image/[GraalVM Native Image capability], you can configure the spec to request it:
+Setting `sourceCompatibility` and `targetCompatibility` tells the Java compiler to produce bytecode compatible with a specific Java version but does *not* enforce which JDK Gradle itself runs with:
 
 ====
-include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-native-image]"]
-include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-native-image]"]
+[.multi-language-sample]
+=====
+[source,kotlin]
+----
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+----
+=====
+[.multi-language-sample]
+=====
+[source,groovy]
+----
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+----
+=====
 ====
 
-Leaving that value unconfigured or set to `false` will not restrict the toolchain selection based on the Native Image capability.
-That means that a Native Image capable JDK can be selected if it matches the other criteria.
+This does *not* guarantee the correct JDK is used and may cause issues when APIs have been backported to older Java versions.
 
-=== Selecting toolchains by virtual machine implementation
+You should only use this method in cases where you need backward compatibility **but cannot use toolchains**.
 
-If your project requires a specific implementation, you can filter based on the implementation as well.
-Currently available implementations to choose from are:
+[[sec:java-home-toolchain]]
+=== 4. Environment variables (`JAVA_HOME`)
 
-`VENDOR_SPECIFIC`::
-Acts as a placeholder and matches any implementation from any vendor (e.g. hotspot, zulu, ...)
-`J9`::
-Matches only virtual machine implementations using the OpenJ9/IBM J9 runtime engine.
+You can influence which JDK Gradle uses by setting the `JAVA_HOME` environment variable:
 
-For example, to use an https://www.eclipse.org/openj9/[IBM] JVM, distributed via https://adoptopenjdk.net/[AdoptOpenJDK],
-you can specify the filter as shown in the example below.
+[source,bash]
+----
+export JAVA_HOME=/path/to/java17
+----
+
+This sets a default JDK for all Java-based tools on your system, including Gradle and Maven.
+
+WARNING: This does not override Gradle’s toolchain support or other project-specific configurations.
+
+This approach is useful for legacy projects that do not use toolchains and expect a specific JDK to be active in the environment.
+
+However, since `JAVA_HOME` applies globally, it cannot be used to specify different JDK versions for different projects.
+It is more reliable to use <<sec:java-toolchains,toolchains>>, which allow setting the Java version at the project level.
+
+[[sec:ide-settings-toolchain]]
+=== 5. IDE settings
+
+Most modern IDEs allow you to configure the JVM used to run Gradle when working with a project.
+This setting affects how Gradle itself is executed inside the IDE, but not how your code is compiled—unless the build does not explicitly specify a toolchain.
+
+If your build does not define a Java toolchain, Gradle may fall back to using the Java version defined by the IDE settings. This can lead to unintended and non-reproducible behavior, especially if different team members use different IDE configurations.
+
+You should change the IDE's Gradle JVM setting to align with the JVM used on the command line (`JAVA_HOME` or the system’s default Java installation) —ensuring consistent behavior across environments (e.g., when running tests or tasks from the IDE vs the terminal).
+
+You should also change the IDE's Gradle JVM setting if the IDE emits a warning/error when the JVM is not set or does not match with `JAVA_HOME`.
+
+==== IntelliJ IDEA
+
+To configure the Gradle JVM:
+
+1. Open *Settings (Preferences)* > *Build, Execution, Deployment* > *Gradle*.
+2. Set *Gradle JVM* to the desired JDK.
+
+==== Eclipse
+
+To configure the Gradle JVM:
+
+1. Open *Preferences* > *Gradle* > *Gradle JDK*.
+2. Select the appropriate JDK.
+
+NOTE: Some IDEs also allow you to configure the <<gradle_daemon.adoc#gradle_daemon,Gradle Daemon>> JVM in the same settings screen.
+Be careful not to confuse it with the toolchain or project JVM—*make sure you're selecting the correct one.*
+
+=== Combining toolchains
+
+In some cases, you may want to:
+
+- Use a **specific JDK version** for compilation (`toolchains`).
+- Ensure that the compiled bytecode is **compatible with an older Java version** (`--release` or `targetCompatibility`).
+
+For example, to compile with Java 17 but produce Java 11 bytecode:
 
 ====
-include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-matching-implementation]"]
-include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-matching-implementation]"]
+[.multi-language-sample]
+=====
+[source,kotlin]
+----
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release = 11
+}
+----
+=====
+[.multi-language-sample]
+=====
+[source,groovy]
+----
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 11
+}
+----
+=====
 ====
 
-NOTE: The Java major version, the vendor (if specified) and implementation (if specified) will be tracked as an input for compilation and test execution.
+=== Comparison table for setting project toolchains
 
-[[sec:configuring_toolchain_specifications]]
-=== Configuring toolchain specifications
+|===
+| Method | Ensures Correct JDK? | Auto Downloads JDK? | Prevents Accidental API Use?
 
-Gradle allows configuring multiple properties that affect the selection of a toolchain, such as language version or vendor.
-Even though these properties can be configured independently, the configuration must follow certain rules in order to form a _valid_ specification.
+| Java toolchains
+| ✅ Yes
+| ✅ Yes
+| ❌ No
 
-A `JavaToolchainSpec` is considered _valid_ in two cases:
+| `--release` flag
+| ❌ No
+| ❌ No
+| ✅ Yes
 
-1. when no properties have been set, i.e. the specification is _empty_;
-2. when `languageVersion` has been set, optionally followed by setting any other property.
+| Source & Target compatibility
+| ❌ No
+| ❌ No
+| ❌ No
 
-In other words, if a vendor or an implementation are specified, they must be accompanied by the language version.
-Gradle distinguishes between toolchain specifications that configure the language version and the ones that do not.
-A specification without a language version, in most cases, would be treated as a one that selects the toolchain of the current build.
+| Environment variables (`JAVA_HOME`)
+| ✅ Yes (but only globally)
+| ❌ No
+| ❌ No
 
-Usage of _invalid_ instances of `JavaToolchainSpec` results in a build error since Gradle 8.0.
+| IDE settings
+| ✅ Yes (inside the IDE)
+| ❌ No
+| ❌ No
+|===
 
+Recommendation:
+
+- *For most users:* Use Java toolchains (`toolchain.languageVersion`).
+- *For strict compatibility enforcement:* Use the `--release` flag.
+- *For advanced cases:* Combine toolchains and `--release`.
+- *Avoid* `sourceCompatibility` and `targetCompatibility` unless necessary.
+- *Use `JAVA_HOME`* only if you need a default system-wide JDK version.
+- *Use IDE settings* if you want Gradle to match your IDE's JDK version.
 
 == Toolchains for tasks
 
@@ -189,6 +311,106 @@ include::sample[dir="snippets/java/toolchain-config-task/groovy/",files="build.g
 
 WARNING: The examples above use tasks with `RegularFileProperty` and `DirectoryProperty` properties which allow lazy configuration.
 Doing respectively `launcher.get().executablePath`, `launcher.get().metadata.installationPath` or `compiler.get().executablePath` instead will give you the full path for the given toolchain but note that this may realize (and provision) a toolchain eagerly.
+
+[[sec:using-java-toolchains]]
+== Using Java toolchains
+
+Using Java toolchains allows Gradle to automatically download and manage the required JDK version for your build. It ensures that the correct Java version is used for both compilation and execution.
+
+You can define what toolchain to use for a project by stating the Java language version in the `java` extension block:
+
+====
+include::sample[dir="snippets/java/toolchain-basic/kotlin",files="build.gradle.kts[tags=toolchain]"]
+include::sample[dir="snippets/java/toolchain-basic/groovy",files="build.gradle[tags=toolchain]"]
+====
+
+Executing the build (e.g. using `gradle check`) will now handle several things for you and others running your build:
+
+1. Gradle configures all compile, test and javadoc tasks to use the defined toolchain.
+2. Gradle detects <<#sec:auto_detection,locally installed toolchains>>.
+3. Gradle chooses a toolchain matching the requirements (any Java 17 toolchain for the example above).
+4. If no matching toolchain is found, Gradle can automatically download a matching one based on the configured <<#sub:download_repositories,toolchain download repositories>>.
+
+[NOTE]
+====
+Toolchain support is available in the Java plugins and for the tasks they define.
+
+For the Groovy plugin, compilation is supported but not yet Groovydoc generation.
+For the Scala plugin, compilation and Scaladoc generation are supported.
+====
+
+[[sec:vendors]]
+==== Selecting toolchains by vendor
+
+In case your build has specific requirements from the used JRE/JDK, you may want to define the vendor for the toolchain as well.
+link:{javadocPath}/org/gradle/jvm/toolchain/JvmVendorSpec.html[`JvmVendorSpec`] has a list of well-known JVM vendors recognized by Gradle.
+The advantage is that Gradle can handle any inconsistencies across JDK versions in how exactly the JVM encodes the vendor information.
+
+====
+include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-known-vendor]"]
+include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-known-vendor]"]
+====
+
+If the vendor you want to target is not a known vendor, you can still restrict the toolchain to those matching the `java.vendor` system property of the available toolchains.
+
+The following snippet uses filtering to include a subset of available toolchains.
+This example only includes toolchains whose `java.vendor` property contains the given match string.
+The matching is done in a case-insensitive manner.
+
+====
+include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-matching-vendor]"]
+include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-matching-vendor]"]
+====
+
+[[sec:native_image]]
+==== Selecting toolchains that support GraalVM native image
+
+If your project needs a toolchain with https://www.graalvm.org/latest/reference-manual/native-image/[GraalVM Native Image capability], you can configure the spec to request it:
+
+====
+include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-native-image]"]
+include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-native-image]"]
+====
+
+Leaving that value unconfigured or set to `false` will not restrict the toolchain selection based on the Native Image capability.
+That means that a Native Image capable JDK can be selected if it matches the other criteria.
+
+==== Selecting toolchains by virtual machine implementation
+
+If your project requires a specific implementation, you can filter based on the implementation as well.
+Currently available implementations to choose from are:
+
+`VENDOR_SPECIFIC`::
+Acts as a placeholder and matches any implementation from any vendor (e.g. hotspot, zulu, ...)
+`J9`::
+Matches only virtual machine implementations using the OpenJ9/IBM J9 runtime engine.
+
+For example, to use an https://www.eclipse.org/openj9/[IBM] JVM, distributed via https://adoptopenjdk.net/[AdoptOpenJDK],
+you can specify the filter as shown in the example below.
+
+====
+include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradle.kts[tags=toolchain-matching-implementation]"]
+include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-matching-implementation]"]
+====
+
+NOTE: The Java major version, the vendor (if specified) and implementation (if specified) will be tracked as an input for compilation and test execution.
+
+[[sec:configuring_toolchain_specifications]]
+==== Configuring toolchain specifications
+
+Gradle allows configuring multiple properties that affect the selection of a toolchain, such as language version or vendor.
+Even though these properties can be configured independently, the configuration must follow certain rules in order to form a _valid_ specification.
+
+A `JavaToolchainSpec` is considered _valid_ in two cases:
+
+1. when no properties have been set, i.e. the specification is _empty_;
+2. when `languageVersion` has been set, optionally followed by setting any other property.
+
+In other words, if a vendor or an implementation are specified, they must be accompanied by the language version.
+Gradle distinguishes between toolchain specifications that configure the language version and the ones that do not.
+A specification without a language version, in most cases, would be treated as a one that selects the toolchain of the current build.
+
+Usage of _invalid_ instances of `JavaToolchainSpec` results in a build error since Gradle 8.0.
 
 [[sec:auto_detection]]
 == Auto-detection of installed toolchains

--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -56,7 +56,7 @@ See the table below for the Java version supported by a specific Gradle release:
 | 21| 8.4 | 8.5
 | 22| 8.7 | 8.8
 | 23| 8.10 | 8.10
-| 24| 8.14 | N/A
+| 24| 8.14 | 8.14
 | 25| N/A | N/A
 |===
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -223,6 +223,12 @@ For full details, see the https://github.com/google/guava/releases[Guava release
 The incubating `EclipseClasspath.baseSourceOutputDir` was previously declared as a `Property<File>`.
 It has now been correctly updated to a `DirectoryProperty` to reflect the intended type.
 
+==== Upgrade to Groovy 3.0.24
+
+Groovy has been updated to https://groovy-lang.org/changelogs/changelog-3.0.24.html[Groovy 3.0.24].
+
+Since the previous version was 3.0.22, this includes changes for https://groovy-lang.org/changelogs/changelog-3.0.23.html[Groovy 3.0.23] as well.
+
 === Deprecations
 
 [[null-attribute-lookup]]

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/plugin_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/plugin_basics.adoc
@@ -37,6 +37,7 @@ Plugins are distributed in three ways:
 2. **Community plugins** - Gradle's community shares plugins via the https://plugins.gradle.org[Gradle Plugin Portal].
 3. **Local plugins** - Gradle enables users to create custom plugins using link:{javadocPath}/org/gradle/api/Plugin.html[APIs].
 
+[[applying_plugins]]
 == Applying plugins
 
 *Applying* a plugin to a project allows the plugin to extend the project's capabilities.

--- a/platforms/documentation/docs/src/samples/groovy/library-publishing/groovy/my-library/build.gradle
+++ b/platforms/documentation/docs/src/samples/groovy/library-publishing/groovy/my-library/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:3.0.22'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.24'
 }
 
 publishing {

--- a/platforms/documentation/docs/src/samples/groovy/library-publishing/kotlin/my-library/build.gradle.kts
+++ b/platforms/documentation/docs/src/samples/groovy/library-publishing/kotlin/my-library/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.codehaus.groovy:groovy-all:3.0.22")
+    implementation("org.codehaus.groovy:groovy-all:3.0.24")
 }
 
 publishing {

--- a/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/groovy/avoid-this/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/groovy/avoid-this/build.gradle
@@ -1,0 +1,14 @@
+// tag::avoid-this[]
+buildscript {
+    repositories {
+        gradlePluginPortal() // <1>
+    }
+
+    dependencies {
+        classpath("com.google.protobuf:com.google.protobuf.gradle.plugin:0.9.4") // <2>
+    }
+}
+
+apply plugin: "java" // <3>
+apply plugin: "com.google.protobuf" // <4>
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/groovy/do-this/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/groovy/do-this/build.gradle
@@ -1,0 +1,6 @@
+// tag::do-this[]
+plugins {
+    id("java") // <1>
+    id("com.google.protobuf").version("0.9.4") // <2>
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/groovy/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = "use-plugins-block"
+
+include ":do-this", ":avoid-this"

--- a/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/kotlin/avoid-this/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/kotlin/avoid-this/build.gradle.kts
@@ -1,0 +1,14 @@
+// tag::avoid-this[]
+buildscript {
+    repositories {
+        gradlePluginPortal() // <1>
+    }
+
+    dependencies {
+        classpath("com.google.protobuf:com.google.protobuf.gradle.plugin:0.9.4") // <2>
+    }
+}
+
+apply(plugin = "java") // <3>
+apply(plugin = "com.google.protobuf") // <4>
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/kotlin/do-this/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/kotlin/do-this/build.gradle.kts
@@ -1,0 +1,6 @@
+// tag::do-this[]
+plugins {
+    id("java") // <1>
+    id("com.google.protobuf").version("0.9.4") // <2>
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/kotlin/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "use-plugins-block"
+
+include(":do-this", ":avoid-this")

--- a/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/tests/usePluginsBlock-avoid.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/tests/usePluginsBlock-avoid.out
@@ -1,0 +1,49 @@
+
+> Task :avoid-this:tasks
+
+------------------------------------------------------------
+Tasks runnable from project ':avoid-this'
+------------------------------------------------------------
+
+Build tasks
+-----------
+assemble - Assembles the outputs of this project.
+build - Assembles and tests this project.
+buildDependents - Assembles and tests this project and all projects that depend on it.
+buildNeeded - Assembles and tests this project and all projects it depends on.
+classes - Assembles main classes.
+clean - Deletes the build directory.
+jar - Assembles a jar archive containing the classes of the 'main' feature.
+testClasses - Assembles test classes.
+
+Documentation tasks
+-------------------
+javadoc - Generates Javadoc API documentation for the 'main' feature.
+
+Help tasks
+----------
+artifactTransforms - Displays the Artifact Transforms that can be executed in project ':avoid-this'.
+buildEnvironment - Displays all buildscript dependencies declared in project ':avoid-this'.
+dependencies - Displays all dependencies declared in project ':avoid-this'.
+dependencyInsight - Displays the insight into a specific dependency in project ':avoid-this'.
+help - Displays a help message.
+javaToolchains - Displays the detected java toolchains.
+outgoingVariants - Displays the outgoing variants of project ':avoid-this'.
+projects - Displays the sub-projects of project ':avoid-this'.
+properties - Displays the properties of project ':avoid-this'.
+resolvableConfigurations - Displays the configurations that can be resolved in project ':avoid-this'.
+tasks - Displays the tasks runnable from project ':avoid-this'.
+
+Verification tasks
+------------------
+check - Runs all checks.
+test - Runs the test suite.
+
+Rules
+-----
+Pattern: clean<TaskName>: Cleans the output files of a task.
+Pattern: build<ConfigurationName>: Assembles the artifacts of a configuration.
+
+To see all tasks and more detail, run gradle tasks --all
+
+To see more detail about a task, run gradle help --task <task>

--- a/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/tests/usePluginsBlock-do.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/tests/usePluginsBlock-do.out
@@ -1,0 +1,49 @@
+
+> Task :do-this:tasks
+
+------------------------------------------------------------
+Tasks runnable from project ':do-this'
+------------------------------------------------------------
+
+Build tasks
+-----------
+assemble - Assembles the outputs of this project.
+build - Assembles and tests this project.
+buildDependents - Assembles and tests this project and all projects that depend on it.
+buildNeeded - Assembles and tests this project and all projects it depends on.
+classes - Assembles main classes.
+clean - Deletes the build directory.
+jar - Assembles a jar archive containing the classes of the 'main' feature.
+testClasses - Assembles test classes.
+
+Documentation tasks
+-------------------
+javadoc - Generates Javadoc API documentation for the 'main' feature.
+
+Help tasks
+----------
+artifactTransforms - Displays the Artifact Transforms that can be executed in project ':do-this'.
+buildEnvironment - Displays all buildscript dependencies declared in project ':do-this'.
+dependencies - Displays all dependencies declared in project ':do-this'.
+dependencyInsight - Displays the insight into a specific dependency in project ':do-this'.
+help - Displays a help message.
+javaToolchains - Displays the detected java toolchains.
+outgoingVariants - Displays the outgoing variants of project ':do-this'.
+projects - Displays the sub-projects of project ':do-this'.
+properties - Displays the properties of project ':do-this'.
+resolvableConfigurations - Displays the configurations that can be resolved in project ':do-this'.
+tasks - Displays the tasks runnable from project ':do-this'.
+
+Verification tasks
+------------------
+check - Runs all checks.
+test - Runs the test suite.
+
+Rules
+-----
+Pattern: clean<TaskName>: Cleans the output files of a task.
+Pattern: build<ConfigurationName>: Assembles the artifacts of a configuration.
+
+To see all tasks and more detail, run gradle tasks --all
+
+To see more detail about a task, run gradle help --task <task>

--- a/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/tests/usePluginsBlock.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/usePluginsBlock/tests/usePluginsBlock.sample.conf
@@ -1,0 +1,13 @@
+commands: [{
+    executable: gradle
+    args: ":avoid-this:tasks"
+    expected-output-file: usePluginsBlock-avoid.out
+    allow-additional-output: true // Time to produce I/O may vary
+    allow-disordered-output: true // Kotlin tasks list will include an additional Kotlin DSL Extensions task
+}, {
+    executable: gradle
+    args: ":do-this:tasks"
+    expected-output-file: usePluginsBlock-do.out
+    allow-additional-output: true // Time to produce I/O may vary
+    allow-disordered-output: true // Kotlin tasks list will include an additional Kotlin DSL Extensions task
+}]

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsApiBuildOperationIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsApiBuildOperationIntegrationTest.groovy
@@ -21,9 +21,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 import org.gradle.operations.problems.ProblemUsageProgressDetails
-import org.gradle.util.internal.TextUtil
 
 import static org.gradle.api.problems.fixtures.ReportingScript.getProblemReportingScript
+import static org.gradle.util.internal.TextUtil.escapeString
 
 class ProblemsApiBuildOperationIntegrationTest extends AbstractIntegrationSpec {
     def buildOperations = new BuildOperationsFixture(executer, testDirectoryProvider)
@@ -129,18 +129,18 @@ class ProblemsApiBuildOperationIntegrationTest extends AbstractIntegrationSpec {
             ${ProblemId.name} problemId = ${ProblemId.name}.create("type", "label", problemGroup)
             problems.getReporter().report(problemId) {
                 it.contextualLabel("contextual label")
-                it.documentedAt("https://example.org/doc")
-                it.fileLocation("${TextUtil.escapeString(location0)}")
-                it.lineInFileLocation("${TextUtil.escapeString(location1)}", 25)
-                it.lineInFileLocation("${TextUtil.escapeString(location2)}", 35, 4)
-                it.lineInFileLocation("${TextUtil.escapeString(location3)}", 45, 7, 10)
-                it.offsetInFileLocation("${TextUtil.escapeString(location4)}", 55, 20)
-                it.stackLocation()
-                it.details("problem details")
-                it.solution("solution 1")
-                it.solution("solution 2")
-                it.severity(Severity.ERROR)
-                it.withException(new IllegalArgumentException("problem exception"))
+                  .documentedAt("https://example.org/doc")
+                  .fileLocation("${escapeString(location0)}")
+                  .lineInFileLocation("${escapeString(location1)}", 25)
+                  .lineInFileLocation("${escapeString(location2)}", 35, 4)
+                  .lineInFileLocation("${escapeString(location3)}", 45, 7, 10)
+                  .offsetInFileLocation("${escapeString(location4)}", 55, 20)
+                  .stackLocation()
+                  .details("problem details")
+                  .solution("solution 1")
+                  .solution("solution 2")
+                  .severity(Severity.ERROR)
+                  .withException(new IllegalArgumentException("problem exception"))
             }
         """
 
@@ -221,8 +221,7 @@ class ProblemsApiBuildOperationIntegrationTest extends AbstractIntegrationSpec {
             .multiProjectBuild("included", ['sub1', 'sub2']) {
                 file('sub1').file('build.gradle') << getProblemReportingScript("""
                     ${problemIdScript()}
-                    problems.getReporter().report(problemId) {
-                    }
+                    problems.getReporter().report(problemId) {}
                 """)
             }
 

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -169,14 +169,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 offset == 1
                 length == 2
             }
-            contextualLocations.size() == 2
-            with((contextualLocations[0] as StackTraceLocation).fileLocation as LineInFileLocation) {
-                length == -1
-                column == -1
-                line == 13
-                path == buildFile.absolutePath
-            }
-            with(contextualLocations[1] as TaskLocation) {
+            with(contextualLocations[0] as TaskLocation) {
                 buildTreePath == ':reportProblem'
             }
         }
@@ -203,16 +196,8 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
                 line == 1
                 path == 'test-location'
             }
-            contextualLocations.size() == 2
-            with((contextualLocations.get(0) as StackTraceLocation).fileLocation as LineInFileLocation) {
-                length == -1
-                column == -1
-                line == 13
-                path == buildFile.absolutePath
-            }
-            with(contextualLocations.get(1) as TaskLocation) {
-                it.buildTreePath == ':reportProblem'
-            }
+            contextualLocations.size() == 1
+            (contextualLocations.get(0) as TaskLocation).buildTreePath == ':reportProblem'
         }
     }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblems.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblems.java
@@ -60,7 +60,6 @@ public class DefaultProblems implements InternalProblems {
     public ProblemReporter getReporter() {
         return createReporter();
     }
-
     @NonNull
     private DefaultProblemReporter createReporter() {
         return new DefaultProblemReporter(

--- a/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompileToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompileToolchainIntegrationTest.groovy
@@ -24,8 +24,8 @@ import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.fixture.GroovyCoverage
+import org.gradle.util.internal.GroovyDependencyUtil
 import org.gradle.util.internal.TextUtil
-import org.gradle.util.internal.VersionNumber
 import org.junit.Assume
 
 import static org.gradle.util.internal.GroovyDependencyUtil.groovyModuleDependency
@@ -205,7 +205,7 @@ class GroovyCompileToolchainIntegrationTest extends MultiVersionIntegrationSpec 
 
         buildFile << """
             dependencies {
-                testImplementation "org.spockframework:spock-core:${getSpockVersion(versionNumber)}"
+                testImplementation "${GroovyDependencyUtil.spockModuleDependency("spock-core", versionNumber)}"
             }
 
             testing.suites.test.useJUnitJupiter()
@@ -236,10 +236,6 @@ class GroovyCompileToolchainIntegrationTest extends MultiVersionIntegrationSpec 
 
         where:
         javaVersion << JavaVersion.values().findAll { JavaVersion.VERSION_1_8 <= it && GroovyCoverage.supportsJavaVersion("$versionNumber", it) }
-    }
-
-    private def getSpockVersion(VersionNumber groovyVersion) {
-        return "2.3-groovy-${groovyVersion.major}.${groovyVersion.minor}"
     }
 
     private TestFile configureTool(Jvm jdk) {

--- a/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -21,8 +21,8 @@ import org.gradle.test.fixtures.VersionCoverage
 import org.gradle.util.internal.VersionNumber
 
 class GroovyCoverage {
-    private static final String[] PREVIOUS = ['1.5.8', '1.6.9', '1.7.11', '1.8.8', '2.0.5', '2.1.9', '2.2.2', '2.3.10', '2.4.15', '2.5.8', '3.0.22']
-    private static final String[] FUTURE = ['4.0.22']
+    private static final String[] PREVIOUS = ['1.5.8', '1.6.9', '1.7.11', '1.8.8', '2.0.5', '2.1.9', '2.2.2', '2.3.10', '2.4.15', '2.5.8', '3.0.24']
+    private static final String[] FUTURE = ['4.0.26']
 
     static final Set<String> SUPPORTED_BY_JDK
 
@@ -88,7 +88,7 @@ class GroovyCoverage {
         allVersions.addAll(FUTURE)
 
         if (javaVersion.isCompatibleWith(JavaVersion.VERSION_24)) {
-            return VersionCoverage.versionsAtLeast(allVersions, '3.0.23') // Tentative, not released yet
+            return VersionCoverage.versionsAtLeast(allVersions, '3.0.24')
         } else if (javaVersion.isCompatibleWith(JavaVersion.VERSION_15)) {
             // Latest 3.0.x patches support Java 15+
             return VersionCoverage.versionsAtLeast(allVersions, '3.0.0')

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
     testImplementation(projects.native)
     testImplementation(testFixtures(projects.core))
     testImplementation(testFixtures(projects.platformBase))
+    testImplementation(testFixtures(projects.languageGroovy))
     testImplementation(testFixtures(projects.toolchainsJvm))
     testImplementation(testFixtures(projects.toolchainsJvmShared))
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -165,6 +165,29 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
         result.error.contains("2 warnings\n")
     }
 
+    def "problem is received when a single-file note happens"() {
+        given:
+        possibleFileLocations.put(writeJavaCausingOneNoteCompilationWarnings("Foo").absolutePath, 2)
+        buildFile.text = buildFile.text.replaceAll(/"-Xlint:all"/, "")
+
+        when:
+        run("compileJava")
+
+        then:
+        verifyAll(receivedProblem(0)) {
+            assertLocations(it, false, false)
+            severity == Severity.ADVICE
+            fqid == 'compilation:java:compiler-note-unchecked-filename'
+            contextualLabel == "${buildFile.parentFile.path}/src/main/java/Foo.java uses unchecked or unsafe operations.".replace('/', File.separator)
+        }
+        verifyAll(receivedProblem(1)) {
+            assertLocations(it, false, false)
+            severity == Severity.ADVICE
+            fqid == 'compilation:java:compiler-note-unchecked-recompile'
+            contextualLabel == "Recompile with -Xlint:unchecked for details."
+        }
+    }
+
     def "problems are received when a multi-file warning happens"() {
         given:
         possibleFileLocations.put(writeJavaCausingTwoCompilationWarnings("Foo").absolutePath, 2)
@@ -321,7 +344,7 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
                 it.path == fooFileLocation.absolutePath
             }
             details == """\
-$fooFileLocation:5: warning: [cast] redundant cast to $expectedType
+$fooFileLocation:11: warning: [cast] redundant cast to $expectedType
         String s = (String)"Hello World";
                    ^"""
         }
@@ -332,7 +355,7 @@ $fooFileLocation:5: warning: [cast] redundant cast to $expectedType
             contextualLabel == 'redundant cast to java.lang.String'
             solutions.empty
             details == """\
-${fooFileLocation}:9: warning: [cast] redundant cast to $expectedType
+${fooFileLocation}:7: warning: [cast] redundant cast to $expectedType
         String s = (String)"Hello World";
                    ^"""
         }
@@ -524,6 +547,7 @@ ${fooFileLocation}:9: warning: [cast] redundant cast to $expectedType
         boolean expectLineLocation = true,
         boolean expectOffsetLocation = !expectLineLocation
     ) {
+
         assert problem.contextualLabel != null, "Expected contextual label to be non-null, but was null"
 
         def locations = problem.originLocations + problem.contextualLocations
@@ -578,6 +602,12 @@ ${fooFileLocation}:9: warning: [cast] redundant cast to $expectedType
         def generator = new ProblematicClassGenerator(testDirectory, className)
         generator.addWarning()
         generator.addWarning()
+        return generator.save()
+    }
+
+    TestFile writeJavaCausingOneNoteCompilationWarnings(String className) {
+        def generator = new ProblematicClassGenerator(testDirectory, className)
+        generator.addNotable()
         return generator.save()
     }
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
@@ -23,6 +23,8 @@ import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.CompiledLanguage
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
+import org.gradle.testing.fixture.GroovyCoverage
+import org.gradle.util.internal.GroovyDependencyUtil
 import org.gradle.util.internal.TextUtil
 import spock.lang.Issue
 
@@ -438,6 +440,7 @@ class GroovyIncrementalCompilationAfterFailureIntegrationTest extends BaseIncrem
     def "removes all classes for a recompiled source from output to stash dir for Spock tests when super class is changed"() {
         given:
         buildFile.clear()
+        def groovyVersion = GroovyCoverage.CURRENT_STABLE
         buildFile """
             plugins {
                 id 'groovy'
@@ -445,8 +448,8 @@ class GroovyIncrementalCompilationAfterFailureIntegrationTest extends BaseIncrem
             }
             ${mavenCentralRepository()}
             dependencies {
-                testImplementation 'org.codehaus.groovy:groovy:3.0.22'
-                testImplementation 'org.spockframework:spock-core:2.1-groovy-3.0'
+                testImplementation '${GroovyDependencyUtil.groovyModuleDependency("groovy", groovyVersion)}'
+                testImplementation '${GroovyDependencyUtil.spockModuleDependency("spock-core", groovyVersion)}'
             }
             tasks.withType(GroovyCompile) {
                 options.incremental = true

--- a/platforms/jvm/language-java/src/testFixtures/groovy/org/gradle/api/tasks/compile/fixtures/ProblematicClassGenerator.groovy
+++ b/platforms/jvm/language-java/src/testFixtures/groovy/org/gradle/api/tasks/compile/fixtures/ProblematicClassGenerator.groovy
@@ -29,6 +29,8 @@ class ProblematicClassGenerator {
 
         // Get the class name from the file name
         this.sourceFile << """\
+import java.util.List;
+
 public class ${className} {
 
 """
@@ -50,6 +52,16 @@ public class ${className} {
 public void error${errorIndex}() {
     // Missing semicolon will trigger an error
     String s = "Hello, World!"
+}
+"""
+    }
+
+    void addNotable() {
+        errorIndex += 1
+        sourceFile << """\
+public void notable${errorIndex}() {
+    Object someObject = "Hello, World!";
+    List<String> strings = (List<String>) someObject; // Unchecked cast
 }
 """
     }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformFilteringIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformFilteringIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.junit.platform
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import spock.lang.Issue
 
@@ -170,6 +171,7 @@ class JUnitPlatformFilteringIntegrationTest extends JUnitPlatformIntegrationSpec
         '''
 
         when:
+        maybeExpectArchUnitUnsafeDeprecationWarning()
         succeeds('test')
 
         then:
@@ -215,6 +217,7 @@ class JUnitPlatformFilteringIntegrationTest extends JUnitPlatformIntegrationSpec
         '''
 
         when:
+        maybeExpectArchUnitUnsafeDeprecationWarning()
         succeeds('test')
 
         then:
@@ -261,5 +264,14 @@ class JUnitPlatformFilteringIntegrationTest extends JUnitPlatformIntegrationSpec
         expect:
         fails('test')
         errorOutput.contains("No tests found for given includes")
+    }
+
+    /**
+     * ArchUnit uses an Guava version older than 33.4.5, which emits this warning when being used with Java 24+.
+     */
+    private void maybeExpectArchUnitUnsafeDeprecationWarning() {
+        if (JavaVersion.current() >= JavaVersion.VERSION_24) {
+            executer.expectDeprecationWarning("WARNING: A terminally deprecated method in sun.misc.Unsafe has been called")
+        }
     }
 }

--- a/platforms/software/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
+++ b/platforms/software/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
@@ -2,10 +2,10 @@
 commons-math=3.6.1
 commons-text=1.13.0
 groovy=3.0.24
-guava=33.4.0-jre
-junit-jupiter=5.12.0
+guava=33.4.5-jre
+junit-jupiter=5.12.1
 junit=4.13.2
-kotlin=2.1.20-RC
+kotlin=2.1.20
 scala-library=2.13.16
 scala-xml=1.2.0
 scala=2.13

--- a/released-versions.json
+++ b/released-versions.json
@@ -1,7 +1,7 @@
 {
   "latestReleaseSnapshot": {
-    "version": "8.14-20250403043412+0000",
-    "buildTime": "20250403043412+0000"
+    "version": "8.14-20250404052051+0000",
+    "buildTime": "20250404052051+0000"
   },
   "latestRc": {
     "version": "8.14-milestone-7",

--- a/subprojects/core/src/main/java/org/gradle/util/internal/GroovyDependencyUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/GroovyDependencyUtil.java
@@ -72,4 +72,18 @@ public class GroovyDependencyUtil {
         }
         return dependency.toString();
     }
+
+    /**
+     * Returns Spock coordinates based on Groovy version.
+     */
+    public static String spockModuleDependency(String module, String version) {
+        return spockModuleDependency(module, VersionNumber.parse(version));
+    }
+
+    /**
+     * Returns Spock coordinates based on Groovy version.
+     */
+    public static String spockModuleDependency(String module, VersionNumber version) {
+        return "org.spockframework:" + module + ":2.3-groovy-" + version.getMajor() + "." + version.getMinor();
+    }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -605,6 +605,18 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
             gradleInvocation.implicitLauncherJvmArgs.add(debugLauncher.toDebugArgument());
         }
         gradleInvocation.implicitLauncherJvmArgs.add("-ea");
+
+        // Note: it's possible we shouldn't calculate _any_ implicit JVM args when requested to use only the specified ones, but to preserve behavior I only excluded the new flag here
+        if (useOnlyRequestedJvmOpts) {
+            return;
+        }
+
+        JavaVersion javaVersion = getJavaVersionFromJavaHome();
+        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_24)) {
+            // Remove known warning that occurs in the launcher. This can be fixed by refactoring the bin/gradle start script to pass the flag or by adding the flag to the launcher JAR
+            // and refactoring the start script to use that JAR instead of a main class.
+            gradleInvocation.implicitLauncherJvmArgs.add("--enable-native-access=ALL-UNNAMED");
+        }
     }
 
     protected static String joinAndQuoteJvmArgs(List<String> buildJvmArgs) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.groovy
@@ -162,7 +162,12 @@ class DefaultGradleDistribution implements GradleDistribution {
             return javaVersion >= JavaVersion.VERSION_1_8 && javaVersion <= JavaVersion.VERSION_22
         }
 
-        return javaVersion >= JavaVersion.VERSION_1_8 && maybeEnforceHighestVersion(javaVersion, JavaVersion.VERSION_23)
+        // 8.14 added JDK 24 support
+        if (isSameOrOlder("8.13")) {
+            return javaVersion >= JavaVersion.VERSION_1_8 && javaVersion <= JavaVersion.VERSION_23
+        }
+
+        return javaVersion >= JavaVersion.VERSION_1_8 && maybeEnforceHighestVersion(javaVersion, JavaVersion.VERSION_24)
     }
 
     @Override

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -55,7 +55,7 @@ abstract class AbstractSmokeTest extends Specification {
         static bnd = "7.1.0"
 
         // https://plugins.gradle.org/plugin/com.netflix.nebula.dependency-recommender
-        static nebulaDependencyRecommender = "12.5.1"
+        static nebulaDependencyRecommender = "12.6.0"
 
         // https://plugins.gradle.org/plugin/com.netflix.nebula.plugin-plugin
         static nebulaPluginPlugin = "21.2.2"
@@ -67,7 +67,7 @@ abstract class AbstractSmokeTest extends Specification {
         static ideaExt = "1.1.10"
 
         // https://plugins.gradle.org/plugin/com.netflix.nebula.dependency-lock
-        static nebulaDependencyLock = Versions.of("15.1.1")
+        static nebulaDependencyLock = Versions.of("15.2.0")
 
         // https://plugins.gradle.org/plugin/com.netflix.nebula.resolution-rules
         static nebulaResolutionRules = "11.4.1"
@@ -79,7 +79,7 @@ abstract class AbstractSmokeTest extends Specification {
         static asciidoctor = Versions.of("3.3.2", "4.0.4")
 
         // https://plugins.gradle.org/plugin/com.github.spotbugs
-        static spotbugs = "6.1.3"
+        static spotbugs = "6.1.7"
 
         // https://plugins.gradle.org/plugin/com.bmuschko.docker-java-application
         static docker = "9.4.0"
@@ -88,7 +88,7 @@ abstract class AbstractSmokeTest extends Specification {
         static springDependencyManagement = "1.1.7"
 
         // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-gradle-plugin
-        static springBoot = "3.4.2"
+        static springBoot = "3.4.4"
 
         // https://developer.android.com/studio/releases/build-tools
         static androidTools = "35.0.0"
@@ -119,10 +119,10 @@ abstract class AbstractSmokeTest extends Specification {
         static errorProne = "4.1.0"
 
         // https://plugins.gradle.org/plugin/com.google.protobuf
-        static protobufPlugin = "0.9.4"
+        static protobufPlugin = "0.9.5"
 
         // https://central.sonatype.com/artifact/com.google.protobuf/protobuf-java/versions
-        static protobufTools = "4.29.3"
+        static protobufTools = "4.30.2"
 
         // https://plugins.gradle.org/plugin/org.gradle.test-retry
         static testRetryPlugin = "1.6.2"
@@ -134,28 +134,28 @@ abstract class AbstractSmokeTest extends Specification {
         static undercouchDownload = Versions.of("5.6.0")
 
         // https://github.com/micronaut-projects/micronaut-gradle-plugin/releases
-        static micronaut = "4.4.5"
+        static micronaut = "4.5.1"
 
         // https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties
-        static gradleGitProperties = Versions.of("2.4.2")
+        static gradleGitProperties = Versions.of("2.5.0")
 
         // https://plugins.gradle.org/plugin/org.flywaydb.flyway
-        static flyway = Versions.of("11.3.0")
+        static flyway = Versions.of("11.4.0")
 
         // https://plugins.gradle.org/plugin/net.ltgt.apt
         static apt = Versions.of("0.21")
 
         // https://plugins.gradle.org/plugin/io.gitlab.arturbosch.detekt
-        static detekt = Versions.of("1.23.7")
+        static detekt = Versions.of("1.23.8")
 
         // https://plugins.gradle.org/plugin/com.diffplug.spotless
         static spotless = Versions.of("7.0.2")
 
         // https://plugins.gradle.org/plugin/com.google.cloud.tools.jib
-        static jib = Versions.of("3.4.4")
+        static jib = Versions.of("3.4.5")
 
         // https://plugins.gradle.org/plugin/io.freefair.lombok
-        static lombok = Versions.of("8.12")
+        static lombok = Versions.of("8.13.1")
 
         // https://plugins.gradle.org/plugin/com.moowork.node
         static node = Versions.of("1.3.1")
@@ -164,7 +164,7 @@ abstract class AbstractSmokeTest extends Specification {
         static newNode = Versions.of("7.1.0")
 
         // https://plugins.gradle.org/plugin/org.jlleitschuh.gradle.ktlint
-        static ktlint = Versions.of("12.1.2")
+        static ktlint = Versions.of("12.2.0")
 
         // https://plugins.gradle.org/plugin/org.jlleitschuh.gradle.ktlint-idea
         static ktlintIdea = Versions.of("11.6.1")
@@ -177,22 +177,22 @@ abstract class AbstractSmokeTest extends Specification {
         static nohttp = Versions.of("0.0.11")
 
         // https://plugins.gradle.org/plugin/org.jenkins-ci.jpi
-        static jenkinsJpi = Versions.of("0.52.0")
+        static jenkinsJpi = Versions.of("0.53.1")
 
         // https://github.com/cashapp/paparazzi/releases
         static paparazzi = "1.3.5"
 
         // https://mvnrepository.com/artifact/com.guardsquare/proguard-gradle
-        static proguardGradle = "7.6.1"
+        static proguardGradle = "7.7.0"
 
         // https://plugins.gradle.org/plugin/com.palantir.consistent-versions
-        static palantirConsistentVersions = "2.31.0"
+        static palantirConsistentVersions = "2.32.0"
 
         // https://github.com/etiennestuder/teamcity-build-scan-plugin/releases
         static teamCityGradlePluginRef = "v0.35"
 
         // https://github.com/jenkinsci/gradle-plugin/releases
-        static jenkinsGradlePluginRef = "gradle-2.14"
+        static jenkinsGradlePluginRef = "gradle-2.14.1"
 
         // https://github.com/gradle/develocity-bamboo-plugin/releases
         static bambooGradlePluginRef = "develocity-bamboo-plugin-2.2.3"

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.GradleVersion
 
 /**
  * https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
@@ -61,12 +60,6 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
 
         when:
         def runner = runner('checkDep')
-        if (bomSupportProvider == "nebula recommender plugin") {
-            runner.expectDeprecationWarning(
-                "Declaring an 'is-' property with a Boolean type has been deprecated. Starting with Gradle 9.0, this property will be ignored by Gradle. The combination of method name and return type is not consistent with Java Bean property rules and will become unsupported in future versions of Groovy. Add a method named 'getStrictMode' with the same behavior and mark the old one with @Deprecated, or change the type of 'netflix.nebula.dependency.recommender.provider.RecommendationProviderContainer.isStrictMode' (and the setter) to 'boolean'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#groovy_boolean_properties",
-                "https://github.com/nebula-plugins/nebula-dependency-recommender-plugin/issues/127"
-            )
-        }
         runner.build()
 
         then:

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -151,9 +151,9 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         "3.19.2"
     ]
 
-    // Current injection scripts support Develocity plugin 3.3 and above
+    // Current injection scripts support Develocity plugin 3.6.4 and above
     private static final List<String> SUPPORTED_BY_CI_INJECTION = SUPPORTED
-        .findAll { VersionNumber.parse("3.3") <= VersionNumber.parse(it) }
+        .findAll { VersionNumber.parse("3.6.4") <= VersionNumber.parse(it) }
 
     // This refers to GradleEnterprisePluginCheckInService and does not cover LegacyGradleEnterprisePluginCheckInService
     private static final VersionNumber FIRST_VERSION_SUPPORTING_CHECK_IN_SERVICE = VersionNumber.parse("3.4")

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
-import org.gradle.util.GradleVersion
 import spock.lang.Issue
 
 class NebulaPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements ValidationMessageChecker {
@@ -48,11 +47,7 @@ class NebulaPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implement
             """
 
         then:
-        runner('build')
-            .expectDeprecationWarning(
-                "Declaring an 'is-' property with a Boolean type has been deprecated. Starting with Gradle 9.0, this property will be ignored by Gradle. The combination of method name and return type is not consistent with Java Bean property rules and will become unsupported in future versions of Groovy. Add a method named 'getStrictMode' with the same behavior and mark the old one with @Deprecated, or change the type of 'netflix.nebula.dependency.recommender.provider.RecommendationProviderContainer.isStrictMode' (and the setter) to 'boolean'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#groovy_boolean_properties",
-                "https://github.com/nebula-plugins/nebula-dependency-recommender-plugin/issues/127"
-            ).build()
+        runner('build').build()
     }
 
     @Issue('https://plugins.gradle.org/plugin/com.netflix.nebula.plugin-plugin')


### PR DESCRIPTION
- **Add Best Practice: Use Plugins Block**
- **add more project toolchain options**
- **Remove speculation about plugins block**
- **Only get exception for location information if asked for.**
- **address feedback from @alllex**
- **Support Java 24 for running Gradle**
- **Make BlockingHttpServerTest work with Java 24**
- **Fix/ignore doctests on Java 24**
- **Pass native flag to the launcher in tests**
- **Add native flag to expected daemon args in tests**
- **Only get exception for location information if asked for.**
- **Remove stackAsOriginLocation()**
- **Fix tests**
- **final changes for @alllex**
- **Update Ivy to 2.5.3**
- **Feedback**
- **Update versions of smoke-tested plugins**
- **Publish version 8.14-20250404052051+0000**
