### PR TITLE
Fix test

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/ProblemProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/ProblemProgressEventCrossVersionTest.groovy
@@ -59,7 +59,6 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
             plugins {
               id 'java-library'
             }
-            repositories.jcenter()
             task bar {}
             task baz {}
         """
@@ -79,7 +78,7 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
 
         then:
         thrown(BuildException)
-        listener.problems.size() == 2
+        listener.problems.size() == 1
     }
 
     @TargetGradleVersion(">=8.5 <8.9")

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/ProblemProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/ProblemProgressEventCrossVersionTest.groovy
@@ -54,12 +54,10 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
     @TargetGradleVersion(">=6.9.4 <=8.5")
     def "Problems not exposed in target version 8.5 and lower"() {
         given:
-
         buildFile """
             plugins {
               id 'java-library'
             }
-            repositories.jcenter()
             task bar {}
             task baz {}
         """

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r89/ProblemProgressEventCrossVersionTest.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r89/ProblemProgressEventCrossVersionTest.groovy
@@ -65,11 +65,10 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
             plugins {
               id 'java-library'
             }
-            repositories.jcenter()
             task bar {}
             task baz {}
         """
-
+        settingsFile << 'rootProject.name = "root"'
 
         when:
         def listener = new ProblemProgressListener()
@@ -85,16 +84,8 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
 
         then:
         thrown(BuildException)
-        listener.problems.size() == 2
-        verifyAll(listener.problems[0]) {
-            definition.id.displayName == "The RepositoryHandler.jcenter() method has been deprecated."
-            definition.id.group.displayName == "Deprecation"
-            definition.id.group.name == "deprecation"
-            definition.severity == Severity.WARNING
-            locations.size() == (targetVersion < GradleVersion.version('8.13') ? 2 : 1)
-            (locations[0] as LineInFileLocation).path == buildFileLocation(buildFile, targetVersion)
-            additionalData.asMap['type'] == 'USER_CODE_DIRECT'
-        }
+        listener.problems.size() == 1
+        listener.problems[0].contextualLabel.contextualLabel == "Cannot locate tasks that match ':ba' as task 'ba' is ambiguous in root project 'root'. Candidates are: 'bar', 'baz'."
     }
 
     def "Problems expose details via Tooling API events with failure"() {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes these build failures: https://ge.gradle.org/s/zyclipxl4pciu/tests/overview?outcome=FAILED

The build failures occurred due to the removal of the deprecated `jcenter()` method. When inspecting the failing tests it turned out that they do too much: the expectations we want to verify is whether problems appear in the presence of a build failure. The content itself is verified by other tests already, hence the removal of the detailed assertion. 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
