### PR TITLE
Revert "Properly wire task dependencies to Antlr sourceset (#32625)"

### DIFF
--- a/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AntlrPluginIntegrationTest.groovy
+++ b/platforms/software/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AntlrPluginIntegrationTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.api.plugins.antlr
 
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
-import spock.lang.Issue
 
 import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
 import static org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
@@ -37,7 +36,20 @@ class AntlrPluginIntegrationTest extends WellBehavedPluginTest {
         """
         and:
 
-        file("src/main/antlr/org/acme/TestGrammar.g") << testGrammarSource
+        file("src/main/antlr/org/acme/TestGrammar.g") << """ class TestGrammar extends Parser;
+        options {
+            buildAST = true;
+        }
+
+        expr:   mexpr (PLUS^ mexpr)* SEMI!
+        ;
+
+        mexpr
+        :   atom (STAR^ atom)*
+        ;
+
+        atom:   INT
+        ;"""
 
         when:
         succeeds("generateGrammarSource")
@@ -90,46 +102,5 @@ class AntlrPluginIntegrationTest extends WellBehavedPluginTest {
 
         expect:
         succeeds 'help'
-    }
-
-    @Issue('https://github.com/gradle/gradle/issues/19555')
-    def "creates proper dependency wiring between generated source set and source generation task"() {
-        given:
-        buildFile << """
-            apply plugin: "java"
-            apply plugin: "antlr"
-
-            ${mavenCentralRepository()}
-
-            java {
-                withSourcesJar()
-            }
-        """
-
-        and:
-        file("src/main/antlr/TestGrammar.g") << testGrammarSource
-
-        when:
-        succeeds('sourcesJar')
-
-        then:
-        executed(':generateGrammarSource')
-    }
-
-    private static String getTestGrammarSource() {
-        return """ class TestGrammar extends Parser;
-        options {
-            buildAST = true;
-        }
-
-        expr:   mexpr (PLUS^ mexpr)* SEMI!
-        ;
-
-        mexpr
-        :   atom (STAR^ atom)*
-        ;
-
-        atom:   INT
-        ;"""
     }
 }

--- a/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -19,6 +19,7 @@ package org.gradle.api.plugins.antlr;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.DefaultSourceSet;
@@ -28,7 +29,6 @@ import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.antlr.internal.DefaultAntlrSourceDirectorySet;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.TaskProvider;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -82,23 +82,28 @@ public abstract class AntlrPlugin implements Plugin<Project> {
                     //    naming conventions via call to sourceSet.getTaskName()
                     final String taskName = sourceSet.getTaskName("generate", "GrammarSource");
 
-                    // 3) Set up the Antlr output directory
+                    // 3) Set up the Antlr output directory (adding to javac inputs!)
                     final String outputDirectoryName = project.getBuildDir() + "/generated-src/antlr/" + sourceSet.getName();
                     final File outputDirectory = new File(outputDirectoryName);
+                    sourceSet.getJava().srcDir(outputDirectory);
 
-                    // 4) Register a source-generating task, and
-                    TaskProvider<AntlrTask> antlrTask = project.getTasks().register(taskName, AntlrTask.class, new Action<AntlrTask>() {
+                    project.getTasks().register(taskName, AntlrTask.class, new Action<AntlrTask>() {
                         @Override
                         public void execute(AntlrTask antlrTask) {
                             antlrTask.setDescription("Processes the " + sourceSet.getName() + " Antlr grammars.");
-                            // 4.1) set up convention mapping for default sources (allows user to not have to specify)
+                            // 4) set up convention mapping for default sources (allows user to not have to specify)
                             antlrTask.setSource(antlrSourceSet);
                             antlrTask.setOutputDirectory(outputDirectory);
                         }
                     });
 
-                    // 5) Add that task's outputs to the Java source set
-                    sourceSet.getJava().srcDir(antlrTask);
+                    // 5) register fact that antlr should be run before compiling
+                    project.getTasks().named(sourceSet.getCompileJavaTaskName(), new Action<Task>() {
+                        @Override
+                        public void execute(Task task) {
+                            task.dependsOn(taskName);
+                        }
+                    });
                 }
             });
     }

--- a/platforms/software/antlr/src/test/groovy/org/gradle/api/plugins/antlr/AntlrPluginTest.groovy
+++ b/platforms/software/antlr/src/test/groovy/org/gradle/api/plugins/antlr/AntlrPluginTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.plugins.antlr
 
 import org.gradle.api.Action
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
-import spock.lang.Issue
 
 import static org.gradle.api.reflect.TypeOf.typeOf
 
@@ -93,21 +92,5 @@ class AntlrPluginTest extends AbstractProjectBuilderSpec {
         then:
         def main = project.sourceSets.main
         main.extensions.extensionsSchema.find { it.name == 'antlr' }.publicType == typeOf(AntlrSourceDirectorySet)
-    }
-
-    @Issue('https://github.com/gradle/gradle/issues/19555')
-    def 'adds task dependency to sourcesJar'() {
-        when:
-        project.pluginManager.apply(AntlrPlugin)
-
-        and:
-        project.java {
-            withSourcesJar()
-        }
-
-        then:
-        def generateGrammarSource = project.tasks.generateGrammarSource
-        def sourcesJar = project.tasks.sourcesJar
-        sourcesJar.taskDependencies.getDependencies(null).contains(generateGrammarSource)
     }
 }


### PR DESCRIPTION
This reverts commit 679d5d9f95ed90e983598de302b5be511379053f, reversing changes made to 045d72357546003a86c6c8140c9ef365ebb63bfc.

Fixes #33180.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
