### PR TITLE
Optimize ReproducibleDirectoryWalker and add performance tests for reproducible archives

### DIFF
--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -910,6 +910,11 @@
       "coverage" : {
         "per_commit" : [ "linux", "windows", "macOs" ]
       }
+    }, {
+      "testProject" : "largeMonolithicJavaProject",
+      "coverage" : {
+        "per_commit" : [ "linux" ]
+      }
     } ]
   }, {
     "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.test for non-abi change",

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -922,6 +922,24 @@
       }
     } ]
   }, {
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.test for non-abi change with reproducible archives",
+    "groups" : [ {
+      "testProject" : "largeJavaMultiProject",
+      "coverage" : {
+        "per_day" : [ "linux" ]
+      }
+    }, {
+      "testProject" : "largeMonolithicJavaProject",
+      "coverage" : {
+        "per_day" : [ "linux" ]
+      }
+    }, {
+      "testProject" : "mediumJavaMultiProjectWithTestNG",
+      "coverage" : {
+        "per_day" : [ "linux" ]
+      }
+    } ]
+  }, {
     "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble (parallel false)",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -904,25 +904,15 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.test for non-abi change",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for non-abi change with reproducible archives",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
-        "per_day" : [ "linux" ]
-      }
-    }, {
-      "testProject" : "largeMonolithicJavaProject",
-      "coverage" : {
-        "per_day" : [ "linux" ]
-      }
-    }, {
-      "testProject" : "mediumJavaMultiProjectWithTestNG",
-      "coverage" : {
-        "per_day" : [ "linux" ]
+        "per_commit" : [ "linux", "windows", "macOs" ]
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.test for non-abi change with reproducible archives",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.test for non-abi change",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ReproducibleDirectoryWalker.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ReproducibleDirectoryWalker.java
@@ -16,12 +16,13 @@
 
 package org.gradle.api.internal.file.collections;
 
-import org.gradle.api.GradleException;
+import com.google.common.base.Preconditions;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -34,7 +35,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 public class ReproducibleDirectoryWalker implements DirectoryWalker {
-    private final static Comparator<Path> SORT_BY_PATH = Comparator.comparing(Path::toString);
+    private final static Comparator<PathWithAttributes> FILES_FIRST = Comparator
+        .comparing(PathWithAttributes::isDirectory)
+        .thenComparing(p -> p.path.toString());
 
     private final FileSystem fileSystem;
 
@@ -44,26 +47,17 @@ public class ReproducibleDirectoryWalker implements DirectoryWalker {
 
     @Override
     public void walkDir(Path rootDir, RelativePath rootPath, FileVisitor visitor, Spec<? super FileTreeElement> spec, AtomicBoolean stopFlag, boolean postfix) {
-        try {
-            PathVisitor pathVisitor = new PathVisitor(spec, postfix, visitor, stopFlag, rootPath, fileSystem);
-            visit(rootDir, pathVisitor);
-        } catch (IOException e) {
-            throw new GradleException(String.format("Could not list contents of directory '%s'.", rootDir), e);
-        }
+        PathVisitor pathVisitor = new PathVisitor(spec, postfix, visitor, stopFlag, rootPath, fileSystem);
+        visit(toPathWithAttributes(rootDir), pathVisitor);
     }
 
-    private static FileVisitResult visit(Path path, PathVisitor pathVisitor) throws IOException {
-        BasicFileAttributes attrs;
-        try {
-            attrs = Files.readAttributes(path, BasicFileAttributes.class);
-        } catch (IOException e) {
-            try {
-                attrs = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-            } catch (IOException next) {
-                return pathVisitor.visitFileFailed(path, next);
-            }
+    private static FileVisitResult visit(PathWithAttributes pathWithAttributes, PathVisitor pathVisitor) {
+        if (pathWithAttributes.exception != null) {
+            return pathVisitor.visitFileFailed(pathWithAttributes.path, pathWithAttributes.exception);
         }
 
+        Path path = pathWithAttributes.path;
+        BasicFileAttributes attrs = Preconditions.checkNotNull(pathWithAttributes.attributes);
         if (attrs.isDirectory()) {
             FileVisitResult fvr = pathVisitor.preVisitDirectory(path, attrs);
             if (fvr == FileVisitResult.SKIP_SUBTREE || fvr == FileVisitResult.TERMINATE) {
@@ -71,8 +65,11 @@ public class ReproducibleDirectoryWalker implements DirectoryWalker {
             }
             IOException exception = null;
             try (Stream<Path> fileStream = Files.list(path)) {
-                Iterable<Path> files = () -> fileStream.sorted(SORT_BY_PATH).iterator();
-                for (Path child : files) {
+                Iterable<PathWithAttributes> files = () -> fileStream
+                    .map(ReproducibleDirectoryWalker::toPathWithAttributes)
+                    .sorted(FILES_FIRST)
+                    .iterator();
+                for (PathWithAttributes child : files) {
                     FileVisitResult childResult = visit(child, pathVisitor);
                     if (childResult == FileVisitResult.TERMINATE) {
                         return childResult;
@@ -84,6 +81,38 @@ public class ReproducibleDirectoryWalker implements DirectoryWalker {
             return pathVisitor.postVisitDirectory(path, exception);
         } else {
             return pathVisitor.visitFile(path, attrs);
+        }
+    }
+
+    private static PathWithAttributes toPathWithAttributes(Path path) {
+        try {
+            BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class);
+            return new PathWithAttributes(path, attributes, null);
+        } catch (IOException ignored) {
+            try {
+                BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+                return new PathWithAttributes(path, attributes, null);
+            } catch (IOException e) {
+                return new PathWithAttributes(path, null, e);
+            }
+        }
+    }
+
+    private static class PathWithAttributes {
+        private final Path path;
+        @Nullable
+        private final BasicFileAttributes attributes;
+        @Nullable
+        private final IOException exception;
+
+        public PathWithAttributes(Path path, @Nullable BasicFileAttributes attrs, @Nullable IOException exception) {
+            this.path = path;
+            this.attributes = attrs;
+            this.exception = exception;
+        }
+
+        public boolean isDirectory() {
+            return attributes != null && attributes.isDirectory();
         }
     }
 }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ReproducibleDirectoryWalker.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ReproducibleDirectoryWalker.java
@@ -34,6 +34,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 public class ReproducibleDirectoryWalker implements DirectoryWalker {
+    private final static Comparator<Path> SORT_BY_PATH = Comparator.comparing(Path::toString);
+
     private final FileSystem fileSystem;
 
     public ReproducibleDirectoryWalker(FileSystem fileSystem) {
@@ -69,7 +71,7 @@ public class ReproducibleDirectoryWalker implements DirectoryWalker {
             }
             IOException exception = null;
             try (Stream<Path> fileStream = Files.list(path)) {
-                Iterable<Path> files = () -> fileStream.sorted(FILES_FIRST).iterator();
+                Iterable<Path> files = () -> fileStream.sorted(SORT_BY_PATH).iterator();
                 for (Path child : files) {
                     FileVisitResult childResult = visit(child, pathVisitor);
                     if (childResult == FileVisitResult.TERMINATE) {
@@ -84,6 +86,4 @@ public class ReproducibleDirectoryWalker implements DirectoryWalker {
             return pathVisitor.visitFile(path, attrs);
         }
     }
-
-    private final static Comparator<Path> FILES_FIRST = Comparator.<Path, Boolean>comparing(x -> x.toFile().isDirectory()).thenComparing(Path::toString);
 }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ReproducibleDirectoryWalker.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/ReproducibleDirectoryWalker.java
@@ -86,6 +86,9 @@ public class ReproducibleDirectoryWalker implements DirectoryWalker {
 
     private static PathWithAttributes toPathWithAttributes(Path path) {
         try {
+            // This is the same logic as used in java.nio.file.FileTreeWalker:
+            // Attempts to get attributes of a file. If it fails it might mean this is a link
+            // and a link target might not exist so try to get attributes of a link
             BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class);
             return new PathWithAttributes(path, attributes, null);
         } catch (IOException ignored) {

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DirectoryFileTreeTest.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DirectoryFileTreeTest.groovy
@@ -90,24 +90,24 @@ class DirectoryFileTreeTest extends AbstractProjectBuilderSpec {
     }
 
     /**
-    file structure:
-    root
-        rootFile1
-        dir1
-           dirFile1
-           dirFile2
-        rootFile2
-
-        Test that the files are really walked breadth first
+     * file structure:
+     * root
+     *   A
+     *   B
+     *   C
+     *      D
+     *      E
+     *   F
      */
-    def "walk breadth first - isReproducible: #visitor.isReproducibleFileOrder"() {
+    def "walk depth-first prefix - isReproducible: #visitor.isReproducibleFileOrder"() {
         given:
         def root = temporaryFolder.createDir("root")
-        def rootFile1 = root.createFile("rootFile1")
-        def dir1 = root.createDir("dir1")
-        def dirFile1 = dir1.createFile("dirFile1")
-        def dirFile2 = dir1.createFile("dirFile2")
-        def rootFile2 = root.createFile("rootFile2")
+        def a = root.createFile("A")
+        def b = root.createFile("B")
+        def c = root.createDir("C")
+        def d = c.createFile("D")
+        def e = c.createFile("E")
+        def f = root.createFile("F")
 
         def fileTree = new DirectoryFileTree(root, new PatternSet(), TestFiles.fileSystem(), false)
 
@@ -115,20 +115,38 @@ class DirectoryFileTreeTest extends AbstractProjectBuilderSpec {
         fileTree.visit(visitor)
 
         then:
-        visitor.visited.sort() == [rootFile1, rootFile2, dir1, dirFile1, dirFile2].sort()
+        // Check that all files are visited
+        visitor.visited.collect().sort() == [a, b, c, d, e, f]
+        // Check that parent is visited before children
+        visitor.visited.indexOf(c) < visitor.visited.indexOf(d)
+        visitor.visited.indexOf(c) < visitor.visited.indexOf(e)
+        if (visitor.isReproducibleFileOrder) {
+            assert visitor.visited == [a, b, c, d, e, f]
+        }
 
         where:
         visitor << [new TestVisitor(false), new TestVisitor(true)]
     }
 
-    def "walk depth first - isReproducible: #visitor.isReproducibleFileOrder"() {
+    /**
+     * file structure:
+     * root
+     *   A
+     *   B
+     *   C
+     *      D
+     *      E
+     *   F
+     */
+    def "walk depth-first postfix - isReproducible: #visitor.isReproducibleFileOrder"() {
         given:
         def root = temporaryFolder.createDir("root")
-        def rootFile1 = root.createFile("rootFile1")
-        def dir1 = root.createDir("dir1")
-        def dirFile1 = dir1.createFile("dirFile1")
-        def dirFile2 = dir1.createFile("dirFile2")
-        def rootFile2 = root.createFile("rootFile2")
+        def a = root.createFile("A")
+        def b = root.createFile("B")
+        def c = root.createDir("C")
+        def d = c.createFile("D")
+        def e = c.createFile("E")
+        def f = root.createFile("F")
 
         def fileTree = new DirectoryFileTree(root, new PatternSet(), TestFiles.fileSystem(), false).postfix()
 
@@ -136,7 +154,14 @@ class DirectoryFileTreeTest extends AbstractProjectBuilderSpec {
         fileTree.visit(visitor)
 
         then:
-        visitor.visited.sort() == [rootFile1, rootFile2, dirFile2, dirFile1, dir1].sort()
+        // Check that all files are visited
+        visitor.visited.collect().sort() == [a, b, c, d, e, f]
+        // Check that children are visited before parent
+        visitor.visited.indexOf(c) > visitor.visited.indexOf(d)
+        visitor.visited.indexOf(c) > visitor.visited.indexOf(e)
+        if (visitor.isReproducibleFileOrder) {
+            assert visitor.visited == [a, b, d, e, c, f]
+        }
 
         where:
         visitor << [new TestVisitor(false), new TestVisitor(true)]
@@ -170,32 +195,42 @@ class DirectoryFileTreeTest extends AbstractProjectBuilderSpec {
         visitor << [new TestVisitor(false), new TestVisitor(true)]
     }
 
+    /**
+     * file structure:
+     * root
+     *   A
+     *   B
+     *   C
+     *      D
+     *      E
+     *   F
+     */
     def "visitor can stop visit - isReproducible: #visitor.isReproducibleFileOrder"() {
         given:
         def root = temporaryFolder.createDir("root")
-        def rootFile1 = root.createFile("rootFile1")
-        def dir1 = root.createDir("dir1")
-        def dirFile1 = dir1.createFile("dirFile1")
-        def dirFile2 = dir1.createFile("dirFile2")
-        dir1.createDir("dir1Dir").createFile("dir1Dir1File1")
-        def rootFile2 = root.createFile("rootFile2")
+        def a = root.createFile("A")
+        def b = root.createFile("B")
+        def c = root.createDir("C")
+        def d = c.createFile("D")
+        def e = c.createFile("E")
+        def f = root.createFile("F")
 
         def fileTree = new DirectoryFileTree(root, new PatternSet(), TestFiles.fileSystem(), false)
 
         when:
-        visitor.stopOn = rootFile2
+        visitor.stopOn = d
         fileTree.visit(visitor)
 
         then:
-        visitor.visited == [rootFile1, rootFile2]
+        visitor.visited == [a, b, c, d]
 
         when:
         visitor = new TestVisitor(true)
-        visitor.stopOn = dirFile1
+        visitor.stopOn = f
         fileTree.visit(visitor)
 
         then:
-        visitor.visited == [rootFile1, rootFile2, dir1, dirFile1]
+        visitor.visited == [a, b, c, d, e, f]
 
         where:
         visitor << [new TestVisitor(true)] // stopping at a given point assumes the order is fixed, so only reproducible visitor makes sense here

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DirectoryFileTreeTest.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DirectoryFileTreeTest.groovy
@@ -121,7 +121,7 @@ class DirectoryFileTreeTest extends AbstractProjectBuilderSpec {
         visitor.visited.indexOf(c) < visitor.visited.indexOf(d)
         visitor.visited.indexOf(c) < visitor.visited.indexOf(e)
         if (visitor.isReproducibleFileOrder) {
-            assert visitor.visited == [a, b, c, d, e, f]
+            assert visitor.visited == [a, b, f, c, d, e]
         }
 
         where:
@@ -160,7 +160,7 @@ class DirectoryFileTreeTest extends AbstractProjectBuilderSpec {
         visitor.visited.indexOf(c) > visitor.visited.indexOf(d)
         visitor.visited.indexOf(c) > visitor.visited.indexOf(e)
         if (visitor.isReproducibleFileOrder) {
-            assert visitor.visited == [a, b, d, e, c, f]
+            assert visitor.visited == [a, b, f, d, e, c]
         }
 
         where:
@@ -222,7 +222,7 @@ class DirectoryFileTreeTest extends AbstractProjectBuilderSpec {
         fileTree.visit(visitor)
 
         then:
-        visitor.visited == [a, b, c, d]
+        visitor.visited == [a, b, f, c, d]
 
         when:
         visitor = new TestVisitor(true)
@@ -230,7 +230,7 @@ class DirectoryFileTreeTest extends AbstractProjectBuilderSpec {
         fileTree.visit(visitor)
 
         then:
-        visitor.visited == [a, b, c, d, e, f]
+        visitor.visited == [a, b, f]
 
         where:
         visitor << [new TestVisitor(true)] // stopping at a given point assumes the order is fixed, so only reproducible visitor makes sense here

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/AbstractIncrementalExecutionPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/AbstractIncrementalExecutionPerformanceTest.groovy
@@ -42,11 +42,9 @@ class AbstractIncrementalExecutionPerformanceTest extends AbstractCrossVersionPe
         runner.args.add("-D${StartParameterBuildOptions.ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME}=${configurationCachingEnabled}")
     }
 
-    protected boolean enableReproducibleArchives(boolean reproducibleArchivesEnabled, CrossVersionPerformanceTestRunner runner) {
-        if (reproducibleArchivesEnabled) {
-            runner.addBuildMutator { invocationSettings ->
-                new EnableReproducibleArchivesMutator(invocationSettings.projectDir)
-            }
+    protected boolean enableReproducibleArchives(CrossVersionPerformanceTestRunner runner) {
+        runner.addBuildMutator { invocationSettings ->
+            new EnableReproducibleArchivesMutator(invocationSettings.projectDir)
         }
     }
 

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/AbstractIncrementalExecutionPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/AbstractIncrementalExecutionPerformanceTest.groovy
@@ -42,14 +42,20 @@ class AbstractIncrementalExecutionPerformanceTest extends AbstractCrossVersionPe
         runner.args.add("-D${StartParameterBuildOptions.ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME}=${configurationCachingEnabled}")
     }
 
-    protected boolean enableReproducibleArchives(CrossVersionPerformanceTestRunner runner) {
-        runner.addBuildMutator { invocationSettings ->
-            new EnableReproducibleArchivesMutator(invocationSettings.projectDir)
+    protected boolean enableReproducibleArchives(CrossVersionPerformanceTestRunner runner, boolean reproducibleArchivesEnabled) {
+        if (reproducibleArchivesEnabled) {
+            runner.addBuildMutator { invocationSettings ->
+                new EnableReproducibleArchivesMutator(invocationSettings.projectDir)
+            }
         }
     }
 
     protected static configurationCachingMessage(boolean configurationCachingEnabled) {
         return configurationCachingEnabled ? " with configuration caching" : ""
+    }
+
+    protected static reproducibleArchivesMessage(boolean reproducibleArchivesEnabled) {
+        return reproducibleArchivesEnabled ? " with reproducible archives" : ""
     }
 
     class EnableReproducibleArchivesMutator implements BuildMutator {

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
@@ -101,7 +101,7 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
     @RunFor(
         @Scenario(type = PER_DAY, operatingSystems = LINUX, testProjects = ["largeJavaMultiProject", "mediumJavaMultiProjectWithTestNG", "largeMonolithicJavaProject"])
     )
-    def "test for non-abi change"() {
+    def "test for non-abi change#reproducibleArchivesMessage"() {
         given:
         def testProject = JavaTestProject.projectFor(runner.testProject)
         runner.warmUpRuns = 2
@@ -109,6 +109,7 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
         runner.tasksToRun = ['test']
         // Pre-4.0 versions run into memory problems with this test
         runner.minimumBaseVersion = "4.0"
+        enableReproducibleArchives(reproducibleArchivesEnabled, runner)
         runner.addBuildMutator { new ApplyNonAbiChangeToJavaSourceFileMutator(new File(it.projectDir, testProject.config.fileToChangeByScenario['test'])) }
 
         when:
@@ -116,6 +117,11 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
 
         then:
         result.assertCurrentVersionHasNotRegressed()
+
+        where:
+        reproducibleArchivesMessage  | reproducibleArchivesEnabled
+        ""                            | true
+        " with reproducible archives" | false
     }
 
     @RunFor([

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
@@ -109,8 +109,10 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
         runner.tasksToRun = ['test']
         // Pre-4.0 versions run into memory problems with this test
         runner.minimumBaseVersion = "4.0"
-        enableReproducibleArchives(reproducibleArchivesEnabled, runner)
         runner.addBuildMutator { new ApplyNonAbiChangeToJavaSourceFileMutator(new File(it.projectDir, testProject.config.fileToChangeByScenario['test'])) }
+        if (reproducibleArchivesEnabled) {
+            enableReproducibleArchives(runner)
+        }
 
         when:
         def result = runner.run()
@@ -120,8 +122,8 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
 
         where:
         reproducibleArchivesMessage   | reproducibleArchivesEnabled
-        ""                            | true
-        " with reproducible archives" | false
+        ""                            | false
+        " with reproducible archives" | true
     }
 
     @RunFor([

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
@@ -119,7 +119,7 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        reproducibleArchivesMessage  | reproducibleArchivesEnabled
+        reproducibleArchivesMessage   | reproducibleArchivesEnabled
         ""                            | true
         " with reproducible archives" | false
     }

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
@@ -50,6 +50,7 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
 
     @RunFor([
         @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = ["largeGroovyMultiProject", "largeMonolithicJavaProject", "largeMonolithicGroovyProject"], iterationMatcher = "assemble for non-abi change"),
+        @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = ["largeMonolithicJavaProject"], iterationMatcher = "assemble for non-abi change with reproducible archives"),
         @Scenario(type = PER_COMMIT, operatingSystems = [LINUX, WINDOWS, MAC_OS], testProjects = "largeJavaMultiProject")
     ])
     def "assemble for non-abi change#configurationCaching#reproducibleArchives"() {


### PR DESCRIPTION
In https://github.com/gradle/gradle/issues/30871#issuecomment-2813000201 I discovered that `file.isDirectory()` has performance impact. This change optimizes it by reusing attributes and removes regression when using reproducible archives.

I also added `JavaIncrementalExecutionPerformanceTest.assemble for non-abi change with reproducible archives`  performance test and enabled it for `largeJavaMultiProject` and `largeMonolithicJavaProject`. 
I enabled `largeJavaMultiProject` since it's enabled by default for `assemble for non-abi change` test.
And I enabled it for `largeMonolithicJavaProject` since this project regressed the most when enabling reproducible builds.