### PR TITLE
Require workers to explicitly list additional internal services

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -80,6 +80,8 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
         this.calculatedValueFactory = calculatedValueFactory;
         this.execOperations = execOperations;
         // TODO - dedupe logic copied from DefaultBuildServicesRegistry
+        // TODO: Is it intentional we use a service registry that allows all services, even internal ones, to be injected?
+        //       All other usages of `IsolationScheme` use a specially crafted service registry only allowing certain services to be injected.
         this.paramsInstantiator = instantiatorFactory.decorateScheme().withServices(services).instantiator();
         this.specInstantiator = instantiatorFactory.decorateLenient(services);
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
@@ -22,7 +22,6 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.services.BuildServiceRegistry;
-import org.gradle.api.specs.Spec;
 import org.gradle.internal.Cast;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.reflect.Types;
@@ -40,7 +39,6 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -174,15 +172,12 @@ public class IsolationScheme<IMPLEMENTATION, PARAMS> {
     /**
      * Returns the services available for injection into the implementation instance.
      */
-    public ServiceLookup servicesForImplementation(@Nullable PARAMS params, ServiceLookup allServices) {
-        return servicesForImplementation(params, allServices, Collections.emptyList(), c -> false);
-    }
-
-    /**
-     * Returns the services available for injection into the implementation instance.
-     */
-    public ServiceLookup servicesForImplementation(@Nullable PARAMS params, ServiceLookup allServices, Collection<? extends Class<?>> additionalWhiteListedServices, Spec<Class<?>> whiteListPolicy) {
-        return new ServicesForIsolatedObject(interfaceType, noParamsType, params, allServices, additionalWhiteListedServices, whiteListPolicy);
+    public ServiceLookup servicesForImplementation(
+        @Nullable PARAMS params,
+        ServiceLookup allServices,
+        Collection<? extends Class<?>> additionalWhiteListedServices
+    ) {
+        return new ServicesForIsolatedObject(interfaceType, noParamsType, params, allServices, additionalWhiteListedServices);
     }
 
     private static class ServicesForIsolatedObject implements ServiceLookup {
@@ -190,23 +185,20 @@ public class IsolationScheme<IMPLEMENTATION, PARAMS> {
         private final Class<?> noParamsType;
         private final Collection<? extends Class<?>> additionalWhiteListedServices;
         private final ServiceLookup allServices;
-        private final Object params;
-        private final Spec<Class<?>> whiteListPolicy;
+        private final @Nullable Object params;
 
         public ServicesForIsolatedObject(
             Class<?> interfaceType,
             Class<?> noParamsType,
             @Nullable Object params,
             ServiceLookup allServices,
-            Collection<? extends Class<?>> additionalWhiteListedServices,
-            Spec<Class<?>> whiteListPolicy
+            Collection<? extends Class<?>> additionalWhiteListedServices
         ) {
             this.interfaceType = interfaceType;
             this.noParamsType = noParamsType;
             this.additionalWhiteListedServices = additionalWhiteListedServices;
             this.allServices = allServices;
             this.params = params;
-            this.whiteListPolicy = whiteListPolicy;
         }
 
         @Nullable
@@ -245,9 +237,6 @@ public class IsolationScheme<IMPLEMENTATION, PARAMS> {
                     if (serviceClass.isAssignableFrom(whiteListedService)) {
                         return allServices.find(whiteListedService);
                     }
-                }
-                if (whiteListPolicy.isSatisfiedBy(serviceClass)) {
-                    return allServices.find(serviceClass);
                 }
             }
             return null;

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/isolated/IsolationSchemeTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/isolated/IsolationSchemeTest.groovy
@@ -66,7 +66,7 @@ class IsolationSchemeTest extends Specification {
         def service = Stub(serviceType)
         _ * allServices.find(serviceType) >> service
 
-        def injectedServices = scheme.servicesForImplementation(params, allServices)
+        def injectedServices = scheme.servicesForImplementation(params, allServices, [])
 
         when:
         def result = injectedServices.find(serviceType)
@@ -89,7 +89,7 @@ class IsolationSchemeTest extends Specification {
         def params = Stub(SomeParams)
         _ * allServices.find(serviceType) >> null
 
-        def injectedServices = scheme.servicesForImplementation(params, allServices)
+        def injectedServices = scheme.servicesForImplementation(params, allServices, [])
 
         when:
         def result = injectedServices.find(serviceType)
@@ -112,7 +112,7 @@ class IsolationSchemeTest extends Specification {
         def allServices = Mock(ServiceLookup)
         def params = Stub(SomeParams)
 
-        def injectedServices = scheme.servicesForImplementation(params, allServices)
+        def injectedServices = scheme.servicesForImplementation(params, allServices, [])
 
         when:
         def result = injectedServices.find(Instantiator)
@@ -132,7 +132,7 @@ class IsolationSchemeTest extends Specification {
         def allServices = Mock(ServiceLookup)
         def params = Stub(SomeParams)
 
-        def injectedServices = scheme.servicesForImplementation(params, allServices)
+        def injectedServices = scheme.servicesForImplementation(params, allServices, [])
 
         when:
         def result = injectedServices.find(SomeParams)
@@ -150,7 +150,7 @@ class IsolationSchemeTest extends Specification {
     def "cannot query parameters when parameters are null"() {
         def allServices = Mock(ServiceLookup)
 
-        def injectedServices = scheme.servicesForImplementation(null, allServices)
+        def injectedServices = scheme.servicesForImplementation(null, allServices, [])
 
         when:
         injectedServices.find(SomeParams)

--- a/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
+++ b/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
@@ -21,11 +21,13 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 
+import java.util.Set;
+
 @ServiceScope(Scope.UserHome.class)
 public interface ActionExecutionSpecFactory {
     <T extends WorkParameters> TransportableActionExecutionSpec newTransportableSpec(IsolatedParametersActionExecutionSpec<T> spec);
 
-    <T extends WorkParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkAction<T>> implementationClass, T params, WorkerRequirement workerRequirement, boolean usesInternalServices);
+    <T extends WorkParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkAction<T>> implementationClass, T params, WorkerRequirement workerRequirement, Set<Class<?>> additionalWhitelistedServices);
 
     <T extends WorkParameters> SimpleActionExecutionSpec<T> newSimpleSpec(IsolatedParametersActionExecutionSpec<T> spec);
 

--- a/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/IsolatedParametersActionExecutionSpec.java
+++ b/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/IsolatedParametersActionExecutionSpec.java
@@ -21,6 +21,7 @@ import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 
 import java.io.File;
+import java.util.Set;
 
 public class IsolatedParametersActionExecutionSpec<T extends WorkParameters> {
     private final Class<? extends WorkAction<T>> implementationClass;
@@ -28,11 +29,20 @@ public class IsolatedParametersActionExecutionSpec<T extends WorkParameters> {
     private final Isolatable<T> isolatedParams;
     private final ClassLoaderStructure classLoaderStructure;
     private final File baseDir;
-    private final boolean usesInternalServices;
+    private final Set<Class<?>> additionalWhitelistedServices;
     private final String displayName;
     private final File projectCacheDir;
 
-    public IsolatedParametersActionExecutionSpec(Class<? extends WorkAction<T>> implementationClass, String displayName, String actionImplementationClassName, Isolatable<T> isolatedParams, ClassLoaderStructure classLoaderStructure, File baseDir, File projectCacheDir, boolean usesInternalServices) {
+    public IsolatedParametersActionExecutionSpec(
+        Class<? extends WorkAction<T>> implementationClass,
+        String displayName,
+        String actionImplementationClassName,
+        Isolatable<T> isolatedParams,
+        ClassLoaderStructure classLoaderStructure,
+        File baseDir,
+        File projectCacheDir,
+        Set<Class<?>> additionalWhitelistedServices
+    ) {
         this.implementationClass = implementationClass;
         this.displayName = displayName;
         this.actionImplementationClassName = actionImplementationClassName;
@@ -40,7 +50,7 @@ public class IsolatedParametersActionExecutionSpec<T extends WorkParameters> {
         this.classLoaderStructure = classLoaderStructure;
         this.baseDir = baseDir;
         this.projectCacheDir = projectCacheDir;
-        this.usesInternalServices = usesInternalServices;
+        this.additionalWhitelistedServices = additionalWhitelistedServices;
     }
 
     public String getDisplayName() {
@@ -69,8 +79,8 @@ public class IsolatedParametersActionExecutionSpec<T extends WorkParameters> {
         return actionImplementationClassName;
     }
 
-    public boolean isInternalServicesRequired() {
-        return usesInternalServices;
+    public Set<Class<?>> getAdditionalWhitelistedServices() {
+        return additionalWhitelistedServices;
     }
 
     public Isolatable<T> getIsolatedParams() {

--- a/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/SimpleActionExecutionSpec.java
+++ b/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/SimpleActionExecutionSpec.java
@@ -19,19 +19,21 @@ package org.gradle.workers.internal;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 
+import java.util.Set;
+
 public class SimpleActionExecutionSpec<T extends WorkParameters> {
     private final Class<? extends WorkAction<T>> implementationClass;
     private final T params;
-    private final boolean usesInternalServices;
+    private final Set<Class<?>> additionalWhitelistedServices;
 
-    public SimpleActionExecutionSpec(Class<? extends WorkAction<T>> implementationClass, T params, boolean usesInternalServices) {
+    public SimpleActionExecutionSpec(Class<? extends WorkAction<T>> implementationClass, T params, Set<Class<?>> additionalWhitelistedServices) {
         this.implementationClass = implementationClass;
         this.params = params;
-        this.usesInternalServices = usesInternalServices;
+        this.additionalWhitelistedServices = additionalWhitelistedServices;
     }
 
-    public boolean isInternalServicesRequired() {
-        return usesInternalServices;
+    public Set<Class<?>> getAdditionalWhitelistedServices() {
+        return additionalWhitelistedServices;
     }
 
     public Class<? extends WorkAction<T>> getImplementationClass() {

--- a/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/TransportableActionExecutionSpec.java
+++ b/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/TransportableActionExecutionSpec.java
@@ -17,30 +17,31 @@
 package org.gradle.workers.internal;
 
 import java.io.File;
+import java.util.Set;
 
 public class TransportableActionExecutionSpec {
     protected final String implementationClassName;
     private final byte[] serializedParameters;
     private final ClassLoaderStructure classLoaderStructure;
     private final File baseDir;
-    private final boolean usesInternalServices;
+    private final Set<String> additionalWhitelistedServicesClassNames;
     private final File projectCacheDir;
 
-    public TransportableActionExecutionSpec(String implementationClassName, byte[] serializedParameters, ClassLoaderStructure classLoaderStructure, File baseDir, File projectCacheDir, boolean usesInternalServices) {
+    public TransportableActionExecutionSpec(String implementationClassName, byte[] serializedParameters, ClassLoaderStructure classLoaderStructure, File baseDir, File projectCacheDir, Set<String> additionalWhitelistedServicesClassNames) {
         this.implementationClassName = implementationClassName;
         this.serializedParameters = serializedParameters;
         this.classLoaderStructure = classLoaderStructure;
         this.baseDir = baseDir;
         this.projectCacheDir = projectCacheDir;
-        this.usesInternalServices = usesInternalServices;
+        this.additionalWhitelistedServicesClassNames = additionalWhitelistedServicesClassNames;
     }
 
     public File getBaseDir() {
         return baseDir;
     }
 
-    public boolean isInternalServicesRequired() {
-        return usesInternalServices;
+    public Set<String> getAdditionalWhitelistedServicesClassNames() {
+        return additionalWhitelistedServicesClassNames;
     }
 
     public ClassLoaderStructure getClassLoaderStructure() {

--- a/platforms/core-execution/daemon-server-worker/src/test/groovy/org/gradle/workers/internal/TransportableActionExecutionSpecSerializerTest.groovy
+++ b/platforms/core-execution/daemon-server-worker/src/test/groovy/org/gradle/workers/internal/TransportableActionExecutionSpecSerializerTest.groovy
@@ -27,10 +27,9 @@ class TransportableActionExecutionSpecSerializerTest extends Specification {
     def outputStream = new ByteArrayOutputStream()
     def encoder = new KryoBackedEncoder(outputStream)
     def bytes = [ (byte) 1, (byte) 2, (byte) 3 ] as byte[]
-    def usesInternalServices = true
 
     def "can serialize and deserialize a spec with a hierarchical classloader structure"() {
-        def spec = new TransportableActionExecutionSpec(Runnable.class.name, bytes, classLoaderStructure(), new File("/foo"), new File("/project-cache"), usesInternalServices)
+        def spec = new TransportableActionExecutionSpec(Runnable.class.name, bytes, classLoaderStructure(), new File("/foo"), new File("/project-cache"), ["foo"] as Set)
 
         when:
         serializer.write(encoder, spec)
@@ -46,11 +45,11 @@ class TransportableActionExecutionSpecSerializerTest extends Specification {
         decodedSpec.classLoaderStructure == spec.classLoaderStructure
         decodedSpec.baseDir.canonicalPath == spec.baseDir.canonicalPath
         decodedSpec.projectCacheDir.canonicalPath == spec.projectCacheDir.canonicalPath
-        decodedSpec.internalServicesRequired
+        decodedSpec.additionalWhitelistedServicesClassNames == (["foo"] as Set)
     }
 
     def "can serialize and deserialize a spec with a flat classloader structure"() {
-        def spec = new TransportableActionExecutionSpec(Runnable.class.name, bytes, flatClassLoaderStructure(), new File("/foo"), new File("/project-cache"), usesInternalServices)
+        def spec = new TransportableActionExecutionSpec(Runnable.class.name, bytes, flatClassLoaderStructure(), new File("/foo"), new File("/project-cache"), ["foo"] as Set)
 
         when:
         serializer.write(encoder, spec)
@@ -67,7 +66,7 @@ class TransportableActionExecutionSpecSerializerTest extends Specification {
         decodedSpec.classLoaderStructure.spec == null
         decodedSpec.baseDir.canonicalPath == spec.baseDir.canonicalPath
         decodedSpec.projectCacheDir.canonicalPath == spec.projectCacheDir.canonicalPath
-        decodedSpec.internalServicesRequired
+        decodedSpec.additionalWhitelistedServicesClassNames == (["foo"] as Set)
     }
 
     def filteringClassloaderSpec() {

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -52,6 +52,7 @@ import org.gradle.workers.WorkerSpec;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -145,6 +146,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
 
         return instantiator.newInstance(DefaultWorkQueue.class, this, spec, daemonWorkerFactory);
     }
+
     private <T extends WorkParameters> AsyncWorkCompletion submitWork(Class<? extends WorkAction<T>> workActionClass, Action<? super T> parameterAction, WorkerSpec workerSpec, WorkerFactory workerFactory) {
         Class<T> parameterType = isolationScheme.parameterTypeFor(workActionClass);
         T parameters = (parameterType == null) ? null : instantiator.newInstance(parameterType);
@@ -157,7 +159,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         IsolatedParametersActionExecutionSpec<?> spec;
         try {
             // Isolate parameters in this thread prior to starting work in a separate thread
-            spec = actionExecutionSpecFactory.newIsolatedSpec(description, workActionClass, parameters, workerRequirement, false);
+            spec = actionExecutionSpecFactory.newIsolatedSpec(description, workActionClass, parameters, workerRequirement, Collections.emptySet());
         } catch (Throwable t) {
             throw new WorkExecutionException(description, t);
         }

--- a/platforms/core-execution/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
+++ b/platforms/core-execution/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
@@ -62,7 +62,7 @@ class WorkerDaemonClientTest extends Specification {
     }
 
     def spec() {
-        return new IsolatedParametersActionExecutionSpec(TestWorkAction, "action", "impl", null, null, null, null, false)
+        return new IsolatedParametersActionExecutionSpec(TestWorkAction, "action", "impl", null, null, null, null, [] as Set)
     }
 
     static abstract class TestWorkAction implements WorkAction<WorkParameters.None> {

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
@@ -23,8 +23,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.provider.Property;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Classpath;
@@ -79,21 +77,6 @@ public abstract class JacocoReportBase extends JacocoBase {
 
     @Inject
     protected Instantiator getInstantiator() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Required for decorating reports container callbacks for tracing user code application.
-     *
-     * @since 5.1
-     */
-    @Inject
-    protected CollectionCallbackActionDecorator getCallbackActionDecorator() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Inject
-    protected IsolatedAntBuilder getAntBuilder() {
         throw new UnsupportedOperationException();
     }
 

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
@@ -86,7 +86,7 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
     public Compiler<GroovyJavaJointCompileSpec> newCompiler(GroovyJavaJointCompileSpec spec) {
         MinimalGroovyCompileOptions groovyOptions = spec.getGroovyCompileOptions();
         CompilerWorkerExecutor compilerWorkerExecutor = newExecutor(groovyOptions);
-        Compiler<GroovyJavaJointCompileSpec> groovyCompiler = new DaemonGroovyCompiler(workerDirectoryProvider.getWorkingDirectory(), DaemonSideCompiler.class, classPathRegistry, compilerWorkerExecutor, classLoaderRegistry, forkOptionsFactory, jvmVersionDetector, problems.getInternalReporter());
+        Compiler<GroovyJavaJointCompileSpec> groovyCompiler = new DaemonGroovyCompiler(workerDirectoryProvider.getWorkingDirectory(), classPathRegistry, compilerWorkerExecutor, classLoaderRegistry, forkOptionsFactory, jvmVersionDetector, problems.getInternalReporter());
         return new AnnotationProcessorDiscoveringCompiler<>(new NormalizingGroovyCompiler(groovyCompiler), processorDetector);
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -23,7 +23,6 @@ import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
-import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
 import org.gradle.workers.internal.DaemonForkOptions;
@@ -33,18 +32,17 @@ import org.gradle.workers.internal.KeepAliveMode;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.Set;
 
 public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> {
-    private final Class<? extends Compiler<JavaCompileSpec>> compilerClass;
-    private final Object[] compilerConstructorArguments;
+    private final JavaHomeBasedJavaCompilerFactory javaCompilerFactory;
     private final JavaForkOptionsFactory forkOptionsFactory;
     private final File daemonWorkingDir;
     private final ClassPathRegistry classPathRegistry;
 
-    public DaemonJavaCompiler(File daemonWorkingDir, Class<? extends Compiler<JavaCompileSpec>> compilerClass, Object[] compilerConstructorArguments, CompilerWorkerExecutor compilerWorkerExecutor, JavaForkOptionsFactory forkOptionsFactory, ClassPathRegistry classPathRegistry) {
+    public DaemonJavaCompiler(File daemonWorkingDir, JavaHomeBasedJavaCompilerFactory javaCompilerFactory, CompilerWorkerExecutor compilerWorkerExecutor, JavaForkOptionsFactory forkOptionsFactory, ClassPathRegistry classPathRegistry) {
         super(compilerWorkerExecutor);
-        this.compilerClass = compilerClass;
-        this.compilerConstructorArguments = compilerConstructorArguments;
+        this.javaCompilerFactory = javaCompilerFactory;
         this.forkOptionsFactory = forkOptionsFactory;
         this.daemonWorkingDir = daemonWorkingDir;
         this.classPathRegistry = classPathRegistry;
@@ -52,7 +50,12 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
 
     @Override
     protected CompilerWorkerExecutor.CompilerParameters getCompilerParameters(JavaCompileSpec spec) {
-        return new JavaCompilerParameters(compilerClass.getName(), compilerConstructorArguments, spec);
+        return new JavaCompilerParameters(JdkJavaCompiler.class.getName(), new Object[]{javaCompilerFactory}, spec);
+    }
+
+    @Override
+    protected Set<Class<?>> getAdditionalCompilerServices() {
+        return Collections.emptySet();
     }
 
     @Override

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactory.java
@@ -88,7 +88,7 @@ public class DefaultJavaCompilerFactory implements JavaCompilerFactory {
         }
 
         if (ForkingJavaCompileSpec.class.isAssignableFrom(type)) {
-            return (Compiler<T>) new DaemonJavaCompiler(workingDirProvider.getWorkingDirectory(), JdkJavaCompiler.class, new Object[]{getJavaHomeBasedJavaCompilerFactory()}, new ProcessIsolatedCompilerWorkerExecutor(workerDaemonFactory, actionExecutionSpecFactory, projectCacheDir), forkOptionsFactory, classPathRegistry);
+            return (Compiler<T>) new DaemonJavaCompiler(workingDirProvider.getWorkingDirectory(), getJavaHomeBasedJavaCompilerFactory(), new ProcessIsolatedCompilerWorkerExecutor(workerDaemonFactory, actionExecutionSpecFactory, projectCacheDir), forkOptionsFactory, classPathRegistry);
         } else {
             return (Compiler<T>) new JdkJavaCompiler(getJavaHomeBasedJavaCompilerFactory(), problems);
         }

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
@@ -65,7 +65,6 @@ class DefaultJavaCompilerFactoryTest extends Specification {
         compiler.delegate instanceof AnnotationProcessorDiscoveringCompiler
         compiler.delegate.delegate instanceof NormalizingJavaCompiler
         compiler.delegate.delegate.delegate instanceof DaemonJavaCompiler
-        compiler.delegate.delegate.delegate.compilerClass == JdkJavaCompiler.class
     }
 
     private static class TestCommandLineJavaSpec extends DefaultJavaCompileSpec implements CommandLineJavaCompileSpec {

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
@@ -38,7 +38,7 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
 
     @Override
     public WorkResult execute(T spec) {
-        DefaultWorkResult result = compilerWorkerExecutor.execute(getCompilerParameters(spec), toDaemonForkOptions(spec));
+        DefaultWorkResult result = compilerWorkerExecutor.execute(getCompilerParameters(spec), toDaemonForkOptions(spec), getAdditionalCompilerServices());
         if (result.isSuccess()) {
             return result;
         } else {
@@ -49,6 +49,12 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
     protected abstract DaemonForkOptions toDaemonForkOptions(T spec);
 
     protected abstract CompilerWorkerExecutor.CompilerParameters getCompilerParameters(T spec);
+
+    /**
+     * Additional services required by {@link CompilerWorkerExecutor.CompilerParameters#getCompilerClassName()} which
+     * are not already permitted for injection in worker actions.
+     */
+    protected abstract Set<Class<?>> getAdditionalCompilerServices();
 
     protected BaseForkOptions mergeForkOptions(BaseForkOptions left, BaseForkOptions right) {
         BaseForkOptions merged = new BaseForkOptions();

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractIsolatedCompilerWorkerExecutor.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractIsolatedCompilerWorkerExecutor.java
@@ -31,6 +31,7 @@ import org.gradle.workers.internal.ProvidesWorkResult;
 import org.gradle.workers.internal.WorkerFactory;
 
 import javax.inject.Inject;
+import java.util.Set;
 
 /**
  * Base implementation of {@link CompilerWorkerExecutor} which handles submitting a compile work item to execute.
@@ -48,11 +49,11 @@ abstract public class AbstractIsolatedCompilerWorkerExecutor implements Compiler
     abstract IsolatedClassLoaderWorkerRequirement getIsolatedWorkerRequirement(DaemonForkOptions daemonForkOptions);
 
     @Override
-    public DefaultWorkResult execute(CompilerParameters parameters, DaemonForkOptions daemonForkOptions) {
+    public DefaultWorkResult execute(CompilerParameters parameters, DaemonForkOptions daemonForkOptions, Set<Class<?>> additionalWhitelistedClasses) {
         IsolatedClassLoaderWorkerRequirement workerRequirement = getIsolatedWorkerRequirement(daemonForkOptions);
         BuildOperationAwareWorker worker = workerFactory.getWorker(workerRequirement);
 
-        return worker.execute(actionExecutionSpecFactory.newIsolatedSpec("compiler daemon", CompilerWorkAction.class, parameters, workerRequirement, true));
+        return worker.execute(actionExecutionSpecFactory.newIsolatedSpec("compiler daemon", CompilerWorkAction.class, parameters, workerRequirement, additionalWhitelistedClasses));
     }
 
     public static class CompilerWorkAction implements WorkAction<CompilerParameters>, ProvidesWorkResult {

--- a/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/CompilerWorkerExecutor.java
+++ b/platforms/jvm/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/CompilerWorkerExecutor.java
@@ -22,6 +22,7 @@ import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.workers.internal.DefaultWorkResult;
 
 import java.io.Serializable;
+import java.util.Set;
 
 /**
  * Encapsulates the logic to execute a work item for an {@link AbstractDaemonCompiler}.
@@ -30,7 +31,7 @@ public interface CompilerWorkerExecutor {
     /**
      * Executes a compiler specified by the {@link CompilerParameters}
      */
-    DefaultWorkResult execute(CompilerParameters parameters, DaemonForkOptions daemonForkOptions);
+    DefaultWorkResult execute(CompilerParameters parameters, DaemonForkOptions daemonForkOptions, Set<Class<?>> additionalWhitelistedServices);
 
     abstract class CompilerParameters implements WorkParameters, Serializable {
         private final String compilerClassName;

--- a/platforms/jvm/plugins-jvm-test-suite/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
+++ b/platforms/jvm/plugins-jvm-test-suite/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.dsl.DependencyFactory;
 import org.gradle.api.internal.tasks.JvmConstants;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
@@ -328,7 +329,7 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
             IsolationScheme<JvmTestToolchain<?>, JvmTestToolchainParameters> isolationScheme = new IsolationScheme<>(uncheckedCast(JvmTestToolchain.class), JvmTestToolchainParameters.class, JvmTestToolchainParameters.None.class);
             Class<T> parametersType = isolationScheme.parameterTypeFor(type);
             T parameters = parametersType == null ? null : objectFactory.newInstance(parametersType);
-            ServiceLookup lookup = isolationScheme.servicesForImplementation(parameters, parentServices, Collections.emptyList(), p -> true);
+            ServiceLookup lookup = isolationScheme.servicesForImplementation(parameters, parentServices, Collections.singleton(DependencyFactory.class));
             return new FrameworkCachingJvmTestToolchain<>(instantiatorFactory.decorate(lookup).newInstance(type));
         }
     }

--- a/platforms/jvm/scala/src/main/java/org/gradle/api/internal/tasks/scala/ScalaCompilerFactory.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/api/internal/tasks/scala/ScalaCompilerFactory.java
@@ -63,8 +63,15 @@ public class ScalaCompilerFactory implements CompilerFactory<ScalaJavaJointCompi
 
         // currently, we leave it to ZincScalaCompiler to also compile the Java code
         Compiler<ScalaJavaJointCompileSpec> scalaCompiler = new DaemonScalaCompiler<>(
-            daemonWorkingDir, ZincScalaCompilerFacade.class, new Object[] {hashedScalaClasspath},
-            compilerWorkerExecutor, zincClasspathFiles, forkOptionsFactory, classPathRegistry, classLoaderRegistry);
+            daemonWorkingDir,
+            hashedScalaClasspath,
+            compilerWorkerExecutor,
+            zincClasspathFiles,
+            forkOptionsFactory,
+            classPathRegistry,
+            classLoaderRegistry
+        );
+
         return new NormalizingScalaCompiler(scalaCompiler);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransform.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransform.java
@@ -90,6 +90,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -412,7 +413,7 @@ public class DefaultTransform implements Transform {
 
     private TransformAction<?> newTransformAction(Provider<FileSystemLocation> inputArtifactProvider, TransformDependencies transformDependencies, @Nullable InputChanges inputChanges) {
         TransformParameters parameters = isolatedParameters.get().getIsolatedParameterObject().isolate();
-        ServiceLookup services = new IsolationScheme<>(TransformAction.class, TransformParameters.class, TransformParameters.None.class).servicesForImplementation(parameters, internalServices);
+        ServiceLookup services = new IsolationScheme<>(TransformAction.class, TransformParameters.class, TransformParameters.None.class).servicesForImplementation(parameters, internalServices, Collections.emptySet());
         services = new TransformServiceLookup(inputArtifactProvider, requiresDependencies ? transformDependencies : null, inputChanges, services);
         return instanceFactory.newInstance(services);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/RegisteredBuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/RegisteredBuildServiceProvider.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.services.internal;
 
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.provider.ProviderInternal;
@@ -33,6 +32,7 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.function.Consumer;
 
 // TODO:configuration-cache - complain when used at configuration time, except when opted in to this
@@ -173,8 +173,7 @@ public class RegisteredBuildServiceProvider<T extends BuildService<P>, P extends
         return isolationScheme.servicesForImplementation(
             isolatedParameters,
             internalServices,
-            ImmutableList.of(),
-            serviceType -> false
+            Collections.emptySet()
         );
     }
 

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -2984,6 +2984,22 @@
             "changes": []
         },
         {
+            "type": "org.gradle.testing.jacoco.tasks.JacocoReportBase",
+            "member": "Method org.gradle.testing.jacoco.tasks.JacocoReportBase.getAntBuilder()",
+            "acceptation": "Removed protected method injecting internal class",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.testing.jacoco.tasks.JacocoReportBase",
+            "member": "Method org.gradle.testing.jacoco.tasks.JacocoReportBase.getCallbackActionDecorator()",
+            "acceptation": "Removed protected method injecting internal class",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
             "type": "org.gradle.util.ClosureBackedAction",
             "member": "Class org.gradle.util.ClosureBackedAction",
             "acceptation": "Deprecated in 8.x",


### PR DESCRIPTION
For compiler workers, we allowed them to inject any internal service they want. With this change, we require these workers to explicitly list all additional internal services they use.

This simplifies the IsolationScheme API a bit.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
