### PR TITLE
doc: Clarify guidelines around getters/setters that wrap Property and/or Provider

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/lazy_configuration.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/lazy_configuration.adoc
@@ -389,7 +389,9 @@ Guidelines to be successful with the Provider API:
 ** For configurable properties, expose the link:{javadocPath}/org/gradle/api/provider/Property.html[Property] directly through a single getter.
 ** For non-configurable properties, expose an link:{javadocPath}/org/gradle/api/provider/Provider.html[Provider] directly through a single getter.
 
-2. Avoid simplifying calls like `obj.getProperty().get()` and `obj.getProperty().set(T)` in your code by introducing additional getters and setters.
+2. Do not try to simplify calls like `obj.getProperty().get()` and `obj.getProperty().set(T)` in your code by introducing additional getters and setters.
+Using such wrapper methods would undermine the purpose of `Property` and prevent wiring of properties together.
+It would cause the current value to be obtained immediately (rather than being lazily evaluated).
 
 3. When migrating your plugin to use providers, follow these guidelines:
 ** If it's a new property, expose it as a link:{javadocPath}/org/gradle/api/provider/Property.html[Property] or link:{javadocPath}/org/gradle/api/provider/Provider.html[Provider] using a single getter.


### PR DESCRIPTION
### Context

While implementing the conversion to lazy properties, I noticed a portion of the documentation warning us against an anti-pattern without explaining the problem being prevented/avoided.

I asked about this in the Gradle Forums at https://discuss.gradle.org/t/seeking-clarification-on-lazy-configuration-documentation/50966/2 and am updating the documentation to clarify the intent of the warning/guideline based on the answer.


# Manual testing

## GIVEN
I ran `./gradlew :docs:docs`

## WHEN

I opened the local path `platforms/documentation/docs/build/working/usermanual/final/lazy_configuration.html` with my web browser (Firefox).

## THEN

Here's a screenshot showing the relevant portion of the file that was modified:

![Using the Provider API](https://github.com/user-attachments/assets/bfedbbd3-6066-4e29-afe4-c338684d472a)


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
