### PR TITLE
Add Environment.Properties.get(String)

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -370,10 +370,7 @@ class ConfigurationCacheFingerprintWriter(
     }
 
     override fun systemProperty(name: String, value: String?) {
-        if (isInputTrackingDisabled()) {
-            return
-        }
-        addSystemPropertyToFingerprint(name, value)
+        systemPropertyRead(name, value, null)
     }
 
     private
@@ -396,10 +393,7 @@ class ConfigurationCacheFingerprintWriter(
     }
 
     override fun envVariable(name: String, value: String?) {
-        if (isInputTrackingDisabled()) {
-            return
-        }
-        addEnvVariableToFingerprint(name, value)
+        envVariableRead(name, value, null)
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -369,6 +369,13 @@ class ConfigurationCacheFingerprintWriter(
         addSystemPropertiesPrefixedByToFingerprint(prefix, snapshot)
     }
 
+    override fun systemProperty(name: String, value: String?) {
+        if (isInputTrackingDisabled()) {
+            return
+        }
+        addSystemPropertyToFingerprint(name, value)
+    }
+
     private
     fun addSystemPropertiesPrefixedByToFingerprint(prefix: String, snapshot: Map<String, String?>) {
         val filteredSnapshot = snapshot.mapValues { e ->
@@ -386,6 +393,13 @@ class ConfigurationCacheFingerprintWriter(
             return
         }
         addEnvVariablesPrefixedByToFingerprint(prefix, snapshot)
+    }
+
+    override fun envVariable(name: String, value: String?) {
+        if (isInputTrackingDisabled()) {
+            return
+        }
+        addEnvVariableToFingerprint(name, value)
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/Environment.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/services/Environment.kt
@@ -55,15 +55,17 @@ class ConfigurationCacheEnvironment(
     }
 
     override fun getSystemProperties(): Environment.Properties =
-        TrackingProperties(System.getProperties().uncheckedCast(),
-            { prefix, snapshot -> listener.systemPropertiesPrefixedBy(prefix, snapshot)},
-            {name, value -> listener.systemProperty(name, value)}
+        TrackingProperties(
+            System.getProperties().uncheckedCast(),
+            { prefix, snapshot -> listener.systemPropertiesPrefixedBy(prefix, snapshot) },
+            { name, value -> listener.systemProperty(name, value) }
         )
 
     override fun getVariables(): Environment.Properties =
-        TrackingProperties(System.getenv(), { prefix, snapshot ->
-            listener.envVariablesPrefixedBy(prefix, snapshot)},
-            {name, value -> listener.envVariable(name, value)}
+        TrackingProperties(
+            System.getenv(),
+            { prefix, snapshot -> listener.envVariablesPrefixedBy(prefix, snapshot) },
+            { name, value -> listener.envVariable(name, value) }
         )
 
     private
@@ -106,6 +108,7 @@ open class DefaultEnvironment : Environment {
         override fun byNamePrefix(prefix: String): Map<String, String> =
             map.filterKeysByPrefix(prefix)
 
-        override fun get(name: String): String? = map[name]
+        override fun get(name: String): String? =
+            map[name]
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/Environment.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/Environment.java
@@ -61,5 +61,14 @@ public interface Environment {
          * @return a map containing only the properties whose name start with the given prefix.
          */
         Map<String, String> byNamePrefix(String prefix);
+
+        /**
+         * Returns the value of the property with the given name, or {@code null} if it does not exist.
+         *
+         * @param name the property to lookup
+         * @return the property value, or {@code null} if the property does not exist
+         */
+        @Nullable
+        String get(String name);
     }
 }


### PR DESCRIPTION
This allows to retrieve one env var without creating a provider while still being tracked by CC.

I created this after a chat with @mlopatkin on #33020 and the idea would be to use this instead of provider [there](https://github.com/gradle/gradle/pull/33020/files#diff-62059fcdfcf4d5c2470345d9e4ba86b425353a31ca66bc2095f126effb9d6f0eR142)

I am not sure how this type is tested though, I failed to locate tests.

I am also surprised I did not have to add any kind of `@Incubating`, `@since`, ...
