### PR TITLE
Make GradleException a ResolutionProvider

### DIFF
--- a/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/resources/InsecureProtocolException.java
+++ b/platforms/core-configuration/file-operations/src/main/java/org/gradle/api/internal/resources/InsecureProtocolException.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.resources;
 
 import org.gradle.api.InvalidUserCodeException;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.Arrays;
 import java.util.List;

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptException.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptException.kt
@@ -19,7 +19,7 @@ package org.gradle.kotlin.dsl.provider.plugins.precompiled
 import org.gradle.api.GradleException
 import org.gradle.internal.exceptions.Contextual
 import org.gradle.internal.exceptions.LocationAwareException
-import org.gradle.internal.exceptions.ResolutionProvider
+import org.gradle.api.ResolutionProvider
 import java.lang.reflect.InvocationTargetException
 
 

--- a/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/internal/InsecureProtocolException.java
+++ b/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/internal/InsecureProtocolException.java
@@ -17,7 +17,7 @@
 package org.gradle.caching.http.internal;
 
 import org.gradle.api.InvalidUserCodeException;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.Arrays;
 import java.util.List;

--- a/platforms/core-runtime/base-services/src/integTest/groovy/org/gradle/internal/exceptions/DefaultMultiCauseExceptionIntegrationTest.groovy
+++ b/platforms/core-runtime/base-services/src/integTest/groovy/org/gradle/internal/exceptions/DefaultMultiCauseExceptionIntegrationTest.groovy
@@ -88,7 +88,7 @@ class DefaultMultiCauseExceptionIntegrationTest  extends AbstractIntegrationSpec
 
     private String defineTestException() {
         return """
-            class TestResolutionProviderException extends RuntimeException implements org.gradle.internal.exceptions.ResolutionProvider {
+            class TestResolutionProviderException extends RuntimeException implements org.gradle.api.ResolutionProvider {
                 private final String resolution
 
                 TestResolutionProviderException(String resolution) {

--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/exceptions/DefaultMultiCauseExceptionTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/internal/exceptions/DefaultMultiCauseExceptionTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.exceptions
 
-
+import org.gradle.api.ResolutionProvider
 import spock.lang.Specification
 
 class DefaultMultiCauseExceptionTest extends Specification {

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/NoUsableDaemonFoundException.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/NoUsableDaemonFoundException.java
@@ -18,7 +18,7 @@ package org.gradle.launcher.daemon.client;
 
 import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.Collections;
 import java.util.List;

--- a/platforms/core-runtime/stdlib-java-extensions/build.gradle.kts
+++ b/platforms/core-runtime/stdlib-java-extensions/build.gradle.kts
@@ -19,3 +19,8 @@ dependencies {
 
     implementation(projects.buildProcessStartup)
 }
+
+packageCycles {
+    // Allows GradleException to implement ResolutionProvider
+    excludePatterns.add("org/gradle/internal/exceptions/**")
+}

--- a/platforms/core-runtime/stdlib-java-extensions/build.gradle.kts
+++ b/platforms/core-runtime/stdlib-java-extensions/build.gradle.kts
@@ -19,8 +19,3 @@ dependencies {
 
     implementation(projects.buildProcessStartup)
 }
-
-packageCycles {
-    // Allows GradleException to implement ResolutionProvider
-    excludePatterns.add("org/gradle/internal/exceptions/**")
-}

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/api/GradleException.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/api/GradleException.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api;
 
-import org.gradle.internal.exceptions.ResolutionProvider;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -51,10 +50,6 @@ public class GradleException extends RuntimeException implements ResolutionProvi
     public GradleException(String message, List<String> resolutions, @Nullable Throwable cause) {
         super(message, cause);
         this.resolutions.addAll(resolutions);
-    }
-
-    public void addResolution(String resolution) {
-        resolutions.add(resolution);
     }
 
     @Override

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/api/GradleException.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/api/GradleException.java
@@ -26,7 +26,7 @@ import java.util.List;
  * Intended to be the base class of all exceptions thrown by Gradle.
  * <p>
  * Implements {@link ResolutionProvider} to allow the thrower to provide potential resolutions for an exception
- * that Gradle will display.
+ * that Gradle will display upon failure.
  */
 public class GradleException extends RuntimeException implements ResolutionProvider {
     private final List<String> resolutions = new ArrayList<>();
@@ -52,6 +52,7 @@ public class GradleException extends RuntimeException implements ResolutionProvi
         this.resolutions.addAll(resolutions);
     }
 
+    @Incubating
     @Override
     public List<String> getResolutions() {
         return new ArrayList<>(resolutions);

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/api/GradleException.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/api/GradleException.java
@@ -16,21 +16,49 @@
 
 package org.gradle.api;
 
+import org.gradle.internal.exceptions.ResolutionProvider;
 import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
- * <p><code>GradleException</code> is the base class of all exceptions thrown by Gradle.</p>
+ * Intended to be the base class of all exceptions thrown by Gradle.
+ * <p>
+ * Implements {@link ResolutionProvider} to allow the thrower to provide potential resolutions for an exception
+ * that Gradle will display.
  */
-public class GradleException extends RuntimeException {
+public class GradleException extends RuntimeException implements ResolutionProvider {
+    private final List<String> resolutions = new ArrayList<>();
+
     public GradleException() {
         super();
     }
 
     public GradleException(String message) {
-        super(message);
+        this(message, Collections.emptyList());
+    }
+
+    public GradleException(String message, List<String> resolutions) {
+        this(message, resolutions, null);
     }
 
     public GradleException(String message, @Nullable Throwable cause) {
+        this(message, Collections.emptyList(), cause);
+    }
+
+    public GradleException(String message, List<String> resolutions, @Nullable Throwable cause) {
         super(message, cause);
+        this.resolutions.addAll(resolutions);
+    }
+
+    public void addResolution(String resolution) {
+        resolutions.add(resolution);
+    }
+
+    @Override
+    public List<String> getResolutions() {
+        return new ArrayList<>(resolutions);
     }
 }

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/api/ResolutionProvider.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/api/ResolutionProvider.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api;
 
-import org.jspecify.annotations.NullMarked;
-
 import java.util.List;
 
 /**
@@ -26,7 +24,8 @@ import java.util.List;
  * Exceptions can implement this interface in order to provide a list of resolutions
  * that are then displayed in the suggestion section of the error message.
  */
-@NullMarked
+
+@Incubating
 public interface ResolutionProvider {
     /**
      * Returns a list of potential resolutions for this exception.

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/api/ResolutionProvider.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/api/ResolutionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.exceptions;
+package org.gradle.api;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -22,10 +22,16 @@ import java.util.List;
 
 /**
  * A provider of resolutions for an exception.
- * Exceptions can be derived from this interface to provide a list of resolutions that are then displayed in the suggestion section of the error message.
+ * <p>
+ * Exceptions can implement this interface in order to provide a list of resolutions
+ * that are then displayed in the suggestion section of the error message.
  */
-
 @NullMarked
 public interface ResolutionProvider {
+    /**
+     * Returns a list of potential resolutions for this exception.
+     *
+     * @return a list of resolutions
+     */
     List<String> getResolutions();
 }

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/exceptions/DefaultMultiCauseException.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/exceptions/DefaultMultiCauseException.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.exceptions;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.ResolutionProvider;
 import org.gradle.internal.Factory;
 
 import java.io.IOException;

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/exceptions/MultiCauseException.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/exceptions/MultiCauseException.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.exceptions;
 
+import org.gradle.api.ResolutionProvider;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.util.List;

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledScriptException.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledScriptException.java
@@ -17,7 +17,7 @@
 package org.gradle.plugin.devel.internal.precompiled;
 
 import org.gradle.api.GradleException;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.Collections;
 import java.util.List;

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/install/exceptions/ToolchainDownloadException.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/install/exceptions/ToolchainDownloadException.java
@@ -18,7 +18,7 @@ package org.gradle.jvm.toolchain.internal.install.exceptions;
 
 import org.gradle.api.GradleException;
 import org.gradle.internal.exceptions.Contextual;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/install/exceptions/ToolchainProvisioningException.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/install/exceptions/ToolchainProvisioningException.java
@@ -21,7 +21,7 @@ import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.Arrays;
 import java.util.List;

--- a/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/internal/DefaultWrapperVersionsResources.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/internal/DefaultWrapperVersionsResources.java
@@ -19,7 +19,7 @@ package org.gradle.api.tasks.wrapper.internal;
 import org.gradle.api.GradleException;
 import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.wrapper.WrapperVersionsResources;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildInitException.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildInitException.java
@@ -18,7 +18,7 @@ package org.gradle.buildinit.plugins.internal;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.GradleException;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.Collections;
 import java.util.List;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -105,7 +105,7 @@ import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerBroadcast;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.model.CalculatedValue;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/VersionConflictException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/VersionConflictException.java
@@ -19,7 +19,7 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphValidationException;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.List;
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/InsecureProtocolException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/InsecureProtocolException.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.repositories;
 
 import org.gradle.api.InvalidUserCodeException;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.Arrays;
 import java.util.List;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/exception/AbstractResolutionFailureException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/exception/AbstractResolutionFailureException.java
@@ -28,7 +28,7 @@ import org.gradle.internal.component.resolution.failure.ReportableAsProblem;
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.resolution.failure.interfaces.ResolutionFailure;
 import org.gradle.internal.exceptions.Contextual;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 import org.gradle.internal.exceptions.StyledException;
 import org.gradle.util.internal.TextUtil;
 import org.jspecify.annotations.Nullable;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/InvalidLockFileException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/InvalidLockFileException.java
@@ -16,12 +16,13 @@
 
 package org.gradle.internal.locking;
 
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.GradleException;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.Collections;
 import java.util.List;
 
-public class InvalidLockFileException extends RuntimeException implements ResolutionProvider {
+public class InvalidLockFileException extends GradleException implements ResolutionProvider {
     private final String resolutionMessage;
 
     public InvalidLockFileException(String displayName, Exception cause, String resolutionMessage) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/MissingLockStateException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/MissingLockStateException.java
@@ -17,13 +17,14 @@
 package org.gradle.internal.locking;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.GradleException;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.List;
 
-public class MissingLockStateException extends RuntimeException implements ResolutionProvider {
+public class MissingLockStateException extends GradleException implements ResolutionProvider {
 
     private static final List<String> RESOLUTIONS;
     static {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionNotFoundException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionNotFoundException.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.jspecify.annotations.NonNull;
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -41,7 +41,7 @@ import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvedDependenc
 import org.gradle.internal.InternalTransformer;
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.exceptions.MultiCauseException;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.util.internal.CollectionUtils;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/transform/VariantTransformConfigurationException.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/transform/VariantTransformConfigurationException.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.internal.exceptions.Contextual;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 
 import java.util.Arrays;
 import java.util.List;

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -35,7 +35,7 @@ import org.gradle.internal.exceptions.FailureResolutionAware;
 import org.gradle.internal.exceptions.MultiCauseException;
 import org.gradle.internal.exceptions.NonGradleCause;
 import org.gradle.internal.exceptions.NonGradleCauseExceptionsHolder;
-import org.gradle.internal.exceptions.ResolutionProvider;
+import org.gradle.api.ResolutionProvider;
 import org.gradle.internal.exceptions.StyledException;
 import org.gradle.internal.logging.text.BufferingStyledTextOutput;
 import org.gradle.internal.logging.text.LinePrefixingStyledTextOutput;

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
@@ -18,6 +18,7 @@ package org.gradle.process.internal.worker.child;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.ResolutionProvider;
 import org.gradle.api.internal.ClassPathProvider;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.jvm.JavaVersionParser;
@@ -159,6 +160,7 @@ public class WorkerProcessClassPathProvider implements ClassPathProvider {
                 JavaReflectionUtil.class,
                 JavaMethod.class,
                 GradleException.class,
+                ResolutionProvider.class,
                 NoSuchPropertyException.class,
                 NoSuchMethodException.class,
                 UncheckedException.class,

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/exception/DefaultExceptionAnalyserTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/exception/DefaultExceptionAnalyserTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.internal.Describables
 import org.gradle.internal.exceptions.Contextual
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.exceptions.MultiCauseException
-import org.gradle.internal.exceptions.ResolutionProvider
+import org.gradle.api.ResolutionProvider
 import org.gradle.problems.Location
 import org.gradle.problems.ProblemDiagnostics
 import org.gradle.problems.buildtree.ProblemDiagnosticsFactory

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -49,6 +49,26 @@
             ]
         },
         {
+            "type": "org.gradle.api.GradleException",
+            "member": "Class org.gradle.api.GradleException",
+            "acceptation": "Making ResolutionProvider public API",
+            "changes": [
+                "org.gradle.api.ResolutionProvider"
+            ]
+        },
+        {
+            "type": "org.gradle.api.GradleException",
+            "member": "Constructor org.gradle.api.GradleException(java.lang.String,java.util.List)",
+            "acceptation": "Making ResolutionProvider public API",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.GradleException",
+            "member": "Constructor org.gradle.api.GradleException(java.lang.String,java.util.List,java.lang.Throwable)",
+            "acceptation": "Making ResolutionProvider public API",
+            "changes": []
+        },
+        {
             "type": "org.gradle.api.Project",
             "member": "Method org.gradle.api.Project.exec(groovy.lang.Closure)",
             "acceptation": "Remove deprecated method",
@@ -87,6 +107,18 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.ResolutionProvider",
+            "member": "Class org.gradle.api.ResolutionProvider",
+            "acceptation": "Making ResolutionProvider public API",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.ResolutionProvider",
+            "member": "Method org.gradle.api.ResolutionProvider.getResolutions()",
+            "acceptation": "Making ResolutionProvider public API",
+            "changes": []
         },
         {
             "type": "org.gradle.api.Script",

--- a/testing/architecture-test/src/changes/archunit-store/public-api-mutable-properties.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-mutable-properties.txt
@@ -5,6 +5,7 @@ Method <org.gradle.api.AntBuilder.getProperties()> does not have raw return type
 Method <org.gradle.api.AntBuilder.getReferences()> does not have raw return type (java.util.Map) assignable to any of [Provider] in (AntBuilder.java:0)
 Method <org.gradle.api.BuildableComponentSpec.getBuildTask()> does not have raw return type (org.gradle.api.Task) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (BuildableComponentSpec.java:0)
 Method <org.gradle.api.CheckableComponentSpec.getCheckTask()> does not have raw return type (org.gradle.api.Task) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (CheckableComponentSpec.java:0)
+Method <org.gradle.api.GradleException.getResolutions()> does not have raw return type (java.util.List) assignable to any of [Provider] in (GradleException.java:0)
 Method <org.gradle.api.InvalidActionClosureException.getArgument()> does not have raw return type (java.lang.Object) assignable to any of [Provider] in (InvalidActionClosureException.java:0)
 Method <org.gradle.api.InvalidActionClosureException.getClosure()> does not have raw return type (groovy.lang.Closure) assignable to any of [Provider] in (InvalidActionClosureException.java:0)
 Method <org.gradle.api.Project.getAllTasks(boolean)> does not have raw return type (java.util.Map) assignable to any of [Provider] in (Project.java:0)


### PR DESCRIPTION
This promotes `ResolutionProvider` to a public API, and makes 2 types that implemented it but extended `RuntimeException` instead extend `GradleException`.

This should help prevent the proliferation of custom exceptions that exist solely to implement `ResolutionProvider` in a particular narrow circumstance instead of just using the more generic `GradleException`.
