### PR TITLE
Decrease all distribution size by 1M

### DIFF
--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getDistributionSizeMiB() {
-        return 211
+        return 209
     }
 
     @Requires(UnitTestPreconditions.StableGroovy) // cannot link to public javadocs of Groovy snapshots like https://docs.groovy-lang.org/docs/groovy-4.0.5-SNAPSHOT/html/gapi/


### PR DESCRIPTION
It's failing the promotion build: https://ge.gradle.org/s/67g3cjsl45nr2/tests/task/:distributions-integ-tests:forkingIntegTest/details/org.gradle.AllDistributionIntegrationSpec/distribution%20size%20should%20not%20change%20too%20much?top-execution=1