### PR TITLE
Replace broken links in sample_cross_project_output_sharing.html documentation

### DIFF
--- a/platforms/documentation/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
+++ b/platforms/documentation/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
@@ -4,9 +4,9 @@ This is one way you can share information across project boundaries. (Another wa
 
 [NOTE]
 ====
-This demonstrates the <<../userguide/cross_project_publications.adoc#simple-sharing-artifacts-between-projects, simple version>> of sharing information across project boundaries, by explicitly specifying which producer project's _consumable configuration_ to use for a locally available artifact.
+This demonstrates the simple version of sharing information across project boundaries, by explicitly specifying which producer project's _consumable configuration_ to use for a locally available artifact.
 
-When the producer publishes an artifact to a repository, to retrieve that artifact you will need to use <<../userguide/cross_project_publications.adoc#variant-aware-sharing, the advanced version>> of variant aware dependency resolution.
+When the producer publishes an artifact to a repository, to retrieve that artifact you will need to use link:{userManualPath}/how_to_share_outputs_between_projects.html[the advanced version] of variant aware dependency resolution.
 This method will also work locally.
 ====
 
@@ -32,7 +32,7 @@ include::sample[dir="groovy",files="consumer/build.gradle[]"]
 
 See also:
 
-- <<../userguide/cross_project_publications.adoc#cross_project_publications, Sharing outputs between projects>>
+- link:{userManualPath}/how_to_share_outputs_between_projects.html[How to Share Artifacts Between Projects]
 
 == Anti-patterns:
 


### PR DESCRIPTION
Resolves #33617

### Context

- Removed link for the 'simple version' which actually redirected to the page for the 'advanced version'.
- Fixed obsolete links which redirected from `cross_project_publications.adoc` to `how_to_share_outputs_between_projects.adoc`.

#### Tests

- [x] I checked the preview locally with `./gradlew serveDocs` and confirmed that the links are working correctly.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
