### PR TITLE
Fix flaky JavaCrossCompilationIntegrationTest

### DIFF
--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.integtests.fixtures.jvm.TestJavaClassUtil
 import org.gradle.internal.FileUtils
+import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.serialize.JavaClassUtil
 import org.gradle.test.fixtures.archive.JarTestFixture
 
@@ -64,6 +65,9 @@ class JavaCrossCompilationIntegrationTest extends AbstractIntegrationSpec implem
     }
 
     def "can build and run application using Java #jdk.javaVersionMajor"() {
+        if (jdk.javaVersionMajor == Jvm.current().javaVersionMajor) {
+            jdk = Jvm.current()
+        }
         given:
         buildFile << """
             plugins {


### PR DESCRIPTION
Smilar to https://github.com/gradle/gradle/pull/33258,  if there are more than 1 installations found in the test, it will fail. This PR makes it more robust if there is more than one installations found per major java version.