### PR TITLE
Bump Gson to version 2.13.0

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -195,7 +195,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.12.1</version>
+            <version>2.13.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
         api("com.github.javaparser:javaparser-symbol-solver-core:$javaParserVersion")
         api("com.google.guava:guava:33.4.6-jre")
         api("com.google.errorprone:error_prone_annotations:2.5.1")
-        api("com.google.code.gson:gson:2.12.1") // keep in sync with settings.gradle.kts
+        api("com.google.code.gson:gson:2.13.0") // keep in sync with settings.gradle.kts
         api("com.nhaarman:mockito-kotlin:1.6.0")
         api("com.thoughtworks.qdox:qdox:2.0.3")
         api("com.uwyn:jhighlight:1.0")

--- a/packaging/distributions-dependencies/build.gradle.kts
+++ b/packaging/distributions-dependencies/build.gradle.kts
@@ -96,7 +96,7 @@ dependencies {
         api(libs.groovyTemplates)       { version { strictly(libs.groovyVersion) }}
         api(libs.groovyTest)            { version { strictly(libs.groovyVersion) }}
         api(libs.groovyXml)             { version { strictly(libs.groovyVersion) }}
-        api(libs.gson)                  { version { strictly("2.12.1") }}
+        api(libs.gson)                  { version { strictly("2.13.0") }}
         api(libs.h2Database)            { version { strictly("2.2.220") }}
         api(libs.hamcrest)              { version { strictly(hamcrestVersion) }}
         api("org.hamcrest:hamcrest-core") { version { strictly(hamcrestVersion) }}

--- a/platforms/documentation/docs/src/samples/java/modules-with-transform/groovy/application/build.gradle
+++ b/platforms/documentation/docs/src/samples/java/modules-with-transform/groovy/application/build.gradle
@@ -34,7 +34,7 @@ tasks.named('compileJava') {
 }
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.12.1'          // real module
+    implementation 'com.google.code.gson:gson:2.13.0'          // real module
     implementation 'org.apache.commons:commons-lang3:3.10'     // automatic module
     implementation 'commons-beanutils:commons-beanutils:1.9.4' // plain library (also brings in other libraries transitively)
     implementation 'commons-cli:commons-cli:1.4'               // plain library

--- a/platforms/documentation/docs/src/samples/java/modules-with-transform/kotlin/application/build.gradle.kts
+++ b/platforms/documentation/docs/src/samples/java/modules-with-transform/kotlin/application/build.gradle.kts
@@ -34,7 +34,7 @@ extraJavaModuleInfo {
 // end::extraModuleInfo[]
 
 dependencies {
-    implementation("com.google.code.gson:gson:2.12.1")          // real module
+    implementation("com.google.code.gson:gson:2.13.0")          // real module
     implementation("org.apache.commons:commons-lang3:3.10")     // automatic module
     implementation("commons-beanutils:commons-beanutils:1.9.4") // plain library (also brings in other libraries transitively)
     implementation("commons-cli:commons-cli:1.4")               // plain library

--- a/platforms/documentation/docs/src/samples/java/modules-with-transform/tests/runTask.out
+++ b/platforms/documentation/docs/src/samples/java/modules-with-transform/tests/runTask.out
@@ -1,5 +1,5 @@
 org.gradle.sample.app - 1.0.2
-com.google.gson - 2.12.1
+com.google.gson - 2.13.0
 org.apache.commons.lang3 - 3.10
 org.apache.commons.cli - 3.2.2
 org.apache.commons.beanutils - 1.9.4

--- a/platforms/documentation/docs/src/snippets/java-library/module-disabled/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/java-library/module-disabled/groovy/build.gradle
@@ -17,7 +17,7 @@ tasks.named('compileJava') {
 // end::disableModulePath[]
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.12.1'
+    implementation 'com.google.code.gson:gson:2.13.0'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation 'commons-cli:commons-cli:1.4'
 }

--- a/platforms/documentation/docs/src/snippets/java-library/module-disabled/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java-library/module-disabled/kotlin/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.compileJava {
 // end::disableModulePath[]
 
 dependencies {
-    implementation("com.google.code.gson:gson:2.12.1")
+    implementation("com.google.code.gson:gson:2.13.0")
     implementation("org.apache.commons:commons-lang3:3.10")
     implementation("commons-cli:commons-cli:1.4")
 }

--- a/platforms/documentation/docs/src/snippets/java-library/module/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/java-library/module/groovy/build.gradle
@@ -17,7 +17,7 @@ tasks.named('compileJava') {
 
 // tag::dependencies[]
 dependencies {
-    implementation 'com.google.code.gson:gson:2.12.1'      // real module
+    implementation 'com.google.code.gson:gson:2.13.0'      // real module
     implementation 'org.apache.commons:commons-lang3:3.10' // automatic module
     implementation 'commons-cli:commons-cli:1.4'           // plain library
 }

--- a/platforms/documentation/docs/src/snippets/java-library/module/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java-library/module/kotlin/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.compileJava {
 
 // tag::dependencies[]
 dependencies {
-    implementation("com.google.code.gson:gson:2.12.1")      // real module
+    implementation("com.google.code.gson:gson:2.13.0")      // real module
     implementation("org.apache.commons:commons-lang3:3.10") // automatic module
     implementation("commons-cli:commons-cli:1.4")           // plain library
 }

--- a/platforms/documentation/docs/src/snippets/java/fixtures/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/java/fixtures/groovy/build.gradle
@@ -38,6 +38,6 @@ configurations {
 dependencies {
     // Adds a dependency on the test fixtures of Gson, however this
     // project doesn't publish such a thing
-    functionalTest testFixtures("com.google.code.gson:gson:2.12.1")
+    functionalTest testFixtures("com.google.code.gson:gson:2.13.0")
 }
 // end::external-test-fixtures-dependency[]

--- a/platforms/documentation/docs/src/snippets/java/fixtures/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java/fixtures/kotlin/build.gradle.kts
@@ -36,6 +36,6 @@ val functionalTestClasspath by configurations.creating {
 dependencies {
     // Adds a dependency on the test fixtures of Gson, however this
     // project doesn't publish such a thing
-    functionalTest(testFixtures("com.google.code.gson:gson:2.12.1"))
+    functionalTest(testFixtures("com.google.code.gson:gson:2.13.0"))
 }
 // end::external-test-fixtures-dependency[]

--- a/platforms/documentation/docs/src/snippets/java/fixtures/tests/dependencyInsight.out
+++ b/platforms/documentation/docs/src/snippets/java/fixtures/tests/dependencyInsight.out
@@ -1,19 +1,19 @@
 
 > Task :dependencyInsight
-com.google.code.gson:gson:2.12.1 FAILED
+com.google.code.gson:gson:2.13.0 FAILED
    Failures:
-      - Could not resolve com.google.code.gson:gson:2.12.1.
+      - Could not resolve com.google.code.gson:gson:2.13.0.
           - Unable to find a variant with the requested capability: feature 'test-fixtures':
-               - Variant 'compile' provides 'com.google.code.gson:gson:2.12.1'
-               - Variant 'enforced-platform-compile' provides 'com.google.code.gson:gson-derived-enforced-platform:2.12.1'
-               - Variant 'enforced-platform-runtime' provides 'com.google.code.gson:gson-derived-enforced-platform:2.12.1'
-               - Variant 'javadoc' provides 'com.google.code.gson:gson:2.12.1'
-               - Variant 'platform-compile' provides 'com.google.code.gson:gson-derived-platform:2.12.1'
-               - Variant 'platform-runtime' provides 'com.google.code.gson:gson-derived-platform:2.12.1'
-               - Variant 'runtime' provides 'com.google.code.gson:gson:2.12.1'
-               - Variant 'sources' provides 'com.google.code.gson:gson:2.12.1'
+               - Variant 'compile' provides 'com.google.code.gson:gson:2.13.0'
+               - Variant 'enforced-platform-compile' provides 'com.google.code.gson:gson-derived-enforced-platform:2.13.0'
+               - Variant 'enforced-platform-runtime' provides 'com.google.code.gson:gson-derived-enforced-platform:2.13.0'
+               - Variant 'javadoc' provides 'com.google.code.gson:gson:2.13.0'
+               - Variant 'platform-compile' provides 'com.google.code.gson:gson-derived-platform:2.13.0'
+               - Variant 'platform-runtime' provides 'com.google.code.gson:gson-derived-platform:2.13.0'
+               - Variant 'runtime' provides 'com.google.code.gson:gson:2.13.0'
+               - Variant 'sources' provides 'com.google.code.gson:gson:2.13.0'
 
-com.google.code.gson:gson:2.12.1 FAILED
+com.google.code.gson:gson:2.13.0 FAILED
 \--- functionalTestClasspath
 
 A web-based, searchable dependency report is available by adding the --scan option.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,7 +30,7 @@ buildscript {
     dependencies {
         // update Gson to the desired version, needed here as org.gradle.toolchains.foojay-resolver-convention brings in an older version below
         // https://github.com/gradle/foojay-toolchains/issues/99
-        classpath("com.google.code.gson:gson:2.12.1") // keep in sync with build-logic-commons/build-platform/build.gradle.kts
+        classpath("com.google.code.gson:gson:2.13.0") // keep in sync with build-logic-commons/build-platform/build.gradle.kts
     }
 }
 


### PR DESCRIPTION
See also #33025

https://github.com/google/gson/releases/tag/gson-parent-2.13.0

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
