### PR TITLE
Don't pass convention reference to convention mapping configuration objects

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -56,7 +56,7 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
     // These are properties that should not be allowed to use convention mapping
     private final Set<String> _ineligiblePropertyNames;
 
-    private final Map<String, MappedPropertyImpl> _mappings = new HashMap<String, MappedPropertyImpl>();
+    private final Map<String, MappedPropertyImpl> _mappings = new HashMap<>();
 
     public ConventionAwareHelper(IConventionAware source, org.gradle.api.plugins.Convention convention) {
         this._source = source;
@@ -103,20 +103,20 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
     private boolean mapConventionOn(SupportsConvention target, MappedPropertyImpl mapping) {
         if (target instanceof FileSystemLocationProperty) {
             FileSystemLocationPropertyInternal<?> asFileSystemLocationProperty = Cast.uncheckedNonnullCast(target);
-            asFileSystemLocationProperty.conventionFromAnyFile(new DefaultProvider<>(() -> mapping.getValue(_convention, _source)));
+            asFileSystemLocationProperty.conventionFromAnyFile(new DefaultProvider<>(() -> mapping.getValue()));
         } else if (target instanceof Property) {
             Property<Object> asProperty = Cast.uncheckedNonnullCast(target);
-            asProperty.convention(new DefaultProvider<>(() -> mapping.getValue(_convention, _source)));
+            asProperty.convention(new DefaultProvider<>(() -> mapping.getValue()));
         } else if (target instanceof MapProperty) {
             MapProperty<Object, Object> asMapProperty = Cast.uncheckedNonnullCast(target);
-            DefaultProvider<Map<Object, Object>> convention = new DefaultProvider<>(() -> Cast.uncheckedNonnullCast(mapping.getValue(_convention, _source)));
+            DefaultProvider<Map<Object, Object>> convention = new DefaultProvider<>(() -> Cast.uncheckedNonnullCast(mapping.getValue()));
             asMapProperty.convention(convention);
         } else if (target instanceof HasMultipleValues) {
             HasMultipleValues<Object> asCollectionProperty = Cast.uncheckedNonnullCast(target);
-            asCollectionProperty.convention(new DefaultProvider<>(() -> Cast.uncheckedNonnullCast(mapping.getValue(_convention, _source))));
+            asCollectionProperty.convention(new DefaultProvider<>(() -> Cast.uncheckedNonnullCast(mapping.getValue())));
         } else if (target instanceof ConfigurableFileCollection) {
             ConfigurableFileCollection asFileCollection = Cast.uncheckedNonnullCast(target);
-            asFileCollection.convention((Callable) () -> mapping.getValue(_convention, _source));
+            asFileCollection.convention((Callable) () -> mapping.getValue());
         } else {
             return false;
         }
@@ -127,15 +127,8 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
     public MappedProperty map(String propertyName, final Closure<?> value) {
         return map(propertyName, new MappedPropertyImpl() {
             @Override
-            public Object doGetValue(org.gradle.api.plugins.Convention convention, IConventionAware conventionAwareObject) {
-                switch (value.getMaximumNumberOfParameters()) {
-                    case 0:
-                        return value.call();
-                    case 1:
-                        return value.call(convention);
-                    default:
-                        return value.call(convention, conventionAwareObject);
-                }
+            public Object doGetValue() {
+                return value.call();
             }
         });
     }
@@ -144,7 +137,7 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
     public MappedProperty map(String propertyName, final Callable<?> value) {
         return map(propertyName, new MappedPropertyImpl() {
             @Override
-            public Object doGetValue(org.gradle.api.plugins.Convention convention, IConventionAware conventionAwareObject) {
+            public Object doGetValue() {
                 return uncheckedCall(value);
             }
         });
@@ -178,7 +171,7 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
                 useMapping = false;
             }
             if (useMapping) {
-                returnValue = Cast.uncheckedNonnullCast(_mappings.get(propertyName).getValue(_convention, _source));
+                returnValue = Cast.uncheckedNonnullCast(_mappings.get(propertyName).getValue());
             }
         }
         return returnValue;
@@ -200,12 +193,12 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
         private Object cachedValue;
 
         @Nullable
-        public Object getValue(org.gradle.api.plugins.Convention convention, IConventionAware conventionAwareObject) {
+        public Object getValue() {
             if (!cache) {
-                return doGetValue(convention, conventionAwareObject);
+                return doGetValue();
             }
             if (!haveValue) {
-                cachedValue = doGetValue(convention, conventionAwareObject);
+                cachedValue = doGetValue();
                 haveValue = true;
             }
             return cachedValue;
@@ -218,6 +211,6 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
         }
 
         @Nullable
-        abstract Object doGetValue(org.gradle.api.plugins.Convention convention, IConventionAware conventionAwareObject);
+        abstract Object doGetValue();
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

We're planning to remove Conventions from the codebase. Convention mapping, despite the similarity in name, is an independent feature that does not require Conventions. In the convention mapping implementation, we passed a convention reference to the convention mapping configuration, but it is never actually used anywhere, not in Gradle code, nor in third-party plugins as far as we know, therefore the impact of the breaking change should be minimal.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
