### PR TITLE
Introduce ManagedType annotation

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -31,26 +31,18 @@ import groovy.lang.GroovyObject;
 import groovy.lang.MetaClass;
 import org.gradle.api.Action;
 import org.gradle.api.Describable;
-import org.gradle.api.DomainObjectSet;
-import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.IsolatedAction;
-import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NonExtensible;
-import org.gradle.api.artifacts.dsl.DependencyCollector;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.ConfigurableFileTree;
-import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.plugins.software.SoftwareType;
+import org.gradle.api.model.ManagedType;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.HasMultipleValues;
-import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.provider.SetProperty;
 import org.gradle.api.provider.SupportsConvention;
 import org.gradle.api.reflect.InjectionPointQualifier;
 import org.gradle.api.tasks.Nested;
@@ -110,26 +102,6 @@ import static org.gradle.api.internal.GeneratedSubclasses.unpack;
  * </ul>
  */
 abstract class AbstractClassGenerator implements ClassGenerator {
-    /**
-     * Types that are allowed to be instantiated directly by Gradle when exposed as a getter on a type.
-     *
-     * @implNote Keep in sync with platforms/documentation/docs/src/docs/userguide/authoring-builds/gradle-properties/properties_providers.adoc
-     * @see ManagedObjectFactory#newInstance
-     */
-    private static final ImmutableSet<Class<?>> MANAGED_PROPERTY_TYPES = ImmutableSet.of(
-        ConfigurableFileCollection.class,
-        ConfigurableFileTree.class,
-        ListProperty.class,
-        SetProperty.class,
-        MapProperty.class,
-        RegularFileProperty.class,
-        DirectoryProperty.class,
-        Property.class,
-        NamedDomainObjectContainer.class,
-        ExtensiblePolymorphicDomainObjectContainer.class,
-        DomainObjectSet.class,
-        DependencyCollector.class
-    );
 
     private static final ImmutableSet<Class<? extends Annotation>> NESTED_ANNOTATION_TYPES = ImmutableSet.of(
         Nested.class,
@@ -408,7 +380,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
     private static boolean isManagedProperty(PropertyMetadata property) {
         // Property is readable and without a setter of property type and the type can be created
-        return property.isReadableWithoutSetterOfPropertyType() && (MANAGED_PROPERTY_TYPES.contains(property.getType()) || hasNestedAnnotation(property));
+        return property.isReadableWithoutSetterOfPropertyType() && (property.getType().isAnnotationPresent(ManagedType.class) || hasNestedAnnotation(property));
     }
 
     private static boolean hasNestedAnnotation(PropertyMetadata property) {

--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectSet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectSet.java
@@ -16,6 +16,7 @@
 package org.gradle.api;
 
 import groovy.lang.Closure;
+import org.gradle.api.model.ManagedType;
 import org.gradle.api.specs.Spec;
 
 import java.util.Set;
@@ -27,6 +28,7 @@ import java.util.Set;
  *
  * @param <T> The type of objects in this set.
  */
+@ManagedType
 public interface DomainObjectSet<T> extends DomainObjectCollection<T>, Set<T> {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/ExtensiblePolymorphicDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/ExtensiblePolymorphicDomainObjectContainer.java
@@ -17,6 +17,7 @@ package org.gradle.api;
 
 import groovy.lang.Closure;
 import org.gradle.api.internal.rules.NamedDomainObjectFactoryRegistry;
+import org.gradle.api.model.ManagedType;
 
 /**
  * A {@link org.gradle.api.PolymorphicDomainObjectContainer} that can be extended at runtime to
@@ -26,6 +27,7 @@ import org.gradle.api.internal.rules.NamedDomainObjectFactoryRegistry;
  *
  * @param <T> the (base) container element type
  */
+@ManagedType
 public interface ExtensiblePolymorphicDomainObjectContainer<T> extends PolymorphicDomainObjectContainer<T>, NamedDomainObjectFactoryRegistry<T> {
     /**
      * Registers a factory for creating elements of the specified type. Typically, the specified type

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectContainer.java
@@ -16,6 +16,7 @@
 package org.gradle.api;
 
 import groovy.lang.Closure;
+import org.gradle.api.model.ManagedType;
 import org.gradle.api.provider.Provider;
 import org.gradle.util.Configurable;
 
@@ -32,6 +33,7 @@ import org.gradle.util.Configurable;
  *
  * @param <T> The type of objects in this container.
  */
+@ManagedType
 public interface NamedDomainObjectContainer<T> extends NamedDomainObjectSet<T>, Configurable<NamedDomainObjectContainer<T>> {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyCollector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyCollector.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.model.ManagedType;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderConvertible;
 
@@ -49,6 +50,7 @@ import java.util.Set;
  *
  * @since 8.6
  */
+@ManagedType
 @NonExtensible
 @SuppressWarnings("JavadocReference")
 public interface DependencyCollector {

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -17,6 +17,7 @@ package org.gradle.api.file;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
+import org.gradle.api.model.ManagedType;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.HasConfigurableValue;
 import org.gradle.api.provider.SupportsConvention;
@@ -30,6 +31,7 @@ import java.util.Set;
  *
  * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors.</p>
  */
+@ManagedType
 @SupportsKotlinAssignmentOverloading
 public interface ConfigurableFileCollection extends FileCollection, HasConfigurableValue, SupportsConvention {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileTree.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileTree.java
@@ -16,6 +16,7 @@
 package org.gradle.api.file;
 
 import org.gradle.api.Buildable;
+import org.gradle.api.model.ManagedType;
 import org.gradle.api.tasks.util.PatternFilterable;
 
 import java.io.File;
@@ -26,6 +27,7 @@ import java.util.Set;
  *
  * <p>You can obtain a {@code ConfigurableFileTree} instance by calling {@link org.gradle.api.Project#fileTree(java.util.Map)}.</p>
  */
+@ManagedType
 public interface ConfigurableFileTree extends FileTree, DirectoryTree, PatternFilterable, Buildable {
     /**
      * Specifies base directory for this file tree using the given path. The path is evaluated as per {@link

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.file;
 
+import org.gradle.api.model.ManagedType;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
@@ -33,6 +34,7 @@ import java.io.File;
  *
  * @since 4.3
  */
+@ManagedType
 public interface DirectoryProperty extends FileSystemLocationProperty<Directory> {
     /**
      * Returns a {@link FileTree} that allows the files and directories contained in this directory to be queried.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/RegularFileProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/RegularFileProperty.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.file;
 
+import org.gradle.api.model.ManagedType;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
@@ -33,6 +34,7 @@ import java.io.File;
  *
  * @since 4.3
  */
+@ManagedType
 public interface RegularFileProperty extends FileSystemLocationProperty<RegularFile> {
     /**
      * {@inheritDoc}

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ManagedType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ManagedType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.model;
+
+import org.gradle.api.Incubating;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Marks types that can be instantiated by Gradle via the managed object infrastructure.
+ * <p>
+ * Types annotated with this annotation will be automatically instantiated by Gradle
+ * when constructing managed objects. See the below example:
+ *
+ * <pre class='autoTested'>
+ * interface MyObject {
+ *     ConfigurableFileCollection getFiles();
+ *     RegularFileProperty getProperty();
+ * }
+ *
+ * def instance = objects.newInstance(MyObject)
+ * instance.files.from(file("foo.txt"))
+ * instance.property.set(file("bar.txt"))
+ * </pre>
+ *
+ * @since 9.0.0
+ */
+@Incubating
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ManagedType {
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ManagedType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ManagedType.java
@@ -18,6 +18,7 @@ package org.gradle.api.model;
 
 import org.gradle.api.Incubating;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -41,6 +42,7 @@ import java.lang.annotation.RetentionPolicy;
  * @since 9.0.0
  */
 @Incubating
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ManagedType {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.model.ManagedType;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
@@ -37,6 +38,7 @@ import java.util.List;
  * @param <T> the type of elements.
  * @since 4.3
  */
+@ManagedType
 public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T> {
     /**
      * {@inheritDoc}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -18,6 +18,7 @@ package org.gradle.api.provider;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
+import org.gradle.api.model.ManagedType;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
@@ -41,6 +42,7 @@ import java.util.Set;
  * @param <V> the type of values.
  * @since 5.1
  */
+@ManagedType
 @SupportsKotlinAssignmentOverloading
 public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableValue, SupportsConvention {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -17,6 +17,7 @@
 package org.gradle.api.provider;
 
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
+import org.gradle.api.model.ManagedType;
 import org.gradle.api.model.ObjectFactory;
 import org.jspecify.annotations.Nullable;
 
@@ -49,6 +50,7 @@ import org.jspecify.annotations.Nullable;
  * @param <T> Type of value represented by the property
  * @since 4.3
  */
+@ManagedType
 @SupportsKotlinAssignmentOverloading
 public interface Property<T> extends Provider<T>, HasConfigurableValue, SupportsConvention {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.model.ManagedType;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
@@ -37,6 +38,7 @@ import java.util.Set;
  * @param <T> the type of elements.
  * @since 4.5
  */
+@ManagedType
 public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
     /**
      * {@inheritDoc}


### PR DESCRIPTION
This allows us to remove the explicit list of types that the managed object infra can instantiate. This gets us further toward decoupling the managed object infrastructure from the types it can instantiate.

We considered using org.gradle.model.Managed, but based on the javadoc, this type is tightly coupled to the software model, so we decided to use a new annotation instead

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
