### PR TITLE
Relax test condition

### DIFF
--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -284,6 +284,8 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
         when:
         executer.withStackTraceChecksDisabled()
         executer.ignoreCleanupAssertions()
+
+        then:
         fails(
             "buildAction",
             "-PclientJdk=" + clientJdkVersion.majorVersion,
@@ -291,9 +293,6 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
             "-Porg.gradle.java.installations.paths=${AvailableJavaHomes.getAvailableJvms().collect { it.javaHome.absolutePath }.join(",")}",
             "-PgradleVersion=" + gradleVersion
         )
-
-        then:
-        failure.assertHasErrorOutput("Unsupported major.minor version 52.0")
 
         where:
         gradleDaemonJdkVersion  | gradleVersion


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes https://github.com/gradle/gradle/issues/32972

We’ve observed on CI that older Gradle builds running on Java versions lower than those supported by the Tooling API build actions can fail in multiple ways, not just with the straightforward `Unsupported major.minor version X` error. To make the integration test more robust, this change ensures the test only checks that the scenario fails, without depending on any specific output messages. This avoids brittle assumptions about the build failure message.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
