### PR TITLE
Remove deprecated auto-apply flag for Dependency Analysis plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,5 +29,3 @@ systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 defaultPerformanceBaselines=9.0-commit-2dfe6ab67ab6c
 #-----------------------------------------till here^
 systemProp.dependency.analysis.test.analysis=false
-# Disable automatic recursive application of the plugin to subprojects
-dependency.analysis.autoapply=false


### PR DESCRIPTION
We recently upgraded from 1.x to 2.x version of the plugin, where the auto-apply feature was deprecated. Since we didn't want the auto-apply for IP-related reasons, we can simply drop the flag

Before this change, the plugin [writes](https://ge.gradle.org/s/rew7w5br2rpoo/console-log?page=1#L166) a warning to the console:
```
dependency.analysis.autoapply is set to false, but this is now the only behavior, and the flag has no effect. You should remove it from your build scripts.
```

---

Related PR on the plugin side: https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1242