### PR TITLE
Remove IBM_SEMERU

### DIFF
--- a/build-logic-commons/settings.gradle.kts
+++ b/build-logic-commons/settings.gradle.kts
@@ -32,7 +32,7 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention").version("0.10.0")
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
 
 includeBuild("../build-logic-settings")

--- a/build-logic-settings/settings.gradle.kts
+++ b/build-logic-settings/settings.gradle.kts
@@ -41,7 +41,7 @@ pluginManagement {
 plugins {
     id("com.gradle.develocity").version("4.0.1") // Run `java build-logic-settings/UpdateDevelocityPluginVersion.java <new-version>` to update
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.2")
-    id("org.gradle.toolchains.foojay-resolver-convention").version("0.10.0")
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
 
 include("build-environment")

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -22,7 +22,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention").version("0.10.0")
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
 
 dependencyResolutionManagement {

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/part3_multi_project_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/part3_multi_project_builds.adoc
@@ -281,7 +281,7 @@ To add `lib` to the build, update the `settings.gradle(.kts)` file in the root a
 [source,kotlin]
 ----
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "authoring-tutorial"
@@ -296,7 +296,7 @@ include("lib") // Add lib to the build
 [source, groovy]
 ----
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 rootProject.name = 'authoring-tutorial'
@@ -523,7 +523,7 @@ To add our `license-plugin` build to the root project, update the root `settings
 [source,kotlin]
 ----
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "authoring-tutorial"
@@ -540,7 +540,7 @@ includeBuild("gradle/license-plugin") // Add the new build
 [source, groovy]
 ----
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 rootProject.name = 'running-tutorial-groovy'

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/part4_settings_file.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/part4_settings_file.adoc
@@ -86,7 +86,7 @@ Let's break down the settings file in our project root directory:
 [source,kotlin]
 ----
 plugins {                                                                   // <1>
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"  // <2>
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"  // <2>
 }
 
 rootProject.name = "authoring-tutorial"                                     // <3>
@@ -108,7 +108,7 @@ includeBuild("gradle/license-plugin")                                       // <
 [source, groovy]
 ----
 plugins {                                                                   // <1>
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'   // <2>
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'   // <2>
 }
 
 rootProject.name = 'running-tutorial-groovy'                                // <3>

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -39,6 +39,12 @@ The previous step will help you identify potential problems by issuing deprecati
 [[changes_9.0]]
 == Upgrading from 8.14 and earlier
 
+=== Removed APIs
+
+==== JvmVendorSpec.IBM_SEMERU
+
+The deprecated `JvmVendorSpec.IBM_SEMERU` constant has been removed. Its usage should be replaced by link:{javadocPath}/org/gradle/jvm/toolchain/JvmVendorSpec.html#IBM[`JvmVendorSpec.IBM`].
+
 === Potential breaking changes
 
 ==== Lowest supported Kotlin Gradle Plugin version change

--- a/platforms/documentation/docs/src/snippets/daemon-jvm/customized-task/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/daemon-jvm/customized-task/groovy/settings.gradle
@@ -1,6 +1,6 @@
 plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = 'customized-task'

--- a/platforms/documentation/docs/src/snippets/daemon-jvm/customized-task/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/daemon-jvm/customized-task/kotlin/settings.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "customized-task"

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/catalogs-platforms/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/catalogs-platforms/groovy/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 rootProject.name = 'temp'

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/catalogs-platforms/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/catalogs-platforms/kotlin/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "temp"

--- a/platforms/documentation/docs/src/snippets/java/toolchain-foojay/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-foojay/groovy/settings.gradle
@@ -1,5 +1,5 @@
 // tag::plugin-application[]
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 // end::plugin-application[]

--- a/platforms/documentation/docs/src/snippets/java/toolchain-foojay/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-foojay/kotlin/settings.gradle.kts
@@ -1,5 +1,5 @@
 // tag::plugin-application[]
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention").version("0.10.0")
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
 // end::plugin-application[]

--- a/platforms/documentation/docs/src/snippets/java/toolchain-management/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-management/groovy/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver' version '0.10.0'
+    id 'org.gradle.toolchains.foojay-resolver' version '1.0.0'
 }
 
 import java.util.Optional

--- a/platforms/documentation/docs/src/snippets/java/toolchain-management/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/java/toolchain-management/kotlin/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver").version("0.10.0")
+    id("org.gradle.toolchains.foojay-resolver").version("1.0.0")
 }
 
 import org.gradle.api.Plugin

--- a/platforms/documentation/docs/src/snippets/plugins/simple/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/plugins/simple/groovy/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {  // <1>
 
 // tag::simple-setting-plugins[]
 plugins {   // <2>
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 // end::simple-setting-plugins[]
 

--- a/platforms/documentation/docs/src/snippets/plugins/simple/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/plugins/simple/kotlin/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {  // <1>
 
 // tag::simple-setting-plugins[]
 plugins {   // <2>
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 // end::simple-setting-plugins[]
 

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
@@ -57,15 +57,6 @@ public abstract class JvmVendorSpec {
     public static final JvmVendorSpec IBM = matching(KnownJvmVendor.IBM);
 
     /**
-     * A constant for using <a href="https://developer.ibm.com/languages/java/semeru-runtimes/">IBM Semeru Runtimes</a> as the JVM vendor.
-     *
-     * @since 7.4
-     * @deprecated We are grouping all IBM runtimes under the '{@code IBM}' vendor, won't keep a separate constant for Semeru ones. Just use '{@code IBM}' instead.
-     */
-    @Deprecated
-    public static final JvmVendorSpec IBM_SEMERU = matching(KnownJvmVendor.IBM); // Intentionally duplicating `IBM` to get a new object.
-
-    /**
      * A constant for using <a href="https://www.jetbrains.com/jetbrains-runtime">JetBrains Runtime</a> as the JVM vendor.
      *
      * @since 8.4

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
@@ -186,7 +186,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
 
         when:
         executer.expectDocumentedDeprecationWarning "Requesting JVM vendor IBM_SEMERU. " +
-            "This behavior has been deprecated. This is scheduled to be removed in Gradle 10.0. " +
+            "This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#ibm_semeru_should_not_be_used"
 
         then:

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
@@ -170,33 +170,6 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
         failure.assertHasCause("The value for property 'languageVersion' is final and cannot be changed any further")
     }
 
-    def "nag user when toolchain spec is IBM_SEMERU"() {
-        given:
-        buildFile """
-            apply plugin: "java"
-
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(11)
-                    vendor = JvmVendorSpec.IBM_SEMERU
-                    implementation = JvmImplementation.J9
-                }
-            }
-        """
-
-        when:
-        executer.expectDocumentedDeprecationWarning "Requesting JVM vendor IBM_SEMERU. " +
-            "This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#ibm_semeru_should_not_be_used"
-
-        then:
-        fails ':build'
-        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
-            .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-            .assertHasCause("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=11, vendor=IBM, implementation=J9, nativeImageCapable=false}. " +
-                "Toolchain auto-provisioning is not enabled.")
-    }
-
     def "does not nag user when toolchain spec is IBM"() {
         given:
         buildFile """

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -126,7 +126,7 @@ public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
             // https://github.com/gradle/gradle/issues/23155
             // This should make the spec invalid when the enum gets removed
             DeprecationLogger.deprecateBehaviour("Requesting JVM vendor IBM_SEMERU.")
-                .willBeRemovedInGradle10()
+                .willBeRemovedInGradle9()
                 .withUpgradeGuideSection(8, "ibm_semeru_should_not_be_used")
                 .nagUser();
         }

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -18,7 +18,6 @@ package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.provider.Property;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JvmImplementation;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
@@ -122,14 +121,6 @@ public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
     @SuppressWarnings("deprecation")
     @Override
     public boolean isValid() {
-        if (getVendor().getOrNull() == JvmVendorSpec.IBM_SEMERU) {
-            // https://github.com/gradle/gradle/issues/23155
-            // This should make the spec invalid when the enum gets removed
-            DeprecationLogger.deprecateBehaviour("Requesting JVM vendor IBM_SEMERU.")
-                .willBeRemovedInGradle9()
-                .withUpgradeGuideSection(8, "ibm_semeru_should_not_be_used")
-                .nagUser();
-        }
         return getLanguageVersion().isPresent() || isSecondaryPropertiesUnchanged();
     }
 

--- a/platforms/jvm/toolchains-jvm-shared/src/test/groovy/org/gradle/jvm/toolchain/internal/JvmInstallationMetadataMatcherTest.groovy
+++ b/platforms/jvm/toolchains-jvm-shared/src/test/groovy/org/gradle/jvm/toolchain/internal/JvmInstallationMetadataMatcherTest.groovy
@@ -69,14 +69,6 @@ class JvmInstallationMetadataMatcherTest extends Specification {
         'semeru11'       | semeruJvm11()            | JavaVersion.VERSION_11  | JvmVendorSpec.IBM         | JvmImplementation.J9
         'semeru16'       | semeruJvm16()            | JavaVersion.VERSION_16  | JvmVendorSpec.IBM         | JvmImplementation.J9
         'semeru17'       | semeruJvm17()            | JavaVersion.VERSION_17  | JvmVendorSpec.IBM         | JvmImplementation.J9
-
-        'semeru11'       | semeruJvm11()            | JavaVersion.VERSION_11  | JvmVendorSpec.IBM_SEMERU  | JvmImplementation.VENDOR_SPECIFIC
-        'semeru16'       | semeruJvm16()            | JavaVersion.VERSION_16  | JvmVendorSpec.IBM_SEMERU  | JvmImplementation.VENDOR_SPECIFIC
-        'semeru17'       | semeruJvm17()            | JavaVersion.VERSION_17  | JvmVendorSpec.IBM_SEMERU  | JvmImplementation.VENDOR_SPECIFIC
-
-        'semeru11'       | semeruJvm11()            | JavaVersion.VERSION_11  | JvmVendorSpec.IBM_SEMERU  | JvmImplementation.J9
-        'semeru16'       | semeruJvm16()            | JavaVersion.VERSION_16  | JvmVendorSpec.IBM_SEMERU  | JvmImplementation.J9
-        'semeru17'       | semeruJvm17()            | JavaVersion.VERSION_17  | JvmVendorSpec.IBM_SEMERU  | JvmImplementation.J9
     }
 
     def createExecHandleFactory(Map<String, String> actualProperties) {

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/SimpleGlobalFilesBuildSettingsDescriptor.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/SimpleGlobalFilesBuildSettingsDescriptor.java
@@ -55,7 +55,7 @@ public class SimpleGlobalFilesBuildSettingsDescriptor implements BuildContentGen
             builder.plugin(
                 "Apply the foojay-resolver plugin to allow automatic download of JDKs",
                 "org.gradle.toolchains.foojay-resolver-convention",
-                "0.10.0",
+                "1.0.0",
                 null
             );
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,8 +29,6 @@ pluginManagement {
 
 buildscript {
     dependencies {
-        // update Gson to the desired version, needed here as org.gradle.toolchains.foojay-resolver-convention brings in an older version below
-        // https://github.com/gradle/foojay-toolchains/issues/99
         classpath("com.google.code.gson:gson:2.13.1") // keep in sync with build-logic-commons/build-platform/build.gradle.kts
     }
 }
@@ -40,7 +38,7 @@ plugins {
     id("gradlebuild.configuration-cache-compatibility")
     id("com.gradle.develocity").version("4.0.1") // Run `java build-logic-settings/UpdateDevelocityPluginVersion.java <new-version>` to update
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.2")
-    id("org.gradle.toolchains.foojay-resolver-convention").version("0.10.0")
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
 
 includeBuild("build-logic-commons")

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1786,6 +1786,14 @@
             ]
         },
         {
+            "type": "org.gradle.jvm.toolchain.JvmVendorSpec",
+            "member": "Field IBM_SEMERU",
+            "acceptation": "Deprecated API",
+            "changes": [
+                "Field has been removed"
+            ]
+        },
+        {
             "type": "org.gradle.kotlin.dsl.BuiltinPluginIdExtensionsKt",
             "member": "Method org.gradle.kotlin.dsl.BuiltinPluginIdExtensionsKt.getComponent-reporting-tasks(org.gradle.plugin.use.PluginDependenciesSpec)",
             "acceptation": "Removing component reporting tasks from HelpTasksPlugin",


### PR DESCRIPTION
This reintroduces the removal attempted in #33050 and reverted in #33193

The Foojay plugin needed to be adapted to that removal, and it was done for the upcoming 1.0.0 release.

Creating this as a draft to verify CI. Will promote once Foojay 1.0.0 is released.