### PR TITLE
Fix snippets for reproducible archives to mention also permissions

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/working_with_files.adoc
@@ -1010,11 +1010,8 @@ Files that only have a different timestamp or permissions also causes difference
 
 All link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html[AbstractArchiveTask] (e.g. Jar, Zip) tasks shipped with Gradle include support for producing reproducible archives.
 
-For example, to make a `Zip` task reproducible you need to set
- link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:reproducibleFileOrder[Zip.isReproducibleFileOrder()] to `true`,
- link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:preserveFileTimestamps[Zip.isPreserveFileTimestamps()] to `false`,
- link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:dirPermissions[Zip.getDirPermissions()] to `755`
- and link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:filePermissions[Zip.getFilePermissions()] to `644`.
+For example, to make a `Zip` task reproducible you need to set link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:reproducibleFileOrder[Zip.isReproducibleFileOrder()] to `true` and link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:preserveFileTimestamps[Zip.isPreserveFileTimestamps()] to `false`.
+Additionally, you need to set permissions explicitly, for example link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:dirPermissions[Zip.getDirPermissions()] to `755` and link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:filePermissions[Zip.getFilePermissions()] to `644`.
 In order to make all archive tasks in your build reproducible, consider adding the following configuration to your build file:
 
 ====

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/working_with_files.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/working_with_files.adoc
@@ -1006,11 +1006,15 @@ This is necessary for projects like https://reproducible-builds.org/[reproducibl
 
 Reproducing the same byte-for-byte archive poses some challenges since the order of the files in an archive is influenced by the underlying file system.
 Each time a ZIP, TAR, JAR, WAR or EAR is built from source, the order of the files inside the archive may change.
-Files that only have a different timestamp also causes differences in archives from build to build.
+Files that only have a different timestamp or permissions also causes differences in archives from build to build.
 
 All link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html[AbstractArchiveTask] (e.g. Jar, Zip) tasks shipped with Gradle include support for producing reproducible archives.
 
-For example, to make a `Zip` task reproducible you need to set link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:reproducibleFileOrder[Zip.isReproducibleFileOrder()] to `true` and link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:preserveFileTimestamps[Zip.isPreserveFileTimestamps()] to `false`.
+For example, to make a `Zip` task reproducible you need to set
+ link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:reproducibleFileOrder[Zip.isReproducibleFileOrder()] to `true`,
+ link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:preserveFileTimestamps[Zip.isPreserveFileTimestamps()] to `false`,
+ link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:dirPermissions[Zip.getDirPermissions()] to `755`
+ and link:{groovyDslPath}/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:filePermissions[Zip.getFilePermissions()] to `644`.
 In order to make all archive tasks in your build reproducible, consider adding the following configuration to your build file:
 
 ====

--- a/platforms/documentation/docs/src/snippets/buildCache/reproducible-archives/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/buildCache/reproducible-archives/groovy/build.gradle
@@ -1,5 +1,7 @@
 tasks.register('createZip', Zip) {
     preserveFileTimestamps = false
     reproducibleFileOrder = true
+    dirPermissions { unix("755") }
+    filePermissions { unix("644") }
     // ...
 }

--- a/platforms/documentation/docs/src/snippets/buildCache/reproducible-archives/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/buildCache/reproducible-archives/kotlin/build.gradle.kts
@@ -1,5 +1,7 @@
 tasks.register<Zip>("createZip") {
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true
+    dirPermissions { unix("755") }
+    filePermissions { unix("644") }
     // ...
 }

--- a/platforms/documentation/docs/src/snippets/files/archives/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/files/archives/groovy/build.gradle
@@ -49,6 +49,8 @@ tasks.register('tar', Tar) {
 tasks.withType(AbstractArchiveTask).configureEach {
     preserveFileTimestamps = false
     reproducibleFileOrder = true
+    dirPermissions { unix("755") }
+    filePermissions { unix("644") }
 }
 // end::reproducible[]
 

--- a/platforms/documentation/docs/src/snippets/files/archives/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/files/archives/kotlin/build.gradle.kts
@@ -51,6 +51,8 @@ tasks.register<Tar>("tar") {
 tasks.withType<AbstractArchiveTask>().configureEach {
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true
+    dirPermissions { unix("755") }
+    filePermissions { unix("644") }
 }
 // end::reproducible[]
 


### PR DESCRIPTION
This fixes snippets in
https://docs.gradle.org/current/userguide/common_caching_problems.html#volatile_outputs

and 
https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives

to set default values also for permissions

Fixes https://github.com/gradle/gradle/issues/33296

Changes can be seen here:
https://builds.gradle.org/repository/download/Gradle_Master_Check_BuildDistributions/97864361:id/distributions/gradle-9.0-docs.zip!/gradle-9.0-20250505132211%2B0000/docs/userguide/working_with_files.html#sec:reproducible_archives