### PR TITLE
Update deprecation for mutating properties that have been migrated

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
@@ -231,7 +231,9 @@ public abstract class ValueState<S> {
             } else if (warnOnUpgradedPropertyChanges) {
                 String shownDisplayName = displayName.getDisplayName();
                 DeprecationLogger.deprecateBehaviour("Changing property value of " + shownDisplayName + " at execution time.")
-                    .startingWithGradle9("changing property value of " + shownDisplayName + " at execution time is deprecated and will fail in Gradle 10")
+                    // this should only happen in Gradle 10, when Provider API migration will come to the mainline,
+                    // so forbidding it must wait until Gradle 11
+                    .startingWithGradle11("changing property value of " + shownDisplayName + " at execution time will become an error")
                     // TODO add documentation
                     .undocumented()
                     .nagUser();

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -31,6 +31,7 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
 
     private static final GradleVersion GRADLE9 = GradleVersion.version("9.0");
     private static final GradleVersion GRADLE10 = GradleVersion.version("10.0");
+    private static final GradleVersion GRADLE11 = GradleVersion.version("11.0");
 
     @Nullable
     protected String summary;
@@ -137,6 +138,14 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
      */
     public WithDeprecationTimeline startingWithGradle10(String message) {
         this.deprecationTimeline = DeprecationTimeline.startingWithVersion(GRADLE10, message);
+        return new WithDeprecationTimeline(this);
+    }
+
+    /**
+     * Output: Starting with Gradle 11.0, ${message}.
+     */
+    public WithDeprecationTimeline startingWithGradle11(String message) {
+        this.deprecationTimeline = DeprecationTimeline.startingWithVersion(GRADLE11, message);
         return new WithDeprecationTimeline(this);
     }
 


### PR DESCRIPTION
Deprecation for mutating properties that have been migrated has been postponed to 10.0, since the Provider API migration will only come to master when master is being prepared for 10.0.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
