### PR TITLE
Fix duplicate section id

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -279,7 +279,7 @@ This property was previously used to configure the JVM target version for code c
 
 To set the target JVM version, you should now <<kotlin_dsl#sec:kotlin-dsl_plugin,configure a Java Toolchain>> instead.
 
-[[gradle_enterprise_extension_deprecated]]
+[[gradle_enterprise_extension_removed]]
 ==== Removal of the `gradle-enterprise` plugin block extension in Kotlin DSL
 
 In Kotlin DSL based `settings.gradle.kts` files, you could previously use the `gradle-enterprise` plugin block extension to apply the Gradle Enterprise plugin using the same version bundled with `gradle --scan`:


### PR DESCRIPTION
The section id had been duplicated in the same file, once for the deprecation and once for the actual removal.