### PR TITLE
Change distribution size check to be less picky and not depend on the version number string size

### DIFF
--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -185,12 +185,13 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
         coreLibJarsCount + packagedPluginsJarCount + agentJarsCount + thirdPartyLibJarsCount
     }
 
-    def "distribution size should not exceed a certain number"() {
+    def "distribution size should not change too much"() {
         expect:
         def actual = (int) Math.ceil((double) getZip().size() / 1024 / 1024)
         def expected = getDistributionSizeMiB()
 
-        assert actual == expected: "Distribution content needs to be verified. Current size: ${actual} MiB. Expected size: ${expected} MiB."
+        assert actual <= expected + 1: "Distribution is at least 1MiB larger, content needs to be verified. Current size: ${actual} MiB. Expected size: ${expected} MiB."
+        assert actual >= expected - 1: "Distribution is  at least 1MiB smaller, content needs to be verified. Current size: ${actual} MiB. Expected size: ${expected} MiB."
     }
 
     def "no duplicate jar entries in distribution"() {


### PR DESCRIPTION
Before this change, the distribution size check required the tests to declare the exact expected size of distributions in MiB. It turns out that this can pass during development, CI validation but then fail at promotion time. This is because when promoting, the version number string gets smaller and this as an impact on the final distributions sizes and can make that check fail.

Here is an example [failure during promotion](https://ge.gradle.org/s/siqwd42sqdt2i/tests/task/:distributions-integ-tests:forkingIntegTest/details/org.gradle.SrcDistributionIntegrationSpec/distribution%20size%20should%20not%20exceed%20a%20certain%20number?focused-exception-line=0-2&top-execution=1) that passed all the previous checks.

This commit lets the distributions sizes tests check whether the distributions are growing or shrinking by more than 1MiB instead of asserting size equality. It should still provide a valuable signal when the distributions sizes change too much while preventing surprising and annoying scenarios such as the one described above.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
