### PR TITLE
Postpone release for prohibiting undeclared service usage

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -94,7 +94,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDocumentedDeprecationWarning(
             "Build service 'counter' is being used by task ':broken' without the corresponding declaration via 'Task#usesService'. " +
                 "This behavior has been deprecated. " +
-                "This will fail with an error in Gradle 9.0. " +
+                "This will fail with an error in Gradle 10.0. " +
                 "Declare the association between the task by declaring the consuming property as a '@ServiceReference'. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#undeclared_build_service_usage"
         )
@@ -143,7 +143,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDocumentedDeprecationWarning(
             "Build service 'counter' is being used by task ':broken' without the corresponding declaration via 'Task#usesService'. " +
                 "This behavior has been deprecated. " +
-                "This will fail with an error in Gradle 9.0. " +
+                "This will fail with an error in Gradle 10.0. " +
                 "Declare the association between the task by declaring the consuming property as a '@ServiceReference'. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#undeclared_build_service_usage"
         )
@@ -220,7 +220,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDocumentedDeprecationWarning(
             "Build service 'counter' is being used by task ':compileJava' without the corresponding declaration via 'Task#usesService'. " +
                 "This behavior has been deprecated. " +
-                "This will fail with an error in Gradle 9.0. " +
+                "This will fail with an error in Gradle 10.0. " +
                 "Declare the association between the task by declaring the consuming property as a '@ServiceReference'. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#undeclared_build_service_usage"
         )

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProviderNagger.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProviderNagger.java
@@ -52,7 +52,7 @@ public class BuildServiceProviderNagger implements BuildServiceProvider.Listener
         deprecateBehaviour(undeclaredBuildServiceUsage(provider, task))
             .withProblemIdDisplayName("Build Service " + provider.getName()+ " undeclared usage")
             .withAdvice("Declare the association between the task by declaring the consuming property as a '@ServiceReference'.")
-            .willBecomeAnErrorInGradle9()
+            .willBecomeAnErrorInGradle10()
             .withUpgradeGuideSection(7, "undeclared_build_service_usage")
             .nagUser();
     }


### PR DESCRIPTION
Changing target release from 9 to 10, but we are [not even issuing the deprecation](https://github.com/gradle/gradle/pull/31419/files) at this time.



### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
