### PR TITLE
Fix build_file_basics.adoc example code and text conflicting

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/build_file_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/build_file_basics.adoc
@@ -99,7 +99,7 @@ include::sample[dir="snippets/init/generated/kotlin",files="app/build.gradle.kts
 include::sample[dir="snippets/init/generated/groovy",files="app/build.gradle[tags=init-app]"]
 ====
 
-In this example, the main class (i.e., the point where the program's execution begins) is `com.example.Main`.
+In this example, the main class (i.e., the point where the program's execution begins) is `org.example.App`.
 
 Build scripts are evaluated during the configuration phase of a build, and they serve as the main entry point for defining a (sub)project’s build logic.
 In addition to applying plugins and setting convention properties, build scripts can:


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Same as #33340.
I screwed the history of patch-1 and it didn't let me reopen after I fixed it.

https://docs.gradle.org/current/userguide/build_file_basics.html#3_use_convention_properties
Snippet says `mainClass = "org.example.App"` but text says "In this example, the main class (i.e., the point where the program’s execution begins) is `com.example.Main`."
This 7 character PR fixes that in favor of the snippet. Sorry, it was opened via github webeditor. So I didn't see all that coming and have no clue how to comply to all the requirements. Feel free to just incorporate this change into any other PR by any means and just close this one.
<!-- Fixes #? -->
https://github.com/gradle/gradle/pull/33340

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
