### PR TITLE
Move software model reporting tasks out of default help tasks

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/plugins/HelpTasksPluginIntegrationTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/plugins/HelpTasksPluginIntegrationTest.groovy
@@ -37,6 +37,6 @@ class HelpTasksPluginIntegrationTest extends WellBehavedPluginTest {
         succeeds "tasks"
 
         where:
-        task << ["help", "projects", "tasks", "properties", "dependencyInsight", "dependencies", "components", "model"]
+        task << ["help", "projects", "tasks", "properties", "dependencyInsight", "dependencies"]
     }
 }

--- a/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/TaskReportTaskIntegrationTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/TaskReportTaskIntegrationTest.groovy
@@ -445,6 +445,10 @@ b
         when:
         settingsFile << "rootProject.name = 'test-project'"
         buildFile """
+            plugins {
+                id 'component-model-base'
+            }
+
             model {
                 tasks {
                     create('a')

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
@@ -40,7 +40,6 @@ public abstract class HelpTasksPlugin implements Plugin<Project> {
     public static final String PROPERTIES_TASK = DiagnosticsTaskNames.PROPERTIES_TASK;
     public static final String DEPENDENCIES_TASK = DiagnosticsTaskNames.DEPENDENCIES_TASK;
     public static final String DEPENDENCY_INSIGHT_TASK = DiagnosticsTaskNames.DEPENDENCY_INSIGHT_TASK;
-    public static final String COMPONENTS_TASK = DiagnosticsTaskNames.COMPONENTS_TASK;
 
     /**
      * The name of the outgoing variants report task.
@@ -66,7 +65,6 @@ public abstract class HelpTasksPlugin implements Plugin<Project> {
     public static final String ARTIFACT_TRANSFORMS_TASK = DiagnosticsTaskNames.ARTIFACT_TRANSFORMS_TASK;
 
     public static final String MODEL_TASK = DiagnosticsTaskNames.MODEL_TASK;
-    public static final String DEPENDENT_COMPONENTS_TASK = DiagnosticsTaskNames.DEPENDENT_COMPONENTS_TASK;
 
     @Override
     public void apply(final Project project) {
@@ -79,21 +77,9 @@ public abstract class HelpTasksPlugin implements Plugin<Project> {
         tasks.register(ProjectInternal.TASKS_TASK, TaskReportTask.class, new TaskReportTaskAction(projectName, getChildProjectsForInternalUse(project).isEmpty()));
         tasks.register(PROPERTIES_TASK, PropertyReportTask.class, new PropertyReportTaskAction(projectName));
 
-        registerDeprecatedSoftwareModelTasks(tasks, projectName);
-
         tasks.withType(TaskReportTask.class).configureEach(task -> {
             task.getShowTypes().convention(false);
         });
-    }
-
-    /**
-     * Registers the deprecated tasks used by the Software Model.
-     * <p>
-     * Note that these tasks <strong>are</strong> deprecated, even though they do not emit a deprecation warning when run.
-     */
-    @SuppressWarnings("deprecation")
-    private void registerDeprecatedSoftwareModelTasks(TaskContainer tasks, String projectName) {
-        tasks.register(MODEL_TASK, org.gradle.api.reporting.model.ModelReport.class, new ModelReportAction(projectName));
     }
 
     private static class HelpAction implements Action<Help> {
@@ -154,21 +140,6 @@ public abstract class HelpTasksPlugin implements Plugin<Project> {
         public void execute(PropertyReportTask task) {
             task.setDescription("Displays the properties of " + projectName + ".");
             task.setGroup(HELP_GROUP);
-            task.setImpliesSubProjects(true);
-        }
-    }
-
-    @SuppressWarnings("deprecation")
-    private static class ModelReportAction implements Action<org.gradle.api.reporting.model.ModelReport> {
-        private final String projectName;
-
-        public ModelReportAction(String projectName) {
-            this.projectName = projectName;
-        }
-
-        @Override
-        public void execute(org.gradle.api.reporting.model.ModelReport task) {
-            task.setDescription("Displays the configuration model of " + projectName + ". [deprecated]");
             task.setImpliesSubProjects(true);
         }
     }

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/ModelReportingTasksPlugin.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/ModelReportingTasksPlugin.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.diagnostics.internal.DiagnosticsTaskNames;
+
+/**
+ * Plugin that adds tasks to report on the deprecated software models configured for the project.
+ *
+ * @since 9.0
+ */
+@Incubating
+abstract public class ModelReportingTasksPlugin implements Plugin<Project> {
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void apply(Project project) {
+        project.getTasks().register(DiagnosticsTaskNames.MODEL_TASK, org.gradle.api.reporting.model.ModelReport.class, new ModelReportAction(project.toString()));
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class ModelReportAction implements Action<org.gradle.api.reporting.model.ModelReport> {
+        private final String projectName;
+
+        public ModelReportAction(String projectName) {
+            this.projectName = projectName;
+        }
+
+        @Override
+        public void execute(org.gradle.api.reporting.model.ModelReport task) {
+            task.setDescription("Displays the configuration model of " + projectName + ". [deprecated]");
+            task.setImpliesSubProjects(true);
+        }
+    }
+}

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/internal/ModelReportingTasksPlugin.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/internal/ModelReportingTasksPlugin.java
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins;
+package org.gradle.api.plugins.internal;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.diagnostics.internal.DiagnosticsTaskNames;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Plugin that adds tasks to report on the deprecated software models configured for the project.
  *
  * @since 9.0
  */
-@Incubating
+
+@NullMarked
 abstract public class ModelReportingTasksPlugin implements Plugin<Project> {
 
     @Override
@@ -37,6 +38,7 @@ abstract public class ModelReportingTasksPlugin implements Plugin<Project> {
     }
 
     @SuppressWarnings("deprecation")
+    @NullMarked
     private static class ModelReportAction implements Action<org.gradle.api.reporting.model.ModelReport> {
         private final String projectName;
 

--- a/platforms/core-configuration/base-diagnostics/src/main/resources/META-INF/gradle-plugins/org.gradle.model-reporting-tasks.properties
+++ b/platforms/core-configuration/base-diagnostics/src/main/resources/META-INF/gradle-plugins/org.gradle.model-reporting-tasks.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=org.gradle.api.plugins.ModelReportingTasksPlugin

--- a/platforms/core-configuration/base-diagnostics/src/main/resources/META-INF/gradle-plugins/org.gradle.model-reporting-tasks.properties
+++ b/platforms/core-configuration/base-diagnostics/src/main/resources/META-INF/gradle-plugins/org.gradle.model-reporting-tasks.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-implementation-class=org.gradle.api.plugins.ModelReportingTasksPlugin
+implementation-class=org.gradle.api.plugins.internal.ModelReportingTasksPlugin

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -1134,9 +1134,9 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCacheFails("ok", "-DPROP=12")
 
         then:
-        outputContains("Configuration cache entry discarded with 19 problems")
+        outputContains("Configuration cache entry discarded with 16 problems")
         problems.assertFailureHasProblems(failure) {
-            totalProblemsCount = 19
+            totalProblemsCount = 16
             withInput("Script 'script.gradle': system property 'PROP'")
             withProblem("Script 'script.gradle': line 4: registration of listener on 'Gradle.buildFinished' is unsupported")
         }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelMapIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/ModelMapIntegrationTest.groovy
@@ -257,7 +257,9 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
             class Rules extends RuleSource {
                 @Model void things(ModelMap<Thing> things) { }
             }
+
             apply plugin: Rules
+            apply plugin: 'model-reporting-tasks'
 
             model {
                 things {
@@ -314,7 +316,9 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
             class Rules extends RuleSource {
                 @Model void things(ModelMap<List<String>> things) { }
             }
+
             apply plugin: Rules
+            apply plugin: 'model-reporting-tasks'
 
             model {
                 things { it.create("elem") }
@@ -325,7 +329,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         succeeds "model"
         ModelReportOutput.from(output).hasNodeStructure {
             things {
-                elem(type: 'java.util.List<java.lang.String>', creator: 'things { ... } @ build.gradle line 8, column 17 > create(elem)')
+                elem(type: 'java.util.List<java.lang.String>', creator: 'things { ... } @ build.gradle line 10, column 17 > create(elem)')
             }
         }
     }
@@ -340,7 +344,9 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
                 @Model
                 void things(ModelMap<Thing> things) {}
             }
+
             apply plugin: Rules
+            apply plugin: 'model-reporting-tasks'
 
             model {
                 things {
@@ -351,7 +357,7 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         fails "model"
-        failureHasCause "Exception thrown while executing model rule: things { ... } @ build.gradle line 12, column 17"
+        failureHasCause "Exception thrown while executing model rule: things { ... } @ build.gradle line 14, column 17"
         failureHasCause "Cannot create 'things.thing' with type 'UnknownThing' as this is not a subtype of 'Thing'."
     }
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
@@ -419,6 +419,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
             }
 
             apply plugin: MyPlugin
+            apply plugin: 'model-reporting-tasks'
         '''
 
         expect:
@@ -453,6 +454,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
             }
 
             apply plugin: MyPlugin
+            apply plugin: 'model-reporting-tasks'
         '''
 
         expect:
@@ -486,6 +488,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
             }
 
             apply plugin: MyPlugin
+            apply plugin: 'model-reporting-tasks'
         '''
 
         expect:
@@ -546,6 +549,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
             }
 
             apply plugin: MyPlugin
+            apply plugin: 'model-reporting-tasks'
         '''
 
         expect:
@@ -574,6 +578,7 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
             }
 
             apply type: MyPlugin
+            apply plugin: 'model-reporting-tasks'
         '''
 
         expect:

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelRuleIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelRuleIntegrationTest.groovy
@@ -191,6 +191,7 @@ class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
             }
 
             apply type: RulePlugin
+            apply plugin: 'model-reporting-tasks'
         '''
 
         then:

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelGroovyScalarConfigurationIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelGroovyScalarConfigurationIntegrationTest.groovy
@@ -521,6 +521,7 @@ The following types/formats are supported:
             }
 
             apply type: RulePlugin
+            apply plugin: 'model-reporting-tasks'
         '''
 
         when:

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedScalarCollectionsIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedScalarCollectionsIntegrationTest.groovy
@@ -344,6 +344,8 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
     def "reports problem when managed type declares a #type of managed type"() {
         when:
         buildFile """
+        apply plugin: 'model-reporting-tasks'
+
         @Managed
         interface Thing { }
 
@@ -361,7 +363,7 @@ class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
         fails 'model'
 
         and:
-        failure.assertHasCause "Exception thrown while executing model rule: container(Container) @ build.gradle line 11, column 13"
+        failure.assertHasCause "Exception thrown while executing model rule: container(Container) @ build.gradle line 13, column 13"
         failure.assertHasCause("""A model element of type: 'Container' can not be constructed.
 Its property 'java.util.$type<Thing> items' is not a valid scalar collection
 A scalar collection can not contain 'Thing's
@@ -374,6 +376,8 @@ A valid scalar collection takes the form of List<T> or Set<T> where 'T' is one o
     def "reports problem when managed type declares a #type of subtype of scalar type"() {
         when:
         buildFile """
+        apply plugin: 'model-reporting-tasks'
+
         class Thing extends File {
             Thing(String s) { super(s) }
         }
@@ -392,7 +396,7 @@ A valid scalar collection takes the form of List<T> or Set<T> where 'T' is one o
         fails 'model'
 
         and:
-        failure.assertHasCause "Exception thrown while executing model rule: container(Container) @ build.gradle line 12, column 13"
+        failure.assertHasCause "Exception thrown while executing model rule: container(Container) @ build.gradle line 14, column 13"
         failure.assertHasCause("""A model element of type: 'Container' can not be constructed.
 Its property 'java.util.$type<Thing> items' is not a valid scalar collection
 A scalar collection can not contain 'Thing's

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy
@@ -121,6 +121,7 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
             }
 
             apply type: RulePlugin
+            apply plugin: 'model-reporting-tasks'
         '''
 
         then:
@@ -372,6 +373,8 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
     def "can specify managed models with file types"() {
         when:
         buildFile '''
+            apply plugin: 'model-reporting-tasks'
+            
             @Managed
             interface FileContainer {
                 File getFile()

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ManagedTypeDslIntegrationTest.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ManagedTypeDslIntegrationTest.groovy
@@ -21,6 +21,11 @@ import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 @UnsupportedWithConfigurationCache(because = "software model")
 class ManagedTypeDslIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        buildFile << '''
+            apply plugin: 'model-reporting-tasks'
+        '''
+    }
 
     def "can configure a child of a managed type using a nested closure syntax"() {
         buildFile << '''
@@ -121,8 +126,8 @@ model {
         fails "model"
 
         then:
-        failure.assertHasLineNumber(15)
-        failure.assertHasCause('Exception thrown while executing model rule: barry { ... } @ build.gradle line 14, column 5')
+        failure.assertHasLineNumber(17)
+        failure.assertHasCause('Exception thrown while executing model rule: barry { ... } @ build.gradle line 16, column 5')
         failure.assertHasCause('No signature of method: Person.address() is applicable for argument types: (')
     }
 
@@ -147,8 +152,8 @@ model {
         fails "model"
 
         then:
-        failure.assertHasLineNumber(9)
-        failure.assertHasCause('Exception thrown while executing model rule: barry { ... } @ build.gradle line 8, column 5')
+        failure.assertHasLineNumber(11)
+        failure.assertHasCause('Exception thrown while executing model rule: barry { ... } @ build.gradle line 10, column 5')
         failure.assertHasCause('No signature of method: Person.names() is applicable for argument types: (')
     }
 
@@ -174,8 +179,8 @@ model {
         fails "model"
 
         then:
-        failure.assertHasLineNumber(11)
-        failure.assertHasCause('Exception thrown while executing model rule: barry { ... } @ build.gradle line 10, column 5')
+        failure.assertHasLineNumber(13)
+        failure.assertHasCause('Exception thrown while executing model rule: barry { ... } @ build.gradle line 12, column 5')
         failure.assertHasCause('No signature of method: Person.input() is applicable for argument types: (')
     }
 
@@ -200,8 +205,8 @@ model {
         fails "model"
 
         then:
-        failure.assertHasLineNumber(10)
-        failure.assertHasCause('Exception thrown while executing model rule: barry { ... } @ build.gradle line 9, column 5')
+        failure.assertHasLineNumber(12)
+        failure.assertHasCause('Exception thrown while executing model rule: barry { ... } @ build.gradle line 11, column 5')
         failure.assertHasCause('No signature of method: Person.name() is applicable for argument types: (')
     }
 }

--- a/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
+++ b/platforms/core-configuration/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
@@ -37,6 +37,7 @@ class MyPlugin extends RuleSource {
 }
 
 apply plugin: MyPlugin
+apply plugin: 'model-reporting-tasks'
 '''
     }
 
@@ -257,8 +258,8 @@ model {
 '''
         expect:
         fails "model"
-        failure.assertHasLineNumber(18)
-        failure.assertHasCause('Exception thrown while executing model rule: create(main) { ... } @ build.gradle line 17, column 9')
+        failure.assertHasLineNumber(19)
+        failure.assertHasCause('Exception thrown while executing model rule: create(main) { ... } @ build.gradle line 18, column 9')
         failure.assertHasCause('No signature of method: org.gradle.api.Project.create() is applicable for argument types:')
     }
 
@@ -393,7 +394,7 @@ model {
 
         expect:
         fails 'model'
-        failure.assertHasCause('Exception thrown while executing model rule: main(Thing) { ... } @ build.gradle line 17, column 9')
+        failure.assertHasCause('Exception thrown while executing model rule: main(Thing) { ... } @ build.gradle line 18, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
     }
 
@@ -411,7 +412,7 @@ model {
 
         expect:
         fails 'model'
-        failure.assertHasCause('Exception thrown while executing model rule: main { ... } @ build.gradle line 17, column 9')
+        failure.assertHasCause('Exception thrown while executing model rule: main { ... } @ build.gradle line 18, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
     }
 
@@ -429,7 +430,7 @@ model {
 
         expect:
         fails 'model'
-        failure.assertHasCause('Exception thrown while executing model rule: all { ... } @ build.gradle line 17, column 9')
+        failure.assertHasCause('Exception thrown while executing model rule: all { ... } @ build.gradle line 18, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
     }
 
@@ -447,7 +448,7 @@ model {
 
         expect:
         fails 'model'
-        failure.assertHasCause('Exception thrown while executing model rule: withType(Thing) { ... } @ build.gradle line 17, column 9')
+        failure.assertHasCause('Exception thrown while executing model rule: withType(Thing) { ... } @ build.gradle line 18, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
     }
 
@@ -465,7 +466,7 @@ model {
 
         expect:
         fails 'model'
-        failure.assertHasCause('Exception thrown while executing model rule: beforeEach(Thing) { ... } @ build.gradle line 17, column 9')
+        failure.assertHasCause('Exception thrown while executing model rule: beforeEach(Thing) { ... } @ build.gradle line 18, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
     }
 
@@ -483,7 +484,7 @@ model {
 
         expect:
         fails 'model'
-        failure.assertHasCause('Exception thrown while executing model rule: afterEach(Thing) { ... } @ build.gradle line 17, column 9')
+        failure.assertHasCause('Exception thrown while executing model rule: afterEach(Thing) { ... } @ build.gradle line 18, column 9')
         failure.assertHasCause('No such property: unknown for class: Thing')
     }
 }

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -565,6 +565,13 @@ plugins {
 TIP: The `jvm-toolchains` plugin is automatically applied by the <<java_library_plugin.adoc#java_library_plugin,Java Library Plugin>> and other JVM-related plugins.
 If you are already applying one of those, no further action is needed.
 
+==== The `model` and `component` tasks are no longer automatically added
+
+The `model` and `component` tasks report on the structure of legacy software model objects configured for the project.
+Previously, these tasks were automatically added to the project for every build.
+These tasks are now only added to a project when a rule-based plugin is applied (such as those provided by Gradle's support for building native software).
+
+
 [[changes_8.14]]
 == Upgrading from 8.13 and earlier
 

--- a/platforms/documentation/docs/src/snippets/modelRules/basicRuleSourcePlugin/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/modelRules/basicRuleSourcePlugin/groovy/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'model-reporting-tasks'
+    id 'component-reporting-tasks'
+}
 // tag::managed-type-plugin-and-dsl[]
 // tag::managed-type-and-plugin[]
 // tag::managed-type[]

--- a/platforms/documentation/docs/src/snippets/modelRules/basicRuleSourcePlugin/tests/basicRuleSourcePlugin-model-task.out
+++ b/platforms/documentation/docs/src/snippets/modelRules/basicRuleSourcePlugin/tests/basicRuleSourcePlugin-model-task.out
@@ -9,7 +9,7 @@ Root project 'basic-rule-source-plugin'
       | Type:   	Person
       | Creator: 	PersonRules#person(Person)
       | Rules:
-         ⤷ person { ... } @ build.gradle line 97, column 3
+         ⤷ person { ... } @ build.gradle line 101, column 3
          ⤷ PersonRules#setFirstName(Person)
     + age
           | Type:   	int

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -320,7 +320,9 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
      * Returns the set of implicit task names expected for any project for the target Gradle version.
      */
     Set<String> getImplicitTasks() {
-        if (targetVersion >= GradleVersion.version("8.13")) {
+        if (targetVersion >= GradleVersion.version("9.0")) {
+            return ['artifactTransforms', 'buildEnvironment', 'dependencies', 'dependencyInsight', 'help', 'javaToolchains', 'projects', 'properties', 'tasks', 'outgoingVariants', 'resolvableConfigurations']
+        } else if (targetVersion >= GradleVersion.version("8.13")) {
             return ['artifactTransforms', 'buildEnvironment', 'components', 'dependencies', 'dependencyInsight', 'dependentComponents', 'help', 'javaToolchains', 'projects', 'properties', 'tasks', 'model', 'outgoingVariants', 'resolvableConfigurations']
         } else if (targetVersion >= GradleVersion.version("7.5")) {
             return ['buildEnvironment', 'components', 'dependencies', 'dependencyInsight', 'dependentComponents', 'help', 'javaToolchains', 'projects', 'properties', 'tasks', 'model', 'outgoingVariants', 'resolvableConfigurations']
@@ -355,7 +357,9 @@ abstract class ToolingApiSpecification extends Specification implements KotlinDs
      * Returns the set of invisible implicit task names expected for a root project for the target Gradle version.
      */
     Set<String> getRootProjectImplicitInvisibleTasks() {
-        if (targetVersion >= GradleVersion.version("6.8")) {
+        if (targetVersion >= GradleVersion.version("9.0")) {
+            return ['prepareKotlinBuildScriptModel']
+        } else if (targetVersion >= GradleVersion.version("6.8")) {
             return ['prepareKotlinBuildScriptModel', 'components', 'dependentComponents', 'model']
         } else if (targetVersion >= GradleVersion.version("5.3")) {
             return ['prepareKotlinBuildScriptModel']

--- a/platforms/software/platform-base/src/main/java/org/gradle/platform/base/plugins/ComponentBasePlugin.java
+++ b/platforms/software/platform-base/src/main/java/org/gradle/platform/base/plugins/ComponentBasePlugin.java
@@ -55,6 +55,8 @@ public abstract class ComponentBasePlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(LifecycleBasePlugin.class);
+        project.getPluginManager().apply("org.gradle.model-reporting-tasks");
+        project.getPluginManager().apply("org.gradle.component-reporting-tasks");
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/platforms/software/platform-base/src/test/groovy/org/gradle/language/base/plugins/ComponentModelBasePluginTest.groovy
+++ b/platforms/software/platform-base/src/test/groovy/org/gradle/language/base/plugins/ComponentModelBasePluginTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.language.base.plugins
 
-import org.gradle.api.plugins.ComponentReportingTasksPlugin
-import org.gradle.api.plugins.ModelReportingTasksPlugin
+import org.gradle.api.plugins.internal.ComponentReportingTasksPlugin
+import org.gradle.api.plugins.internal.ModelReportingTasksPlugin
 import org.gradle.platform.base.*
 import org.gradle.platform.base.plugins.BinaryBasePlugin
 import org.gradle.platform.base.plugins.ComponentBasePlugin

--- a/platforms/software/platform-base/src/test/groovy/org/gradle/language/base/plugins/ComponentModelBasePluginTest.groovy
+++ b/platforms/software/platform-base/src/test/groovy/org/gradle/language/base/plugins/ComponentModelBasePluginTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.language.base.plugins
 
+import org.gradle.api.plugins.ComponentReportingTasksPlugin
+import org.gradle.api.plugins.ModelReportingTasksPlugin
 import org.gradle.platform.base.*
 import org.gradle.platform.base.plugins.BinaryBasePlugin
 import org.gradle.platform.base.plugins.ComponentBasePlugin
@@ -28,11 +30,13 @@ class ComponentModelBasePluginTest extends PlatformBaseSpecification {
         }
 
         then:
-        project.pluginManager.pluginContainer.size() == 5
+        project.pluginManager.pluginContainer.size() == 7
         project.pluginManager.pluginContainer.findPlugin(ComponentBasePlugin) != null
         project.pluginManager.pluginContainer.findPlugin(BinaryBasePlugin) != null
         project.pluginManager.pluginContainer.findPlugin(LanguageBasePlugin) != null
         project.pluginManager.pluginContainer.findPlugin(LifecycleBasePlugin) != null
+        project.pluginManager.pluginContainer.findPlugin(ComponentReportingTasksPlugin) != null
+        project.pluginManager.pluginContainer.findPlugin(ModelReportingTasksPlugin) != null
     }
 
     def "registers base types"() {

--- a/platforms/software/platform-base/src/test/groovy/org/gradle/language/base/plugins/LanguageBasePluginTest.groovy
+++ b/platforms/software/platform-base/src/test/groovy/org/gradle/language/base/plugins/LanguageBasePluginTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.language.base.plugins
 
-import org.gradle.api.plugins.ComponentReportingTasksPlugin
-import org.gradle.api.plugins.ModelReportingTasksPlugin
+import org.gradle.api.plugins.internal.ComponentReportingTasksPlugin
+import org.gradle.api.plugins.internal.ModelReportingTasksPlugin
 import org.gradle.language.base.LanguageSourceSet
 import org.gradle.platform.base.PlatformBaseSpecification
 import org.gradle.platform.base.plugins.ComponentBasePlugin

--- a/platforms/software/platform-base/src/test/groovy/org/gradle/language/base/plugins/LanguageBasePluginTest.groovy
+++ b/platforms/software/platform-base/src/test/groovy/org/gradle/language/base/plugins/LanguageBasePluginTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.language.base.plugins
 
+import org.gradle.api.plugins.ComponentReportingTasksPlugin
+import org.gradle.api.plugins.ModelReportingTasksPlugin
 import org.gradle.language.base.LanguageSourceSet
 import org.gradle.platform.base.PlatformBaseSpecification
 import org.gradle.platform.base.plugins.ComponentBasePlugin
@@ -28,9 +30,11 @@ class LanguageBasePluginTest extends PlatformBaseSpecification {
         }
 
         then:
-        project.pluginManager.pluginContainer.size() == 3
+        project.pluginManager.pluginContainer.size() == 5
         project.pluginManager.pluginContainer.findPlugin(ComponentBasePlugin) != null
         project.pluginManager.pluginContainer.findPlugin(LifecycleBasePlugin) != null
+        project.pluginManager.pluginContainer.findPlugin(ComponentReportingTasksPlugin) != null
+        project.pluginManager.pluginContainer.findPlugin(ModelReportingTasksPlugin) != null
     }
 
     def "registers LanguageSourceSet"() {

--- a/platforms/software/platform-base/src/test/groovy/org/gradle/platform/base/plugins/BinaryBasePluginTest.groovy
+++ b/platforms/software/platform-base/src/test/groovy/org/gradle/platform/base/plugins/BinaryBasePluginTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.platform.base.plugins
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.plugins.ComponentReportingTasksPlugin
+import org.gradle.api.plugins.ModelReportingTasksPlugin
 import org.gradle.language.base.LanguageSourceSet
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.platform.base.BinarySpec
@@ -30,9 +32,11 @@ class BinaryBasePluginTest extends PlatformBaseSpecification {
         }
 
         then:
-        project.pluginManager.pluginContainer.size() == 3
+        project.pluginManager.pluginContainer.size() == 5
         project.pluginManager.pluginContainer.findPlugin(ComponentBasePlugin) != null
         project.pluginManager.pluginContainer.findPlugin(LifecycleBasePlugin) != null
+        project.pluginManager.pluginContainer.findPlugin(ComponentReportingTasksPlugin) != null
+        project.pluginManager.pluginContainer.findPlugin(ModelReportingTasksPlugin) != null
     }
 
     def "registers BinarySpec"() {

--- a/platforms/software/platform-base/src/test/groovy/org/gradle/platform/base/plugins/BinaryBasePluginTest.groovy
+++ b/platforms/software/platform-base/src/test/groovy/org/gradle/platform/base/plugins/BinaryBasePluginTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.platform.base.plugins
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.plugins.ComponentReportingTasksPlugin
-import org.gradle.api.plugins.ModelReportingTasksPlugin
+import org.gradle.api.plugins.internal.ComponentReportingTasksPlugin
+import org.gradle.api.plugins.internal.ModelReportingTasksPlugin
 import org.gradle.language.base.LanguageSourceSet
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.platform.base.BinarySpec

--- a/platforms/software/platform-base/src/test/groovy/org/gradle/platform/base/plugins/ComponentBasePluginTest.groovy
+++ b/platforms/software/platform-base/src/test/groovy/org/gradle/platform/base/plugins/ComponentBasePluginTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.platform.base.plugins
 
-import org.gradle.api.plugins.ComponentReportingTasksPlugin
-import org.gradle.api.plugins.ModelReportingTasksPlugin
+import org.gradle.api.plugins.internal.ComponentReportingTasksPlugin
+import org.gradle.api.plugins.internal.ModelReportingTasksPlugin
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.platform.base.ComponentSpec
 import org.gradle.platform.base.PlatformBaseSpecification

--- a/platforms/software/platform-base/src/test/groovy/org/gradle/platform/base/plugins/ComponentBasePluginTest.groovy
+++ b/platforms/software/platform-base/src/test/groovy/org/gradle/platform/base/plugins/ComponentBasePluginTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.platform.base.plugins
 
+import org.gradle.api.plugins.ComponentReportingTasksPlugin
+import org.gradle.api.plugins.ModelReportingTasksPlugin
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.platform.base.ComponentSpec
 import org.gradle.platform.base.PlatformBaseSpecification
@@ -31,15 +33,17 @@ class ComponentBasePluginTest extends PlatformBaseSpecification {
         project.pluginManager.pluginContainer.hasPlugin(ComponentBasePlugin)
     }
 
-    def "applies lifecycle base plugin only"() {
+    def "applies lifecycle base and reporting plugins only"() {
         when:
         dsl {
             apply plugin: ComponentBasePlugin
         }
 
         then:
-        project.pluginManager.pluginContainer.size() == 2
+        project.pluginManager.pluginContainer.size() == 4
         project.pluginManager.pluginContainer.findPlugin(LifecycleBasePlugin) != null
+        project.pluginManager.pluginContainer.findPlugin(ComponentReportingTasksPlugin) != null
+        project.pluginManager.pluginContainer.findPlugin(ModelReportingTasksPlugin) != null
     }
 
     def "registers ComponentSpec"() {

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/components/DiagnosticsComponentReportIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/components/DiagnosticsComponentReportIntegrationTest.groovy
@@ -24,6 +24,13 @@ class DiagnosticsComponentReportIntegrationTest extends AbstractNativeComponentR
     @RequiresInstalledToolChain
     @ToBeFixedForConfigurationCache(because = ":components")
     def "informs the user when project has no components defined"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'component-reporting-tasks'
+            }
+        """
+
         when:
         executer.withArgument("--no-problems-report")
         succeeds "components"

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependents/DependentComponentsReportIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependents/DependentComponentsReportIntegrationTest.groovy
@@ -25,6 +25,13 @@ class DependentComponentsReportIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "help displays dependents report task options"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'component-reporting-tasks'
+            }
+        """
+
         when:
         run "help", "--task", "dependentComponents"
 
@@ -38,7 +45,11 @@ class DependentComponentsReportIntegrationTest extends AbstractIntegrationSpec {
 
     def "displays empty dependents report for an empty project"() {
         given:
-        buildFile
+        buildFile << """
+            plugins {
+                id 'component-reporting-tasks'
+            }
+        """
 
         when:
         run "dependentComponents"

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -29,7 +29,11 @@ class ModelReportIntegrationTest extends AbstractIntegrationSpec {
 
     def "displays basic structure of an empty project"() {
         given:
-        buildFile
+        buildFile << """
+            plugins {
+                id 'model-reporting-tasks'
+            }
+        """
 
         when:
         run "model"

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -27,14 +27,16 @@ class ModelReportIntegrationTest extends AbstractIntegrationSpec {
         super.setupExecuter()
     }
 
-    def "displays basic structure of an empty project"() {
-        given:
+    def setup() {
         buildFile << """
             plugins {
                 id 'model-reporting-tasks'
+                id 'component-reporting-tasks'
             }
         """
+    }
 
+    def "displays basic structure of an empty project"() {
         when:
         run "model"
 
@@ -91,9 +93,9 @@ model {
         then:
         ModelReportOutput.from(output).hasNodeStructure {
             container {
-                ids(type: 'java.util.List<java.lang.Integer>', creator: 'container(Container) { ... } @ build.gradle line 12, column 5', nodeValue: '[]')
-                labels(type: 'java.util.List<java.lang.String>', creator: 'container(Container) { ... } @ build.gradle line 12, column 5', nodeValue: "[bug, blocker]")
-                values(type: 'java.util.List<java.lang.Double>', creator: 'container(Container) { ... } @ build.gradle line 12, column 5', nodeValue: 'null')
+                ids(type: 'java.util.List<java.lang.Integer>', creator: 'container(Container) { ... } @ build.gradle line 17, column 5', nodeValue: '[]')
+                labels(type: 'java.util.List<java.lang.String>', creator: 'container(Container) { ... } @ build.gradle line 17, column 5', nodeValue: "[bug, blocker]")
+                values(type: 'java.util.List<java.lang.Double>', creator: 'container(Container) { ... } @ build.gradle line 17, column 5', nodeValue: 'null')
             }
         }
     }
@@ -210,16 +212,16 @@ model {
         then:
         ModelReportOutput.from(output).hasNodeStructure {
             nullCredentials {
-                password(type: 'java.lang.String', creator: 'nullCredentials(PasswordCredentials) { ... } @ build.gradle line 27, column 5')
-                username(type: 'java.lang.String', creator: 'nullCredentials(PasswordCredentials) { ... } @ build.gradle line 27, column 5')
+                password(type: 'java.lang.String', creator: 'nullCredentials(PasswordCredentials) { ... } @ build.gradle line 32, column 5')
+                username(type: 'java.lang.String', creator: 'nullCredentials(PasswordCredentials) { ... } @ build.gradle line 32, column 5')
             }
             numbers {
                 threshold(nodeValue: "0.8")
                 value(nodeValue: "5")
             }
             primaryCredentials {
-                password(nodeValue: 'hunter2', type: 'java.lang.String', creator: 'primaryCredentials(PasswordCredentials) { ... } @ build.gradle line 22, column 5')
-                username(nodeValue: 'uname', type: 'java.lang.String', creator: 'primaryCredentials(PasswordCredentials) { ... } @ build.gradle line 22, column 5')
+                password(nodeValue: 'hunter2', type: 'java.lang.String', creator: 'primaryCredentials(PasswordCredentials) { ... } @ build.gradle line 27, column 5')
+                username(nodeValue: 'uname', type: 'java.lang.String', creator: 'primaryCredentials(PasswordCredentials) { ... } @ build.gradle line 27, column 5')
             }
             unsetNumbers {
                 threshold(nodeValue: '0.0')
@@ -274,37 +276,37 @@ model {
         modelReportOutput.nodeContentEquals('''
 + nullCredentials
       | Type:   \tPasswordCredentials
-      | Creator: \tnullCredentials(PasswordCredentials) @ build.gradle line 27, column 5
+      | Creator: \tnullCredentials(PasswordCredentials) @ build.gradle line 32, column 5
     + password
           | Type:   \tjava.lang.String
           | Value:  \tnull
-          | Creator: \tnullCredentials(PasswordCredentials) @ build.gradle line 27, column 5
+          | Creator: \tnullCredentials(PasswordCredentials) @ build.gradle line 32, column 5
     + username
           | Type:   \tjava.lang.String
           | Value:  \tnull
-          | Creator: \tnullCredentials(PasswordCredentials) @ build.gradle line 27, column 5
+          | Creator: \tnullCredentials(PasswordCredentials) @ build.gradle line 32, column 5
 + numbers
       | Type:   \tNumbers
-      | Creator: \tnumbers(Numbers) { ... } @ build.gradle line 28, column 5
+      | Creator: \tnumbers(Numbers) { ... } @ build.gradle line 33, column 5
     + threshold
           | Type:   \tdouble
           | Value:  \t0.8
-          | Creator: \tnumbers(Numbers) { ... } @ build.gradle line 28, column 5
+          | Creator: \tnumbers(Numbers) { ... } @ build.gradle line 33, column 5
     + value
           | Type:   \tjava.lang.Integer
           | Value:  \t5
-          | Creator: \tnumbers(Numbers) { ... } @ build.gradle line 28, column 5
+          | Creator: \tnumbers(Numbers) { ... } @ build.gradle line 33, column 5
 + primaryCredentials
       | Type:   \tPasswordCredentials
-      | Creator: \tprimaryCredentials(PasswordCredentials) { ... } @ build.gradle line 22, column 5
+      | Creator: \tprimaryCredentials(PasswordCredentials) { ... } @ build.gradle line 27, column 5
     + password
           | Type:   \tjava.lang.String
           | Value:  \thunter2
-          | Creator: \tprimaryCredentials(PasswordCredentials) { ... } @ build.gradle line 22, column 5
+          | Creator: \tprimaryCredentials(PasswordCredentials) { ... } @ build.gradle line 27, column 5
     + username
           | Type:   \tjava.lang.String
           | Value:  \tuname
-          | Creator: \tprimaryCredentials(PasswordCredentials) { ... } @ build.gradle line 22, column 5
+          | Creator: \tprimaryCredentials(PasswordCredentials) { ... } @ build.gradle line 27, column 5
 + tasks
       | Type:   \torg.gradle.model.ModelMap<org.gradle.api.Task>
       | Creator: \tProject.<init>.tasks()
@@ -418,15 +420,15 @@ model {
              ⤷ copyToTaskContainer
 + unsetNumbers
       | Type:   \tNumbers
-      | Creator: \tunsetNumbers(Numbers) { ... } @ build.gradle line 32, column 5
+      | Creator: \tunsetNumbers(Numbers) { ... } @ build.gradle line 37, column 5
     + threshold
           | Type:   \tdouble
           | Value:  \t0.0
-          | Creator: \tunsetNumbers(Numbers) { ... } @ build.gradle line 32, column 5
+          | Creator: \tunsetNumbers(Numbers) { ... } @ build.gradle line 37, column 5
     + value
           | Type:   \tjava.lang.Integer
           | Value:  \tnull
-          | Creator: \tunsetNumbers(Numbers) { ... } @ build.gradle line 32, column 5
+          | Creator: \tunsetNumbers(Numbers) { ... } @ build.gradle line 37, column 5
 
 ''')
     }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportTaskIntegrationTest.groovy
@@ -23,6 +23,13 @@ import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 class ModelReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
     def "should display the model report task options"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'model-reporting-tasks'
+            }
+        """
+        
         when:
         run "help", "--task", "model"
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/ComponentReportingTasksPlugin.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/ComponentReportingTasksPlugin.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.diagnostics.internal.DiagnosticsTaskNames;
+
+/**
+ * Plugin that adds tasks to report on the deprecated software model components configured for the project.
+ *
+ * @since 9.0
+ */
+@Incubating
+abstract public class ComponentReportingTasksPlugin implements Plugin<Project> {
+    @Override
+    @SuppressWarnings("deprecation")
+    public void apply(Project project) {
+        project.getTasks().register(DiagnosticsTaskNames.COMPONENTS_TASK, org.gradle.api.reporting.components.ComponentReport.class, new ComponentReportAction(project.toString()));
+        project.getTasks().register(DiagnosticsTaskNames.DEPENDENT_COMPONENTS_TASK, org.gradle.api.reporting.dependents.DependentComponentsReport.class, new DependentComponentsReportAction(project.toString()));
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class ComponentReportAction implements Action<org.gradle.api.reporting.components.ComponentReport> {
+        private final String projectName;
+
+        public ComponentReportAction(String projectName) {
+            this.projectName = projectName;
+        }
+
+        @Override
+        public void execute(org.gradle.api.reporting.components.ComponentReport task) {
+            task.setDescription("Displays the components produced by " + projectName + ". [deprecated]");
+            task.setImpliesSubProjects(true);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class DependentComponentsReportAction implements Action<org.gradle.api.reporting.dependents.DependentComponentsReport> {
+        private final String projectName;
+
+        public DependentComponentsReportAction(String projectName) {
+            this.projectName = projectName;
+        }
+
+        @Override
+        public void execute(org.gradle.api.reporting.dependents.DependentComponentsReport task) {
+            task.setDescription("Displays the dependent components of components in " + projectName + ". [deprecated]");
+            task.setImpliesSubProjects(true);
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/SoftwareReportingTasksPlugin.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/SoftwareReportingTasksPlugin.java
@@ -49,7 +49,7 @@ public abstract class SoftwareReportingTasksPlugin implements Plugin<Project> {
         tasks.register(HelpTasksPlugin.DEPENDENCY_INSIGHT_TASK, DependencyInsightReportTask.class, new DependencyInsightReportTaskAction(projectName));
         tasks.register(HelpTasksPlugin.DEPENDENCIES_TASK, DependencyReportTask.class, new DependencyReportTaskAction(projectName));
         tasks.register(BuildEnvironmentReportTask.TASK_NAME, BuildEnvironmentReportTask.class, new BuildEnvironmentReportTaskAction(projectName));
-        registerDeprecatedSoftwareModelTasks(tasks, projectName);
+
         tasks.register(HelpTasksPlugin.OUTGOING_VARIANTS_TASK, OutgoingVariantsReportTask.class, task -> {
             task.setDescription("Displays the outgoing variants of " + projectName + ".");
             task.setGroup(HelpTasksPlugin.HELP_GROUP);
@@ -71,17 +71,6 @@ public abstract class SoftwareReportingTasksPlugin implements Plugin<Project> {
         tasks.withType(TaskReportTask.class).configureEach(task -> {
             task.getShowTypes().convention(false);
         });
-    }
-
-    /**
-     * Registers the deprecated tasks used by the Software Model.
-     * <p>
-     * Note that these tasks <strong>are</strong> deprecated, even though they do not emit a deprecation warning when run.
-     */
-    @SuppressWarnings("deprecation")
-    private void registerDeprecatedSoftwareModelTasks(TaskContainer tasks, String projectName) {
-        tasks.register(HelpTasksPlugin.COMPONENTS_TASK, org.gradle.api.reporting.components.ComponentReport.class, new ComponentReportAction(projectName));
-        tasks.register(HelpTasksPlugin.DEPENDENT_COMPONENTS_TASK, org.gradle.api.reporting.dependents.DependentComponentsReport.class, new DependentComponentsReportAction(projectName));
     }
 
     private static class DependencyInsightReportTaskAction implements Action<DependencyInsightReportTask> {
@@ -126,36 +115,6 @@ public abstract class SoftwareReportingTasksPlugin implements Plugin<Project> {
         public void execute(BuildEnvironmentReportTask task) {
             task.setDescription("Displays all buildscript dependencies declared in " + projectName + ".");
             task.setGroup(HelpTasksPlugin.HELP_GROUP);
-            task.setImpliesSubProjects(true);
-        }
-    }
-
-    @SuppressWarnings("deprecation")
-    private static class ComponentReportAction implements Action<org.gradle.api.reporting.components.ComponentReport> {
-        private final String projectName;
-
-        public ComponentReportAction(String projectName) {
-            this.projectName = projectName;
-        }
-
-        @Override
-        public void execute(org.gradle.api.reporting.components.ComponentReport task) {
-            task.setDescription("Displays the components produced by " + projectName + ". [deprecated]");
-            task.setImpliesSubProjects(true);
-        }
-    }
-
-    @SuppressWarnings("deprecation")
-    private static class DependentComponentsReportAction implements Action<org.gradle.api.reporting.dependents.DependentComponentsReport> {
-        private final String projectName;
-
-        public DependentComponentsReportAction(String projectName) {
-            this.projectName = projectName;
-        }
-
-        @Override
-        public void execute(org.gradle.api.reporting.dependents.DependentComponentsReport task) {
-            task.setDescription("Displays the dependent components of components in " + projectName + ". [deprecated]");
             task.setImpliesSubProjects(true);
         }
     }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/internal/ComponentReportingTasksPlugin.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/internal/ComponentReportingTasksPlugin.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.api.plugins;
+package org.gradle.api.plugins.internal;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.diagnostics.internal.DiagnosticsTaskNames;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Plugin that adds tasks to report on the deprecated software model components configured for the project.
  *
  * @since 9.0
  */
-@Incubating
+@NullMarked
 abstract public class ComponentReportingTasksPlugin implements Plugin<Project> {
     @Override
     @SuppressWarnings("deprecation")
@@ -37,6 +37,7 @@ abstract public class ComponentReportingTasksPlugin implements Plugin<Project> {
     }
 
     @SuppressWarnings("deprecation")
+    @NullMarked
     private static class ComponentReportAction implements Action<org.gradle.api.reporting.components.ComponentReport> {
         private final String projectName;
 
@@ -52,6 +53,7 @@ abstract public class ComponentReportingTasksPlugin implements Plugin<Project> {
     }
 
     @SuppressWarnings("deprecation")
+    @NullMarked
     private static class DependentComponentsReportAction implements Action<org.gradle.api.reporting.dependents.DependentComponentsReport> {
         private final String projectName;
 

--- a/platforms/software/software-diagnostics/src/main/resources/META-INF/gradle-plugins/org.gradle.component-reporting-tasks.properties
+++ b/platforms/software/software-diagnostics/src/main/resources/META-INF/gradle-plugins/org.gradle.component-reporting-tasks.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-implementation-class=org.gradle.api.plugins.ComponentReportingTasksPlugin
+implementation-class=org.gradle.api.plugins.internal.ComponentReportingTasksPlugin

--- a/platforms/software/software-diagnostics/src/main/resources/META-INF/gradle-plugins/org.gradle.component-reporting-tasks.properties
+++ b/platforms/software/software-diagnostics/src/main/resources/META-INF/gradle-plugins/org.gradle.component-reporting-tasks.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=org.gradle.api.plugins.ComponentReportingTasksPlugin

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskCreationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskCreationIntegrationTest.groovy
@@ -610,6 +610,7 @@ class MyPlugin extends RuleSource {
     }
 }
 apply type: MyPlugin
+apply plugin: 'model-reporting-tasks'
 """
 
         when:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1526,8 +1526,14 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     public void prepareForRuleBasedPlugins() {
         if (!preparedForRuleBasedPlugins) {
             preparedForRuleBasedPlugins = true;
+            addModelAndComponentReportingTasks();
             ruleBasedPluginListenerBroadcast.getSource().prepareForRuleBasedPlugins(this);
         }
+    }
+
+    private void addModelAndComponentReportingTasks() {
+        getPluginManager().apply("org.gradle.model-reporting-tasks");
+        getPluginManager().apply("org.gradle.component-reporting-tasks");
     }
 
     @Inject

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1526,14 +1526,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     public void prepareForRuleBasedPlugins() {
         if (!preparedForRuleBasedPlugins) {
             preparedForRuleBasedPlugins = true;
-            addModelAndComponentReportingTasks();
             ruleBasedPluginListenerBroadcast.getSource().prepareForRuleBasedPlugins(this);
         }
-    }
-
-    private void addModelAndComponentReportingTasks() {
-        getPluginManager().apply("org.gradle.model-reporting-tasks");
-        getPluginManager().apply("org.gradle.component-reporting-tasks");
     }
 
     @Inject

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/NewDefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/NewDefaultProjectTest.groovy
@@ -33,11 +33,11 @@ class NewDefaultProjectTest extends AbstractProjectBuilderSpec {
 
         then:
         rootTasks.size() == 2
-        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":components", ":dependencies", ":dependencyInsight", ":dependentComponents", ":foo", ":help", ":init", ":javaToolchains", ":model", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
-        rootTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:components", ":a:dependencies", ":a:dependencyInsight", ":a:dependentComponents", ":a:foo", ":a:help", ":a:javaToolchains", ":a:model", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
+        rootTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
 
         aTasks.size() == 1
-        aTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:components", ":a:dependencies", ":a:dependencyInsight", ":a:dependentComponents", ":a:foo", ":a:help", ":a:javaToolchains", ":a:model", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        aTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
     }
 
     def "provides all tasks non-recursively"() {
@@ -51,10 +51,10 @@ class NewDefaultProjectTest extends AbstractProjectBuilderSpec {
 
         then:
         rootTasks.size() == 1
-        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":components", ":dependencies", ":dependencyInsight", ":dependentComponents", ":foo", ":help", ":init", ":javaToolchains", ":model", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
+        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
 
         aTasks.size() == 1
-        aTasks[a]*.path as Set == [":a:bar", ":a:artifactTransforms", ":a:buildEnvironment", ":a:components", ":a:dependencies", ":a:dependencyInsight", ":a:dependentComponents", ":a:foo", ":a:help", ":a:javaToolchains", ":a:model", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        aTasks[a]*.path as Set == [":a:bar", ":a:artifactTransforms", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
     }
 
     def "provides task by name recursively"() {

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -737,12 +737,6 @@
             ]
         },
         {
-            "type": "org.gradle.api.plugins.ComponentReportingTasksPlugin",
-            "member": "Constructor org.gradle.api.plugins.ComponentReportingTasksPlugin()",
-            "acceptation": "Removing component reporting tasks from HelpTasksPlugin",
-            "changes": []
-        },
-        {
             "type": "org.gradle.api.plugins.HelpTasksPlugin",
             "member": "Field COMPONENTS_TASK",
             "acceptation": "This task is no longer associated with HelpTasksPlugin",
@@ -957,12 +951,6 @@
             "changes": [
                 "Method has been removed"
             ]
-        },
-        {
-            "type": "org.gradle.api.plugins.ModelReportingTasksPlugin",
-            "member": "Constructor org.gradle.api.plugins.ModelReportingTasksPlugin()",
-            "acceptation": "Removing model reporting tasks from HelpTasksPlugin",
-            "changes": []
         },
         {
             "type": "org.gradle.api.plugins.ProjectReportsPluginConvention",

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -737,6 +737,28 @@
             ]
         },
         {
+            "type": "org.gradle.api.plugins.ComponentReportingTasksPlugin",
+            "member": "Constructor org.gradle.api.plugins.ComponentReportingTasksPlugin()",
+            "acceptation": "Removing component reporting tasks from HelpTasksPlugin",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.plugins.HelpTasksPlugin",
+            "member": "Field COMPONENTS_TASK",
+            "acceptation": "This task is no longer associated with HelpTasksPlugin",
+            "changes": [
+                "Field has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.HelpTasksPlugin",
+            "member": "Field DEPENDENT_COMPONENTS_TASK",
+            "acceptation": "This task is no longer associated with HelpTasksPlugin",
+            "changes": [
+                "Field has been removed"
+            ]
+        },
+        {
             "type": "org.gradle.api.plugins.JavaPluginConvention",
             "member": "Class org.gradle.api.plugins.JavaPluginConvention",
             "acceptation": "Removed deprecated feature",
@@ -935,6 +957,12 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ModelReportingTasksPlugin",
+            "member": "Constructor org.gradle.api.plugins.ModelReportingTasksPlugin()",
+            "acceptation": "Removing model reporting tasks from HelpTasksPlugin",
+            "changes": []
         },
         {
             "type": "org.gradle.api.plugins.ProjectReportsPluginConvention",
@@ -1694,6 +1722,22 @@
             "acceptation": "Removed deprecated method",
             "changes": [
                 "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.BuiltinPluginIdExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.BuiltinPluginIdExtensionsKt.getComponent-reporting-tasks(org.gradle.plugin.use.PluginDependenciesSpec)",
+            "acceptation": "Removing component reporting tasks from HelpTasksPlugin",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.BuiltinPluginIdExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.BuiltinPluginIdExtensionsKt.getModel-reporting-tasks(org.gradle.plugin.use.PluginDependenciesSpec)",
+            "acceptation": "Removing model reporting tasks from HelpTasksPlugin",
+            "changes": [
+                "Method added to public class"
             ]
         },
         {


### PR DESCRIPTION
We can't remove these tasks altogether, since they are relevant for native builds, but we move them so that they are only added when a rule based model plugin is added. 

Fixes #15023. 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
