### PR TITLE
Support different Daemon and Client java version restrictions in TAPI tests

### DIFF
--- a/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
+++ b/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.integtests
 
 import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.SimpleCrossVersionFixture
+import org.gradle.integtests.fixtures.OtherGradleVersionFixture
 import org.gradle.integtests.fixtures.StaleOutputJavaProject
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.executer.AbstractGradleExecuter
@@ -31,7 +31,7 @@ import static org.gradle.integtests.fixtures.StaleOutputJavaProject.JAR_TASK_NAM
 import static org.gradle.util.internal.GFileUtils.forceDelete
 
 @IntegrationTestTimeout(240)
-class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec implements SimpleCrossVersionFixture {
+class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec implements OtherGradleVersionFixture {
 
     private final GradleExecuter mostRecentReleaseExecuter = otherVersion.executer(temporaryFolder, buildContext) as AbstractGradleExecuter
 

--- a/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
+++ b/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
@@ -18,25 +18,22 @@ package org.gradle.integtests
 
 import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.SimpleCrossVersionFixture
 import org.gradle.integtests.fixtures.StaleOutputJavaProject
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.integtests.fixtures.executer.AbstractGradleExecuter
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
-import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
-import org.gradle.internal.jvm.Jvm
-import org.gradle.util.GradleVersion
-import org.junit.Assume
 import spock.lang.Issue
 
 import static org.gradle.integtests.fixtures.StaleOutputJavaProject.JAR_TASK_NAME
 import static org.gradle.util.internal.GFileUtils.forceDelete
 
 @IntegrationTestTimeout(240)
-class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
+class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec implements SimpleCrossVersionFixture {
 
-    private final ReleasedVersionDistributions releasedVersionDistributions = new ReleasedVersionDistributions()
-    private final GradleExecuter mostRecentReleaseExecuter = releasedVersionDistributions.mostRecentRelease.executer(temporaryFolder, buildContext)
+    private final GradleExecuter mostRecentReleaseExecuter = otherVersion.executer(temporaryFolder, buildContext) as AbstractGradleExecuter
 
     def cleanup() {
         mostRecentReleaseExecuter.cleanup()
@@ -44,12 +41,6 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
         buildFile << "apply plugin: 'base'\n"
-        // When adding support for a new JDK version, the previous release might not work with it yet.
-        Assume.assumeTrue(releasedVersionDistributions.mostRecentRelease.daemonWorksWith(Jvm.current().javaVersionMajor))
-    }
-
-    GradleVersion getMostRecentReleaseVersion() {
-        releasedVersionDistributions.mostRecentRelease.version
     }
 
     @Issue("https://github.com/gradle/gradle/issues/821")

--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -21,14 +21,13 @@ Versions not listed here may or may not work.
 == Java Runtime
 
 Gradle runs on the Java Virtual Machine (JVM), which is often provided by either a JDK or JRE.
-A JVM version between 8 and 24 is required to execute Gradle.
+A JVM version between 17 and 24 is required to execute Gradle.
 JVM 25 and later versions are not yet supported.
 
-Executing the Gradle daemon with JVM 16 or earlier has been deprecated and will become an error in Gradle 9.0.
 The Gradle wrapper, Gradle client, Tooling API client, and TestKit client will remain compatible with JVM 8.
 
-JDK 6 and 7 can be used for <<building_java_projects.adoc#sec:java_cross_compilation,compilation>>.
-Testing with JVM 6 and 7 is deprecated and will not be supported in Gradle 9.0.
+JDK 6 above can be used for <<building_java_projects.adoc#sec:java_cross_compilation,compilation>>.
+JVM 8 and above can be used for executing tests.
 
 Any fully supported version of Java can be used for compilation or testing.
 However, the latest Java version may only be supported for compilation or testing, not for running Gradle.

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerConventionalPluginClasspathInjectionIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerConventionalPluginClasspathInjectionIntegrationTest.groovy
@@ -36,12 +36,15 @@ class GradleRunnerConventionalPluginClasspathInjectionIntegrationTest extends Ba
     }
 
     def "uses conventional plugin classpath if requested and is available"() {
-        expect:
-        pluginUnderTest.build().exposeMetadata {
+        when:
+        def result = pluginUnderTest.build().exposeMetadata {
             runner('helloWorld')
                 .withPluginClasspath()
                 .build()
         }
+
+        then:
+        result.task(":helloWorld").outcome == TaskOutcome.SUCCESS
     }
 
     @InspectsBuildOutput

--- a/platforms/extensibility/test-kit/src/testFixtures/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
+++ b/platforms/extensibility/test-kit/src/testFixtures/groovy/org/gradle/testkit/runner/fixtures/PluginUnderTest.groovy
@@ -20,9 +20,11 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution
 import org.gradle.internal.classpath.DefaultClassPath
+import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
+import org.junit.Assume
 
 class PluginUnderTest {
 
@@ -84,7 +86,13 @@ class PluginUnderTest {
     PluginUnderTest build() {
         writeSourceFiles()
         writeBuildScript()
-        def executer = new GradleContextualExecuter(new UnderDevelopmentGradleDistribution(), testDirectoryProvider, IntegrationTestBuildContext.INSTANCE)
+
+        // TODO: Can we make this run with the target distribution?
+        // That way we can run tests that use PluginUnderTest in more scenarios
+        def distribution = new UnderDevelopmentGradleDistribution()
+        Assume.assumeTrue("PluginUnderTest is compatible with the current JVM", distribution.daemonWorksWith(Jvm.current().javaVersionMajor))
+        def executer = new GradleContextualExecuter(distribution, testDirectoryProvider, IntegrationTestBuildContext.INSTANCE)
+
         try {
             executer
                 .usingProjectDirectory(projectDir)

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
@@ -20,7 +20,7 @@ import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.SimpleCrossVersionFixture
+import org.gradle.integtests.fixtures.OtherGradleVersionFixture
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution
 import org.gradle.integtests.tooling.fixture.ConfigurableOperation
@@ -49,7 +49,7 @@ import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
 @Issue("GRADLE-1933")
 @Retry(condition = { onWindowsSocketDisappearance(instance, failure) }, mode = SETUP_FEATURE_CLEANUP, count = 2)
 @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "concurrent tooling api is only supported for forked mode")
-class ConcurrentToolingApiIntegrationSpec extends AbstractIntegrationSpec implements SimpleCrossVersionFixture {
+class ConcurrentToolingApiIntegrationSpec extends AbstractIntegrationSpec implements OtherGradleVersionFixture {
 
     @Rule
     final ConcurrentTestUtil concurrent = new ConcurrentTestUtil()

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
@@ -20,14 +20,13 @@ import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.SimpleCrossVersionFixture
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution
-import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.integtests.tooling.fixture.ConfigurableOperation
 import org.gradle.integtests.tooling.fixture.ToolingApi
 import org.gradle.integtests.tooling.fixture.ToolingApiConnector
 import org.gradle.internal.classpath.ClassPath
-import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.precondition.Requires
@@ -38,7 +37,6 @@ import org.gradle.tooling.internal.consumer.Distribution
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener
 import org.gradle.tooling.model.GradleProject
 import org.gradle.tooling.model.idea.IdeaProject
-import org.junit.Assume
 import org.junit.Rule
 import spock.lang.Issue
 import spock.lang.Retry
@@ -51,7 +49,7 @@ import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
 @Issue("GRADLE-1933")
 @Retry(condition = { onWindowsSocketDisappearance(instance, failure) }, mode = SETUP_FEATURE_CLEANUP, count = 2)
 @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "concurrent tooling api is only supported for forked mode")
-class ConcurrentToolingApiIntegrationSpec extends AbstractIntegrationSpec {
+class ConcurrentToolingApiIntegrationSpec extends AbstractIntegrationSpec implements SimpleCrossVersionFixture {
 
     @Rule
     final ConcurrentTestUtil concurrent = new ConcurrentTestUtil()
@@ -79,12 +77,7 @@ class ConcurrentToolingApiIntegrationSpec extends AbstractIntegrationSpec {
 
     def "handles different target gradle versions concurrently"() {
         given:
-        def last = new ReleasedVersionDistributions().getMostRecentRelease()
-        // When adding support for a new JDK version, the previous release might not work with it yet.
-        Assume.assumeTrue(last.daemonWorksWith(Jvm.current().javaVersionMajor))
-        assert dist != last
-        println "Combination of versions used: current - $dist, last - $last"
-        def oldDistApi = new ToolingApi(last, temporaryFolder)
+        def oldDistApi = new ToolingApi(otherVersion, temporaryFolder)
 
         buildFile << "apply plugin: 'java'"
 

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.integtests.tooling
 import org.gradle.api.logging.LogLevel
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
-import org.gradle.integtests.fixtures.SimpleCrossVersionFixture
+import org.gradle.integtests.fixtures.OtherGradleVersionFixture
 import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.integtests.tooling.fixture.TextUtil
 import org.gradle.integtests.tooling.fixture.ToolingApi
@@ -38,7 +38,7 @@ import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.LOG_LEV
 import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.runLogScript
 import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.validateLogs
 
-class ToolingApiIntegrationTest extends AbstractIntegrationSpec implements SimpleCrossVersionFixture {
+class ToolingApiIntegrationTest extends AbstractIntegrationSpec implements OtherGradleVersionFixture {
 
     final ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
 

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -18,19 +18,16 @@ package org.gradle.integtests.tooling
 import org.gradle.api.logging.LogLevel
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
-import org.gradle.integtests.fixtures.executer.GradleDistribution
+import org.gradle.integtests.fixtures.SimpleCrossVersionFixture
 import org.gradle.integtests.fixtures.executer.GradleHandle
-import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.integtests.tooling.fixture.TextUtil
 import org.gradle.integtests.tooling.fixture.ToolingApi
-import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.time.CountdownTimer
 import org.gradle.internal.time.Time
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.GradleProject
 import org.gradle.util.GradleVersion
-import org.junit.Assume
 import spock.lang.Issue
 
 import java.time.ZoneOffset
@@ -41,17 +38,14 @@ import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.LOG_LEV
 import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.runLogScript
 import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.validateLogs
 
-class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
+class ToolingApiIntegrationTest extends AbstractIntegrationSpec implements SimpleCrossVersionFixture {
 
     final ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
-    final GradleDistribution otherVersion = new ReleasedVersionDistributions().mostRecentRelease
 
     TestFile projectDir
 
     def setup() {
         projectDir = temporaryFolder.testDirectory
-        // When adding support for a new JDK version, the previous release might not work with it yet.
-        Assume.assumeTrue(otherVersion.daemonWorksWith(Jvm.current().javaVersionMajor))
 
         settingsFile.touch()
     }
@@ -60,7 +54,6 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
         propertiesFile << "org.gradle.logging.level=quiet"
         buildFile << LOG_LEVEL_TEST_SCRIPT
     }
-
 
     def "tooling api uses to the current version of gradle when none has been specified"() {
         buildFile << "assert gradle.gradleVersion == '${GradleVersion.current().version}'"

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClassLoaderProvider.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClassLoaderProvider.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.tooling.fixture
 
 import org.apache.commons.io.output.TeeOutputStream
+import org.gradle.api.internal.jvm.JavaVersionParser
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution
@@ -98,6 +99,7 @@ class ToolingApiClassLoaderProvider {
         sharedSpec.allowClass(TeeOutputStream)
         sharedSpec.allowClass(ClassLoaderFixture)
         sharedSpec.allowClass(SupportedJavaVersionsExpectations)
+        sharedSpec.allowClass(JavaVersionParser)
         def sharedClassLoader = classLoaderFactory.createFilteringClassLoader(Thread.currentThread().getContextClassLoader(), sharedSpec)
 
         def parentClassLoader = new MultiParentClassLoader(toolingApi.classLoader, sharedClassLoader)

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiCompatibilityTestInterceptor.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiCompatibilityTestInterceptor.groovy
@@ -19,21 +19,11 @@ package org.gradle.integtests.tooling.fixture
 import org.gradle.integtests.fixtures.GradleDistributionTool
 import org.gradle.integtests.fixtures.compatibility.AbstractCompatibilityTestInterceptor
 import org.gradle.integtests.fixtures.compatibility.CoverageContext
-import org.gradle.integtests.fixtures.executer.GradleDistribution
-import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 
 class ToolingApiCompatibilityTestInterceptor extends AbstractCompatibilityTestInterceptor {
 
     protected ToolingApiCompatibilityTestInterceptor(Class<?> target) {
         super(target)
-    }
-
-    /**
-     * Tooling API tests will can run against any version back to Gradle 0.8.
-     */
-    @Override
-    protected List<GradleDistribution> choosePreviousVersionsToTest(ReleasedVersionDistributions previousVersions) {
-        return previousVersions.all
     }
 
     @Override
@@ -46,7 +36,7 @@ class ToolingApiCompatibilityTestInterceptor extends AbstractCompatibilityTestIn
     }
 
     @Override
-    protected Collection<Execution> createDistributionExecutionsFor(GradleDistributionTool versionedTool) {
+    protected Collection<Execution> createExecutionsFor(GradleDistributionTool versionedTool) {
         return [new ToolingApiExecution(current, versionedTool.distribution)]
     }
 

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiExecution.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiExecution.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.tooling.fixture
 
+import org.gradle.api.internal.jvm.JavaVersionParser
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.extensions.AbstractMultiTestInterceptor
 import org.gradle.util.GradleVersion
@@ -81,19 +82,25 @@ class ToolingApiExecution extends AbstractMultiTestInterceptor.Execution {
 
     @Override
     boolean isTestEnabled(AbstractMultiTestInterceptor.TestDetails testDetails) {
-        ToolingApiVersion toolingVersionAnnotation = testDetails.getAnnotation(ToolingApiVersion)
-        Spec<GradleVersion> toolingVersionSpec = toVersionSpec(toolingVersionAnnotation)
-        if (!toolingVersionSpec.isSatisfiedBy(this.toolingApiVersion)) {
-            return false
-        }
+        int currentJavaVersion = JavaVersionParser.parseCurrentMajorVersion()
+        return toolingApiSupported(testDetails, currentJavaVersion) && daemonSupported(testDetails, currentJavaVersion)
+    }
+
+    private boolean daemonSupported(AbstractMultiTestInterceptor.TestDetails testDetails, int jvmVersion) {
         TargetGradleVersion gradleVersionAnnotation = testDetails.getAnnotation(TargetGradleVersion)
         Spec<GradleVersion> gradleVersionSpec = toVersionSpec(gradleVersionAnnotation)
-        return gradleVersionSpec.isSatisfiedBy(this.gradleVersion)
+        gradleVersionSpec.isSatisfiedBy(this.gradleVersion) && gradle.daemonWorksWith(jvmVersion)
+    }
+
+    private boolean toolingApiSupported(AbstractMultiTestInterceptor.TestDetails testDetails, int jvmVersion) {
+        ToolingApiVersion toolingVersionAnnotation = testDetails.getAnnotation(ToolingApiVersion)
+        Spec<GradleVersion> toolingVersionSpec = toVersionSpec(toolingVersionAnnotation)
+        toolingVersionSpec.isSatisfiedBy(this.toolingApiVersion) && toolingApi.clientWorksWith(jvmVersion)
     }
 
     private static Spec<GradleVersion> toVersionSpec(annotation) {
         if (annotation == null) {
-            return Specs.SATISFIES_ALL
+            return Specs.satisfyAll()
         }
         return GRADLE_VERSION_SPEC.toSpec(constraintFor(annotation))
     }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiExecution.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiExecution.groovy
@@ -82,7 +82,10 @@ class ToolingApiExecution extends AbstractMultiTestInterceptor.Execution {
 
     @Override
     boolean isTestEnabled(AbstractMultiTestInterceptor.TestDetails testDetails) {
-        int currentJavaVersion = JavaVersionParser.parseCurrentMajorVersion()
+        // We cannot use JavaVersionParser.parseCurrentMajorVersion, since that method
+        // is new and the target distribution version of the class sometimes shadows the
+        // version of this class that has the new method.
+        int currentJavaVersion = JavaVersionParser.parseMajorVersion(System.getProperty("java.version"))
         return toolingApiSupported(testDetails, currentJavaVersion) && daemonSupported(testDetails, currentJavaVersion)
     }
 

--- a/testing/internal-integ-testing/build.gradle.kts
+++ b/testing/internal-integ-testing/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     implementation(projects.serviceProvider)
     implementation(projects.serviceRegistryBuilder)
     implementation(projects.time)
+    implementation(projects.toolingApi)
     implementation(projects.wrapperShared)
 
     implementation(testFixtures(projects.buildOperations))

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/GradleDistributionTool.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/GradleDistributionTool.java
@@ -23,15 +23,9 @@ import java.util.Objects;
 
 public class GradleDistributionTool implements VersionedTool {
     private final GradleDistribution distribution;
-    private final String ignored;
 
     public GradleDistributionTool(GradleDistribution distribution) {
-        this(distribution, null);
-    }
-
-    public GradleDistributionTool(GradleDistribution distribution, String ignored) {
         this.distribution = distribution;
-        this.ignored = ignored;
     }
 
     @Override
@@ -41,10 +35,6 @@ public class GradleDistributionTool implements VersionedTool {
 
     public GradleDistribution getDistribution() {
         return distribution;
-    }
-
-    public String getIgnored() {
-        return ignored;
     }
 
     @Override

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/OtherGradleVersionFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/OtherGradleVersionFixture.groovy
@@ -24,7 +24,7 @@ import org.junit.Assume
 /**
  * A fixture allowing an integration test to leverage another arbitrary Gradle distribution.
  */
-trait SimpleCrossVersionFixture {
+trait OtherGradleVersionFixture {
 
     /**
      * Get the distribution for another Gradle version, ensuring that Gradle version

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SimpleCrossVersionFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SimpleCrossVersionFixture.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.gradle.integtests.fixtures.executer.GradleDistribution
+import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
+import org.gradle.internal.jvm.Jvm
+import org.junit.Assume
+
+/**
+ * A fixture allowing an integration test to leverage another arbitrary Gradle distribution.
+ */
+trait SimpleCrossVersionFixture {
+
+    /**
+     * Get the distribution for another Gradle version, ensuring that Gradle version
+     * can execute on the current JVM.
+     */
+    GradleDistribution getOtherVersion() {
+        GradleDistribution otherVersion = new ReleasedVersionDistributions().mostRecentRelease
+
+        // Make sure the prior distribution supports the JVM we are testing on.
+        def currentVersion = Jvm.current().javaVersionMajor
+        Assume.assumeTrue(otherVersion.clientWorksWith(currentVersion))
+        Assume.assumeTrue(otherVersion.daemonWorksWith(currentVersion))
+
+        return otherVersion
+    }
+
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.groovy
@@ -20,10 +20,52 @@ import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.cache.internal.CacheVersion
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.tooling.internal.consumer.DefaultGradleConnector
 import org.gradle.util.GradleVersion
 
 class DefaultGradleDistribution implements GradleDistribution {
-    private static final String DISABLE_HIGHEST_JAVA_VERSION = "org.gradle.java.version.disableHighest";
+
+    /**
+     * The java version mapped to the first Gradle version that supports it.
+     *
+     * @see <a href="https://docs.gradle.org/current/userguide/compatibility.html#java_runtime">link</a>
+     */
+    private static final Map<Integer, String> MAX_SUPPORTED_JAVA_VERSIONS = [
+        9: "4.3",
+        10: "4.7",
+        11: "5.0",
+        12: "5.4", // 5.4 officially added support for JDK 12, but it worked before then.
+        13: "6.0",
+        14: "6.3",
+        15: "6.7",
+        16: "7.0",
+        17: "7.3",
+        18: "7.5",
+        19: "7.6",
+        20: "8.3",
+        21: "8.5",
+        22: "8.8",
+        23: "8.10",
+        24: "8.14"
+    ]
+
+    /**
+     * The java version mapped to the first Gradle version that required it as
+     * a minimum for the daemon.
+     */
+    private static final Map<Integer, String> MIN_SUPPORTED_DAEMON_JAVA_VERSIONS = [
+        8: "5.0",
+        17: "9.0"
+    ]
+
+    /**
+     * The java version mapped to the first Gradle version that required it as
+     * a minimum for clients.
+     */
+    private static final Map<Integer, String> MIN_SUPPORTED_CLIENT_JAVA_VERSIONS = [
+        8: "5.0"
+    ]
+
     private final GradleVersion version;
     private final TestFile gradleHomeDir;
     private final TestFile binDistribution;
@@ -60,92 +102,68 @@ class DefaultGradleDistribution implements GradleDistribution {
     }
 
     @Override
-    boolean daemonWorksWith(int javaVersion) {
-        // 3.x - 4.6 works on Java 7 - 8
-        if (isSameOrOlder("4.6")) {
-            return javaVersion >= 7 && javaVersion <= 8
+    boolean clientWorksWith(int jvmVersion) {
+        if (!isSupportedGradleVersion()) {
+            return false
         }
 
-        if (isSameOrOlder("4.11")) {
-            return javaVersion >= 7 && javaVersion <= 10
+        return jvmVersion >= getMinSupportedClientJavaVersion() && jvmVersion <= getMaxSupportedJavaVersion()
+    }
+
+    @Override
+    boolean daemonWorksWith(int jvmVersion) {
+        if (!isSupportedGradleVersion()) {
+            return false
         }
 
-        // 5.4 officially added support for JDK 12, but it worked before then.
-        if (isSameOrOlder("5.7")) {
-            return javaVersion >= 8 && javaVersion <= 12
-        }
-
-        if (isSameOrOlder("6.0")) {
-            return javaVersion >= 8 && javaVersion <= 13
-        }
-
-        // 6.7 added official support for JDK15
-        if (isSameOrOlder("6.6.1")) {
-            return javaVersion >= 8 && javaVersion <= 14
-        }
-
-        // 7.0 added official support for JDK16
-        // milestone 2 was published with Groovy 3 upgrade and without asm upgrade yet
-        // subsequent milestones and RCs will support JDK16
-        if (isSameOrOlder("7.0-milestone-2")) {
-            return javaVersion >= 8 && javaVersion <= 15
-        }
-
-        // 7.3 added JDK 17 support
-        if (isSameOrOlder("7.2")) {
-            return javaVersion >= 8 && javaVersion <= 16
-        }
-
-        // 7.5 added JDK 18 support
-        if (isSameOrOlder("7.4.2")) {
-            return javaVersion >= 8 && javaVersion <= 17
-        }
-
-        // 7.6 added JDK 19 support
-        if (isSameOrOlder("7.5.1")) {
-            return javaVersion >= 8 && javaVersion <= 18
-        }
-
-        // 8.3 added JDK 20 support
-        if (isSameOrOlder("8.2.1")) {
-            return javaVersion >= 8 && javaVersion <= 19
-        }
-
-        // 8.5 added JDK 21 support
-        if (isSameOrOlder("8.4")) {
-            return javaVersion >= 8 && javaVersion <= 20
-        }
-
-        // 8.8 added JDK 22 support
-        if (isSameOrOlder("8.7")) {
-            return javaVersion >= 8 && javaVersion <= 21
-        }
-
-        // 8.10 added JDK 23 support
-        if (isSameOrOlder("8.9")) {
-            return javaVersion >= 8 && javaVersion <= 22
-        }
-
-        // 8.14 added JDK 24 support
-        if (isSameOrOlder("8.13")) {
-            return javaVersion >= 8 && javaVersion <= 23
-        }
-
-        // 9.0+ requires Java 17
-        if (isSameOrOlder("8.14")) {
-            return javaVersion >= 8 && javaVersion <= 24
-        }
-
-        return javaVersion >= 17 && maybeEnforceHighestVersion(javaVersion, 24)
+        return jvmVersion >= getMinSupportedDaemonJavaVersion() && jvmVersion <= getMaxSupportedJavaVersion()
     }
 
     /**
-     * Returns true if the given java version is less than the given highest version bound.  Always returns
-     * true if the highest version check is disabled via system property.
+     * Return true if this Gradle version is supported for cross version tests.
+     * <p>
+     * If you hit this condition and your tests are not executing, you should update
+     * your tests to not run against this version.
      */
-    private static boolean maybeEnforceHighestVersion(int javaVersion, int highestVersion) {
-        boolean disableHighest = System.getProperty(DISABLE_HIGHEST_JAVA_VERSION) != null
-        return disableHighest || javaVersion <= highestVersion
+    boolean isSupportedGradleVersion() {
+        // TODO: Make this an assertion so we don't accidentally skip test coverage
+        // when we think we are running tests against old versions
+        return version >= DefaultGradleConnector.MINIMUM_SUPPORTED_GRADLE_VERSION
+    }
+
+    private int getMaxSupportedJavaVersion() {
+        return findCorrespondingVersion(
+            8, // Java 8 support was added in Gradle 2.0
+            MAX_SUPPORTED_JAVA_VERSIONS
+        )
+    }
+
+    private int getMinSupportedClientJavaVersion() {
+        return findCorrespondingVersion(
+            7, // Java 7 has been required since Gradle 3.0
+            MIN_SUPPORTED_CLIENT_JAVA_VERSIONS
+        )
+    }
+
+    private int getMinSupportedDaemonJavaVersion() {
+        return findCorrespondingVersion(
+            7, // Java 7 has been required since Gradle 3.0
+            MIN_SUPPORTED_DAEMON_JAVA_VERSIONS
+        )
+    }
+
+    private int findCorrespondingVersion(int start, Map<Integer, String> versionMap) {
+        int current = start
+
+        for (Map.Entry<Integer, String> entry : versionMap) {
+            if (isOlder(entry.value)) {
+                return current
+            } else {
+                current = entry.key
+            }
+        }
+
+        return current
     }
 
     @Override
@@ -237,12 +255,20 @@ class DefaultGradleDistribution implements GradleDistribution {
         return !isSameOrOlder("8.8")
     }
 
+    private boolean isNewer(String otherVersion) {
+        version > GradleVersion.version(otherVersion)
+    }
+
+    protected boolean isOlder(String otherVersion) {
+        version < GradleVersion.version(otherVersion)
+    }
+
     protected boolean isSameOrNewer(String otherVersion) {
-        return isVersion(otherVersion) || version.compareTo(GradleVersion.version(otherVersion)) > 0;
+        return isVersion(otherVersion) || isNewer(otherVersion)
     }
 
     protected boolean isSameOrOlder(String otherVersion) {
-        return isVersion(otherVersion) || version.compareTo(GradleVersion.version(otherVersion)) <= 0;
+        return isVersion(otherVersion) || isOlder(otherVersion)
     }
 
     protected boolean isVersion(String otherVersionString) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
@@ -42,6 +42,11 @@ public interface GradleDistribution {
     GradleExecuter executer(TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext);
 
     /**
+     * Returns true if this distribution's client supports the given JVM version.
+     */
+    boolean clientWorksWith(int jvmVersion);
+
+    /**
      * Returns true if this distribution's daemon supports the given JVM version.
      */
     boolean daemonWorksWith(int jvmVersion);

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/ReleasedVersionDistributions.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/ReleasedVersionDistributions.java
@@ -19,12 +19,14 @@ package org.gradle.integtests.fixtures.versions;
 import org.gradle.integtests.fixtures.executer.GradleDistribution;
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext;
 import org.gradle.internal.Factory;
+import org.gradle.tooling.internal.consumer.DefaultGradleConnector;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.CollectionUtils;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static org.gradle.util.internal.CollectionUtils.findFirst;
 import static org.gradle.util.internal.CollectionUtils.sort;
@@ -94,8 +96,9 @@ public class ReleasedVersionDistributions {
     }
 
     public List<GradleDistribution> getSupported() {
-        final GradleVersion firstSupported = GradleVersion.version("1.0");
-        return CollectionUtils.filter(getAll(), element -> element.getVersion().compareTo(firstSupported) >= 0);
+        return getAll().stream()
+            .filter(element -> element.getVersion().compareTo(DefaultGradleConnector.MINIMUM_SUPPORTED_GRADLE_VERSION) >= 0)
+            .collect(Collectors.toList());
     }
 
     public GradleDistribution getDistribution(final GradleVersion gradleVersion) {

--- a/testing/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistributionTest.groovy
+++ b/testing/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistributionTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer
+
+import org.gradle.util.GradleVersion
+import spock.lang.Specification
+
+/**
+ * Tests {@link DefaultGradleDistribution}.
+ */
+class DefaultGradleDistributionTest extends Specification {
+
+    def "reports correct version compatibility"() {
+        def dist = new DefaultGradleDistribution(GradleVersion.version(version), null, null)
+
+        expect:
+        !dist.clientWorksWith(minClient - 1)
+        dist.clientWorksWith(minClient)
+
+        !dist.daemonWorksWith(minDaemon - 1)
+        dist.daemonWorksWith(minDaemon)
+
+        dist.clientWorksWith(max)
+        !dist.clientWorksWith(max + 1)
+
+        dist.daemonWorksWith(max)
+        !dist.daemonWorksWith(max + 1)
+
+        where:
+        version   | minDaemon | minClient | max
+        "4.0"     | 7         | 7         | 8
+        "4.2.99"  | 7         | 7         | 8
+        "4.3"     | 7         | 7         | 9
+        "4.99"    | 7         | 7         | 10
+        "5.0"     | 8         | 8         | 11
+        "7.2.99"  | 8         | 8         | 16
+        "7.3"     | 8         | 8         | 17
+        "8.14.99" | 8         | 8         | 24
+        "9.0"     | 17        | 8         | 24
+    }
+
+}

--- a/testing/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/versions/ReleasedVersionDistributionsTest.groovy
+++ b/testing/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/versions/ReleasedVersionDistributionsTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.integtests.fixtures.versions
 
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.internal.Factory
+import org.gradle.tooling.internal.consumer.DefaultGradleConnector
+import org.gradle.util.internal.DefaultGradleVersion
 import spock.lang.Specification
 
 import static org.gradle.util.GradleVersion.version
@@ -69,11 +71,14 @@ class ReleasedVersionDistributionsTest extends Specification {
     }
 
     def "get supported does that"() {
+        given:
+        def minVersion = ((DefaultGradleVersion) DefaultGradleConnector.MINIMUM_SUPPORTED_GRADLE_VERSION).majorVersion
+
         when:
-        props.versions = "1.3-rc-1 1.2 0.8"
+        props.versions = "${minVersion}.3-rc-1 ${minVersion}.2 ${minVersion - 1}.8".toString()
 
         then:
-        versions().supported*.version == [version("1.3-rc-1"), version("1.2")]
+        versions().supported*.version == [version("${minVersion}.3-rc-1"), version("${minVersion}.2")]
     }
 
     def "get previous distribution for #description"() {


### PR DESCRIPTION
In prior versions of Gradle, the daemon and client java version restrictions were the same.

Starting in 9.0, we have different constraints for which java versions the client and daemon may run on.

We update GradleDistribution to add a new clientWorksWith(int) method. This differs from the existing daemonWorksWith(int) method.

Then, we update TAPI tests to use this new method to determine if a given test should be executed.

In general, TAPI tests run in two directions. current client -> X daemon and X client -> current daemon. We use the clientWorksWith and daemonWorksWith methods, depending on the versions and 'direction' to expand the test scenarios we can test.

In the past, we verified java compatibility only based on the daemon java compatibility. Now, we are more precise and can test the scenario where and the current client tests and old daemon using a JVM version that is now unsupported by the daemon.

Prepares for https://github.com/gradle/gradle/issues/33448

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
