### PR TITLE
Don't fail integMultiVersionTest if no tests are found

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.integration-tests.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.integration-tests.gradle.kts
@@ -42,4 +42,8 @@ createTestTask("integMultiVersionTest", "forking", sourceSet, TestType.INTEGRATI
     // This test task runs only multi-version tests and is intended to be used in the late pipeline to sweep up versions not previously tested
     includeSpockAnnotation("org.gradle.integtests.fixtures.compatibility.MultiVersionTestCategory")
     (options as JUnitPlatformOptions).includeEngines("spock")
+    filter {
+        setFailOnNoMatchingTests(false)
+        includeTestsMatching("*")
+    }
 }


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/4668

Since Gradle 9, when test sources are present and no filters are applied, if the `test` task executes but does not discover any tests, it will now fail with an error.

In our use case, the test task is created via a global function `createTestTask` so it's possible that some subprojects don't have any tests in `integMultiVersionTest`. We want it not to fail in this case.

However, this looks ugly. @ghale is there any better way to do so?