### PR TITLE
Use current JVM for test if target major version is same

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestJavaVersionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestJavaVersionIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.testing
 
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
+import org.gradle.internal.jvm.Jvm
 import org.gradle.testing.fixture.AbstractTestingMultiVersionIntegrationTest
 import org.junit.Assume
 
@@ -33,6 +34,13 @@ abstract class AbstractTestJavaVersionIntegrationTest extends AbstractTestingMul
 
     def "can run test on java #jdk.javaVersionMajor"() {
         Assume.assumeTrue(supportsJavaVersion(jdk.javaVersionMajor))
+
+        if (jdk.javaVersionMajor == Jvm.current().javaVersionMajor) {
+            // if current JAVA_HOME and target jdk are different, but have same major version
+            // the test will start with JAVA_HOME=/path/to/jdk-1 and -Porg.gradle.java.installations.paths=/path/to/jdk-2
+            // resulting in flakiness result
+            jdk = Jvm.current()
+        }
 
         given:
         file("src/test/java/SomeTest.java") << """

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJavaVersionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJavaVersionIntegrationTest.groovy
@@ -79,6 +79,12 @@ class TestTaskJavaVersionIntegrationTest extends AbstractIntegrationSpec impleme
     }
 
     def "uses configured toolchain"() {
+        if (otherJdk.javaVersionMajor == Jvm.current().javaVersionMajor) {
+            // if current JAVA_HOME and target jdk are different, but have same major version
+            // the test will start with JAVA_HOME=/path/to/jdk-1 and -Porg.gradle.java.installations.paths=/path/to/jdk-2
+            // resulting in flakiness result
+            otherJdk = Jvm.current()
+        }
         buildFile << """
             ${baseProjectForJdk(otherJdk)}
             ${withTestToolchain(otherJdk)}


### PR DESCRIPTION
After `JUnit4JavaVersionIntegrationTest` is introduced we found [a flaky failure](https://ge.gradle.org/s/oxyrjwohys32a/tests/task/:testing-jvm:parallelIntegTest/details/org.gradle.testing.junit.junit4.JUnit4JavaVersionIntegrationTest/can%20run%20test%20on%20java%2021%204.13.2?top-execution=1): the test runs on an agent with two Java 21 installations: 

- `JAVA_HOME: /opt/jdk/open-jdk-21`
- `-Porg.gradle.java.installations.paths=/opt/java/openjdk`

The test could select either one. This PR makes the behavior deterministic.