### PR TITLE
Fix symmetrical nullability of Javadoc and TestNGOptions properties

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
@@ -613,6 +613,23 @@ Joe!""")
         file("build/docs/javadoc/pkg/internal/IFoo.html").assertDoesNotExist()
     }
 
+    def "can set nullable properties to null in Kotlin DSL"() {
+        given:
+        buildKotlinFile << """
+            plugins {
+                id("java")
+            }
+            tasks.javadoc {
+                destinationDir = null
+                title = null
+                maxMemory = null
+                executable = null
+            }
+        """
+        expect:
+        succeeds "help"
+    }
+
     private TestFile writeSourceFile() {
         file("src/main/java/Foo.java") << "public class Foo {}"
     }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -107,12 +107,15 @@ import static org.gradle.util.internal.GUtil.isTrue;
 @CacheableTask
 public abstract class Javadoc extends SourceTask {
 
+    @Nullable
     private File destinationDir;
 
     private boolean failOnError = true;
 
+    @Nullable
     private String title;
 
+    @Nullable
     private String maxMemory;
 
     private final StandardJavadocDocletOptions options = new StandardJavadocDocletOptions();
@@ -120,6 +123,7 @@ public abstract class Javadoc extends SourceTask {
     private FileCollection classpath = getProject().files();
     private final ModularitySpec modularity;
 
+    @Nullable
     private String executable;
     private final Property<JavadocTool> javadocTool;
 
@@ -262,7 +266,7 @@ public abstract class Javadoc extends SourceTask {
     /**
      * <p>Sets the directory to generate the documentation into.</p>
      */
-    public void setDestinationDir(File destinationDir) {
+    public void setDestinationDir(@Nullable File destinationDir) {
         this.destinationDir = destinationDir;
     }
 
@@ -281,7 +285,7 @@ public abstract class Javadoc extends SourceTask {
      *
      * @param maxMemory The amount of memory
      */
-    public void setMaxMemory(String maxMemory) {
+    public void setMaxMemory(@Nullable String maxMemory) {
         this.maxMemory = maxMemory;
     }
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestNGOptionsIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestNGOptionsIntegrationTest.groovy
@@ -95,4 +95,27 @@ public class ExcludedTest {
 }
 """
     }
+
+    def "can set nullable properties to null in Kotlin DSL"() {
+        given:
+        buildKotlinFile << """
+            testing {
+                suites {
+                    test {
+                        useTestNG()
+                        targets.all {
+                            testTask.configure {
+                                options {
+                                    parallel = null
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+    }
 }

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
@@ -324,7 +324,7 @@ public abstract class TestNGOptions extends TestFrameworkOptions {
         return parallel;
     }
 
-    public void setParallel(String parallel) {
+    public void setParallel(@Nullable String parallel) {
         this.parallel = parallel;
     }
 

--- a/testing/architecture-test/src/changes/archunit-store/public-api-symmetrical-accessors-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-symmetrical-accessors-nullability.txt
@@ -8,7 +8,6 @@ Accessors for org.gradle.api.tasks.JavaExec.executable don't use symmetrical @Nu
 Accessors for org.gradle.api.tasks.SourceSetOutput.resourcesDir don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.bundling.War.classpath don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.bundling.Zip.metadataCharset don't use symmetrical @Nullable
-Accessors for org.gradle.api.tasks.testing.testng.TestNGOptions.parallel don't use symmetrical @Nullable
 Accessors for org.gradle.caching.http.HttpBuildCache.url don't use symmetrical @Nullable
 Accessors for org.gradle.external.javadoc.MinimalJavadocOptions.destinationDirectory don't use symmetrical @Nullable
 Accessors for org.gradle.ide.visualstudio.tasks.GenerateFiltersFileTask.inputFile don't use symmetrical @Nullable

--- a/testing/architecture-test/src/changes/archunit-store/public-api-symmetrical-accessors-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-symmetrical-accessors-nullability.txt
@@ -8,8 +8,6 @@ Accessors for org.gradle.api.tasks.JavaExec.executable don't use symmetrical @Nu
 Accessors for org.gradle.api.tasks.SourceSetOutput.resourcesDir don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.bundling.War.classpath don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.bundling.Zip.metadataCharset don't use symmetrical @Nullable
-Accessors for org.gradle.api.tasks.javadoc.Javadoc.destinationDir don't use symmetrical @Nullable
-Accessors for org.gradle.api.tasks.javadoc.Javadoc.maxMemory don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.testing.testng.TestNGOptions.parallel don't use symmetrical @Nullable
 Accessors for org.gradle.caching.http.HttpBuildCache.url don't use symmetrical @Nullable
 Accessors for org.gradle.external.javadoc.MinimalJavadocOptions.destinationDirectory don't use symmetrical @Nullable


### PR DESCRIPTION
* Relates to #24767 
* These two are no brainers as we simply add `@Nullable` to the setter, which is non-breaking, and these types are already `@NullMarked`


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
