### PR TITLE
Remove use of BuildOutputCleanupRegistry in Java

### DIFF
--- a/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
+++ b/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
@@ -93,41 +93,6 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
         'out'        | false      | 'reconfigured build directory'
     }
 
-    def "production class files outside of 'build' are removed"() {
-        given:
-        def javaProject = new StaleOutputJavaProject(testDirectory, 'out')
-        buildFile << """
-            apply plugin: 'java'
-
-            sourceSets {
-                main {
-                    java.destinationDirectory.set(file('out/classes/java/main'))
-                }
-            }
-        """.stripIndent()
-
-        when:
-        result = runWithMostRecentFinalRelease(JAR_TASK_NAME)
-
-        then:
-        javaProject.mainClassFile.assertIsFile()
-        javaProject.redundantClassFile.assertIsFile()
-
-        when:
-        forceDelete(javaProject.redundantSourceFile)
-        succeeds JAR_TASK_NAME
-
-        then:
-        javaProject.mainClassFile.assertIsFile()
-        javaProject.redundantClassFile.assertDoesNotExist()
-
-        when:
-        succeeds JAR_TASK_NAME
-
-        then:
-        javaProject.assertBuildTasksSkipped(result)
-    }
-
     // We register the output directory before task execution and would have deleted output files at the end of configuration.
     @Issue("https://github.com/gradle/gradle/issues/821")
     @UnsupportedWithConfigurationCache

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -285,6 +285,14 @@ Refer to Gradle’s link:compatibility.html#kotlin[compatibility matrix] for det
 
 NOTE: Plugins written using the Kotlin DSL and published with Gradle 7.x or 8.x remain compatible with Gradle 6.8 and newer.
 
+==== Stale outputs placed outside of the build directory are no longer deleted
+
+In previous versions of Gradle, class files placed outside of the build directory were deleted when they were considered stale. This was a special case for class files registered as the output of a source set.
+
+This is not a common practice and required Gradle to eagerly realize all compile related tasks in every build. As of Gradle 9.0, this special case has been removed.
+
+Gradle will still delete stale outputs inside the build directory as necessary.
+
 ==== Scala plugins no longer create unresolvable configurations
 
 Previously, the Scala plugins used configurations named `incrementalScalaAnalysisFor` to resolve incremental analysis information between projects.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -285,13 +285,13 @@ Refer to Gradle’s link:compatibility.html#kotlin[compatibility matrix] for det
 
 NOTE: Plugins written using the Kotlin DSL and published with Gradle 7.x or 8.x remain compatible with Gradle 6.8 and newer.
 
-==== Stale outputs placed outside of the build directory are no longer deleted
+==== Stale outputs outside the build directory are no longer deleted
 
-In previous versions of Gradle, class files placed outside of the build directory were deleted when they were considered stale. This was a special case for class files registered as the output of a source set.
+In previous versions of Gradle, class files located outside the build directory were deleted when considered stale. This was a special case for class files registered as outputs of a source set.
 
-This is not a common practice and required Gradle to eagerly realize all compile related tasks in every build. As of Gradle 9.0, this special case has been removed.
+Because this setup is uncommon and forced Gradle to eagerly realize all compile related tasks in every build, the behavior has been removed in Gradle 9.0.
 
-Gradle will still delete stale outputs inside the build directory as necessary.
+Gradle will continue to clean up stale outputs inside the build directory as needed.
 
 ==== Scala plugins no longer create unresolvable configurations
 

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -107,7 +107,7 @@ public class JvmPluginsHelper {
         sourceDirectorySet.getDestinationDirectory().convention(target.getLayout().getBuildDirectory().dir(sourceSetChildPath));
 
         DefaultSourceSetOutput sourceSetOutput = Cast.cast(DefaultSourceSetOutput.class, sourceSet.getOutput());
-        sourceSetOutput.getClassesDirs().from(sourceDirectorySet.getDestinationDirectory()).builtBy(compileTask);
+        sourceSetOutput.getClassesDirs().from(sourceDirectorySet.getClassesDirectory());
         sourceSetOutput.getGeneratedSourcesDirs().from(options.flatMap(CompileOptions::getGeneratedSourceOutputDirectory));
         sourceDirectorySet.compiledBy(compileTask, AbstractCompile::getDestinationDirectory);
     }

--- a/platforms/jvm/plugins-java/build.gradle.kts
+++ b/platforms/jvm/plugins-java/build.gradle.kts
@@ -14,12 +14,10 @@ dependencies {
     api(libs.inject)
 
     implementation(projects.baseServices)
-    implementation(projects.execution)
     implementation(projects.languageJvm)
     implementation(projects.ivy)
     implementation(projects.maven)
     implementation(projects.modelCore)
-    implementation(projects.serviceLookup)
     implementation(projects.softwareDiagnostics)
     implementation(projects.stdlibJavaExtensions)
     implementation(projects.platformBase)

--- a/platforms/jvm/plugins-java/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/platforms/jvm/plugins-java/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -47,7 +47,6 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.diagnostics.DependencyInsightReportTask;
 import org.gradle.api.tasks.testing.Test;
-import org.gradle.internal.execution.BuildOutputCleanupRegistry;
 import org.gradle.jvm.component.internal.DefaultJvmSoftwareComponent;
 import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
 import org.gradle.testing.base.TestingExtension;
@@ -270,9 +269,6 @@ public abstract class JavaPlugin implements Plugin<Project> {
         project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getArtifacts()
             .add(javaComponent.getMainFeature().getRuntimeElementsConfiguration().getArtifacts().iterator().next());
 
-        BuildOutputCleanupRegistry buildOutputCleanupRegistry = projectInternal.getServices().get(BuildOutputCleanupRegistry.class);
-        configureSourceSets(buildOutputCleanupRegistry, sourceSets);
-
         configureTestTaskOrdering(project.getTasks());
         configureDiagnostics(project, javaComponent.getMainFeature());
         configureBuild(project);
@@ -329,11 +325,6 @@ public abstract class JavaPlugin implements Plugin<Project> {
                 strategy.defaultResolutionConfiguration(Usage.JAVA_RUNTIME, sourceSet.getRuntimeClasspathConfigurationName());
             });
         });
-    }
-
-    private static void configureSourceSets(final BuildOutputCleanupRegistry buildOutputCleanupRegistry, SourceSetContainer sourceSets) {
-        // Register the project's source set output directories
-        sourceSets.all(sourceSet -> buildOutputCleanupRegistry.registerOutputs(sourceSet.getOutput()));
     }
 
     /**


### PR DESCRIPTION
Fixes #23932 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
