### PR TITLE
Remove usage of deprecated JUnit API when running against version 1.10+

### DIFF
--- a/packaging/distributions-dependencies/build.gradle.kts
+++ b/packaging/distributions-dependencies/build.gradle.kts
@@ -25,7 +25,7 @@ val bouncycastleVersion = "1.78.1"
 val hamcrestVersion = "3.0"
 val jacksonVersion = "2.16.1"
 val jaxbVersion = "3.0.0"
-val junit5Version = "5.8.2"
+val junit5Version = "5.10.5"
 val mavenVersion = "3.9.5"
 val mavenResolverVersion = "1.9.16" // Should remain in-sync with `mavenVersion`
 val nativePlatformVersion = "0.22-milestone-28"
@@ -134,8 +134,8 @@ dependencies {
         api(libs.junitJupiter)          { version { strictly(junit5Version) }}
         api(libs.junit5JupiterApi)      { version { strictly(junit5Version) }}
         api(libs.junit5Vintage)         { version { strictly(junit5Version) }}
-        api(libs.junitPlatform)         { version { strictly("1.8.2") }}
-        api(libs.junitPlatformEngine)   { version { strictly("1.8.2") }}
+        api(libs.junitPlatform)         { version { strictly("1.10.5") }}
+        api(libs.junitPlatformEngine)   { version { strictly("1.10.5") }}
         api(libs.jzlib)                 { version { strictly("1.1.3") }}
         api(libs.kryo)                  { version { strictly("2.24.0") }}
         api(libs.log4jToSlf4j)          { version { strictly(slf4jVersion) }}

--- a/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
+++ b/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
@@ -262,11 +262,10 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
 
     private Set<TestIdentifier> getAncestors(TestIdentifier testIdentifier) {
         Set<TestIdentifier> result = new LinkedHashSet<>();
-        Optional<String> parentId = testIdentifier.getParentId();
-        while (parentId.isPresent()) {
-            TestIdentifier parent = currentTestPlan.getTestIdentifier(parentId.get());
-            result.add(parent);
-            parentId = parent.getParentId();
+        Optional<TestIdentifier> parent = getParent(testIdentifier);
+        while (parent.isPresent()) {
+            result.add(parent.get());
+            parent = getParent(parent.get());
         }
         return result;
     }
@@ -281,9 +280,19 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
             if (isTestClassIdentifier(current)) {
                 return current;
             }
-            current = current.getParentId().map(currentTestPlan::getTestIdentifier).orElse(null);
+            current = getParent(current).orElse(null);
         }
         return null;
+    }
+
+    @SuppressWarnings("deprecation")
+    private Optional<TestIdentifier> getParent(TestIdentifier testIdentifier) {
+        try {
+            return testIdentifier.getParentIdObject().map(currentTestPlan::getTestIdentifier);
+        } catch (NoSuchMethodError ignore) {
+            // To support pre-1.10 versions of the JUnit Platform
+            return testIdentifier.getParentId().map(currentTestPlan::getTestIdentifier);
+        }
     }
 
     private boolean isTestClassIdentifier(TestIdentifier testIdentifier) {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformUserGuideIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformUserGuideIntegrationTest.groovy
@@ -214,7 +214,8 @@ import org.junit.jupiter.api.*;
 @DisplayName("TestInfo Demo")
 class TestInfoDemo {
 
-    TestInfoDemo(TestInfo testInfo) {
+    @BeforeAll
+    static void initClass(TestInfo testInfo) {
         assertEquals("TestInfo Demo", testInfo.getDisplayName());
     }
 

--- a/platforms/jvm/testing-jvm/src/testFixtures/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
+++ b/platforms/jvm/testing-jvm/src/testFixtures/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
@@ -23,10 +23,10 @@ package org.gradle.testing.fixture
 class JUnitCoverage {
     final static String LATEST_JUNIT3_VERSION = '3.8.2'
     final static String LATEST_JUNIT4_VERSION = '4.13.2'
-    final static String LATEST_JUNIT5_VERSION = '5.9.2'
+    final static String LATEST_JUNIT5_VERSION = '5.12.2'
     final static String LATEST_JUPITER_VERSION = LATEST_JUNIT5_VERSION
     final static String LATEST_VINTAGE_VERSION = LATEST_JUNIT5_VERSION
-    final static String LATEST_PLATFORM_VERSION = '1.9.2'
+    final static String LATEST_PLATFORM_VERSION = '1.12.2'
     final static String LATEST_ARCHUNIT_VERSION = '0.22.0'
     final static List<String> JUNIT4_LARGE_COVERAGE = [LATEST_JUNIT4_VERSION, '4.0', '4.4', '4.8.2']
     final static List<String> JUNIT4_IGNORE_ON_CLASS = [LATEST_JUNIT4_VERSION, '4.4', '4.8.2']


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

The `TestPlan.getTestIdentifier(String)` method was deprecated in JUnit 5.10.0 (released on Jul 23, 2023). Its replacement takes a JUnit `UniqueId` instead of a `String` which avoids converting `UniqueId` objects to `Strings` and vice-versa (by calling `TestIdentifier.getParentIdObject()` rather than TestIdentifier.getParentId()`) and thus requires fewer memory allocations.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
