### PR TITLE
Remove unnecessary Groovy libs

### DIFF
--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
@@ -380,13 +380,11 @@ dependencies {
         ideFileContainsEntry("groovy-${groovyVersion}.jar", ["groovy-${groovyVersion}-sources.jar"], [])
         ideFileContainsEntry("groovy-ant-${groovyVersion}.jar", ["groovy-ant-${groovyVersion}-sources.jar"], [])
         ideFileContainsEntry("groovy-astbuilder-${groovyVersion}.jar", ["groovy-astbuilder-${groovyVersion}-sources.jar"], [])
-        ideFileContainsEntry("groovy-console-${groovyVersion}.jar", ["groovy-console-${groovyVersion}-sources.jar"], [])
         ideFileContainsEntry("groovy-datetime-${groovyVersion}.jar", ["groovy-datetime-${groovyVersion}-sources.jar"], [])
         ideFileContainsEntry("groovy-dateutil-${groovyVersion}.jar", ["groovy-dateutil-${groovyVersion}-sources.jar"], [])
         ideFileContainsEntry("groovy-groovydoc-${groovyVersion}.jar", ["groovy-groovydoc-${groovyVersion}-sources.jar"], [])
         ideFileContainsEntry("groovy-json-${groovyVersion}.jar", ["groovy-json-${groovyVersion}-sources.jar"], [])
         ideFileContainsEntry("groovy-nio-${groovyVersion}.jar", ["groovy-nio-${groovyVersion}-sources.jar"], [])
-        ideFileContainsEntry("groovy-sql-${groovyVersion}.jar", ["groovy-sql-${groovyVersion}-sources.jar"], [])
         ideFileContainsEntry("groovy-templates-${groovyVersion}.jar", ["groovy-templates-${groovyVersion}-sources.jar"], [])
         ideFileContainsEntry("groovy-xml-${groovyVersion}.jar", ["groovy-xml-${groovyVersion}-sources.jar"], [])
     }

--- a/platforms/jvm/plugins-groovy/src/test/groovy/org/gradle/api/tasks/GroovyRuntimeTest.groovy
+++ b/platforms/jvm/plugins-groovy/src/test/groovy/org/gradle/api/tasks/GroovyRuntimeTest.groovy
@@ -62,11 +62,10 @@ class GroovyRuntimeTest extends AbstractProjectBuilderSpec {
         ])
 
         then:
-        classpath.files.size() == 12
+        classpath.files.size() == 10
         classpath.files.contains(project.file("groovy-${groovyVersion}.jar"))
         classpath.files.contains(project.file("groovy-ant-${groovyVersion}.jar"))
         classpath.files.contains(project.file("groovy-astbuilder-${groovyVersion}.jar"))
-        classpath.files.contains(project.file("groovy-console-${groovyVersion}.jar"))
         classpath.files.contains(project.file("groovy-datetime-${groovyVersion}.jar"))
         classpath.files.contains(project.file("groovy-dateutil-${groovyVersion}.jar"))
         classpath.files.contains(project.file("groovy-templates-${groovyVersion}.jar"))
@@ -74,7 +73,6 @@ class GroovyRuntimeTest extends AbstractProjectBuilderSpec {
         classpath.files.contains(project.file("groovy-xml-${groovyVersion}.jar"))
         classpath.files.contains(project.file("groovy-groovydoc-${groovyVersion}.jar"))
         classpath.files.contains(project.file("groovy-nio-${groovyVersion}.jar"))
-        classpath.files.contains(project.file("groovy-sql-${groovyVersion}.jar"))
 
         where:
         groovyVersion << GroovyCoverage.SINCE_3_0
@@ -108,9 +106,9 @@ class GroovyRuntimeTest extends AbstractProjectBuilderSpec {
         "2.1.2"              | "-indy"    | "org.codehaus.groovy" | ["groovy", "groovy-ant"]
         "2.5.2"              | ""         | "org.codehaus.groovy" | ["groovy", "groovy-ant", "groovy-templates"]
         "2.5.2"              | "-indy"    | "org.codehaus.groovy" | ["groovy", "groovy-ant", "groovy-templates"]
-        "3.0.10"             | ""         | "org.codehaus.groovy" | ["groovy", "groovy-ant", "groovy-templates", "groovy-json", "groovy-xml", "groovy-groovydoc", "groovy-astbuilder", "groovy-console", "groovy-datetime", "groovy-dateutil", "groovy-nio", "groovy-sql"]
-        "3.0.10"             | "-indy"    | "org.codehaus.groovy" | ["groovy", "groovy-ant", "groovy-templates", "groovy-json", "groovy-xml", "groovy-groovydoc", "groovy-astbuilder", "groovy-console", "groovy-datetime", "groovy-dateutil", "groovy-nio", "groovy-sql"]
-        "4.0.0"              | ""         | "org.apache.groovy"   | ["groovy", "groovy-ant", "groovy-templates", "groovy-json", "groovy-xml", "groovy-groovydoc", "groovy-astbuilder", "groovy-console", "groovy-datetime", "groovy-dateutil", "groovy-nio", "groovy-sql"]
+        "3.0.10"             | ""         | "org.codehaus.groovy" | ["groovy", "groovy-ant", "groovy-templates", "groovy-json", "groovy-xml", "groovy-groovydoc", "groovy-astbuilder", "groovy-datetime", "groovy-dateutil", "groovy-nio"]
+        "3.0.10"             | "-indy"    | "org.codehaus.groovy" | ["groovy", "groovy-ant", "groovy-templates", "groovy-json", "groovy-xml", "groovy-groovydoc", "groovy-astbuilder", "groovy-datetime", "groovy-dateutil", "groovy-nio"]
+        "4.0.0"              | ""         | "org.apache.groovy"   | ["groovy", "groovy-ant", "groovy-templates", "groovy-json", "groovy-xml", "groovy-groovydoc", "groovy-astbuilder", "groovy-datetime", "groovy-dateutil", "groovy-nio"]
     }
 
     def "useful error message is produced when no groovy runtime could be found on a classpath"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
@@ -892,7 +892,7 @@ class ArtifactTransformExecutionBuildOperationIntegrationTest extends AbstractIn
 
         // Check the final component ids do not change within the chain.
         outputContains("""components = ${
-            ((['file1.jar', 'file2.jar'] + (['Local Groovy'] * 13) + ['project :producer', 'com.test:test:4.2'])).collectMany {
+            ((['file1.jar', 'file2.jar'] + (['Local Groovy'] * 11) + ['project :producer', 'com.test:test:4.2'])).collectMany {
                 [it] * 3 // The multiplier creates three copies of everything.
             }
         }""")

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -150,12 +150,10 @@ dependencies {
 
     // Libraries that are not used in this project but required in the distribution
     runtimeOnly(libs.groovyAstbuilder)
-    runtimeOnly(libs.groovyConsole)
     runtimeOnly(libs.groovyDateUtil)
     runtimeOnly(libs.groovyDatetime)
     runtimeOnly(libs.groovyDoc)
     runtimeOnly(libs.groovyNio)
-    runtimeOnly(libs.groovySql)
 
     testImplementation(projects.buildInit)
     testImplementation(projects.platformJvm)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DependencyClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DependencyClassPathProvider.java
@@ -51,13 +51,11 @@ public class DependencyClassPathProvider implements ClassPathProvider {
         "groovy",
         "groovy-ant",
         "groovy-astbuilder",
-        "groovy-console",
         "groovy-datetime",
         "groovy-dateutil",
         "groovy-groovydoc",
         "groovy-json",
         "groovy-nio",
-        "groovy-sql",
         "groovy-templates",
         "groovy-xml"
     );


### PR DESCRIPTION
This removes a few groovy libs that we bundle with Gradle and should not be necessary.  There are other libs we should consider for removal, but there is some tangling with other stuff (e.g. `GroovyDoc` depends on the groovydoc libraries in some cases) and we should consider deprecating some things like `localGroovy()` and `GroovyRuntime` before yanking these out.

Fixes #33000 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
