### PR TITLE
Avoid exposing Lazy as service type

### DIFF
--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
@@ -131,6 +131,7 @@ public class DaemonClientToolchainServices implements ServiceRegistrationProvide
         installationSuppliers.add(new OsXInstallationSupplier(os, new DefaultOsXJavaHomeCommand(execHandleFactory)));
         installationSuppliers.add(new WindowsInstallationSupplier(windowsRegistry, os));
 
+        // Caveat: when adding new manually created services ensure to close them if required, since the service registry does not manage them
         CurrentBuildPlatform currentBuildPlatform = new CurrentBuildPlatform(systemInfo, os);
         DefaultFilePropertyFactory filePropertyFactory = new DefaultFilePropertyFactory(propertyHost, fileResolver, fileCollectionFactory);
         DecompressionCoordinator decompressionCoordinator = new DefaultDecompressionCoordinator(scopedCacheBuilderFactory);

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
@@ -48,16 +48,15 @@ import org.gradle.internal.jvm.inspection.DefaultJvmMetadataDetector;
 import org.gradle.internal.jvm.inspection.JavaInstallationRegistry;
 import org.gradle.internal.jvm.inspection.JvmInstallationProblemReporter;
 import org.gradle.internal.jvm.inspection.JvmMetadataDetector;
-import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationIdFactory;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.reflect.DirectInstantiator;
-import org.gradle.internal.service.Provides;
-import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.resource.ExternalResourceFactory;
 import org.gradle.internal.resource.transport.http.HttpClientHelper;
+import org.gradle.internal.service.Provides;
+import org.gradle.internal.service.ServiceRegistrationProvider;
 import org.gradle.internal.time.Clock;
 import org.gradle.jvm.toolchain.internal.AsdfInstallationSupplier;
 import org.gradle.jvm.toolchain.internal.DefaultOsXJavaHomeCommand;
@@ -84,8 +83,6 @@ import java.util.Optional;
 
 /**
  * Those services are only useful when daemon toolchain is active and there is no compatible running daemon.
- * <p>
- * This is why we only expose one service, wrapped in a {@link Lazy}, and which triggers the creation of all needed instances.
  */
 public class DaemonClientToolchainServices implements ServiceRegistrationProvider {
 
@@ -101,7 +98,7 @@ public class DaemonClientToolchainServices implements ServiceRegistrationProvide
     }
 
     @Provides
-    protected Lazy<JavaToolchainQueryService> createJavaToolchainQueryService(
+    protected JavaToolchainQueryService createJavaToolchainQueryService(
         JvmMetadataDetector jvmMetadataDetector,
         FileSystem fileSystem,
         ListenerManager listenerManager,
@@ -124,30 +121,28 @@ public class DaemonClientToolchainServices implements ServiceRegistrationProvide
         SystemInfo systemInfo,
         ScopedCacheBuilderFactory scopedCacheBuilderFactory
     ) {
-        return Lazy.unsafe().of(() -> {
-            // NOTE: These need to be kept in sync with ToolchainsJvmServices
-            List<InstallationSupplier> installationSuppliers = new ArrayList<>(8);
-            installationSuppliers.add(new AsdfInstallationSupplier(toolchainConfiguration));
-            installationSuppliers.add(new IntellijInstallationSupplier(toolchainConfiguration));
-            installationSuppliers.add(new JabbaInstallationSupplier(toolchainConfiguration));
-            installationSuppliers.add(new SdkmanInstallationSupplier(toolchainConfiguration));
-            installationSuppliers.add(new LinuxInstallationSupplier());
-            installationSuppliers.add(new OsXInstallationSupplier(os, new DefaultOsXJavaHomeCommand(execHandleFactory)));
-            installationSuppliers.add(new WindowsInstallationSupplier(windowsRegistry, os));
+        // NOTE: These need to be kept in sync with ToolchainsJvmServices
+        List<InstallationSupplier> installationSuppliers = new ArrayList<>(8);
+        installationSuppliers.add(new AsdfInstallationSupplier(toolchainConfiguration));
+        installationSuppliers.add(new IntellijInstallationSupplier(toolchainConfiguration));
+        installationSuppliers.add(new JabbaInstallationSupplier(toolchainConfiguration));
+        installationSuppliers.add(new SdkmanInstallationSupplier(toolchainConfiguration));
+        installationSuppliers.add(new LinuxInstallationSupplier());
+        installationSuppliers.add(new OsXInstallationSupplier(os, new DefaultOsXJavaHomeCommand(execHandleFactory)));
+        installationSuppliers.add(new WindowsInstallationSupplier(windowsRegistry, os));
 
-            CurrentBuildPlatform currentBuildPlatform = new CurrentBuildPlatform(systemInfo, os);
-            DefaultFilePropertyFactory filePropertyFactory = new DefaultFilePropertyFactory(propertyHost, fileResolver, fileCollectionFactory);
-            DecompressionCoordinator decompressionCoordinator = new DefaultDecompressionCoordinator(scopedCacheBuilderFactory);
-            Deleter deleter = new DefaultDeleter(clock::getCurrentTime, fileSystem::isSymlink, os.isWindows());
-            FileOperations fileOperations = new DefaultFileOperations(fileResolver, DirectInstantiator.INSTANCE, directoryFileTreeFactory, new DefaultFileHasher(new DefaultStreamHasher()), DefaultResourceHandler.Factory.from(fileResolver, null, fileSystem, temporaryFileProvider, null), fileCollectionFactory, propertyFactory, fileSystem, PatternSet::new, deleter, documentationRegistry, DefaultTaskDependencyFactory.withNoAssociatedProject(), new DefaultProviderFactory(), decompressionCoordinator, temporaryFileProvider);
-            JdkCacheDirectory jdkCacheDirectory = new DefaultJdkCacheDirectory(gradleUserHomeDirProvider, fileOperations, fileLockManager, new DefaultJvmMetadataDetector(execHandleFactory, gradleUserHomeTemporaryFileProvider), gradleUserHomeTemporaryFileProvider);
-            JavaInstallationRegistry javaInstallationRegistry = new DefaultJavaInstallationRegistry(toolchainConfiguration, installationSuppliers, jvmMetadataDetector, null, OperatingSystem.current(), progressLoggerFactory, fileResolver, jdkCacheDirectory, new JvmInstallationProblemReporter());
-            JavaToolchainHttpRedirectVerifierFactory redirectVerifierFactory = new JavaToolchainHttpRedirectVerifierFactory();
-            HttpClientHelper.Factory httpClientHelperFactory = HttpClientHelper.Factory.createFactory(new DocumentationRegistry());
-            ExternalResourceFactory externalResourceFactory = new DaemonToolchainExternalResourceFactory(fileSystem, listenerManager, redirectVerifierFactory, httpClientHelperFactory, progressLoggerFactory, clock, operationIdFactory, buildProgressListener);
-            SecureFileDownloader secureFileDownloader = new SecureFileDownloader(externalResourceFactory);
-            DaemonJavaToolchainProvisioningService javaToolchainProvisioningService = new DaemonJavaToolchainProvisioningService(secureFileDownloader, jdkCacheDirectory, currentBuildPlatform, toolchainDownloadUrlProvider, toolchainConfiguration.isDownloadEnabled(), progressLoggerFactory);
-            return new JavaToolchainQueryService(jvmMetadataDetector, filePropertyFactory, javaToolchainProvisioningService, javaInstallationRegistry, null);
-        });
+        CurrentBuildPlatform currentBuildPlatform = new CurrentBuildPlatform(systemInfo, os);
+        DefaultFilePropertyFactory filePropertyFactory = new DefaultFilePropertyFactory(propertyHost, fileResolver, fileCollectionFactory);
+        DecompressionCoordinator decompressionCoordinator = new DefaultDecompressionCoordinator(scopedCacheBuilderFactory);
+        Deleter deleter = new DefaultDeleter(clock::getCurrentTime, fileSystem::isSymlink, os.isWindows());
+        FileOperations fileOperations = new DefaultFileOperations(fileResolver, DirectInstantiator.INSTANCE, directoryFileTreeFactory, new DefaultFileHasher(new DefaultStreamHasher()), DefaultResourceHandler.Factory.from(fileResolver, null, fileSystem, temporaryFileProvider, null), fileCollectionFactory, propertyFactory, fileSystem, PatternSet::new, deleter, documentationRegistry, DefaultTaskDependencyFactory.withNoAssociatedProject(), new DefaultProviderFactory(), decompressionCoordinator, temporaryFileProvider);
+        JdkCacheDirectory jdkCacheDirectory = new DefaultJdkCacheDirectory(gradleUserHomeDirProvider, fileOperations, fileLockManager, new DefaultJvmMetadataDetector(execHandleFactory, gradleUserHomeTemporaryFileProvider), gradleUserHomeTemporaryFileProvider);
+        JavaInstallationRegistry javaInstallationRegistry = new DefaultJavaInstallationRegistry(toolchainConfiguration, installationSuppliers, jvmMetadataDetector, null, OperatingSystem.current(), progressLoggerFactory, fileResolver, jdkCacheDirectory, new JvmInstallationProblemReporter());
+        JavaToolchainHttpRedirectVerifierFactory redirectVerifierFactory = new JavaToolchainHttpRedirectVerifierFactory();
+        HttpClientHelper.Factory httpClientHelperFactory = HttpClientHelper.Factory.createFactory(new DocumentationRegistry());
+        ExternalResourceFactory externalResourceFactory = new DaemonToolchainExternalResourceFactory(fileSystem, listenerManager, redirectVerifierFactory, httpClientHelperFactory, progressLoggerFactory, clock, operationIdFactory, buildProgressListener);
+        SecureFileDownloader secureFileDownloader = new SecureFileDownloader(externalResourceFactory);
+        DaemonJavaToolchainProvisioningService javaToolchainProvisioningService = new DaemonJavaToolchainProvisioningService(secureFileDownloader, jdkCacheDirectory, currentBuildPlatform, toolchainDownloadUrlProvider, toolchainConfiguration.isDownloadEnabled(), progressLoggerFactory);
+        return new JavaToolchainQueryService(jvmMetadataDetector, filePropertyFactory, javaToolchainProvisioningService, javaInstallationRegistry, null);
     }
 }


### PR DESCRIPTION
Wrapping a service in `Lazy<>` when declaring and injecting it only works by accident for the intended purpose. It appears to work, because the service registry reduces the service type to a raw type of `Lazy`. Since there are no other "lazy" services in the same registry, it does the right thing for the wrong reason.

Additionally, wrapping things in `Lazy` also removes the ability of the service registry to detect `Closeable` services, which need to be cleaned up, once the service registry is disposed of.

---

The change in this PR is more of a temporary mitigation, so that other folks don't see this as a "working" pattern and don't try this in other places.

As a follow-up we should introduce some defensive measures in the service registry to prevent from such problematic patterns to accidentally appear.