### PR TITLE
Defer making mutating dependencies an error to 10.0

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -2127,7 +2127,7 @@ The `ArtifactIdentifier` class has been deprecated for removal in Gradle 9.0.
 [[dependency_mutate_dependency_collector_after_finalize]]
 ==== Deprecate mutating `DependencyCollector` dependencies after observation
 
-Starting in Gradle 9.0, mutating dependencies sourced from a link:{javadocPath}/org/gradle/api/artifacts/dsl/DependencyCollector.html[DependencyCollector], after those dependencies have been observed will result in an error.
+Starting in Gradle 10.0, mutating dependencies sourced from a link:{javadocPath}/org/gradle/api/artifacts/dsl/DependencyCollector.html[DependencyCollector], after those dependencies have been observed will result in an error.
 The `DependencyCollector` interface is used to declare dependencies within the test suites DSL.
 
 Consider the following example where a test suite's dependency is mutated after it is observed:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/artifacts/dsl/DependencyCollectorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/artifacts/dsl/DependencyCollectorIntegrationTest.groovy
@@ -57,7 +57,7 @@ class DependencyCollectorIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Mutating dependency com:foo:1.0 after it has been finalized has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#dependency_mutate_dependency_collector_after_finalize")
+        executer.expectDocumentedDeprecationWarning("Mutating dependency com:foo:1.0 after it has been finalized has been deprecated. This will fail with an error in Gradle 10.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#dependency_mutate_dependency_collector_after_finalize")
         succeeds("help")
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyCollector.java
@@ -75,7 +75,7 @@ public abstract class DefaultDependencyCollector implements DependencyCollector 
             ((AbstractModuleDependency) mutable).addMutationValidator(dep -> {
                 if (((PropertyInternal<?>) getDependencies()).isFinalized()) {
                     DeprecationLogger.deprecateAction("Mutating dependency " + dep + " after it has been finalized")
-                        .willBecomeAnErrorInGradle9()
+                        .willBecomeAnErrorInGradle10()
                         .withUpgradeGuideSection(8, "dependency_mutate_dependency_collector_after_finalize")
                         .nagUser();
                 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -111,12 +111,8 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         def result = kgpRunner(false, kotlinPluginVersion, 'test', 'integTest')
             .deprecations(KotlinDeprecations) {
                 runner.expectLegacyDeprecationWarningIf(
-                    kotlinPluginVersion.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_0_0,
-                    "Mutating dependency DefaultExternalModuleDependency{group='org.jetbrains.kotlin', name='kotlin-test-junit5', version='null', configuration='default'} after it has been finalized has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#dependency_mutate_dependency_collector_after_finalize"
-                )
-                runner.expectLegacyDeprecationWarningIf(
                     kotlinPluginVersion.baseVersion == KotlinGradlePluginVersions.KOTLIN_2_0_0,
-                    "Mutating dependency org.jetbrains.kotlin:kotlin-test-junit5: after it has been finalized has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#dependency_mutate_dependency_collector_after_finalize"
+                    "Mutating dependency org.jetbrains.kotlin:kotlin-test-junit5: after it has been finalized has been deprecated. This will fail with an error in Gradle 10.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#dependency_mutate_dependency_collector_after_finalize"
                 )
             }.build()
 


### PR DESCRIPTION
This would require us to stop testing KGP 2.0.0 and is not important enough for that.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
