### PR TITLE
docs: improve `docsTest`

### DIFF
--- a/.teamcity/src/main/kotlin/common/CommonExtensions.kt
+++ b/.teamcity/src/main/kotlin/common/CommonExtensions.kt
@@ -211,8 +211,8 @@ fun BuildType.paramsForBuildToolBuild(
         param("env.ANDROID_HOME", os.androidHome)
         param("env.ANDROID_SDK_ROOT", os.androidHome)
         param("env.GRADLE_INTERNAL_REPO_URL", "%gradle.internal.repository.url%")
-        if (os == Os.MACOS) {
-            // Use fewer parallel forks on macOs, since the agents are not very powerful.
+        if (os == Os.MACOS && arch == Arch.AMD64) {
+            // Use fewer parallel forks only on Intel macOS builds, since they are not very powerful.
             param("maxParallelForks", "2")
         }
         if (os == Os.LINUX || os == Os.MACOS) {

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -624,8 +624,6 @@ tasks.named<Test>("docsTest") {
     systemProperties.clear()
 
     filter {
-        // workaround for https://github.com/gradle/dotcom/issues/5958
-        isFailOnNoMatchingTests = false
         // Only execute C++ sample tests on Linux because it is the configured target
         if (!OperatingSystem.current().isLinux) {
             excludeTestsMatching("org.gradle.docs.samples.*.building-cpp-*.sample")

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -609,7 +609,6 @@ tasks.named("quickTest") {
 
 // TODO add some kind of test precondition support in sample test conf
 tasks.named<Test>("docsTest") {
-    maxParallelForks = 2
     // The org.gradle.samples plugin uses Exemplar to execute integration tests on the samples.
     // Exemplar doesn't know about that it's running in the context of the gradle/gradle build
     // so it uses the Gradle distribution from the running build. This is not correct, because


### PR DESCRIPTION
* Stop limiting `docsTest` to only 2 parallel forks Instead inherit the setting from the build overall to benefit from tuning there
* Remove obsolete workaround `isFailOnNoMatchingTests` to properly report if no tests match the given filter
* Apply the global `maxParallelForks=2` limitation only on AMD64 builds running on old Intel macs as the Apple Silicon macs are much faster

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
