### PR TITLE
Upgrade configuration deprecation infrastructure error messages

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ConfigurationUsageChangingFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.util.GradleVersion
 import spock.lang.Issue
 
 class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec implements ConfigurationUsageChangingFixture {
@@ -134,7 +135,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("The testConf configuration has been deprecated for resolution. This will fail with an error in Gradle 9.0. Please resolve the anotherConf configuration instead. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
+        executer.expectDocumentedDeprecationWarning("The testConf configuration has been deprecated for resolution. This will fail with an error in Gradle ${GradleVersion.current().getMajorVersion() + 1}.0. Please resolve the anotherConf configuration instead. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
         executer.expectDocumentedDeprecationWarning("Calling toRootComponent() on configuration ':testConf' has been deprecated. This will fail with an error in Gradle 10.0. This configuration does not allow this method to be called. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
         succeeds 'resolve'
     }
@@ -707,7 +708,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
             }
         """
         expect:
-        executer.expectDocumentedDeprecationWarning("The testConf configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use the anotherConf configuration instead. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
+        executer.expectDocumentedDeprecationWarning("The testConf configuration has been deprecated for dependency declaration. This will fail with an error in Gradle ${GradleVersion.current().getMajorVersion() + 1}.0. Please use the anotherConf configuration instead. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
         succeeds 'help'
     }
     // endregion Migrating configurations

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.resolve.api
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
+import org.gradle.util.GradleVersion
 
 @FluidDependenciesResolveTest
 class ConfigurationRolesIntegrationTest extends AbstractIntegrationSpec {
@@ -242,7 +243,7 @@ Instead, a resolvable ('canBeResolved=true') dependency configuration that exten
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("The con configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
+        executer.expectDocumentedDeprecationWarning("The con configuration has been deprecated for consumption. This will fail with an error in Gradle ${GradleVersion.current().getMajorVersion() + 1}.0. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
         succeeds("resolve")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/InvalidConfigurationUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/InvalidConfigurationUsageIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.integtests.resolve.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.GradleVersion
 
 class InvalidConfigurationUsageIntegrationTest extends AbstractIntegrationSpec {
     def "causing invalid resolution via #methodName for role #role fails"() {
@@ -118,7 +119,7 @@ class InvalidConfigurationUsageIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning("Calling $methodName on configuration ':custom' has been deprecated. This will fail with an error in Gradle 10.0. This configuration does not allow this method to be called. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
-        executer.expectDocumentedDeprecationWarning("The custom configuration has been deprecated for resolution. This will fail with an error in Gradle 9.0. Please resolve another configuration instead. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
+        executer.expectDocumentedDeprecationWarning("The custom configuration has been deprecated for resolution. This will fail with an error in Gradle ${GradleVersion.current().getMajorVersion() + 1}.0. Please resolve another configuration instead. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
         executer.expectDocumentedDeprecationWarning("Calling toRootComponent() on configuration ':custom' has been deprecated. This will fail with an error in Gradle 10.0. This configuration does not allow this method to be called. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
         succeeds('help')
 
@@ -179,7 +180,7 @@ class InvalidConfigurationUsageIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("The foo configuration has been deprecated for resolution. This will fail with an error in Gradle 9.0. Please resolve another configuration instead. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
+        executer.expectDocumentedDeprecationWarning("The foo configuration has been deprecated for resolution. This will fail with an error in Gradle ${GradleVersion.current().getMajorVersion() + 1}.0. Please resolve another configuration instead. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
         executer.expectDocumentedDeprecationWarning("Calling toRootComponent() on configuration ':foo' has been deprecated. This will fail with an error in Gradle 10.0. This configuration does not allow this method to be called. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
         succeeds("help")
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphVariantSelector.java
@@ -281,7 +281,7 @@ public class GraphVariantSelector {
         if (targetVariant.getMetadata().isDeprecated()) {
             DeprecationLogger.deprecateConfiguration(targetVariant.getName())
                 .forConsumption()
-                .willBecomeAnErrorInGradle9()
+                .willBecomeAnErrorInNextMajorGradleVersion()
                 .withUserManual("declaring_dependencies", "sec:deprecated-configurations")
                 .nagUser();
         }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.tasks.diagnostics
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.GradleVersion
 
 class DependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
     def "omits repeated dependencies in case of circular dependencies"() {
@@ -1056,7 +1057,7 @@ compileClasspath - Compile classpath for source set 'main'.
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
+        executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle ${GradleVersion.current().getMajorVersion() + 1}.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
 
         expect:
         succeeds ':a:dependencies'

--- a/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
@@ -73,7 +73,7 @@ public interface DeprecatableConfiguration extends Configuration {
         if (isDeprecatedForConsumption()) {
             DeprecationLogger.deprecateConfiguration(getName())
                 .forConsumption()
-                .willBecomeAnErrorInGradle9()
+                .willBecomeAnErrorInNextMajorGradleVersion()
                 .withUserManual("declaring_dependencies", "sec:deprecated-configurations")
                 .nagUser();
         }
@@ -87,7 +87,7 @@ public interface DeprecatableConfiguration extends Configuration {
             DeprecationLogger.deprecateConfiguration(getName())
                 .forDependencyDeclaration()
                 .replaceWith(getDeclarationAlternatives())
-                .willBecomeAnErrorInGradle9()
+                .willBecomeAnErrorInNextMajorGradleVersion()
                 .withUserManual("declaring_dependencies", "sec:deprecated-configurations")
                 .nagUser();
         }
@@ -101,7 +101,7 @@ public interface DeprecatableConfiguration extends Configuration {
             DeprecationLogger.deprecateConfiguration(getName())
                 .forResolution()
                 .replaceWith(getResolutionAlternatives())
-                .willBecomeAnErrorInGradle9()
+                .willBecomeAnErrorInNextMajorGradleVersion()
                 .withUserManual("declaring_dependencies", "sec:deprecated-configurations")
                 .nagUser();
         }


### PR DESCRIPTION
Update these messages from claiming they will become an error in 9.0 to 10.0

Also use `willBecomeAnErrorInNextMajorGradleVersion` and make the tests more dynamic so that we won't need to manually update these in the future

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
