### PR TITLE
Don't exclude detached configurations from usage changing warnings

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -627,7 +627,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         "configurations.maybeCreateConsumableUnlocked('additionalRuntimeClasspath')"    | ConfigurationRoles.CONSUMABLE | true  | "internal unlocked role-based configuration, if it doesn't already exist"
     }
 
-    def "changing usage on detached configurations does not warn"() {
+    def "changing usage on detached configurations warns"() {
         given:
         buildFile << """
             def detached = project.configurations.detachedConfiguration()
@@ -642,6 +642,9 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         """
 
         expect:
+        expectConsumableChanging(":detachedConfiguration1", false)
+        expectResolvableChanging(":detachedConfiguration1", false)
+        expectDeclarableChanging(":detachedConfiguration1", false)
         run "help"
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/KotlinDslVersionCatalogExtensionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/KotlinDslVersionCatalogExtensionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.catalog
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ConfigurationUsageChangingFixture
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import spock.lang.Issue
 
@@ -27,7 +28,7 @@ import spock.lang.Issue
  * tests so avoid adding tests here if they cannot be expressed with the Groovy DSL.
  */
 @LeaksFileHandles("Kotlin Compiler Daemon working directory")
-class KotlinDslVersionCatalogExtensionIntegrationTest extends AbstractHttpDependencyResolutionTest {
+class KotlinDslVersionCatalogExtensionIntegrationTest extends AbstractHttpDependencyResolutionTest implements ConfigurationUsageChangingFixture {
     def setup() {
         settingsKotlinFile << """
             rootProject.name = "test"
@@ -134,6 +135,9 @@ class KotlinDslVersionCatalogExtensionIntegrationTest extends AbstractHttpDepend
         lib.artifact.expectGet()
 
         then:
+        7.times {
+            expectConsumableChanging(":buildSrc:detachedConfiguration${it+1}", false)
+        }
         succeeds ':checkDeps'
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1622,13 +1622,9 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         // KGP continues to set the already-set value for a given usage even though it is already set
         boolean redundantChange = current == newValue;
 
-        // KGP disables `consumable` on detached configurations even though this is not necessary
-        boolean disableUsageForDetached = isDetachedConfiguration() && !newValue;
-
         // This property exists to allow KGP to test whether they have properly resolved this deprecation.
         // This property WILL be removed without warning.
-        if ((redundantChange || disableUsageForDetached) &&
-            !Boolean.getBoolean("org.gradle.internal.deprecation.preliminary.Configuration.redundantUsageChangeWarning.enabled")
+        if (redundantChange && !Boolean.getBoolean("org.gradle.internal.deprecation.preliminary.Configuration.redundantUsageChangeWarning.enabled")
         ) {
             return;
         }


### PR DESCRIPTION
Attempt to get ahead of https://github.com/gradle/gradle/pull/33135