### PR TITLE
Run `df -T` on EC2

### DIFF
--- a/.teamcity/scripts/configure_build_env_on_ec2.sh
+++ b/.teamcity/scripts/configure_build_env_on_ec2.sh
@@ -39,3 +39,5 @@ if [ -d "/opt/gradle-cache" ]; then
   echo "Setting READ_ONLY Gradle cache via env.GRADLE_RO_DEP_CACHE to use /opt/gradle-cache"
 fi
 
+# Print details of volumes to help us understand https://github.com/gradle/gradle-private/issues/4642
+df -T


### PR DESCRIPTION
To understand https://github.com/gradle/gradle-private/issues/4642, we need to know which FS the build is running on. This PR runs `df -T` to print the details of FS.