### PR TITLE
Simplify project identity path calculation

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/Path.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/Path.java
@@ -74,6 +74,8 @@ public class Path implements Comparable<Path> {
     private volatile String fullPath;
 
     private Path(String[] segments, boolean absolute) {
+        assert !(segments.length == 0 && !absolute) : "Empty relative paths are forbidden";
+
         this.segments = segments;
         this.absolute = absolute;
 
@@ -98,9 +100,18 @@ public class Path implements Comparable<Path> {
      * </pre>
      */
     public Path append(Path path) {
+        if (segments.length == 0) {
+            if (absolute == path.absolute) {
+                return path;
+            } else {
+                return new Path(path.segments, absolute);
+            }
+        }
+
         if (path.segments.length == 0) {
             return this;
         }
+
         String[] concat = new String[segments.length + path.segments.length];
         System.arraycopy(segments, 0, concat, 0, segments.length);
         System.arraycopy(path.segments, 0, concat, segments.length, path.segments.length);

--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/util/PathTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/util/PathTest.groovy
@@ -139,6 +139,18 @@ class PathTest extends Specification {
         path.append(Path.path('relative:subpath')) == Path.path(':path:relative:subpath')
     }
 
+    def "appending empty paths"() {
+        def relativeFoo = path("foo")
+        def absoluteFoo = path(':foo')
+
+        expect:
+        ROOT.append(ROOT).is(ROOT)
+        ROOT.append(absoluteFoo).is(absoluteFoo)
+        absoluteFoo.append(ROOT).is(absoluteFoo)
+        relativeFoo.append(ROOT).is(relativeFoo)
+        ROOT.append(relativeFoo) == absoluteFoo
+    }
+
     def "appends path to relative path"() {
         when:
         def path = path('path')

--- a/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -304,11 +304,6 @@ public class ProjectBuilderImpl {
         }
 
         @Override
-        public Path calculateIdentityPathForProject(Path projectPath) {
-            return projectPath;
-        }
-
-        @Override
         public StartParameterInternal getStartParameter() {
             throw new UnsupportedOperationException();
         }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -122,11 +122,6 @@ public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState
     }
 
     @Override
-    public Path calculateIdentityPathForProject(Path projectPath) {
-        return getIdentityPath().append(projectPath);
-    }
-
-    @Override
     public Action<? super DependencySubstitutions> getRegisteredDependencySubstitutions() {
         return buildDefinition.getDependencySubstitutions();
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -111,11 +111,6 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
     }
 
     @Override
-    public Path calculateIdentityPathForProject(Path projectPath) {
-        return getBuildController().getGradle().getIdentityPath().append(projectPath);
-    }
-
-    @Override
     public File getBuildRootDir() {
         return buildDefinition.getBuildRootDir();
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -142,11 +142,6 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
     }
 
     @Override
-    public Path calculateIdentityPathForProject(Path path) {
-        return path;
-    }
-
-    @Override
     protected void ensureChildBuildConfigured() {
         // nothing to do for the root build
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -109,11 +109,6 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
     }
 
     @Override
-    public Path calculateIdentityPathForProject(Path projectPath) {
-        return getBuildController().getGradle().getIdentityPath().append(projectPath);
-    }
-
-    @Override
     public File getBuildRootDir() {
         return getBuildController().getGradle().getServices().get(BuildLayout.class).getRootDirectory();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -128,6 +128,8 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
 
     /**
      * Returns a unique path for this build within the current Gradle invocation.
+     * <p>
+     * Prefer {@link BuildState#getIdentityPath()}.
      */
     Path getIdentityPath();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -60,7 +60,9 @@ public interface BuildState {
     /**
      * Calculates the identity path for a project in this build.
      */
-    Path calculateIdentityPathForProject(Path projectPath) throws IllegalStateException;
+    default Path calculateIdentityPathForProject(Path projectPath) {
+        return getIdentityPath().append(projectPath);
+    }
 
     /**
      * Loads the projects for this build so that {@link #getProjects()} can be used, if not already done.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/PublicBuildPath.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/PublicBuildPath.java
@@ -16,15 +16,14 @@
 
 package org.gradle.internal.build;
 
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.Path;
 
 /**
  * A reference to public path for a build, available via the service registry.
- *
- * Usages of {@link GradleInternal#getIdentityPath()} should be migrated to this type, to avoid unnecessary penetration of GradleInternal.
+ * <p>
+ * Prefer {@link BuildState#getIdentityPath()}.
  */
 @ServiceScope(Scope.Build.class)
 public interface PublicBuildPath {


### PR DESCRIPTION
There are 5 implementations of BuildState, each of which implements a method to determine how a project identity path is derived from a project path.

Ever since #10998, Gradle identity paths are known statically and are identical to the BuildState identity paths. Therefore the nested builds which used getBuildController().getGradle().getIdentityPath() as the base of their project paths can just use their own identity path as base.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
