### PR TITLE
Make `ValidatePlugin` usage without Java Toolchains plugin an error

### DIFF
--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
@@ -835,7 +835,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         assertValidationSucceeds()
     }
 
-    def "missing Java Toolchain plugin causes a deprecation warning"() {
+    def "missing Java Toolchain plugin causes a build failure"() {
         given:
         source("producer/settings.gradle") << ""
         source("producer/build.gradle") << "plugins { id 'java' }"
@@ -855,21 +855,15 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             .run()
 
         executer.inDirectory(file("consumer"))
-            .expectDocumentedDeprecationWarning(
-                "Using task ValidatePlugins without applying the Java Toolchain plugin. " +
-                    "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
-                    "Consult the upgrading guide for further information: " +
-                    "https://docs.gradle.org/current/userguide/upgrading_version_8.html#validate_plugins_without_java_toolchain"
-            )
 
         then:
-        succeeds "validatePlugins"
+        fails "validatePlugins"
 
         and:
         verifyAll(receivedProblem) {
-            fqid == 'deprecation:missing-java-toolchain-plugin'
-            contextualLabel == 'Using task ValidatePlugins without applying the Java Toolchain plugin. This behavior has been deprecated.'
+            fqid == 'validation:missing-java-toolchain-plugin'
+            contextualLabel == 'Using task ValidatePlugins without applying the Java Toolchain plugin is not supported.'
+            definition.documentationLink.url.endsWith("/userguide/upgrading_version_8.html#validate_plugins_without_java_toolchain")
         }
-
     }
 }

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
@@ -17,11 +17,16 @@
 package org.gradle.plugin.devel.tasks;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.problems.Problem;
+import org.gradle.api.problems.ProblemId;
+import org.gradle.api.problems.ProblemReporter;
+import org.gradle.api.problems.Problems;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblemReporter;
 import org.gradle.api.problems.internal.InternalProblems;
@@ -38,9 +43,8 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.execution.WorkValidationException;
-import org.gradle.internal.jvm.Jvm;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.plugin.devel.tasks.internal.ValidateAction;
@@ -93,13 +97,20 @@ public abstract class ValidatePlugins extends DefaultTask {
                 if (getLauncher().isPresent()) {
                     spec.getForkOptions().setExecutable(getLauncher().get().getExecutablePath());
                 } else {
-                    DeprecationLogger.deprecateBehaviour("Using task ValidatePlugins without applying the Java Toolchain plugin.")
-                        .withProblemIdDisplayName("Using task ValidatePlugins without applying the Java Toolchain plugin.")
-                        .withProblemId("missing-java-toolchain-plugin")
-                        .willBecomeAnErrorInGradle9()
-                        .withUpgradeGuideSection(8, "validate_plugins_without_java_toolchain")
-                        .nagUser();
-                    spec.getForkOptions().setExecutable(Jvm.current().getJavaExecutable());
+                    ProblemId problemId = ProblemId.create(
+                        "missing-java-toolchain-plugin",
+                        "Using task ValidatePlugins without applying the Java Toolchain plugin",
+                        GradleCoreProblemGroup.validation().thisGroup()
+                    );
+                    ProblemReporter problemReporter = getServices().get(Problems.class).getReporter();
+                    GradleException exception = new GradleException(problemId.getDisplayName() + " is not supported.");
+                    throw problemReporter.throwing(
+                        exception,
+                        problemReporter.create(problemId, problemSpec -> {
+                            problemSpec.documentedAt(Documentation.upgradeGuide(8, "validate_plugins_without_java_toolchain").getUrl());
+                            problemSpec.contextualLabel(exception.getMessage());
+                        })
+                    );
                 }
                 spec.getClasspath().setFrom(getClasses(), getClasspath());
             })

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -96,7 +96,6 @@ class KnownProblemIds {
         'deprecation:creating-a-configuration-with-a-name-that-starts-with-detachedconfiguration': ['Creating a configuration with a name that starts with \'detachedConfiguration\' has been deprecated.'],
         'deprecation:custom-task-action': ['Custom Task action has been deprecated.'],
         'deprecation:executing-gradle-on-jvm-versions-and-lower': ['Executing Gradle on JVM versions ' + (SupportedJavaVersions.FUTURE_MINIMUM_DAEMON_JAVA_VERSION - 1) + ' and lower has been deprecated.'],
-        'deprecation:missing-java-toolchain-plugin': ['Using task ValidatePlugins without applying the Java Toolchain plugin.'],
         'deprecation:included-build-script': ['Included build script has been deprecated.'],
         'deprecation:included-build-task': ['Included build task has been deprecated.'],
         'deprecation:init-script': ['Init script has been deprecated.'],
@@ -142,6 +141,7 @@ class KnownProblemIds {
         'validation:type-validation:invalid-use-of-type-annotation': ['Incorrect use of type annotation'],
         'validation:type-validation:not-cacheable-without-reason': ['Not cacheable without reason'],
         'validation:configuration-cache:cannot-serialize-object-of-type-org-gradle-api-defaulttask-a-subtype-of-org-gradle-api-task-as-these-are-not-supported-with-the-configuration-cache': ['cannot serialize object of type \'org.gradle.api.DefaultTask\', a subtype of \'org.gradle.api.Task\', as these are not supported with the configuration cache.'],
+        'validation:missing-java-toolchain-plugin': ['Using task ValidatePlugins without applying the Java Toolchain plugin'],
 
         // dependency resolution failures
         'dependency-variant-resolution:configuration-not-compatible': ['Configuration selected by name is not compatible'],


### PR DESCRIPTION
Turns a deprecation into an error for `ValidatePlugin` tasks used without applying the
infrastructure Java Toolchains plugin.