### PR TITLE
Turn deprecated add methods on configurations container into failures

### DIFF
--- a/platforms/jvm/plugins-jvm-test-suite/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
+++ b/platforms/jvm/plugins-jvm-test-suite/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
@@ -1028,7 +1028,6 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
             // alphabetical ordering seems to interfere here, if we used `s` instead of `t`, the check passes just fine
             def testImplHolder = configurations.create("uasdf")
             def testCopy = configurations.testImplementation.copy()
-            configurations.add(testCopy)
             testImplHolder.extendsFrom(testCopy)
 
             task assertCopyCanBeResolved {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -37,6 +37,9 @@ import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.problems.ProblemId;
+import org.gradle.api.problems.Severity;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Actions;
@@ -172,44 +175,33 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         return new UnknownConfigurationException(String.format("Configuration with name '%s' not found.", name));
     }
 
+    private RuntimeException failOnAttemptToAdd(String behavior) {
+        GradleException ex = new GradleException(behavior + " ");
+        ProblemId id = ProblemId.create("method-not-allowed", "Method call not allowed", GradleCoreProblemGroup.configurationUsage());
+        throw problemsService.getInternalReporter().throwing(ex, id, spec -> {
+            spec.contextualLabel(ex.getMessage());
+            spec.severity(Severity.ERROR);
+        });
+    }
+
     @Override
-    public boolean add(Configuration o) {
-        DeprecationLogger.deprecateBehaviour("Adding a configuration directly to the configuration container.")
-            .withAdvice("Use a factory method instead.")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "adding_to_configuration_container")
-            .nagUser();
-        return super.add(o);
+    public boolean add(@Nullable Configuration o) {
+        throw failOnAttemptToAdd("Adding a configuration directly to the configuration container is not allowed.  Use a factory method instead.");
     }
 
     @Override
     public boolean addAll(Collection<? extends Configuration> c) {
-        DeprecationLogger.deprecateBehaviour("Adding a collection of configurations directly to the configuration container.")
-            .withAdvice("Use a factory method instead.")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "adding_to_configuration_container")
-            .nagUser();
-        return super.addAll(c);
+        throw failOnAttemptToAdd("Adding a collection of configurations directly to the configuration container is not allowed.  Use a factory method instead.");
     }
 
     @Override
     public void addLater(Provider<? extends Configuration> provider) {
-        DeprecationLogger.deprecateBehaviour("Adding a configuration provider directly to the configuration container.")
-            .withAdvice("Use a factory method instead.")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "adding_to_configuration_container")
-            .nagUser();
-        super.addLater(provider);
+        throw failOnAttemptToAdd("Adding a configuration provider directly to the configuration container is not allowed.  Use a factory method instead.");
     }
 
     @Override
     public void addAllLater(Provider<? extends Iterable<Configuration>> provider) {
-        DeprecationLogger.deprecateBehaviour("Adding a provider of configurations directly to the configuration container.")
-            .withAdvice("Use a factory method instead.")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "adding_to_configuration_container")
-            .nagUser();
-        super.addAllLater(provider);
+        throw failOnAttemptToAdd("Adding a provider of configurations directly to the configuration container is not allowed.  Use a factory method instead.");
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -176,7 +176,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     }
 
     private RuntimeException failOnAttemptToAdd(String behavior) {
-        GradleException ex = new GradleException(behavior + " ");
+        GradleException ex = new GradleException(behavior);
         ProblemId id = ProblemId.create("method-not-allowed", "Method call not allowed", GradleCoreProblemGroup.configurationUsage());
         throw problemsService.getInternalReporter().throwing(ex, id, spec -> {
             spec.contextualLabel(ex.getMessage());
@@ -186,22 +186,22 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
 
     @Override
     public boolean add(@Nullable Configuration o) {
-        throw failOnAttemptToAdd("Adding a configuration directly to the configuration container is not allowed.  Use a factory method instead.");
+        throw failOnAttemptToAdd("Adding a configuration directly to the configuration container is not allowed.  Use a factory method instead to create a new configuration in the container.");
     }
 
     @Override
     public boolean addAll(Collection<? extends Configuration> c) {
-        throw failOnAttemptToAdd("Adding a collection of configurations directly to the configuration container is not allowed.  Use a factory method instead.");
+        throw failOnAttemptToAdd("Adding a collection of configurations directly to the configuration container is not allowed.  Use a factory method instead to create a new configuration in the container.");
     }
 
     @Override
     public void addLater(Provider<? extends Configuration> provider) {
-        throw failOnAttemptToAdd("Adding a configuration provider directly to the configuration container is not allowed.  Use a factory method instead.");
+        throw failOnAttemptToAdd("Adding a configuration provider directly to the configuration container is not allowed.  Use a factory method instead to create a new configuration in the container.");
     }
 
     @Override
     public void addAllLater(Provider<? extends Iterable<Configuration>> provider) {
-        throw failOnAttemptToAdd("Adding a provider of configurations directly to the configuration container is not allowed.  Use a factory method instead.");
+        throw failOnAttemptToAdd("Adding a provider of configurations directly to the configuration container is not allowed.  Use a factory method instead to create a new configuration in the container.");
     }
 
     @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -395,7 +395,7 @@ class DefaultConfigurationContainerTest extends Specification {
         configurationContainer.register("foo")
         configurationContainer.create("bar")
         then:
-        configurationContainer.withType(ConfigurationInternal).toList()*.name == ["bar", "foo"]
+        configurationContainer.withType(ConfigurationInternal).toList()*.name == ["bar"] // This should include "foo" too, but it doesn't yet
     }
 
     def "can't #addMethod a #description to a configuration container"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.configurations
 
-import groovy.test.NotYetImplemented
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
@@ -46,6 +45,7 @@ import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
+import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Specification
 
 class DefaultConfigurationContainerTest extends Specification {
@@ -389,13 +389,29 @@ class DefaultConfigurationContainerTest extends Specification {
     }
 
     // withType when used with a class that is not a super-class of the container does not work with registered elements
-    @NotYetImplemented
+    @ToBeImplemented
     def "can find all configurations even when they're registered"() {
         when:
         configurationContainer.register("foo")
         configurationContainer.create("bar")
         then:
         configurationContainer.withType(ConfigurationInternal).toList()*.name == ["bar", "foo"]
+    }
+
+    def "can't #addMethod a #description to a configuration container"() {
+        when:
+        configurationContainer."$addMethod"(addMe)
+
+        then:
+        def e = thrown(GradleException)
+        e.message == "Adding a $description directly to the configuration container is not allowed.  Use a factory method instead to create a new configuration in the container."
+
+        where:
+        description                         | addMethod     | addMe
+        "configuration"                     | "add"         | Mock(Configuration.class)
+        "configuration provider"            | "addLater"    | Mock(Provider.class)
+        "collection of configurations"      | "addAll"      | [Mock(Configuration.class), Mock(Configuration.class)]
+        "provider of configurations"        | "addAllLater" | Mock(Provider.class)
     }
 
     def verifyRole(ConfigurationRole role, String name, @DelegatesTo(ConfigurationContainerInternal) Closure producer) {


### PR DESCRIPTION
Merge https://github.com/gradle/gradle/pull/33188 first, then retarget this to `master`.