### PR TITLE
Avoid using default PMD ruleset if custom is provided

### DIFF
--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdCustomRulesIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdCustomRulesIntegrationTest.groovy
@@ -58,6 +58,7 @@ class PmdCustomRulesIntegrationTest extends AbstractPmdPluginVersionIntegrationT
                 id "java-library"
             }
             pmd {
+                consoleOutput = true
                 toolVersion = '$version'
                 incrementalAnalysis = ${supportIncrementalAnalysis()}
             }
@@ -72,6 +73,42 @@ class PmdCustomRulesIntegrationTest extends AbstractPmdPluginVersionIntegrationT
         expect:
         fails(":pmdMain")
         errorOutput.contains("PMD rule violations were found")
+        output.contains("AvoidCatchingThrowable")
+    }
+
+    def "overrides default rules if custom rules are configured in pmdMain only"() {
+        given:
+        buildFile << """
+            plugins {
+                id "pmd"
+                id "java-library"
+            }
+
+            ${requiredSourceCompatibility()}
+
+            ${mavenCentralRepository()}
+
+            pmd {
+                toolVersion = '$version'
+                incrementalAnalysis = ${supportIncrementalAnalysis()}
+            }
+
+            pmdMain {
+                $customRuleSetConfig
+            }
+        """
+
+        file("src/main/java/org/gradle/ruleusing/Class1.java") << breakingDefaultRulesCode()
+        file("rules.xml") << customRuleSet()
+
+        expect:
+        succeeds(":pmdMain")
+
+        where:
+        customRuleSetConfig << [
+            'ruleSetConfig = resources.text.fromFile("rules.xml")',
+            'ruleSetFiles = files("rules.xml")'
+        ]
     }
 
     private static breakingDefaultRulesCode() {
@@ -83,7 +120,8 @@ class PmdCustomRulesIntegrationTest extends AbstractPmdPluginVersionIntegrationT
                 void foo() {
                    try {
                    } catch(Throwable t) {
-                       System.out.println("Rule from category/java/errorprone.xml: Should not call throwable");
+                       // AvoidCatchingThrowable: https://docs.pmd-code.org/latest/pmd_rules_java_errorprone.html#avoidcatchingthrowable
+                       System.out.println("Rule from category/java/errorprone.xml: Should not catch throwable");
                    }
                 }
             }

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
@@ -49,6 +49,7 @@ import org.gradle.workers.WorkQueue;
 import org.jspecify.annotations.Nullable;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -97,11 +98,18 @@ public abstract class Pmd extends AbstractCodeQualityTask implements Reporting<P
         parameters.getAntLibraryClasspath().setFrom(getPmdClasspath());
         parameters.getPmdClasspath().setFrom(getPmdClasspath());
         parameters.getTargetJdk().set(getTargetJdk());
-        parameters.getRuleSets().set(getRuleSets());
+
         parameters.getRuleSetConfigFiles().from(getRuleSetFiles());
         if (getRuleSetConfig() != null) {
             parameters.getRuleSetConfigFiles().from(getRuleSetConfig().asFile());
         }
+        if (getRuleSets().size() == 1 && getRuleSets().get(0).equals("category/java/errorprone.xml")
+                && !parameters.getRuleSetConfigFiles().isEmpty()) {
+            parameters.getRuleSets().set(Collections.emptyList());
+        } else {
+            parameters.getRuleSets().set(getRuleSets());
+        }
+
         parameters.getIgnoreFailures().set(getIgnoreFailures());
         parameters.getConsoleOutput().set(isConsoleOutput());
         parameters.getStdOutIsAttachedToTerminal().set(stdOutIsAttachedToTerminal());


### PR DESCRIPTION
Fixes #32980 

### Context
This solution is not good, maybe you can point me in the correct solution.

If the user would explicitly configure `ruleSets = ["category/java/errorprone.xml"]`, then this would be ignored as the property has the default value. We would need to figure out, if the user provided just a custom ruleset or also additionally the property ruleSets...

This seems to be working with conventions. Is this possible for the tasks as well?

What's missing: Unit tests (where?), maybe a better documentation to address #8514.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
