### PR TITLE
Bump Gson to version 2.12.1 to benefit from configurable pretty printing

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
         api("com.github.javaparser:javaparser-symbol-solver-core:$javaParserVersion")
         api("com.google.guava:guava:33.4.6-jre")
         api("com.google.errorprone:error_prone_annotations:2.5.1")
-        api("com.google.code.gson:gson:2.8.9")
+        api("com.google.code.gson:gson:2.12.1") // keep in sync with settings.gradle.kts
         api("com.nhaarman:mockito-kotlin:1.6.0")
         api("com.thoughtworks.qdox:qdox:2.0.3")
         api("com.uwyn:jhighlight:1.0")

--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild.dependency-modules.gradle.kts
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild.dependency-modules.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import com.google.gson.Gson
+import com.google.gson.Strictness
 import com.google.gson.reflect.TypeToken
 import com.google.gson.stream.JsonReader
 import gradlebuild.basics.repoRoot
@@ -99,7 +100,7 @@ fun readCapabilitiesFromJson() {
 
 fun readCapabilities(source: File): List<CapabilitySpec> {
     JsonReader(source.reader(Charsets.UTF_8)).use { reader ->
-        reader.isLenient = true
+        reader.strictness = Strictness.LENIENT
         return Gson().fromJson(reader)
     }
 }

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -593,20 +593,6 @@
             <pgp value="47504B76CF89C15C0512D9AFE16AB52D79FD224F"/>
          </artifact>
       </component>
-      <component group="com.google.code.gson" name="gson" version="2.8.6">
-         <artifact name="gson-2.8.6.jar">
-            <pgp value="AFCC4C7594D09E2182C60E0F7A01B0F236E5430F"/>
-         </artifact>
-      </component>
-      <component group="com.google.code.gson" name="gson" version="2.8.9">
-         <artifact name="gson-2.8.9.jar">
-            <pgp value="C7BE5BCC9FEC15518CFDA882B0F3710FA64900E7"/>
-            <ignored-keys>
-               <ignored-key id="B0F3710FA64900E7" reason="PGP verification failed"/>
-            </ignored-keys>
-            <sha256 value="d3999291855de495c94c743761b8ab5176cfeabe281a5ab0d8e8d45326fd703e" origin="Needed because PGP signature verification failed!"/>
-         </artifact>
-      </component>
       <component group="com.google.errorprone" name="error_prone_annotations" version="2.1.3">
          <artifact name="error_prone_annotations-2.1.3.jar">
             <pgp value="F05E5F90E43E837F9DD8C781BF935C771A8474F8"/>

--- a/packaging/distributions-dependencies/build.gradle.kts
+++ b/packaging/distributions-dependencies/build.gradle.kts
@@ -97,7 +97,7 @@ dependencies {
         api(libs.groovyTemplates)       { version { strictly(libs.groovyVersion) }}
         api(libs.groovyTest)            { version { strictly(libs.groovyVersion) }}
         api(libs.groovyXml)             { version { strictly(libs.groovyVersion) }}
-        api(libs.gson)                  { version { strictly("2.10") }}
+        api(libs.gson)                  { version { strictly("2.12.1") }}
         api(libs.h2Database)            { version { strictly("2.2.220") }}
         api(libs.hamcrest)              { version { strictly(hamcrestVersion) }}
         api("org.hamcrest:hamcrest-core") { version { strictly(hamcrestVersion) }}

--- a/platforms/documentation/docs/src/samples/java/modules-with-transform/groovy/application/build.gradle
+++ b/platforms/documentation/docs/src/samples/java/modules-with-transform/groovy/application/build.gradle
@@ -34,7 +34,7 @@ tasks.named('compileJava') {
 }
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.8.9'           // real module
+    implementation 'com.google.code.gson:gson:2.12.1'          // real module
     implementation 'org.apache.commons:commons-lang3:3.10'     // automatic module
     implementation 'commons-beanutils:commons-beanutils:1.9.4' // plain library (also brings in other libraries transitively)
     implementation 'commons-cli:commons-cli:1.4'               // plain library

--- a/platforms/documentation/docs/src/samples/java/modules-with-transform/kotlin/application/build.gradle.kts
+++ b/platforms/documentation/docs/src/samples/java/modules-with-transform/kotlin/application/build.gradle.kts
@@ -34,7 +34,7 @@ extraJavaModuleInfo {
 // end::extraModuleInfo[]
 
 dependencies {
-    implementation("com.google.code.gson:gson:2.8.9")           // real module
+    implementation("com.google.code.gson:gson:2.12.1")          // real module
     implementation("org.apache.commons:commons-lang3:3.10")     // automatic module
     implementation("commons-beanutils:commons-beanutils:1.9.4") // plain library (also brings in other libraries transitively)
     implementation("commons-cli:commons-cli:1.4")               // plain library

--- a/platforms/documentation/docs/src/samples/java/modules-with-transform/tests/runTask.out
+++ b/platforms/documentation/docs/src/samples/java/modules-with-transform/tests/runTask.out
@@ -1,5 +1,5 @@
 org.gradle.sample.app - 1.0.2
-com.google.gson - 2.8.9
+com.google.gson - 2.12.1
 org.apache.commons.lang3 - 3.10
 org.apache.commons.cli - 3.2.2
 org.apache.commons.beanutils - 1.9.4

--- a/platforms/documentation/docs/src/snippets/java-library/module-disabled/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/java-library/module-disabled/groovy/build.gradle
@@ -17,7 +17,7 @@ tasks.named('compileJava') {
 // end::disableModulePath[]
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.google.code.gson:gson:2.12.1'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation 'commons-cli:commons-cli:1.4'
 }

--- a/platforms/documentation/docs/src/snippets/java-library/module-disabled/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java-library/module-disabled/kotlin/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.compileJava {
 // end::disableModulePath[]
 
 dependencies {
-    implementation("com.google.code.gson:gson:2.8.9")
+    implementation("com.google.code.gson:gson:2.12.1")
     implementation("org.apache.commons:commons-lang3:3.10")
     implementation("commons-cli:commons-cli:1.4")
 }

--- a/platforms/documentation/docs/src/snippets/java-library/module/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/java-library/module/groovy/build.gradle
@@ -17,7 +17,7 @@ tasks.named('compileJava') {
 
 // tag::dependencies[]
 dependencies {
-    implementation 'com.google.code.gson:gson:2.8.9'       // real module
+    implementation 'com.google.code.gson:gson:2.12.1'      // real module
     implementation 'org.apache.commons:commons-lang3:3.10' // automatic module
     implementation 'commons-cli:commons-cli:1.4'           // plain library
 }

--- a/platforms/documentation/docs/src/snippets/java-library/module/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java-library/module/kotlin/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.compileJava {
 
 // tag::dependencies[]
 dependencies {
-    implementation("com.google.code.gson:gson:2.8.9")       // real module
+    implementation("com.google.code.gson:gson:2.12.1")      // real module
     implementation("org.apache.commons:commons-lang3:3.10") // automatic module
     implementation("commons-cli:commons-cli:1.4")           // plain library
 }

--- a/platforms/documentation/docs/src/snippets/java/fixtures/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/java/fixtures/groovy/build.gradle
@@ -38,6 +38,6 @@ configurations {
 dependencies {
     // Adds a dependency on the test fixtures of Gson, however this
     // project doesn't publish such a thing
-    functionalTest testFixtures("com.google.code.gson:gson:2.8.5")
+    functionalTest testFixtures("com.google.code.gson:gson:2.12.1")
 }
 // end::external-test-fixtures-dependency[]

--- a/platforms/documentation/docs/src/snippets/java/fixtures/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java/fixtures/kotlin/build.gradle.kts
@@ -36,6 +36,6 @@ val functionalTestClasspath by configurations.creating {
 dependencies {
     // Adds a dependency on the test fixtures of Gson, however this
     // project doesn't publish such a thing
-    functionalTest(testFixtures("com.google.code.gson:gson:2.8.5"))
+    functionalTest(testFixtures("com.google.code.gson:gson:2.12.1"))
 }
 // end::external-test-fixtures-dependency[]

--- a/platforms/documentation/docs/src/snippets/java/fixtures/tests/dependencyInsight.out
+++ b/platforms/documentation/docs/src/snippets/java/fixtures/tests/dependencyInsight.out
@@ -1,19 +1,19 @@
 
 > Task :dependencyInsight
-com.google.code.gson:gson:2.8.5 FAILED
+com.google.code.gson:gson:2.12.1 FAILED
    Failures:
-      - Could not resolve com.google.code.gson:gson:2.8.5.
+      - Could not resolve com.google.code.gson:gson:2.12.1.
           - Unable to find a variant with the requested capability: feature 'test-fixtures':
-               - Variant 'compile' provides 'com.google.code.gson:gson:2.8.5'
-               - Variant 'enforced-platform-compile' provides 'com.google.code.gson:gson-derived-enforced-platform:2.8.5'
-               - Variant 'enforced-platform-runtime' provides 'com.google.code.gson:gson-derived-enforced-platform:2.8.5'
-               - Variant 'javadoc' provides 'com.google.code.gson:gson:2.8.5'
-               - Variant 'platform-compile' provides 'com.google.code.gson:gson-derived-platform:2.8.5'
-               - Variant 'platform-runtime' provides 'com.google.code.gson:gson-derived-platform:2.8.5'
-               - Variant 'runtime' provides 'com.google.code.gson:gson:2.8.5'
-               - Variant 'sources' provides 'com.google.code.gson:gson:2.8.5'
+               - Variant 'compile' provides 'com.google.code.gson:gson:2.12.1'
+               - Variant 'enforced-platform-compile' provides 'com.google.code.gson:gson-derived-enforced-platform:2.12.1'
+               - Variant 'enforced-platform-runtime' provides 'com.google.code.gson:gson-derived-enforced-platform:2.12.1'
+               - Variant 'javadoc' provides 'com.google.code.gson:gson:2.12.1'
+               - Variant 'platform-compile' provides 'com.google.code.gson:gson-derived-platform:2.12.1'
+               - Variant 'platform-runtime' provides 'com.google.code.gson:gson-derived-platform:2.12.1'
+               - Variant 'runtime' provides 'com.google.code.gson:gson:2.12.1'
+               - Variant 'sources' provides 'com.google.code.gson:gson:2.12.1'
 
-com.google.code.gson:gson:2.8.5 FAILED
+com.google.code.gson:gson:2.12.1 FAILED
 \--- functionalTestClasspath
 
 A web-based, searchable dependency report is available by adding the --scan option.

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
@@ -804,7 +804,7 @@ class GradleModuleMetadataParserTest extends Specification {
         then:
         def e = thrown(MetaDataParseException)
         e.message == 'Could not parse module metadata <resource>'
-        e.cause.message == 'Expected BEGIN_OBJECT but was BEGIN_ARRAY at line 1 column 2 path $'
+        e.cause.message == 'Expected BEGIN_OBJECT but was BEGIN_ARRAY at line 1 column 2 path $\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#unexpected-json-structure'
     }
 
     def "fails on missing format version"() {
@@ -848,7 +848,7 @@ class GradleModuleMetadataParserTest extends Specification {
         then:
         def e = thrown(MetaDataParseException)
         e.message == "Could not parse module metadata <resource>: unsupported format version '123.4' specified in module metadata. This version of Gradle supports format version 1.1."
-        e.cause.message == "Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 1 column 42 path \$.variants"
+        e.cause.message == "Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 1 column 42 path \$.variants\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#unexpected-json-structure"
     }
 
     def "is lenient with version checks if we manage to parse content (#label, version = #version)"() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,14 @@ pluginManagement {
     includeBuild("build-logic-settings")
 }
 
+buildscript {
+    dependencies {
+        // update Gson to the desired version, needed here as org.gradle.toolchains.foojay-resolver-convention brings in an older version below
+        // https://github.com/gradle/foojay-toolchains/issues/99
+        classpath("com.google.code.gson:gson:2.12.1") // keep in sync with build-logic-commons/build-platform/build.gradle.kts
+    }
+}
+
 plugins {
     id("gradlebuild.build-environment")
     id("gradlebuild.configuration-cache-compatibility")


### PR DESCRIPTION
Relevant releases are:
https://github.com/google/gson/releases/tag/gson-parent-2.10.1
https://github.com/google/gson/releases/tag/gson-parent-2.11.0
https://github.com/google/gson/releases/tag/gson-parent-2.12.0
https://github.com/google/gson/releases/tag/gson-parent-2.12.1

Our distribution goes from `2.10.0` => `2.12.1`, our build-logic from `2.10.1` => `2.12.1` because of https://github.com/gradle/foojay-toolchains/issues/99

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
