### PR TITLE
Configuration Cache problems reporting improvements

### DIFF
--- a/platforms/core-configuration/configuration-cache-base/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache-base/build.gradle.kts
@@ -33,5 +33,4 @@ dependencies {
 
     implementation(projects.baseServices)
     implementation(projects.serviceLookup)
-    implementation(projects.stdlibKotlinExtensions)
 }

--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/problems/AbstractProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/problems/AbstractProblemsListener.kt
@@ -16,28 +16,11 @@
 
 package org.gradle.internal.cc.base.problems
 
-import org.gradle.internal.cc.base.exceptions.ConfigurationCacheError
-import org.gradle.internal.cc.base.exceptions.ConfigurationCacheThrowable
-import org.gradle.internal.extensions.stdlib.maybeUnwrapInvocationTargetException
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyTrace
-import org.gradle.internal.configuration.problems.StructuredMessage
-import org.gradle.internal.configuration.problems.StructuredMessageBuilder
-import java.io.IOException
 
 
 abstract class AbstractProblemsListener : ProblemsListener {
-
-    override fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) {
-        // Let IO and configuration cache exceptions surface to the top.
-        if (error is IOException || error is ConfigurationCacheThrowable) {
-            throw error
-        }
-        throw ConfigurationCacheError(
-            "Configuration cache state could not be cached: $trace: ${StructuredMessage.build(message).render()}",
-            error.maybeUnwrapInvocationTargetException()
-        )
-    }
 
     override fun forIncompatibleTask(trace: PropertyTrace, reason: String): ProblemsListener = this
 }

--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -71,7 +71,6 @@ dependencies {
     implementation(projects.stdlibSerializationCodecs)
     implementation(projects.toolingApi)
 
-    implementation(libs.fastutil)
     implementation(libs.guava)
     implementation(libs.jspecify)
     implementation(libs.kryo)

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncompatibleTasksIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncompatibleTasksIntegrationTest.groovy
@@ -131,10 +131,10 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.problems.assertFailureHasTooManyProblems(failure) {
             withProblem("Build file 'build.gradle': line 9: invocation of 'Task.project' at execution time is unsupported.")
-            withProblem("Task `:declared` of type `Broken`: cannot deserialize object of type 'org.gradle.api.artifacts.ConfigurationContainer' as these are not supported with the configuration cache.")
-            withProblem("Task `:declared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
             withProblem("Task `:notDeclared` of type `Broken`: cannot deserialize object of type 'org.gradle.api.artifacts.ConfigurationContainer' as these are not supported with the configuration cache.")
             withProblem("Task `:notDeclared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
+            withProblem("Task `:declared` of type `Broken`: cannot deserialize object of type 'org.gradle.api.artifacts.ConfigurationContainer' as these are not supported with the configuration cache.")
+            withProblem("Task `:declared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
             withIncompatibleTask(":declared", "retains configuration container.")
             totalProblemsCount = 6
             problemsWithStackTraceCount = 2
@@ -447,8 +447,8 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         fixture.assertStateStoredAndDiscarded {
             loadsAfterStore = false
             problem("Build file 'build.gradle': line 9: invocation of 'Task.project' at execution time is unsupported.", 2)
-            serializationProblem("Task `:declared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
             serializationProblem("Task `:notDeclared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
+            serializationProblem("Task `:declared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -353,16 +353,17 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
 
         and:
         configurationCache.assertStateStoreFailed()
-        outputContains("Configuration cache entry discarded with 2 problems.")
-        failure.assertHasFailures(1)
+        outputContains("Configuration cache entry discarded with 3 problems.")
+        failure.assertHasFailures(2)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)
         failure.assertHasDescription("Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'")
         failure.assertHasCause("BOOM")
-        problems.assertResultHasProblems(failure) {
-            totalProblemsCount = 2
+        problems.assertFailureHasProblems(failure) {
+            totalProblemsCount = 3
             withProblem("Task `:problems` of type `org.gradle.api.DefaultTask`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
-            problemsWithStackTraceCount = 0
+            withProblem("Task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'")
+            problemsWithStackTraceCount = 1
         }
 
         when:
@@ -373,16 +374,17 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
 
         and:
         configurationCache.assertStateStoreFailed()
-        outputContains("Configuration cache entry discarded with 2 problems.")
+        outputContains("Configuration cache entry discarded with 3 problems.")
         failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)
         failure.assertHasDescription("Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'")
         failure.assertHasCause("BOOM")
         problems.assertResultHasProblems(failure) {
-            totalProblemsCount = 2
+            totalProblemsCount = 3
             withProblem("Task `:problems` of type `org.gradle.api.DefaultTask`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.")
-            problemsWithStackTraceCount = 0
+            withProblem("Task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'")
+            problemsWithStackTraceCount = 1
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -618,7 +618,7 @@ class DefaultConfigurationCache internal constructor(
                 storeFailure
             } catch (error: Exception) {
                 // Invalidate state on serialization errors
-                problems.failingBuildDueToSerializationError()
+                problems.onStoreSerializationError()
                 throw error
             }
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/TaskExecutionAccessCheckers.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/TaskExecutionAccessCheckers.kt
@@ -18,9 +18,9 @@ package org.gradle.internal.cc.impl
 
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier
-import org.gradle.internal.evaluation.EvaluationContext
 import org.gradle.api.internal.tasks.TaskExecutionAccessChecker
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
+import org.gradle.internal.evaluation.EvaluationContext
 import org.gradle.internal.execution.WorkExecutionTracker
 
 
@@ -74,7 +74,7 @@ abstract class AbstractTaskProjectAccessChecker(
      * Either way, errors here are false positives: the failing tasks are CC-compatible when CC actually stores them.
      */
     private
-    fun currentEvaluationShouldBeReducedByStore() : Boolean {
+    fun currentEvaluationShouldBeReducedByStore(): Boolean {
         // If we've loaded from the cache, then all stores already happened. Everything not reduced by this point should be reported.
         if (graphLoadingState.isLoadedFromCache()) {
             return false

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -113,8 +113,8 @@ class ConfigurationCacheStartParameter internal constructor(
     val isDebug: Boolean
         get() = startParameter.isConfigurationCacheDebug
 
-    val failOnProblems: Boolean
-        get() = startParameter.configurationCacheProblems == ConfigurationCacheProblemsOption.Value.FAIL
+    val warningMode: Boolean
+        get() = startParameter.configurationCacheProblems == ConfigurationCacheProblemsOption.Value.WARN
 
     val recreateCache: Boolean
         get() = startParameter.isConfigurationCacheRecreateCache

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -113,7 +113,7 @@ class ConfigurationCacheStartParameter internal constructor(
     val isDebug: Boolean
         get() = startParameter.isConfigurationCacheDebug
 
-    val warningMode: Boolean
+    val isWarningMode: Boolean
         get() = startParameter.configurationCacheProblems == ConfigurationCacheProblemsOption.Value.WARN
 
     val recreateCache: Boolean

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -94,7 +94,7 @@ class ConfigurationCacheProblems(
     val postBuildHandler = PostBuildProblemsHandler()
 
     private
-    val warningMode = startParameter.warningMode
+    val isWarningMode: Boolean = startParameter.isWarningMode
 
     private
     var seenSerializationErrorOnStore = false
@@ -258,7 +258,7 @@ class ConfigurationCacheProblems(
     private
     fun ProblemSeverity.toProblemSeverity() = when {
         this == ProblemSeverity.Suppressed -> Severity.ADVICE
-        warningMode -> Severity.WARNING
+        isWarningMode -> Severity.WARNING
         else -> Severity.ERROR
     }
 
@@ -271,7 +271,7 @@ class ConfigurationCacheProblems(
     }
 
     fun queryFailure(summary: Summary = summarizer.get(), htmlReportFile: File? = null): Throwable? {
-        val failDueToProblems = summary.deferredProblemCount > 0 && !warningMode
+        val failDueToProblems = summary.deferredProblemCount > 0 && !isWarningMode
         val hasTooManyProblems = hasTooManyProblems(summary)
         val summaryText = { summary.textForConsole(cacheAction.summaryText(), htmlReportFile) }
         return when {
@@ -379,7 +379,7 @@ class ConfigurationCacheProblems(
 
     private
     fun discardStateDueToProblems(summary: Summary) =
-        !warningMode && (summary.totalProblemCount > 0 || incompatibleTasks.isNotEmpty())
+        !isWarningMode && (summary.totalProblemCount > 0 || incompatibleTasks.isNotEmpty())
 
     private
     fun hasTooManyProblems(summary: Summary) =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -94,7 +94,7 @@ class ConfigurationCacheProblems(
     val postBuildHandler = PostBuildProblemsHandler()
 
     private
-    var isFailOnProblems = startParameter.failOnProblems
+    var isFailOnProblems = !startParameter.warningMode
 
     private
     var isFailingBuildDueToSerializationError = false

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -277,11 +277,11 @@ class ConfigurationCacheProblems(
         val summaryText = { summary.textForConsole(cacheAction.summaryText(), htmlReportFile) }
         return when {
             failDueToProblems -> {
-                ConfigurationCacheProblemsException(summary.causes, summaryText)
+                ConfigurationCacheProblemsException(summary.originalProblemExceptions, summaryText)
             }
 
             hasTooManyProblems -> {
-                TooManyConfigurationCacheProblemsException(summary.causes, summaryText)
+                TooManyConfigurationCacheProblemsException(summary.originalProblemExceptions, summaryText)
             }
 
             else -> null

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -154,13 +154,14 @@ class ConfigurationCacheProblems(
             throw error
         }
 
+        val wrappedMessage = StructuredMessage.build(message)
+        val originalError = error.maybeUnwrapInvocationTargetException()
         val wrappedError = ConfigurationCacheError(
             // TODO: the message is not precise, since some errors can happen during load
-            "Configuration cache state could not be cached: $trace: ${StructuredMessage.build(message).render()}",
-            error.maybeUnwrapInvocationTargetException()
+            "Configuration cache state could not be cached: $trace: ${wrappedMessage.render()}",
+            originalError
         )
-        val failure = failureFactory.create(error)
-        val problem = PropertyProblem(trace, StructuredMessage.build(message), wrappedError, failure)
+        val problem = PropertyProblem(trace, wrappedMessage, wrappedError, failureFactory.create(originalError))
         onProblem(problem, ProblemSeverity.Interrupting)
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -93,6 +93,7 @@ class ConfigurationCacheProblemsSummary(
             when (severity) {
                 ProblemSeverity.Deferred -> deferredProblemCount += 1
                 ProblemSeverity.Suppressed -> suppressedProblemCount += 1
+                ProblemSeverity.Interrupting -> {}
             }
             if (overflowed) {
                 return false
@@ -233,6 +234,7 @@ fun consoleComparatorForProblem(): Comparator<UniquePropertyProblem> =
  *
  * Deferred problems go first because their presence is the cause of the Configuration Cache build failure.
  * Suppressed problems are included, but their presence alone would not have triggered a build failure.
+ * Interrupting problems will have a dedicated build failure, so they have the lowest summary priority.
  */
 private
 fun consoleComparatorForSeverity(): Comparator<ProblemSeverity> =
@@ -240,6 +242,7 @@ fun consoleComparatorForSeverity(): Comparator<ProblemSeverity> =
         when (it) {
             ProblemSeverity.Deferred -> 1
             ProblemSeverity.Suppressed -> 2
+            ProblemSeverity.Interrupting -> 3
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -92,8 +92,6 @@ class ConfigurationCacheProblemsSummary(
             when (severity) {
                 ProblemSeverity.Failure -> failureCount += 1
                 ProblemSeverity.Suppressed -> suppressedCount += 1
-                ProblemSeverity.Warning -> {}
-                ProblemSeverity.Info -> {}
             }
             if (overflowed) {
                 return false

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -16,9 +16,9 @@
 
 package org.gradle.internal.cc.impl.problems
 
+import com.google.common.collect.Comparators
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
-import com.google.common.collect.Ordering
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.internal.configuration.problems.PropertyProblem
 import org.gradle.internal.extensions.stdlib.capitalized
@@ -180,7 +180,8 @@ class Summary(
 
     private
     fun topProblemsForConsole(): Sequence<UniquePropertyProblem> =
-        Ordering.from(consoleComparatorForProblemWithSeverity()).leastOf(uniqueProblems.entries, MAX_CONSOLE_PROBLEMS)
+        uniqueProblems.entries.stream()
+            .collect(Comparators.least(MAX_CONSOLE_PROBLEMS, consoleComparatorForProblemWithSeverity()))
             .asSequence()
             .map { it.key }
 

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummaryTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummaryTest.kt
@@ -35,15 +35,15 @@ class ConfigurationCacheProblemsSummaryTest {
         val subject = ConfigurationCacheProblemsSummary(maxCollectedProblems = 2)
         assertTrue(
             "1st problem",
-            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Failure)
+            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Deferred)
         )
         assertTrue(
             "2nd problem (same message as 1st but different location)",
-            subject.onProblem(buildLogicProblem("build.gradle.kts", "failure"), ProblemSeverity.Failure)
+            subject.onProblem(buildLogicProblem("build.gradle.kts", "failure"), ProblemSeverity.Deferred)
         )
         assertFalse(
             "overflow",
-            subject.onProblem(buildLogicProblem("build.gradle", "another failure"), ProblemSeverity.Failure)
+            subject.onProblem(buildLogicProblem("build.gradle", "another failure"), ProblemSeverity.Deferred)
         )
         assertThat(
             subject.get().uniqueProblemCount,
@@ -56,21 +56,21 @@ class ConfigurationCacheProblemsSummaryTest {
         val subject = ConfigurationCacheProblemsSummary(maxCollectedProblems = 2)
         assertTrue(
             "1st problem",
-            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Failure)
+            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Deferred)
         )
         assertTrue(
             "2nd problem",
-            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Failure)
+            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Deferred)
         )
         assertFalse(
             "overflow",
-            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Failure)
+            subject.onProblem(buildLogicProblem("build.gradle", "failure"), ProblemSeverity.Deferred)
         )
 
         val summary = subject.get()
         assertThat(
             "Keeps track of total problem count regardless of maxCollectedProblems",
-            summary.problemCount,
+            summary.totalProblemCount,
             equalTo(3)
         )
     }

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummaryTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummaryTest.kt
@@ -46,7 +46,7 @@ class ConfigurationCacheProblemsSummaryTest {
             subject.onProblem(buildLogicProblem("build.gradle", "another failure"), ProblemSeverity.Deferred)
         )
         assertThat(
-            subject.get().uniqueProblemCount,
+            subject.get().problemCauseCount,
             equalTo(2)
         )
     }

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.serialization.codecs
 
+import org.gradle.internal.cc.base.exceptions.ConfigurationCacheError
 import org.gradle.internal.cc.base.problems.AbstractProblemsListener
 import org.gradle.internal.cc.base.serialize.IsolateOwners
 import org.gradle.internal.cc.impl.serialize.Codecs
@@ -23,6 +24,9 @@ import org.gradle.internal.cc.impl.serialize.DefaultClassDecoder
 import org.gradle.internal.cc.impl.serialize.DefaultClassEncoder
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyProblem
+import org.gradle.internal.configuration.problems.PropertyTrace
+import org.gradle.internal.configuration.problems.StructuredMessage
+import org.gradle.internal.configuration.problems.StructuredMessageBuilder
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.extensions.stdlib.useToRun
 import org.gradle.internal.io.NullOutputStream
@@ -59,6 +63,10 @@ abstract class AbstractUserTypeCodecTest {
                 object : AbstractProblemsListener() {
                     override fun onProblem(problem: PropertyProblem) {
                         problems += problem
+                    }
+
+                    override fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) {
+                        onProblem(PropertyProblem(trace, StructuredMessage.build(message), error))
                     }
                 }
             )
@@ -150,6 +158,10 @@ abstract class AbstractUserTypeCodecTest {
     private fun loggingProblemsListener() = object : AbstractProblemsListener() {
         override fun onProblem(problem: PropertyProblem) {
             println(problem)
+        }
+
+        override fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) {
+            throw ConfigurationCacheError(StructuredMessage.build(message).render(), error)
         }
     }
 

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
@@ -30,6 +30,14 @@ enum class ProblemSeverity {
     Deferred,
 
     /**
+     * Problems that interrupt the current operation immediately after being discovered and recorded.
+     *
+     * The exception is normally turned into a dedicated build failure.
+     * These problems are still present in the report and can appear in the console summary.
+     */
+    Interrupting,
+
+    /**
      * A problem produced by a task marked as [notCompatibleWithConfigurationCache][org.gradle.api.Task.notCompatibleWithConfigurationCache].
      */
     Suppressed,

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
@@ -20,7 +20,8 @@ enum class ProblemSeverity {
 
     /**
      * Problems that are reported to the user sometime after they are discovered,
-     * but which will fail the build, unless warning mode is active.
+     * but which will fail the build, unless [warning-mode][org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption.Value.WARN]
+     * is active.
      *
      * Collecting deferred problems is useful to provide the user with the overview
      * of potentially many things that make the build not compatible with Configuration Cache,

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
@@ -17,7 +17,17 @@
 package org.gradle.internal.cc.impl.problems
 
 enum class ProblemSeverity {
-    Failure,
+
+    /**
+     * Problems that are reported to the user sometime after they are discovered,
+     * but which will fail the build, unless warning mode is active.
+     *
+     * Collecting deferred problems is useful to provide the user with the overview
+     * of potentially many things that make the build not compatible with Configuration Cache,
+     * instead of failing the build on the first encounter. Many serialization problems
+     * fall into this category.
+     */
+    Deferred,
 
     /**
      * A problem produced by a task marked as [notCompatibleWithConfigurationCache][org.gradle.api.Task.notCompatibleWithConfigurationCache].

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
@@ -17,11 +17,10 @@
 package org.gradle.internal.cc.impl.problems
 
 enum class ProblemSeverity {
-    Info,
     Failure,
-    Warning,
+
     /**
-     * A problem produced by a task marked as [notCompatibleWithConfigurationCache][Task.notCompatibleWithConfigurationCache].
+     * A problem produced by a task marked as [notCompatibleWithConfigurationCache][org.gradle.api.Task.notCompatibleWithConfigurationCache].
      */
-    Suppressed
+    Suppressed,
 }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/CommonReport.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/CommonReport.kt
@@ -27,7 +27,6 @@ import org.gradle.internal.cc.impl.problems.HtmlReportWriter
 import org.gradle.internal.cc.impl.problems.JsonModelWriter
 import org.gradle.internal.cc.impl.problems.JsonSource
 import org.gradle.internal.cc.impl.problems.JsonWriter
-import org.gradle.internal.cc.impl.problems.ProblemSeverity
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.extensions.stdlib.capitalized

--- a/platforms/core-configuration/graph-isolation/src/main/kotlin/org/gradle/internal/isolate/graph/IsolatedActionSerializer.kt
+++ b/platforms/core-configuration/graph-isolation/src/main/kotlin/org/gradle/internal/isolate/graph/IsolatedActionSerializer.kt
@@ -21,7 +21,11 @@ import org.gradle.internal.cc.base.exceptions.ConfigurationCacheError
 import org.gradle.internal.cc.base.logger
 import org.gradle.internal.cc.base.problems.AbstractProblemsListener
 import org.gradle.internal.configuration.problems.PropertyProblem
+import org.gradle.internal.configuration.problems.PropertyTrace
+import org.gradle.internal.configuration.problems.StructuredMessage
+import org.gradle.internal.configuration.problems.StructuredMessageBuilder
 import org.gradle.internal.extensions.stdlib.invert
+import org.gradle.internal.extensions.stdlib.maybeUnwrapInvocationTargetException
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.extensions.stdlib.useToRun
 import org.gradle.internal.serialize.Decoder
@@ -181,5 +185,13 @@ object ThrowingProblemsListener : AbstractProblemsListener() {
     override fun onProblem(problem: PropertyProblem) {
         // TODO: consider throwing more specific exception
         throw ConfigurationCacheError("Failed to isolate 'GradleLifecycle' action: ${problem.message}")
+    }
+
+    override fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) {
+        // TODO: consider throwing more specific exception
+        throw ConfigurationCacheError(
+            "Failed to isolate 'GradleLifecycle' action:: $trace: ${StructuredMessage.build(message).render()}",
+            error.maybeUnwrapInvocationTargetException()
+        )
     }
 }

--- a/platforms/core-configuration/graph-isolation/src/main/kotlin/org/gradle/internal/isolate/graph/IsolatedActionSerializer.kt
+++ b/platforms/core-configuration/graph-isolation/src/main/kotlin/org/gradle/internal/isolate/graph/IsolatedActionSerializer.kt
@@ -190,7 +190,7 @@ object ThrowingProblemsListener : AbstractProblemsListener() {
     override fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) {
         // TODO: consider throwing more specific exception
         throw ConfigurationCacheError(
-            "Failed to isolate 'GradleLifecycle' action:: $trace: ${StructuredMessage.build(message).render()}",
+            "Failed to isolate 'GradleLifecycle' action: $trace: ${StructuredMessage.build(message).render()}",
             error.maybeUnwrapInvocationTargetException()
         )
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -107,6 +107,7 @@ class KnownProblemIds {
         'deprecation:properties-should-be-assigned-using-the-propname-value-syntax-setting-a-property-via-the-gradle-generated-propname-value-or-propname-value-syntax-in-groovy-dsl': ['Properties should be assigned using the \'propName = value\' syntax. Setting a property via the Gradle-generated \'propName value\' or \'propName\\(value\\)\' syntax in Groovy DSL has been deprecated.'],
         'deprecation:repository-jcenter' : ['The RepositoryHandler.jcenter\\(\\) method has been deprecated.'],
         'task-selection:no-matches': ['No matches', 'cannot locate task'],
+        'validation:configuration-cache:error-writing-value-of-type-org-gradle-api-internal-file-collections-defaultconfigurablefilecollection': ['error writing value of type \'org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection\''],
         'validation:configuration-cache:registration-of-listener-on-gradle-buildfinished-is-unsupported': ['registration of listener on \'Gradle.buildFinished\' is unsupported'],
         'validation:configuration-cache:invocation-of-task-project-at-execution-time-is-unsupported': ['invocation of \'Task.project\' at execution time is unsupported.'],
         'plugin-application:target-type-mismatch': ['Unexpected plugin type'],


### PR DESCRIPTION
A number of enhancements and refactorings in preparation to fixing https://github.com/gradle/gradle/issues/32542.

The main goal of the PR is to be able to better handle CC problems that interrupt the current operation immediately on discovery, while still being shown in the CC report. Historically, CC serialization **errors** are reported as build failures independently from the "aggregating" CC build failure. An example of a serialization error is an exception thrown from Java serialization logic of a bean. The aggregating failure happens at the end of the build, after the execution-time problems are reported as well.

This PR preserves the independent build failure of CC serialization errors, but it also adds the aggregating build failure if one were to happen in the absence of serialization errors. Basically, there can be two build failures now, when running with CC. The motivation for this is to show the user all the things we've already discovered that would still fail their build even if they fix the early serialization error.

---

We also introduce a couple of terminology changes in the implementation, that should makes things easier to reason and talk about:

- Rename CC problem severity `Failure` to `Deferred` to highlight the role of the problem in the reporting flow
- Refactor `isFailOnProblems` to `warningMode`

Some other improvements along the way:

- Sort the CC problems in the summary by the severity relevance, moving the `Deferred` problems to the top (incidentally moving `Suppressed` problems down, as less important for making the build compatible)
- Remove the `Info` and `Warning` CC problem severities, that are not currently required for report-generation logic
- Report a non-CC specific message on GradleLifecycle error, untying it a bit from the CC machinery