### PR TITLE
Add indy and condy support to class dependencies analyzer

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractClassChangeIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractClassChangeIncrementalCompilationIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.java.compile.incremental
 
-
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 abstract class AbstractClassChangeIncrementalCompilationIntegrationTest extends AbstractJavaGroovyIncrementalCompilationSupport {
@@ -564,32 +562,6 @@ abstract class AbstractClassChangeIncrementalCompilationIntegrationTest extends 
 
         then:
         recompiledWithFailure('Runnable r = (B) b;', 'A', 'B')
-    }
-
-    @Ignore("Broken due to https://github.com/gradle/gradle/issues/33161")
-    def "detects changes to class referenced in method body via lambda"() {
-        given:
-        source '''class A {
-    void doSomething() {
-        takeRunnable((B) () -> {
-            System.out.println("Hello");
-        });
-    }
-
-    void takeRunnable(Runnable r) {
-        r.run();
-    }
-}'''
-        source '''interface B extends Runnable {
-}'''
-
-        outputs.snapshot { run language.compileTaskName }
-
-        when:
-        file("src/main/${languageName}/B.${languageName}").text = "class B { }"
-
-        then:
-        recompiledWithFailure('takeRunnable((B) () -> {', 'A', 'B')
     }
 
     def "detects changes to class referenced through return type"() {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseJavaClassChangeIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseJavaClassChangeIncrementalCompilationIntegrationTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.java.compile.incremental
 
 import org.gradle.integtests.fixtures.CompiledLanguage
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
 import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
@@ -119,6 +121,54 @@ public class Other {}
 
         then:
         outputs.recompiledClasses 'Lambda2', 'Consumer'
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/33161")
+    def "detects changes to class referenced in method body via lambda"() {
+        given:
+        source '''class A {
+            void doSomething() {
+                takeRunnable((B) () -> {
+                    System.out.println("Hello");
+                });
+            }
+
+            void takeRunnable(Runnable r) {
+                r.run();
+            }
+        }'''
+        source "interface B extends Runnable {}"
+
+        outputs.snapshot { run language.compileTaskName }
+
+        when:
+        file("src/main/${languageName}/B.${languageName}").text = "class B { }"
+
+        then:
+        recompiledWithFailure('takeRunnable((B) () -> {', 'A', 'B')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/33161")
+    @Requires(value = UnitTestPreconditions.Jdk21OrLater, reason = "JDK 21+ required for new enum switch expressions")
+    def "detects changes to class referenced in method body via enum in switch expression"() {
+        given:
+        source """class A {
+            void doSomething(Object o) {
+                switch (o) {
+                    case B.INSTANCE -> System.out.println("B");
+                    default -> System.out.println("Default");
+                }
+            }
+        }"""
+        source "enum B { INSTANCE }"
+
+        outputs.snapshot { run language.compileTaskName }
+
+        when:
+        file("src/main/${languageName}/B.${languageName}").text = "class B { }"
+
+        then:
+        recompiledWithFailure('case B.INSTANCE ->', 'A', 'B')
     }
 
     def "renaming inner class removes stale class file"() {

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/BootstrapMethod.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/BootstrapMethod.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental.asm;
+
+import org.jspecify.annotations.NullMarked;
+import org.objectweb.asm.ConstantDynamic;
+import org.objectweb.asm.Handle;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unifying type between {@code invokedynamic} and {@code CONSTANT_Dynamic} bootstrap methods.
+ */
+@NullMarked
+public final class BootstrapMethod {
+    public static BootstrapMethod fromIndy(Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
+        return new BootstrapMethod(bootstrapMethodHandle, Arrays.asList(bootstrapMethodArguments));
+    }
+
+    public static BootstrapMethod fromConstantDynamic(ConstantDynamic constantDynamic) {
+        return new BootstrapMethod(constantDynamic.getBootstrapMethod(), new ConstantDynamicBootstrapArguments(constantDynamic));
+    }
+
+    @NullMarked
+    private static class ConstantDynamicBootstrapArguments extends AbstractList<Object> {
+        private final ConstantDynamic constantDynamic;
+
+        public ConstantDynamicBootstrapArguments(ConstantDynamic constantDynamic) {
+            this.constantDynamic = constantDynamic;
+        }
+
+        @Override
+        public Object get(int index) {
+            return constantDynamic.getBootstrapMethodArgument(index);
+        }
+
+        @Override
+        public int size() {
+            return constantDynamic.getBootstrapMethodArgumentCount();
+        }
+    }
+
+    private final Handle handle;
+    private final List<Object> arguments;
+
+    private BootstrapMethod(Handle handle, List<Object> arguments) {
+        this.handle = handle;
+        this.arguments = arguments;
+    }
+
+    public Handle getHandle() {
+        return handle;
+    }
+
+    public List<Object> getArguments() {
+        return arguments;
+    }
+}

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
@@ -18,28 +18,52 @@ package org.gradle.api.internal.tasks.compile.incremental.asm;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
-import org.gradle.api.internal.initialization.transform.utils.ClassAnalysisUtils;
-import org.objectweb.asm.signature.SignatureReader;
-import org.objectweb.asm.signature.SignatureVisitor;
 import org.gradle.api.internal.cache.StringInterner;
+import org.gradle.api.internal.initialization.transform.utils.ClassAnalysisUtils;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassAnalysis;
 import org.gradle.model.internal.asm.AsmConstants;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ConstantDynamic;
+import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.ModuleVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.TypePath;
+import org.objectweb.asm.signature.SignatureReader;
+import org.objectweb.asm.signature.SignatureVisitor;
 
 import java.lang.annotation.RetentionPolicy;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
 public class ClassDependenciesVisitor extends ClassVisitor {
 
-    private final static int API = AsmConstants.ASM_LEVEL;
+    private static final int API = AsmConstants.ASM_LEVEL;
+    /**
+     * Handle describing {@link java.lang.invoke.ConstantBootstraps#invoke(MethodHandles.Lookup, String, Class, MethodHandle, Object...)}.
+     */
+    private static final Handle CONSTANT_BOOTSTRAPS_INVOKE = new Handle(
+        Opcodes.H_INVOKESTATIC,
+        "java/lang/invoke/ConstantBootstraps",
+        "invoke",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/invoke/MethodHandle;[Ljava/lang/Object;)Ljava/lang/Object;",
+        false
+    );
+    /**
+     * Handle describing {@link java.lang.constant.ClassDesc#of(String)}.
+     */
+    private static final Handle CLASS_DESC_OF = new Handle(
+        Opcodes.H_INVOKESTATIC,
+        "java/lang/constant/ClassDesc",
+        "of",
+        "(Ljava/lang/String;)Ljava/lang/constant/ClassDesc;",
+        true
+    );
 
     private final IntSet constants;
     private final Set<String> privateTypes;
@@ -165,12 +189,16 @@ public class ClassDependenciesVisitor extends ClassVisitor {
     public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
         Set<String> types = isAccessible(access) ? accessibleTypes : privateTypes;
         maybeAddClassTypesFromSignature(signature, types);
+        addTypesFromMethodDescriptor(types, desc);
+        return new MethodVisitor(types);
+    }
+
+    private void addTypesFromMethodDescriptor(Set<String> types, String desc) {
         Type methodType = Type.getMethodType(desc);
         maybeAddDependentType(types, methodType.getReturnType());
         for (Type argType : methodType.getArgumentTypes()) {
             maybeAddDependentType(types, argType);
         }
-        return new MethodVisitor(types);
     }
 
     @Override
@@ -251,6 +279,76 @@ public class ClassDependenciesVisitor extends ClassVisitor {
         public org.objectweb.asm.AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
             maybeAddDependentType(types, Type.getType(descriptor));
             return new AnnotationVisitor(types);
+        }
+
+        @Override
+        public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
+            if (tryHandleSpecialBootstrapMethod(BootstrapMethod.fromIndy(bootstrapMethodHandle, bootstrapMethodArguments))) {
+                return;
+            }
+            addTypesFromMethodDescriptor(types, descriptor);
+            maybeAddDependentType(types, Type.getObjectType(bootstrapMethodHandle.getOwner()));
+
+            for (Object arg : bootstrapMethodArguments) {
+                addDependentTypeFromBootstrapMethodArgument(arg);
+            }
+        }
+
+        @Override
+        public void visitLdcInsn(Object value) {
+            if (value instanceof ConstantDynamic) {
+                addDependentTypesFromConstantDynamic((ConstantDynamic) value);
+            }
+        }
+
+        private void addDependentTypesFromConstantDynamic(ConstantDynamic arg) {
+            if (tryHandleSpecialBootstrapMethod(BootstrapMethod.fromConstantDynamic(arg))) {
+                return;
+            }
+            maybeAddDependentType(types, Type.getObjectType(arg.getBootstrapMethod().getOwner()));
+
+            for (int i = 0; i < arg.getBootstrapMethodArgumentCount(); i++) {
+                addDependentTypeFromBootstrapMethodArgument(arg.getBootstrapMethodArgument(i));
+            }
+        }
+
+        private void addDependentTypeFromBootstrapMethodArgument(Object arg) {
+            if (arg instanceof Type) {
+                maybeAddDependentType(types, (Type) arg);
+            } else if (arg instanceof Handle) {
+                maybeAddDependentType(types, Type.getObjectType(((Handle) arg).getOwner()));
+            } else if (arg instanceof ConstantDynamic) {
+                addDependentTypesFromConstantDynamic((ConstantDynamic) arg);
+            }
+        }
+
+        /**
+         * Some bootstrap methods describe a dependency on a class, despite not containing a class reference in their
+         * arguments. One way this can happen is with qualified enums in a switch expression, where they will bootstrap
+         * a class constant using {@link java.lang.constant.ClassDesc#of(String)}. The string represents a class name
+         * which must be a dependency of the class being analyzed.
+         *
+         * @param bootstrapMethod the bootstrap method to check
+         * @return if the bootstrap method was handled and its types added to the dependency set
+         */
+        private boolean tryHandleSpecialBootstrapMethod(BootstrapMethod bootstrapMethod) {
+            // Currently this method only handles the ClassDesc#of case, but there may be others in the future.
+            // If so, this code should be refactored out to its own method.
+            if (!bootstrapMethod.getHandle().equals(CONSTANT_BOOTSTRAPS_INVOKE)) {
+                return false;
+            }
+            if (bootstrapMethod.getArguments().size() != 2) {
+                return false;
+            }
+            if (!CLASS_DESC_OF.equals(bootstrapMethod.getArguments().get(0))) {
+                return false;
+            }
+            Object className = bootstrapMethod.getArguments().get(1);
+            if (!(className instanceof String)) {
+                return false;
+            }
+            maybeAddDependentType(types, Type.getObjectType(((String) className).replace('.', '/')));
+            return true;
         }
     }
 


### PR DESCRIPTION
Fixes #33161 

The current cases are to handle constructs that can be emitted by javac and groovyc. More may need to be added later.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
