### PR TITLE
Remove internal API `BuildOperationExecutor.getCurrentOperation()`

### DIFF
--- a/platforms/core-runtime/base-services/src/integTest/groovy/org/gradle/internal/operations/BuildOperationExecutorIntegrationTest.groovy
+++ b/platforms/core-runtime/base-services/src/integTest/groovy/org/gradle/internal/operations/BuildOperationExecutorIntegrationTest.groovy
@@ -110,24 +110,4 @@ class BuildOperationExecutorIntegrationTest extends AbstractIntegrationSpec {
         then:
         file("build1result.txt").text != file("build2result.txt").text
     }
-
-    // This was added to keep KMP compatible with changes in Gradle 8.8
-    def "can get current build operation via BuildOperationExecutor.getCurrentBuildOperation()" () {
-        buildFile << """
-            import org.gradle.internal.operations.*
-
-            task currentBuildOperation {
-                doLast {
-                    println "Current build operation: " + services.get(BuildOperationExecutor).currentOperation
-                }
-            }
-        """
-
-        when:
-        executer.expectDeprecationWarning("Internal API BuildOperationExecutor.getCurrentOperation() has been deprecated. This is scheduled to be removed in Gradle 9.0.")
-        succeeds("currentBuildOperation")
-
-        then:
-        outputContains("Current build operation: Execute doLast {} action for :currentBuildOperation")
-    }
 }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
@@ -74,7 +74,4 @@ public interface BuildOperationExecutor {
      * @see BuildOperationExecutor#runAll(BuildOperationWorker, Action)
      */
     <O extends BuildOperation> void runAll(BuildOperationWorker<O> worker, Action<BuildOperationQueue<O>> schedulingAction, BuildOperationConstraint buildOperationConstraint);
-
-    @Deprecated
-    BuildOperationRef getCurrentOperation();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
@@ -22,7 +22,6 @@ import org.gradle.internal.SystemProperties;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.concurrent.Stoppable;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.work.WorkerLimits;
 import org.jspecify.annotations.Nullable;
@@ -126,20 +125,6 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
         for (ManagedExecutor pool : managedExecutors.values()) {
             pool.stop();
         }
-    }
-
-    @Deprecated
-    @Override
-    public BuildOperationRef getCurrentOperation() {
-        DeprecationLogger.deprecateInternalApi("BuildOperationExecutor.getCurrentOperation()")
-            .willBeRemovedInGradle9()
-            .undocumented()
-            .nagUser();
-        BuildOperationRef operationRef = currentBuildOperationRef.get();
-        if (operationRef == null) {
-            throw new IllegalStateException("No operation is currently running.");
-        }
-        return operationRef;
     }
 
     private class QueueWorker<O extends BuildOperation> implements BuildOperationQueue.QueueWorker<O> {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
@@ -72,12 +72,6 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
         throw new UnsupportedOperationException();
     }
 
-    @Deprecated
-    @Override
-    public BuildOperationRef getCurrentOperation() {
-        throw new UnsupportedOperationException();
-    }
-
     public static class TestBuildOperationQueue<O extends RunnableBuildOperation> implements BuildOperationQueue<O> {
 
         public final BuildOperationRunner runner;

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -88,6 +88,8 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         kotlinVersion << TestedVersions.kotlin.versions.findAll {
             // versions prior to 2.0.0 don't support java 21
             (JavaVersion.current() < JavaVersion.VERSION_21 || VersionNumber.parse(it) >= VersionNumber.parse('2.0.0-Beta1'))
+            // versions prior to 2.0.20 use deprecated APIs removed in Gradle 9.0
+            && VersionNumber.parse(it) >= KotlinGradlePluginVersions.KOTLIN_2_0_20
         }
     }
 


### PR DESCRIPTION
We've tried to remove this internal API in Gradle 8.8 (see https://github.com/gradle/gradle/pull/28398), but it broke KMP, so we deprecated it instead (see https://github.com/gradle/gradle/pull/28671).

Now we can remove it for good in Gradle 9.0.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
