### PR TITLE
Add fail-on-no-matching-tests option to gradle test

### DIFF
--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -488,7 +488,6 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
         forkOptions.setDebug(enabled);
     }
 
-
     /**
      * {@inheritDoc}
      */
@@ -523,6 +522,26 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
     @ToBeReplacedByLazyProperty
     public boolean getFailFast() {
         return super.getFailFast();
+    }
+
+    /**
+     * Enables failing the task if no tests match the filter configuration.
+     */
+    @Option(option = "fail-on-no-matching-tests", description = "Fails the task if no tests match the filter.")
+    @Override
+    public void setFailOnNoMatchingTests(boolean failOnNoMatchingTests) {
+        super.setFailOnNoMatchingTests(failOnNoMatchingTests);
+    }
+
+    /**
+     * Indicates if this task will fail if no tests match the filter configuration.
+     *
+     * @return whether this task will fail if no tests match the filter configuration
+     */
+    @Override
+    @ToBeReplacedByLazyProperty
+    public boolean getFailOnNoMatchingTests() {
+        return super.getFailOnNoMatchingTests();
     }
 
     /**

--- a/platforms/jvm/testing-jvm/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/platforms/jvm/testing-jvm/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -94,6 +94,7 @@ class TestTest extends AbstractConventionTaskTest {
         test.getReports().getHtml().outputLocation.getOrNull() == null
         test.getIncludes().isEmpty()
         test.getExcludes().isEmpty()
+        test.getFailOnNoMatchingTests()
         !test.getIgnoreFailures()
         !test.getFailFast()
     }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -659,6 +659,15 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         this.failFast = failFast;
     }
 
+    @Internal
+    boolean getFailOnNoMatchingTests() {
+        return getFilter().isFailOnNoMatchingTests();
+    }
+
+    void setFailOnNoMatchingTests(boolean failOnNoMatchingTests) {
+        getFilter().setFailOnNoMatchingTests(failOnNoMatchingTests);
+    }
+
     /**
      * The reports that this task potentially produces.
      *

--- a/testing/architecture-test/src/changes/archunit-store/provider-task-properties.txt
+++ b/testing/architecture-test/src/changes/archunit-store/provider-task-properties.txt
@@ -176,6 +176,7 @@ Method <org.gradle.api.tasks.testing.Test.getEnvironment()> does not have raw re
 Method <org.gradle.api.tasks.testing.Test.getExcludes()> does not have raw return type (java.util.Set) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (Test.java:0)
 Method <org.gradle.api.tasks.testing.Test.getExecutable()> does not have raw return type (java.lang.String) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (Test.java:0)
 Method <org.gradle.api.tasks.testing.Test.getFailFast()> does not have raw return type (boolean) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (Test.java:0)
+Method <org.gradle.api.tasks.testing.Test.getFailOnNoMatchingTests()> does not have raw return type (boolean) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (Test.java:0)
 Method <org.gradle.api.tasks.testing.Test.getForkEvery()> does not have raw return type (long) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (Test.java:0)
 Method <org.gradle.api.tasks.testing.Test.getIncludes()> does not have raw return type (java.util.Set) assignable to any of [Property, MapProperty, ListProperty, SetProperty] in (Test.java:0)
 Method <org.gradle.api.tasks.testing.Test.getJavaVersion()> does not have raw return type (org.gradle.api.JavaVersion) assignable to any of [Provider] in (Test.java:0)


### PR DESCRIPTION
This commit connects the pre-existing property and methods `TestFilter#isFailOnNoMatchingTests` as an option on the `org.gradle.api.tasks.testing.Test` task class. This enables new `--fail-on-no-matching-tests` (default behavior, still; unchanged here) and `--no-fail-on-no-matching-tests` flags to the `gradle test` command.

In particular, if you ran a `gradle test --tests 'some.pkg.*'` invocation on a project with subprojects with varying tests, you would usually see failures due to some projects not having any tests matching the given pattern. With this change, you can run:

    gradle test --tests 'some.pkg.*' --no-fail-on-no-matching-tests

and run all tests in your project with that pattern, and no failures on subprojects that don't have such tests.

### Context

Prior issue reports and discussions:

- https://github.com/gradle/gradle/issues/19815
- https://stackoverflow.com/questions/30474767/no-tests-found-for-given-includes-error-when-running-parameterized-unit-test-in

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
