### PR TITLE
Remove suppression of standard output messages

### DIFF
--- a/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
+++ b/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
@@ -171,7 +171,7 @@ class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/33288")
-    def "does not interfere with output of subsequent tasks"() {
+    def "does not interfere with output of parallel tasks"() {
         file("src/main/groovy/pkg/Thing.groovy") << """
             package pkg
 

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -24,7 +24,6 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.internal.tasks.GroovydocAntAction;
-import org.gradle.api.logging.LogLevel;
 import org.gradle.api.provider.Property;
 import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.CacheableTask;
@@ -100,10 +99,6 @@ public abstract class Groovydoc extends SourceTask {
     private final Property<Boolean> processScripts = getProject().getObjects().property(Boolean.class);
 
     private final Property<Boolean> includeMainForScripts = getProject().getObjects().property(Boolean.class);
-
-    public Groovydoc() {
-        getLogging().captureStandardOutput(LogLevel.INFO);
-    }
 
     @Inject
     protected abstract WorkerExecutor getWorkerExecutor();


### PR DESCRIPTION
In 8.14, we made GroovyDoc use the Worker API, so it can now run in parallel with other tasks in the same project.  This exacerbates #27897 and causes more output to potentially be lost.

Fixes #33288 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
