### PR TITLE
Cleanup project finder

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
@@ -64,6 +64,23 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasErrorOutput("No variants exist")
     }
 
+    def "cannot declare project dependencies using path notation in buildscript block"() {
+        buildFile << """
+            buildscript {
+                dependencies {
+                    classpath(project(path: ":bar"))
+                }
+            }
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("Project dependencies cannot be declared here.")
+    }
+
+    // This is not desired behavior.
     def "project buildscript classpath configuration can select another project"() {
         settingsFile << """
             include "first"
@@ -668,7 +685,6 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasDescription("Could not resolve all artifacts for configuration 'classpath'")
     }
 
-    @ToBeImplemented
     def "init script resolution failure clearly indicates a project buildscript has failed"() {
         initScriptFile << """
             buildscript {
@@ -677,7 +693,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
 
-            // Force resolution. For some reason the classpath configuration is not resolved by iteslf.
+            // Force resolution. For some reason the classpath configuration is not resolved by itself.
             buildscript.configurations.classpath.files
         """
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/TypeSafeProjectDependencyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/TypeSafeProjectDependencyFactory.java
@@ -29,7 +29,7 @@ public abstract class TypeSafeProjectDependencyFactory {
     }
 
     protected ProjectDependencyInternal create(String path) {
-        return (ProjectDependencyInternal) factory.create(finder.getProject(path).getOwner());
+        return (ProjectDependencyInternal) factory.create(finder.resolveIdentityPath(path));
     }
 
     protected TypeSafeProjectDependencyFactory getFactory() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ProjectDependencyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ProjectDependencyFactory.java
@@ -52,7 +52,7 @@ public class ProjectDependencyFactory {
             @MapKey("path") String path,
             @MapKey("configuration") @Nullable String configuration
         ) {
-            ProjectDependency defaultProjectDependency = factory.create(projectFinder.getProject(path).getOwner());
+            ProjectDependency defaultProjectDependency = factory.create(projectFinder.resolveIdentityPath(path));
             if (configuration != null) {
                 defaultProjectDependency.setTargetConfiguration(configuration);
             }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/ProjectAccessorsSourceGeneratorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/ProjectAccessorsSourceGeneratorTest.groovy
@@ -29,10 +29,10 @@ import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.api.internal.classpath.DefaultModuleRegistry
 import org.gradle.api.internal.classpath.ModuleRegistry
-import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.installation.CurrentGradleInstallation
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Path
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -45,10 +45,11 @@ class ProjectAccessorsSourceGeneratorTest extends Specification {
 
     private final Map<String, GeneratedCode> generatedCode = [:]
     private final DefaultProjectDependencyFactory projectDependencyFactory = Stub(DefaultProjectDependencyFactory) {
-        create(_) >> Stub(ProjectDependencyInternal)
+        create(_ as Path) >> Stub(ProjectDependencyInternal)
     }
-    private final ProjectFinder projectFinder = Stub(ProjectFinder) {
-        getProject(_) >> Stub(ProjectInternal)
+
+    def projectFinder = Mock(ProjectFinder) {
+        resolveIdentityPath(_ as String) >> { args -> Path.path(args[0]) }
     }
 
     @Rule

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ProjectFinder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ProjectFinder.java
@@ -15,17 +15,24 @@
  */
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.util.Path;
 
+/**
+ * Resolves potentially relative string-typed project paths to build-tree project identity {@link Path}s,
+ * relative to some base project.
+ */
 @ServiceScope({Scope.Gradle.class, Scope.Project.class})
 public interface ProjectFinder {
+
     /**
-     * Locates the project with the provided path, failing if not found.
-     *
-     * @param path Can be relative or absolute
-     * @return The project belonging to the path, never null.
+     * Resolves the given string-typed project path to build-tree project identity {@link Path}.
+     * <p>
+     * The given path may be a relative path, in which case it is resolved to an absolute project path
+     * relative to this project finder's base project. Then, the absolute project path is converted to
+     * a build-tree project identity path based on the base project's owning build.
      */
-    ProjectInternal getProject(String path);
+    Path resolveIdentityPath(String path);
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/UnknownProjectFinder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/UnknownProjectFinder.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import org.gradle.api.UnknownProjectException;
-import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.util.Path;
 
 public class UnknownProjectFinder implements ProjectFinder {
     private final String exceptionMessage;
@@ -27,7 +27,8 @@ public class UnknownProjectFinder implements ProjectFinder {
     }
 
     @Override
-    public ProjectInternal getProject(String path) {
+    public Path resolveIdentityPath(String path) {
         throw new UnknownProjectException(exceptionMessage);
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/DefaultProjectFinder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/DefaultProjectFinder.java
@@ -17,19 +17,24 @@
 package org.gradle.internal.service.scopes;
 
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
-import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
+import org.gradle.util.Path;
 
-import java.util.function.Supplier;
-
+/**
+ * Default implementation of {@link ProjectFinder}.
+ */
 public class DefaultProjectFinder implements ProjectFinder {
-    private final Supplier<ProjectInternal> baseProjectSupplier;
 
-    public DefaultProjectFinder(Supplier<ProjectInternal> baseProjectSupplier) {
-        this.baseProjectSupplier = baseProjectSupplier;
+    private final ProjectState baseProject;
+
+    public DefaultProjectFinder(ProjectState baseProject) {
+        this.baseProject = baseProject;
     }
 
     @Override
-    public ProjectInternal getProject(String path) {
-        return baseProjectSupplier.get().project(path);
+    public Path resolveIdentityPath(String path) {
+        Path resolvedProjectPath = baseProject.getIdentity().getProjectPath().absolutePath(Path.path(path));
+        return baseProject.getOwner().calculateIdentityPathForProject(resolvedProjectPath);
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -19,7 +19,6 @@ import org.gradle.api.execution.TaskExecutionGraphListener;
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.plugins.DefaultPluginManager;
 import org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget;
@@ -106,11 +105,6 @@ public class GradleScopeServices implements ServiceRegistrationProvider {
     @Provides
     TaskExecutionPreparer createTaskExecutionPreparer(BuildTaskScheduler buildTaskScheduler, BuildOperationRunner buildOperationRunner, BuildModelParameters buildModelParameters) {
         return new DefaultTaskExecutionPreparer(buildTaskScheduler, buildOperationRunner, buildModelParameters);
-    }
-
-    @Provides
-    ProjectFinder createProjectFinder(final GradleInternal gradle) {
-        return new DefaultProjectFinder(gradle::getRootProject);
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -302,7 +302,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected ProjectFinder createProjectFinder() {
-        return new DefaultProjectFinder(() -> project);
+        return new DefaultProjectFinder(project.getOwner());
     }
 
     @Provides

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
@@ -79,15 +79,19 @@ class DefaultProjectDependencyConstraintTest extends Specification {
         }
         projectState.getMutableModel() >> project
 
+        def projectStateRegistry = Mock(ProjectStateRegistry) {
+            stateFor(Path.ROOT) >> projectState
+        }
+
         def dependencyFactory = new DefaultProjectDependencyFactory(
             TestUtil.instantiatorFactory().decorateLenient(),
             new CapabilityNotationParserFactory(false).create(),
             TestUtil.objectFactory(),
             AttributeTestUtil.attributesFactory(),
-            Mock(ProjectStateRegistry)
+            projectStateRegistry
         )
 
-        def projectDependency = dependencyFactory.create(projectState)
+        def projectDependency = dependencyFactory.create(Path.ROOT)
         new DefaultProjectDependencyConstraint(projectDependency)
     }
 }


### PR DESCRIPTION
Simplify the logic of project finder so that it no longer needs to operate on Project instances but can instead use ProjectState and BuildState.

Previously, it returned entire Project instances, but now only returns a resolved path to a project, which is sufficient to create a ProjectDependency. The goal here is to migrate all factories that create project dependencies to use identity paths instead of whole Project instances

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
