### PR TITLE
Change some Work execution validations from WARNING to ERROR

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedValidationUtil.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedValidationUtil.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.NullMarked;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.api.problems.Severity.WARNING;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
@@ -61,7 +62,7 @@ public class NestedValidationUtil {
                     .id("nested-type-unsupported", "Nested type unsupported", GradleCoreProblemGroup.validation().property())
                     .contextualLabel("with nested type '" + beanType.getName() + "' is not supported")
                     .documentedAt(userManual("validation_problems", "unsupported_nested_type"))
-                    .severity(WARNING)
+                    .severity(ERROR)
                     .details(reason)
                     .solution("Use a different input annotation if type is not a bean")
                     .solution("Use a different package that doesn't conflict with standard Java or Kotlin types for custom types")

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedValidationUtil.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedValidationUtil.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.gradle.api.problems.Severity.ERROR;
-import static org.gradle.api.problems.Severity.WARNING;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 /**
@@ -103,7 +102,7 @@ public class NestedValidationUtil {
                     .id("nested-map-unsupported-key-type", "Unsupported nested map key", GradleCoreProblemGroup.validation().property())
                     .contextualLabel("where key of nested map is of type '" + keyType.getName() + "'")
                     .documentedAt(userManual("validation_problems", "unsupported_key_type_of_nested_map"))
-                    .severity(WARNING)
+                    .severity(ERROR)
                     .details("Key of nested map must be an enum or one of the following types: " + getSupportedKeyTypes())
                     .solution("Change type of key to an enum or one of the following types: " + getSupportedKeyTypes())
             );

--- a/platforms/core-configuration/model-reflect/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/platforms/core-configuration/model-reflect/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -195,6 +195,16 @@ trait ValidationMessageChecker {
             .render()
     }
 
+    String missingCachingAnnotationMessage(@DelegatesTo(value = MissingCachingAnnotation, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        missingCachingAnnotationConfig(spec).render()
+    }
+
+    MissingCachingAnnotation missingCachingAnnotationConfig(@DelegatesTo(value = MissingCachingAnnotation, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        def config = display(MissingCachingAnnotation, 'disable_caching_by_default', spec)
+        config.description("must be annotated either with ${config.cacheableAnnotation} or with @DisableCachingByDefault")
+            .reason("The ${config.workType} author should make clear why a ${config.workType} is not cacheable.")
+    }
+
     String missingAnnotationMessage(@DelegatesTo(value = MissingAnnotation, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
         missingAnnotationConfig(spec).render()
     }
@@ -817,6 +827,42 @@ trait ValidationMessageChecker {
 
         MissingAnnotation kind(String kind) {
             this.kind = kind
+            this
+        }
+    }
+
+    static class MissingCachingAnnotation extends ValidationMessageDisplayConfiguration<MissingCachingAnnotation> {
+        String workType
+        String cacheableAnnotation
+
+        MissingCachingAnnotation(ValidationMessageChecker checker) {
+            super(checker)
+        }
+
+        MissingCachingAnnotation forTask() {
+            workType("task")
+            cacheableAnnotation("@CacheableTask")
+            solution("Add @DisableCachingByDefault(because = ...).")
+            solution("Add ${cacheableAnnotation}.")
+            solution("Add @UntrackedTask(because = ...).")
+            return this
+        }
+
+        MissingCachingAnnotation forTransformAction() {
+            workType("transform action")
+            cacheableAnnotation("@CacheableTransform")
+            solution("Add @DisableCachingByDefault(because = ...).")
+            solution("Add ${cacheableAnnotation}.")
+            return this
+        }
+
+        MissingCachingAnnotation workType(String workType) {
+            this.workType = workType
+            this
+        }
+
+        MissingCachingAnnotation cacheableAnnotation(String cacheableAnnotation) {
+            this.cacheableAnnotation = cacheableAnnotation
             this
         }
     }

--- a/platforms/core-configuration/model-reflect/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/platforms/core-configuration/model-reflect/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -510,7 +510,7 @@ trait ValidationMessageChecker {
         String asSingleLine = convertToSingleLine(message)
         String deprecationMessage = asSingleLine + (asSingleLine.endsWith(" ") ? '' : ' ') +
             "This behavior has been deprecated. " +
-            "This behavior is scheduled to be removed in Gradle 9.0. " +
+            "This will fail with an error in Gradle 10.0. " +
             "Execution optimizations are disabled to ensure correctness. " +
             documentationRegistry.getDocumentationRecommendationFor("information", docId, section)
         executer.expectDocumentedDeprecationWarning(deprecationMessage)

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/InputPropertyAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/InputPropertyAnnotationHandler.java
@@ -37,7 +37,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Locale;
 
-import static org.gradle.api.problems.Severity.WARNING;
+import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.OPTIONAL;
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.REPLACES_EAGER_PROPERTY;
@@ -139,7 +139,7 @@ public class InputPropertyAnnotationHandler extends AbstractInputPropertyAnnotat
                     .id(TextUtil.screamingSnakeToKebabCase(UNSUPPORTED_VALUE_TYPE) + "-for-input", "Unsupported value type for @Input annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("has @Input annotation used on type '%s' or a property of this type", URL.class.getName()))
                     .documentedAt(userManual(VALIDATION_PROBLEMS, UNSUPPORTED_VALUE_TYPE.toLowerCase(Locale.ROOT)))
-                    .severity(WARNING)
+                    .severity(ERROR)
                     .details(String.format("Type '%s' is not supported on properties annotated with @Input because Java Serialization can be inconsistent for this type", URL.class.getName()))
                     .solution("Use type 'java.net.URI' instead")
             );

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart1IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart1IntegrationTest.groovy
@@ -542,25 +542,8 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
 
         expect:
         assertValidationFailsWith([
-            warning("""
-                Type 'MyTask' must be annotated either with @CacheableTask or with @DisableCachingByDefault.
-
-                Reason: The task author should make clear why a task is not cacheable.
-
-                Possible solutions:
-                  1. Add @DisableCachingByDefault(because = ...).
-                  2. Add @CacheableTask.
-                  3. Add @UntrackedTask(because = ...).
-            """.stripIndent(true).trim(), "validation_problems", "disable_caching_by_default"),
-            warning("""
-                Type 'MyTransformAction' must be annotated either with @CacheableTransform or with @DisableCachingByDefault.
-
-                Reason: The transform action author should make clear why a transform action is not cacheable.
-
-                Possible solutions:
-                  1. Add @DisableCachingByDefault(because = ...).
-                  2. Add @CacheableTransform.
-            """.stripIndent(true).trim(), "validation_problems", "disable_caching_by_default")
+            error(missingCachingAnnotationConfig { forTask().type("MyTask") }, "validation_problems", "disable_caching_by_default"),
+            error(missingCachingAnnotationConfig { forTransformAction().type("MyTransformAction") }, "validation_problems", "disable_caching_by_default")
         ])
 
          and:

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
@@ -76,13 +76,13 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         expect:
         executer.withArgument("-Dorg.gradle.internal.max.validation.errors=7")
         assertValidationFailsWith([
-            warning(unsupportedValueTypeConfig { type('MyTask').property('direct').propertyType('URL') }, "validation_problems", "unsupported_value_type"),
-            warning(unsupportedValueTypeConfig { type('MyTask').property('listPropertyInput').propertyType('ListProperty<URL>') }, "validation_problems", "unsupported_value_type"),
-            warning(unsupportedValueTypeConfig { type('MyTask').property('mapPropertyInput').propertyType('MapProperty<String, URL>') }, "validation_problems", "unsupported_value_type"),
-            warning(unsupportedValueTypeConfig { type('MyTask').property('nestedBean.nestedInput').propertyType('Property<URL>') }, "validation_problems", "unsupported_value_type"),
-            warning(unsupportedValueTypeConfig { type('MyTask').property('propertyInput').propertyType('Property<URL>') }, "validation_problems", "unsupported_value_type"),
-            warning(unsupportedValueTypeConfig { type('MyTask').property('providerInput').propertyType('Provider<URL>') }, "validation_problems", "unsupported_value_type"),
-            warning(unsupportedValueTypeConfig { type('MyTask').property('setPropertyInput').propertyType('SetProperty<URL>') }, "validation_problems", "unsupported_value_type"),
+            error(unsupportedValueTypeConfig { type('MyTask').property('direct').propertyType('URL') }, "validation_problems", "unsupported_value_type"),
+            error(unsupportedValueTypeConfig { type('MyTask').property('listPropertyInput').propertyType('ListProperty<URL>') }, "validation_problems", "unsupported_value_type"),
+            error(unsupportedValueTypeConfig { type('MyTask').property('mapPropertyInput').propertyType('MapProperty<String, URL>') }, "validation_problems", "unsupported_value_type"),
+            error(unsupportedValueTypeConfig { type('MyTask').property('nestedBean.nestedInput').propertyType('Property<URL>') }, "validation_problems", "unsupported_value_type"),
+            error(unsupportedValueTypeConfig { type('MyTask').property('propertyInput').propertyType('Property<URL>') }, "validation_problems", "unsupported_value_type"),
+            error(unsupportedValueTypeConfig { type('MyTask').property('providerInput').propertyType('Provider<URL>') }, "validation_problems", "unsupported_value_type"),
+            error(unsupportedValueTypeConfig { type('MyTask').property('setPropertyInput').propertyType('SetProperty<URL>') }, "validation_problems", "unsupported_value_type"),
         ])
 
         and:
@@ -643,7 +643,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         expect:
         executer.withArgument("-Dorg.gradle.internal.max.validation.errors=1")
         assertValidationFailsWith([
-            warning(nestedMapUnsupportedKeyTypeConfig { type('MyTask').property("mapWithUnsupportedKey").keyType("java.lang.Boolean") }, 'validation_problems', 'unsupported_key_type_of_nested_map'),
+            error(nestedMapUnsupportedKeyTypeConfig { type('MyTask').property("mapWithUnsupportedKey").keyType("java.lang.Boolean") }, 'validation_problems', 'unsupported_key_type_of_nested_map'),
         ])
 
         and:
@@ -683,7 +683,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         expect:
         def reason = "Type is in 'java.*' or 'javax.*' package that are reserved for standard Java API types."
         assertValidationFailsWith([
-            warning(nestedTypeUnsupportedConfig { type("MyTask").property("my$typeName").annotatedType(className).reason(reason) },
+            error(nestedTypeUnsupportedConfig { type("MyTask").property("my$typeName").annotatedType(className).reason(reason) },
                 'validation_problems', 'unsupported_nested_type'),
         ])
 
@@ -781,7 +781,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
 
         expect:
         assertValidationFailsWith([
-            warning(nestedTypeUnsupportedConfig { type("MyTask").property("my$typeName").annotatedType(className).reason(reason) },
+            error(nestedTypeUnsupportedConfig { type("MyTask").property("my$typeName").annotatedType(className).reason(reason) },
                 'validation_problems', 'unsupported_nested_type'),
         ])
 

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
@@ -54,7 +54,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.gradle.api.problems.Severity.WARNING;
+import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 public abstract class ValidateAction implements WorkAction<ValidateAction.Params> {
@@ -194,7 +194,7 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
                             .id(TextUtil.screamingSnakeToKebabCase(ValidationTypes.NOT_CACHEABLE_WITHOUT_REASON), "Not cacheable without reason", GradleCoreProblemGroup.validation().type())
                             .contextualLabel("must be annotated either with " + cacheableAnnotation + " or with " + disableCachingAnnotation)
                             .documentedAt(userManual("validation_problems", "disable_caching_by_default"))
-                            .severity(WARNING)
+                            .severity(ERROR)
                             .details("The " + workType + " author should make clear why a " + workType + " is not cacheable")
                             .solution("Add " + disableCachingAnnotation + "(because = ...)")
                             .solution("Add " + cacheableAnnotation);

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
@@ -46,12 +46,11 @@ public class DefaultWorkValidationWarningRecorder implements ValidateStep.Valida
             .collect(joining());
         LOGGER.warn("Execution optimizations have been disabled for {} to ensure correctness due to the following reasons:{}", work.getDisplayName(), uniqueWarnings);
 
-        warnings.forEach(warning -> {
-            withDocumentation(warning, deprecateBehaviour(convertToSingleLine(renderMinimalInformationAbout(warning, false, false)))
-                    .withContext("Execution optimizations are disabled to ensure correctness.")
-                    .willBecomeAnErrorInNextMajorGradleVersion())
-                    .nagUser();
-            }
+        warnings.forEach(warning -> withDocumentation(warning, deprecateBehaviour(convertToSingleLine(renderMinimalInformationAbout(warning, false, false)))
+            .withContext("Execution optimizations are disabled to ensure correctness.")
+            // Bump this to a next major version when we bump Gradle major version
+            .willBecomeAnErrorInGradle10())
+            .nagUser()
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
@@ -49,7 +49,7 @@ public class DefaultWorkValidationWarningRecorder implements ValidateStep.Valida
         warnings.forEach(warning -> {
             withDocumentation(warning, deprecateBehaviour(convertToSingleLine(renderMinimalInformationAbout(warning, false, false)))
                     .withContext("Execution optimizations are disabled to ensure correctness.")
-                    .willBecomeAnErrorInGradle10())
+                    .willBecomeAnErrorInNextMajorGradleVersion())
                     .nagUser();
             }
         );

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
@@ -49,7 +49,7 @@ public class DefaultWorkValidationWarningRecorder implements ValidateStep.Valida
         warnings.forEach(warning -> {
             withDocumentation(warning, deprecateBehaviour(convertToSingleLine(renderMinimalInformationAbout(warning, false, false)))
                     .withContext("Execution optimizations are disabled to ensure correctness.")
-                    .willBeRemovedInGradle9())
+                    .willBecomeAnErrorInGradle10())
                     .nagUser();
             }
         );

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
@@ -46,6 +46,7 @@ public class DefaultWorkValidationWarningRecorder implements ValidateStep.Valida
             .collect(joining());
         LOGGER.warn("Execution optimizations have been disabled for {} to ensure correctness due to the following reasons:{}", work.getDisplayName(), uniqueWarnings);
 
+        // We are logging all the warnings that we encountered during validation here
         warnings.forEach(warning -> withDocumentation(warning, deprecateBehaviour(convertToSingleLine(renderMinimalInformationAbout(warning, false, false)))
             .withContext("Execution optimizations are disabled to ensure correctness.")
             // Bump this to a next major version when we bump Gradle major version

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -66,9 +66,6 @@ public class DefaultNodeValidator implements NodeValidator {
     }
 
     private void logWarnings(List<? extends InternalProblem> problems) {
-        // We are logging the warnings that we encountered, so this should be always the next Gradle version.
-        // What should happen when preparing the next major version is to change warnings to errors, so that we
-        // can start adding new warnings.
         problems.stream()
             .filter(DefaultNodeValidator::isWarning)
             .forEach(problem -> {
@@ -78,7 +75,7 @@ public class DefaultNodeValidator implements NodeValidator {
                 String warning = convertToSingleLine(renderMinimalInformationAbout(problem, false, false));
                 withDocumentation(problem, DeprecationLogger.deprecateBehaviour(warning)
                     .withContext("Execution optimizations are disabled to ensure correctness.")
-                    .willBecomeAnErrorInGradle10())
+                    .willBecomeAnErrorInNextMajorGradleVersion())
                     .nagUser();
             });
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -66,6 +66,9 @@ public class DefaultNodeValidator implements NodeValidator {
     }
 
     private void logWarnings(List<? extends InternalProblem> problems) {
+        // We are logging the warnings that we encountered, so this should be always the next Gradle version.
+        // What should happen when preparing the next major version is to change warnings to errors, so that we
+        // can start adding new warnings.
         problems.stream()
             .filter(DefaultNodeValidator::isWarning)
             .forEach(problem -> {
@@ -75,7 +78,7 @@ public class DefaultNodeValidator implements NodeValidator {
                 String warning = convertToSingleLine(renderMinimalInformationAbout(problem, false, false));
                 withDocumentation(problem, DeprecationLogger.deprecateBehaviour(warning)
                     .withContext("Execution optimizations are disabled to ensure correctness.")
-                    .willBeRemovedInGradle9())
+                    .willBecomeAnErrorInGradle10())
                     .nagUser();
             });
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -66,6 +66,7 @@ public class DefaultNodeValidator implements NodeValidator {
     }
 
     private void logWarnings(List<? extends InternalProblem> problems) {
+        // We are logging all the warnings that we encountered during validation here
         problems.stream()
             .filter(DefaultNodeValidator::isWarning)
             .forEach(problem -> {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -75,7 +75,8 @@ public class DefaultNodeValidator implements NodeValidator {
                 String warning = convertToSingleLine(renderMinimalInformationAbout(problem, false, false));
                 withDocumentation(problem, DeprecationLogger.deprecateBehaviour(warning)
                     .withContext("Execution optimizations are disabled to ensure correctness.")
-                    .willBecomeAnErrorInNextMajorGradleVersion())
+                    // Bump this to a next major version when we bump Gradle major version
+                    .willBecomeAnErrorInGradle10())
                     .nagUser();
             });
     }


### PR DESCRIPTION
Changes:
- Change unsupported `@Nested` types from WARNING to ERROR
- Change unsupported `@Nested` Map key types from WARNING to ERROR
- Change URL as input from WARNING to ERROR
- Change missing cachability annotation for tasks and artifact transforms from WARNING to ERROR
- Any validation warnings now nags that it will become an error in  Gradle 10 instead of Gradle 9