### PR TITLE
Use boolean flags for target platforms

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.distribution-testing.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.distribution-testing.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 import gradlebuild.basics.repoRoot
-import gradlebuild.basics.testJavaVersion
 import gradlebuild.cleanup.services.CachesCleaner
 import gradlebuild.integrationtests.extension.IntegrationTestExtension
 import gradlebuild.integrationtests.setSystemPropertiesOfTestJVM
@@ -88,9 +87,4 @@ fun DistributionTest.configureGradleTestEnvironment() {
 
 fun DistributionTest.setJvmArgsOfTestJvm() {
     jvmArgs("-Xmx${project.the<IntegrationTestExtension>().testJvmXmx.get()}", "-XX:+HeapDumpOnOutOfMemoryError")
-
-    val testJavaVersion = JavaLanguageVersion.of(project.testJavaVersion)
-    if (!testJavaVersion.canCompileOrRun(8)) {
-        jvmArgs("-XX:MaxPermSize=768m")
-    }
 }

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -38,11 +38,13 @@ import gradlebuild.basics.testing.includeSpockAnnotation
 import gradlebuild.filterEnvironmentVariables
 import gradlebuild.jvm.argumentproviders.CiEnvironmentProvider
 import gradlebuild.jvm.extension.UnitTestAndCompileExtension
+import org.gradle.internal.jvm.JpmsConfiguration
 import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.Duration
+import java.util.Optional
 
 plugins {
     groovy
@@ -52,7 +54,9 @@ plugins {
 }
 
 // Create an extension that allows projects to configure the way they are compiled and tested.
+//
 // Particularly, we let them describe the "platform" they are targeting, like a Gradle worker, daemon, etc.
+//
 // Furthermore, we let them describe whether they are using any "workarounds" like:
 // - Using JDK internal classes
 // - Using Java standard library APIs that were introduced after the JVM version they are targeting
@@ -60,16 +64,22 @@ plugins {
 //
 // All of these workarounds should be generally avoided, but, with this data we can configure the
 // compile tasks to permit some of these requirements.
-// TODO: Rename this. It controls more than just java compilation.
-val gradlebuildJava = extensions.create<UnitTestAndCompileExtension>("gradlebuildJava").apply {
-    // By default, assume a library targets the daemon and does not use any workarounds
-    usedInDaemon()
-    usesJdkInternals.convention(false)
-    usesFutureStdlib.convention(false)
-    usesIncompatibleDependencies.convention(false)
+val gradleModule = extensions.create<UnitTestAndCompileExtension>("gradleModule").apply {
+    // By default, assume a library targets only the daemon
+    // TODO: Eventually, all projects should explicitly declare their target platform(s)
+    usedForStartup = false
+    usedInWrapper = false
+    usedInWorkers = false
+    usedInClient = false
+    usedInDaemon = true
+
+    // And assume it does not use any workarounds
+    usesJdkInternals = false
+    usesFutureStdlib = false
+    usesIncompatibleDependencies = false
 }
 
-enforceCompatibility(gradlebuildJava)
+enforceCompatibility(gradleModule)
 
 removeTeamcityTempProperty()
 addDependencies()
@@ -106,19 +116,20 @@ fun configureCompileDefaults() {
  * for Groovy to ensure it compiles against the correct classes.
  */
 private
-fun enforceCompatibility(gradlebuildJava: UnitTestAndCompileExtension) {
+fun enforceCompatibility(gradleModule: UnitTestAndCompileExtension) {
     // When using the release flag, compiled code cannot access JDK internal classes or standard library
     // APIs defined in future versions of Java. If either of these cases are true, we do not use the
     // release flag, but instead set the source and target compatibility flags.
-    val useRelease = gradlebuildJava.usesJdkInternals.zip(gradlebuildJava.usesFutureStdlib) { internals, futureApis -> !internals && !futureApis }
+    val useRelease = gradleModule.usesJdkInternals.zip(gradleModule.usesFutureStdlib) { internals, futureApis -> !internals && !futureApis }
 
-    val targetVersion = gradlebuildJava.targetVersion
-    enforceJavaCompatibility(targetVersion, useRelease)
-    enforceGroovyCompatibility(targetVersion)
-    enforceKotlinCompatibility(targetVersion, useRelease)
+    val productionJvmVersion = gradleModule.computeProductionJvmTargetVersion()
+
+    enforceJavaCompatibility(productionJvmVersion, useRelease)
+    enforceGroovyCompatibility(productionJvmVersion)
+    enforceKotlinCompatibility(productionJvmVersion, useRelease)
 
     project.afterEvaluate {
-        if (gradlebuildJava.usesIncompatibleDependencies.get()) {
+        if (gradleModule.usesIncompatibleDependencies.get()) {
             // Some projects use dependencies that target higher JVM versions
             // than the projects target. Disable dependency management checks
             // that verify these dependencies have compatible java versions.
@@ -127,23 +138,67 @@ fun enforceCompatibility(gradlebuildJava: UnitTestAndCompileExtension) {
     }
 }
 
+/**
+ * Given the declared target platforms of a given Gradle module, determine
+ * the JVM version that the production code should target.
+ */
+fun UnitTestAndCompileExtension.computeProductionJvmTargetVersion(): Provider<Int> {
+    // Should be kept in sync with org.gradle.internal.jvm.SupportedJavaVersions
+    val versionProviders = listOf(
+        versionProvider(usedForStartup, 6),
+        versionProvider(usedInWrapper, 6), // TODO: Should be 8
+        versionProvider(usedInWorkers, 8),
+        versionProvider(usedInClient, 8),
+        versionProvider(usedInDaemon, 8),
+    )
+
+    val iterator = versionProviders.iterator()
+    var state = iterator.next()
+    while (iterator.hasNext()) {
+        state = state.zip(iterator.next()) { left , right ->
+            if (left.isPresent) {
+                if (right.isPresent) {
+                    Optional.of(minOf(left.get(), right.get()))
+                } else {
+                    left
+                }
+            } else {
+                right
+            }
+        }
+    }
+
+    return state.map { it.orElseThrow {
+        GradleException("No target JVM version configured. Specify a target platform on ${UnitTestAndCompileExtension::class.java.simpleName}")
+    }}
+}
+
+fun versionProvider(booleanProperty: Provider<Boolean>, version: Int): Provider<Optional<Int>> =
+    booleanProperty.map {
+        if (it) {
+            Optional.of(version)
+        } else {
+            Optional.empty()
+        }
+    }
+
 fun enforceJavaCompatibility(targetVersion: Provider<Int>, useRelease: Provider<Boolean>) {
     tasks.withType<JavaCompile>().configureEach {
         // Set the release flag is requested.
         // Otherwise, we set the source and target compatibility in the afterEvaluate below.
-        options.release = useRelease.flatMap { doUseRelease -> targetVersion.filter { doUseRelease } }
+        options.release = useRelease.zip(targetVersion) { doUseRelease, target -> if (doUseRelease) { target } else { null } }
 
         // If we are targeting Java < 8, we need to use a different compiler,
         // since compilers will only cross-compile down to a certain version.
-        javaCompiler = javaToolchains.compilerFor {
-            languageVersion = targetVersion.flatMap {
-                if (it >= 8) {
-                    // The toolchain on the project is able to target JDK >= 8
-                    java.toolchain.languageVersion
-                } else {
-                    // To compile Java 6 and 7 sources, we need an older compiler
-                    // We choose 11 since it supports both of these versions.
-                    provider { JavaLanguageVersion.of(11) }
+        javaCompiler = targetVersion.flatMap { version ->
+            if (version >= 8) {
+                // The build jvm (Java 17) is able to target JDK >= 8
+                javaToolchains.compilerFor(java.toolchain)
+            } else {
+                // To compile Java 6 and 7 sources, we need an older compiler.
+                // We choose 11 since it supports both of these versions.
+                javaToolchains.compilerFor {
+                    languageVersion = JavaLanguageVersion.of(11)
                 }
             }
         }
@@ -299,10 +354,6 @@ fun addCompileAllTasks() {
     }
 }
 
-fun Test.jvmVersionForTest(): JavaLanguageVersion {
-    return JavaLanguageVersion.of(project.testJavaVersion)
-}
-
 fun Test.configureSpock() {
     systemProperty("spock.configuration", "GradleBuildSpockConfig.groovy")
 }
@@ -325,26 +376,17 @@ fun Test.configureFlakyTest() {
     }
 }
 
-fun Test.configureJvmForTest() {
-    jvmArgumentProviders.add(CiEnvironmentProvider(this))
-    val launcher = project.javaToolchains.launcherFor {
-        languageVersion = jvmVersionForTest()
+fun Test.runWithJavaVersion(testJvmVersion: JavaLanguageVersion) {
+    javaLauncher = project.javaToolchains.launcherFor {
+        languageVersion = testJvmVersion
         if (project.testJavaVendor.isPresent) {
             vendor = project.testJavaVendor
         }
     }
-    javaLauncher = launcher
-    if (jvmVersionForTest().canCompileOrRun(9)) {
+
+    if (testJvmVersion.canCompileOrRun(9)) {
         if (isUnitTest() || usesEmbeddedExecuter()) {
-            // Temporary workaround for smoke tests until we have the new API (`forDaemonProcesses`) available normally.
-            val clazz = org.gradle.internal.jvm.JpmsConfiguration::class.java
-            val jpmsArgs = try {
-                val non24CompatibleArgs = clazz.getDeclaredField("GRADLE_DAEMON_JPMS_ARGS").get(null) as List<*>
-                non24CompatibleArgs + (if (jvmVersionForTest().canCompileOrRun(24)) listOf("--enable-native-access=ALL-UNNAMED") else emptyList<String>())
-            } catch (ignored: NoSuchFieldException) {
-                clazz.getMethod("forDaemonProcesses", Int::class.java, Boolean::class.java).invoke(null, jvmVersionForTest().asInt(), true)
-            }
-            jvmArgs(jpmsArgs as List<*>)
+            jvmArgs(JpmsConfiguration.forDaemonProcesses(testJvmVersion.asInt(), true))
         } else {
             jvmArgs(listOf("--add-opens", "java.base/java.util=ALL-UNNAMED")) // Used in tests by native platform library: WrapperProcess.getEnv
             jvmArgs(listOf("--add-opens", "java.base/java.lang=ALL-UNNAMED")) // Used in tests by ClassLoaderUtils
@@ -393,7 +435,9 @@ fun configureTests() {
 
         maxParallelForks = project.maxParallelForks
 
-        configureJvmForTest()
+        jvmArgumentProviders.add(CiEnvironmentProvider(this))
+        runWithJavaVersion(JavaLanguageVersion.of(project.testJavaVersion))
+
         if (name != "archTest") {
             // TODO distinguish archTest and other tests
             addOsAsInputs()

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/extension/UnitTestAndCompileExtension.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/extension/UnitTestAndCompileExtension.kt
@@ -17,8 +17,6 @@
 package gradlebuild.jvm.extension
 
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.kotlin.dsl.*
 
 /**
  * An extension intended for configuring the manner in which a project is
@@ -35,7 +33,7 @@ abstract class UnitTestAndCompileExtension {
 
     /**
      * Set this flag to true if the project compiles against Java standard library APIs
-     * that were introduced after the [targetVersion] of the project.
+     * that were introduced after the target JVM bytecode version of the project.
      *
      * This workaround should be used sparingly.
      */
@@ -43,59 +41,42 @@ abstract class UnitTestAndCompileExtension {
 
     /**
      * Set this flag to true if the project compiles against dependencies that target a
-     * higher JVM version than the [targetVersion] of the project.
+     * higher JVM version than the target JVM bytecode version of the project.
      *
      * This workaround should be used sparingly.
      */
     abstract val usesIncompatibleDependencies: Property<Boolean>
 
     /**
-     * Stores the mutable value of the target bytecode version for this project,
-     * but is protected to prevent the user from setting it directly.
-     */
-    protected abstract val targetVersionProperty: Property<Int>
-
-    /**
-     * Get the target bytecode version for this project.
-     *
-     * To configure this value, call a `usedIn*` method.
-     */
-    val targetVersion: Provider<Int>
-        get() = targetVersionProperty
-
-    /**
-     * Declares that this Gradle module runs within a worker process.
-     */
-    fun usedInWorkers() {
-        targetVersionProperty = 8
-    }
-
-    /**
-     * Declare that this Gradle module runs as an entrypoint to user-executed
+     * Declare that this Gradle module runs as part of an entrypoint to user-executed
      * processes, and therefore should compile to a lower version of Java --
      * in order to ensure comprehensible error messages when executing Gradle
      * on an unsupported JVM version.
      * <p>
-     * This runtime target should only be used by the wrapper and the various
+     * This runtime target should only be used by the various
      * "-main" modules containing main methods.
      */
-    fun usedForStartup() {
-        targetVersionProperty = 6
-    }
+    abstract val usedForStartup: Property<Boolean>
 
     /**
-     * Declares that this Gradle module runs within a client process, such
+     * Declare that this Gradle module runs as part of the Gradle Wrapper.
+     */
+    abstract val usedInWrapper: Property<Boolean>
+
+    /**
+     * Declare that this Gradle module runs as part of worker process.
+     */
+    abstract val usedInWorkers: Property<Boolean>
+
+    /**
+     * Declare that this Gradle module runs as part of a client process, such
      * as the Tooling API client or CLI client.
      */
-    fun usedInToolingApi() {
-        targetVersionProperty = 8
-    }
+    abstract val usedInClient: Property<Boolean>
 
     /**
-     * Declares that this Gradle module runs within the Gradle daemon.
+     * Declare that this Gradle module runs as part of the Gradle daemon.
      */
-    fun usedInDaemon() {
-        targetVersionProperty = 8
-    }
+    abstract val usedInDaemon: Property<Boolean>
 
 }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.java-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.java-library.gradle.kts
@@ -17,7 +17,5 @@
 plugins {
     `java-library`
     id("gradlebuild.jvm-library")
-    id("gradlebuild.test-fixtures")
-    id("gradlebuild.arch-test")
     id("gradlebuild.private-javadoc")
 }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.jvm-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.jvm-library.gradle.kts
@@ -49,6 +49,6 @@ configure<DependencyAnalysisSubExtension> {
             exclude(":internal-instrumentation-processor")
         }
 
-        ignoreSourceSet("archTest", "crossVersionTest", "docsTest", "integTest", "jmh", "peformanceTest", "smokeTest", "testInterceptors", "testFixtures", "smokeIdeTest")
+        ignoreSourceSet("archTest", "crossVersionTest", "integTest", "jmh", "testFixtures")
     }
 }

--- a/platforms/core-configuration/bean-serialization-services/build.gradle.kts
+++ b/platforms/core-configuration/bean-serialization-services/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 
 description = "Configuration Cache services supporting bean serialization"
 
-gradlebuildJava {
+gradleModule {
     usesJdkInternals = true
 }
 

--- a/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
+++ b/platforms/core-configuration/core-serialization-codecs/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 description = "Configuration Cache serialization codecs for :core (and family) types"
 
-gradlebuildJava {
+gradleModule {
     usesFutureStdlib = true
 }
 

--- a/platforms/core-configuration/file-operations/build.gradle.kts
+++ b/platforms/core-configuration/file-operations/build.gradle.kts
@@ -20,10 +20,9 @@ plugins {
 
 description = "Operations on files, such as archiving, copying, deleting"
 
-// TODO: ensure code is compliant with requirements for workers
-// This project was part of :core and similarly is included in the Worker runtime classpath (see WorkerProcessClassPathProvider)
-// So it should either be compliant or split into parts that are used and not used for workers.
-//gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 errorprone {
     disabledChecks.addAll(

--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 description = "Implementation of configuration model types and annotation metadata handling (Providers, software model, conventions)"
 
-gradlebuildJava {
+gradleModule {
     usesJdkInternals = true
 }
 

--- a/platforms/core-execution/daemon-server-worker/build.gradle.kts
+++ b/platforms/core-execution/daemon-server-worker/build.gradle.kts
@@ -21,9 +21,9 @@ plugins {
 description = "Worker RequestHandler that hosts long-running daemon server which can execute arbitrary WorkerAction requests. " +
     "These classes are loaded in a separate worker daemon process and should have a minimal dependency set."
 
-// TODO: These classes _are_ used in workers, but require Java 8. We should
-// enable this flag in Gradle 9.0 when workers target Java 8.
-// gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
 

--- a/platforms/core-execution/hashing/build.gradle.kts
+++ b/platforms/core-execution/hashing/build.gradle.kts
@@ -5,7 +5,10 @@ plugins {
 
 description = "Tools for creating secure hashes for files and other content"
 
-gradlebuildJava.usedInWorkers() // org.gradle.internal.nativeintegration.filesystem.Stat is used in workers
+gradleModule {
+    // org.gradle.internal.nativeintegration.filesystem.Stat is used in workers
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.stdlibJavaExtensions)

--- a/platforms/core-execution/request-handler-worker/build.gradle.kts
+++ b/platforms/core-execution/request-handler-worker/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 description = "Worker action that implements RequestHandler worker protocol. " +
     "These classes are loaded in a separate worker daemon process and should have a minimal dependency set."
 
-// TODO: These classes _are_ used in workers, but require Java 8. We should
-// enable this flag in Gradle 9.0 when workers target Java 8.
-// gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.baseServices)

--- a/platforms/core-execution/worker-main/build.gradle.kts
+++ b/platforms/core-execution/worker-main/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 description = "Contains the main class that is loaded in a worker process, which is able to execute arbitrary actions. " +
     "These classes are loaded in a separate worker daemon process and should have a minimal dependency set."
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.serviceLookup)

--- a/platforms/core-runtime/base-asm/build.gradle.kts
+++ b/platforms/core-runtime/base-asm/build.gradle.kts
@@ -20,7 +20,9 @@ plugins {
 
 description = "Base asm classes and utilities for Gradle's internal use"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(libs.asm)

--- a/platforms/core-runtime/base-services/build.gradle.kts
+++ b/platforms/core-runtime/base-services/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 
 description = "A set of generic services and utilities."
 
-gradlebuildJava {
-    usedInWorkers()
+gradleModule {
+    usedInWorkers = true
     usesFutureStdlib = true
 }
 

--- a/platforms/core-runtime/build-operations/build.gradle.kts
+++ b/platforms/core-runtime/build-operations/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 
 description = "Build operations are our way to inspect the process of executing a build"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.stdlibJavaExtensions)

--- a/platforms/core-runtime/build-option/build.gradle.kts
+++ b/platforms/core-runtime/build-option/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 
 description = "The Gradle build option parser."
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.cli)

--- a/platforms/core-runtime/build-process-startup/build.gradle.kts
+++ b/platforms/core-runtime/build-process-startup/build.gradle.kts
@@ -25,8 +25,8 @@ description = """
     as they are used by process entry-points in order to verify java version compatibility.
     """
 
-gradlebuildJava {
-    usedForStartup()
+gradleModule {
+    usedForStartup = true
     usesIncompatibleDependencies = true // For testFixtures
 }
 

--- a/platforms/core-runtime/classloaders/build.gradle.kts
+++ b/platforms/core-runtime/classloaders/build.gradle.kts
@@ -22,8 +22,8 @@ plugins {
 
 description = "Tools to handle classloaders"
 
-gradlebuildJava{
-    usedInWorkers()
+gradleModule {
+    usedInWorkers = true
     usesFutureStdlib = true
 }
 

--- a/platforms/core-runtime/cli/build.gradle.kts
+++ b/platforms/core-runtime/cli/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 
 description = "Utilities for parsing command line arguments"
 
-gradlebuildJava {
-    usedForStartup() // Used in the wrapper
+gradleModule {
+    usedInWrapper = true
     usesIncompatibleDependencies = true // For test dependencies
 }
 

--- a/platforms/core-runtime/concurrent/build.gradle.kts
+++ b/platforms/core-runtime/concurrent/build.gradle.kts
@@ -21,7 +21,9 @@ plugins {
 
 description = "Tools to work with managed executors"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.stdlibJavaExtensions)

--- a/platforms/core-runtime/file-temp/build.gradle.kts
+++ b/platforms/core-runtime/file-temp/build.gradle.kts
@@ -20,7 +20,9 @@ plugins {
 
 description = "Utilities for working with temporary files & directories"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.stdlibJavaExtensions)

--- a/platforms/core-runtime/files/build.gradle.kts
+++ b/platforms/core-runtime/files/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 
 description = "Base tools to work with files"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.stdlibJavaExtensions)

--- a/platforms/core-runtime/gradle-cli-main/build.gradle.kts
+++ b/platforms/core-runtime/gradle-cli-main/build.gradle.kts
@@ -22,8 +22,8 @@ plugins {
 
 description = "Java 6-compatible entry point of the `gradle` command. Bootstraps the implementation in :gradle-cli."
 
-gradlebuildJava {
-    usedForStartup()
+gradleModule {
+    usedForStartup = true
     usesIncompatibleDependencies = true
 }
 

--- a/platforms/core-runtime/instrumentation-agent/build.gradle.kts
+++ b/platforms/core-runtime/instrumentation-agent/build.gradle.kts
@@ -4,9 +4,9 @@ plugins {
 
 description = "A Java agent implementation that instruments loaded classes"
 
-// Agent's premain is invoked before main(), so it should not cause the startup to fail because of the too new class file format.
-gradlebuildJava {
-    usedForStartup()
+gradleModule {
+    // Agent's premain is invoked before main(), so it should not cause the startup to fail because of the too new class file format.
+    usedForStartup = true
     usesIncompatibleDependencies = true // For test dependencies
 }
 

--- a/platforms/core-runtime/io/build.gradle.kts
+++ b/platforms/core-runtime/io/build.gradle.kts
@@ -21,7 +21,9 @@ plugins {
 
 description = "I/O utilities"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(libs.jspecify)

--- a/platforms/core-runtime/logging-api/build.gradle.kts
+++ b/platforms/core-runtime/logging-api/build.gradle.kts
@@ -20,7 +20,9 @@ plugins {
 
 description = "Logging API"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(libs.slf4jApi)

--- a/platforms/core-runtime/logging/build.gradle.kts
+++ b/platforms/core-runtime/logging/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 
 description = "Logging infrastructure"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.stdlibJavaExtensions)

--- a/platforms/core-runtime/messaging/build.gradle.kts
+++ b/platforms/core-runtime/messaging/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 
 description = "Implementation of messaging between Gradle processes"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.concurrent)

--- a/platforms/core-runtime/native/build.gradle.kts
+++ b/platforms/core-runtime/native/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 
 description = "This project contains various native operating system integration utilities"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 /**
  * Use Java 8 compatibility for JMH benchmarks

--- a/platforms/core-runtime/process-memory-services/build.gradle.kts
+++ b/platforms/core-runtime/process-memory-services/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 
 description = "Process memory abstractions."
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.concurrent)

--- a/platforms/core-runtime/serialization/build.gradle.kts
+++ b/platforms/core-runtime/serialization/build.gradle.kts
@@ -21,8 +21,8 @@ plugins {
 
 description = "Tools to serialize data"
 
-gradlebuildJava {
-    usedInWorkers()
+gradleModule {
+    usedInWorkers = true
     usesFutureStdlib = true
 }
 

--- a/platforms/core-runtime/service-lookup/build.gradle.kts
+++ b/platforms/core-runtime/service-lookup/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 
 description = "Internal API to dynamically lookup services provided by Gradle modules"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(libs.jspecify)

--- a/platforms/core-runtime/service-provider/build.gradle.kts
+++ b/platforms/core-runtime/service-provider/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 
 description = "Internal API to declare services provided by Gradle modules"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.serviceLookup)

--- a/platforms/core-runtime/service-registry-builder/build.gradle.kts
+++ b/platforms/core-runtime/service-registry-builder/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 
 description = "Internal API for composing service registries"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.serviceLookup)

--- a/platforms/core-runtime/service-registry-impl/build.gradle.kts
+++ b/platforms/core-runtime/service-registry-impl/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 
 description = "Implementation of the service registry framework"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.serviceLookup)

--- a/platforms/core-runtime/stdlib-java-extensions/build.gradle.kts
+++ b/platforms/core-runtime/stdlib-java-extensions/build.gradle.kts
@@ -7,7 +7,9 @@ plugins {
 
 description = "Extensions to the Java language that are used across the Gradle codebase"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     compileOnly(libs.jetbrainsAnnotations)

--- a/platforms/core-runtime/time/build.gradle.kts
+++ b/platforms/core-runtime/time/build.gradle.kts
@@ -21,7 +21,9 @@ plugins {
 
 description = "Monotonic clock implementation"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.stdlibJavaExtensions)

--- a/platforms/core-runtime/wrapper-main/build.gradle.kts
+++ b/platforms/core-runtime/wrapper-main/build.gradle.kts
@@ -26,8 +26,8 @@ plugins {
 
 description = "Entry point of the Gradle wrapper command"
 
-gradlebuildJava {
-    usedForStartup() // Used in the wrapper
+gradleModule {
+    usedForStartup = true
     usesFutureStdlib = true
     usesIncompatibleDependencies = true // For test dependencies
 }

--- a/platforms/core-runtime/wrapper-shared/build.gradle.kts
+++ b/platforms/core-runtime/wrapper-shared/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 
 description = "Utility code shared between the wrapper and the Gradle distribution"
 
-gradlebuildJava {
-    usedForStartup() // Used in the wrapper
+gradleModule {
+    usedInWrapper = true
     usesIncompatibleDependencies = true // For test dependencies
 }
 

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -47,6 +47,12 @@ configurations.docsTestImplementation {
     exclude("org.slf4j", "slf4j-simple")
 }
 
+dependencyAnalysis {
+    issues {
+        ignoreSourceSet(sourceSets.docsTest.name)
+    }
+}
+
 dependencies {
     // generate Javadoc for the full Gradle distribution
     runtimeOnly(project(":distributions-full"))

--- a/platforms/enterprise/enterprise-logging/build.gradle.kts
+++ b/platforms/enterprise/enterprise-logging/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
 
 description = "Logging API consumed by the Develocity plugin"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.buildOperations)

--- a/platforms/enterprise/enterprise-workers/build.gradle.kts
+++ b/platforms/enterprise/enterprise-workers/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 
 description = "Develocity plugin dependencies that also need to be exposed to workers"
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(libs.jspecify)

--- a/platforms/ide/problems-api/build.gradle.kts
+++ b/platforms/ide/problems-api/build.gradle.kts
@@ -25,9 +25,11 @@ description = """A problems description API
     |
     |It's a stripped down version of the original code available
     |at https://github.com/melix/jdoctor/
-""".trimMargin()
+"""
 
-gradlebuildJava.usedInWorkers()
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.baseServices)

--- a/platforms/ide/problems-api/build.gradle.kts
+++ b/platforms/ide/problems-api/build.gradle.kts
@@ -19,12 +19,12 @@ plugins {
 }
 
 description = """A problems description API
-    |
-    |This project provides base classes to describe problems and their
-    |solutions, in a way that enforces the creation of good error messages.
-    |
-    |It's a stripped down version of the original code available
-    |at https://github.com/melix/jdoctor/
+
+This project provides base classes to describe problems and their
+solutions, in a way that enforces the creation of good error messages.
+
+It's a stripped down version of the original code available
+at https://github.com/melix/jdoctor/
 """
 
 gradleModule {

--- a/platforms/ide/tooling-api/build.gradle.kts
+++ b/platforms/ide/tooling-api/build.gradle.kts
@@ -6,8 +6,9 @@ plugins {
 
 description = "Gradle Tooling API - the programmatic API to invoke Gradle"
 
-gradlebuildJava {
-    usedInToolingApi()
+gradleModule {
+    usedInClient = true
+
     // JSpecify annotations on static inner type return types
     usesJdkInternals = true
 }

--- a/platforms/jvm/java-compiler-plugin/build.gradle.kts
+++ b/platforms/jvm/java-compiler-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 description = "A Java compiler plugin used by Gradle's incremental compiler"
 
-gradlebuildJava {
+gradleModule {
     usesJdkInternals = true
 }
 

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 description = "Source for JavaCompile, JavaExec and Javadoc tasks, it also contains logic for incremental Java compilation"
 
-gradlebuildJava {
+gradleModule {
     usesJdkInternals = true
 }
 

--- a/platforms/jvm/testing-jvm-infrastructure/build.gradle.kts
+++ b/platforms/jvm/testing-jvm-infrastructure/build.gradle.kts
@@ -18,13 +18,15 @@ plugins {
     id("gradlebuild.distribution.api-java")
 }
 
-gradlebuildJava.usedInWorkers()
-
 description = """JVM-specific test infrastructure, including support for bootstrapping and configuring test workers
 and executing tests.
 Few projects should need to depend on this module directly. Most external interactions with this module are through the
 various implementations of WorkerTestClassProcessorFactory.
 """
+
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.stdlibJavaExtensions)

--- a/platforms/software/testing-base-infrastructure/build.gradle.kts
+++ b/platforms/software/testing-base-infrastructure/build.gradle.kts
@@ -2,9 +2,11 @@ plugins {
     id("gradlebuild.distribution.api-java")
 }
 
-gradlebuildJava.usedInWorkers()
-
 description = """Generalized test infrastructure to support executing tests in test workers."""
+
+gradleModule {
+    usedInWorkers = true
+}
 
 dependencies {
     api(projects.baseServices)

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -18,16 +18,20 @@ tasks.classpathManifest {
 
 // Instrumentation interceptors for tests
 // Separated from the test source set since we don't support incremental annotation processor with Java/Groovy joint compilation
-sourceSets {
-    val testInterceptors = create("testInterceptors") {
-        compileClasspath += sourceSets.main.get().output
-        runtimeClasspath += sourceSets.main.get().output
-    }
-    getByName("test") {
-        compileClasspath += testInterceptors.output
-        runtimeClasspath += testInterceptors.output
+val testInterceptors = sourceSets.create("testInterceptors") {
+    compileClasspath += sourceSets.main.get().output
+    runtimeClasspath += sourceSets.main.get().output
+}
+sourceSets.test {
+    compileClasspath += testInterceptors.output
+    runtimeClasspath += testInterceptors.output
+}
+dependencyAnalysis {
+    issues {
+        ignoreSourceSet(testInterceptors.name)
     }
 }
+
 val testInterceptorsImplementation: Configuration by configurations.getting {
     extendsFrom(configurations.implementation.get())
 }

--- a/testing/performance/build.gradle.kts
+++ b/testing/performance/build.gradle.kts
@@ -39,5 +39,7 @@ dependencyAnalysis {
         onUnusedDependencies {
             exclude(libs.junitJupiter)
         }
+
+        ignoreSourceSet(sourceSets.performanceTest.name)
     }
 }

--- a/testing/public-api-tests/build.gradle.kts
+++ b/testing/public-api-tests/build.gradle.kts
@@ -19,9 +19,6 @@ import gradlebuild.integrationtests.tasks.IntegrationTest
 plugins {
     // TODO Can we apply less here?
     id("gradlebuild.internal.java")
-
-//    id("gradlebuild.repositories")
-//    id("gradlebuild.integration-tests")
 }
 
 val testRepo = configurations.dependencyScope("testRepo")

--- a/testing/smoke-ide-test/build.gradle.kts
+++ b/testing/smoke-ide-test/build.gradle.kts
@@ -12,6 +12,12 @@ val smokeIdeTestSourceSet = sourceSets.create("smokeIdeTest") {
     runtimeClasspath += sourceSets.main.get().output
 }
 
+dependencyAnalysis {
+    issues {
+        ignoreSourceSet(smokeIdeTestSourceSet.name)
+    }
+}
+
 addDependenciesAndConfigurations("smokeIde")
 
 val smokeIdeTestImplementation: Configuration by configurations

--- a/testing/smoke-test/build.gradle.kts
+++ b/testing/smoke-test/build.gradle.kts
@@ -13,6 +13,12 @@ val smokeTestSourceSet = sourceSets.create("smokeTest") {
     runtimeClasspath += sourceSets.main.get().output
 }
 
+dependencyAnalysis {
+    issues {
+        ignoreSourceSet(smokeTestSourceSet.name)
+    }
+}
+
 addDependenciesAndConfigurations("smoke")
 
 val smokeTestImplementation: Configuration by configurations


### PR DESCRIPTION
Instead of useInWorkers() use usedInWorkers = true Rename gradlebuildJava to gradleModule
Cleanup configuration of dependency analysis plugin to move ignored source sets to where they are declared

Next steps are to add validation that these flags are properly set for each project, and then to update daemon to compile to java 17


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
