### PR TITLE
Remove unnecessary calls to inhibit deprecations

### DIFF
--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -59,9 +59,7 @@ dependencies {
     implementation(projects.serviceLookup)
     implementation(projects.time)
     implementation(projects.fileTemp)
-    implementation(projects.logging)
     implementation(projects.loggingApi)
-    implementation(projects.logging)
     implementation(projects.problemsRendering)
     implementation(projects.toolingApi)
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.internal.Factory;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.internal.JavaExecutableUtils;
@@ -48,7 +47,7 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
 
         if (compileOptions.isFork()) {
             @SuppressWarnings("deprecation")
-            File forkJavaHome = DeprecationLogger.whileDisabled(compileOptions.getForkOptions()::getJavaHome);
+            File forkJavaHome = compileOptions.getForkOptions().getJavaHome();
             if (forkJavaHome != null) {
                 LOGGER.info("Compilation mode: command line compilation");
                 return getCommandLineSpec(Jvm.forHome(forkJavaHome).getJavacExecutable());

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileExecutableUtils.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileExecutableUtils.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.compile;
 import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.api.tasks.compile.JavaCompile;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec;
 import org.jspecify.annotations.Nullable;
@@ -36,7 +35,7 @@ public class JavaCompileExecutableUtils {
 
         ForkOptions forkOptions = task.getOptions().getForkOptions();
         @SuppressWarnings("deprecation")
-        File customJavaHome = DeprecationLogger.whileDisabled(forkOptions::getJavaHome);
+        File customJavaHome = forkOptions.getJavaHome();
         if (customJavaHome != null) {
             return SpecificInstallationToolchainSpec.fromJavaHome(propertyFactory, customJavaHome);
         }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompilerDaemonForkOptions.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompilerDaemonForkOptions.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.tasks.compile.ForkOptions;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.jspecify.annotations.Nullable;
 
 import java.io.File;
@@ -34,7 +33,7 @@ public class MinimalJavaCompilerDaemonForkOptions extends MinimalCompilerDaemonF
         this.executable = forkOptions.getExecutable();
         this.tempDir = forkOptions.getTempDir();
         @SuppressWarnings("deprecation")
-        File customJavaHome = DeprecationLogger.whileDisabled(forkOptions::getJavaHome);
+        File customJavaHome = forkOptions.getJavaHome();
         this.javaHome = customJavaHome;
         setJvmArgs(forkOptions.getAllJvmArgs());
     }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -56,7 +56,6 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.internal.jvm.DefaultModularitySpec;
@@ -264,7 +263,7 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
 
         ForkOptions forkOptions = getOptions().getForkOptions();
         @SuppressWarnings("deprecation")
-        File customJavaHome = DeprecationLogger.whileDisabled(forkOptions::getJavaHome);
+        File customJavaHome = forkOptions.getJavaHome();
         if (customJavaHome != null) {
             JavaExecutableUtils.validateMatchingFiles(
                 customJavaHome, "Toolchain from `javaHome` property on `ForkOptions`",


### PR DESCRIPTION
In #33005, we removed the deprecations for `ForkOptions.getJavaHome()`.  However, we did not remove the places where we were calling `getJavaHome()` with the deprecation logger disabled.  Those calls are now unnecessary and we can call `getJavaHome()` directly.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
