### PR TITLE
Revert convention mapping removals

### DIFF
--- a/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -60,19 +60,17 @@ import static org.gradle.plugins.ear.EarPlugin.DEFAULT_LIB_DIR_NAME;
 public abstract class Ear extends Jar {
     public static final String EAR_EXTENSION = "ear";
 
-    private final Property<String> libDirName;
+    private String libDirName;
     private final Property<Boolean> generateDeploymentDescriptor;
-    private final Property<DeploymentDescriptor> deploymentDescriptor;
+    private DeploymentDescriptor deploymentDescriptor;
     private CopySpec lib;
     private final DirectoryProperty appDir;
 
     public Ear() {
         getArchiveExtension().set(EAR_EXTENSION);
         setMetadataCharset("UTF-8");
-        libDirName = getObjectFactory().property(String.class).convention(DEFAULT_LIB_DIR_NAME);
         generateDeploymentDescriptor = getObjectFactory().property(Boolean.class);
         generateDeploymentDescriptor.convention(true);
-        deploymentDescriptor = getObjectFactory().property(DeploymentDescriptor.class);
         lib = getRootSpec().addChildBeforeSpec(getMainSpec()).into(
             callable(() -> GUtil.elvis(getLibDirName(), DEFAULT_LIB_DIR_NAME))
         );
@@ -191,10 +189,10 @@ public abstract class Ear extends Jar {
     }
 
     private DeploymentDescriptor forceDeploymentDescriptor() {
-        if (!deploymentDescriptor.isPresent()) {
-            deploymentDescriptor.set(getObjectFactory().newInstance(DefaultDeploymentDescriptor.class));
+        if (deploymentDescriptor == null) {
+            deploymentDescriptor = getObjectFactory().newInstance(DefaultDeploymentDescriptor.class);
         }
-        return deploymentDescriptor.get();
+        return deploymentDescriptor;
     }
 
     /**
@@ -241,11 +239,11 @@ public abstract class Ear extends Jar {
     @Input
     @ToBeReplacedByLazyProperty
     public String getLibDirName() {
-        return libDirName.getOrNull();
+        return libDirName;
     }
 
     public void setLibDirName(@Nullable String libDirName) {
-        this.libDirName.set(libDirName);
+        this.libDirName = libDirName;
     }
 
     /**
@@ -264,11 +262,11 @@ public abstract class Ear extends Jar {
     @Internal
     @ToBeReplacedByLazyProperty
     public DeploymentDescriptor getDeploymentDescriptor() {
-        return deploymentDescriptor.getOrNull();
+        return deploymentDescriptor;
     }
 
     public void setDeploymentDescriptor(DeploymentDescriptor deploymentDescriptor) {
-        this.deploymentDescriptor.set(deploymentDescriptor);
+        this.deploymentDescriptor = deploymentDescriptor;
     }
 
     /**

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultSingleFileReport.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultSingleFileReport.java
@@ -18,16 +18,24 @@ package org.gradle.api.reporting.internal;
 
 import org.gradle.api.Describable;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.internal.IConventionAware;
+import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.internal.Describables;
 
 import javax.inject.Inject;
+import java.io.File;
 
 public abstract class DefaultSingleFileReport extends SimpleReport implements SingleFileReport {
 
     @Inject
     public DefaultSingleFileReport(String name, Describable owner) {
         super(name, Describables.of(name, "report for", owner), OutputType.FILE);
+        // This is for backwards compatibility for plugins that attach a convention mapping to the replaced property
+        // TODO - this wiring should happen automatically (and be deprecated too)
+        getOutputLocation().convention(getProjectLayout().file(new DefaultProvider<>(() -> {
+            return (File) ((IConventionAware) DefaultSingleFileReport.this).getConventionMapping().getConventionValue(null, "destination", false);
+        })));
         getRequired().convention(false);
     }
 

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/SingleDirectoryReport.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/SingleDirectoryReport.java
@@ -18,6 +18,8 @@ package org.gradle.api.reporting.internal;
 
 import org.gradle.api.Describable;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.internal.IConventionAware;
+import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.internal.Describables;
 import org.jspecify.annotations.Nullable;
@@ -34,6 +36,9 @@ public abstract class SingleDirectoryReport extends SimpleReport implements Dire
     public SingleDirectoryReport(String name, Describable owner, @Nullable String relativeEntryPath) {
         super(name, Describables.of(name, "report for", owner), OutputType.DIRECTORY);
         this.relativeEntryPath = relativeEntryPath;
+        getOutputLocation().convention(getProjectLayout().dir(new DefaultProvider<>(() -> {
+            return (File) ((IConventionAware) SingleDirectoryReport.this).getConventionMapping().getConventionValue(null, "destination", false);
+        })));
         getRequired().convention(false);
     }
 

--- a/testing/architecture-test/src/changes/archunit-store/public-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-nullability.txt
@@ -615,6 +615,8 @@ Class <org.gradle.plugin.devel.plugins.MavenPluginPublishPlugin$2> is not annota
 Class <org.gradle.plugin.devel.plugins.MavenPluginPublishPlugin$3> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (MavenPluginPublishPlugin.java:0)
 Class <org.gradle.plugin.devel.plugins.MavenPluginPublishPlugin> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (MavenPluginPublishPlugin.java:0)
 Class <org.gradle.plugins.ear.Ear> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (Ear.java:0)
+Class <org.gradle.plugins.ear.EarPlugin$1> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (EarPlugin.java:0)
+Class <org.gradle.plugins.ear.EarPlugin$2> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (EarPlugin.java:0)
 Class <org.gradle.plugins.ear.EarPlugin> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (EarPlugin.java:0)
 Class <org.gradle.plugins.ear.descriptor.DeploymentDescriptor> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (DeploymentDescriptor.java:0)
 Class <org.gradle.plugins.ear.descriptor.EarModule> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (EarModule.java:0)


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->



### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

When we started working on https://github.com/gradle/gradle/issues/33355 the initial assessment was that in order to remove conventions, we also need to remove convention mapping. Later, we found that it's not necessary. By that time, we already merged some convention mapping removal. This PR reverts the already removed convention mappings.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
