### PR TITLE
Sort AvailableJavaHome candidates using production comparator

### DIFF
--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.integtests.fixtures.jvm.TestJavaClassUtil
 import org.gradle.internal.FileUtils
-import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.serialize.JavaClassUtil
 import org.gradle.test.fixtures.archive.JarTestFixture
 
@@ -65,9 +64,6 @@ class JavaCrossCompilationIntegrationTest extends AbstractIntegrationSpec implem
     }
 
     def "can build and run application using Java #jdk.javaVersionMajor"() {
-        if (jdk.javaVersionMajor == Jvm.current().javaVersionMajor) {
-            jdk = Jvm.current()
-        }
         given:
         buildFile << """
             plugins {

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.ScalaCoverage
 import org.gradle.integtests.fixtures.jvm.JavaToolchainBuildOperationsFixture
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
-import org.gradle.internal.jvm.Jvm
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.test.preconditions.UnitTestPreconditions
@@ -185,9 +184,6 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
     def "compilation emits toolchain usage events"() {
         captureBuildOperations()
         def jdk = AvailableJavaHomes.getDifferentJdk { it.languageVersion.majorVersion.toInteger() in 21..24 }
-        if (jdk.javaVersionMajor == Jvm.current().javaVersionMajor) {
-            jdk = Jvm.current()
-        }
 
         def jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(jdk)
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestJavaVersionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestJavaVersionIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.testing
 
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
-import org.gradle.internal.jvm.Jvm
 import org.gradle.testing.fixture.AbstractTestingMultiVersionIntegrationTest
 import org.junit.Assume
 
@@ -34,13 +33,6 @@ abstract class AbstractTestJavaVersionIntegrationTest extends AbstractTestingMul
 
     def "can run test on java #jdk.javaVersionMajor"() {
         Assume.assumeTrue(supportsJavaVersion(jdk.javaVersionMajor))
-
-        if (jdk.javaVersionMajor == Jvm.current().javaVersionMajor) {
-            // if current JAVA_HOME and target jdk are different, but have same major version
-            // the test will start with JAVA_HOME=/path/to/jdk-1 and -Porg.gradle.java.installations.paths=/path/to/jdk-2
-            // resulting in flakiness result
-            jdk = Jvm.current()
-        }
 
         given:
         file("src/test/java/SomeTest.java") << """

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJavaVersionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJavaVersionIntegrationTest.groovy
@@ -79,12 +79,6 @@ class TestTaskJavaVersionIntegrationTest extends AbstractIntegrationSpec impleme
     }
 
     def "uses configured toolchain"() {
-        if (otherJdk.javaVersionMajor == Jvm.current().javaVersionMajor) {
-            // if current JAVA_HOME and target jdk are different, but have same major version
-            // the test will start with JAVA_HOME=/path/to/jdk-1 and -Porg.gradle.java.installations.paths=/path/to/jdk-2
-            // resulting in flakiness result
-            otherJdk = Jvm.current()
-        }
         buildFile << """
             ${baseProjectForJdk(otherJdk)}
             ${withTestToolchain(otherJdk)}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/JavaExecJavaVersionIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/JavaExecJavaVersionIntegrationSpec.groovy
@@ -33,10 +33,6 @@ import spock.lang.Issue
 class JavaExecJavaVersionIntegrationSpec extends AbstractIntegrationSpec implements JavaToolchainFixture {
 
     def "up-to-date when executing JavaExec task twice in a row with the same java version"() {
-        if (jdk.javaVersionMajor == Jvm.current().javaVersionMajor) {
-            jdk = Jvm.current()
-        }
-
         given:
         configureJavaExecTask()
 
@@ -114,9 +110,6 @@ class JavaExecJavaVersionIntegrationSpec extends AbstractIntegrationSpec impleme
     }
 
     def "can execute ExecOperations.javaexec on java #jvm"() {
-        if (jvm.javaVersionMajor == Jvm.current().javaVersionMajor) {
-            jvm = Jvm.current()
-        }
         given:
         configureExecOperationTask()
 
@@ -132,9 +125,6 @@ class JavaExecJavaVersionIntegrationSpec extends AbstractIntegrationSpec impleme
     }
 
     def "can execute ProviderFactory.javaexec on java #jvm"() {
-        if (jvm.javaVersionMajor == Jvm.current().javaVersionMajor) {
-            jvm = Jvm.current()
-        }
         given:
         configureProviderFactoryTask()
 


### PR DESCRIPTION
This ensures that the current JDK is always prioritized over all other candidates, meaning when version a java version X is requested from AvailableJavaHomes, and the current JVM is version X, we will return the current JVM.

This is useful in scenarios where the Gradle build under test is using toolchains and wants to verify the java home of the toolchain that is selected. If AvailableJavaHomes returns a jdk different from the one the build is executed with, the build will still choose the installation it is running on, instead of the one provided.

Using the production comparator solves this, and allows us to remove a number of special cases in tests that ensured the current JVM was selected when the current JVM's version is requsted from AvailableJavaHomes.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
