### PR TITLE
Recommend setting no fail on AbstractTestTask

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -601,7 +601,7 @@ This behavior can be disabled by setting the `failOnNoDiscoveredTests` property 
 .build.gradle.kts
 [source,kotlin]
 ----
-tasks.withType<Test>().configureEach {
+tasks.withType<AbstractTestTask>().configureEach {
     failOnNoDiscoveredTests = false
 }
 ----
@@ -611,7 +611,7 @@ tasks.withType<Test>().configureEach {
 .build.gradle
 [source,groovy]
 ----
-tasks.withType(Test).configureEach {
+tasks.withType(AbstractTestTask).configureEach {
     failOnNoDiscoveredTests = false
 }
 ----


### PR DESCRIPTION
This covers more cases, such as non-JVM Kotlin multiplatform targets.
