### PR TITLE
Let Configuration Cache serialize Java 11 collections correctly

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheJavaCollectionsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheJavaCollectionsIntegrationTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
+import spock.lang.Issue
+
+class ConfigurationCacheJavaCollectionsIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    @Issue('https://github.com/gradle/gradle/issues/26942')
+    @Requires(value = UnitTestPreconditions.Jdk11OrLater)
+    def 'restores Java 11 collections'() {
+        given:
+        buildFile '''
+            import java.util.*;
+
+            class CollectionsTask extends DefaultTask {
+                private List<String> list = List.of('foo', 'bar')
+                private Set<String> set = Set.of('foo', 'bar')
+                private Map<String, String> map = Map.of('foo', 'bar')
+
+                @TaskAction def print() {
+                    [list: list, set: set.sort(), map: map].each {
+                        println it
+                    }
+                }
+            }
+
+            tasks.register('collections', CollectionsTask)
+        '''
+
+        when:
+        configurationCacheRun 'collections'
+
+        then:
+        outputContains 'list=[foo, bar]'
+        outputContains 'set=[bar, foo]'
+        outputContains 'map={foo=bar}'
+    }
+}

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaObjectSerializationCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaObjectSerializationCodec.kt
@@ -175,7 +175,7 @@ class JavaObjectSerializationCodec(
 
                     replacement::class.java === value::class.java -> {
                         // Avoid a StackOverflowException when the replacement and value are of the same type.
-                        // TODO:configuration-cache This is likely incorrect when the class also supports the `writeObject` protocol.
+                        // TODO:configuration-cache Skipping Java serialization for the replacement is likely incorrect when the class also supports the `writeObject` protocol
                         writeEnum(Format.ReadResolveBean)
                         encodeBean(value)
                     }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaObjectSerializationCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaObjectSerializationCodec.kt
@@ -30,6 +30,7 @@ import org.gradle.internal.serialize.graph.decodePreservingIdentity
 import org.gradle.internal.serialize.graph.encodeBean
 import org.gradle.internal.serialize.graph.encodePreservingIdentityOf
 import org.gradle.internal.serialize.graph.readEnum
+import org.gradle.internal.serialize.graph.readNonNull
 import org.gradle.internal.serialize.graph.withBeanTrace
 import org.gradle.internal.serialize.graph.withImmediateMode
 import org.gradle.internal.serialize.graph.writeEnum
@@ -107,8 +108,13 @@ class JavaObjectSerializationCodec(
                     }
                 }
 
-                Format.ReadResolve -> {
+                Format.ReadResolveBean -> {
                     readResolve(decodeBean())
+                        .also { putIdentity(id, it) }
+                }
+
+                Format.ReadResolveAny -> {
+                    readResolve(readNonNull())
                         .also { putIdentity(id, it) }
                 }
 
@@ -159,14 +165,25 @@ class JavaObjectSerializationCodec(
         override suspend fun WriteContext.encode(value: Any) {
             encodePreservingIdentityOf(value) {
                 val replacement = writeReplace.invoke(value)
-                if (replacement is SerializedLambda) {
-                    writeEnum(Format.SerializedLambda)
-                    SerializedLambdaParametersCheckingCodec.run {
-                        encode(replacement)
+                when {
+                    replacement is SerializedLambda -> {
+                        writeEnum(Format.SerializedLambda)
+                        SerializedLambdaParametersCheckingCodec.run {
+                            encode(replacement)
+                        }
                     }
-                } else {
-                    writeEnum(Format.ReadResolve)
-                    encodeBean(replacement)
+
+                    replacement::class.java === value::class.java -> {
+                        // Avoid a StackOverflowException when the replacement and value are of the same type.
+                        // TODO:configuration-cache This is likely incorrect when the class also supports the `writeObject` protocol.
+                        writeEnum(Format.ReadResolveBean)
+                        encodeBean(value)
+                    }
+
+                    else -> {
+                        writeEnum(Format.ReadResolveAny)
+                        write(replacement)
+                    }
                 }
             }
         }
@@ -176,7 +193,7 @@ class JavaObjectSerializationCodec(
     object ReadResolveEncoding : Encoding {
         override suspend fun WriteContext.encode(value: Any) {
             encodePreservingIdentityOf(value) {
-                writeEnum(Format.ReadResolve)
+                writeEnum(Format.ReadResolveBean)
                 encodeBean(value)
             }
         }
@@ -184,7 +201,8 @@ class JavaObjectSerializationCodec(
 
     private
     enum class Format {
-        ReadResolve,
+        ReadResolveBean,
+        ReadResolveAny,
         WriteObject,
         ReadObject,
         SerializedLambda

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaSerializationEncodingLookup.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/jos/JavaSerializationEncodingLookup.kt
@@ -45,8 +45,8 @@ class JavaSerializationEncodingLookup {
     fun calculateEncoding(type: Class<*>): EncodingDetails {
         val candidates = type.allMethods()
         val encoding = writeReplaceEncodingFor(candidates)
-            ?: readResolveEncodingFor(candidates)
             ?: writeObjectEncodingFor(candidates)
+            ?: readResolveEncodingFor(candidates)
             ?: readObjectEncodingFor(candidates)
         return EncodingDetails(encoding)
     }


### PR DESCRIPTION
By:

1. Allowing objects returned by `writeReplace` to use Java serialization
2. correctly handling objects with both, `writeObject` and `readResolve` methods; this is the case for the `java.util.CollSer` objects used by Java 11 collections as their serialized representation;

Fixes #26942

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
