### PR TITLE
Drop Factory support from service registries

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheHost.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheHost.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.cc.impl
 
-import org.gradle.internal.Factory
 import org.gradle.internal.cc.base.serialize.HostServiceProvider
 import org.gradle.internal.service.scopes.Scope.Build
 import org.gradle.internal.service.scopes.ServiceScope
@@ -30,6 +29,4 @@ interface ConfigurationCacheHost : HostServiceProvider {
     fun createBuild(settingsFile: File?): ConfigurationCacheBuild
 
     fun visitBuilds(visitor: (VintageGradleBuild) -> Unit)
-
-    fun <T : Any> factory(serviceType: Class<T>): Factory<T>
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
@@ -32,7 +32,6 @@ import org.gradle.initialization.DefaultProjectDescriptor
 import org.gradle.initialization.DefaultSettings
 import org.gradle.initialization.SettingsState
 import org.gradle.initialization.layout.BuildLayout
-import org.gradle.internal.Factory
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.RootBuildState
@@ -67,9 +66,6 @@ class DefaultConfigurationCacheHost internal constructor(
 
     override fun <T : Any> service(serviceType: Class<T>): T =
         gradle.services.get(serviceType)
-
-    override fun <T : Any> factory(serviceType: Class<T>): Factory<T> =
-        gradle.services.getFactory(serviceType)
 
     private
     class DefaultVintageGradleBuild(override val state: BuildState) : VintageGradleBuild {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -677,8 +677,4 @@ class DefaultConfigurationCacheIO internal constructor(
     private
     inline fun <reified T : Any> service() =
         host.service<T>()
-
-    private
-    inline fun <reified T : Any> factory() =
-        host.factory(T::class.java)
 }

--- a/platforms/core-runtime/service-lookup/build.gradle.kts
+++ b/platforms/core-runtime/service-lookup/build.gradle.kts
@@ -7,7 +7,7 @@ description = "Internal API to dynamically lookup services provided by Gradle mo
 gradlebuildJava.usedInWorkers()
 
 dependencies {
-    api(projects.stdlibJavaExtensions)
-
     api(libs.jspecify)
+
+    implementation(projects.stdlibJavaExtensions)
 }

--- a/platforms/core-runtime/service-lookup/src/main/java/org/gradle/internal/service/ServiceRegistry.java
+++ b/platforms/core-runtime/service-lookup/src/main/java/org/gradle/internal/service/ServiceRegistry.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.internal.service;
 
-import org.gradle.internal.Factory;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.lang.annotation.Annotation;
@@ -69,28 +68,6 @@ public interface ServiceRegistry extends ServiceLookup {
     @Override
     Object find(Type serviceType) throws ServiceLookupException;
 
-    /**
-     * Locates a factory which can create services of the given type.
-     *
-     * @param type The service type that the factory should create.
-     * @param <T> The service type that the factory should create.
-     * @return The factory. Never returns null.
-     * @throws UnknownServiceException When there is no factory available for services of the given type.
-     * @throws ServiceLookupException On failure to lookup the specified service factory.
-     */
-    <T> Factory<T> getFactory(Class<T> type) throws UnknownServiceException, ServiceLookupException;
-
-    /**
-     * Creates a new service instance of the given type.
-     *
-     * @param type The service type
-     * @param <T> The service type.
-     * @return The instance. Never returns null.
-     * @throws UnknownServiceException When there is no factory available for services of the given type.
-     * @throws ServiceLookupException On failure to lookup the specified service factory.
-     */
-    <T> T newInstance(Class<T> type) throws UnknownServiceException, ServiceLookupException;
-
     ServiceRegistry EMPTY = new ServiceRegistry() {
         @Override
         public <T> T get(Class<T> serviceType) throws UnknownServiceException, ServiceLookupException {
@@ -112,18 +89,8 @@ public interface ServiceRegistry extends ServiceLookup {
             return null;
         }
 
-        @Override
-        public <T> Factory<T> getFactory(Class<T> type) throws UnknownServiceException, ServiceLookupException {
-            throw emptyServiceRegistryException(type);
-        }
-
         private UnknownServiceException emptyServiceRegistryException(Type type) {
             return new UnknownServiceException(type, "Nothing is available in the empty service registry.");
-        }
-
-        @Override
-        public <T> T newInstance(Class<T> type) throws UnknownServiceException, ServiceLookupException {
-            throw emptyServiceRegistryException(type);
         }
 
         @Override

--- a/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistrationProvider.java
+++ b/platforms/core-runtime/service-provider/src/main/java/org/gradle/internal/service/ServiceRegistrationProvider.java
@@ -37,9 +37,6 @@ package org.gradle.internal.service;
  *
  * <p>
  * Any other methods will not be ignored.
- * <p>
- * Factories are declared similarly by having the method return {@code Factory<SomeService>}.
- * The factories are used by {@link ServiceRegistry#getFactory(Class)} and {@link ServiceRegistry#newInstance(Class)} methods.
  *
  * <h3>Registering dynamically</h3>
  * You can register services dynamically by declaring a {@code configure} method with a {@link ServiceRegistration} parameter.

--- a/platforms/core-runtime/service-registry-impl/build.gradle.kts
+++ b/platforms/core-runtime/service-registry-impl/build.gradle.kts
@@ -9,11 +9,11 @@ gradlebuildJava.usedInWorkers()
 dependencies {
     api(projects.serviceLookup)
     api(projects.serviceProvider)
-    api(projects.stdlibJavaExtensions)
 
     api(libs.jspecify)
 
     implementation(projects.concurrent)
+    implementation(projects.stdlibJavaExtensions)
 
     implementation(libs.inject)
 }

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -72,8 +72,10 @@ import static org.gradle.util.internal.CollectionUtils.join;
  *
  * </ul>
  *
- * <p>Service instances are closed when the registry that created them is closed using {@link #close()}. If a service instance or factory implements {@link java.io.Closeable} or {@link
- * org.gradle.internal.concurrent.Stoppable} then the appropriate {@link Closeable#close()} or {@link Stoppable#stop()} method is called. Instances are closed in reverse dependency order.</p>
+ * <p>Service instances are closed when the registry that created them is closed using {@link #close()}.
+ * If a service instance implements {@link java.io.Closeable} or {@link org.gradle.internal.concurrent.Stoppable}
+ * then the appropriate {@link Closeable#close()} or {@link Stoppable#stop()} method is called.
+ * Instances are closed in reverse dependency order.
  *
  * <p>Service registries are arranged in a hierarchy. If a service of a given type cannot be located, the registry uses its parent registry, if any, to locate the service.</p>
  *

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.internal.service;
 
-import org.gradle.internal.Cast;
-import org.gradle.internal.Factory;
 import org.gradle.internal.InternalTransformer;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
@@ -74,9 +72,7 @@ import static org.gradle.util.internal.CollectionUtils.join;
  *
  * </ul>
  *
- * <p>Service instances are created on demand. {@link #getFactory(Class)} looks for a service instance which implements {@code Factory<T>} where {@code T} is the expected type.</p>
- *
- * <p>Service instances and factories are closed when the registry that created them is closed using {@link #close()}. If a service instance or factory implements {@link java.io.Closeable} or {@link
+ * <p>Service instances are closed when the registry that created them is closed using {@link #close()}. If a service instance or factory implements {@link java.io.Closeable} or {@link
  * org.gradle.internal.concurrent.Stoppable} then the appropriate {@link Closeable#close()} or {@link Stoppable#stop()} method is called. Instances are closed in reverse dependency order.</p>
  *
  * <p>Service registries are arranged in a hierarchy. If a service of a given type cannot be located, the registry uses its parent registry, if any, to locate the service.</p>
@@ -363,23 +359,6 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
     }
 
     @Override
-    public <T> Factory<T> getFactory(Class<T> type) {
-        assertValidServiceType(type);
-        Service provider = getFactoryService(type);
-        Factory<T> factory = provider == null ? null : Cast.<Factory<T>>uncheckedCast(provider.get());
-        if (factory == null) {
-            throw new UnknownServiceException(type, String.format("No factory for objects of type %s available in %s.", format(type), getDisplayName()));
-        }
-        return factory;
-    }
-
-    @Nullable
-    private Service getFactoryService(Class<?> serviceType) {
-        serviceRequested();
-        return allServices.getFactory(serviceType, null);
-    }
-
-    @Override
     public <T> List<T> getAll(Class<T> serviceType) throws ServiceLookupException {
         assertValidServiceType(serviceType);
         List<T> services = new ArrayList<T>();
@@ -421,11 +400,6 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
         }
     }
 
-    @Override
-    public <T> T newInstance(Class<T> type) {
-        return getFactory(type).create();
-    }
-
     private class OwnServices implements ServiceProvider {
         private final Map<Class<?>, List<ServiceProvider>> providersByType = new HashMap<Class<?>, List<ServiceProvider>>(16, 0.5f);
         private final CompositeStoppable stoppable = CompositeStoppable.stoppable();
@@ -434,44 +408,6 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
 
         public OwnServices() {
             providersByType.put(ServiceRegistry.class, Collections.<ServiceProvider>singletonList(new ThisAsService(ServiceAccess.getPublicScope())));
-        }
-
-        @Override
-        public Service getFactory(Class<?> type, @Nullable ServiceAccessToken token) {
-            List<ServiceProvider> serviceProviders = getProviders(Factory.class);
-            if (serviceProviders.isEmpty()) {
-                return null;
-            }
-            if (serviceProviders.size() == 1) {
-                return serviceProviders.get(0).getFactory(type, token);
-            }
-
-            List<Service> services = new ArrayList<Service>(serviceProviders.size());
-            for (ServiceProvider serviceProvider : serviceProviders) {
-                Service service = serviceProvider.getFactory(type, token);
-                if (service != null) {
-                    services.add(service);
-                }
-            }
-
-            if (services.isEmpty()) {
-                return null;
-            }
-            if (services.size() == 1) {
-                return services.get(0);
-            }
-
-            Set<String> descriptions = new TreeSet<String>();
-            for (Service candidate : services) {
-                descriptions.add(candidate.getDisplayName());
-            }
-
-            Formatter formatter = new Formatter();
-            formatter.format("Multiple factories for objects of type %s available in %s:", format(type), getDisplayName());
-            for (String description : descriptions) {
-                formatter.format("%n   - %s", description);
-            }
-            throw new ServiceLookupException(formatter.toString());
         }
 
         @Override
@@ -729,11 +665,6 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
 
         BindState state = BindState.UNBOUND;
 
-        // Singleton service is implemented by a single instance and must extend/implement all declared service types.
-        // But it can only implement a single `Factory<? extends ElementType>` due to Java type constraints.
-        // The value of the field is computed lazily.
-        Class<?> factoryElementType;
-
         SingletonService(DefaultServiceRegistry owner, ServiceAccessScope accessScope, List<? extends Type> serviceTypes) {
             super(owner);
 
@@ -825,71 +756,6 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
             }
             return visitor;
         }
-
-        @Override
-        public Service getFactory(Class<?> elementType, @Nullable ServiceAccessToken token) {
-            if (!accessScope.contains(token)) {
-                return null;
-            }
-            if (!isFactoryFor(elementType)) {
-                return null;
-            }
-            return prepare();
-        }
-
-        // Finds the first element type of `Factory<? extends ElementType>` in the type hierarchy
-        @Nullable
-        private static Class<?> findFactoryElementType(Type type) {
-            Class<?> c = unwrap(type);
-            if (!Factory.class.isAssignableFrom(c)) {
-                return null;
-            }
-
-            if (type instanceof ParameterizedType) {
-                // Check if type is Factory<? extends ElementType>
-                ParameterizedType parameterizedType = (ParameterizedType) type;
-                if (parameterizedType.getRawType().equals(Factory.class)) {
-                    Type actualType = parameterizedType.getActualTypeArguments()[0];
-                    if (actualType instanceof Class) {
-                        return (Class<?>) actualType;
-                    }
-                }
-            }
-
-            // Check if type extends Factory<? extends ElementType>
-            for (Type interfaceType : c.getGenericInterfaces()) {
-                Class<?> parentFactoryElementType = findFactoryElementType(interfaceType);
-                if (parentFactoryElementType != null) {
-                    return parentFactoryElementType;
-                }
-            }
-
-            return null;
-        }
-
-        @Nullable
-        private static Class<?> findFactoryElementType(List<? extends Type> factoryCandidates) {
-            for (Type factoryCandidate : factoryCandidates) {
-                Class<?> factoryElementType = findFactoryElementType(factoryCandidate);
-                if (factoryElementType != null) {
-                    return factoryElementType;
-                }
-            }
-
-            return null;
-        }
-
-        private boolean isFactoryFor(Class<?> elementType) {
-            // This method can be called concurrently, but in the worst case we repeat the computation
-            if (factoryElementType == null) {
-                Class<?> foundFactoryElementType = findFactoryElementType(serviceTypes);
-                factoryElementType = foundFactoryElementType == null ? NonFactoryMarker.class : foundFactoryElementType;
-            }
-
-            return !factoryElementType.equals(NonFactoryMarker.class) && elementType.isAssignableFrom(factoryElementType);
-        }
-
-        private interface NonFactoryMarker {}
     }
 
     private static abstract class FactoryService extends SingletonService {
@@ -1206,17 +1072,6 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
         }
 
         @Override
-        public Service getFactory(Class<?> type, @Nullable ServiceAccessToken token) {
-            for (ServiceProvider serviceProvider : serviceProviders) {
-                Service factory = serviceProvider.getFactory(type, token);
-                if (factory != null) {
-                    return factory;
-                }
-            }
-            return null;
-        }
-
-        @Override
         public Visitor getAll(Class<?> serviceType, @Nullable ServiceAccessToken token, Visitor visitor) {
             for (ServiceProvider serviceProvider : serviceProviders) {
                 visitor = serviceProvider.getAll(serviceType, token, visitor);
@@ -1250,11 +1105,6 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
         }
 
         @Override
-        public Service getFactory(Class<?> serviceType, @Nullable ServiceAccessToken token) {
-            return parent.getFactory(serviceType, token);
-        }
-
-        @Override
         public Service getService(Type serviceType, @Nullable ServiceAccessToken token) {
             return parent.getService(serviceType, token);
         }
@@ -1279,10 +1129,6 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
         if (serviceType instanceof ParameterizedType) {
             ParameterizedType parameterizedType = (ParameterizedType) serviceType;
             Type rawType = parameterizedType.getRawType();
-            if (rawType.equals(Factory.class)) {
-                final Type typeArg = parameterizedType.getActualTypeArguments()[0];
-                return getFactoryService(typeArg, token, serviceProvider);
-            }
             if (rawType instanceof Class) {
                 if (((Class<?>) rawType).isAssignableFrom(List.class)) {
                     Type typeArg = parameterizedType.getActualTypeArguments()[0];
@@ -1298,27 +1144,6 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
         }
 
         throw new ServiceValidationException(String.format("Locating services with type %s is not supported.", format(serviceType)));
-    }
-
-    @Nullable
-    private static Service getFactoryService(Type type, @Nullable ServiceAccessToken token, ServiceProvider serviceProvider) {
-        if (type instanceof Class) {
-            return serviceProvider.getFactory((Class) type, token);
-        }
-        if (type instanceof WildcardType) {
-            final WildcardType wildcardType = (WildcardType) type;
-            if (wildcardType.getLowerBounds().length == 1 && wildcardType.getUpperBounds().length == 1) {
-                if (wildcardType.getLowerBounds()[0] instanceof Class && wildcardType.getUpperBounds()[0].equals(Object.class)) {
-                    return serviceProvider.getFactory((Class<?>) wildcardType.getLowerBounds()[0], token);
-                }
-            }
-            if (wildcardType.getLowerBounds().length == 0 && wildcardType.getUpperBounds().length == 1) {
-                if (wildcardType.getUpperBounds()[0] instanceof Class) {
-                    return serviceProvider.getFactory((Class<?>) wildcardType.getUpperBounds()[0], token);
-                }
-            }
-        }
-        throw new ServiceValidationException(String.format("Locating services with type %s is not supported.", format(type)));
     }
 
     private static Service getCollectionService(Type elementType, @Nullable ServiceAccessToken token, ServiceProvider serviceProvider) {
@@ -1501,12 +1326,6 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
             if (serviceType.equals(ServiceRegistry.class)) {
                 return this;
             }
-            return null;
-        }
-
-        @Override
-        public Service getFactory(Class<?> type, @Nullable ServiceAccessToken token) {
-            // Note: if any implementation is added, it must check the [accessScope] first
             return null;
         }
 

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceProvider.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ServiceProvider.java
@@ -29,12 +29,8 @@ interface ServiceProvider extends Stoppable {
     /**
      * Locates a service instance of the given type. Returns null if this provider does not provide a service of this type.
      */
-    @Nullable Service getService(Type serviceType, @Nullable ServiceAccessToken token);
-
-    /**
-     * Locates a factory for services of the given type. Returns null if this provider does not provide any services of this type.
-     */
-    @Nullable Service getFactory(Class<?> type, @Nullable ServiceAccessToken token);
+    @Nullable
+    Service getService(Type serviceType, @Nullable ServiceAccessToken token);
 
     /**
      * Collects all services of the given type.

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryConcurrencyTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryConcurrencyTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.service
 
-import org.gradle.internal.Factory
+
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 class DefaultServiceRegistryConcurrencyTest extends ConcurrentSpec {
@@ -49,39 +49,6 @@ class DefaultServiceRegistryConcurrencyTest extends ConcurrentSpec {
             start {
                 assert registry.get(String) == "12"
                 assert registry.get(Long) == 123
-            }
-        }
-    }
-
-    def "multiple threads can locate factories"() {
-        def registry = new DefaultServiceRegistry()
-        registry.addProvider(new ServiceRegistrationProvider() {
-            @Provides
-            Factory<String> createString(BigDecimal value) {
-                return { value.toString() } as Factory
-            }
-
-            @Provides
-            Factory<Integer> createInteger(Long value) {
-                return { 12 } as Factory
-            }
-
-            @Provides
-            Long createLong() {
-                return 2L
-            }
-
-            @Provides
-            BigDecimal createBigDecimal() {
-                return 123
-            }
-        })
-
-        expect:
-        10.times {
-            start {
-                assert registry.getFactory(Integer).create() == 12
-                assert registry.getFactory(String).create() == "123"
             }
         }
     }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
@@ -389,6 +389,7 @@ class ToolingApi implements TestRule {
 
         @Override
         DefaultGradleConnector createConnector() {
+            // Before Gradle 9.0, there was ServiceRegistry.getFactory(Class<T> type): org.gradle.internal.Factory<T>
             return serviceRegistry.getFactory(DefaultGradleConnector).create()
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/ImplicitInputsCapturingInstantiator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/ImplicitInputsCapturingInstantiator.java
@@ -17,7 +17,6 @@ package org.gradle.internal.resolve.caching;
 
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.internal.Cast;
-import org.gradle.internal.Factory;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceLookupException;
@@ -42,7 +41,6 @@ import java.util.List;
  *
  * If recording inputs is not required, the {@link #newInstance(Class, Object...)}
  * method can still be called, in which case it creates a non capturing instance.
- *
  */
 @NullMarked
 public class ImplicitInputsCapturingInstantiator implements Instantiator {
@@ -117,16 +115,6 @@ public class ImplicitInputsCapturingInstantiator implements Instantiator {
                 return ((ImplicitInputsProvidingService)service).withImplicitInputRecorder(registrar);
             }
             return service;
-        }
-
-        @Override
-        public <T> Factory<T> getFactory(Class<T> type) throws UnknownServiceException, ServiceLookupException {
-            return serviceRegistry.getFactory(type);
-        }
-
-        @Override
-        public <T> T newInstance(Class<T> type) throws UnknownServiceException, ServiceLookupException {
-            return serviceRegistry.newInstance(type);
         }
     }
 }


### PR DESCRIPTION
The absolute majority of internal services have been using dedicated types for factories, and the usage of the `ServiceRegistry.getFactory()` functionality was very limited. After a number of refactorings, we were able to eliminate the rest of the usages and now remove this functionality altogether, simplifying the implementation and reducing the number of ways to do things.

Related refactorings:
- https://github.com/gradle/gradle/pull/33090
- https://github.com/gradle/gradle/pull/32792
- https://github.com/gradle/gradle/pull/32806

---

Even though, we remove this functionality now, we might want to resurrect it in the future. But it would be best to consider the requirements then, as things like Java requirements may be relaxed or there may be a need to a different lifecycle management for such services.