### PR TITLE
Remove links to archived gradle-credentials-plugin from documentation

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/publishing_gradle_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/publishing_gradle_plugins.adoc
@@ -40,14 +40,14 @@ Follow the instructions on the https://plugins.gradle.org/user/register[registra
 
 image::plugin-portal-registration-page.png[]
 
-Store your API key in your Gradle configuration (gradle.publish.key and gradle.publish.secret) or use a plugin like Seauc Credentials plugin or Gradle Credentials plugin for secure management.
+Store your API key in your Gradle configuration (gradle.publish.key and gradle.publish.secret) or use a plugin like Seauc Credentials plugin for secure management.
 
 image::plugin-portal-api-keys.png[]
 
 It is common practice to copy and paste the text into your <<build_environment.adoc#sec:gradle_configuration_properties,$HOME/.gradle/gradle.properties>> file, but you can also place it in any other valid location.
 All the plugin requires is that the `gradle.publish.key` and `gradle.publish.secret` are available as project properties when the appropriate Plugin Portal tasks are executed.
 
-If you are concerned about placing your credentials in `gradle.properties`, check out the https://plugins.gradle.org/plugin/de.qaware.seu.as.code.credentials[Seauc Credentials plugin] or the https://plugins.gradle.org/plugin/nu.studer.credentials[Gradle Credentials plugin].
+If you are concerned about placing your credentials in `gradle.properties`, check out the https://plugins.gradle.org/plugin/de.qaware.seu.as.code.credentials[Seauc Credentials plugin].
 
 Alternatively, you can provide the API key via `GRADLE_PUBLISH_KEY` and `GRADLE_PUBLISH_SECRET` environment variables.
 This approach might be useful for CI/CD pipelines.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/supported_repository_protocols.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-repositories/supported_repository_protocols.adoc
@@ -51,7 +51,7 @@ These protocols determine how Gradle communicates with the repositories to resol
 | <<#sec:gcs-repositories,Documentation>>
 |===
 
-NOTE: Usernames and passwords should never be stored in plain text in your build files. Instead, store credentials in a local `gradle.properties` file or use an open-source Gradle plugin for encrypting and consuming credentials, such as the link:https://plugins.gradle.org/plugin/nu.studer.credentials[credentials plugin].
+NOTE: Usernames and passwords should never be stored in plain text in your build files. Instead, store credentials in a local `gradle.properties` file, or provide the credentials via environment variables.
 
 The transport protocol is specified as part of the repository URL.
 


### PR DESCRIPTION
Fixes #33306

### Context

Currently, the following two pages refer to the archived [gradle-credentials-plugin](https://github.com/etiennestuder/gradle-credentials-plugin).

- https://docs.gradle.org/8.14/userguide/supported_repository_protocols.html
- https://docs.gradle.org/8.14/userguide/publishing_gradle_plugins.html

This PR removes those links to gradle-credentials-plugin.

I have checked the preview locally with `./gradlew serveDocs -PquickDocs`.

|supported_repository_protocols.html|publishing_gradle_plugins.html|
|---|---|
|![スクリーンショット 2025-05-10 22 58 41](https://github.com/user-attachments/assets/6e749ad7-d92f-418a-bce7-31508160f1c1)|![スクリーンショット 2025-05-10 22 59 22](https://github.com/user-attachments/assets/aea6042c-3c7e-4a8f-b486-2c54c4062576)|


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
