### PR TITLE
Inline transformImpl method

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/UserGuideTransformTask.groovy
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/UserGuideTransformTask.groovy
@@ -71,17 +71,15 @@ abstract class UserGuideTransformTask extends DefaultTask {
     def transform() {
         XIncludeAwareXmlProvider provider = new XIncludeAwareXmlProvider()
         provider.parse(sourceFile.get().asFile)
-        transformImpl(provider.document)
-        provider.write(destFile.get().asFile)
-    }
 
-    private def transformImpl(Document doc) {
         use(BuildableDOMCategory) {
-            addVersionInfo(doc)
-            transformApiLinks(doc)
-            transformWebsiteLinks(doc)
-            fixProgramListings(doc)
+            addVersionInfo(provider.document)
+            transformApiLinks(provider.document)
+            transformWebsiteLinks(provider.document)
+            fixProgramListings(provider.document)
         }
+
+        provider.write(destFile.get().asFile)
     }
 
     def addVersionInfo(Document doc) {


### PR DESCRIPTION
We've seen such errors;

```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':docs:dslStandaloneDocbook'. 

Caused by: org.gradle.internal.metaobject.AbstractDynamicObject$CustomMessageMissingMethodException: Could not find method transformImpl() for arguments [[#document: null]] on task ':docs:dslStandaloneDocbook' of type gradlebuild.docs.UserGuideTransformTask.  
    at org.gradle.internal.metaobject.AbstractDynamicObject$CustomMissingMethodExecutionFailed.<init>(AbstractDynamicObject.java:195) 
    at org.gradle.internal.metaobject.AbstractDynamicObject.methodMissingException(AbstractDynamicObject.java:189)  
    at org.gradle.internal.metaobject.AbstractDynamicObject.invokeMethod(AbstractDynamicObject.java:172)  
    at gradlebuild.docs.UserGuideTransformTask_Decorated.invokeMethod(Unknown Source) 
    at gradlebuild.docs.UserGuideTransformTask.transform(UserGuideTransformTask.groovy:74) 
```

This is an attempt to unblock us by inlining the method.