### PR TITLE
Update warnAboutNeedToMutateUsage from deprecation to failure

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -139,23 +139,6 @@ public interface ConfigurationInternal extends DeprecatableConfiguration, Config
     ConfigurationRole getRoleAtCreation();
 
     /**
-     * Indicates if the allowed usages of this configuration (consumable, resolvable, declarable) can be changed.
-     *
-     * @return {@code true} if so; {@code false} otherwise
-     */
-    boolean usageCanBeMutated();
-
-    /**
-     * Update a configuration's allowed and disallowed usage to match the given role
-     *
-     * This method does <strong>NOT</strong> warn.  This method does <strong>NOT</strong> modify deprecation status.  It
-     * is only meant to be called by the container.
-     *
-     * @param role the role specifying the usage the conf should possess
-     */
-     void setAllowedUsageFromRole(ConfigurationRole role);
-
-    /**
      * Test if the given configuration can either be declared against or extends another
      * configuration which can be declared against.
      * This method should probably be made {@code private} when upgrading to Java 9.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1478,11 +1478,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         usageCanBeMutated = false;
     }
 
-    @Override
-    public boolean usageCanBeMutated() {
-        return usageCanBeMutated;
-    }
-
     @SuppressWarnings("deprecation")
     private void assertUsageIsMutable() {
         if (!usageCanBeMutated) {
@@ -1654,19 +1649,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         if (canBeDeclaredAgainst != allowed) {
             validateMutation(MutationType.USAGE);
             canBeDeclaredAgainst = allowed;
-        }
-    }
-
-    @Override
-    public void setAllowedUsageFromRole(ConfigurationRole role) {
-        if (isCanBeConsumed() != role.isConsumable()) {
-            setCanBeConsumedInternal(role.isConsumable());
-        }
-        if (isCanBeResolved() != role.isResolvable()) {
-            setCanBeResolvedInternal(role.isResolvable());
-        }
-        if (isCanBeDeclared() != role.isDeclarable()) {
-            setCanBeDeclaredInternal(role.isDeclarable());
         }
     }
 


### PR DESCRIPTION
After https://github.com/gradle/gradle/pull/33188 merges, retarget this to `master`.