### PR TITLE
Add Best Practice: Use Simple String GAV Notation for Declaring Dependencies

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_dependencies.adoc
@@ -237,3 +237,43 @@ include::sample[dir="snippets/bestPractices/avoidDuplicateDependencies/groovy/do
 === Tags
 
 `<<tags_reference.adoc#tag:dependencies,#dependencies>>`
+
+[[single-gav-string]]
+== Prefer the single GAV (`group:artifact:version`) String Syntax
+
+When declaring dependencies without a version catalog, prefer using the single GAV string form `implementation("org.example:library:1.0")`.
+Avoid using the multi-parameter map form unless necessary `implementation(group = "org.example", name = "library", version = "1.0")`.
+
+=== Explanation
+
+All of these formats are functionally equivalent in Gradle, but the single-string form is more concise, easier to read, and is widely adopted in the broader JVM ecosystem.
+
+This format is also recommended by link:https://central.sonatype.com/artifact/com.google.guava/guava[Maven Central] in its documentation and usage examples, making it the most familiar and consistent style for developers across tools.
+
+Use the map-style declaration only when you need to customize the dependency (for example, to <<resolution_rules.adoc#sec:exclude-trans-deps,exclude transitive dependencies>>).
+
+=== Example
+
+==== Don't Do This
+
+====
+include::sample[dir="snippets/bestPractices/useGAVString-avoid/kotlin",files="build.gradle.kts[tags=avoid-this]"]
+include::sample[dir="snippets/bestPractices/useGAVString-avoid/groovy",files="build.gradle[tags=avoid-this]"]
+====
+<1> Avoid the map notation
+
+==== Do This Instead
+
+====
+include::sample[dir="snippets/bestPractices/useGAVString-do/kotlin",files="build.gradle.kts[tags=do-this]"]
+include::sample[dir="snippets/bestPractices/useGAVString-do/groovy",files="build.gradle[tags=do-this]"]
+====
+<1> Use the string notation
+
+=== References
+
+- <<declaring_dependencies_basics.adoc#declaring-dependencies-basics,Declaring Dependencies Basics>>
+
+=== Tags
+
+`<<tags_reference.adoc#tag:dependencies,#dependencies>>`

--- a/platforms/documentation/docs/src/snippets/bestPractices/useGavString-avoid/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useGavString-avoid/groovy/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id("java")
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::avoid-this[]
+dependencies {
+    implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/useGavString-avoid/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useGavString-avoid/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'use-gav-strings-avoid'

--- a/platforms/documentation/docs/src/snippets/bestPractices/useGavString-avoid/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useGavString-avoid/kotlin/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("java")
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::avoid-this[]
+dependencies {
+    implementation(group = "com.google.guava", name = "guava", version = "32.1.2-jre")
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/useGavString-avoid/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useGavString-avoid/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "use-gav-strings-avoid"

--- a/platforms/documentation/docs/src/snippets/bestPractices/useGavString-do/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useGavString-do/groovy/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id("java")
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::do-this[]
+dependencies {
+    implementation 'com.google.guava:guava:32.1.2-jre'
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/useGavString-do/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useGavString-do/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'use-gav-strings-do'

--- a/platforms/documentation/docs/src/snippets/bestPractices/useGavString-do/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useGavString-do/kotlin/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("java")
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::do-this[]
+dependencies {
+    implementation("com.google.guava:guava:32.1.2-jre")
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/useGavString-do/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useGavString-do/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "use-gav-strings-do"


### PR DESCRIPTION
`./gradlew :docs:docsTest --tests "*.snippet-best-practices-use-gav-string-do_*"`
`./gradlew :docs:docsTest --tests "*.snippet-best-practices-use-gav-string-avoid_*"`
