### PR TITLE
Remove deprecated StartParameterInternal.isConfigurationCache

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -41,7 +41,7 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
 
     override val forceLocallyBuiltKotlinDslPlugins = false
 
-    private val oldestSupportedKotlinDslPluginVersion = "4.1.3"
+    private val oldestSupportedKotlinDslPluginVersion = "4.2.0"
 
     @Test
     @Requires(NotEmbeddedExecutor::class)
@@ -63,6 +63,7 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
         withBuildScript("""plugins { id("some") }""")
 
         expectConventionDeprecations()
+        expectConfigurationCacheRequestedDeprecation()
 
         build("help").apply {
 
@@ -112,6 +113,7 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
         withBuildScript("""plugins { id("some") }""")
 
         expectConventionDeprecations()
+        expectConfigurationCacheRequestedDeprecation()
         executer.expectDeprecationWarning("w: Language version 1.4 is deprecated and its support will be removed in a future version of Kotlin")
 
         build("help").apply {
@@ -144,6 +146,16 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Consult the upgrading guide for further information: " +
                 "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
+        )
+    }
+
+    private
+    fun expectConfigurationCacheRequestedDeprecation() {
+        executer.expectDocumentedDeprecationWarning(
+            "The StartParameter.isConfigurationCacheRequested property has been deprecated. " +
+                "This is scheduled to be removed in Gradle 10.0. " +
+                "Please use 'configurationCache.requested' property on 'BuildFeatures' service instead. Consult the upgrading guide for further information:" +
+                " https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_startparameter_is_configuration_cache_requested"
         )
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -130,14 +130,6 @@ public class StartParameterInternal extends StartParameter {
     }
 
     /**
-     * Used by the Kotlin plugin, via reflection.
-     */
-    @Deprecated
-    public boolean isConfigurationCache() {
-        return getConfigurationCache().get();
-    }
-
-    /**
      * Is the configuration cache requested? Note: depending on the build action, this may not be the final value for this option.
      *
      * Consider querying {@link BuildModelParameters} instead.


### PR DESCRIPTION
This is no longer used by KGP since 1.9.20 (see https://youtrack.jetbrains.com/issue/KT-61457) and in Gradle 9.0 we plan to require 2.1.20 anyways.

Fixes #22907, we never added the nag but as this is internal anyways I don't think it matters. Let me know if you think differently.

### Context
This method interferes with some tests in Groovy 4 due to a change in resolution order for `startParameter.configurationCache` -- it used to resolve to `getConfigurationCache()`, but now resolves to `isConfigurationCache()`. Removing this fixes this in both 3 and 4.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
