### PR TITLE
update JavaDoc of setDestinationDir in TestReport

### DIFF
--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
@@ -89,7 +89,7 @@ public abstract class TestReport extends DefaultTask {
     /**
      * Sets the directory to write the HTML report to.
      *
-     * <strong>This method is {@code @Deprecated}, please use {@link #getTestResults()} instead to access the new collection property.</strong>
+     * <strong>This method is {@code @Deprecated}, please use {@link #getDestinationDirectory()} instead to access the new collection property.</strong>
      */
     @Deprecated
     public void setDestinationDir(File destinationDir) {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
The function setDestinationDir() in TestReport.java is  Deprecated. It is instead of getDestinationDirectory(). But JavaDoc is wrong ,it links to getTestResults. It will mislead users.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
