### PR TITLE
Defer relative Java executable deprecation to Gradle 10

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -3943,7 +3943,7 @@ beforeSettings {
 [[no_relative_paths_for_java_executables]]
 ==== Deprecated using relative paths to specify Java executables
 
-Using relative file paths to point to Java executables is now deprecated and will become an error in Gradle 9.
+Using relative file paths to point to Java executables is now deprecated and will become an error in Gradle 10.
 This is done to reduce confusion about what such relative paths should resolve against.
 
 [[task_convention]]

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -80,7 +80,7 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.expectDocumentedDeprecationWarning("Configuring a Java executable via a relative path. " +
-            "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+            "This behavior has been deprecated. This will fail with an error in Gradle 10.0. " +
             "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
             "Configure an absolute path to a Java executable instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#no_relative_paths_for_java_executables")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -54,7 +54,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.expectDocumentedDeprecationWarning("Configuring a Java executable via a relative path. " +
-            "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+            "This behavior has been deprecated. This will fail with an error in Gradle 10.0. " +
             "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
             "Configure an absolute path to a Java executable instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#no_relative_paths_for_java_executables")

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
@@ -149,7 +149,7 @@ Joe!""")
 
         when:
         executer.expectDocumentedDeprecationWarning("Configuring a Java executable via a relative path. " +
-                "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+                "This behavior has been deprecated. This will fail with an error in Gradle 10.0. " +
                 "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
                 "Configure an absolute path to a Java executable instead. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#no_relative_paths_for_java_executables")

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJavaVersionIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJavaVersionIntegrationTest.groovy
@@ -119,7 +119,7 @@ class TestTaskJavaVersionIntegrationTest extends AbstractIntegrationSpec impleme
 
         when:
         executer.expectDocumentedDeprecationWarning("Configuring a Java executable via a relative path. " +
-            "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+            "This behavior has been deprecated. This will fail with an error in Gradle 10.0. " +
             "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
             "Configure an absolute path to a Java executable instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#no_relative_paths_for_java_executables")

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/JavaExecutableUtils.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/JavaExecutableUtils.java
@@ -35,7 +35,7 @@ public class JavaExecutableUtils {
             DeprecationLogger.deprecateBehaviour("Configuring a Java executable via a relative path.")
                     .withContext("Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against.")
                     .withAdvice("Configure an absolute path to a Java executable instead.")
-                    .willBecomeAnErrorInGradle9()
+                    .willBecomeAnErrorInGradle10()
                     .withUpgradeGuideSection(8, "no_relative_paths_for_java_executables")
                     .nagUser();
         }


### PR DESCRIPTION
It's unclear what we should be doing here.

The meaning of CompileOptions.executable and JavaExec.executable seem to be mixed up and tied to how we deal with setting Java Home as well.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
