### PR TITLE
Fix branch filter of NightlyDocumentation job

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/PublishNightlyDocumentation.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlyDocumentation.kt
@@ -46,8 +46,7 @@ class PublishNightlyDocumentation(
                     // https://www.jetbrains.com/help/teamcity/2022.04/configuring-schedule-triggers.html#general-syntax-1
                     // We want it to be triggered only when there're pending changes in the specific vcs root, i.e. GradleMaster/GradleRelease
                     triggerRules = "+:root=${VersionedSettingsBranch.fromDslContext().vcsRootId()}:."
-                    // The promotion itself will be triggered on gradle-promote's master branch
-                    branchFilter = "+:master"
+                    branchFilter = "+:<default>"
                 }
             }
         }


### PR DESCRIPTION
We found that [Nightly Documentation job](https://builds.gradle.org/buildConfiguration/Gradle_Release_Promotion_NightlyDocumentation) hasn't been triggered for a while, even though there are new commits in `release` branch. This PR should fix it by using the correct branch filter.