### PR TITLE
Replace signing plugin convention mappings with property fields

### DIFF
--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -73,7 +73,7 @@ import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
 @DisableCachingByDefault(because = "Not made cacheable, yet")
 public abstract class Sign extends DefaultTask implements SignatureSpec {
 
-    private SignatureType signatureType;
+    final Property<SignatureType> signatureType;
     private Signatory signatory;
     final Property<Boolean> required;
     private final Transient<DomainObjectSet<Signature>> signatures = Transient.of(getProject().getObjects().domainObjectSet(Signature.class));
@@ -97,6 +97,7 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
 
     @Inject
     public Sign() {
+        signatureType = getProject().getObjects().property(SignatureType.class);
         required = getProject().getObjects().property(Boolean.class).convention(true);
         // If we aren't required and don't have a signatory then we just don't run
         onlyIf("Signing is required, or signatory is set", spec(task -> isRequired() || getSignatory() != null));
@@ -348,12 +349,12 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
     @Nested
     @Optional
     public SignatureType getSignatureType() {
-        return signatureType;
+        return signatureType.getOrNull();
     }
 
     @Override
     public void setSignatureType(SignatureType signatureType) {
-        this.signatureType = signatureType;
+        this.signatureType.set(signatureType);
     }
 
     /**

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -74,7 +74,7 @@ import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
 public abstract class Sign extends DefaultTask implements SignatureSpec {
 
     final Property<SignatureType> signatureType;
-    private Signatory signatory;
+    final Property<Signatory> signatory;
     final Property<Boolean> required;
     private final Transient<DomainObjectSet<Signature>> signatures = Transient.of(getProject().getObjects().domainObjectSet(Signature.class));
 
@@ -98,6 +98,7 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
     @Inject
     public Sign() {
         signatureType = getProject().getObjects().property(SignatureType.class);
+        signatory = getProject().getObjects().property(Signatory.class);
         required = getProject().getObjects().property(Boolean.class).convention(true);
         // If we aren't required and don't have a signatory then we just don't run
         onlyIf("Signing is required, or signatory is set", spec(task -> isRequired() || getSignatory() != null));
@@ -214,7 +215,7 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
      * Changes the signatory of the signatures.
      */
     public void signatory(Signatory signatory) {
-        this.signatory = signatory;
+        this.signatory.set(signatory);
     }
 
     /**
@@ -366,12 +367,12 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
     @Nested
     @Optional
     public Signatory getSignatory() {
-        return signatory;
+        return signatory.getOrNull();
     }
 
     @Override
     public void setSignatory(Signatory signatory) {
-        this.signatory = signatory;
+        this.signatory.set(signatory);
     }
 
     /**

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationArtifact;
 import org.gradle.api.publish.internal.PublicationInternal;
@@ -74,7 +75,7 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
 
     private SignatureType signatureType;
     private Signatory signatory;
-    private boolean required = true;
+    final Property<Boolean> required;
     private final Transient<DomainObjectSet<Signature>> signatures = Transient.of(getProject().getObjects().domainObjectSet(Signature.class));
 
     private final Cached<Collection<Signature.Generator>> generators = Cached.of(this::computeCachedSignatures);
@@ -96,6 +97,7 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
 
     @Inject
     public Sign() {
+        required = getProject().getObjects().property(Boolean.class).convention(true);
         // If we aren't required and don't have a signatory then we just don't run
         onlyIf("Signing is required, or signatory is set", spec(task -> isRequired() || getSignatory() != null));
     }
@@ -380,12 +382,12 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
     @Input
     @ToBeReplacedByLazyProperty
     public boolean isRequired() {
-        return required;
+        return required.get();
     }
 
     @Override
     public void setRequired(boolean required) {
-        this.required = required;
+        this.required.set(required);
     }
 
     /**

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SignOperation.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SignOperation.java
@@ -19,6 +19,8 @@ import com.google.common.base.Function;
 import groovy.lang.Closure;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.plugins.signing.signatory.Signatory;
@@ -51,9 +53,13 @@ abstract public class SignOperation implements SignatureSpec {
     /**
      * Whether or not it is required that this signature be generated.
      */
-    private boolean required;
+    final Property<Boolean> required;
 
     private final List<Signature> signatures = new ArrayList<Signature>();
+
+    protected SignOperation(ObjectFactory objects) {
+        required = objects.property(Boolean.class).convention(false);
+    }
 
     @ToBeReplacedByLazyProperty
     public String getDisplayName() {
@@ -89,13 +95,13 @@ abstract public class SignOperation implements SignatureSpec {
 
     @Override
     public void setRequired(boolean required) {
-        this.required = required;
+        this.required.set(required);
     }
 
     @Override
     @ToBeReplacedByLazyProperty
     public boolean isRequired() {
-        return required;
+        return required.get();
     }
 
     /**

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SignOperation.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SignOperation.java
@@ -43,7 +43,7 @@ abstract public class SignOperation implements SignatureSpec {
     /**
      * The file representation of the signature(s).
      */
-    private SignatureType signatureType;
+    final Property<SignatureType> signatureType;
 
     /**
      * The signatory to the generated digital signatures.
@@ -58,6 +58,7 @@ abstract public class SignOperation implements SignatureSpec {
     private final List<Signature> signatures = new ArrayList<Signature>();
 
     protected SignOperation(ObjectFactory objects) {
+        signatureType = objects.property(SignatureType.class);
         required = objects.property(Boolean.class).convention(false);
     }
 
@@ -73,13 +74,13 @@ abstract public class SignOperation implements SignatureSpec {
 
     @Override
     public void setSignatureType(SignatureType signatureType) {
-        this.signatureType = signatureType;
+        this.signatureType.set(signatureType);
     }
 
     @Override
     @ToBeReplacedByLazyProperty
     public SignatureType getSignatureType() {
-        return signatureType;
+        return signatureType.getOrNull();
     }
 
     @Override
@@ -147,7 +148,7 @@ abstract public class SignOperation implements SignatureSpec {
      * Change the signature type for signature generation.
      */
     public SignOperation signatureType(SignatureType type) {
-        this.signatureType = type;
+        this.signatureType.set(type);
         return this;
     }
 

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SignOperation.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SignOperation.java
@@ -48,7 +48,7 @@ abstract public class SignOperation implements SignatureSpec {
     /**
      * The signatory to the generated digital signatures.
      */
-    private Signatory signatory;
+    final Property<Signatory> signatory;
 
     /**
      * Whether or not it is required that this signature be generated.
@@ -59,6 +59,7 @@ abstract public class SignOperation implements SignatureSpec {
 
     protected SignOperation(ObjectFactory objects) {
         signatureType = objects.property(SignatureType.class);
+        signatory = objects.property(Signatory.class);
         required = objects.property(Boolean.class).convention(false);
     }
 
@@ -85,13 +86,13 @@ abstract public class SignOperation implements SignatureSpec {
 
     @Override
     public void setSignatory(Signatory signatory) {
-        this.signatory = signatory;
+        this.signatory.set(signatory);
     }
 
     @Override
     @ToBeReplacedByLazyProperty
     public Signatory getSignatory() {
-        return signatory;
+        return signatory.getOrNull();
     }
 
     @Override
@@ -156,7 +157,7 @@ abstract public class SignOperation implements SignatureSpec {
      * Change the signatory for signature generation.
      */
     public SignOperation signatory(Signatory signatory) {
-        this.signatory = signatory;
+        this.signatory.set(signatory);
         return this;
     }
 

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -305,11 +305,14 @@ public abstract class SigningExtension {
 
         ConventionMapping conventionMapping = ((IConventionAware) spec).getConventionMapping();
         conventionMapping.map("signatory", this::getSignatory);
-        conventionMapping.map("signatureType", this::getSignatureType);
         if (spec instanceof Sign) {
-            ((Sign) spec).required.convention(this.required);
+            Sign signTask = (Sign) spec;
+            signTask.signatureType.convention(project.provider(this::getSignatureType));
+            signTask.required.convention(this.required);
         } else if (spec instanceof SignOperation) {
-            ((SignOperation) spec).required.convention(this.required);
+            SignOperation signOperation = (SignOperation) spec;
+            signOperation.signatureType.convention(project.provider(this::getSignatureType));
+            signOperation.required.convention(this.required);
         } else {
             throw new InvalidUserDataException("Cannot add conventions to signature spec '" + spec + "' as it is not a Sign or SignOperation");
         }

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -25,8 +25,6 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.internal.ConventionMapping;
-import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
@@ -299,19 +297,15 @@ public abstract class SigningExtension {
      * Adds conventions to the given spec, using this settings object's default signatory and signature type as the default signatory and signature type for the spec.
      */
     protected void addSignatureSpecConventions(SignatureSpec spec) {
-        if (!(spec instanceof IConventionAware)) {
-            throw new InvalidUserDataException("Cannot add conventions to signature spec '" + spec + "' as it is not convention aware");
-        }
-
-        ConventionMapping conventionMapping = ((IConventionAware) spec).getConventionMapping();
-        conventionMapping.map("signatory", this::getSignatory);
         if (spec instanceof Sign) {
             Sign signTask = (Sign) spec;
             signTask.signatureType.convention(project.provider(this::getSignatureType));
+            signTask.signatory.convention(project.provider(this::getSignatory));
             signTask.required.convention(this.required);
         } else if (spec instanceof SignOperation) {
             SignOperation signOperation = (SignOperation) spec;
             signOperation.signatureType.convention(project.provider(this::getSignatureType));
+            signOperation.signatory.convention(project.provider(this::getSignatory));
             signOperation.required.convention(this.required);
         } else {
             throw new InvalidUserDataException("Cannot add conventions to signature spec '" + spec + "' as it is not a Sign or SignOperation");

--- a/platforms/software/signing/src/main/java/org/gradle/plugins/signing/internal/SignOperationInternal.java
+++ b/platforms/software/signing/src/main/java/org/gradle/plugins/signing/internal/SignOperationInternal.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.signing.internal;
 
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.plugins.signing.SignOperation;
 
 import javax.inject.Inject;
@@ -28,7 +29,8 @@ public class SignOperationInternal extends SignOperation {
     private final ProjectLayout projectLayout;
 
     @Inject
-    public SignOperationInternal(ProjectLayout projectLayout) {
+    public SignOperationInternal(ObjectFactory objects, ProjectLayout projectLayout) {
+        super(objects);
         this.projectLayout = projectLayout;
     }
 


### PR DESCRIPTION
This is part of getting rid of conventions for Gradle 9.0.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
