### PR TITLE
Add opt out for no tests discovered error

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -487,8 +487,32 @@ configurations {
 
 When test sources are present and no filters are applied, the `test` task will now fail with an error if it runs but doesn’t discover any tests.
 This is to help prevent misconfigurations where the tests are written for one test framework but the test task is mistakenly configured to use another test framework.
-
 If filters are applied, the outcome depends on the `failOnNoMatchingTests` property.
+
+This behavior can be disabled by setting the `failOnNoDiscoveredTests` property to `false` in the test task configuration:
+
+====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+tasks.withType<Test>().configureEach {
+    failOnNoDiscoveredTests = false
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+tasks.withType(Test).configureEach {
+    failOnNoDiscoveredTests = false
+}
+----
+=====
+====
 
 [[validate_plugins_without_java_toolchain_90]]
 ==== `ValidatePlugins` task now requires Java Toolchains
@@ -520,7 +544,7 @@ plugins {
 =====
 ====
 
-TIP: The `jvm-toolchains` plugin is automatically applied by the <<java_library_plugin.adoc#java_library_plugin,Java Library Plugin>> and other JVM-related plugins. 
+TIP: The `jvm-toolchains` plugin is automatically applied by the <<java_library_plugin.adoc#java_library_plugin,Java Library Plugin>> and other JVM-related plugins.
 If you are already applying one of those, no further action is needed.
 
 [[changes_8.14]]

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/Snippets.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/Snippets.groovy
@@ -59,7 +59,7 @@ abstract class Snippets {
             import org.gradle.api.internal.tasks.testing.TestExecutionSpec
             import org.gradle.api.tasks.testing.AbstractTestTask
 
-            class CustomTestTask extends AbstractTestTask {
+            abstract class CustomTestTask extends AbstractTestTask {
                 CustomTestTask() {
                     binaryResultsDirectory.set(new File(getProject().buildDir, "CustomTestTask"))
                     reports.html.required.set(false)

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
@@ -46,7 +46,7 @@ class TestTaskFailOnNoTestIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         fails("test")
-        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration.")
+        failure.assertHasCause("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration. If this is not a misconfiguration, this error can be disabled by setting the 'failOnNoDiscoveredTests' property to false.")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/30315")

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
@@ -71,7 +71,18 @@ class TestTaskFailOnNoTestIntegrationTest extends AbstractIntegrationSpec {
         skipped(":test")
     }
 
-    def createBuildFileWithJUnitJupiter() {
+    def "test succeeds when no test was executed and shouldFailOnNoDiscoveredTests is false"() {
+        createBuildFileWithJUnitJupiter(false)
+
+        file("src/test/java/NotATest.java") << """
+            public class NotATest {}
+        """
+
+        expect:
+        succeeds("test")
+    }
+
+    def createBuildFileWithJUnitJupiter(boolean shouldFailOnNoDiscoveredTests = true) {
         buildFile << """
             plugins {
                 id 'java'
@@ -83,6 +94,11 @@ class TestTaskFailOnNoTestIntegrationTest extends AbstractIntegrationSpec {
             }
             testing.suites.test {
                 useJUnitJupiter()
+                targets.all {
+                    testTask.configure {
+                        ${shouldFailOnNoDiscoveredTests ? "" : "failOnNoDiscoveredTests = false"}
+                    }
+                }
             }
         """.stripIndent()
     }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -52,8 +52,10 @@ import org.gradle.api.internal.tasks.testing.results.StateTrackingTestResultProc
 import org.gradle.api.internal.tasks.testing.results.TestListenerAdapter;
 import org.gradle.api.internal.tasks.testing.results.TestListenerInternal;
 import org.gradle.api.logging.LogLevel;
+import org.gradle.api.provider.Property;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.Reporting;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
@@ -188,6 +190,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         reports.getHtml().getRequired().set(true);
 
         filter = instantiator.newInstance(DefaultTestFilter.class);
+        getFailOnNoDiscoveredTests().convention(true);
     }
 
     @Inject
@@ -548,7 +551,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
             // - If there are filters and the task is configured to fail when no tests match the filters, throw an exception
             // - Otherwise, this is fine - the task should succeed with no warnings or errors
             if (testsAreNotFiltered()) {
-                if (testCountLogger.getTotalDiscoveredItems() == 0) {
+                if (testCountLogger.getTotalDiscoveredItems() == 0 && getFailOnNoDiscoveredTests().get()) {
                     throw new TestExecutionException("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration.");
                 }
             } else if (shouldFailOnNoMatchingTests()) {
@@ -722,4 +725,12 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
     public TestFilter getFilter() {
         return filter;
     }
+
+    /**
+     * Whether the task should fail if test sources are present, but no tests are discovered during test execution.  Defaults to true.
+     *
+     * @since 9.0
+     */
+    @Input
+    abstract public Property<Boolean> getFailOnNoDiscoveredTests();
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -552,7 +552,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
             // - Otherwise, this is fine - the task should succeed with no warnings or errors
             if (testsAreNotFiltered()) {
                 if (testCountLogger.getTotalDiscoveredItems() == 0 && getFailOnNoDiscoveredTests().get()) {
-                    throw new TestExecutionException("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration.");
+                    throw new TestExecutionException("There are test sources present and no filters are applied, but the test task did not discover any tests to execute. This is likely due to a misconfiguration. Please check your test configuration. If this is not a misconfiguration, this error can be disabled by setting the 'failOnNoDiscoveredTests' property to false.");
                 }
             } else if (shouldFailOnNoMatchingTests()) {
                 throw new TestExecutionException(createNoMatchingTestErrorMessage());

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1577,6 +1577,23 @@
             ]
         },
         {
+            "type": "org.gradle.api.tasks.testing.AbstractTestTask",
+            "member": "Method org.gradle.api.tasks.testing.AbstractTestTask.getFailOnNoDiscoveredTests()",
+            "acceptation": "Adding as a stable opt-out for new behavior in 9.0",
+            "changes": [
+                "Method added to public class",
+                "Abstract method has been added to this class"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.testing.Test",
+            "member": "Class org.gradle.api.tasks.testing.Test",
+            "acceptation": "Opt-out for new behavior in 9.0",
+            "changes": [
+                "Abstract method has been added to a superclass"
+            ]
+        },
+        {
             "type": "org.gradle.api.tasks.testing.Test",
             "member": "Method org.gradle.api.tasks.testing.Test.getSystemProperties()",
             "acceptation": "Values of returned map can be null",


### PR DESCRIPTION
In #33003 we made it an error when the test task has test classes, but no tests are discovered during test execution.  This was to catch the scenario where the test task is misconfigured to use the wrong test framework (rather than succeeding and giving the impression that the tests were run successfully).  One important case this doesn't consider is when the test engine is doing filtering that Gradle is not aware of.  In this case, it presents just like a misconfigured test task, but in actuality, the tests were just filtered out in a way that Gradle could not detect and there is no reasonable recourse for the build author to handle the error.  It's likely there are other edge cases, too, where it is "normal" for there to be classes but still no tests are reported back from the test engine.

To handle this, we keep the default behavior of failing when Gradle detects this scenario, but provide an opt-out flag that allows users to disable the failure if they determine it is normal for no tests to be discovered.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
