### PR TITLE
Fix CC serialization issues caused by AccessTracking classes

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -647,7 +647,7 @@
     "name": "input-tracking",
     "path": "platforms/core-configuration/input-tracking",
     "unitTests": true,
-    "functionalTests": false,
+    "functionalTests": true,
     "crossVersionTests": false
   },
   {

--- a/platforms/core-configuration/input-tracking/build.gradle.kts
+++ b/platforms/core-configuration/input-tracking/build.gradle.kts
@@ -7,4 +7,6 @@ description = "Configuration input discovery code"
 dependencies {
     api(libs.jspecify)
     api(libs.guava)
+
+    integTestDistributionRuntimeOnly(projects.distributionsCore)
 }

--- a/platforms/core-configuration/input-tracking/src/integTest/groovy/org/gradle/internal/configuration/inputs/InputTrackingIntegrationTest.groovy
+++ b/platforms/core-configuration/input-tracking/src/integTest/groovy/org/gradle/internal/configuration/inputs/InputTrackingIntegrationTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.configuration.inputs
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import spock.lang.Issue
+
+class InputTrackingIntegrationTest extends AbstractIntegrationSpec {
+
+    @Issue("https://github.com/gradle/gradle/issues/32564")
+    @ToBeFixedForConfigurationCache(
+        because = "values() are not tracked",
+        iterationMatchers = ".*\\.values\\(\\).*"
+    )
+    def "can use instrumented #value as task input"() {
+        given:
+        buildFile """
+            abstract class PrintEnvTask extends DefaultTask {
+                @Input
+                Object toPrint
+
+                @TaskAction
+                def action() {
+                    println String.valueOf(toPrint)
+                }
+            }
+
+            tasks.register("printEnv", PrintEnvTask) {
+                toPrint = ${value}
+            }
+        """
+
+        when:
+        executer.withEnvironmentVars(SOME_PROPERTY: "FIRST_VALUE")
+        run "-DSOME_PROPERTY=FIRST_VALUE", "printEnv"
+
+        then:
+        outputContains(expectedFirstResult)
+
+        when:
+        executer.withEnvironmentVars(SOME_PROPERTY: "SECOND_VALUE")
+        run "-DSOME_PROPERTY=SECOND_VALUE", "printEnv"
+
+        then:
+        outputContains(expectedSecondResult)
+
+        where:
+        value                          | expectedFirstResult         | expectedSecondResult
+        "System.getenv()"              | "SOME_PROPERTY=FIRST_VALUE" | "SOME_PROPERTY=SECOND_VALUE"
+        "System.getenv().entrySet()"   | "SOME_PROPERTY=FIRST_VALUE" | "SOME_PROPERTY=SECOND_VALUE"
+        "System.getenv().keySet()"     | "SOME_PROPERTY"             | "SOME_PROPERTY"
+        "System.getenv().values()"     | "FIRST_VALUE"               | "SECOND_VALUE"
+        "System.properties"            | "SOME_PROPERTY=FIRST_VALUE" | "SOME_PROPERTY=SECOND_VALUE"
+        "System.properties.entrySet()" | "SOME_PROPERTY=FIRST_VALUE" | "SOME_PROPERTY=SECOND_VALUE"
+        "System.properties.keySet()"   | "SOME_PROPERTY"             | "SOME_PROPERTY"
+        "System.properties.values()"   | "FIRST_VALUE"               | "SECOND_VALUE"
+    }
+}

--- a/platforms/core-configuration/input-tracking/src/main/java/org/gradle/internal/configuration/inputs/AccessTrackingEnvMap.java
+++ b/platforms/core-configuration/input-tracking/src/main/java/org/gradle/internal/configuration/inputs/AccessTrackingEnvMap.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ForwardingMap;
 import org.jspecify.annotations.Nullable;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -28,7 +29,7 @@ import java.util.function.BiConsumer;
 /**
  * A wrapper for the {@link System#getenv()} result that notifies a listener about accesses.
  */
-public class AccessTrackingEnvMap extends ForwardingMap<String, String> {
+public class AccessTrackingEnvMap extends ForwardingMap<String, String> implements Serializable {
     private final Map<String, String> delegate;
     private final BiConsumer<? super String, ? super String> onAccess;
 
@@ -65,7 +66,7 @@ public class AccessTrackingEnvMap extends ForwardingMap<String, String> {
 
     @Override
     public Set<String> keySet() {
-        return new AccessTrackingSet<>(super.keySet(), trackingListener());
+        return new AccessTrackingSet<>(super.keySet(), keyTrackingListener());
     }
 
     @Nullable
@@ -130,7 +131,7 @@ public class AccessTrackingEnvMap extends ForwardingMap<String, String> {
         delegate.forEach(onAccess);
     }
 
-    private AccessTrackingSet.Listener trackingListener() {
+    private AccessTrackingSet.Listener keyTrackingListener() {
         return new AccessTrackingSet.Listener() {
             @Override
             public void onAccess(@Nullable Object o) {
@@ -176,5 +177,13 @@ public class AccessTrackingEnvMap extends ForwardingMap<String, String> {
                 // Environment variables are immutable.
             }
         };
+    }
+
+    private Object writeReplace() {
+        // When we serialize the whole map, it is likely used as a task input.
+        // We don't know how it is going to be used afterward, and we cannot affect the fingerprint during execution.
+        // Let's be pessimistic and consider everything an input. On a bright side, we don't need access tracking for the deserialized thing.
+        reportAggregatingAccess();
+        return delegate;
     }
 }

--- a/platforms/core-configuration/input-tracking/src/main/java/org/gradle/internal/configuration/inputs/AccessTrackingEnvMap.java
+++ b/platforms/core-configuration/input-tracking/src/main/java/org/gradle/internal/configuration/inputs/AccessTrackingEnvMap.java
@@ -44,7 +44,7 @@ public class AccessTrackingEnvMap extends ForwardingMap<String, String> implemen
     }
 
     @Override
-    public String get(@Nullable Object key) {
+    public @Nullable String get(@Nullable Object key) {
         return getAndReport(key);
     }
 

--- a/platforms/core-configuration/input-tracking/src/main/java/org/gradle/internal/configuration/inputs/AccessTrackingProperties.java
+++ b/platforms/core-configuration/input-tracking/src/main/java/org/gradle/internal/configuration/inputs/AccessTrackingProperties.java
@@ -186,7 +186,7 @@ public class AccessTrackingProperties extends Properties {
     }
 
     @Override
-    public Object putIfAbsent(Object key, Object value) {
+    public @Nullable Object putIfAbsent(Object key, Object value) {
         Object oldValue;
         synchronized (delegate) {
             oldValue = delegate.putIfAbsent(key, value);

--- a/platforms/core-configuration/input-tracking/src/main/java/org/gradle/internal/configuration/inputs/AccessTrackingProperties.java
+++ b/platforms/core-configuration/input-tracking/src/main/java/org/gradle/internal/configuration/inputs/AccessTrackingProperties.java
@@ -96,7 +96,6 @@ public class AccessTrackingProperties extends Properties {
         void onClear();
     }
 
-    // TODO(https://github.com/gradle/configuration-cache/issues/337) Only a limited subset of method is tracked currently.
     private final Properties delegate;
     private final Listener listener;
 
@@ -113,7 +112,7 @@ public class AccessTrackingProperties extends Properties {
 
     @Override
     public Set<String> stringPropertyNames() {
-        return new AccessTrackingSet<>(delegate.stringPropertyNames(), trackingListener());
+        return new AccessTrackingSet<>(delegate.stringPropertyNames(), keyTrackingListener());
     }
 
     @Override
@@ -142,7 +141,7 @@ public class AccessTrackingProperties extends Properties {
 
     @Override
     public Set<Object> keySet() {
-        return new AccessTrackingSet<>(delegate.keySet(), trackingListener());
+        return new AccessTrackingSet<>(delegate.keySet(), keyTrackingListener());
     }
 
     @Override
@@ -556,7 +555,7 @@ public class AccessTrackingProperties extends Properties {
         return clazz == String.class || Primitives.isWrapperType(clazz);
     }
 
-    private AccessTrackingSet.Listener trackingListener() {
+    private AccessTrackingSet.Listener keyTrackingListener() {
         return new AccessTrackingSet.Listener() {
             @Override
             public void onAccess(@Nullable Object o) {

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -83,6 +83,7 @@ public class JpmsConfiguration {
             "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED", // required by JavaObjectSerializationCodec.kt
             "--add-opens=java.base/java.nio.charset=ALL-UNNAMED", // required by BeanSchemaKt
             "--add-opens=java.base/java.net=ALL-UNNAMED", // required by JavaObjectSerializationCodec
+            "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED", // required by AccessTrackingProperties
             "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED", // serialized from org.gradle.internal.file.StatStatistics$Collector
             "--add-opens=java.xml/javax.xml.namespace=ALL-UNNAMED" // serialized from IvyDescriptorFileGenerator.Model
         ));


### PR DESCRIPTION
They or their views can be used wholesale as task inputs, so they must be CC-serializable to some extent. Prior to this commit we were trying to serialize the getenv() result or views, like keySet(), as beans and failed because of non-serializable lambdas or JDK-internal classes inside.

This commit doesn't make the lambda serializable, but instead introduces serialization doubles. For starters, serializing the map or its view means that we're making everything a CC input. This means we don't need to track accesses in the deserialized value, and thus we can just store the contents, with some workarounds for CC serialization quirks.

We have to add another `--add-opens` because of
`System.getProperties().getEntries()`. Serializing the entries requires accessing the private `ConcurrentHashMap.MapEntry` class.

Fixes #32564.