### PR TITLE
Spike of "not supported at execution time" warning

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/StableConfigurationCacheUnsupportedApiManagerAction.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/StableConfigurationCacheUnsupportedApiManagerAction.kt
@@ -78,6 +78,15 @@ class StableConfigurationCacheUnsupportedApiManagerAction(
             }
         }
 
+        override fun onConfigurationOnlyStateAccess(invocationDescription: String, task: TaskInternal) {
+            if (featureFlags.isEnabled(FeaturePreviews.Feature.STABLE_CONFIGURATION_CACHE)) {
+                DeprecationLogger.deprecateAction("Accessing configuration-time only task state using $invocationDescription() at execution time")
+                    .willBecomeAnErrorInGradle9()
+                    .undocumented()
+                    .nagUser()
+            }
+        }
+
         private
         fun throwUnsupported(reason: String): Nothing =
             throw UnsupportedOperationException("$reason is unsupported with the STABLE_CONFIGURATION_CACHE feature preview.")

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheProblemsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheProblemsListener.kt
@@ -71,6 +71,13 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
         onTaskExecutionAccessProblem(invocationDescription, task)
     }
 
+    override fun onConfigurationOnlyStateAccess(invocationDescription: String, task: TaskInternal) {
+        if (atConfigurationTime()) {
+            return
+        }
+        onTaskExecutionAccessProblem(invocationDescription, task)
+    }
+
     override fun onExternalProcessStarted(command: String, consumer: String?) {
         if (!isStableConfigurationCacheEnabled() || !atConfigurationTime() || isExecutingTask() || isInputTrackingDisabled()) {
             return

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -1044,16 +1044,27 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         return getServices().get(BuildServiceRegistryInternal.class);
     }
 
+    @Override
+    public void notifyConfigurationOnlyStateAccess(String invocationDescription) {
+        if (isAtExecutionTime()) {
+            getTaskExecutionAccessBroadcaster().onConfigurationOnlyStateAccess(invocationDescription, this);
+        }
+    }
+
     private void notifyProjectAccess() {
-        if (state.getExecuting()) {
+        if (isAtExecutionTime()) {
             getTaskExecutionAccessBroadcaster().onProjectAccess("Task.project", this);
         }
     }
 
     private void notifyTaskDependenciesAccess(String invocationDescription) {
-        if (state.getExecuting()) {
+        if (isAtExecutionTime()) {
             getTaskExecutionAccessBroadcaster().onTaskDependenciesAccess(invocationDescription, this);
         }
+    }
+
+    private boolean isAtExecutionTime() {
+        return state.getExecuting();
     }
 
     private TaskExecutionAccessListener getTaskExecutionAccessBroadcaster() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -121,4 +121,13 @@ public interface TaskInternal extends Task, Configurable<Task> {
      */
     @Internal
     TaskDependency getLifecycleDependencies();
+
+    /**
+     * Called before accessing the state that is only accessible at configuration time.
+     * Typical use is to guard calls to the transient state that isn't available after restoring the task from the configuration cache.
+     * Calls to this method at execution time may yield a deprecation warning or a configuration cache problem.
+     *
+     * @param invocationDescription the description of the invocation, e.g. `TaskClass.methodName`, without trailing parentheses
+     */
+    void notifyConfigurationOnlyStateAccess(String invocationDescription);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecutionAccessListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecutionAccessListener.java
@@ -33,4 +33,9 @@ public interface TaskExecutionAccessListener {
      * Called when accessing task dependencies during task execution.
      */
     void onTaskDependenciesAccess(String invocationDescription, TaskInternal task);
+
+    /**
+     * Called when accessing task configuration-only state during task execution.
+     */
+    void onConfigurationOnlyStateAccess(String invocationDescription, TaskInternal task);
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
@@ -67,6 +67,7 @@ public abstract class PublishToMavenRepository extends AbstractPublishToMaven {
      */
     @Internal
     public MavenArtifactRepository getRepository() {
+        notifyConfigurationOnlyStateAccess("PublishToMavenRepository.getRepository");
         return repository.get();
     }
 


### PR DESCRIPTION
Certain task APIs are only meant for configuration time, so we should emit an error when someone tries to use these APIs at the execution time. In most cases, this usage will result in hard failure afterwards, because the state is not fully restored when running from the cache.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
