### PR TITLE
Prove that Kotlin DSL build scripts are recompiled on `internal` visibility change to `public`

### DIFF
--- a/gradle/detekt.yml
+++ b/gradle/detekt.yml
@@ -56,4 +56,6 @@ exceptions:
 naming:
   MemberNameEqualsClassName:
     active: false
+  FunctionNaming:
+    functionPattern: '[a-z][a-zA-Z0-9]*|`[^`]*`'
 

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/AbstractCompileAvoidanceIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/AbstractCompileAvoidanceIntegrationTest.kt
@@ -132,7 +132,7 @@ abstract class AbstractCompileAvoidanceIntegrationTest : AbstractKotlinIntegrati
     }
 
     protected
-    fun configureProjectAndExpectCompileFailure(expectedFailure: String) {
+    fun configureProjectAndExpectCompileFailure(@Suppress("SameParameterValue") expectedFailure: String) {
         val error = executer.runWithFailure().error
         MatcherAssert.assertThat(error, CoreMatchers.containsString(expectedFailure))
     }

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/BuildScriptCompileAvoidanceIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/BuildScriptCompileAvoidanceIntegrationTest.kt
@@ -476,7 +476,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractCompileAvoidanceInteg
     }
 
     private
-    fun buildKotlinJarForBuildScriptClasspath(classBody: String): Pair<String, String> {
+    fun buildKotlinJarForBuildScriptClasspath(@Suppress("SameParameterValue") classBody: String): Pair<String, String> {
         val baseDir = "buildscript"
         withDefaultSettingsIn(baseDir).appendText(
             """

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/BuildScriptCompileAvoidanceIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/BuildScriptCompileAvoidanceIntegrationTest.kt
@@ -329,6 +329,30 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractCompileAvoidanceInteg
     }
 
     @Test
+    fun `recompiles buildscript on internal function visibility change to public in buildSrc class`() {
+        val className = givenKotlinClassInBuildSrcContains(
+            """
+            fun foo() = bar()
+            internal fun bar() {
+                // do nothing
+            }
+            """
+        )
+        withUniqueScript("$className().foo()")
+        configureProject().assertBuildScriptCompiled()
+
+        givenKotlinClassInBuildSrcContains(
+            """
+            fun foo() = bar()
+            fun bar() {
+                // do nothing
+            }
+            """
+        )
+        configureProject().assertBuildScriptCompiled()
+    }
+
+    @Test
     fun `avoids buildscript recompilation on non ABI changes to multifile class in buildSrc`() {
         val multifileAnnotations = """
             @file:JvmName("Utils")

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/PrecompiledPluginsCompileAvoidanceIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/PrecompiledPluginsCompileAvoidanceIntegrationTest.kt
@@ -17,7 +17,6 @@
 package org.gradle.kotlin.dsl.compile
 
 import org.gradle.util.internal.ToBeImplemented
-import org.junit.Ignore
 import org.junit.Test
 
 
@@ -28,7 +27,6 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
     fun `avoids buildscript recompilation when task is configured in precompiled script plugin`() {
         val pluginId = "my-plugin"
         withPrecompiledScriptPluginInBuildSrc(
-            pluginId,
             """
                 println("foo")
                 tasks.register("foo")
@@ -44,7 +42,6 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
         configureProject().assertBuildScriptCompiled().assertOutputContains("foo")
 
         withPrecompiledScriptPluginInBuildSrc(
-            pluginId,
             """
                 tasks.register("foo") { doLast { println("bar from task") } }
             """
@@ -59,7 +56,6 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
     fun `recompiles buildscript when plugins applied from a precompiled plugin change`() {
         val pluginId = "my-plugin"
         withPrecompiledScriptPluginInBuildSrc(
-            pluginId,
             """
                 plugins {
                     id("java-library")
@@ -77,7 +73,6 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
         configureProject().assertBuildScriptCompiled().assertOutputContains("foo")
 
         withPrecompiledScriptPluginInBuildSrc(
-            pluginId,
             """
                 plugins {
                     id("java")
@@ -97,7 +92,6 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
             }
         """
         withPrecompiledScriptPluginInBuildSrc(
-            pluginId,
             """
                 $extensionClass
                 project.extensions.create<TestExtension>("foo")
@@ -116,7 +110,6 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
         configureProject().assertBuildScriptCompiled()
 
         withPrecompiledScriptPluginInBuildSrc(
-            pluginId,
             """
                 $extensionClass
                 project.extensions.create<TestExtension>("bar")
@@ -129,7 +122,6 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
     fun `avoids buildscript recompilation on non ABI change in precompiled script plugin`() {
         val pluginId = "my-plugin"
         withPrecompiledScriptPluginInBuildSrc(
-            pluginId,
             """
                 println("foo")
             """
@@ -144,7 +136,6 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
         configureProject().assertBuildScriptCompiled().assertOutputContains("foo")
 
         withPrecompiledScriptPluginInBuildSrc(
-            pluginId,
             """
                 println("bar")
             """
@@ -156,7 +147,6 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
     fun `recompiles buildscript when new task is registered in precompiled script plugin`() {
         val pluginId = "my-plugin"
         withPrecompiledScriptPluginInBuildSrc(
-            pluginId,
             """
                 println("foo")
             """
@@ -171,7 +161,6 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
         configureProject().assertBuildScriptCompiled().assertOutputContains("foo")
 
         withPrecompiledScriptPluginInBuildSrc(
-            pluginId,
             """
                 println("bar")
                 tasks.register("foo")
@@ -181,7 +170,8 @@ class PrecompiledPluginsCompileAvoidanceIntegrationTest : AbstractCompileAvoidan
     }
 
     private
-    fun withPrecompiledScriptPluginInBuildSrc(pluginId: String, pluginSource: String) {
+    fun withPrecompiledScriptPluginInBuildSrc(pluginSource: String) {
+        val pluginId = "my-plugin"
         withKotlinDslPluginInBuildSrc()
         withFile("buildSrc/src/main/kotlin/$pluginId.gradle.kts", pluginSource)
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
* Fixes #24352
* This PR only adds test coverage, the actual fix was in https://github.com/gradle/gradle/pull/26645

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
