### PR TITLE
Replace warning with error when no tests are executed

### DIFF
--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SimpleJavaContinuousIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SimpleJavaContinuousIntegrationTest.groovy
@@ -28,6 +28,13 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
     def setup() {
         buildFile << """
             apply plugin: 'java'
+
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation "junit:junit:4.13.2"
+            }
         """
     }
 
@@ -97,7 +104,9 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
     def "can run tests"() {
         when:
         def sourceFile = file("src/main/java/Thing.java") << "class Thing {}"
-        def testFile = file("src/test/java/TestThing.java") << "class TestThing extends Thing{}"
+        def testFile = file("src/test/java/TestThing.java") << "public class TestThing extends Thing { @org.junit.Test public void test() {} }"
+
+        then:
         def resourceFile = file("src/main/resources/thing.text") << "thing"
 
         then:
@@ -113,7 +122,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         skipped(":processResources")
 
         when:
-        testFile.text = "class TestThing extends Thing { static public int FLAG = 1; }"
+        testFile.text = "public class TestThing extends Thing { static public int FLAG = 1; @org.junit.Test public void test() {} }"
 
         then:
         buildTriggeredAndSucceeded()
@@ -132,7 +141,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
     def "failing main source build ignores changes to test source"() {
         when:
         def sourceFile = file("src/main/java/Thing.java") << "class Thing {}"
-        def testSourceFile = file("src/test/java/ThingTest.java") << "class ThingTest {}"
+        def testSourceFile = file("src/test/java/ThingTest.java") << "public class ThingTest { @org.junit.Test public void test() {} }"
 
         then:
         succeeds("test")
@@ -152,7 +161,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         failureDescriptionStartsWith("Execution failed for task ':compileJava'.")
 
         when:
-        testSourceFile.text = "class ThingTest {}"
+        testSourceFile.text = "public class ThingTest { @org.junit.Test public void test() {} }"
 
         then:
         noBuildTriggered()

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -96,7 +96,9 @@ Due to the way the configurations were created, they were unresolvable and produ
 These configurations are no longer created or used.
 
 ==== Gradle no longer implicitly builds certain artifacts when running assemble
-In previous versions of Gradle, the `assemble` task would implicitly build artifacts of any configuration where the `visible` flag was not set to `false`.  This behavior has been removed in Gradle 9.0.  If you have a custom configuration whose artifacts should be built when running `assemble`, you should add a dependency from the artifact to the `assemble` task.
+In previous versions of Gradle, the `assemble` task would implicitly build artifacts of any configuration where the `visible` flag was not set to `false`.
+This behavior has been removed in Gradle 9.0.
+If you have a custom configuration whose artifacts should be built when running `assemble`, you should add a dependency from the artifact to the `assemble` task.
 
 ====
 [.multi-language-sample]
@@ -144,7 +146,9 @@ tasks.named("assemble") {
 ====
 
 ==== Gradle no longer implicitly adds certain artifacts to the archives configuration
-In previous versions of Gradle, the `archives` configuration would implicitly include artifacts of any configuration where the `visible` flag was not set to `false`.  This behavior has been removed in Gradle 9.0.  If you have a custom configuration whose artifacts should be included in the `archives` configuration, you should add the artifact directly to the `archives` configuration.
+In previous versions of Gradle, the `archives` configuration would implicitly include artifacts of any configuration where the `visible` flag was not set to `false`.
+This behavior has been removed in Gradle 9.0.
+If you have a custom configuration whose artifacts should be included in the `archives` configuration, you should add the artifact directly to the `archives` configuration.
 
 ====
 [.multi-language-sample]
@@ -196,16 +200,30 @@ configurations {
 ====
 
 ==== The Ear and War plugins may build additional artifacts when running assemble
-In previous versions of Gradle, special handling would apply when the `ear`, `war` and `java` plugins were applied to a project in any combination. For example, if the `ear` plugin was applied, the war and jar artifacts would not be built when the `assemble` task executed.  Similarly, if the `war` plugin were applied, the jar artifact would not be built.  This special handling has been removed in Gradle 9.0.  This means that the artifacts for all plugins applied will be built when the `assemble` task is executed.  For example, if the `ear`, `war`, and `jar` plugins are applied to a project, the ear, war and jar artifacts will all be built when the `assemble` task is executed.
+In previous versions of Gradle, special handling would apply when the `ear`, `war` and `java` plugins were applied to a project in any combination.
+For example, if the `ear` plugin was applied, the war and jar artifacts would not be built when the `assemble` task executed.
+Similarly, if the `war` plugin were applied, the jar artifact would not be built.
+This special handling has been removed in Gradle 9.0.
+This means that the artifacts for all plugins applied will be built when the `assemble` task is executed.  For example, if the `ear`, `war`, and `jar` plugins are applied to a project, the ear, war and jar artifacts will all be built when the `assemble` task is executed.
 
 ==== The Ear and War plugins may add additional artifacts to the archives configuration
-In previous versions of Gradle, special handling would apply when the `ear`, `war` and `java` plugins were applied to a project in any combination. For example, if the `ear` plugin was applied, the war and jar artifacts would not be included in the `archives` configuration.  Similarly, if the `war` plugin were applied, the jar artifact would not be included in the `archives` configuration.  This special handling has been removed in Gradle 9.0.  This means that the artifacts for all plugins applied will be included in the `archives` configuration.  For example, if the `ear`, `war`, and `jar` plugins are applied to a project, the ear, war and jar artifacts will all be included in the `archives` configuration.
+In previous versions of Gradle, special handling would apply when the `ear`, `war` and `java` plugins were applied to a project in any combination.
+For example, if the `ear` plugin was applied, the war and jar artifacts would not be included in the `archives` configuration.
+Similarly, if the `war` plugin were applied, the jar artifact would not be included in the `archives` configuration.
+This special handling has been removed in Gradle 9.0.
+This means that the artifacts for all plugins applied will be included in the `archives` configuration.
+For example, if the `ear`, `war`, and `jar` plugins are applied to a project, the ear, war and jar artifacts will all be included in the `archives` configuration.
 
 ==== `kotlinDslPluginOptions.jvmTarget` has been removed
 
 The `kotlinDslPluginOptions.jvmTarget` property, which was previously used to configure the JVM target for code compiled with the `kotlin-dsl` plugin, has been removed in Gradle 9.0.
 
 To set the target JVM version going forward, you should <<kotlin_dsl#sec:kotlin-dsl_plugin,configure a Java Toolchain>> instead.
+
+==== The `test` task now fails when no tests are discovered
+When test sources are present and no filters are applied, if the `test` task executes but does not discover any tests, it will now fail with an error.
+This is to help prevent misconfigurations where the tests are written for one test framework but the test task is mistakenly configured to use another test framework.
+When filters are present, however, the value of `failOnNoMatchingTests` will determine whether the task fails or not when all tests are filtered out.
 
 [[changes_8.14]]
 == Upgrading from 8.13 and earlier

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BuildProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BuildProgressCrossVersionSpec.groovy
@@ -132,6 +132,9 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification implements W
         given:
         buildFile << """
             allprojects { apply plugin: 'java' }
+
+            // This just prevents Gradle from failing because there are test sources but no tests
+            test { include 'foo' }
 """
         file("src/main/java/Thing.java") << """class Thing { }"""
         file("src/test/java/Thing.java") << """class ThingTest { }"""

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
@@ -55,30 +55,6 @@ class JavaProjectIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    void handlesTestSrcWhichDoesNotContainAnyTestCases() {
-        given:
-        testFile("build.gradle") << """
-            plugins {
-                id("java")
-            }
-
-            ${mavenCentralRepository()}
-
-            testing.suites.test.useJUnit()
-        """
-        testFile("src/test/java/org/gradle/NotATest.java") << """
-            package org.gradle;
-            public class NotATest {}
-        """
-
-        expect:
-        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
-            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
-        executer.withTasks("build").run()
-    }
-
-    @Test
     void javadocGenerationFailureBreaksBuild() throws IOException {
         TestFile buildFile = testFile("build.gradle")
         buildFile.write("apply plugin: 'java'")

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
@@ -46,7 +46,7 @@ class TestTaskFailOnNoTestIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         fails("test")
-        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.")
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration.")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/30315")

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
@@ -37,19 +37,16 @@ class TestTaskFailOnNoTestIntegrationTest extends AbstractIntegrationSpec {
         succeeds("test")
     }
 
-    def "test succeeds with warning if no test was executed"() {
+    def "test fails when no test was executed"() {
         createBuildFileWithJUnitJupiter()
 
         file("src/test/java/NotATest.java") << """
             public class NotATest {}
         """
 
-        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
-            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
-
         expect:
-        succeeds("test")
+        fails("test")
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/30315")

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailOnNoTestIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailOnNoTestIntegrationTest.groovy
@@ -41,12 +41,9 @@ class TestNGFailOnNoTestIntegrationTest extends TestNGTestFrameworkIntegrationTe
             public class NotATest {}
         """
 
-        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
-            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
-
         expect:
-        succeeds('test')
+        fails('test')
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.")
     }
 
     def "test source and test task use different test frameworks"() {
@@ -65,11 +62,8 @@ class TestNGFailOnNoTestIntegrationTest extends TestNGTestFrameworkIntegrationTe
 
         createPassingFailingTest()
 
-        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
-            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
-
         expect:
-        succeeds('test')
+        fails('test')
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.")
     }
 }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailOnNoTestIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailOnNoTestIntegrationTest.groovy
@@ -43,7 +43,7 @@ class TestNGFailOnNoTestIntegrationTest extends TestNGTestFrameworkIntegrationTe
 
         expect:
         fails('test')
-        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.")
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration.")
     }
 
     def "test source and test task use different test frameworks"() {
@@ -64,6 +64,6 @@ class TestNGFailOnNoTestIntegrationTest extends TestNGTestFrameworkIntegrationTe
 
         expect:
         fails('test')
-        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.")
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration.")
     }
 }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
@@ -108,13 +108,10 @@ class TestNGTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegratio
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
-            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
-        succeeds "test"
+        fails "test"
 
         then:
-        testResult.assertNoTestClassesExecuted()
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/18566")

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
@@ -111,7 +111,7 @@ class TestNGTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegratio
         fails "test"
 
         then:
-        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.")
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration.")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/18566")

--- a/platforms/jvm/testing-jvm/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
+++ b/platforms/jvm/testing-jvm/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
@@ -199,7 +199,7 @@ class TestTaskSpec extends AbstractProjectBuilderSpec {
         def closure = Mock(Closure)
 
         given:
-        expectTestSuitePasses()
+        expectTestPasses()
 
         task.beforeSuite(closure)
 
@@ -216,7 +216,7 @@ class TestTaskSpec extends AbstractProjectBuilderSpec {
         def closure = Mock(Closure)
 
         given:
-        expectTestSuitePasses()
+        expectTestPasses()
 
         task.afterSuite(closure)
 

--- a/platforms/jvm/testing-jvm/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/platforms/jvm/testing-jvm/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -26,10 +26,13 @@ import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree
 import org.gradle.api.internal.provider.AbstractProperty
+import org.gradle.api.internal.tasks.testing.TestCompleteEvent
+import org.gradle.api.internal.tasks.testing.TestDescriptorInternal
 import org.gradle.api.internal.tasks.testing.TestExecuter
 import org.gradle.api.internal.tasks.testing.TestExecutionSpec
 import org.gradle.api.internal.tasks.testing.TestFramework
 import org.gradle.api.internal.tasks.testing.TestResultProcessor
+import org.gradle.api.internal.tasks.testing.TestStartEvent
 import org.gradle.api.internal.tasks.testing.junit.JUnitTestFramework
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider
 import org.gradle.api.internal.tasks.testing.report.TestReporter
@@ -61,6 +64,8 @@ class TestTest extends AbstractConventionTaskTest {
 
     def testExecuterMock = Mock(TestExecuter)
     def testFrameworkMock = Mock(TestFramework)
+
+
 
     private FileCollection classpathMock = TestFiles.fixed(new File("classpath"))
     private Test test
@@ -101,7 +106,9 @@ class TestTest extends AbstractConventionTaskTest {
         test.executeTests()
 
         then:
-        1 * testExecuterMock.execute(_ as TestExecutionSpec, _ as TestResultProcessor)
+        1 * testExecuterMock.execute(_ as TestExecutionSpec, _ as TestResultProcessor) >> { TestExecutionSpec testExecutionSpec, TestResultProcessor processor ->
+            oneSuccessfulTest(processor)
+        }
     }
 
     def "calls test reporter if set"() {
@@ -115,7 +122,9 @@ class TestTest extends AbstractConventionTaskTest {
 
         then:
         1 * testReporter.generateReport(_ as TestResultsProvider, reportDir)
-        1 * testExecuterMock.execute(_ as TestExecutionSpec, _ as TestResultProcessor)
+        1 * testExecuterMock.execute(_ as TestExecutionSpec, _ as TestResultProcessor) >> { TestExecutionSpec testExecutionSpec, TestResultProcessor processor ->
+            oneSuccessfulTest(processor)
+        }
     }
 
     def "generates test report if no reporter set"() {
@@ -127,7 +136,9 @@ class TestTest extends AbstractConventionTaskTest {
 
         then:
         reportDir.assertContainsDescendants("index.html")
-        1 * testExecuterMock.execute(_ as TestExecutionSpec, _ as TestResultProcessor)
+        1 * testExecuterMock.execute(_ as TestExecutionSpec, _ as TestResultProcessor) >> { TestExecutionSpec testExecutionSpec, TestResultProcessor processor ->
+            oneSuccessfulTest(processor)
+        }
     }
 
     def "execute with test failures and ignore failures"() {
@@ -139,7 +150,9 @@ class TestTest extends AbstractConventionTaskTest {
         test.executeTests()
 
         then:
-        1 * testExecuterMock.execute(_ as TestExecutionSpec, _ as TestResultProcessor)
+        1 * testExecuterMock.execute(_ as TestExecutionSpec, _ as TestResultProcessor) >> { TestExecutionSpec testExecutionSpec, TestResultProcessor processor ->
+            oneSuccessfulTest(processor)
+        }
     }
 
     def "scans for test classes in the classes dir"() {
@@ -342,5 +355,36 @@ class TestTest extends AbstractConventionTaskTest {
         def e = thrown(AbstractProperty.PropertyQueryException)
         assertHasMatchingCause(e, m -> m.startsWith("Toolchain installation '${invalidJavac.parentFile.parentFile.absolutePath}' could not be probed:"))
         assertHasMatchingCause(e, m -> m ==~ /Cannot run program .*java.*/)
+    }
+
+    def oneSuccessfulTest(TestResultProcessor processor) {
+        def suiteDescriptor = Mock(TestDescriptorInternal)
+        def testDescriptor = Mock(TestDescriptorInternal)
+        suiteDescriptor.id >> "suite"
+        suiteDescriptor.parent >> null
+        suiteDescriptor.composite >> true
+
+        testDescriptor.id >> "test"
+        testDescriptor.parent >> suiteDescriptor
+        testDescriptor.composite >> false
+        testDescriptor.className >> "class"
+        testDescriptor.classDisplayName >> "class"
+        testDescriptor.name >> "method"
+        testDescriptor.displayName >> "method"
+
+        def suiteStartEvent = Stub(TestStartEvent) {
+            getParentId() >> null
+        }
+        def testStartEvent = Stub(TestStartEvent) {
+            getParentId() >> "suite"
+        }
+        def finishEvent = Stub(TestCompleteEvent) {
+            getResultType() >> TestResult.ResultType.SUCCESS
+        }
+
+        processor.started(suiteDescriptor, suiteStartEvent)
+        processor.started(testDescriptor, testStartEvent)
+        processor.completed("test", finishEvent)
+        processor.completed("suite", finishEvent)
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -549,7 +549,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
             // - Otherwise, this is fine - the task should succeed with no warnings or errors
             if (testsAreNotFiltered()) {
                 if (testCountLogger.getTotalDiscoveredItems() == 0) {
-                    throw new TestExecutionException("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.");
+                    throw new TestExecutionException("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration.");
                 }
             } else if (shouldFailOnNoMatchingTests()) {
                 throw new TestExecutionException(createNoMatchingTestErrorMessage());

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -65,7 +65,6 @@ import org.gradle.api.tasks.testing.logging.TestLoggingContainer;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
 import org.gradle.internal.concurrent.CompositeStoppable;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.dispatch.Dispatch;
 import org.gradle.internal.dispatch.MethodInvocation;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -545,12 +544,12 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
             handleTestFailures();
         } else if (testCountLogger.getTotalTests() == 0) {
             // No tests were executed, the following rules apply:
-            // - If there are no filters, and no tests or test suites were discovered, emit a deprecation warning
+            // - If there are no filters, and no tests or test suites were discovered, fail
             // - If there are filters and the task is configured to fail when no tests match the filters, throw an exception
             // - Otherwise, this is fine - the task should succeed with no warnings or errors
             if (testsAreNotFiltered()) {
                 if (testCountLogger.getTotalDiscoveredItems() == 0) {
-                    emitDeprecationMessage();
+                    throw new TestExecutionException("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.");
                 }
             } else if (shouldFailOnNoMatchingTests()) {
                 throw new TestExecutionException(createNoMatchingTestErrorMessage());
@@ -560,14 +559,6 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
 
     private boolean shouldFailOnNoMatchingTests() {
         return patternFiltersSpecified() && filter.isFailOnNoMatchingTests();
-    }
-
-    private void emitDeprecationMessage() {
-        DeprecationLogger.deprecateBehaviour("No test executed.")
-            .withAdvice("There are test sources present but no test was executed. Please check your test configuration.")
-            .willBecomeAnErrorInGradle9()
-            .withUpgradeGuideSection(8, "test_task_fail_on_no_test_executed")
-            .nagUser();
     }
 
     boolean testsAreNotFiltered() {

--- a/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -153,18 +153,15 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         failure.assertHasCause("There were failing tests. See the report at:")
     }
 
-    def "lack of tests produce an empty report"() {
+    def "lack of tests when sources are present and no filters causes failure"() {
         given:
         createEmptyProject()
 
         when:
-        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
-            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
-        succeeds "check"
+        fails "check"
 
         then:
-        testResult.assertNoTestClassesExecuted()
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.")
     }
 
     def "adding and removing tests remove old tests from reports"() {

--- a/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -161,7 +161,7 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         fails "check"
 
         then:
-        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration.  Please check your test configuration.")
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration.")
     }
 
     def "adding and removing tests remove old tests from reports"() {


### PR DESCRIPTION
We would now fail in 9.0 when there are test sources and no filters are applied, but no tests are actually executed.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
