### PR TITLE
Fix `ScriptCachingIntegrationTest` wrongly failing because of debug logged stacktraces

### DIFF
--- a/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
+++ b/testing/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
@@ -253,6 +253,11 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
             misses(buildFile)
         }
 
+        // and: ignore debug stack traces in output causing flakiness
+        executer.beforeExecute {
+            executer.withStackTraceChecksDisabled()
+        }
+
         // expect: memory hog released
         val runs = 10
         // For some reason we have 5 references to the task class.


### PR DESCRIPTION
Disable stack trace check in ScriptCachingIntegrationTest

This test relies on debug logs. It happens that some stacktraces are logged on debug level, and they cause this test to wrongly fail.

e.g. https://ge.gradle.org/s/4jqlcxnvuxhe6/tests/task/:soak:forkingIntegTest/details/org.gradle.kotlin.dsl.caching.ScriptCachingIntegrationTest/in-memory%20script%20class%20loading%20cache%20releases%20memory%20of%20unused%20entries?focused-exception-line=0-0&top-execution=1

Apparently this is going on for some time in a flaky way and is now getting worse and fail on each run because of a dependency jar failing to classpath-normalize because of an unparseable .properties file.

https://ge.gradle.org/scans/tests?search.relativeStartTime=P90D&tests.container=org.gradle.kotlin.dsl.caching.ScriptCachingIntegrationTest&tests.test=in-memory%20script%20class%20loading%20cache%20releases%20memory%20of%20unused%20entries

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
