### PR TITLE
Add avoid dependencies duplicates best practice

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_general.adoc
@@ -57,3 +57,39 @@ include::sample[dir="snippets/bestPractices/usePluginsBlock/groovy/do-this",file
 
 === Tags
 `#structuring-builds`
+
+[[avoid_duplicate_dependencies]]
+== Avoid Declaring Dependencies Multiple Times
+
+You should avoid duplicating dependencies in your build scripts, whether with different versions or in different dependency configurations.
+
+=== Explanation
+
+Duplicating dependencies in build scripts can lead to several problems:
+
+* Conflicting versions may cause unexpected behavior or runtime errors due to version mismatches
+* Confusion during maintenance of build scripts and dependencies
+
+=== Example
+
+==== Don't Do This
+
+====
+include::sample[dir="snippets/bestPractices/avoidDuplicateDependencies/kotlin",files="build.gradle.kts[tags=avoid-this]"]
+include::sample[dir="snippets/bestPractices/avoidDuplicateDependencies/groovy",files="build.gradle[tags=avoid-this]"]
+====
+
+<1> Dependency on library version `1.10.0`
+<2> Redundant declaration that can be removed
+
+==== Do This Instead
+
+====
+include::sample[dir="snippets/bestPractices/avoidDuplicateDependencies/kotlin",files="build.gradle.kts[tags=do-this]"]
+include::sample[dir="snippets/bestPractices/avoidDuplicateDependencies/groovy",files="build.gradle[tags=do-this]"]
+====
+
+<1> Declare dependency once
+
+=== Tags
+`#dependency-management`

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/groovy/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java-library'
+}
+
+// tag::avoid-this[]
+dependencies {
+    implementation("org.jetbrains:kotlinx-coroutines-core:1.10.0") // <1>
+    // ...
+    // long dependencies declaration list continues
+    // ...
+    implementation("org.jetbrains:kotlinx-coroutines-core:1.6.0") // <2>
+}
+// end::avoid-this[]
+
+// tag::do-this[]
+dependencies {
+    implementation("org.jetbrains:kotlinx-coroutines-core:1.10.0") // <1>
+}
+// end::do-this[]
+
+// dummy task to be used in tests
+tasks.register("dummyTask")

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "avoidDuplicateDependencies"

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/kotlin/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    `java-library`
+}
+
+// tag::avoid-this[]
+dependencies {
+    implementation("org.jetbrains:kotlinx-coroutines-core:1.10.0") // <1>
+    // ...
+    // long dependencies declaration list continues
+    // ...
+    implementation("org.jetbrains:kotlinx-coroutines-core:1.6.0") // <2>
+}
+// end::avoid-this[]
+
+// tag::do-this[]
+dependencies {
+    implementation("org.jetbrains:kotlinx-coroutines-core:1.10.0") // <1>
+}
+// end::do-this[]
+
+// dummy task to be used in tests
+tasks.register("dummyTask")

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "avoidDuplicateDependencies"

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/tests/avoidDuplicateDependencies.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/tests/avoidDuplicateDependencies.out
@@ -1,0 +1,3 @@
+> Task :dummyTask UP-TO-DATE
+
+BUILD SUCCESSFUL in 0s

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/tests/avoidDuplicateDependencies.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidDuplicateDependencies/tests/avoidDuplicateDependencies.sample.conf
@@ -1,0 +1,5 @@
+commands: [{
+    executable: gradle
+    args: ":dummyTask"
+    expected-output-file: avoidDuplicateDependencies.out
+}]


### PR DESCRIPTION
Add a general best practice about declaring dependencies duplicates.

./gradlew serveDocs -> http://127.0.0.1:8000/userguide/bp_general.html#best_practices_general

I also thought about adding a sample when same dependency is declared in multiple scopes.
i.e.
 
```
dependencies {
   api("foo:bar:1.0")
   implementation("foo:bar:1.0")
}
```

but I'm not sure how to add multiple samples to the single BP. So I decided to drop this sample, as it is not very bad. just a confusion. i.e. when maintaining this dependency.

Let me know if it is worth adding.