### PR TITLE
Fix Daemon toolchain ignoring specified Environment variables via TAPI

### DIFF
--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -43,8 +43,7 @@ public class DaemonParameters {
 
     public static final List<String> DEFAULT_JVM_ARGS = ImmutableList.of("-Xmx512m", "-Xms256m", "-XX:MaxMetaspaceSize=384m", "-XX:+HeapDumpOnOutOfMemoryError");
 
-    private final ToolchainConfiguration toolchainConfiguration = new DefaultToolchainConfiguration();
-
+    private final ToolchainConfiguration toolchainConfiguration;
     private final File gradleUserHomeDir;
 
     private File baseDir;
@@ -64,10 +63,14 @@ public class DaemonParameters {
     private ToolchainDownloadUrlProvider toolchainDownloadUrlProvider;
 
     public DaemonParameters(File gradleUserHomeDir, FileCollectionFactory fileCollectionFactory) {
-        this(gradleUserHomeDir, fileCollectionFactory, Collections.<String, String>emptyMap());
+        this(gradleUserHomeDir, fileCollectionFactory, Collections.emptyMap());
     }
 
     public DaemonParameters(File gradleUserHomeDir, FileCollectionFactory fileCollectionFactory, Map<String, String> extraSystemProperties) {
+        this(gradleUserHomeDir, fileCollectionFactory, extraSystemProperties, null);
+    }
+
+    public DaemonParameters(File gradleUserHomeDir, FileCollectionFactory fileCollectionFactory, Map<String, String> extraSystemProperties, @Nullable Map<String, String> environmentVariables) {
         this.jvmOptions = new JvmOptions(fileCollectionFactory);
         if (!extraSystemProperties.isEmpty()) {
             jvmOptions.systemProperties(extraSystemProperties);
@@ -75,7 +78,8 @@ public class DaemonParameters {
         jvmOptions.jvmArgs(DEFAULT_JVM_ARGS);
         this.gradleUserHomeDir = gradleUserHomeDir;
         this.baseDir = new File(gradleUserHomeDir, "daemon");
-        this.envVariables = new HashMap<>(System.getenv());
+        this.envVariables = environmentVariables == null ? new HashMap<>(System.getenv()) : environmentVariables;
+        toolchainConfiguration = new DefaultToolchainConfiguration(this.envVariables);
     }
 
     public DaemonRequestContext toRequestContext() {
@@ -163,10 +167,6 @@ public class DaemonParameters {
 
     public void setJvmArgs(Iterable<String> jvmArgs) {
         jvmOptions.setAllJvmArgs(jvmArgs);
-    }
-
-    public void setEnvironmentVariables(Map<String, String> envVariables) {
-        this.envVariables = envVariables == null ? new HashMap<String, String>(System.getenv()) : envVariables;
     }
 
     public void setDebug(boolean debug) {

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -347,7 +347,7 @@ public class ProviderConnection {
 
         AllProperties properties = new LayoutToPropertiesConverter(buildLayoutFactory).convert(initialProperties, buildLayoutResult);
 
-        DaemonParameters daemonParams = new DaemonParameters(buildLayoutResult.getGradleUserHomeDir(), fileCollectionFactory);
+        DaemonParameters daemonParams = new DaemonParameters(buildLayoutResult.getGradleUserHomeDir(), fileCollectionFactory, Collections.emptyMap(), operationParameters.getEnvironmentVariables(null));
         new DaemonBuildOptions().propertiesConverter().convert(properties.getProperties(), daemonParams);
         if (operationParameters.getDaemonBaseDir() != null) {
             daemonParams.setBaseDir(operationParameters.getDaemonBaseDir());
@@ -378,11 +378,6 @@ public class ProviderConnection {
 
         // Include the system properties that are defined in the daemon JVM args
         properties = properties.merge(daemonParams.getSystemProperties());
-
-        Map<String, String> envVariables = operationParameters.getEnvironmentVariables(null);
-        if (envVariables != null) {
-            daemonParams.setEnvironmentVariables(envVariables);
-        }
 
         File javaHome = operationParameters.getJavaHome();
         if (javaHome != null) {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/DaemonToolchainCrossVersionTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.tooling.GradleConnectionException
 import org.junit.Assume
-import spock.lang.Ignore
 
 // 8.8 did not support configuring the set of available Java homes or disabling auto-detection
 @TargetGradleVersion(">=8.9")
@@ -59,27 +58,6 @@ class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements
         when:
         withConnection {
             it.newBuild().forTasks("help").run()
-        }
-
-        then:
-        assertDaemonUsedJvm(otherJvm.javaHome)
-    }
-
-    @Ignore("https://github.com/gradle/gradle/issues/32969")
-    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
-    def "Given criteria matching JAVA_HOME environment variable and disabled auto-detection When executing any task Then daemon jvm was set up with expected configuration"() {
-        given:
-        def otherJvm = AvailableJavaHomes.differentVersion
-        writeJvmCriteria(otherJvm.javaVersion.majorVersion)
-        captureJavaHome()
-
-        when:
-        withConnection {
-            it.newBuild()
-                .setEnvironmentVariables(["JAVA_HOME": otherJvm.javaHome.absolutePath])
-                .forTasks("help").withArguments(
-                "-Dorg.gradle.java.installations.auto-detect=false",
-            ).run()
         }
 
         then:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r90/DaemonToolchainCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r90/DaemonToolchainCrossVersionTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r90
+
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.DaemonJvmPropertiesFixture
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
+
+@TargetGradleVersion(">=9.0")
+class DaemonToolchainCrossVersionTest extends ToolingApiSpecification implements DaemonJvmPropertiesFixture {
+
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given criteria matching JAVA_HOME environment variable and disabled auto-detection When executing any task Then daemon jvm was set up with expected configuration"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        writeJvmCriteria(otherJvm.javaVersion.majorVersion)
+        captureJavaHome()
+
+        when:
+        withConnection {
+            it.newBuild()
+                .setEnvironmentVariables(["JAVA_HOME": otherJvm.javaHome.absolutePath])
+                .forTasks("help").withArguments(
+                "-Dorg.gradle.java.installations.auto-detect=false",
+            ).run()
+        }
+
+        then:
+        assertDaemonUsedJvm(otherJvm.javaHome)
+    }
+
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given custom toolchain location using environment variable and disabled auto-detection When executing any task Then daemon jvm was set up with expected configuration"() {
+        given:
+        def otherJvm = AvailableJavaHomes.differentVersion
+        writeJvmCriteria(otherJvm.javaVersion.majorVersion)
+        captureJavaHome()
+
+        when:
+        withConnection {
+            it.newBuild()
+                .setEnvironmentVariables(["OTHER_JAVA_HOME": otherJvm.javaHome.absolutePath])
+                .forTasks("help").withArguments(
+                    "-Porg.gradle.java.installations.fromEnv=OTHER_JAVA_HOME",
+                    "-Dorg.gradle.java.installations.auto-detect=false",
+            ).run()
+        }
+
+        then:
+        assertDaemonUsedJvm(otherJvm.javaHome)
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r90/JavaCompileToolchainCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r90/JavaCompileToolchainCrossVersionTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r90
+
+import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.JavaToolchainFixture
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
+
+@TargetGradleVersion(">=9.0")
+class JavaCompileToolchainCrossVersionTest extends ToolingApiSpecification implements JavaToolchainFixture {
+
+    def setup() {
+        requireDaemons()
+    }
+
+    @Requires(IntegTestPreconditions.JavaHomeWithDifferentVersionAvailable)
+    def "Given custom toolchain location using environment variable When executing compileJava task Then build used expected toolchain"() {
+        given:
+        file("src/main/java/Foo.java") << """class Foo { }"""
+        def otherJvm = AvailableJavaHomes.differentVersion
+        buildFile << """
+            apply plugin: "java"
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(${otherJvm.javaVersionMajor})
+                }
+            }
+        """
+
+        when:
+        withConnection {
+            // To modify environment variables for crossVersion tests is a must to use real daemon processes and not embedded,
+            // otherwise, those are going to be ignored being this different than properties which uses SystemPropertySetterExecuter
+            // Also, keeping the whole environment is needed as we play with weird encodings on CI
+            it.newBuild().setEnvironmentVariables(System.getenv() + ["OTHER_JAVA_HOME": otherJvm.javaHome.absolutePath])
+                .forTasks(":compileJava").withArguments(
+                    "--info",
+                    "-Porg.gradle.java.installations.fromEnv=OTHER_JAVA_HOME",
+                    "-Porg.gradle.java.installations.auto-detect=false",
+            ).run()
+        }
+
+        then:
+        outputContains("Compiling with toolchain '${otherJvm.javaHome.absolutePath}'")
+        classJavaVersion(javaClassFile("Foo.class")) == JavaVersion.toVersion(otherJvm.javaVersion)
+    }
+}

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/JavaToolchainFixture.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/JavaToolchainFixture.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.fixture
+
+import groovy.transform.SelfType
+import org.gradle.api.JavaVersion
+import org.gradle.test.fixtures.file.TestFile
+
+@SelfType(ToolingApiSpecification)
+trait JavaToolchainFixture {
+
+    void outputContains(String string) {
+        assertHasResult()
+        result.assertOutputContains(string.trim())
+    }
+
+    private assertHasResult() {
+        assert result != null: "result is null, you haven't run succeeds()"
+    }
+
+    /**
+     * Returns the Java version from the compiled class bytecode.
+     */
+    JavaVersion classJavaVersion(File classFile) {
+        assert classFile.exists()
+        return JavaVersion.forClass(classFile.bytes)
+    }
+
+    TestFile javaClassFile(String fqcn) {
+        classFile("java", "main", fqcn)
+    }
+
+    TestFile classFile(String language, String sourceSet, String fqcn) {
+        file("build/classes/", language, sourceSet, fqcn)
+    }
+}

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJavaInstallationRegistry.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJavaInstallationRegistry.java
@@ -119,8 +119,8 @@ public class DefaultJavaInstallationRegistry implements JavaInstallationRegistry
 
     private static List<InstallationSupplier> builtInSuppliers(ToolchainConfiguration toolchainConfiguration, FileResolver fileResolver, JdkCacheDirectory jdkCacheDirectory) {
         List<InstallationSupplier> allSuppliers = new ArrayList<>();
-        allSuppliers.add(new EnvironmentVariableListInstallationSupplier(toolchainConfiguration, fileResolver, System.getenv()));
-        allSuppliers.add(new EnvironmentVariableJavaHomeInstallationSupplier(System.getenv()));
+        allSuppliers.add(new EnvironmentVariableListInstallationSupplier(toolchainConfiguration, fileResolver));
+        allSuppliers.add(new EnvironmentVariableJavaHomeInstallationSupplier(toolchainConfiguration));
         allSuppliers.add(new LocationListInstallationSupplier(toolchainConfiguration, fileResolver));
         allSuppliers.add(new CurrentInstallationSupplier());
         allSuppliers.add(new AutoInstalledInstallationSupplier(toolchainConfiguration, jdkCacheDirectory));

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainConfiguration.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainConfiguration.java
@@ -19,6 +19,7 @@ package org.gradle.jvm.toolchain.internal;
 import com.google.common.annotations.VisibleForTesting;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.os.OperatingSystem;
+import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -38,7 +39,11 @@ public class DefaultToolchainConfiguration implements ToolchainConfiguration {
 
     @Inject
     public DefaultToolchainConfiguration() {
-        this(OperatingSystem.current(), SystemProperties.getInstance(), System.getenv());
+        this(System.getenv());
+    }
+
+    public DefaultToolchainConfiguration(Map<String, String> environment) {
+        this(OperatingSystem.current(), SystemProperties.getInstance(), environment);
     }
 
     @VisibleForTesting
@@ -134,5 +139,11 @@ public class DefaultToolchainConfiguration implements ToolchainConfiguration {
             return new File(asdfEnvVar);
         }
         return new File(systemProperties.getUserHome(), ".sdkman/candidates");
+    }
+
+    @Override
+    @Nullable
+    public String getEnvironmentVariableValue(String variableName) {
+        return environment.get(variableName);
     }
 }

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/EnvironmentVariableJavaHomeInstallationSupplier.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/EnvironmentVariableJavaHomeInstallationSupplier.java
@@ -16,19 +16,16 @@
 
 package org.gradle.jvm.toolchain.internal;
 
-import org.jspecify.annotations.Nullable;
-
 import java.io.File;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 
 public class EnvironmentVariableJavaHomeInstallationSupplier implements InstallationSupplier {
 
-    private final @Nullable String javaHomePath;
+    private final ToolchainConfiguration buildOptions;
 
-    public EnvironmentVariableJavaHomeInstallationSupplier(Map<String, String> environment) {
-        this.javaHomePath = environment.get("JAVA_HOME");
+    public EnvironmentVariableJavaHomeInstallationSupplier(ToolchainConfiguration buildOptions) {
+        this.buildOptions = buildOptions;
     }
 
     @Override
@@ -38,6 +35,7 @@ public class EnvironmentVariableJavaHomeInstallationSupplier implements Installa
 
     @Override
     public Set<InstallationLocation> get() {
+        String javaHomePath = buildOptions.getEnvironmentVariableValue("JAVA_HOME");
         if (javaHomePath == null || javaHomePath.isEmpty()) {
             return Collections.emptySet();
         }

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/EnvironmentVariableListInstallationSupplier.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/EnvironmentVariableListInstallationSupplier.java
@@ -21,7 +21,6 @@ import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,13 +31,11 @@ public class EnvironmentVariableListInstallationSupplier implements Installation
 
     private final ToolchainConfiguration buildOptions;
     private final FileResolver fileResolver;
-    private final Map<String, String> environment;
 
     @Inject
-    public EnvironmentVariableListInstallationSupplier(ToolchainConfiguration buildOptions, FileResolver fileResolver, Map<String, String> environment) {
+    public EnvironmentVariableListInstallationSupplier(ToolchainConfiguration buildOptions, FileResolver fileResolver) {
         this.buildOptions = buildOptions;
         this.fileResolver = fileResolver;
-        this.environment = environment;
     }
 
     @Override
@@ -68,7 +65,7 @@ public class EnvironmentVariableListInstallationSupplier implements Installation
 
     @Nullable
     private String environmentVariableValue(String environmentVariable) {
-        return environment.get(environmentVariable.trim());
+        return buildOptions.getEnvironmentVariableValue(environmentVariable.trim());
     }
 
 

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/ToolchainConfiguration.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/ToolchainConfiguration.java
@@ -53,4 +53,6 @@ public interface ToolchainConfiguration {
     @Nullable File getJabbaHomeDirectory();
 
     File getSdkmanCandidatesDirectory();
+
+    @Nullable String getEnvironmentVariableValue(String variableName);
 }

--- a/platforms/jvm/jvm-services/src/test/groovy/org/gradle/jvm/toolchain/internal/EnvironmentVariableJavaHomeInstallationSupplierTest.groovy
+++ b/platforms/jvm/jvm-services/src/test/groovy/org/gradle/jvm/toolchain/internal/EnvironmentVariableJavaHomeInstallationSupplierTest.groovy
@@ -26,7 +26,8 @@ class EnvironmentVariableJavaHomeInstallationSupplierTest extends Specification 
 
     def "supplies no installations for not defined or empty JAVA_HOME property"() {
         when:
-        def supplier = new EnvironmentVariableJavaHomeInstallationSupplier(environment)
+        def buildOptions = new DefaultToolchainConfiguration(environment)
+        def supplier = new EnvironmentVariableJavaHomeInstallationSupplier(buildOptions)
         def directories = supplier.get()
 
         then:
@@ -39,10 +40,10 @@ class EnvironmentVariableJavaHomeInstallationSupplierTest extends Specification 
     def "supplies installation for JAVA_HOME property"() {
         given:
         def jdk8 = tmpDir.createDir("jdk8")
-        def environment = [JAVA_HOME: jdk8.absolutePath]
+        def buildOptions = new DefaultToolchainConfiguration(["JAVA_HOME": jdk8.absolutePath])
 
         when:
-        def supplier = new EnvironmentVariableJavaHomeInstallationSupplier(environment)
+        def supplier = new EnvironmentVariableJavaHomeInstallationSupplier(buildOptions)
         def directories = supplier.get()
 
         then:

--- a/platforms/jvm/jvm-services/src/test/groovy/org/gradle/jvm/toolchain/internal/EnvironmentVariableListInstallationSupplierTest.groovy
+++ b/platforms/jvm/jvm-services/src/test/groovy/org/gradle/jvm/toolchain/internal/EnvironmentVariableListInstallationSupplierTest.groovy
@@ -26,13 +26,15 @@ import spock.lang.Subject
 class EnvironmentVariableListInstallationSupplierTest extends Specification {
     @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
-    final buildOptions = Mock(ToolchainConfiguration)
     final jdk8 = tmpDir.createDir("jdk8")
     final jdk9 = tmpDir.createDir("jdk9")
-    final Map<String, String> environment = [JDK8: jdk8.absolutePath, JDK9: jdk9.absolutePath]
+    final buildOptions = Mock(ToolchainConfiguration) {
+        getEnvironmentVariableValue("JDK8") >> jdk8.absolutePath
+        getEnvironmentVariableValue("JDK9") >> jdk9.absolutePath
+    }
 
     @Subject
-    def supplier =  new EnvironmentVariableListInstallationSupplier(buildOptions, new IdentityFileResolver(), environment)
+    def supplier =  new EnvironmentVariableListInstallationSupplier(buildOptions, new IdentityFileResolver())
 
     def "supplies no installations for empty property"() {
         when:

--- a/platforms/jvm/toolchains-jvm/build.gradle.kts
+++ b/platforms/jvm/toolchains-jvm/build.gradle.kts
@@ -40,15 +40,15 @@ dependencies {
     api(projects.resources)
     api(projects.toolchainsJvmShared)
 
-    api(libs.kotlinStdlib)
     api(libs.inject)
+    api(libs.jspecify)
+    api(libs.kotlinStdlib)
 
     implementation(projects.baseDiagnostics)
     implementation(projects.fileTemp)
     implementation(projects.modelCore)
 
     implementation(libs.guava)
-    implementation(libs.jspecify)
     implementation(libs.slf4jApi)
 
     testImplementation(testFixtures(projects.core))

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/internal/services/ProviderBackedToolchainConfiguration.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/internal/services/ProviderBackedToolchainConfiguration.java
@@ -23,6 +23,7 @@ import org.gradle.jvm.toolchain.internal.AutoInstalledInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.EnvironmentVariableListInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.ToolchainConfiguration;
+import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -133,5 +134,11 @@ public class ProviderBackedToolchainConfiguration implements ToolchainConfigurat
             return new File(asdfEnvVar);
         }
         return new File(systemProperties.getUserHome(), ".sdkman/candidates");
+    }
+
+    @Override
+    @Nullable
+    public String getEnvironmentVariableValue(String variableName) {
+        return providerFactory.environmentVariable(variableName).getOrNull();
     }
 }


### PR DESCRIPTION
#### Context
Fixes the `EnvironmentVariableListInstallationSupplier` and `EnvironmentVariableJavaHomeInstallationSupplier` to resolve system environment variables using `System.getenv()` ignoring `LongRunningOperation.getEnvironmentVariables()` passed via TAPI. https://github.com/gradle/gradle/issues/32969

_NOTE: This PR was build on top of https://github.com/gradle/gradle/pull/32948 to avoid merge conflicts_

##### Overview 

- `ToolchainConfiguration.java` exposes `getEnvironmentVariableValue` allowing to obtain others environment variables used by `EnvironmentVariableListInstallationSupplier` and `EnvironmentVariableJavaHomeInstallationSupplier` to resolve those instead of using `System.getEnv()`. This last one ignores the environment variables specified via TAPI on `ProviderConnection`
    - Aligned by the fact that previously `ToolchainConfiguration` kept reference to `environment variables`  used to resolve `ASDF_DATA_DIR`, `JABBA_HOME` and other ones
- Expose `environmentVariables` on the constructor of `DefaultToolchainConfiguration`.
   - Allows `DaemonParameters` to create an instance of it with the specified TAPI environment variables from `ProviderConnection`. However, the build still uses `System.getEnv()` because at that time the JVM process already contains those properly from `ProviderOperationParameters`.
- Added `JavaToolchainFixture.groovy` for cross version tests  to help validate task toolchain
  - To modify environment variables for crossVersion tests is a must to use real daemon processes and not embedded,
otherwise, those are going to be ignored being this different than properties which uses `SystemPropertySetterExecuter`  
- Moved old `DaemonToolchainCrossVersionTest.JAVA_HOME` test to proper version Gradle


#### Tests
- [EnvironmentVariableJavaHomeInstallationSupplierTest.groovy](https://github.com/gradle/gradle/pull/33020/files#diff-83e42c4c84bfd37543d58dbcc0eb9c2a46f3539bc72ac8a8186aa94e615df9a8)
- [EnvironmentVariableListInstallationSupplierTest.groovy](https://github.com/gradle/gradle/pull/33020/files#diff-cc2ea2ebceb94c22a461af0c0f680a554da5a8df6e08dc77f0f06eb936ab2fd6)
- [JavaCompileToolchainCrossVersionTest.groovy](https://github.com/gradle/gradle/pull/33020/files#diff-5b435b320129d4789bd8bb2ccfddf66ec4bed968846a9f973a2d905c41fa5055)
- [DaemonToolchainCrossVersionTest.groovy](https://github.com/gradle/gradle/pull/33020/files#diff-2d2f19e192e9eddbbf20d3d2de5972f08dc6d2090f7c87d7c6d95929f9d6d72e)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.
