### PR TITLE
fix grammar error in gradle_wrapper_basics.adoc

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/gradle_wrapper_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/introduction/gradle_wrapper_basics.adoc
@@ -53,7 +53,7 @@ It’s important to distinguish between two ways of running Gradle:
 1. *Using a system-installed Gradle distribution* — by running the `gradle` command.
 2. *Using the Gradle Wrapper* — by running the `gradlew` or `gradlew.bat` script included in a Gradle project.
 
-The Gradle Wrapper is always the recommended to execute a build with the wrapper to ensure a reliable, controlled, and standardized execution of the build.
+The Gradle Wrapper is always the recommended way to execute a build to ensure a reliable, controlled, and standardized execution of the build.
 
 1. Using a system-installed Gradle distribution:
 +


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
in the "wrapper basics" part of the guide there's a sentence with a grammatical error: "The Gradle Wrapper is always the recommended to execute a build with the wrapper to ensure..."

it should probably be "...the recommended WAY to execute a build to ensure..."

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
