### PR TITLE
Make feature flags deprecation message version independent

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/GradleVersion.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/GradleVersion.java
@@ -75,6 +75,18 @@ public abstract class GradleVersion implements Comparable<GradleVersion> {
      */
     public abstract GradleVersion getBaseVersion();
 
+    /**
+     * The next major release following this version.
+     *
+     * The next major is "N.0", where N is the current major version plus 1.
+     *
+     * For example, for "8.0-rc-1", "8.0", "8.7.1" or "8.14",
+     * the next release is "9.0".
+     *
+     * @return the next major release version
+     */
+    public abstract GradleVersion getNextMajorVersion();
+
     @Override
     public abstract int compareTo(GradleVersion o);
 }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/DefaultGradleVersion.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/DefaultGradleVersion.java
@@ -209,7 +209,8 @@ public final class DefaultGradleVersion extends GradleVersion {
         return version(versionPart);
     }
 
-    public DefaultGradleVersion getNextMajorVersion() {
+    @Override
+    public GradleVersion getNextMajorVersion() {
         return version((majorPart + 1) + ".0");
     }
 

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -85,15 +85,21 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
      * Output: This is scheduled to be removed in Gradle 9.0.
      */
     public WithDeprecationTimeline willBeRemovedInGradle9() {
-        this.deprecationTimeline = DeprecationTimeline.willBeRemovedInVersion(GRADLE9);
-        return new WithDeprecationTimeline(this);
+        return willBeRemovedIn(GRADLE9);
     }
 
     /**
      * Output: This is scheduled to be removed in Gradle 10.0.
      */
     public WithDeprecationTimeline willBeRemovedInGradle10() {
-        this.deprecationTimeline = DeprecationTimeline.willBeRemovedInVersion(GRADLE10);
+        return willBeRemovedIn(GRADLE10);
+    }
+
+    /**
+     * Output: This is scheduled to be removed in Gradle [version].
+     */
+    public WithDeprecationTimeline willBeRemovedIn(GradleVersion version) {
+        this.deprecationTimeline = DeprecationTimeline.willBeRemovedInVersion(version);
         return new WithDeprecationTimeline(this);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -54,6 +54,7 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.plugin.management.PluginManagementSpec;
 import org.gradle.plugin.management.internal.PluginManagementSpecInternal;
+import org.gradle.util.GradleVersion;
 import org.gradle.vcs.SourceControl;
 import org.jspecify.annotations.Nullable;
 
@@ -372,7 +373,7 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
             DeprecationLogger
                 .deprecate("enableFeaturePreview('" + feature.name() + "')")
                 .withAdvice("The feature flag is no longer relevant, please remove it from your settings file.")
-                .willBeRemovedInGradle9()
+                .willBeRemovedIn(GradleVersion.current().getNextMajorVersion())
                 .withUserManual("feature_lifecycle", "feature_preview")
                 .nagUser();
         }


### PR DESCRIPTION
### Context

Feature flag deprecation message generation (for inactive flags) is coupled with the current version/next release, risking becoming stale if we forget to update it. This small changeset makes the message update whenever we bump the current major.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
