### PR TITLE
Remove convention mapping usage of already removed `ConfigurableReport.destination`

### DIFF
--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultSingleFileReport.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultSingleFileReport.java
@@ -18,24 +18,16 @@ package org.gradle.api.reporting.internal;
 
 import org.gradle.api.Describable;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.internal.IConventionAware;
-import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.internal.Describables;
 
 import javax.inject.Inject;
-import java.io.File;
 
 public abstract class DefaultSingleFileReport extends SimpleReport implements SingleFileReport {
 
     @Inject
     public DefaultSingleFileReport(String name, Describable owner) {
         super(name, Describables.of(name, "report for", owner), OutputType.FILE);
-        // This is for backwards compatibility for plugins that attach a convention mapping to the replaced property
-        // TODO - this wiring should happen automatically (and be deprecated too)
-        getOutputLocation().convention(getProjectLayout().file(new DefaultProvider<>(() -> {
-            return (File) ((IConventionAware) DefaultSingleFileReport.this).getConventionMapping().getConventionValue(null, "destination", false);
-        })));
         getRequired().convention(false);
     }
 

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/SingleDirectoryReport.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/SingleDirectoryReport.java
@@ -18,8 +18,6 @@ package org.gradle.api.reporting.internal;
 
 import org.gradle.api.Describable;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.internal.IConventionAware;
-import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.internal.Describables;
 import org.jspecify.annotations.Nullable;
@@ -36,9 +34,6 @@ public abstract class SingleDirectoryReport extends SimpleReport implements Dire
     public SingleDirectoryReport(String name, Describable owner, @Nullable String relativeEntryPath) {
         super(name, Describables.of(name, "report for", owner), OutputType.DIRECTORY);
         this.relativeEntryPath = relativeEntryPath;
-        getOutputLocation().convention(getProjectLayout().dir(new DefaultProvider<>(() -> {
-            return (File) ((IConventionAware) SingleDirectoryReport.this).getConventionMapping().getConventionValue(null, "destination", false);
-        })));
         getRequired().convention(false);
     }
 


### PR DESCRIPTION

* Follows up https://github.com/gradle/gradle/pull/33232

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
