### PR TITLE
Add Best Practice: Don't Explicitly Depend on Kotlin StdLib

### DIFF
--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -687,7 +687,7 @@ tasks.named<Test>("docsTest") {
 
         if (javaVersion.isCompatibleWith(JavaVersion.VERSION_24)) {
             // Kotlin does not yet support 24 JDK target
-            excludeTestsMatching("org.gradle.docs.samples.*.best-practices-kotlin-std-lib*")
+            excludeTestsMatching("org.gradle.docs.samples.*.snippet-best-practices-kotlin-std-lib*")
         }
 
         if (OperatingSystem.current().isMacOsX && System.getProperty("os.arch") == "aarch64") {

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -685,6 +685,11 @@ tasks.named<Test>("docsTest") {
             excludeTestsMatching("org.gradle.docs.samples.*.snippet-code-quality-code-quality*")
         }
 
+        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_24)) {
+            // Kotlin does not yet support 24 JDK target
+            excludeTestsMatching("org.gradle.docs.samples.*.best-practices-kotlin-std-lib*")
+        }
+
         if (OperatingSystem.current().isMacOsX && System.getProperty("os.arch") == "aarch64") {
             excludeTestsMatching("org.gradle.docs.samples.*.snippet-native*.sample")
             excludeTestsMatching("org.gradle.docs.samples.*.snippet-swift*.sample")

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
@@ -195,7 +195,7 @@ include::sample[dir="snippets/bestPractices/kotlinStdLib-do/groovy",files="build
 *`stdlib` dependency is not included explicitly*: The standard library remains available for use, and source code requiring it can be compiled without any issues.
 
 === References
-- https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/kotlin.html[the kotlin() function]
+- https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/kotlin.html[the `kotlin()` function]
 
 === Tags
 `<<tags_reference.adoc#tag:dependencies,#dependencies>>`

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
@@ -169,7 +169,7 @@ Kotlin Gradle Plugin automatically adds a dependency on the Kotlin standard libr
 
 === Explanation
 
-The version of the standard library added is the same as the version of the Kotlin Gradle Plugin.
+The version of the standard library added is the same as the version of the Kotlin Gradle Plugin applied to the project.  
 If your build does not require a specific or different version of the standard library, you should avoid adding it manually.
 
 NOTE: Setting the `kotlin.stdlib.default.dependency` property to `false` prevents the Kotlin plugin from automatically adding the Kotlin standard library dependency to your project. This can be useful in specific scenarios, such as when you want to manage the Kotlin standard library dependency version manually.

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
@@ -160,3 +160,42 @@ include::sample[dir="snippets/bestPractices/settingsRepositoriesDo/groovy",files
 
 === Tags
 `<<tags_reference.adoc#tag:structuring-builds,#structuring-builds>>`
+
+[[dont_depend_on_kotlin_stdlib]]
+== Don't Explicitly Depend on the Kotlin Standard Library
+:keywords: dependencies
+
+Kotlin Gradle Plugin automatically adds a dependency on the Kotlin standard library (`stdlib`) to each source set, so there is no need to add it explicitly.
+
+=== Explanation
+
+The version of the standard library added is the same as the version of the Kotlin Gradle Plugin.
+If your build does not depend on a specific or different version of the standard library then an explicit dependency is not needed and shouldn't be added.
+
+Note that setting the `kotlin.stdlib.default.dependency` property to `false` prevents the Kotlin plugin from automatically adding the Kotlin standard library dependency to your project which can be useful in specific scenarios, such as when you want to manage the Kotlin standard library dependency version manually.
+
+=== Example
+
+==== Don't Do This
+
+====
+include::sample[dir="snippets/bestPractices/kotlinStdLib-avoid/kotlin",files="build.gradle.kts[tags=avoid-this]"]
+include::sample[dir="snippets/bestPractices/kotlinStdLib-avoid/groovy",files="build.gradle[tags=avoid-this]"]
+====
+
+<1> *`stdlib` is explicitly depended upon*: This project contains an implicit dependency on the Kotlin standard library, which is required to compile its source code.
+
+==== Do This Instead
+
+====
+include::sample[dir="snippets/bestPractices/kotlinStdLib-do/kotlin",files="build.gradle.kts[tags=do-this]"]
+include::sample[dir="snippets/bestPractices/kotlinStdLib-do/groovy",files="build.gradle[tags=do-this]"]
+====
+
+*`stdlib` dependency is not included explicitly*: The standard library remains available for use, and source code requiring it can be compiled without any issues.
+
+=== References
+- https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/kotlin.html[the kotlin() function]
+
+=== Tags
+`<<tags_reference.adoc#tag:dependencies,#dependencies>>`

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
@@ -172,7 +172,7 @@ Kotlin Gradle Plugin automatically adds a dependency on the Kotlin standard libr
 The version of the standard library added is the same as the version of the Kotlin Gradle Plugin.
 If your build does not depend on a specific or different version of the standard library then an explicit dependency is not needed and shouldn't be added.
 
-Note that setting the `kotlin.stdlib.default.dependency` property to `false` prevents the Kotlin plugin from automatically adding the Kotlin standard library dependency to your project which can be useful in specific scenarios, such as when you want to manage the Kotlin standard library dependency version manually.
+NOTE: Setting the `kotlin.stdlib.default.dependency` property to `false` prevents the Kotlin plugin from automatically adding the Kotlin standard library dependency to your project. This can be useful in specific scenarios, such as when you want to manage the Kotlin standard library dependency version manually.
 
 === Example
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
@@ -170,7 +170,7 @@ Kotlin Gradle Plugin automatically adds a dependency on the Kotlin standard libr
 === Explanation
 
 The version of the standard library added is the same as the version of the Kotlin Gradle Plugin.
-If your build does not depend on a specific or different version of the standard library then an explicit dependency is not needed and shouldn't be added.
+If your build does not require a specific or different version of the standard library, you should avoid adding it manually.
 
 NOTE: Setting the `kotlin.stdlib.default.dependency` property to `false` prevents the Kotlin plugin from automatically adding the Kotlin standard library dependency to your project. This can be useful in specific scenarios, such as when you want to manage the Kotlin standard library dependency version manually.
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_dependencies.adoc
@@ -165,7 +165,7 @@ include::sample[dir="snippets/bestPractices/settingsRepositoriesDo/groovy",files
 == Don't Explicitly Depend on the Kotlin Standard Library
 :keywords: dependencies
 
-Kotlin Gradle Plugin automatically adds a dependency on the Kotlin standard library (`stdlib`) to each source set, so there is no need to add it explicitly.
+The Kotlin Gradle Plugin automatically adds a dependency on the Kotlin standard library (`stdlib`) to each source set, so there is no need to declare it explicitly.
 
 === Explanation
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/tags_reference.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/tags_reference.adoc
@@ -22,6 +22,9 @@ Here you can find a brief explanation of all the tags used in the best practices
 [[tag:caching]]
 `#caching` :: Items that are related to using Gradle's various caching mechanisms, such as <<build_cache.adoc#sec:task_output_caching,caching tasks>>.
 
+[[tag:dependencies]]
+`#dependencies` :: Items that are related to <<dependency_resolution.adoc#dependency-resolution-basics,dependency resolution>> in Gradle, including declaring dependencies, dependency management, and dependency resolution.
+
 [[tag:inputs-and-outputs]]
 `#inputs-and-outputs`:: Items that are related to Gradle <<writing_tasks.adoc#task_inputs_and_outputs,task inputs and outputs>>, the annotations used to declare them, and their proper use.
 
@@ -45,4 +48,3 @@ Here you can find a brief explanation of all the tags used in the best practices
 
 [[tag:version-catalog]]
 `#version-catalog` :: Items that explain how to use <<version_catalogs.adoc#version-catalog,version catalogs>> to centralize dependency declarations.
-

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/groovy/build.gradle
@@ -1,0 +1,9 @@
+// tag::avoid-this[]
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.0.21"
+}
+
+dependencies {
+    api("org.jetbrains.kotlin:kotlin-stdlib:2.0.21") // <1>
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/groovy/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "kotlin-std-lib-avoid"

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/groovy/src/main/kotlin/org/example/Sample.kt
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/groovy/src/main/kotlin/org/example/Sample.kt
@@ -1,0 +1,7 @@
+// tag::avoid-this[]
+class Sample {
+    fun joinStrings(strings: List<String>): String {
+        return strings.joinToString(separator = ", ") // <1>
+    }
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/kotlin/build.gradle.kts
@@ -1,0 +1,9 @@
+// tag::avoid-this[]
+plugins {
+    kotlin("jvm").version("2.0.21")
+}
+
+dependencies {
+    api(kotlin("stdlib")) // <1>
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/kotlin/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "kotlin-std-lib-avoid"

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/kotlin/src/main/kotlin/org/example/Sample.kt
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/kotlin/src/main/kotlin/org/example/Sample.kt
@@ -1,0 +1,7 @@
+// tag::avoid-this[]
+class Sample {
+    fun joinStrings(strings: List<String>): String {
+        return strings.joinToString(separator = ", ") // <1>
+    }
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/tests/kotlinStdLib-avoid.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-avoid/tests/kotlinStdLib-avoid.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: compileKotlin

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/groovy/build.gradle
@@ -1,0 +1,5 @@
+// tag::do-this[]
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.0.21"
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/groovy/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "kotlin-std-lib-do"

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/groovy/src/main/kotlin/org/example/Sample.kt
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/groovy/src/main/kotlin/org/example/Sample.kt
@@ -1,0 +1,7 @@
+// tag::do-this[]
+class Sample {
+    fun joinStrings(strings: List<String>): String {
+        return strings.joinToString(separator = ", ") // <1>
+    }
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/kotlin/build.gradle.kts
@@ -1,0 +1,5 @@
+// tag::do-this[]
+plugins {
+    kotlin("jvm").version("2.0.21")
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/kotlin/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "kotlin-std-lib-do"

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/kotlin/src/main/kotlin/org/example/Sample.kt
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/kotlin/src/main/kotlin/org/example/Sample.kt
@@ -1,0 +1,7 @@
+// tag::do-this[]
+class Sample {
+    fun joinStrings(strings: List<String>): String {
+        return strings.joinToString(separator = ", ") // <1>
+    }
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/tests/kotlinStdLib-do.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/kotlinStdLib-do/tests/kotlinStdLib-do.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: "compileKotlin"


### PR DESCRIPTION
Test with `gradle :docs:docsTest --rerun --tests "*snippet-best-practices-kotlin-std*"`