### PR TITLE
Warning on mutation during forbidden state becomes error, warnings for still-allowed modification of usage expanded

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
@@ -484,7 +484,7 @@ configurations.compile.withDependencies {
         succeeds("resolve")
     }
 
-    def "modifying dependency and constraint attributes are deprecated after resolution"() {
+    def "modifying dependency and constraint attributes is banned after resolution"() {
         given:
         ["1.0", "2.0"].each { version ->
             mavenRepo.module("org", "foo", version).publish()
@@ -536,11 +536,10 @@ configurations.compile.withDependencies {
             }
         """
 
-        expect:
-        executer.expectDocumentedDeprecationWarning("Mutating a configuration after it has been resolved, consumed as a variant, or used for generating published metadata. This behavior has been deprecated. This will fail with an error in Gradle 9.0. The dependency attributes of configuration ':deps' were mutated after the configuration's child configuration ':res' was resolved. After a configuration has been observed, it should not be modified. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutate_configuration_after_locking")
-        executer.expectDocumentedDeprecationWarning("Mutating a configuration after it has been resolved, consumed as a variant, or used for generating published metadata. This behavior has been deprecated. This will fail with an error in Gradle 9.0. The dependency attributes of configuration ':parent' were mutated after the configuration's child configuration ':res' was resolved. After a configuration has been observed, it should not be modified. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutate_configuration_after_locking")
-        executer.expectDocumentedDeprecationWarning("Mutating a configuration after it has been resolved, consumed as a variant, or used for generating published metadata. This behavior has been deprecated. This will fail with an error in Gradle 9.0. The dependency constraint attributes of configuration ':deps' were mutated after the configuration's child configuration ':res' was resolved. After a configuration has been observed, it should not be modified. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutate_configuration_after_locking")
-        executer.expectDocumentedDeprecationWarning("Mutating a configuration after it has been resolved, consumed as a variant, or used for generating published metadata. This behavior has been deprecated. This will fail with an error in Gradle 9.0. The dependency constraint attributes of configuration ':parent' were mutated after the configuration's child configuration ':res' was resolved. After a configuration has been observed, it should not be modified. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutate_configuration_after_locking")
-        succeeds("resolve")
+        when:
+        fails("resolve")
+
+        then:
+        failure.assertHasCause("Cannot mutate a configuration after it has been resolved, consumed as a variant, or used for generating published metadata.  The dependency attributes of configuration ':deps' were mutated after the configuration's child configuration ':res' was resolved.")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -627,7 +627,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         "configurations.maybeCreateConsumableUnlocked('additionalRuntimeClasspath')"    | ConfigurationRoles.CONSUMABLE | true  | "internal unlocked role-based configuration, if it doesn't already exist"
     }
 
-    def "changing usage on detached configurations does not warn"() {
+    def "changing usage on detached configurations warns"() {
         given:
         buildFile << """
             def detached = project.configurations.detachedConfiguration()
@@ -642,6 +642,9 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         """
 
         expect:
+        expectConsumableChanging(":detachedConfiguration1", false)
+        expectResolvableChanging(":detachedConfiguration1", false)
+        expectDeclarableChanging(":detachedConfiguration1", false)
         run "help"
     }
 
@@ -659,41 +662,6 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         expectConsumableChanging(":detachedConfiguration1", false)
         expectResolvableChanging(":detachedConfiguration1", false)
         expectDeclarableChanging(":detachedConfiguration1", false)
-        succeeds('help', "-Dorg.gradle.internal.deprecation.preliminary.Configuration.redundantUsageChangeWarning.enabled=true")
-    }
-
-    def "redundantly changing usage on a role-locked configuration warns when flag is set"() {
-        given:
-        buildFile << """
-            configurations {
-                consumable('cons')
-                resolvable('res')
-                dependencyScope('dep')
-            }
-
-            configurations.cons.canBeConsumed = true
-            configurations.cons.canBeResolved = false
-            configurations.cons.canBeDeclared = false
-
-            configurations.res.canBeConsumed = false
-            configurations.res.canBeResolved = true
-            configurations.res.canBeDeclared = false
-
-            configurations.dep.canBeConsumed = false
-            configurations.dep.canBeResolved = false
-            configurations.dep.canBeDeclared = true
-        """
-
-        expect:
-        expectConsumableChanging(":cons", true)
-        expectResolvableChanging(":cons", false)
-        expectDeclarableChanging(":cons", false)
-        expectConsumableChanging(":res", false)
-        expectResolvableChanging(":res", true)
-        expectDeclarableChanging(":res", false)
-        expectConsumableChanging(":dep", false)
-        expectResolvableChanging(":dep", false)
-        expectDeclarableChanging(":dep", true)
         succeeds('help', "-Dorg.gradle.internal.deprecation.preliminary.Configuration.redundantUsageChangeWarning.enabled=true")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
@@ -18,9 +18,8 @@ package org.gradle.integtests.resolve.api
 
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ProperMethodUsage
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ConfigurationUsageChangingFixture
 
-class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpec implements ConfigurationUsageChangingFixture {
+class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpec {
     def "calling an invalid public API method #methodName for role #role fails"() {
         given:
         buildFile << """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/KotlinDslVersionCatalogExtensionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/KotlinDslVersionCatalogExtensionIntegrationTest.groovy
@@ -134,6 +134,9 @@ class KotlinDslVersionCatalogExtensionIntegrationTest extends AbstractHttpDepend
         lib.artifact.expectGet()
 
         then:
+        7.times {
+            executer.expectDocumentedDeprecationWarning("Calling setCanBeConsumed(false) on configuration ':buildSrc:detachedConfiguration${it+1}' has been deprecated. This will fail with an error in Gradle 10.0. This configuration's role was set upon creation and its usage should not be changed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+        }
         succeeds ':checkDeps'
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ConfigurationUsageChangingFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ConfigurationUsageChangingFixture.groovy
@@ -36,6 +36,6 @@ trait ConfigurationUsageChangingFixture {
     }
 
     void expectChangingUsage(String configurationPath, String method, boolean value) {
-        executer.expectDocumentedDeprecationWarning("Calling $method($value) on configuration '$configurationPath' has been deprecated. This will fail with an error in Gradle 9.0. This configuration's role was set upon creation and its usage should not be changed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+        executer.expectDocumentedDeprecationWarning("Calling $method($value) on configuration '$configurationPath' has been deprecated. This will fail with an error in Gradle 10.0. This configuration's role was set upon creation and its usage should not be changed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
     }
 }


### PR DESCRIPTION
Updates to `maybeWarnOnChangingUsage`.