### PR TITLE
Remove Dependency.contentEquals

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -803,7 +803,7 @@ tasks.withType(JavaCompile) {
 [[deprecated_content_equals]]
 ==== Deprecated `Dependency#contentEquals(Dependency)`
 
-The link:{javadocPath}/org/gradle/api/artifacts/Dependency.html#contentEquals(org.gradle.api.artifacts.Dependency)[Dependency#contentEquals(Dependency)] method has been deprecated and will be removed in Gradle 9.0.
+The `Dependency#contentEquals(Dependency)` method has been deprecated and will be removed in Gradle 9.0.
 
 The method was originally intended to compare dependencies based on their actual target component, regardless of whether they were of different dependency type.
 The existing method does not behave as specified by its Javadoc, and we do not plan to introduce a replacement that does.

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
@@ -178,14 +178,12 @@ task checkDeps
                 conf gradleApi()
             }
 
-            assert dependencies.gradleApi().contentEquals(dependencies.gradleApi())
             assert dependencies.gradleApi().is(dependencies.gradleApi())
             assert dependencies.gradleApi() == dependencies.gradleApi()
             assert configurations.conf.dependencies.contains(dependencies.gradleApi())
         """
 
         then:
-        executer.expectDocumentedDeprecationWarning("The Dependency.contentEquals(Dependency) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Object.equals(Object) instead Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_content_equals")
         succeeds("help")
     }
 
@@ -232,21 +230,4 @@ task checkDeps
         result.hasErrorOutput("Adding a Configuration as a dependency is no longer allowed as of Gradle 8.0.")
     }
 
-    def "contentEquals is deprecated"() {
-        buildFile << """
-            def d1 = dependencies.create(files())
-            def d2 = dependencies.create('org.foo:baz:1.0')
-            def d3 = dependencies.create(project)
-
-            def other = dependencies.create('org.other:foo:1.0')
-
-            d1.contentEquals(other)
-            d2.contentEquals(other)
-            d3.contentEquals(other)
-        """
-
-        expect:
-        3.times { executer.expectDocumentedDeprecationWarning("The Dependency.contentEquals(Dependency) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Object.equals(Object) instead Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_content_equals") }
-        succeeds("help")
-    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultExternalModuleDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultExternalModuleDependency.java
@@ -16,11 +16,9 @@
 
 package org.gradle.api.internal.artifacts.dependencies;
 
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.MutableVersionConstraint;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.jspecify.annotations.Nullable;
 
 public class DefaultExternalModuleDependency extends AbstractExternalModuleDependency implements ExternalModuleDependency {
@@ -44,25 +42,4 @@ public class DefaultExternalModuleDependency extends AbstractExternalModuleDepen
         return copiedModuleDependency;
     }
 
-    @Override
-    @Deprecated
-    public boolean contentEquals(Dependency dependency) {
-
-        DeprecationLogger.deprecateMethod(Dependency.class, "contentEquals(Dependency)")
-            .withAdvice("Use Object.equals(Object) instead")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "deprecated_content_equals")
-            .nagUser();
-
-        if (this == dependency) {
-            return true;
-        }
-        if (dependency == null || getClass() != dependency.getClass()) {
-            return false;
-        }
-
-        ExternalModuleDependency that = (ExternalModuleDependency) dependency;
-        return isContentEqualsFor(that);
-
-    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -131,10 +131,6 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
        return rejectedVersions;
     }
 
-    public String getVersion() {
-        return requiredVersion.isEmpty() ? preferredVersion : requiredVersion;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -16,10 +16,8 @@
 
 package org.gradle.api.internal.artifacts.dependencies;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.capability.DefaultSpecificCapabilitySelector;
@@ -100,31 +98,6 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     }
 
     @Override
-    @Deprecated
-    public boolean contentEquals(Dependency dependency) {
-
-        DeprecationLogger.deprecateMethod(Dependency.class, "contentEquals(Dependency)")
-            .withAdvice("Use Object.equals(Object) instead")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "deprecated_content_equals")
-            .nagUser();
-
-        if (this == dependency) {
-            return true;
-        }
-        if (getClass() != dependency.getClass()) {
-            return false;
-        }
-
-        DefaultProjectDependency that = (DefaultProjectDependency) dependency;
-        if (!isCommonContentEquals(that)) {
-            return false;
-        }
-
-        return getTargetProjectIdentity().equals(that.getTargetProjectIdentity());
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -134,20 +107,8 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         }
 
         DefaultProjectDependency that = (DefaultProjectDependency) o;
-        if (!this.getTargetProjectIdentity().equals(that.getTargetProjectIdentity())) {
-            return false;
-        }
-        if (getTargetConfiguration() != null ? !this.getTargetConfiguration().equals(that.getTargetConfiguration())
-            : that.getTargetConfiguration() != null) {
-            return false;
-        }
-        if (!Objects.equal(getAttributes(), that.getAttributes())) {
-            return false;
-        }
-        if (!Objects.equal(getCapabilitySelectors(), that.getCapabilitySelectors())) {
-            return false;
-        }
-        return true;
+        return getTargetProjectIdentity().equals(that.getTargetProjectIdentity()) &&
+            isCommonContentEquals(that);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DelegatingProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DelegatingProjectDependency.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.catalog;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
@@ -181,12 +180,6 @@ public class DelegatingProjectDependency implements ProjectDependencyInternal {
     @Nullable
     public String getVersion() {
         return delegate.getVersion();
-    }
-
-    @Override
-    @Deprecated
-    public boolean contentEquals(Dependency dependency) {
-        return delegate.contentEquals(dependency);
     }
 
     @Override

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Dependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Dependency.java
@@ -50,17 +50,6 @@ public interface Dependency {
     String getVersion();
 
     /**
-     * Returns whether two dependencies have identical values for their properties. A dependency is an entity with a
-     * key. Therefore dependencies might be equal and yet have different properties.
-     *
-     * @param dependency The dependency to compare this dependency with
-     *
-     * @deprecated Use {@link Object#equals(Object)} instead.
-     */
-    @Deprecated
-    boolean contentEquals(Dependency dependency);
-
-    /**
      * Creates and returns a new dependency with the property values of this one.
      *
      * @return The copy. Never returns null.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -46,17 +46,19 @@ import java.util.Set;
 import static org.gradle.util.internal.ConfigureUtil.configureUsing;
 
 public abstract class AbstractModuleDependency implements ModuleDependency {
+
     private final static Logger LOG = Logging.getLogger(AbstractModuleDependency.class);
 
+    // TODO: Require these to be provided upon construction
     private AttributesFactory attributesFactory;
     private NotationParser<Object, Capability> capabilityNotationParser;
     private ObjectFactory objectFactory;
+
     private DefaultExcludeRuleContainer excludeRuleContainer = new DefaultExcludeRuleContainer();
     private Set<DependencyArtifact> artifacts = new LinkedHashSet<>();
     private ImmutableActionSet<ModuleDependency> onMutate = ImmutableActionSet.empty();
     private @Nullable AttributeContainerInternal attributes;
     private @Nullable ModuleDependencyCapabilitiesInternal moduleDependencyCapabilities;
-
     private @Nullable String configuration;
     private @Nullable String reason;
     private boolean transitive = true;
@@ -85,9 +87,8 @@ public abstract class AbstractModuleDependency implements ModuleDependency {
         return this;
     }
 
-    @Nullable
     @Override
-    public String getTargetConfiguration() {
+    public @Nullable String getTargetConfiguration() {
         return configuration;
     }
 
@@ -136,7 +137,7 @@ public abstract class AbstractModuleDependency implements ModuleDependency {
     }
 
     @Override
-    public DependencyArtifact artifact(Closure configureClosure) {
+    public DependencyArtifact artifact(@SuppressWarnings("rawtypes") Closure configureClosure) {
         return artifact(configureUsing(configureClosure));
     }
 
@@ -181,47 +182,15 @@ public abstract class AbstractModuleDependency implements ModuleDependency {
         }
     }
 
-    protected boolean isKeyEquals(ModuleDependency dependencyRhs) {
-        if (getGroup() != null ? !getGroup().equals(dependencyRhs.getGroup()) : dependencyRhs.getGroup() != null) {
-            return false;
-        }
-        if (!getName().equals(dependencyRhs.getName())) {
-            return false;
-        }
-        if (getTargetConfiguration() != null ? !getTargetConfiguration().equals(dependencyRhs.getTargetConfiguration())
-            : dependencyRhs.getTargetConfiguration()!=null) {
-            return false;
-        }
-        if (getVersion() != null ? !getVersion().equals(dependencyRhs.getVersion())
-                : dependencyRhs.getVersion() != null) {
-            return false;
-        }
-        return true;
-    }
-
     protected boolean isCommonContentEquals(ModuleDependency dependencyRhs) {
-        if (!isKeyEquals(dependencyRhs)) {
-            return false;
-        }
-        if (isTransitive() != dependencyRhs.isTransitive()) {
-            return false;
-        }
-        if (isEndorsingStrictVersions() != dependencyRhs.isEndorsingStrictVersions()) {
-            return false;
-        }
-        if (!Objects.equal(getArtifacts(), dependencyRhs.getArtifacts())) {
-            return false;
-        }
-        if (!Objects.equal(getExcludeRules(), dependencyRhs.getExcludeRules())) {
-            return false;
-        }
-        if (!Objects.equal(getAttributes(), dependencyRhs.getAttributes())) {
-            return false;
-        }
-        if (!Objects.equal(getCapabilitySelectors(), dependencyRhs.getCapabilitySelectors())) {
-            return false;
-        }
-        return true;
+        return Objects.equal(getTargetConfiguration(), dependencyRhs.getTargetConfiguration()) &&
+            isTransitive() == dependencyRhs.isTransitive() &&
+            isEndorsingStrictVersions() == dependencyRhs.isEndorsingStrictVersions() &&
+            Objects.equal(getReason(), dependencyRhs.getReason()) &&
+            Objects.equal(getArtifacts(), dependencyRhs.getArtifacts()) &&
+            Objects.equal(getExcludeRules(), dependencyRhs.getExcludeRules()) &&
+            getAttributes().equals(dependencyRhs.getAttributes()) &&
+            getCapabilitySelectors().equals(dependencyRhs.getCapabilitySelectors());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultFileCollectionDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultFileCollectionDependency.java
@@ -15,18 +15,16 @@
  */
 package org.gradle.api.internal.artifacts.dependencies;
 
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.jspecify.annotations.Nullable;
 
 public class DefaultFileCollectionDependency implements SelfResolvingDependencyInternal, FileCollectionDependency {
 
     private @Nullable String reason;
-    private final ComponentIdentifier targetComponentId;
+    private final @Nullable ComponentIdentifier targetComponentId;
     private final FileCollectionInternal source;
 
     public DefaultFileCollectionDependency(FileCollectionInternal source) {
@@ -48,23 +46,6 @@ public class DefaultFileCollectionDependency implements SelfResolvingDependencyI
     @Override
     public void because(@Nullable String reason) {
         this.reason = reason;
-    }
-
-    @Override
-    @Deprecated
-    public boolean contentEquals(Dependency dependency) {
-
-        DeprecationLogger.deprecateMethod(Dependency.class, "contentEquals(Dependency)")
-            .withAdvice("Use Object.equals(Object) instead")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "deprecated_content_equals")
-            .nagUser();
-
-        if (!(dependency instanceof DefaultFileCollectionDependency)) {
-            return false;
-        }
-        DefaultFileCollectionDependency selfResolvingDependency = (DefaultFileCollectionDependency) dependency;
-        return source.equals(selfResolvingDependency.source);
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultFileCollectionDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultFileCollectionDependencyTest.groovy
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.dependencies
 
-import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.file.FileCollectionInternal
 import spock.lang.Specification
@@ -40,21 +38,6 @@ class DefaultFileCollectionDependencyTest extends Specification {
         then:
         copy.targetComponentId == targetComponent
         copy.files == source
-        copy.contentEquals(dependency)
-        dependency.contentEquals(copy)
-    }
-
-    def contentsAreEqualWhenFileSetsAreEqual() {
-        given:
-        FileCollectionDependency equalDependency = new DefaultFileCollectionDependency(source)
-        FileCollectionDependency differentSource = new DefaultFileCollectionDependency(Mock(FileCollectionInternal))
-        Dependency differentType = Mock(Dependency.class)
-
-        expect:
-        dependency.contentEquals(dependency)
-        dependency.contentEquals(equalDependency)
-        !dependency.contentEquals(differentSource)
-        !dependency.contentEquals(differentType)
     }
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -56,7 +56,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
         def d2 = createProjectDependency()
 
         expect:
-        d1.contentEquals(d2)
+        d1 == d2
     }
 
     void "knows when content is not equal"() {
@@ -65,7 +65,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
         d2.setTransitive(false)
 
         expect:
-        !d1.contentEquals(d2)
+        d1 != d2
     }
 
     void "can copy"() {

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -129,6 +129,14 @@
             ]
         },
         {
+            "type": "org.gradle.api.artifacts.Dependency",
+            "member": "Method org.gradle.api.artifacts.Dependency.contentEquals(org.gradle.api.artifacts.Dependency)",
+            "acceptation": "Removed deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
             "type": "org.gradle.api.artifacts.LenientConfiguration",
             "member": "Method org.gradle.api.artifacts.LenientConfiguration.getArtifacts(org.gradle.api.specs.Spec)",
             "acceptation": "Removed deprecated method",


### PR DESCRIPTION
At the same time, make the existing equals methods more correct

Whether or not these classes should implement equals at all is questionable. Having mutable types inside of a hash set, which some DomainObjectContiners are based on, is a bad idea, as the identity and therefore hash code of the type can change after it is added to the set.

We might even consider removing any implementation of equals and hash code while these dependency types remain mutable

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
