### PR TITLE
Fix broken PMD multiversion tests

### DIFF
--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
@@ -35,7 +35,7 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
 
     def "uses jdk from toolchains set through java plugin"() {
         Assume.assumeTrue(fileLockingIssuesSolved())
-        Assume.assumeTrue(PmdCoverage.supportsJdkVersion(versionNumber, jdk.javaVersion.majorVersion as Integer))
+        Assume.assumeTrue(PmdCoverage.supportsJdkVersion(versionNumber, jdk.javaVersionMajor))
 
         given:
         goodCode()
@@ -54,7 +54,7 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
 
     def "uses jdk from toolchains set through pmd task"() {
         Assume.assumeTrue(fileLockingIssuesSolved())
-        Assume.assumeTrue(PmdCoverage.supportsJdkVersion(versionNumber, jdk.javaVersion.majorVersion as Integer))
+        Assume.assumeTrue(PmdCoverage.supportsJdkVersion(versionNumber, jdk.javaVersionMajor))
 
         given:
         goodCode()

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.plugins.quality.pmd
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
+import org.gradle.quality.integtest.fixtures.PmdCoverage
 import org.gradle.util.internal.VersionNumber
 import org.junit.Assume
 
@@ -34,6 +35,7 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
 
     def "uses jdk from toolchains set through java plugin"() {
         Assume.assumeTrue(fileLockingIssuesSolved())
+        Assume.assumeTrue(PmdCoverage.supportsJdkVersion(versionNumber, jdk.javaVersion.majorVersion as Integer))
 
         given:
         goodCode()
@@ -52,6 +54,7 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
 
     def "uses jdk from toolchains set through pmd task"() {
         Assume.assumeTrue(fileLockingIssuesSolved())
+        Assume.assumeTrue(PmdCoverage.supportsJdkVersion(versionNumber, jdk.javaVersion.majorVersion as Integer))
 
         given:
         goodCode()

--- a/platforms/jvm/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/PmdCoverage.groovy
+++ b/platforms/jvm/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/PmdCoverage.groovy
@@ -69,7 +69,7 @@ class PmdCoverage {
         }
     }
 
-    private static boolean supportsJdkVersion(VersionNumber pmdVersion, int jvmVersion) {
+    static boolean supportsJdkVersion(VersionNumber pmdVersion, int jvmVersion) {
         def supportedSince = VERSION_COVERAGE[jvmVersion]
 
         if (supportedSince == null) {


### PR DESCRIPTION
Fixes the broken tests when running "all versions" for `PmdPluginToolchainsIntegrationTest`.   We may adjust this more in follow up work to remove the skipped scenarios from even running, but for now, this fixes the breakages on master.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
