### PR TITLE
Don't say "Gradle process" around file locks

### DIFF
--- a/platforms/core-execution/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
@@ -316,7 +316,7 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
     }
 
     void assertConfirmationCount(GradleHandle build, FileLock lock = receivingLock) {
-        assert (build.standardOutput =~ "Gradle process at port ${communicator.port} confirmed unlock request for lock with id ${lock.lockId}.").count == 1
+        assert (build.standardOutput =~ "Process at port ${communicator.port} confirmed unlock request for lock with id ${lock.lockId}.").count == 1
     }
 
     void assertReleaseSignalTriggered(GradleHandle build, FileLock lock = receivingLock) {

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -370,10 +370,10 @@ public class DefaultFileLockManager implements FileLockManager {
 
         private LockTimeoutException timeoutException(String lockDisplayName, String thisOperation, File lockFile, String thisProcessPid, FileLockOutcome fileLockOutcome, LockInfo lockInfo) {
             if (fileLockOutcome == FileLockOutcome.LOCKED_BY_ANOTHER_PROCESS) {
-                String message = String.format("Timeout waiting to lock %s. It is currently in use by another Gradle instance.%nOwner PID: %s%nOur PID: %s%nOwner Operation: %s%nOur operation: %s%nLock file: %s", lockDisplayName, lockInfo.pid, thisProcessPid, lockInfo.operation, thisOperation, lockFile);
+                String message = String.format("Timeout waiting to lock %s. It is currently in use by another process.%nOwner PID: %s%nOur PID: %s%nOwner Operation: %s%nOur operation: %s%nLock file: %s", lockDisplayName, lockInfo.pid, thisProcessPid, lockInfo.operation, thisOperation, lockFile);
                 return new LockTimeoutException(message, lockFile);
             } else if (fileLockOutcome == FileLockOutcome.LOCKED_BY_THIS_PROCESS){
-                String message = String.format("Timeout waiting to lock %s. It is currently in use by this Gradle process.Owner Operation: %s%nOur operation: %s%nLock file: %s", lockDisplayName, lockInfo.operation, thisOperation, lockFile);
+                String message = String.format("Timeout waiting to lock %s. It is currently in use by this process. Owner Operation: %s%nOur operation: %s%nLock file: %s", lockDisplayName, lockInfo.operation, thisOperation, lockFile);
                 return new LockTimeoutException(message, lockFile);
             } else {
                 throw new IllegalArgumentException("Unexpected lock outcome: " + fileLockOutcome);
@@ -426,10 +426,10 @@ public class DefaultFileLockManager implements FileLockManager {
                             }
                             if (fileLockContentionHandler.maybePingOwner(lockInfo.port, lockInfo.lockId, displayName, backoff.getTimer().getElapsedMillis() - lastPingTime, backoff.getSignal())) {
                                 lastPingTime = backoff.getTimer().getElapsedMillis();
-                                LOGGER.debug("The file lock for {} is held by a different Gradle process (pid: {}, lockId: {}). Pinged owner at port {}", displayName, lockInfo.pid, lockInfo.lockId, lockInfo.port);
+                                LOGGER.debug("The file lock for {} is held by a different process (pid: {}, lockId: {}). Pinged owner at port {}", displayName, lockInfo.pid, lockInfo.lockId, lockInfo.port);
                             }
                         } else {
-                            LOGGER.debug("The file lock for {} is held by a different Gradle process. I was unable to read on which port the owner listens for lock access requests.", displayName);
+                            LOGGER.debug("The file lock for {} is held by a different process. I was unable to read on which port the owner listens for lock access requests.", displayName);
                         }
                     }
                     return ExponentialBackoff.Result.notSuccessful(lockOutcome);

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockCommunicator.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockCommunicator.java
@@ -87,11 +87,11 @@ public class DefaultFileLockCommunicator implements FileLockCommunicator {
         byte[] bytes = FileLockPacketPayload.encode(lockId, UNLOCK_REQUEST_CONFIRMATION);
         DatagramPacket packet = new DatagramPacket(bytes, bytes.length);
         packet.setSocketAddress(requesterAddress);
-        LOGGER.debug("Confirming unlock request to Gradle process at port {} for lock with id {}.", packet.getPort(), lockId);
+        LOGGER.debug("Confirming unlock request to process at port {} for lock with id {}.", packet.getPort(), lockId);
         try {
             socket.send(packet);
         } catch (IOException e) {
-            LOGGER.debug("Failed to confirm unlock request to Gradle process at port {} for lock with id {}.", packet.getPort(), lockId);
+            LOGGER.debug("Failed to confirm unlock request to process at port {} for lock with id {}.", packet.getPort(), lockId);
         }
     }
 
@@ -101,11 +101,11 @@ public class DefaultFileLockCommunicator implements FileLockCommunicator {
         for (SocketAddress requesterAddress : requesterAddresses) {
             DatagramPacket packet = new DatagramPacket(bytes, bytes.length);
             packet.setSocketAddress(requesterAddress);
-            LOGGER.debug("Confirming lock release to Gradle process at port {} for lock with id {}.", packet.getPort(), lockId);
+            LOGGER.debug("Confirming lock release to process at port {} for lock with id {}.", packet.getPort(), lockId);
             try {
                 socket.send(packet);
             } catch (IOException e) {
-                LOGGER.debug("Failed to confirm lock release to Gradle process at port {} for lock with id {}.", packet.getPort(), lockId);
+                LOGGER.debug("Failed to confirm lock release to process at port {} for lock with id {}.", packet.getPort(), lockId);
             }
         }
     }

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandler.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandler.java
@@ -176,14 +176,14 @@ public class DefaultFileLockContentionHandler implements FileLockContentionHandl
     private void acceptConfirmationAsLockRequester(FileLockPacketPayload payload, Integer port) {
         long lockId = payload.getLockId();
         if (payload.getType() == LOCK_RELEASE_CONFIRMATION) {
-            LOGGER.debug("Gradle process at port {} confirmed lock release for lock with id {}.", port, lockId);
+            LOGGER.debug("Process at port {} confirmed lock release for lock with id {}.", port, lockId);
             FileLockReleasedSignal signal = lockReleasedSignals.get(lockId);
             if (signal != null) {
                 LOGGER.debug("Triggering lock release signal for lock with id {}.", lockId);
                 signal.trigger();
             }
         } else {
-            LOGGER.debug("Gradle process at port {} confirmed unlock request for lock with id {}.", port, lockId);
+            LOGGER.debug("Process at port {} confirmed unlock request for lock with id {}.", port, lockId);
             unlocksConfirmedFrom.put(lockId, port);
         }
     }


### PR DESCRIPTION
This code is used outside of Gradle (in Maven cache extension etc.) and saying Gradle specifically can be confusing. These are low-level error messages about lock files where the name of the process does not add anything anyway.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
