### PR TITLE
Remove ProjectDependency#getDependencyProject

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -33,10 +33,7 @@ dependencies {
         api("org.asciidoctor:asciidoctor-gradle-jvm:4.0.2")
         api("org.jetbrains.kotlin:kotlin-gradle-plugin") { version { strictly(kotlinVersion) } }
         api(kotlin("compiler-embeddable")) { version { strictly(kotlinVersion) } }
-        api("com.autonomousapps:dependency-analysis-gradle-plugin:1.33.0")
-        api("com.squareup.okio:okio:3.4.0") {
-            because("Bump version brought in by dependency-analysis-gradle-plugin, to resolve CVE-2022-3635")
-        }
+        api("com.autonomousapps:dependency-analysis-gradle-plugin:2.16.0")
 
         // Java Libraries
         api("com.github.javaparser:javaparser-core:$javaParserVersion")

--- a/build-logic/root-build/build.gradle.kts
+++ b/build-logic/root-build/build.gradle.kts
@@ -14,7 +14,5 @@ dependencies {
         because("The CachesCleaner service is shared and needs to be on the root classpath")
     }
 
-    implementation("com.autonomousapps:dependency-analysis-gradle-plugin") {
-        exclude(group = "com.google.j2objc", module = "j2objc-annotations") // This has no use in Gradle
-    }
+    implementation("com.autonomousapps:dependency-analysis-gradle-plugin")
 }

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -11,7 +11,6 @@ import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectProvider
-import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyConstraint
@@ -23,6 +22,7 @@ import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Provider
+import org.gradle.util.Path
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
@@ -147,16 +147,16 @@ class DependencyHandlerExtensionsTest {
             events.add("added")
             dependency
         }
-        val project: Project = mock()
-        whenever(dependency.dependencyProject).thenReturn(project)
+        val projectPath: Path = Path.path(":project")
+        whenever(dependency.path).thenReturn(projectPath.path)
 
         dependencies {
 
             "configuration"(project(path = ":project", configuration = "default")) {
                 events.add("configured")
                 assertThat(
-                    dependencyProject,
-                    sameInstance(project)
+                    path,
+                    sameInstance(projectPath.path)
                 )
             }
         }

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -978,7 +978,7 @@ Calling the following methods on link:{javadocPath}/org/gradle/api/artifacts/Con
 [[deprecate_get_dependency_project]]
 ==== Deprecated `ProjectDependency#getDependencyProject()`
 
-The link:{javadocPath}/org/gradle/api/artifacts/ProjectDependency.html#getDependencyProject()[`ProjectDependency#getDependencyProject()`] method has been deprecated and will be removed in Gradle 9.0.
+The `link:{javadocPath}/org/gradle/api/artifacts/ProjectDependency.html[ProjectDependency]#getDependencyProject()` method has been deprecated and will be removed in Gradle 9.0.
 
 Accessing the mutable project instance of other projects should be avoided.
 

--- a/platforms/jvm/language-jvm/src/test/groovy/org/gradle/api/plugins/jvm/internal/TestFixturesDependencyModifiersTest.groovy
+++ b/platforms/jvm/language-jvm/src/test/groovy/org/gradle/api/plugins/jvm/internal/TestFixturesDependencyModifiersTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.internal.artifacts.capability.FeatureCapabilitySelector
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory
-import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.plugins.jvm.TestFixturesDependencyModifiers
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -44,12 +44,8 @@ class TestFixturesDependencyModifiersTest extends Specification {
 
     def "copies given project dependency to select test fixtures"() {
         def modifier = TestUtil.objectFactory().newInstance(TestFixturesDependencyModifiers.TestFixturesDependencyModifier)
-        def projectInternal = Stub(ProjectInternal) {
-            group >> "group"
-            name >> "name"
-            version >> "1.0"
-        }
-        def dependency = new DefaultProjectDependency(projectInternal)
+        def projectState = Stub(ProjectState)
+        def dependency = new DefaultProjectDependency(projectState)
         dependency.setCapabilityNotationParser(new CapabilityNotationParserFactory(true).create())
         dependency.setObjectFactory(TestUtil.objectFactory())
 
@@ -79,12 +75,8 @@ class TestFixturesDependencyModifiersTest extends Specification {
 
     def "does not modify given project dependency to select test fixtures"() {
         def modifier = TestUtil.objectFactory().newInstance(TestFixturesDependencyModifiers.TestFixturesDependencyModifier)
-        def projectInternal = Stub(ProjectInternal) {
-            group >> "group"
-            name >> "name"
-            version >> "1.0"
-        }
-        def dependency = new DefaultProjectDependency(projectInternal)
+        def projectState = Stub(ProjectState)
+        def dependency = new DefaultProjectDependency(projectState)
         dependency.setCapabilityNotationParser(new CapabilityNotationParserFactory(true).create())
         dependency.setObjectFactory(TestUtil.objectFactory())
 

--- a/platforms/jvm/plugins-jvm-test-fixtures/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
+++ b/platforms/jvm/plugins-jvm-test-fixtures/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
@@ -65,7 +65,7 @@ public abstract class JavaTestFixturesPlugin implements Plugin<Project> {
         JvmFeatureInternal feature = new DefaultJvmFeature(
             TEST_FIXTURES_FEATURE_NAME,
             testFixturesSourceSet,
-            Collections.singleton(new ProjectDerivedCapability(project, TEST_FIXTURES_FEATURE_NAME)),
+            Collections.singleton(new ProjectDerivedCapability((ProjectInternal) project, TEST_FIXTURES_FEATURE_NAME)),
             (ProjectInternal) project,
             false
         );

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -864,22 +864,4 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
         "project(':')"       | "root project :"         | ":outgoingVariants"
         "'org:included:1.0'" | "project :included" | ":included:outgoingVariants"
     }
-
-    def "getDependencyProject is deprecated"() {
-        buildFile << """
-            configurations {
-                dependencyScope("foo")
-            }
-
-            dependencies {
-                foo(project)
-            }
-
-            configurations.foo.dependencies.iterator().next().getDependencyProject()
-        """
-
-        expect:
-        executer.expectDocumentedDeprecationWarning("The ProjectDependency.getDependencyProject() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_get_dependency_project")
-        succeeds("help")
-    }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsCompositeBuildsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsCompositeBuildsIntegrationTest.groovy
@@ -35,7 +35,7 @@ class TypeSafeProjectAccessorsCompositeBuildsIntegrationTest extends AbstractTyp
         buildFile << """
             def projectDependency = projects.other
             assert projectDependency instanceof ProjectDependency
-            println("Dependency path: \\"\${projectDependency.dependencyProject.path}\\"")
+            println("Dependency path: \\"\${projectDependency.path}\\"")
         """
 
         when:

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
@@ -16,12 +16,12 @@
 
 package org.gradle.api.internal.artifacts;
 
-import org.gradle.api.Project;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParser;
 import org.gradle.api.internal.attributes.AttributesFactory;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.reflect.Instantiator;
@@ -52,15 +52,15 @@ public class DefaultProjectDependencyFactory {
         this.projectStateRegistry = projectStateRegistry;
     }
 
-    public ProjectDependency create(Project project) {
-        DefaultProjectDependency projectDependency = instantiator.newInstance(DefaultProjectDependency.class, project);
+    public ProjectDependency create(ProjectState projectState) {
+        DefaultProjectDependency projectDependency = instantiator.newInstance(DefaultProjectDependency.class, projectState);
         injectServices(projectDependency);
         return projectDependency;
     }
 
     public ProjectDependency create(Path projectIdentityPath) {
-        Project project = projectStateRegistry.stateFor(projectIdentityPath).getMutableModel();
-        return create(project);
+        ProjectState projectState = projectStateRegistry.stateFor(projectIdentityPath);
+        return create(projectState);
     }
 
     private void injectServices(DefaultProjectDependency projectDependency) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/VariantIdentityUniquenessVerifier.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/VariantIdentityUniquenessVerifier.java
@@ -19,11 +19,11 @@ package org.gradle.api.internal.artifacts.configurations;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import org.gradle.api.GradleException;
-import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 import org.gradle.internal.deprecation.DocumentedFailure;
@@ -160,7 +160,7 @@ public class VariantIdentityUniquenessVerifier {
             }
 
             // If no capabilities are declared, use the implicit capability.
-            Project project = conf.getDomainObjectContext().getProject();
+            ProjectInternal project = conf.getDomainObjectContext().getProject();
             if (project == null) {
                 return ImmutableCapabilities.EMPTY;
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.dependencies;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.Project;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.capability.DefaultSpecificCapabilitySelector;
@@ -25,58 +24,47 @@ import org.gradle.api.internal.artifacts.capability.FeatureCapabilitySelector;
 import org.gradle.api.internal.artifacts.capability.SpecificCapabilitySelector;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
-import org.gradle.internal.deprecation.DeprecationLogger;
 
 import java.util.List;
 
 public class DefaultProjectDependency extends AbstractModuleDependency implements ProjectDependencyInternal {
 
-    private final ProjectInternal dependencyProject;
+    private final ProjectState projectState;
 
-    public DefaultProjectDependency(ProjectInternal dependencyProject) {
-        this.dependencyProject = dependencyProject;
+    public DefaultProjectDependency(ProjectState projectState) {
+        this.projectState = projectState;
     }
 
     @Override
     public String getPath() {
-        return getTargetProjectIdentity().getProjectPath().toString();
-    }
-
-    @Override
-    @Deprecated
-    public Project getDependencyProject() {
-        DeprecationLogger.deprecateMethod(ProjectDependency.class, "getDependencyProject()")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "deprecate_get_dependency_project")
-            .nagUser();
-
-        return dependencyProject;
+        return getTargetProjectIdentity().getProjectPath().getPath();
     }
 
     @Override
     public String getGroup() {
-        return dependencyProject.getGroup().toString();
+        return unsafeGetProject().getGroup().toString();
     }
 
     @Override
     public String getName() {
-        return dependencyProject.getName();
+        return getTargetProjectIdentity().getProjectName();
     }
 
     @Override
     public String getVersion() {
-        return dependencyProject.getVersion().toString();
+        return unsafeGetProject().getVersion().toString();
     }
 
     @Override
     public ProjectIdentity getTargetProjectIdentity() {
-        return dependencyProject.getOwner().getIdentity();
+        return projectState.getIdentity();
     }
 
     @Override
     public ProjectDependency copy() {
-        DefaultProjectDependency copiedProjectDependency = new DefaultProjectDependency(dependencyProject);
+        DefaultProjectDependency copiedProjectDependency = new DefaultProjectDependency(projectState);
         copyTo(copiedProjectDependency);
         return copiedProjectDependency;
     }
@@ -89,7 +77,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
                 if (c instanceof SpecificCapabilitySelector) {
                     return ((DefaultSpecificCapabilitySelector) c).getBackingCapability();
                 } else if (c instanceof FeatureCapabilitySelector) {
-                    return new ProjectDerivedCapability(dependencyProject, ((FeatureCapabilitySelector) c).getFeatureName());
+                    return new ProjectDerivedCapability(unsafeGetProject(), ((FeatureCapabilitySelector) c).getFeatureName());
                 } else {
                     throw new UnsupportedOperationException("Unsupported capability selector type: " + c.getClass().getName());
                 }
@@ -123,6 +111,17 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     @Override
     public String toString() {
         return "project '" + getTargetProjectIdentity().getBuildTreePath() + "'";
+    }
+
+    /**
+     * Any code which depends on this method should be deprecated and removed.
+     * <p>
+     * A project dependency should be a simple wrapper around the _identity_ of a given
+     * project, and should not retain any reference to the actual project instance.
+     */
+    @Deprecated
+    private ProjectInternal unsafeGetProject() {
+        return projectState.getMutableModel();
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DelegatingProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DelegatingProjectDependency.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.catalog;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Project;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
@@ -60,12 +59,6 @@ public class DelegatingProjectDependency implements ProjectDependencyInternal {
     @Override
     public String getPath() {
         return delegate.getPath();
-    }
-
-    @Override
-    @Deprecated
-    public Project getDependencyProject() {
-        return delegate.getDependencyProject();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/TypeSafeProjectDependencyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/TypeSafeProjectDependencyFactory.java
@@ -29,7 +29,7 @@ public abstract class TypeSafeProjectDependencyFactory {
     }
 
     protected ProjectDependencyInternal create(String path) {
-        return (ProjectDependencyInternal) factory.create(finder.getProject(path));
+        return (ProjectDependencyInternal) factory.create(finder.getProject(path).getOwner());
     }
 
     protected TypeSafeProjectDependencyFactory getFactory() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintProjectNotationConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintProjectNotationConverter.java
@@ -20,6 +20,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationConvertResult;
@@ -43,6 +44,6 @@ public class DependencyConstraintProjectNotationConverter implements NotationCon
 
     @Override
     public void convert(Project notation, NotationConvertResult<? super DependencyConstraint> result) throws TypeConversionException {
-        result.converted(instantiator.newInstance(DefaultProjectDependencyConstraint.class, factory.create(notation)));
+        result.converted(instantiator.newInstance(DefaultProjectDependencyConstraint.class, factory.create(((ProjectInternal) notation).getOwner())));
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyProjectNotationConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyProjectNotationConverter.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.notations;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.NotationConvertResult;
 import org.gradle.internal.typeconversion.NotationConverter;
@@ -39,6 +40,6 @@ public class DependencyProjectNotationConverter implements NotationConverter<Pro
 
     @Override
     public void convert(Project notation, NotationConvertResult<? super ProjectDependency> result) throws TypeConversionException {
-        result.converted(factory.create(notation));
+        result.converted(factory.create(((ProjectInternal) notation).getOwner()));
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ProjectDependencyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ProjectDependencyFactory.java
@@ -52,7 +52,7 @@ public class ProjectDependencyFactory {
             @MapKey("path") String path,
             @MapKey("configuration") @Nullable String configuration
         ) {
-            ProjectDependency defaultProjectDependency = factory.create(projectFinder.getProject(path));
+            ProjectDependency defaultProjectDependency = factory.create(projectFinder.getProject(path).getOwner());
             if (configuration != null) {
                 defaultProjectDependency.setTargetConfiguration(configuration);
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
@@ -17,23 +17,24 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.base.Objects;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Project;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.capabilities.CapabilityInternal;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.util.internal.TextUtil;
 import org.jspecify.annotations.Nullable;
 
 public class ProjectDerivedCapability implements CapabilityInternal {
-    private final Project project;
+
+    private final ProjectInternal project;
     private final String featureName;
 
     private volatile String capabilityName;
 
-    public ProjectDerivedCapability(Project project) {
+    public ProjectDerivedCapability(ProjectInternal project) {
         this(project, null);
     }
 
-    public ProjectDerivedCapability(Project project, @Nullable String featureName) {
+    public ProjectDerivedCapability(ProjectInternal project, @Nullable String featureName) {
         this.project = project;
         this.featureName = featureName;
     }
@@ -51,11 +52,12 @@ public class ProjectDerivedCapability implements CapabilityInternal {
         return capabilityName;
     }
 
-    private static String computeCapabilityName(Project project, @Nullable String featureName) {
+    private static String computeCapabilityName(ProjectInternal project, @Nullable String featureName) {
+        String projectName = project.getOwner().getIdentity().getProjectName();
         if (featureName == null) {
-            return project.getName();
+            return projectName;
         }
-        return project.getName() + "-" + TextUtil.camelToKebabCase(featureName);
+        return projectName + "-" + TextUtil.camelToKebabCase(featureName);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverterTest.groovy
@@ -16,18 +16,17 @@
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies
 
 import com.google.common.collect.ImmutableSet
-import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.project.ProjectIdentity
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Path
-import org.gradle.util.TestUtil
 import org.junit.Rule
 
 class ProjectDependencyMetadataConverterTest extends AbstractDependencyDescriptorFactoryInternalSpec {
@@ -44,10 +43,19 @@ class ProjectDependencyMetadataConverterTest extends AbstractDependencyDescripto
     }
 
     def "test create from project dependency"() {
-        when:
-        def configuration = withArtifacts ? null : TEST_DEP_CONF
-        ProjectDependency projectDependency = createProjectDependency(configuration)
+        given:
+        def projectState = Stub(ProjectState) {
+            getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "foo")
+        }
+
+        def projectDependency = new DefaultProjectDependency(projectState)
+        if (!withArtifacts) {
+            projectDependency.setTargetConfiguration(TEST_DEP_CONF)
+        }
+
         setUpDependency(projectDependency, withArtifacts)
+
+        when:
         LocalOriginDependencyMetadata dependencyMetaData = converter.createDependencyMetadata(projectDependency)
 
         then:
@@ -60,16 +68,4 @@ class ProjectDependencyMetadataConverterTest extends AbstractDependencyDescripto
         withArtifacts << [true, false]
     }
 
-    private ProjectDependency createProjectDependency(String dependencyConfiguration) {
-        Project dependencyProject = TestUtil.create(temporaryFolder).rootProject()
-        dependencyProject.setGroup("someGroup")
-        dependencyProject.setVersion("someVersion")
-        if (dependencyConfiguration != null) {
-            dependencyProject.configurations.create(dependencyConfiguration)
-        }
-
-        def dependency = new DefaultProjectDependency(dependencyProject)
-        dependency.setTargetConfiguration(dependencyConfiguration)
-        return dependency
-    }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
@@ -16,9 +16,11 @@
 package org.gradle.api.internal.notations
 
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateRegistry
@@ -30,13 +32,17 @@ import spock.lang.Specification
 
 class ProjectDependencyFactoryTest extends Specification {
 
-    def projectDummy = Mock(ProjectInternal)
+    def projectState = Mock(ProjectState) {
+        getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "foo")
+    }
+    def projectDummy = Mock(ProjectInternal) {
+        getOwner() >> projectState
+    }
+
     def projectFinder = Mock(ProjectFinder)
     def capabilityNotationParser = new CapabilityNotationParserFactory(false).create()
     def projectStateRegistry = Mock(ProjectStateRegistry) {
-        stateFor(Path.path(":foo")) >> Mock(ProjectState) {
-            getMutableModel() >> projectDummy
-        }
+        stateFor(Path.path(":foo")) >> projectState
     }
     def depFactory = new DefaultProjectDependencyFactory(
         TestUtil.instantiatorFactory().decorateLenient(),
@@ -59,7 +65,7 @@ class ProjectDependencyFactoryTest extends Specification {
         def projectDependency = factory.createFromMap(projectFinder, mapNotation);
 
         then:
-        projectDependency.getDependencyProject() == projectDummy
+        projectDependency.path == projectState.identity.projectPath.path
         projectDependency.targetConfiguration == "compile"
         projectDependency.isTransitive() == expectedTransitive
     }
@@ -78,6 +84,6 @@ class ProjectDependencyFactoryTest extends Specification {
 
     def "can create project dependency from path"() {
         expect:
-        depFactory.create(Path.path(":foo")).dependencyProject == projectDummy
+        depFactory.create(Path.path(":foo")).path == projectState.identity.projectPath.path
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/ProjectDerivedCapabilityTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/ProjectDerivedCapabilityTest.groovy
@@ -16,8 +16,12 @@
 
 package org.gradle.internal.component.external.model
 
-import org.gradle.api.Project
 import org.gradle.api.capabilities.Capability
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
+import org.gradle.api.internal.project.ProjectIdentity
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectState
+import org.gradle.util.Path
 import spock.lang.Specification
 
 class ProjectDerivedCapabilityTest extends Specification {
@@ -42,11 +46,14 @@ class ProjectDerivedCapabilityTest extends Specification {
         return capability1 == capability2 && capability1.hashCode() == capability2.hashCode()
     }
 
-    Project project(String group, String name, String version) {
-        Mock(Project) {
+    ProjectInternal project(String group, String name, String version) {
+        Mock(ProjectInternal) {
             getGroup() >> group
             getName() >> name
             getVersion() >> version
+            getOwner() >> Mock(ProjectState) {
+                getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, name)
+            }
         }
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ProjectDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ProjectDependency.java
@@ -34,15 +34,6 @@ public interface ProjectDependency extends ModuleDependency {
     String getPath();
 
     /**
-     * Returns the project associated with this project dependency.
-     *
-     * @deprecated This method will be removed in Gradle 9.0. Accessing the mutable
-     * state of other projects should be avoided.
-     */
-    @Deprecated
-    Project getDependencyProject();
-
-    /**
      * {@inheritDoc}
      */
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
@@ -15,11 +15,15 @@
  */
 package org.gradle.api.internal.artifacts.dependencies
 
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.util.AttributeTestUtil
+import org.gradle.util.Path
 import org.gradle.util.TestUtil
 import spock.lang.Issue
 import spock.lang.Specification
@@ -65,10 +69,16 @@ class DefaultProjectDependencyConstraintTest extends Specification {
     }
 
     private DefaultProjectDependencyConstraint createProjectDependencyConstraint() {
+        def projectState = Stub(ProjectState) {
+            getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "test-project")
+        }
         def project = Mock(ProjectInternal) {
             getGroup() >> "org.example"
             getVersion() >> "0.0.1"
+            getOwner() >> projectState
         }
+        projectState.getMutableModel() >> project
+
         def dependencyFactory = new DefaultProjectDependencyFactory(
             TestUtil.instantiatorFactory().decorateLenient(),
             new CapabilityNotationParserFactory(false).create(),
@@ -76,8 +86,8 @@ class DefaultProjectDependencyConstraintTest extends Specification {
             AttributeTestUtil.attributesFactory(),
             Mock(ProjectStateRegistry)
         )
-        def projectDependency = dependencyFactory.create(project)
-        projectDependency.setTargetConfiguration("mockConfiguration")
+
+        def projectDependency = dependencyFactory.create(projectState)
         new DefaultProjectDependencyConstraint(projectDependency)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -18,35 +18,51 @@ package org.gradle.api.internal.artifacts.dependencies
 
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.component.BuildIdentifier
-import org.gradle.api.artifacts.dsl.DependencyFactory
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
+import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
-import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+import org.gradle.util.AttributeTestUtil
 import org.gradle.util.Path
+import org.gradle.util.TestUtil
+import spock.lang.Specification
 
 import static org.gradle.api.internal.artifacts.dependencies.AbstractModuleDependencySpec.assertDeepCopy
 import static org.gradle.util.Matchers.strictlyEqual
 import static org.hamcrest.MatcherAssert.assertThat
 
-class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
+class DefaultProjectDependencyTest extends Specification {
+
+    ProjectState projectState = Stub(ProjectState) {
+        getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "test-project")
+    }
+
     private ProjectDependency projectDependency
 
     def setup() {
-        projectDependency = project.services.get(DependencyFactory).create(project)
-        project.version = "1.2"
-        project.group = "org.gradle"
+        def project = Mock(ProjectInternal) {
+            getGroup() >> "org.gradle"
+            getVersion() >> "1.2"
+            getOwner() >> projectState
+        }
+        projectState.getMutableModel() >> project
+
+        projectDependency = new DefaultProjectDependency(projectState)
+        projectDependency.setAttributesFactory(AttributeTestUtil.attributesFactory())
+        projectDependency.setCapabilityNotationParser(new CapabilityNotationParserFactory(false).create())
+        projectDependency.setObjectFactory(TestUtil.objectFactory())
     }
 
     def "exposes local project path"() {
         expect:
-        projectDependency.path == project.path
+        projectDependency.path == projectState.identity.projectPath.path
     }
 
     void "provides dependency information"() {
         expect:
         projectDependency.transitive
-        projectDependency.name == project.name
+        projectDependency.name == projectState.identity.projectName
         projectDependency.group == "org.gradle"
         projectDependency.version == "1.2"
     }
@@ -74,7 +90,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
 
         expect:
         assertDeepCopy(d1, copy)
-        d1.dependencyProject == copy.dependencyProject
+        d1.path == copy.path
     }
 
     def "requested capabilities exposes all capability selector types"() {
@@ -95,19 +111,19 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
     }
 
     private createProjectDependency() {
-        def out = new DefaultProjectDependency(project)
+        def out = new DefaultProjectDependency(projectState)
         out.addArtifact(new DefaultDependencyArtifact("name", "type", "ext", "classifier", "url"))
         out
     }
 
     void "knows if is equal"() {
-        def dep1 = new DefaultProjectDependency(project)
-        def dep2 = new DefaultProjectDependency(project)
+        def dep1 = new DefaultProjectDependency(projectState)
+        def dep2 = new DefaultProjectDependency(projectState)
 
-        def dep1WithConf = new DefaultProjectDependency(project)
+        def dep1WithConf = new DefaultProjectDependency(projectState)
         dep1WithConf.setTargetConfiguration("conf1")
 
-        def dep2WithConf = new DefaultProjectDependency(project)
+        def dep2WithConf = new DefaultProjectDependency(projectState)
         dep2WithConf.setTargetConfiguration("conf1")
 
         expect:
@@ -115,18 +131,16 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
         assertThat(dep1WithConf, strictlyEqual(dep2WithConf))
 
         when:
-        def base = new DefaultProjectDependency(project)
+        def base = new DefaultProjectDependency(projectState)
         base.setTargetConfiguration("conf1")
 
-        def differentConf = new DefaultProjectDependency(project)
+        def differentConf = new DefaultProjectDependency(projectState)
         differentConf.setTargetConfiguration("conf2")
 
-        def otherProject = Mock(ProjectInternal) {
-            getOwner() >> Mock(ProjectState) {
-                getIdentity() >> new ProjectIdentity(Mock(BuildIdentifier), Path.path(":foo"), Path.path(":foo"), "foo")
-            }
+        def otherProjectState = Mock(ProjectState) {
+            getIdentity() >> new ProjectIdentity(Mock(BuildIdentifier), Path.path(":foo"), Path.path(":foo"), "foo")
         }
-        def differentProject = new DefaultProjectDependency(otherProject)
+        def differentProject = new DefaultProjectDependency(otherProjectState)
         differentProject.setTargetConfiguration("conf1")
 
         then:

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -249,6 +249,14 @@
             ]
         },
         {
+            "type": "org.gradle.api.artifacts.ProjectDependency",
+            "member": "Method org.gradle.api.artifacts.ProjectDependency.getDependencyProject()",
+            "acceptation": "Removed deprecated method",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
             "type": "org.gradle.api.artifacts.ResolveException",
             "member": "Constructor org.gradle.api.artifacts.ResolveException(java.lang.String,java.lang.Iterable)",
             "acceptation": "Public consturctor was deprecated",

--- a/testing/architecture-test/src/changes/archunit-store/public-api-mutable-properties.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-mutable-properties.txt
@@ -72,7 +72,6 @@ Method <org.gradle.api.artifacts.ModuleDependency.getTargetConfiguration()> does
 Method <org.gradle.api.artifacts.ModuleDependency.isEndorsingStrictVersions()> does not have raw return type (boolean) assignable to any of [Provider] in (ModuleDependency.java:0)
 Method <org.gradle.api.artifacts.ModuleDependency.isTransitive()> does not have raw return type (boolean) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (ModuleDependency.java:0)
 Method <org.gradle.api.artifacts.MutableVersionConstraint.getBranch()> does not have raw return type (java.lang.String) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (MutableVersionConstraint.java:0)
-Method <org.gradle.api.artifacts.ProjectDependency.getDependencyProject()> does not have raw return type (org.gradle.api.Project) assignable to any of [Provider] in (ProjectDependency.java:0)
 Method <org.gradle.api.artifacts.ProjectDependency.getPath()> does not have raw return type (java.lang.String) assignable to any of [Provider] in (ProjectDependency.java:0)
 Method <org.gradle.api.artifacts.ResolutionStrategy.getCapabilitiesResolution()> does not have raw return type (org.gradle.api.artifacts.CapabilitiesResolution) assignable to any of [Provider] in (ResolutionStrategy.java:0)
 Method <org.gradle.api.artifacts.ResolutionStrategy.getComponentSelection()> does not have raw return type (org.gradle.api.artifacts.ComponentSelectionRules) assignable to any of [Provider] in (ResolutionStrategy.java:0)

--- a/testing/internal-architecture-testing/build.gradle.kts
+++ b/testing/internal-architecture-testing/build.gradle.kts
@@ -8,7 +8,8 @@ dependencies {
     api(platform(projects.distributionsDependencies))
     api(libs.archunit)
     api(libs.archunitJunit5Api)
-    api(libs.archunitJunit5) {
+
+    runtimeOnly(libs.archunitJunit5) {
         because("This is what we use to write our architecture tests")
     }
 }

--- a/testing/performance/build.gradle.kts
+++ b/testing/performance/build.gradle.kts
@@ -33,3 +33,11 @@ dependencies {
         because("IDE tests use the Tooling API.")
     }
 }
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            exclude(libs.junitJupiter)
+        }
+    }
+}

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PalantirConsistentVersionsPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PalantirConsistentVersionsPluginSmokeTest.groovy
@@ -18,26 +18,10 @@ package org.gradle.smoketests
 
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
-import org.gradle.util.GradleVersion
-import spock.lang.Ignore
 
 @Requires(UnitTestPreconditions.Jdk11OrLater)
 class PalantirConsistentVersionsPluginSmokeTest extends AbstractSmokeTest {
 
-    /*
-    TODO: Until these are fixed in a new version of the plugin, we need to ignore this test.
-> Extending a detachedConfiguration is not allowed
-
-> Method call not allowed
-    Calling setCanBeConsumed(true) on configuration ':compileClasspathCopy' is not allowed.  This configuration's role was set upon creation and its usage should not be changed.
-
-Called here: https://github.com/tresat/gradle-consistent-versions/blob/develop/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java#L662
-due to:
-https://github.com/tresat/gradle-consistent-versions/blob/23e53fa3b6f7071df8788cecbaeac16f93e90660/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java#L640
-because of:
-https://github.com/tresat/gradle-consistent-versions/blob/23e53fa3b6f7071df8788cecbaeac16f93e90660/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java#L609
-    */
-    @Ignore("Palantir copies compileClasspath and sets it to be consumable, Palantir extends detachedConfigurations")
     def 'basic functionality'() {
         given:
         buildFile << """
@@ -63,49 +47,13 @@ https://github.com/tresat/gradle-consistent-versions/blob/23e53fa3b6f7071df8788c
         file("versions.props") << "com.google.guava:guava = 17.0"
 
         when:
-        runner('--write-locks')
+        def result = runner('--write-locks')
             // They are doing some weird stuff in an afterEvaluate
             // See: https://github.com/palantir/gradle-consistent-versions/blob/28a604723c936f5c93c6591e144c4a1731d570ad/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java#L277
-            .expectLegacyDeprecationWarning("Adding a configuration directly to the configuration container. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Use a factory method instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#adding_to_configuration_container")
-            .expectLegacyDeprecationWarning("The compileClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
-            .expectLegacyDeprecationWarning("The runtimeClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
-            .expectLegacyDeprecationWarning("The testCompileClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
-            .expectLegacyDeprecationWarning("The testRuntimeClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
-            .expectLegacyDeprecationWarning("Mutating a configuration after it has been resolved, consumed as a variant, or used for generating published metadata. This behavior has been deprecated. This will fail with an error in Gradle 9.0. The dependencies of configuration ':gcvLocks' were mutated after the configuration was consumed as a variant. After a configuration has been observed, it should not be modified. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#mutate_configuration_after_locking")
-            .expectLegacyDeprecationWarning("Mutating a configuration after it has been resolved, consumed as a variant, or used for generating published metadata. This behavior has been deprecated. This will fail with an error in Gradle 9.0. The hierarchy of configuration ':apiElements' was mutated after the configuration was consumed as a variant. After a configuration has been observed, it should not be modified. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#mutate_configuration_after_locking")
-            .expectLegacyDeprecationWarning("Mutating a configuration after it has been resolved, consumed as a variant, or used for generating published metadata. This behavior has been deprecated. This will fail with an error in Gradle 9.0. The hierarchy of configuration ':runtimeElements' was mutated after the configuration's child configuration ':default' was consumed as a variant. After a configuration has been observed, it should not be modified. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#mutate_configuration_after_locking")
-            .expectLegacyDeprecationWarning("Mutating a configuration after it has been resolved, consumed as a variant, or used for generating published metadata. This behavior has been deprecated. This will fail with an error in Gradle 9.0. The hierarchy of configuration ':other:apiElements' was mutated after the configuration was consumed as a variant. After a configuration has been observed, it should not be modified. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#mutate_configuration_after_locking")
-            .expectLegacyDeprecationWarning("Mutating a configuration after it has been resolved, consumed as a variant, or used for generating published metadata. This behavior has been deprecated. This will fail with an error in Gradle 9.0. The hierarchy of configuration ':other:runtimeElements' was mutated after the configuration's child configuration ':other:default' was consumed as a variant. After a configuration has been observed, it should not be modified. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#mutate_configuration_after_locking")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':compileClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':runtimeClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':testCompileClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':testRuntimeClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':other:compileClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':other:runtimeClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':other:testCompileClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':other:testRuntimeClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("The ProjectDependency.getDependencyProject() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecate_get_dependency_project")
-            .build()
+            .buildAndFail()
 
         then:
-        file("versions.lock").exists()
-
-        when:
-        def runner = runner("other:dependencies")
-            .expectLegacyDeprecationWarning("Adding a configuration directly to the configuration container. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Use a factory method instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#adding_to_configuration_container")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':compileClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':runtimeClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':testCompileClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':testRuntimeClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':other:compileClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':other:runtimeClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':other:testCompileClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("Calling extendsFrom on configuration ':other:testRuntimeClasspathCopy' has been deprecated. This will fail with an error in Gradle 9.0. Detached configurations should not extend other configurations, this was extending: 'rootConfiguration'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#detached_configurations_cannot_extend")
-            .expectLegacyDeprecationWarning("The ProjectDependency.getDependencyProject() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecate_get_dependency_project")
-
-        def result = runner.build()
-
-        then:
-        result.output.contains("com.google.guava:guava -> 17.0")
+        // This method has been removed in Gradle 9.0
+        result.output.contains("ProjectDependency.getDependencyProject")
     }
 }


### PR DESCRIPTION
At the same time, we update ProjectDependency to accept a ProjectState instead of a mutable project instance.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
