### PR TITLE
Fix withoutArtifactSelectors when project dependency subsituted for module dependency

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -1648,7 +1648,7 @@ Required by:
         }
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/7594")
+    @Issue("https://github.com/gradle/gradle/issues/33490")
     def "can substitute module with project and use withoutArtifactSelectors"() {
         mavenRepo.module("com.external", "libB", "1.0")
             .dependsOn("com.external", "libC", "1.0", "type")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -24,12 +24,10 @@ import spock.lang.Issue
 import java.util.concurrent.CopyOnWriteArrayList
 
 class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec {
-    def resolve = new ResolveTestFixture(buildFile, "conf").expectDefaultConfiguration("runtime")
+    def resolve = new ResolveTestFixture(buildFile, "conf")
 
     def setup() {
         settingsFile << "rootProject.name='depsub'\n"
-        resolve.prepare()
-        resolve.addDefaultVariantDerivationStrategy()
     }
 
     void "forces multiple modules by rule"() {
@@ -65,6 +63,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 failOnVersionConflict()
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -112,6 +111,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -162,6 +162,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -212,6 +213,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -251,6 +253,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -292,6 +295,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -334,6 +338,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -348,7 +353,10 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
 
     void "can substitute modules with project dependency using #name"() {
         settingsFile << 'include "api", "impl"'
+
         buildFile << common
+        resolve.prepare()
+
         file("api/build.gradle") << common
         file("impl/build.gradle") << """
             $common
@@ -388,6 +396,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         settingsFile << 'include "api", "impl"'
 
         buildFile << common
+        resolve.prepare()
 
         file("api/build.gradle") << """
             $common
@@ -440,6 +449,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         settingsFile << 'include "api", "impl"'
 
         buildFile << common
+        resolve.prepare()
 
         file("api/build.gradle") << """
             $common
@@ -486,6 +496,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         settingsFile << 'include "api", "test"'
 
         buildFile << common
+        resolve.prepare()
+
         file("api/build.gradle") << common
 
         file("test/build.gradle") << """
@@ -527,6 +539,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         settingsFile << 'include "api", "impl"'
 
         buildFile << common
+        resolve.prepare()
+
         file("api/build.gradle") << common
 
         file("impl/build.gradle") << """
@@ -564,6 +578,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         settingsFile << 'include "api", "impl"'
 
         buildFile << common
+        resolve.prepare()
+
         file("api/build.gradle") << common
 
         file("impl/build.gradle") << """
@@ -601,6 +617,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         settingsFile << 'include "api", "impl"'
 
         buildFile << common
+        resolve.prepare()
+
         file("api/build.gradle") << common
 
         file("impl/build.gradle") << """
@@ -631,6 +649,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         settingsFile << 'include "api", "impl"'
 
         buildFile << common
+        resolve.prepare()
+
         file("api/build.gradle") << common
 
         file("impl/build.gradle") << """
@@ -664,6 +684,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         settingsFile << 'include "impl", "test"'
 
         buildFile << common
+        resolve.prepare()
+
         file("impl/build.gradle") << common
 
         file("test/build.gradle") << """
@@ -698,6 +720,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         settingsFile << 'include "api", "impl"'
 
         buildFile << common
+        resolve.prepare()
+
         file("api/build.gradle") << common
 
         file("impl/build.gradle") << """
@@ -758,6 +782,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         settingsFile << 'include "impl", "dep1", "dep2"'
 
         buildFile << common
+        resolve.prepare()
 
         file("dep1/build.gradle") << """
             $common
@@ -832,6 +857,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 substitute module('org.utils:a:1.2') using module('org.utils:a:1.4')
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -863,6 +889,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 substitute module('org.utils:a:1.2') using module('org.utils:a:1.2.1')
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -897,6 +924,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -926,6 +954,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -968,6 +997,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         when:
         succeeds "check"
@@ -1024,6 +1054,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         expect:
         succeeds "check"
@@ -1054,6 +1085,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 }
             }
         """
+        resolve.prepare()
 
         when:
         fails "checkDeps"
@@ -1080,7 +1112,8 @@ Required by:
             configurations.conf.resolutionStrategy.dependencySubstitution {
                 substitute project(":") using module("org.gradle:test")
             }
-"""
+        """
+        resolve.prepare()
 
         when:
         fails "checkDeps"
@@ -1105,6 +1138,7 @@ Required by:
                 substitute module(":foo:bar:baz:") using module("")
             }
         """
+        resolve.prepare()
 
         when:
         fails "checkDeps"
@@ -1131,6 +1165,7 @@ Required by:
                 }
             }
         """
+        resolve.prepare()
 
         when:
         fails "checkDeps"
@@ -1155,6 +1190,7 @@ Required by:
                 substitute module('org.utils:a:1.2') using module('org.utils:b:2.1')
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -1189,6 +1225,7 @@ Required by:
                 }
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -1227,6 +1264,7 @@ Required by:
                 substitute module('foo:bar:baz') using module('org:b:1.0')
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -1258,6 +1296,7 @@ Required by:
                 it.useTarget "foobar"
             }
         """
+        resolve.prepare()
 
         when:
         fails "checkDeps"
@@ -1283,6 +1322,7 @@ Required by:
                 substitute module('org:a:1.0') using module('org:c:1.1')
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -1353,6 +1393,7 @@ Required by:
                 substitute module('foo:bar:baz') because('we need integration tests') using module('org:b:1.0')
             }
         """
+        resolve.prepare()
 
         when:
         run "checkDeps"
@@ -1392,6 +1433,7 @@ Required by:
                 }
             }
         """
+        resolve.prepare()
 
         file("sub/build.gradle") << """
             version = '0.0.1'
@@ -1434,13 +1476,13 @@ Required by:
                 }
             }
         """
+        resolve.prepare()
 
         when:
         fails ':checkDeps'
 
         then:
         failure.assertHasCause("Substitution exception")
-
     }
 
     def "can substitute a classified dependency with a non classified version"() {
@@ -1470,6 +1512,7 @@ Required by:
                 conf 'org:other:1.0'
             }
         """
+        resolve.prepare()
 
         when:
         succeeds ':checkDeps'
@@ -1527,7 +1570,6 @@ Required by:
             .publish()
 
         buildFile << """
-
             repositories {
                 maven { url = "${mavenRepo.uri}" }
             }
@@ -1545,6 +1587,7 @@ Required by:
                 conf 'org:other:1.0'
             }
         """
+        resolve.prepare()
 
         when:
         succeeds ':checkDeps'
@@ -1577,12 +1620,14 @@ Required by:
 
         file('lib/build.gradle') << """
             plugins {
-                id 'java-library'
+                id("java-library")
             }
         """
 
         buildFile << """
-            apply plugin: 'java-library'
+            plugins {
+                id("java-library")
+            }
 
             repositories {
                 maven { url = "${mavenRepo.uri}" }
@@ -1598,6 +1643,7 @@ Required by:
                 }
             }
         """
+        resolve.prepare()
 
         when:
         resolve.prepare("runtimeClasspath")
@@ -1611,5 +1657,65 @@ Required by:
                 }
             }
         }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/7594")
+    def "can substitute module with project and use withoutArtifactSelectors"() {
+        mavenRepo.module("com.external", "libB", "1.0")
+            .dependsOn("com.external", "libC", "1.0", "type")
+            .publish()
+
+        settingsFile << """
+            include("libC")
+        """
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${mavenTestRepository()}
+
+            dependencies {
+                implementation("com.external:libB:1.0")
+            }
+
+            configurations.runtimeClasspath.resolutionStrategy.dependencySubstitution {
+                def sub = substitute(module("com.external:libC:1.0"))
+                    .using(project(":libC"))
+
+                if (${withoutArtifactSelectors}) {
+                    sub.withoutArtifactSelectors()
+                }
+            }
+
+            tasks.register("resolve") {
+                def files = configurations.runtimeClasspath.incoming.files
+                doLast {
+                    println(files*.name)
+                }
+            }
+        """
+
+        file("libC/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
+        """
+
+        expect:
+        if (withoutArtifactSelectors) {
+            succeeds(":resolve")
+            outputContains("[libB-1.0.jar, libC.jar]")
+        } else {
+            fails(":resolve")
+            failure.assertHasCause("Could not find libC.type (project :libC)")
+        }
+
+        where:
+        withoutArtifactSelectors << [
+            false,
+            true
+        ]
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalModuleDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalModuleDependencyMetadata.java
@@ -97,9 +97,9 @@ public abstract class ExternalModuleDependencyMetadata implements ModuleDependen
 
     protected abstract ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector);
 
-    protected abstract ModuleDependencyMetadata withArtifacts(List<IvyArtifactName> artifacts);
+    protected abstract ModuleDependencyMetadata withArtifacts(List<IvyArtifactName> newArtifacts);
 
-    protected abstract ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> artifacts);
+    protected abstract ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> newArtifacts);
 
     @Override
     public ModuleComponentSelector getSelector() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalModuleDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalModuleDependencyMetadata.java
@@ -79,7 +79,7 @@ public abstract class ExternalModuleDependencyMetadata implements ModuleDependen
             return withRequestedAndArtifacts(newSelector, artifacts);
         } else if (target instanceof ProjectComponentSelector) {
             ProjectComponentSelector projectTarget = (ProjectComponentSelector) target;
-            return new DefaultProjectDependencyMetadata(projectTarget, this);
+            return new DefaultProjectDependencyMetadata(projectTarget, this.withArtifacts(artifacts));
         } else {
             throw new IllegalArgumentException("Unexpected selector provided: " + target);
         }
@@ -96,6 +96,8 @@ public abstract class ExternalModuleDependencyMetadata implements ModuleDependen
     }
 
     protected abstract ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector);
+
+    protected abstract ModuleDependencyMetadata withArtifacts(List<IvyArtifactName> artifacts);
 
     protected abstract ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> artifacts);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -101,7 +101,11 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
         if (target instanceof ModuleComponentSelector) {
             return new GradleDependencyMetadata((ModuleComponentSelector) target, excludes, constraint, endorsing, reason, force, artifacts);
         }
-        return new DefaultProjectDependencyMetadata((ProjectComponentSelector) target, this);
+        return new DefaultProjectDependencyMetadata((ProjectComponentSelector) target, this.withArtifacts(artifacts));
+    }
+
+    private DependencyMetadata withArtifacts(List<IvyArtifactName> artifacts) {
+        return new GradleDependencyMetadata(selector, excludes, constraint, endorsing, reason, force, artifacts);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyMetadata.java
@@ -105,14 +105,14 @@ public class IvyDependencyMetadata extends ExternalModuleDependencyMetadata {
     }
 
     @Override
-    protected ModuleDependencyMetadata withArtifacts(List<IvyArtifactName> artifacts) {
-        return new IvyDependencyMetadata(configuration, dependencyDescriptor, getReason(), isEndorsingStrictVersions(), artifacts);
+    protected ModuleDependencyMetadata withArtifacts(List<IvyArtifactName> newArtifacts) {
+        return new IvyDependencyMetadata(configuration, dependencyDescriptor, getReason(), isEndorsingStrictVersions(), newArtifacts);
     }
 
     @Override
-    protected ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> artifacts) {
+    protected ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> newArtifacts) {
         IvyDependencyDescriptor newDelegate = dependencyDescriptor.withRequested(newSelector);
-        return new IvyDependencyMetadata(configuration, newDelegate, getReason(), isEndorsingStrictVersions(), artifacts);
+        return new IvyDependencyMetadata(configuration, newDelegate, getReason(), isEndorsingStrictVersions(), newArtifacts);
     }
 
     public ModuleDependencyMetadata withDescriptor(IvyDependencyDescriptor descriptor) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyMetadata.java
@@ -105,6 +105,11 @@ public class IvyDependencyMetadata extends ExternalModuleDependencyMetadata {
     }
 
     @Override
+    protected ModuleDependencyMetadata withArtifacts(List<IvyArtifactName> artifacts) {
+        return new IvyDependencyMetadata(configuration, dependencyDescriptor, getReason(), isEndorsingStrictVersions(), artifacts);
+    }
+
+    @Override
     protected ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> artifacts) {
         IvyDependencyDescriptor newDelegate = dependencyDescriptor.withRequested(newSelector);
         return new IvyDependencyMetadata(configuration, newDelegate, getReason(), isEndorsingStrictVersions(), artifacts);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyMetadata.java
@@ -72,13 +72,13 @@ public class MavenDependencyMetadata extends ExternalModuleDependencyMetadata {
     }
 
     @Override
-    protected ModuleDependencyMetadata withArtifacts(List<IvyArtifactName> artifacts) {
-        return new MavenDependencyMetadata(dependencyDescriptor, getReason(), isEndorsingStrictVersions(), artifacts);
+    protected ModuleDependencyMetadata withArtifacts(List<IvyArtifactName> newArtifacts) {
+        return new MavenDependencyMetadata(dependencyDescriptor, getReason(), isEndorsingStrictVersions(), newArtifacts);
     }
 
     @Override
-    protected ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> artifacts) {
+    protected ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> newArtifacts) {
         MavenDependencyDescriptor newDelegate = dependencyDescriptor.withRequested(newSelector);
-        return new MavenDependencyMetadata(newDelegate, getReason(), isEndorsingStrictVersions(), artifacts);
+        return new MavenDependencyMetadata(newDelegate, getReason(), isEndorsingStrictVersions(), newArtifacts);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyMetadata.java
@@ -72,6 +72,11 @@ public class MavenDependencyMetadata extends ExternalModuleDependencyMetadata {
     }
 
     @Override
+    protected ModuleDependencyMetadata withArtifacts(List<IvyArtifactName> artifacts) {
+        return new MavenDependencyMetadata(dependencyDescriptor, getReason(), isEndorsingStrictVersions(), artifacts);
+    }
+
+    @Override
     protected ModuleDependencyMetadata withRequestedAndArtifacts(ModuleComponentSelector newSelector, List<IvyArtifactName> artifacts) {
         MavenDependencyDescriptor newDelegate = dependencyDescriptor.withRequested(newSelector);
         return new MavenDependencyMetadata(newDelegate, getReason(), isEndorsingStrictVersions(), artifacts);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -20,11 +20,9 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.internal.component.model.DelegatingDependencyMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
-import java.util.Collections;
 import java.util.List;
 
 public class DefaultProjectDependencyMetadata extends DelegatingDependencyMetadata implements ForcingDependencyMetadata {
@@ -40,11 +38,6 @@ public class DefaultProjectDependencyMetadata extends DelegatingDependencyMetada
     @Override
     public ProjectComponentSelector getSelector() {
         return selector;
-    }
-
-    @Override
-    public List<ExcludeMetadata> getExcludes() {
-        return Collections.emptyList();
     }
 
     @Override
@@ -74,7 +67,8 @@ public class DefaultProjectDependencyMetadata extends DelegatingDependencyMetada
     @Override
     public ForcingDependencyMetadata forced() {
         if (delegate instanceof ForcingDependencyMetadata) {
-            return ((ForcingDependencyMetadata) delegate).forced();
+            ForcingDependencyMetadata forced = ((ForcingDependencyMetadata) delegate).forced();
+            return new DefaultProjectDependencyMetadata(selector, forced);
         }
         return this;
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -65,14 +65,11 @@ class ResolveTestFixture {
 
     /**
      * Injects the appropriate stuff into the build script. By default, creates a 'checkDeps' task that resolves the configuration provided in the constructor.
+     *
+     * Prefer {@link #configureSettings()}.
      */
     void prepare(@DelegatesTo(CheckTaskBuilder) Closure closure = {}) {
-        def builder = new CheckTaskBuilder()
-        closure.delegate = builder
-        closure.run()
-        if (builder.configs.isEmpty()) {
-            builder.config(config, "checkDeps")
-        }
+        Map<String, String> configs = getTaskConfigs(closure)
 
         def existingScript = buildFile.exists() ? buildFile.text : ""
         def start = existingScript.indexOf(START_MARKER)
@@ -80,43 +77,74 @@ class ResolveTestFixture {
         if (start >= 0) {
             existingScript = existingScript.substring(0, start) + existingScript.substring(end, existingScript.length())
         }
-        def buildScriptBlock = """
-buildscript {
-    dependencies.classpath files("${ClasspathUtil.getClasspathForClass(GenerateGraphTask).toURI()}")
-}
-"""
-        String generatedContent = ""
-        builder.configs.forEach { config, taskName ->
-            generatedContent += """
-allprojects {
-    tasks.register("${taskName}", ${GenerateGraphTask.name}) {
-        it.outputFile = rootProject.file("\${rootProject.buildDir}/last-graph.txt")
-        it.rootComponent = configurations.${config}.incoming.resolutionResult.rootComponent
-        it.files.from(configurations.${config})
-
-        it.incomingFiles = configurations.${config}.incoming.files
-        it.incomingArtifacts = configurations.${config}.incoming.artifacts
-
-        it.artifactViewFiles = configurations.${config}.incoming.artifactView { }.files
-        it.artifactViewArtifacts = configurations.${config}.incoming.artifactView { }.artifacts
-
-        it.lenientArtifactViewFiles = configurations.${config}.incoming.artifactView { it.lenient = true }.files
-        it.lenientArtifactViewArtifacts = configurations.${config}.incoming.artifactView { it.lenient = true }.artifacts
-
-        it.buildArtifacts = ${buildArtifacts}
-        ${registerInputs(config)}
-    }
-}
-"""
-        }
 
         buildFile.text = """
-$buildScriptBlock
-$existingScript
-$START_MARKER
-$generatedContent
-$END_MARKER
-"""
+            ${buildscriptBlock()}
+            $existingScript
+            $START_MARKER
+            allprojects {
+                ${generateResolveTasks(configs)}
+            }
+            $END_MARKER
+        """
+    }
+
+    private Map<String, String> getTaskConfigs(Closure closure) {
+        def builder = new CheckTaskBuilder()
+        closure.delegate = builder
+        closure.run()
+        if (builder.configs.isEmpty()) {
+            builder.config(config, "checkDeps")
+        }
+        builder.configs
+    }
+
+    private String generateResolveTasks(Map<String, String> configs) {
+        return configs.entrySet().collect {
+            String config = it.key
+            String taskName = it.value
+            """
+                tasks.register("${taskName}", ${GenerateGraphTask.name}) {
+                    it.outputFile = rootProject.file("\${rootProject.buildDir}/last-graph.txt")
+                    it.rootComponent = configurations.${config}.incoming.resolutionResult.rootComponent
+                    it.files.from(configurations.${config})
+
+                    it.incomingFiles = configurations.${config}.incoming.files
+                    it.incomingArtifacts = configurations.${config}.incoming.artifacts
+
+                    it.artifactViewFiles = configurations.${config}.incoming.artifactView { }.files
+                    it.artifactViewArtifacts = configurations.${config}.incoming.artifactView { }.artifacts
+
+                    it.lenientArtifactViewFiles = configurations.${config}.incoming.artifactView { it.lenient = true }.files
+                    it.lenientArtifactViewArtifacts = configurations.${config}.incoming.artifactView { it.lenient = true }.artifacts
+
+                    it.buildArtifacts = ${buildArtifacts}
+                    ${registerInputs(config)}
+                }
+            """
+        }.join("\n")
+    }
+
+    private String buildscriptBlock() {
+        """
+            buildscript {
+                dependencies.classpath files("${ClasspathUtil.getClasspathForClass(GenerateGraphTask).toURI()}")
+            }
+        """
+    }
+
+    /**
+     * Returns Groovy code which when added to the Settings file, enables
+     * the resolve test fixture for all projects.
+     */
+    String configureSettings(@DelegatesTo(CheckTaskBuilder) Closure closure = {}) {
+        def configs = getTaskConfigs(closure)
+        """
+            ${buildscriptBlock()}
+            gradle.lifecycle.beforeProject {
+                ${generateResolveTasks(configs)}
+            }
+        """
     }
 
     /**


### PR DESCRIPTION
When a module dependency is replaced by a project dependency, withoutArtifactSelectors did not work.

It does now

Related to https://github.com/gradle/gradle/issues/7594
Fixes bug introduced in https://github.com/gradle/gradle/pull/13318
Fixes https://github.com/gradle/gradle/issues/33490

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
