### PR TITLE
Upgrade Kotlin again for Milestone 5

### DIFF
--- a/build-logic-commons/basics/build.gradle.kts
+++ b/build-logic-commons/basics/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
         because("Used by class analysis")
     }
 
-    implementation(kotlin("compiler-embeddable") as String) {
+    compileOnly(kotlin("compiler-embeddable") as String) {
         because("Required by KotlinSourceParser")
     }
     implementation(kotlin("gradle-plugin") as String) {

--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -15,9 +15,9 @@ dependencies {
     implementation(projects.moduleIdentity)
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:4.1.0")
 
-    implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:5.2.0")
+    implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:6.1.0")
     // This Kotlin version should only be updated when updating the above kotlin-dsl version
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21-RC")
     implementation("org.gradle:test-retry-gradle-plugin:1.5.2")
 
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.7")

--- a/build-logic/binary-compatibility/build.gradle.kts
+++ b/build-logic/binary-compatibility/build.gradle.kts
@@ -8,6 +8,7 @@ description = "Provides a plugin for configuring japicmp-gradle-plugin to detect
 dependencies {
     api("me.champeau.gradle:japicmp-gradle-plugin")
 
+    implementation(projects.dependencyModules)
     implementation("gradlebuild:basics")
     implementation("gradlebuild:module-identity")
 
@@ -18,7 +19,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm")
     implementation("org.jspecify:jspecify")
     implementation("org.ow2.asm:asm")
-    implementation(kotlin("compiler-embeddable"))
+    compileOnly(kotlin("compiler-embeddable"))
 
     testImplementation("org.jsoup:jsoup")
     testImplementation("org.junit.jupiter:junit-jupiter-engine")

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/JapicmpTask.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/JapicmpTask.java
@@ -16,6 +16,7 @@
 
 package gradlebuild.binarycompatibility;
 
+import gradlebuild.modules.extension.ExternalModulesExtension;
 import japicmp.filter.Filter;
 import me.champeau.gradle.japicmp.JApiCmpWorkAction;
 import me.champeau.gradle.japicmp.JApiCmpWorkerAction;
@@ -80,6 +81,7 @@ public abstract class JapicmpTask extends DefaultTask {
         if (GradleVersion.current().compareTo(GradleVersion.version("6.0")) >= 0) {
             classpath.from(resolveGuava());
         }
+        classpath.from(resolveKotlinCompilerEmbeddable());
         additionalJapicmpClasspath = classpath;
     }
 
@@ -184,6 +186,15 @@ public abstract class JapicmpTask extends DefaultTask {
         DependencyHandler dependencies = project.getDependencies();
         return project.getConfigurations().detachedConfiguration(
                 dependencies.create("com.google.guava:guava:30.1.1-jre")
+        );
+    }
+
+    private Configuration resolveKotlinCompilerEmbeddable() {
+        Project project = getProject();
+        DependencyHandler dependencies = project.getDependencies();
+        String kotlinVersion = new ExternalModulesExtension(true) {}.getKotlinVersion();
+        return project.getConfigurations().detachedConfiguration(
+            dependencies.create("org.jetbrains.kotlin:kotlin-compiler-embeddable:" + kotlinVersion)
         );
     }
 

--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/metadata/HasKotlinFlagsMetadataQuery.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/metadata/HasKotlinFlagsMetadataQuery.kt
@@ -41,7 +41,6 @@ fun KotlinClassMetadata.hasAttribute(memberType: MemberType, jvmSignature: Strin
         is KotlinClassMetadata.MultiFileClassFacade -> false
         is KotlinClassMetadata.SyntheticClass -> false
         is KotlinClassMetadata.Unknown -> false
-        else -> error("Unsupported Kotlin metadata type '${this::class}'")
     }
 
 

--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/sources/SourcesRepository.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/sources/SourcesRepository.kt
@@ -34,6 +34,7 @@ sealed class ApiSourceFile {
     internal
     abstract val currentSourceRoot: File
 
+    @ConsistentCopyVisibility
     data class Java internal constructor(
 
         override val currentFile: File,
@@ -42,6 +43,7 @@ sealed class ApiSourceFile {
 
     ) : ApiSourceFile()
 
+    @ConsistentCopyVisibility
     data class Kotlin internal constructor(
 
         override val currentFile: File,

--- a/build-logic/buildquality/build.gradle.kts
+++ b/build-logic/buildquality/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(projects.performanceTesting)
     implementation(projects.profiling)
     implementation(projects.binaryCompatibility)
+    implementation(projects.dependencyModules)
 
     implementation("org.codenarc:CodeNarc") {
         exclude(group = "org.apache.groovy")
@@ -22,7 +23,7 @@ dependencies {
         exclude(group = "com.google.guava")
     }
     implementation(kotlin("gradle-plugin"))
-    implementation(kotlin("compiler-embeddable") as String) {
+    compileOnly(kotlin("compiler-embeddable") as String) {
         because("Required by IncubatingApiReportTask")
     }
     implementation("com.gradle:develocity-gradle-plugin") {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -120,7 +120,7 @@ fun enforceCompatibility(gradleModule: UnitTestAndCompileExtension) {
     // When using the release flag, compiled code cannot access JDK internal classes or standard library
     // APIs defined in future versions of Java. If either of these cases are true, we do not use the
     // release flag, but instead set the source and target compatibility flags.
-    val useRelease = this.gradleModule.usesJdkInternals.zip(this.gradleModule.usesFutureStdlib) { internals, futureApis -> !internals && !futureApis }
+    val useRelease = gradleModule.usesJdkInternals.zip(gradleModule.usesFutureStdlib) { internals, futureApis -> !internals && !futureApis }
 
     val productionJvmVersion = gradleModule.computeProductionJvmTargetVersion()
 

--- a/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
@@ -209,7 +209,7 @@ plugins.withType(KotlinBaseApiPlugin::class) {
 val compileGradleApiKotlinExtensions = tasks.named("compileGradleApiKotlinExtensions", KotlinCompile::class) {
     configureKotlinCompilerForGradleBuild()
     multiPlatformEnabled = false
-    moduleName = "gradle-kotlin-dsl-extensions"
+    compilerOptions.moduleName = "gradle-kotlin-dsl-extensions"
     source(gradleApiKotlinExtensions)
     libraries.from(runtimeClasspath)
     destinationDirectory = layout.buildDirectory.dir("classes/kotlin-dsl-extensions")

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/transforms/InstrumentationMetadataTransform.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/transforms/InstrumentationMetadataTransform.kt
@@ -95,9 +95,7 @@ abstract class InstrumentationMetadataTransform : TransformAction<TransformParam
     private
     fun handleClassChange(change: FileChange, superTypes: Properties) {
         val className = change.normalizedPath.removeSuffix(".class")
-        // TODO this is a bug in Kotlin 2.0.21 that is fixed in 2.1, remove once upgraded
-        @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
-        when (change.changeType!!) {
+        when (change.changeType) {
             ADDED, MODIFIED -> {
                 // Add also className itself, so we collect all classes
                 val classSuperTypes = (change.file.getClassSuperTypes() + className).filter { it.startsWith("org/gradle") }
@@ -109,8 +107,7 @@ abstract class InstrumentationMetadataTransform : TransformAction<TransformParam
 
     private
     fun handleInstrumentedMetadataFileChange(change: FileChange): MetadataFileChange {
-        @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
-        return when (change.changeType!!) {
+        return when (change.changeType) {
             ADDED, MODIFIED -> MetadataModified(change.file)
             REMOVED -> MetadataRemoved
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-milestone-4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     docsTestImplementation(project(":logging"))
     docsTestImplementation(libs.junit5Vintage)
     docsTestImplementation(libs.junit)
+    docsTestRuntimeOnly(libs.junitPlatform)
 
     integTestDistributionRuntimeOnly(project(":distributions-full"))
 }


### PR DESCRIPTION
This reverts commit https://github.com/gradle/gradle/commit/ad8b92fc649c0f2efe95287bc43e61a5c0cf618a, reversing changes made to https://github.com/gradle/gradle/commit/9feb42a80d8753cbd35b3bd8614abe17b0981768.

Essentially re-apply #33112

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
