### PR TITLE
Improve content of API jar

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/build.gradle.kts
@@ -53,3 +53,7 @@ dependencies {
 packageCycles {
     excludePatterns.add("org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/**")
 }
+
+// Kotlin DSL provider plugins should not be part of the public API
+// TODO Find a way to not register this and the task instead
+configurations.remove(configurations.apiStubElements.get())

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/build.gradle.kts
@@ -44,3 +44,7 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly = true
+
+// Kotlin DSL tooling builders should not be part of the public API
+// TODO Find a way to not register this and the task instead
+configurations.remove(configurations.apiStubElements.get())

--- a/platforms/core-configuration/kotlin-dsl-tooling-models/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-tooling-models/build.gradle.kts
@@ -7,3 +7,7 @@ description = "Kotlin DSL Tooling Models for IDEs"
 dependencies {
     api(libs.jsr305)
 }
+
+// Kotlin DSL tooling models should not be part of the public API
+// TODO Find a way to not register this and the task instead
+configurations.remove(configurations.apiStubElements.get())

--- a/platforms/core-configuration/kotlin-dsl/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl/build.gradle.kts
@@ -163,7 +163,10 @@ configure<KotlinJvmProjectExtension> {
         dependsOn(target.compilations.named("main").flatMap { it.compileTaskProvider })
         into(layout.buildDirectory.dir("generated/kotlin-abi-filtered"))
         from(layout.buildDirectory.dir("generated/kotlin-abi")) {
+            includeEmptyDirs = false
             include(PublicKotlinDslApi.includes)
+            // Those leak in the public API - see org.gradle.kotlin.dsl.NamedDomainObjectContainerScope for example
+            include("org/gradle/kotlin/dsl/support/delegates/*")
             include("META-INF/*.kotlin_module")
             // We do not exclude inlined functions, they are needed for compilation
         }


### PR DESCRIPTION
* Remove more Kotlin DSL types that should not be part of the public API and were not in the generated API jar.
* Fix issue with empty dirs