### PR TITLE
Update XmlTransformerTest to not be sensitive to locales

### DIFF
--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -298,8 +298,6 @@ packageCycles {
 
 tasks.test {
     setForkEvery(200)
-    systemProperty("user.language", "en")
-    systemProperty("user.country", "US")
 }
 
 tasks.compileTestGroovy {

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -298,6 +298,8 @@ packageCycles {
 
 tasks.test {
     setForkEvery(200)
+    systemProperty("user.language", "en")
+    systemProperty("user.country", "US")
 }
 
 tasks.compileTestGroovy {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/xml/XmlTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/xml/XmlTransformerTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.internal.UncheckedException
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.internal.TextUtil
 import org.junit.Rule
+import org.xml.sax.SAXParseException
 import spock.lang.Specification
 
 import javax.xml.parsers.DocumentBuilderFactory
@@ -292,7 +293,11 @@ class XmlTransformerTest extends Specification {
 
         then:
         def e = thrown(UncheckedException)
-        e.message.contains("External DTD: Failed to read external DTD 'thing.dtd', because 'file' access is not allowed")
+        e.cause instanceof SAXParseException
+        // The English message contains "External DTD: Failed to read external DTD 'thing.dtd', because 'file' access is not allowed".
+        // We check only the locale-independent parts:
+        e.message.contains("DTD")
+        e.message.contains("thing.dtd")
     }
 
     def "indentation correct when writing out DOM element (only) if indenting with spaces"() {


### PR DESCRIPTION
Resolves #33638

### Context

Update `XmlTransformerTest` to not be sensitive to locales, since `XmlTransformerTest.groovy` expects the locale to be English.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
