### PR TITLE
Remove deprecated getBaseDir() method on ReportingExtension

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
@@ -43,7 +43,7 @@ tasks.register<UpdateAgpVersions>("updateAgpVersions") {
 
 tasks.register<UpdateKotlinVersions>("updateKotlinVersions") {
     comment = " Generated - Update by running `./gradlew updateKotlinVersions`"
-    minimumSupported = "1.9.21"
+    minimumSupported = "2.0.0"
     propertiesFile = layout.projectDirectory.file("gradle/dependency-management/kotlin-versions.properties")
     compatibilityDocFile = layout.projectDirectory.file("platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc")
 }

--- a/gradle/dependency-management/kotlin-versions.properties
+++ b/gradle/dependency-management/kotlin-versions.properties
@@ -1,2 +1,2 @@
 # Generated - Update by running `./gradlew updateKotlinVersions`
-latests=1.9.21,1.9.25,2.0.0,2.0.21,2.1.0,2.1.20
+latests=2.0.0,2.0.21,2.1.0,2.1.20

--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -67,7 +67,7 @@ We encourage users to try it out and let us know.
 [[kotlin]]
 == Kotlin
 
-Gradle is tested with Kotlin 1.9.21 through 2.1.20.
+Gradle is tested with Kotlin 2.0.0 through 2.1.20.
 Beta and RC versions may or may not work.
 
 .Embedded Kotlin version

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -42,7 +42,7 @@ The previous step will help you identify potential problems by issuing deprecati
 
 ==== Lowest supported Kotlin Gradle Plugin version change
 
-Starting with Gradle 9.0, the minimum supported Kotlin Gradle Plugin version is 1.9.21.
+Starting with Gradle 9.0, the minimum supported Kotlin Gradle Plugin version is 2.0.0.
 Earlier versions are no longer supported as they rely on Gradle APIs that have been removed.
 
 For Gradle 8.x, the minimum supported version was 1.6.10.

--- a/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
@@ -136,19 +136,4 @@ class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds "verify"
     }
-
-    def "ReportingExtension#getBaseDir is deprecated"() {
-        buildFile << """
-            plugins {
-                id("java-base")
-            }
-
-            def reporting = project.extensions.getByType(ReportingExtension)
-            println(reporting.baseDir)
-        """
-
-        expect:
-        executer.expectDocumentedDeprecationWarning("The ReportingExtension.getBaseDir() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the getBaseDirectory() property method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#reporting-base-dir")
-        succeeds("help")
-    }
 }

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/ReportingExtension.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/ReportingExtension.java
@@ -21,7 +21,6 @@ import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 
 import javax.inject.Inject;
@@ -62,25 +61,6 @@ public abstract class ReportingExtension {
         this.baseDirectory = project.getObjects().directoryProperty();
         this.reports = project.getObjects().polymorphicDomainObjectContainer(ReportSpec.class);
         baseDirectory.set(project.getLayout().getBuildDirectory().dir(DEFAULT_REPORTS_DIR_NAME));
-    }
-
-    /**
-     * The base directory for all reports
-     * <p>
-     * This value can be changed, so any files derived from this should be calculated on demand.
-     *
-     * @return The base directory for all reports
-     * @deprecated use {@link #getBaseDirectory()} property instead
-     */
-    @Deprecated
-    public File getBaseDir() {
-        DeprecationLogger.deprecateMethod(ReportingExtension.class, "getBaseDir()")
-            .replaceWith("getBaseDirectory() property")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "reporting-base-dir")
-            .nagUser();
-
-        return baseDirectory.getAsFile().get();
     }
 
     /**

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -482,6 +482,14 @@
         },
         {
             "type": "org.gradle.api.reporting.ReportingExtension",
+            "member": "Method org.gradle.api.reporting.ReportingExtension.getBaseDir()",
+            "acceptation": "Removed deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.reporting.ReportingExtension",
             "member": "Method org.gradle.api.reporting.ReportingExtension.setBaseDir(java.io.File)",
             "acceptation": "Removed deprecated method",
             "changes": [


### PR DESCRIPTION
Removes this deprecated method. 

Note that KGP 1.9 and below use this method.  This effectively makes KGP 2.0.0 and above the only versions of KGP supported on Gradle 9.0 and above.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
