### PR TITLE
Fix `ps` command on Alpine

### DIFF
--- a/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
+++ b/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
@@ -193,6 +193,8 @@ public class KillLeakingJavaProcesses {
             return new String[]{"wmic", "process", "get", "processid,commandline"};
         } else if (isMacOS()) {
             return new String[]{"ps", "x", "-o", "pid,command"};
+        } else if (isAlpine()) {
+            return new String[]{"ps", "x", "-o", "pid,args"};
         } else {
             return new String[]{"ps", "x", "-o", "pid,cmd"};
         }
@@ -204,6 +206,10 @@ public class KillLeakingJavaProcesses {
 
     private static boolean isMacOS() {
         return System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac");
+    }
+
+    private static boolean isAlpine() {
+        return System.getProperty("java.vm.vendor").toLowerCase(Locale.ROOT).contains("alpine");
     }
 
     private static class ExecResult {


### PR DESCRIPTION
This change allows us to build and test Gradle on Alpine.

```
~/gradle $ ps x -o pid,cmd
ps: bad -o argument 'cmd', supported arguments: user,group,comm,args,pid,ppid,pgid,etime,nice,rgroup,ruser,time,tty,vsz,sid,stat,rss
```