### PR TITLE
Postpone removal of deprecated TestKit features to Gradle 10

### DIFF
--- a/platforms/extensibility/test-kit/src/main/java/org/gradle/testkit/runner/internal/ToolingApiGradleExecutor.java
+++ b/platforms/extensibility/test-kit/src/main/java/org/gradle/testkit/runner/internal/ToolingApiGradleExecutor.java
@@ -181,7 +181,7 @@ public class ToolingApiGradleExecutor implements GradleExecutor {
         if (targetGradleVersion.compareTo(MINIMUM_SUPPORTED_GRADLE_VERSION) < 0) {
             DeprecationLogger.deprecate(String.format("The version of Gradle you are using (%s) is deprecated with TestKit. TestKit will only support the last 5 major versions in future.",
                     targetGradleVersion.getVersion()))
-                .willBecomeAnErrorInGradle9()
+                .willBecomeAnErrorInGradle10()
                 .withUserManual("third_party_integration", "sec:embedding_compatibility")
                 .nagUser();
         }

--- a/platforms/extensibility/test-kit/src/main/java/org/gradle/testkit/runner/internal/feature/BuildResultOutputFeatureCheck.java
+++ b/platforms/extensibility/test-kit/src/main/java/org/gradle/testkit/runner/internal/feature/BuildResultOutputFeatureCheck.java
@@ -40,7 +40,7 @@ public class BuildResultOutputFeatureCheck implements FeatureCheck {
             if (targetGradleVersion.compareTo(MINIMUM_SUPPORTED_GRADLE_VERSION) < 0) {
                 DeprecationLogger.deprecate("Capturing build output in debug mode with the GradleRunner for the version of Gradle you are using (%s) is deprecated with TestKit. " +
                         "TestKit will only support the last 5 major versions in future.")
-                    .willBecomeAnErrorInGradle9()
+                    .willBecomeAnErrorInGradle10()
                     .withUserManual("third_party_integration", "sec:embedding_compatibility")
                     .nagUser();
             }


### PR DESCRIPTION
There is no need to fail the builds yet, and we want to keep the warnings explicitly informing the users that those versions are not guaranteed to work.


