### PR TITLE
Use DeprecationLevel.HIDDEN for CharSequence.capitalized() method

### DIFF
--- a/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/configurationcache/extensions/CharSequenceExtensions.kt
+++ b/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/configurationcache/extensions/CharSequenceExtensions.kt
@@ -19,7 +19,8 @@ package org.gradle.configurationcache.extensions
 
 @Deprecated(
     "This was never intended as a public API.",
-    ReplaceWith("this.toString().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }")
+    ReplaceWith("this.toString().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }"),
+    DeprecationLevel.HIDDEN
 )
 fun CharSequence.capitalized(): String =
     toString().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }


### PR DESCRIPTION
Since it's still used in some plugins.

This is used in https://github.com/google/play-services-plugins/blob/0c2a0720fcf98ca3f90417a2fdb2528d21e361e5/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesPlugin.kt#L28

So let's mark it as HIDDEN, since we can't remove it in Gradle 9. And let's remove it in Gradle 10.

This replaces https://github.com/gradle/gradle/pull/33476