### PR TITLE
Tweak avoid `dependsOn` item

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/bp_tasks.adoc
@@ -64,6 +64,7 @@ include::sample[dir="snippets/bestPractices/avoidDependsOn/groovy",files="build.
 <1> *Register Implicit Task Dependency*: `translateGood` requires only one of the files that is produced by `helloWorld`.
 Gradle now understands that `translateGood` requires `helloWorld` to have run successfully first because it needs to create the `message.txt` file which is then used by the translation task.
 Gradle can use this information to optimize task scheduling.
+Using the `map` method avoids eagerly retrieving the `helloWorld` task until the output is needed to determine if `translateGood` should run.
 
 === References
 - <<incremental_build.adoc#sec:task_input_output_side_effects,Task Inputs and Outputs>>

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidDependsOn/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidDependsOn/groovy/build.gradle
@@ -49,6 +49,6 @@ tasks.register("translateBad", SimpleTranslationTask) {
 
 // tag::do-this[]
 tasks.register("translateGood", SimpleTranslationTask) {
-    inputs.file(tasks.named("helloWorld", SimplePrintingTask).get().messageFile) // <1>
+    inputs.file(tasks.named("helloWorld", SimplePrintingTask).map { messageFile }) // <1>
 }
 // end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidDependsOn/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidDependsOn/kotlin/build.gradle.kts
@@ -49,6 +49,6 @@ tasks.register<SimpleTranslationTask>("translateBad") {
 
 // tag::do-this[]
 tasks.register<SimpleTranslationTask>("translateGood") {
-    inputs.file(tasks.named<SimplePrintingTask>("helloWorld").get().messageFile) // <1>
+    inputs.file(tasks.named<SimplePrintingTask>("helloWorld").map { messageFile }) // <1>
 }
 // end::do-this[]


### PR DESCRIPTION
Use more idiomatic map method to link tasks' inputs/outputs