### PR TITLE
Add more grain to CC outcome assertions

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCleanupIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheCleanupIntegrationTest.groovy
@@ -65,7 +65,7 @@ class ConfigurationCacheCleanupIntegrationTest
         expect: 'Gradle to preserve the recent entry and to delete the outdated one'
         def cc = newConfigurationCacheFixture()
         configurationCacheRunNoDaemon 'recent'
-        cc.reused
+        cc.assertStateLoaded()
         !outdated.any { it.exists() }
 
         and:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheFileCollectionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheFileCollectionIntegrationTest.groovy
@@ -255,7 +255,7 @@ class ConfigurationCacheFileCollectionIntegrationTest extends AbstractConfigurat
         configurationCacheRun 'consumer'
 
         then:
-        configurationCache.assertStateStored(true)
+        configurationCache.assertStateStored()
 
         and:
         file('build/consumer-output.txt').text == '42'

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheFlowScopeIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheFlowScopeIntegrationTest.groovy
@@ -31,7 +31,7 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
         configurationCacheRun 'help'
 
         then: 'flow action reacts to build result'
-        configCache.assertStateStored(true)
+        configCache.assertStateStored()
         outputContains '(green)'
 
         when: 'task from cache runs successfully'

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncompatibleTasksIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncompatibleTasksIntegrationTest.groovy
@@ -35,6 +35,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":declared")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
             problem "Build file 'build.gradle': line 16: invocation of 'Task.project' at execution time is unsupported."
             problem "Task `:declared` of type `Broken`: error writing value of type 'BrokenSerializable'"
             incompatibleTask ":declared", "retains configuration container."
@@ -47,8 +48,10 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":declared")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
             problem "Build file 'build.gradle': line 16: invocation of 'Task.project' at execution time is unsupported."
             problem "Task `:declared` of type `Broken`: error writing value of type 'BrokenSerializable'"
+            incompatibleTask ":declared", "retains configuration container."
         }
     }
 
@@ -78,6 +81,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":reportedlyIncompatible")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
         }
 
         fixture.problems.assertResultHasProblems(result) {
@@ -166,6 +170,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":declared")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
         }
 
         when:
@@ -175,6 +180,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":declared")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
         }
     }
 
@@ -243,6 +249,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":declared", ":reliesOnSerialization")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
         }
 
         where:
@@ -269,6 +276,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
             problem("Build file 'build.gradle': line 11: invocation of 'Task.project' at execution time is unsupported.")
         }
     }
@@ -296,6 +304,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
         }
     }
 
@@ -321,6 +330,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
         }
     }
 
@@ -346,6 +356,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
         }
     }
 
@@ -380,6 +391,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
         }
     }
 
@@ -418,12 +430,14 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
         }
     }
 
     private void assertStateStoredAndDiscardedForDeclaredTask(int line) {
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
+            loadsOnStore = false
             problem "Build file 'build.gradle': line $line: invocation of 'Task.project' at execution time is unsupported."
             serializationProblem("Task `:declared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
         }
@@ -431,6 +445,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
 
     private void assertStateStoredAndDiscardedForDeclaredAndNotDeclaredTasks() {
         fixture.assertStateStoredAndDiscarded {
+            loadsOnStore = false
             problem("Build file 'build.gradle': line 9: invocation of 'Task.project' at execution time is unsupported.", 2)
             serializationProblem("Task `:declared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
             serializationProblem("Task `:notDeclared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncompatibleTasksIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncompatibleTasksIntegrationTest.groovy
@@ -35,7 +35,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":declared")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
             problem "Build file 'build.gradle': line 16: invocation of 'Task.project' at execution time is unsupported."
             problem "Task `:declared` of type `Broken`: error writing value of type 'BrokenSerializable'"
             incompatibleTask ":declared", "retains configuration container."
@@ -48,7 +48,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":declared")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
             problem "Build file 'build.gradle': line 16: invocation of 'Task.project' at execution time is unsupported."
             problem "Task `:declared` of type `Broken`: error writing value of type 'BrokenSerializable'"
             incompatibleTask ":declared", "retains configuration container."
@@ -81,7 +81,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":reportedlyIncompatible")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
         }
 
         fixture.problems.assertResultHasProblems(result) {
@@ -170,7 +170,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":declared")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
         }
 
         when:
@@ -180,7 +180,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":declared")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
         }
     }
 
@@ -249,7 +249,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         result.assertTasksExecuted(":declared", ":reliesOnSerialization")
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
         }
 
         where:
@@ -276,7 +276,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
             problem("Build file 'build.gradle': line 11: invocation of 'Task.project' at execution time is unsupported.")
         }
     }
@@ -304,7 +304,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
         }
     }
 
@@ -330,7 +330,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
         }
     }
 
@@ -356,7 +356,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
         }
     }
 
@@ -391,7 +391,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
         }
     }
 
@@ -430,14 +430,14 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
         then:
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
         }
     }
 
     private void assertStateStoredAndDiscardedForDeclaredTask(int line) {
         fixture.assertStateStoredAndDiscarded {
             hasStoreFailure = false
-            loadsOnStore = false
+            loadsAfterStore = false
             problem "Build file 'build.gradle': line $line: invocation of 'Task.project' at execution time is unsupported."
             serializationProblem("Task `:declared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
         }
@@ -445,7 +445,7 @@ class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigu
 
     private void assertStateStoredAndDiscardedForDeclaredAndNotDeclaredTasks() {
         fixture.assertStateStoredAndDiscarded {
-            loadsOnStore = false
+            loadsAfterStore = false
             problem("Build file 'build.gradle': line 9: invocation of 'Task.project' at execution time is unsupported.", 2)
             serializationProblem("Task `:declared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")
             serializationProblem("Task `:notDeclared` of type `Broken`: cannot serialize object of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer', a subtype of 'org.gradle.api.artifacts.ConfigurationContainer', as these are not supported with the configuration cache.")

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheLambdaIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheLambdaIntegrationTest.groovy
@@ -148,6 +148,7 @@ class ConfigurationCacheLambdaIntegrationTest extends AbstractConfigurationCache
 
         then:
         fixture.assertStateStoredAndDiscarded {
+            loadsOnStore = false
             [Configuration.class, SourceDirectorySet.class].each {
                 serializationProblem(
                     "Task `:ok` of type `my.LambdaTask`: cannot serialize a lambda that captures or accepts a parameter of type '" +

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheLambdaIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheLambdaIntegrationTest.groovy
@@ -148,7 +148,7 @@ class ConfigurationCacheLambdaIntegrationTest extends AbstractConfigurationCache
 
         then:
         fixture.assertStateStoredAndDiscarded {
-            loadsOnStore = false
+            loadsAfterStore = false
             [Configuration.class, SourceDirectorySet.class].each {
                 serializationProblem(
                     "Task `:ok` of type `my.LambdaTask`: cannot serialize a lambda that captures or accepts a parameter of type '" +

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -297,7 +297,8 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         failure.assertTasksExecuted()
 
         and:
-        configurationCache.assertStateStored()
+        // TODO: why are we not discarding the state here, the same way we would have discarded it for the execution-time problems?
+        configurationCache.assertStateStoredAndFailedOnLoad()
         failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsFixture.groovy
@@ -20,12 +20,12 @@ import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.FirstParam
 import org.gradle.configuration.ApplyScriptPluginBuildOperationType
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType
-import org.gradle.internal.cc.impl.fixtures.AbstractConfigurationCacheOptInFeatureIntegrationTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheBuildOperationsFixture
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture.HasBuildActions
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture.HasInvalidationReason
+import org.gradle.internal.cc.impl.fixtures.AbstractConfigurationCacheOptInFeatureIntegrationTest
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.tooling.provider.model.internal.QueryToolingModelBuildOperationType
 
@@ -104,6 +104,7 @@ class IsolatedProjectsFixture {
      */
     void assertStateStoredAndDiscarded(@DelegatesTo(StateDiscardedWithProblemsDetails) Closure closure) {
         def details = new StateDiscardedWithProblemsDetails()
+        details.loadsOnStore = false // in most cases IP-problems are registered before Store, so the entry is discarded before Load
         closure.delegate = details
         closure()
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsFixture.groovy
@@ -104,7 +104,7 @@ class IsolatedProjectsFixture {
      */
     void assertStateStoredAndDiscarded(@DelegatesTo(StateDiscardedWithProblemsDetails) Closure closure) {
         def details = new StateDiscardedWithProblemsDetails()
-        details.loadsOnStore = false // in most cases IP-problems are registered before Store, so the entry is discarded before Load
+        details.loadsAfterStore = false // in most cases IP-problems are registered before Store, so the entry is discarded before Load
         closure.delegate = details
         closure()
 
@@ -304,7 +304,7 @@ class IsolatedProjectsFixture {
     private <T extends HasBuildActions> T forModels(T details) {
         details.createsModels = true
         details.runsTasks = false
-        details.loadsOnStore = false
+        details.loadsAfterStore = false
         details
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheBuildOperationsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheBuildOperationsFixture.groovy
@@ -29,10 +29,6 @@ class ConfigurationCacheBuildOperationsFixture {
         this.operations = operations
     }
 
-    boolean getReused() {
-        workGraphStoreOperation() == null && workGraphLoadOperation() != null
-    }
-
     void assertStateLoaded() {
         def load = workGraphLoadOperation()
         assert load != null && load.failure == null

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheBuildOperationsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheBuildOperationsFixture.groovy
@@ -86,6 +86,38 @@ class ConfigurationCacheBuildOperationsFixture {
         assert modelLoadOperation() == null
     }
 
+    void assertStorePhaseSuccessful() {
+        def store = workGraphStoreOperation()
+        assert store != null
+        assert store.failure == null
+    }
+
+    void assertLoadPhaseSuccessful() {
+        def load = workGraphLoadOperation()
+        assert load != null
+        assert load.failure == null
+    }
+
+    void assertStorePhaseFailed() {
+        def store = workGraphStoreOperation()
+        assert store != null
+        assert store.failure != null
+    }
+
+    void assertLoadPhaseFailed() {
+        def load = workGraphLoadOperation()
+        assert load != null
+        assert load.failure != null
+    }
+
+    void assertStorePhaseSkipped() {
+        assert workGraphStoreOperation() == null
+    }
+
+    void assertLoadPhaseSkipped() {
+        assert workGraphLoadOperation() == null
+    }
+
     @Nullable
     private BuildOperationRecord workGraphStoreOperation() {
         operations.singleOrNone("Store configuration cache state")

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheBuildOperationsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheBuildOperationsFixture.groovy
@@ -29,28 +29,44 @@ class ConfigurationCacheBuildOperationsFixture {
         this.operations = operations
     }
 
+    /**
+     * A successful "CC hit"
+     */
     void assertStateLoaded() {
-        def load = workGraphLoadOperation()
-        assert load != null && load.failure == null
-        assert workGraphStoreOperation() == null
+        assertStorePhaseSkipped()
+        assertLoadPhaseSuccessful()
     }
 
+    /**
+     * A "CC hit" with errors happening during load phase
+     */
     void assertStateLoadFailed() {
-        def load = workGraphLoadOperation()
-        assert load != null && load.failure != null
-        assert workGraphStoreOperation() == null
+        assertStorePhaseSkipped()
+        assertLoadPhaseFailed()
     }
 
-    void assertStateStored(boolean expectLoad = true) {
-        def store = workGraphStoreOperation()
-        assert store != null && store.failure == null
-        assert (workGraphLoadOperation() != null) == expectLoad
+    /**
+     * A successful "CC miss" with load-after-store behavior
+     */
+    void assertStateStored() {
+        assertStorePhaseSuccessful()
+        assertLoadPhaseSuccessful()
     }
 
+    /**
+     * A "CC miss" that was aborted after encountering errors before or during store phase
+     */
     void assertStateStoreFailed() {
-        def store = workGraphStoreOperation()
-        assert store != null && store.failure != null
-        assert workGraphLoadOperation() == null
+        assertStorePhaseFailed()
+        assertLoadPhaseSkipped()
+    }
+
+    /**
+     * A "CC miss" that stores successfully, but fails during load with an error
+     */
+    void assertStateStoredAndFailedOnLoad() {
+        assertStorePhaseSuccessful()
+        assertLoadPhaseFailed()
     }
 
     void assertModelStored() {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -440,7 +440,7 @@ class ConfigurationCacheFixture {
         boolean runsTasks = true
         // Whether to expect tooling models, which is normally the case when running any Tooling API build action
         boolean createsModels = false
-        // Whether the load operation is expected, which can may not be the case when building models or dealing with incompatible tasks or store serialization errors
+        // Whether the load operation is expected, which may not be the case when building models or dealing with incompatible tasks or store serialization errors
         boolean loadsAfterStore = true
         boolean hasStoreFailure = true
         boolean hasLoadFailure = false

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -66,7 +66,7 @@ class ConfigurationCacheFixture {
     void assertStateStored(HasBuildActions details) {
         assertHasStoreReason(details)
 
-        assertWorkGraphOrModelStored(details.runsTasks, details.createsModels, details.loadsOnStore)
+        assertWorkGraphOrModelStored(details.runsTasks, details.createsModels, details.loadsAfterStore)
 
         spec.postBuildOutputContains("Configuration cache entry ${details.storeAction}.")
 
@@ -121,7 +121,7 @@ class ConfigurationCacheFixture {
             } else {
                 configurationCacheBuildOperations.assertStorePhaseSuccessful()
             }
-            if (details.loadsOnStore) {
+            if (details.loadsAfterStore) {
                 if (details.hasLoadFailure) {
                     configurationCacheBuildOperations.assertLoadPhaseFailed()
                 } else {
@@ -441,7 +441,7 @@ class ConfigurationCacheFixture {
         // Whether to expect tooling models, which is normally the case when running any Tooling API build action
         boolean createsModels = false
         // Whether the load operation is expected, which can may not be the case when building models or dealing with incompatible tasks or store serialization errors
-        boolean loadsOnStore = true
+        boolean loadsAfterStore = true
         boolean hasStoreFailure = true
         boolean hasLoadFailure = false
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -117,9 +117,18 @@ class ConfigurationCacheFixture {
         assert details.runsTasks || details.createsModels
         if (details.runsTasks) {
             if (details.hasStoreFailure) {
-                configurationCacheBuildOperations.assertStateStoreFailed()
+                configurationCacheBuildOperations.assertStorePhaseFailed()
             } else {
-                configurationCacheBuildOperations.assertStateStored(false)
+                configurationCacheBuildOperations.assertStorePhaseSuccessful()
+            }
+            if (details.loadsOnStore) {
+                if (details.hasLoadFailure) {
+                    configurationCacheBuildOperations.assertLoadPhaseFailed()
+                } else {
+                    configurationCacheBuildOperations.assertLoadPhaseSuccessful()
+                }
+            } else {
+                configurationCacheBuildOperations.assertLoadPhaseSkipped()
             }
         } else {
             configurationCacheBuildOperations.assertNoWorkGraphOperations()
@@ -248,7 +257,10 @@ class ConfigurationCacheFixture {
     private void assertWorkGraphOrModelStored(boolean runsTasks, boolean createsModels, boolean loadAfterStore) {
         assert runsTasks || createsModels
         if (runsTasks) {
-            configurationCacheBuildOperations.assertStateStored(loadAfterStore)
+            configurationCacheBuildOperations.assertStorePhaseSuccessful()
+            if (loadAfterStore) {
+                configurationCacheBuildOperations.assertLoadPhaseSuccessful()
+            }
         } else {
             configurationCacheBuildOperations.assertNoWorkGraphOperations()
         }
@@ -428,8 +440,10 @@ class ConfigurationCacheFixture {
         boolean runsTasks = true
         // Whether to expect tooling models, which is normally the case when running any Tooling API build action
         boolean createsModels = false
+        // Whether the load operation is expected, which can may not be the case when building models or dealing with incompatible tasks or store serialization errors
         boolean loadsOnStore = true
         boolean hasStoreFailure = true
+        boolean hasLoadFailure = false
 
         abstract String getStoreAction()
     }


### PR DESCRIPTION
Allows `ConfigurationCacheFixture` to assert more cases about the status of Store and Load phases of CC