### PR TITLE
Remove configuration usage deprecation

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -134,6 +134,11 @@ It will be removed in Gradle 10.0.
 
 Since Gradle 8.5, the same information can be obtained via the `BuildFeatures` service using `configurationCache.requested` property.
 
+[[undeprecated_configuration_uasge]]
+==== Deprecated configuration usages are no longer deprecated
+
+Starting in 8.0, adding an artifact to a configuration that is neither resolvable nor consumable was deprecated.  This deprecation was overly broad and also captured certain valid usages.  It has been removed in Gradle 8.14.
+
 [[changes_8.13]]
 == Upgrading from 8.12 and earlier
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -506,7 +506,7 @@ The link:{javadocPath}/org/gradle/api/tasks/compile/ForkOptions.html#getJavaHome
 
 Use <<toolchains.adoc#sec:consuming,JVM Toolchains>>, or the link:{javadocPath}/org/gradle/api/tasks/compile/ForkOptions.html#getExecutable()-[executable] property instead.
 
-Note: This deprecation was later link:#undeprecated_fork_options_java_home[removed], and for Gradle versions starting with 8.14, these methods will no longer throw deprecation warnings.
+NOTE: This deprecation was later link:#undeprecated_fork_options_java_home[removed], and for Gradle versions starting with 8.14, these methods will no longer throw deprecation warnings.
 
 [[mutating_buildscript_configurations]]
 ==== Deprecated mutating buildscript configurations

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultArtifactHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultArtifactHandler.java
@@ -24,8 +24,6 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
 import org.gradle.internal.Actions;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.MethodAccess;
 import org.gradle.internal.metaobject.MethodMixIn;
@@ -55,33 +53,10 @@ public class DefaultArtifactHandler implements ArtifactHandler, MethodMixIn {
     }
 
     private PublishArtifact pushArtifact(Configuration configuration, Object notation, Action<? super ConfigurablePublishArtifact> configureAction) {
-        warnIfConfigurationIsDeprecated((DeprecatableConfiguration) configuration);
         ConfigurablePublishArtifact publishArtifact = publishArtifactFactory.parseNotation(notation);
         configuration.getArtifacts().add(publishArtifact);
         configureAction.execute(publishArtifact);
         return publishArtifact;
-    }
-
-    // Update this with issue: https://github.com/gradle/gradle/issues/22339
-    private void warnIfConfigurationIsDeprecated(DeprecatableConfiguration configuration) {
-        // To avoid potentially adding new deprecation warnings in Gradle 8.0, we will maintain
-        // the existing fully deprecated logic here (migrating the method out of DefaultConfiguration
-        // so it isn't mistakenly used elsewhere)
-        if (isFullyDeprecated(configuration)) {
-            DeprecationLogger.deprecateConfiguration(configuration.getName()).forArtifactDeclaration()
-                .willBecomeAnErrorInGradle9()
-                .withUserManual("declaring_dependencies", "sec:deprecated-configurations")
-                .nagUser();
-        }
-    }
-
-    /**
-     * Exists only to maintain the existing fully deprecated logic in Gradle 8.0 - DO NOT USE.
-     */
-    private boolean isFullyDeprecated(DeprecatableConfiguration configuration) {
-        return configuration.isDeprecatedForDeclarationAgainst() &&
-            (!configuration.isCanBeConsumed() || configuration.isDeprecatedForConsumption()) &&
-            (!configuration.isCanBeResolved() || configuration.isDeprecatedForResolution());
     }
 
     @Override


### PR DESCRIPTION
Both AGP and KGP still add artifacts to configurations that trigger this deprecation.  Furthermore, the condition that triggers this deprecation doesn't seem quite right.  Given these two problems, we've decided to remove this deprecation in 9.0 rather than changing it to an error.  We'll create new deprecation(s) for 10.0 that address the correct conditions and work with AGP/KGP to resolve any remaining issues.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
