### PR TITLE
Resolve regression in DefaultArtifactPublicationSet

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DefaultArtifactPublicationSetRegressionTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DefaultArtifactPublicationSetRegressionTest.groovy
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+/**
+ * Tests a regression related to the {@link DefaultArtifactPublicationSet}
+ * <p>
+ * TODO: Delete this test in 9.0, as DAPS has since been removed.
+ */
+@Issue("https://github.com/gradle/gradle/issues/33084")
+class DefaultArtifactPublicationSetRegressionTest extends AbstractIntegrationSpec {
+
+    def "original reproducer with java plugin"() {
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            def bootJar = tasks.register("bootJar", Jar)
+            def bootArchives = configurations.create("bootArchives") {
+                outgoing.artifact(bootJar)
+            }
+
+            def apiElements = configurations.apiElements
+            bootJar.configure {
+                apiElements.outgoing.artifact(bootJar)
+            }
+        """
+
+        expect:
+        succeeds("assemble")
+    }
+
+    def "minimized reproducer directly referencing DAPS"() {
+        buildFile << """
+            plugins {
+                id("base")
+            }
+
+            def jar = tasks.register("jar", Jar)
+            def apiElements = configurations.create("apiElements") {
+                visible = false
+                outgoing.artifact(jar)
+            }
+
+            extensions.getByType(${DefaultArtifactPublicationSet.class.name}.class)
+                .addCandidateInternal(apiElements.outgoing.artifacts.first())
+
+            def bootJar = tasks.register("bootJar", Jar)
+            def bootArchives = configurations.create("bootArchives") {
+                outgoing.artifact(bootJar)
+            }
+
+            bootJar.configure {
+                apiElements.outgoing.artifact(bootJar)
+            }
+        """
+
+        expect:
+        succeeds("assemble")
+    }
+
+    def "minimized reproducer with slightly different error message"() {
+        buildFile << """
+            plugins {
+                id("base")
+            }
+
+            def bootJar = tasks.register("bootJar", Jar)
+            configurations.create("bootArchives") {
+                outgoing.artifact(bootJar)
+            }
+
+            def apiElements = configurations.create("apiElements") {
+                visible = false
+            }
+            bootJar.configure {
+                apiElements.outgoing.artifact(bootJar)
+            }
+        """
+
+        expect:
+        succeeds("assemble")
+    }
+
+    def "minimized reproducer with same error message and base plugin"() {
+        buildFile << """
+            plugins {
+                id("base")
+            }
+
+            def jar = tasks.register("jar", Jar)
+            def apiElements = configurations.create("apiElements") {
+                outgoing.artifact(jar)
+            }
+
+            def bootJar = tasks.register("bootJar", Jar)
+            configurations.create("bootArchives") {
+                outgoing.artifact(bootJar)
+            }
+
+            bootJar.configure {
+                apiElements.outgoing.artifact(bootJar)
+            }
+        """
+
+        expect:
+        succeeds("assemble")
+    }
+}


### PR DESCRIPTION
In some cases, processArtifact can call reset, therefore causing defaultArtifacts to be null in some cases. This reentrant-like behavior caused NPEs.

To resolve this, we compute the new defaultArtifacts in a local variable, and track currentDefault on the stack, in order to avoid the reentrant behavior from messing with its own state.

DAPS has been removed in 9.0. The test added here should be deleted on 9.0 and the changes to DAPS can be discarded.

Fixes https://github.com/gradle/gradle/issues/33084

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
