### PR TITLE
Fix broken cross version tests

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BuildProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/BuildProgressCrossVersionSpec.groovy
@@ -109,6 +109,9 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification implements W
         given:
         buildFile << """
             allprojects { apply plugin: 'java' }
+
+            // This just prevents Gradle from failing because there are test sources but no tests
+            test { include 'foo' }
 """
         file("src/main/java/Thing.java") << """class Thing { }"""
         file("src/test/java/Thing.java") << """class ThingTest { }"""


### PR DESCRIPTION
Fixes [broken cross version test](https://ge.gradle.org/scans/tests?search.names=gitBranchName&search.timeZoneId=America%2FNew_York&search.values=master&tests.container=org.gradle.integtests.tooling.r33.BuildProgressCrossVersionSpec) that only executes later in the CI pipeline.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
