### PR TITLE
Creating detached configurations now uses non-migrating role

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -588,11 +588,11 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
         succeeds(":a:assertCanResolve")
 
         when:
-        executer.expectDocumentedDeprecationWarning("The resCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
         fails(":a:assertCanResolveRecursiveCopy")
 
         then:
-        failure.assertHasCause("Cannot select root node 'resCopy' as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them.")
+        failure.assertHasCause("Could not resolve all files for configuration ':a:resCopy'.")
+        failure.assertHasErrorOutput("No variants exist.")
     }
 
     // this test is largely covered by other tests, but does ensure that there is nothing special about

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -713,43 +713,86 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
     // endregion Migrating configurations
 
     // region Detached configurations
-    def "changing usage on detached configurations does not warn"() {
+    def "changing usage #property = #change (change property to false) on detached configurations is permitted"() {
         given:
         buildFile << """
             def detached = project.configurations.detachedConfiguration()
 
-            assert detached.canBeConsumed
             assert detached.canBeResolved
             assert detached.canBeDeclared
 
-            detached.canBeResolved = false
-            detached.canBeConsumed = false
-            detached.canBeDeclared = false
+            detached.$property($change)
         """
 
         expect:
         run "help"
+
+        where:
+        property | change
+        "setCanBeResolved" | false
+        "setCanBeDeclared" | false
     }
 
-    def "changing usage on detached configurations warns when flag is set"() {
+    def "changing usage #property = #change (change property to true) on detached configurations fails"() {
         given:
         buildFile << """
             def detached = project.configurations.detachedConfiguration()
 
-            assert detached.canBeConsumed
+            assert !detached.canBeConsumed
+
+            detached.$property($change)
+        """
+
+        when:
+        fails "help"
+
+        then:
+        failure.assertHasDescription("A problem occurred evaluating root project '${buildFile.parentFile.name}'.")
+        failure.assertHasCause("""Method call not allowed
+  Calling $property($change) on configuration ':detachedConfiguration1' is not allowed.  This configuration's role was set upon creation and its usage should not be changed.""")
+
+        where:
+        property | change
+        "setCanBeConsumed" | true
+    }
+
+    def "changing usage redundantly on detached configurations warns when flag is set"() {
+        given:
+        buildFile << """
+            def detached = project.configurations.detachedConfiguration()
+
             assert detached.canBeResolved
+            assert !detached.canBeConsumed
             assert detached.canBeDeclared
 
-            detached.canBeResolved = false
+            detached.canBeResolved = true
             detached.canBeConsumed = false
-            detached.canBeDeclared = false
+            detached.canBeDeclared = true
         """
 
         expect:
         expectConsumableChanging(":detachedConfiguration1", false)
-        expectResolvableChanging(":detachedConfiguration1", false)
-        expectDeclarableChanging(":detachedConfiguration1", false)
+        expectResolvableChanging(":detachedConfiguration1", true)
+        expectDeclarableChanging(":detachedConfiguration1", true)
         succeeds('help', "-Dorg.gradle.internal.deprecation.preliminary.Configuration.redundantUsageChangeWarning.enabled=true")
+    }
+
+    def "changing usage redundantly on detached configurations does NOT warn when flag is NOT set"() {
+        given:
+        buildFile << """
+            def detached = project.configurations.detachedConfiguration()
+
+            assert detached.canBeResolved
+            assert !detached.canBeConsumed
+            assert detached.canBeDeclared
+
+            detached.canBeResolved = true
+            detached.canBeConsumed = false
+            detached.canBeDeclared = true
+        """
+
+        expect:
+        succeeds('help')
     }
     // endregion Detached configurations
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -713,6 +713,9 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
     // endregion Migrating configurations
 
     // region Detached configurations
+
+    // Note that this is not desired behavior and ideally any change to a detached configuration's
+    // usage should fail, however we have to allow changes to false for now as KGP does this.
     def "changing usage #property = #change (change property to false) on detached configurations is permitted"() {
         given:
         buildFile << """

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1207,7 +1207,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
             configurationsProvider,
             childResolutionStrategy,
             rootComponentMetadataBuilder,
-            ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE
+            ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE
         );
         configurationsProvider.setTheOnlyConfiguration(copiedConfiguration);
         return copiedConfiguration;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -211,7 +211,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
             detachedConfigurationsProvider,
             resolutionStrategyFactory,
             componentMetadataBuilder,
-            ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE
+            ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE
         );
 
         copyAllTo(detachedConfiguration, dependencies);

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -638,12 +638,13 @@ class DefaultConfigurationSpec extends Specification {
 
         then:
         // This is not desired behavior. Role should be same as detached configuration.
+        // Role of copies are currently set to RESOLVABLE_DEPENDENCY_SCOPE
         copy.canBeDeclared
         copy.canBeResolved
-        copy.canBeConsumed
+        !copy.canBeConsumed
         copy.declarationAlternatives == ["declaration"]
         copy.resolutionAlternatives == ["resolution"]
-        copy.deprecatedForConsumption
+        !copy.deprecatedForConsumption
         !copy.deprecatedForResolution
         !copy.deprecatedForDeclarationAgainst
 
@@ -759,7 +760,7 @@ This method is only meant to be called on configurations which allow the (non-de
         copy.dependencyResolutionListeners.size() == 1
     }
 
-    private prepareConfigurationForCopyTest(configuration = conf()) {
+    private Configuration prepareConfigurationForCopyTest(configuration = conf()) {
         configuration.visible = false
         configuration.transitive = false
         configuration.description = "descript"
@@ -795,7 +796,7 @@ This method is only meant to be called on configurations which allow the (non-de
             assert copy.attributes.getAttribute(it) == original.attributes.getAttribute(it)
         }
         assert copy.canBeResolved == original.canBeResolved
-        assert copy.canBeConsumed == original.canBeConsumed
+        assert !copy.canBeConsumed // Copies are now made as RESOLVABLE_DEPENDENCY_SCOPE, so are non-consumable regardless of the usage of the original
         true
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -637,8 +637,9 @@ class DefaultConfigurationSpec extends Specification {
         def copy = configuration.copy()
 
         then:
-        // This is not desired behavior. Role should be same as detached configuration.
-        // Role of copies are currently set to RESOLVABLE_DEPENDENCY_SCOPE
+        // This is not desired behavior. Ideally the copy method should copy the role of the original.
+        // Instead, the role of copies are currently always set to RESOLVABLE_DEPENDENCY_SCOPE, as
+        // currently copies are detached configurations, and this is the role of all detached configurations.
         copy.canBeDeclared
         copy.canBeResolved
         !copy.canBeConsumed
@@ -795,9 +796,11 @@ This method is only meant to be called on configurations which allow the (non-de
         original.attributes.keySet().each {
             assert copy.attributes.getAttribute(it) == original.attributes.getAttribute(it)
         }
-        assert copy.canBeResolved == original.canBeResolved
-        assert !copy.canBeConsumed // Copies are now made as RESOLVABLE_DEPENDENCY_SCOPE, so are non-consumable regardless of the usage of the original
-        true
+
+        // Copies are now always made as RESOLVABLE_DEPENDENCY_SCOPE, regardless of the usage of the original
+        assert copy.canBeDeclared
+        assert copy.canBeResolved
+        assert !copy.canBeConsumed
     }
 
     def "incoming dependencies set has same name and path as owner configuration"() {


### PR DESCRIPTION
Detached configurations were previously created using the `ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE` role.  Now they are using the `ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE` role.  This narrows their allowed usage to only the expected ones and removes another use of a migrating role in Gradle 9.0.