### PR TITLE
Add SPDX licence identifier to Gradle wrapper manifest

### DIFF
--- a/platforms/core-runtime/wrapper-main/build.gradle.kts
+++ b/platforms/core-runtime/wrapper-main/build.gradle.kts
@@ -63,6 +63,7 @@ val executableJar by tasks.registering(Jar::class) {
     manifest {
         attributes.remove(Attributes.Name.IMPLEMENTATION_VERSION.toString())
         attributes(Attributes.Name.IMPLEMENTATION_TITLE.toString() to "Gradle Wrapper")
+        attributes("SPDX-License-Identifier" to "Apache-2.0")
     }
     from(layout.projectDirectory.dir("src/executable/resources"))
     from(sourceSets.main.get().output)

--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -35,7 +35,7 @@ import java.util.jar.Manifest
 import static org.hamcrest.CoreMatchers.containsString
 
 class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
-    private static final HashCode EXPECTED_WRAPPER_JAR_HASH = HashCode.fromString("81a82aaea5abcc8ff68b3dfcb58b3c3c429378efd98e7433460610fecd7ae45f")
+    private static final HashCode EXPECTED_WRAPPER_JAR_HASH = HashCode.fromString("9687bf4e8beb2c293cfd1393cbf2854ef68f921757302116033f476289abf7b0")
 
     def "generated wrapper scripts use correct line separators"() {
         buildFile << """
@@ -183,9 +183,10 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         Manifest manifest = contents.file('META-INF/MANIFEST.MF').withInputStream { new Manifest(it) } as Manifest
         with(manifest.mainAttributes) {
-            size() == 2
+            size() == 3
             getValue(Attributes.Name.MANIFEST_VERSION) == '1.0'
             getValue(Attributes.Name.IMPLEMENTATION_TITLE) == 'Gradle Wrapper'
+            getValue("SPDX-License-Identifier") == "Apache-2.0"
         }
     }
 


### PR DESCRIPTION
Fixes #31452

**Maintainers**: Please advise if `SPDX-License-Identifier` and/or `Apache-2.0` should be extracted to constants, and if so where should those constants live. The other manifest entries I've seen use constants from `java.util.jar.Attributes.Name`, which only contains very standard manifest keys, or use inline `String`. I didn't see an existing class in the project where such a constant might be placed. If a new place to store constants is needed, would a file in `org.gradle.api.java.archives.internal` be an appropriate place? Bear in mind, there will be at least one other SPDX manifest key (`SPDX-FileCopyrightText`) needed when addressing #31554.

### Context
Some users may benefit from the additional license metadata, which will now advertise the license as Apache-2.0 in `MANIFEST.MF` of `gradle-wrapper.jar`.

This metadata can be used by automated tools that scan files for license compliance, as well as curious individuals who enjoy reading `MANIFEST.MF` files.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
