### PR TITLE
Allow `null` extra properties

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/DefaultExtraPropertiesExtension.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/DefaultExtraPropertiesExtension.java
@@ -109,20 +109,21 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
 
     @Override
     public Map<String, Object> getProperties() {
+        // Must return a mutable map to preserve contract
         // TODO:configuration-cache use a tracking map here
         if (storage == null) {
-            return gradleProperties;
+            return new HashMap<>(gradleProperties);
         }
-        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builderWithExpectedSize(storage.size() + gradleProperties.size());
-        builder.putAll(storage);
+        Map<String, Object> properties = new HashMap<>(storage.size() + gradleProperties.size());
+        properties.putAll(storage);
         for (Map.Entry<String, Object> entry : gradleProperties.entrySet()) {
             if (!storage.containsKey(entry.getKey())) {
                 // TODO:configuration-cache track Gradle property lookup
 //                onGradlePropertyLookup(entry.getKey());
-                builder.put(entry.getKey(), entry.getValue());
+                properties.put(entry.getKey(), entry.getValue());
             }
         }
-        return builder.build();
+        return properties;
     }
 
     @SuppressWarnings("rawtypes")

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/extensibility/ExtraPropertiesExtensionTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/extensibility/ExtraPropertiesExtensionTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.extensibility
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Issue
 import spock.lang.Specification
 
 /**
@@ -188,6 +189,26 @@ abstract class ExtraPropertiesExtensionTest<T extends ExtraPropertiesExtension> 
 
         then:
         notThrown(Exception)
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/33074')
+    def "can add null properties using ext block notation"() {
+        given:
+        Project project = ProjectBuilder.builder().build()
+
+        when:
+        project.ext {
+            aProperty = null as Integer
+        }
+
+        then:
+        notThrown(Exception)
+
+        and:
+        project.ext.has 'aProperty'
+
+        and:
+        project.ext.properties.containsKey('aProperty')
     }
 
     def "can use [] notation to get and set"() {


### PR DESCRIPTION
Build logic is allowed to create extra properties with a null value:
```groovy
    project.ext.aProperty = null
```
Thus, when computing a map with all properties, `ImmutableMap` cannot be used since it does not allow `null` values.

Fixes #33074

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
