### PR TITLE
Cleanup ProjectIdentity

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -918,7 +918,7 @@ class ConfigurationCacheFingerprintWriter(
             writer.write(
                 ProjectSpecificFingerprint.ProjectIdentity(
                     project.buildTreePath,
-                    Path.path(project.buildIdentifier.buildPath),
+                    project.buildPath,
                     project.projectPath
                 )
             )

--- a/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -19,13 +19,11 @@ package org.gradle.testfixtures.internal;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.StartParameterInternal;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.temp.DefaultTemporaryFileProvider;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
@@ -285,11 +283,6 @@ public class ProjectBuilderImpl {
 
         @Override
         public void ensureProjectsConfigured() {
-        }
-
-        @Override
-        public BuildIdentifier getBuildIdentifier() {
-            return DefaultBuildIdentifier.ROOT;
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectPublicationRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectPublicationRegistry.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.SetMultimap;
 import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.internal.Cast;
@@ -76,7 +77,7 @@ public class DefaultProjectPublicationRegistry implements ProjectPublicationRegi
         }
         synchronized (publicationsByBuildId) {
             DefaultPublicationForProject publicationReference = new DefaultPublicationForProject(publication, projectIdentity);
-            publicationsByBuildId.put(projectIdentity.getBuildIdentifier(), publicationReference);
+            publicationsByBuildId.put(new DefaultBuildIdentifier(projectIdentity.getBuildPath()), publicationReference);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
@@ -16,18 +16,15 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
-import com.google.common.base.Objects;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultRootComponentIdentifier;
+import org.gradle.api.internal.artifacts.ProjectComponentIdentifierInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
-import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.local.model.DefaultLibraryBinaryIdentifier;
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier;
@@ -35,7 +32,6 @@ import org.gradle.internal.component.local.model.OpaqueComponentIdentifier;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
-import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
 import java.io.File;
@@ -45,7 +41,8 @@ import java.io.IOException;
  * A thread-safe and reusable serializer for {@link ComponentIdentifier}.
  */
 public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentIdentifier> {
-    private final BuildIdentifierSerializer buildIdentifierSerializer = new BuildIdentifierSerializer();
+
+    private final ProjectIdentitySerializer projectIdentitySerializer = new ProjectIdentitySerializer(new PathSerializer());
 
     @Override
     public ComponentIdentifier read(Decoder decoder) throws IOException {
@@ -55,31 +52,8 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
             throw new IllegalArgumentException("Unable to find component identifier type with id: " + id);
         }
         switch (implementation) {
-            case ROOT_PROJECT: {
-                BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-                String projectName = decoder.readString();
-                ProjectIdentity projectIdentity = new ProjectIdentity(buildIdentifier, Path.ROOT, Path.ROOT, projectName);
-                return new DefaultProjectComponentIdentifier(projectIdentity);
-            }
-            case ROOT_BUILD_PROJECT: {
-                BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-                Path projectPath = Path.path(decoder.readString());
-                ProjectIdentity projectIdentity = new ProjectIdentity(buildIdentifier, projectPath, projectPath, projectPath.getName());
-                return new DefaultProjectComponentIdentifier(projectIdentity);
-            }
-            case OTHER_BUILD_ROOT_PROJECT: {
-                BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-                Path identityPath = Path.path(decoder.readString());
-                ProjectIdentity projectIdentity = new ProjectIdentity(buildIdentifier, identityPath, Path.ROOT, identityPath.getName());
-                return new DefaultProjectComponentIdentifier(projectIdentity);
-            }
-            case OTHER_BUILD_PROJECT: {
-                BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-                Path identityPath = Path.path(decoder.readString());
-                Path projectPath = Path.path(decoder.readString());
-                ProjectIdentity projectIdentity = new ProjectIdentity(buildIdentifier, identityPath, projectPath, identityPath.getName());
-                return new DefaultProjectComponentIdentifier(projectIdentity);
-            }
+            case PROJECT:
+                return new DefaultProjectComponentIdentifier(projectIdentitySerializer.read(decoder));
             case MODULE:
                 return new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(decoder.readString(), decoder.readString()), decoder.readString());
             case SNAPSHOT:
@@ -123,29 +97,9 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
                 encoder.writeString(snapshotIdentifier.getVersion());
                 encoder.writeString(snapshotIdentifier.getTimestamp());
                 break;
-            case ROOT_PROJECT: {
-                ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier) value;
-                writeBuildIdentifierOf(projectComponentIdentifier, encoder);
-                encoder.writeString(projectComponentIdentifier.getProjectName());
-                break;
-            }
-            case ROOT_BUILD_PROJECT: {
-                ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier) value;
-                writeBuildIdentifierOf(projectComponentIdentifier, encoder);
-                encoder.writeString(projectComponentIdentifier.getProjectPath());
-                break;
-            }
-            case OTHER_BUILD_ROOT_PROJECT: {
-                DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) value;
-                writeBuildIdentifierOf(projectComponentIdentifier, encoder);
-                encoder.writeString(projectComponentIdentifier.getIdentityPath().getPath());
-                break;
-            }
-            case OTHER_BUILD_PROJECT: {
-                DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) value;
-                writeBuildIdentifierOf(projectComponentIdentifier, encoder);
-                encoder.writeString(projectComponentIdentifier.getIdentityPath().getPath());
-                encoder.writeString(projectComponentIdentifier.getProjectPath());
+            case PROJECT: {
+                ProjectComponentIdentifierInternal projectComponentIdentifier = (ProjectComponentIdentifierInternal) value;
+                projectIdentitySerializer.write(encoder, projectComponentIdentifier.getProjectIdentity());
                 break;
             }
             case ROOT_COMPONENT: {
@@ -174,21 +128,6 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
         }
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (!super.equals(obj)) {
-            return false;
-        }
-
-        ComponentIdentifierSerializer rhs = (ComponentIdentifierSerializer) obj;
-        return Objects.equal(buildIdentifierSerializer, rhs.buildIdentifierSerializer);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(super.hashCode(), buildIdentifierSerializer);
-    }
-
     private static void writeClassPathNotation(Encoder encoder, DependencyFactoryInternal.ClassPathNotation classPathNotation) throws IOException {
         encoder.writeSmallInt(classPathNotation.ordinal());
     }
@@ -198,30 +137,13 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
         return DependencyFactoryInternal.ClassPathNotation.values()[ordinal];
     }
 
-    private void writeBuildIdentifierOf(ProjectComponentIdentifier projectComponentIdentifier, Encoder encoder) throws IOException {
-        buildIdentifierSerializer.write(encoder, projectComponentIdentifier.getBuild());
-    }
-
-    private Implementation resolveImplementation(ComponentIdentifier value) {
+    private static Implementation resolveImplementation(ComponentIdentifier value) {
         if (value instanceof MavenUniqueSnapshotComponentIdentifier) {
             return Implementation.SNAPSHOT;
         } else if (value instanceof ModuleComponentIdentifier) {
             return Implementation.MODULE;
-        } else if (value instanceof DefaultProjectComponentIdentifier) {
-            DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) value;
-            // Special case some common combinations of names and paths
-            Path projectPath = projectComponentIdentifier.getProjectIdentity().getProjectPath();
-            boolean isARootProject = projectPath.equals(Path.ROOT);
-            if (projectComponentIdentifier.getIdentityPath().equals(Path.ROOT) && isARootProject) {
-                return Implementation.ROOT_PROJECT;
-            }
-            if (projectComponentIdentifier.getIdentityPath().equals(projectPath) && projectPath.getName().equals(projectComponentIdentifier.getProjectName())) {
-                return Implementation.ROOT_BUILD_PROJECT;
-            }
-            if (isARootProject && projectComponentIdentifier.getProjectName().equals(projectComponentIdentifier.getIdentityPath().getName())) {
-                return Implementation.OTHER_BUILD_ROOT_PROJECT;
-            }
-            return Implementation.OTHER_BUILD_PROJECT;
+        } else if (value instanceof ProjectComponentIdentifierInternal) {
+            return Implementation.PROJECT;
         } else if (value instanceof DefaultRootComponentIdentifier) {
             return Implementation.ROOT_COMPONENT;
         } else if (value instanceof LibraryBinaryIdentifier) {
@@ -237,10 +159,7 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
 
     private enum Implementation {
         MODULE(1),
-        ROOT_PROJECT(2),
-        ROOT_BUILD_PROJECT(3),
-        OTHER_BUILD_ROOT_PROJECT(4),
-        OTHER_BUILD_PROJECT(5),
+        PROJECT(2),
         LIBRARY(6),
         SNAPSHOT(7),
         OPAQUE(8),
@@ -249,9 +168,14 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
 
         @Nullable
         public static Implementation valueOf(int id) {
-            Implementation[] values = values();
-            if (id >= values[0].id && id <= values[values.length - 1].id) {
-                return values[id - 1];
+            switch (id) {
+                case 1: return MODULE;
+                case 2: return PROJECT;
+                case 6: return LIBRARY;
+                case 7: return SNAPSHOT;
+                case 8: return OPAQUE;
+                case 9: return OPAQUE_NOTATION;
+                case 10: return ROOT_COMPONENT;
             }
             return null;
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.LibraryComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -32,7 +31,6 @@ import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
-import org.gradle.util.Path;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
@@ -45,15 +43,16 @@ import java.util.Set;
 public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSelector> {
 
     private final AttributeContainerSerializer attributeContainerSerializer;
-    private final BuildIdentifierSerializer buildIdentifierSerializer;
     private final CapabilitySelectorSerializer capabilitySelectorSerializer;
+
+    private final ProjectIdentitySerializer projectIdentitySerializer;
     private final ModuleComponentSelectorSerializer moduleComponentSelectorSerializer;
 
     public ComponentSelectorSerializer(AttributeContainerSerializer attributeContainerSerializer, CapabilitySelectorSerializer capabilitySelectorSerializer) {
         this.attributeContainerSerializer = attributeContainerSerializer;
         this.capabilitySelectorSerializer = capabilitySelectorSerializer;
 
-        this.buildIdentifierSerializer = new BuildIdentifierSerializer();
+        this.projectIdentitySerializer = new ProjectIdentitySerializer(new PathSerializer());
         this.moduleComponentSelectorSerializer = new ModuleComponentSelectorSerializer(attributeContainerSerializer, capabilitySelectorSerializer);
     }
 
@@ -61,32 +60,11 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
     public ComponentSelector read(Decoder decoder) throws IOException {
         byte id = decoder.readByte();
 
-        if (Implementation.ROOT_PROJECT.getId() == id) {
-            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-            String projectName = decoder.readString();
-            ProjectIdentity projectId = new ProjectIdentity(buildIdentifier, Path.ROOT, Path.ROOT, projectName);
+        if (Implementation.PROJECT.getId() == id) {
+            ProjectIdentity projectId = projectIdentitySerializer.read(decoder);
             ImmutableAttributes attributes = readAttributes(decoder);
-            return new DefaultProjectComponentSelector(projectId, attributes, readCapabilitySelectors(decoder));
-        } else if (Implementation.ROOT_BUILD_PROJECT.getId() == id) {
-            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-            Path projectPath = Path.path(decoder.readString());
-            ProjectIdentity projectId = new ProjectIdentity(buildIdentifier, projectPath, projectPath, projectPath.getName());
-            ImmutableAttributes attributes = readAttributes(decoder);
-            return new DefaultProjectComponentSelector(projectId, attributes, readCapabilitySelectors(decoder));
-        } else if (Implementation.OTHER_BUILD_ROOT_PROJECT.getId() == id) {
-            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-            Path identityPath = Path.path(decoder.readString());
-            String projectName = decoder.readString();
-            ProjectIdentity projectId = new ProjectIdentity(buildIdentifier, identityPath, Path.ROOT, projectName);
-            ImmutableAttributes attributes = readAttributes(decoder);
-            return new DefaultProjectComponentSelector(projectId, attributes, readCapabilitySelectors(decoder));
-        } else if (Implementation.OTHER_BUILD_PROJECT.getId() == id) {
-            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-            Path identityPath = Path.path(decoder.readString());
-            Path projectPath = Path.path(decoder.readString());
-            ProjectIdentity projectId = new ProjectIdentity(buildIdentifier, identityPath, projectPath, projectPath.getName());
-            ImmutableAttributes attributes = readAttributes(decoder);
-            return new DefaultProjectComponentSelector(projectId, attributes, readCapabilitySelectors(decoder));
+            ImmutableSet<CapabilitySelector> capabilitySelectors = readCapabilitySelectors(decoder);
+            return new DefaultProjectComponentSelector(projectId, attributes, capabilitySelectors);
         } else if (Implementation.MODULE.getId() == id) {
             return moduleComponentSelectorSerializer.read(decoder);
         } else if (Implementation.LIBRARY.getId() == id) {
@@ -131,30 +109,9 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
 
         if (implementation == Implementation.MODULE) {
             moduleComponentSelectorSerializer.write(encoder, (ModuleComponentSelector) value);
-        } else if (implementation == Implementation.ROOT_PROJECT) {
+        } else if (implementation == Implementation.PROJECT) {
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
-            buildIdentifierSerializer.write(encoder, projectComponentSelector.getProjectIdentity().getBuildIdentifier());
-            encoder.writeString(projectComponentSelector.getProjectIdentity().getProjectName());
-            writeAttributes(encoder, projectComponentSelector.getAttributes());
-            writeCapabilitySelectors(encoder, projectComponentSelector.getCapabilitySelectors());
-        } else if (implementation == Implementation.ROOT_BUILD_PROJECT) {
-            DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
-            buildIdentifierSerializer.write(encoder, projectComponentSelector.getProjectIdentity().getBuildIdentifier());
-            encoder.writeString(projectComponentSelector.getProjectPath());
-            writeAttributes(encoder, projectComponentSelector.getAttributes());
-            writeCapabilitySelectors(encoder, projectComponentSelector.getCapabilitySelectors());
-        } else if (implementation == Implementation.OTHER_BUILD_ROOT_PROJECT) {
-            DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
-            buildIdentifierSerializer.write(encoder, projectComponentSelector.getProjectIdentity().getBuildIdentifier());
-            encoder.writeString(projectComponentSelector.getIdentityPath().getPath());
-            encoder.writeString(projectComponentSelector.getProjectIdentity().getProjectName());
-            writeAttributes(encoder, projectComponentSelector.getAttributes());
-            writeCapabilitySelectors(encoder, projectComponentSelector.getCapabilitySelectors());
-        } else if (implementation == Implementation.OTHER_BUILD_PROJECT) {
-            DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
-            buildIdentifierSerializer.write(encoder, projectComponentSelector.getProjectIdentity().getBuildIdentifier());
-            encoder.writeString(projectComponentSelector.getIdentityPath().getPath());
-            encoder.writeString(projectComponentSelector.getProjectPath());
+            projectIdentitySerializer.write(encoder, projectComponentSelector.getProjectIdentity());
             writeAttributes(encoder, projectComponentSelector.getAttributes());
             writeCapabilitySelectors(encoder, projectComponentSelector.getCapabilitySelectors());
         } else if (implementation == Implementation.LIBRARY) {
@@ -171,42 +128,20 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         attributeContainerSerializer.write(encoder, attributes);
     }
 
-    private ComponentSelectorSerializer.Implementation resolveImplementation(ComponentSelector value) {
-        Implementation implementation;
-
+    private static Implementation resolveImplementation(ComponentSelector value) {
         if (value instanceof DefaultModuleComponentSelector) {
-            implementation = Implementation.MODULE;
+            return Implementation.MODULE;
         } else if (value instanceof DefaultProjectComponentSelector) {
-            DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
-            // Special case some common combinations of names and paths
-            boolean isARootProject = projectComponentSelector.getProjectIdentity().getProjectPath().equals(Path.ROOT);
-            if (projectComponentSelector.getIdentityPath().equals(Path.ROOT) && isARootProject) {
-                return Implementation.ROOT_PROJECT;
-            }
-            if (isARootProject) {
-                return Implementation.OTHER_BUILD_ROOT_PROJECT;
-            }
-            // For non-root project, project name must be the last element of the project path
-            Path projectPath = projectComponentSelector.getProjectIdentity().getProjectPath();
-            String projectName = projectComponentSelector.getProjectIdentity().getProjectName();
-            if (!projectName.equals(projectPath.getName())) {
-                throw new IllegalArgumentException("Unexpected name for project " + projectPath + ". Expected: " + projectPath.getName() + ", found: " + projectName);
-            }
-            if (projectComponentSelector.getIdentityPath().equals(projectPath)) {
-                return Implementation.ROOT_BUILD_PROJECT;
-            }
-            return Implementation.OTHER_BUILD_PROJECT;
+            return Implementation.PROJECT;
         } else if (value instanceof DefaultLibraryComponentSelector) {
-            implementation = Implementation.LIBRARY;
+            return Implementation.LIBRARY;
         } else {
             throw new IllegalArgumentException("Unsupported component selector class: " + value.getClass());
         }
-
-        return implementation;
     }
 
     private enum Implementation {
-        MODULE(1), ROOT_PROJECT(2), ROOT_BUILD_PROJECT(3), OTHER_BUILD_ROOT_PROJECT(4), OTHER_BUILD_PROJECT(5), LIBRARY(6), SNAPSHOT(7);
+        MODULE(1), PROJECT(2), LIBRARY(6);
 
         private final byte id;
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/PathSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/PathSerializer.java
@@ -16,29 +16,37 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
+import org.gradle.util.Path;
 
 import java.io.IOException;
 
 /**
- * A thread-safe and reusable serializer for {@link BuildIdentifier}.
+ * A thread-safe and reusable serializer for {@link Path}.
  */
-public class BuildIdentifierSerializer extends AbstractSerializer<BuildIdentifier> {
-
-    private final PathSerializer pathSerializer = new PathSerializer();
+public class PathSerializer extends AbstractSerializer<Path> {
 
     @Override
-    public BuildIdentifier read(Decoder decoder) throws IOException {
-        return new DefaultBuildIdentifier(pathSerializer.read(decoder));
+    public Path read(Decoder decoder) throws IOException {
+        boolean isRoot = decoder.readBoolean();
+
+        if (isRoot) {
+            return Path.ROOT;
+        } else {
+            return Path.path(decoder.readString());
+        }
     }
 
     @Override
-    public void write(Encoder encoder, BuildIdentifier value) throws IOException {
-        pathSerializer.write(encoder, ((DefaultBuildIdentifier) value).getIdentityPath());
+    public void write(Encoder encoder, Path value) throws IOException {
+        boolean isRoot = value.equals(Path.ROOT);
+        encoder.writeBoolean(isRoot);
+
+        if (!isRoot) {
+            encoder.writeString(value.getPath());
+        }
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ProjectIdentitySerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ProjectIdentitySerializer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
+
+import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+import org.gradle.internal.serialize.Serializer;
+import org.gradle.util.Path;
+
+import java.io.IOException;
+
+/**
+ * A thread-safe, reusable serializer for {@link ProjectIdentity}.
+ */
+public class ProjectIdentitySerializer implements Serializer<ProjectIdentity> {
+
+    private final PathSerializer pathSerializer;
+
+    public ProjectIdentitySerializer(PathSerializer pathSerializer) {
+        this.pathSerializer = pathSerializer;
+    }
+
+    @Override
+    public ProjectIdentity read(Decoder decoder) throws IOException {
+        Path buildPath = pathSerializer.read(decoder);
+
+        boolean isRoot = decoder.readBoolean();
+
+        if (isRoot) {
+            String projectName = decoder.readString();
+            return ProjectIdentity.forRootProject(buildPath, projectName);
+        } else {
+            Path projectPath = pathSerializer.read(decoder);
+            return ProjectIdentity.forSubproject(buildPath, projectPath);
+        }
+    }
+
+    @Override
+    public void write(Encoder encoder, ProjectIdentity value) throws IOException {
+        pathSerializer.write(encoder, value.getBuildPath());
+
+        boolean isRoot = value.getProjectPath().equals(Path.ROOT);
+        encoder.writeBoolean(isRoot);
+
+        if (isRoot) {
+            encoder.writeString(value.getProjectName());
+        } else {
+            pathSerializer.write(encoder, value.getProjectPath());
+        }
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ProjectIdentitySerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ProjectIdentitySerializer.java
@@ -17,9 +17,9 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import org.gradle.api.internal.project.ProjectIdentity;
+import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
-import org.gradle.internal.serialize.Serializer;
 import org.gradle.util.Path;
 
 import java.io.IOException;
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * A thread-safe, reusable serializer for {@link ProjectIdentity}.
  */
-public class ProjectIdentitySerializer implements Serializer<ProjectIdentity> {
+public class ProjectIdentitySerializer extends AbstractSerializer<ProjectIdentity> {
 
     private final PathSerializer pathSerializer;
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
@@ -100,7 +100,7 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
 
     private PlannedTransformStepIdentity createIdentity() {
         ProjectIdentity projectId = transformStep.getOwningProject().getProjectIdentity();
-        String consumerBuildPath = projectId.getBuildIdentifier().getBuildPath();
+        String consumerBuildPath = projectId.getBuildPath().getPath();
         String consumerProjectPath = projectId.getProjectPath().getPath();
         ComponentIdentifier componentId = ComponentToOperationConverter.convertComponentIdentifier(targetComponentVariant.getComponentId());
         Map<String, String> sourceAttributes = AttributesToMapConverter.convertToMap(this.sourceAttributes);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
@@ -74,7 +74,7 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
 
     @Override
     public String getBuildPath() {
-        return projectIdentity.getBuildIdentifier().getBuildPath();
+        return projectIdentity.getBuildPath().getPath();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -39,7 +39,6 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.artifacts.ConfigurationResolver
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultExcludeRule
 import org.gradle.api.internal.artifacts.DefaultResolverResults
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
@@ -1620,19 +1619,16 @@ This method is only meant to be called on configurations which allow the (non-de
     }
 
     private DefaultConfigurationFactory confFactory(String projectPath, String buildPath) {
-        def domainObjectContext = Stub(DomainObjectContext)
         def build = Path.path(buildPath)
         def project = Path.path(projectPath)
         def buildTreePath = build.append(Path.path(projectPath))
+        def identity = project.name != null ? ProjectIdentity.forSubproject(build, project) : ProjectIdentity.forRootProject(build, "foo")
+
+        def domainObjectContext = Stub(DomainObjectContext)
         _ * domainObjectContext.identityPath(_) >> { String p -> buildTreePath.child(p) }
         _ * domainObjectContext.projectPath(_) >> { String p -> project.child(p) }
         _ * domainObjectContext.buildPath >> build
-        _ * domainObjectContext.projectIdentity >> new ProjectIdentity(
-            new DefaultBuildIdentifier(build),
-            buildTreePath,
-            project,
-            project.name ?: "foo"
-        )
+        _ * domainObjectContext.projectIdentity >> identity
         _ * domainObjectContext.model >> StandaloneDomainObjectContext.ANONYMOUS
         _ * domainObjectContext.equals(_) >> true // In these tests, we assume we're in the same context
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependenciesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependenciesTest.groovy
@@ -18,7 +18,6 @@
 package org.gradle.api.internal.artifacts.configurations
 
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.project.ProjectIdentity
@@ -40,10 +39,10 @@ class TasksFromProjectDependenciesTest extends AbstractProjectBuilderSpec {
     def project2State = Mock(ProjectState)
     def project1 = Mock(ProjectInternal)
     def project2 = Mock(ProjectInternal)
-    def projectPath1 = Path.path("project1")
-    def projectPath2 = Path.path("project2")
-    def projectId1 = new ProjectIdentity(DefaultBuildIdentifier.ROOT, projectPath1, projectPath1, "project1")
-    def projectId2 = new ProjectIdentity(DefaultBuildIdentifier.ROOT, projectPath2, projectPath2, "project2")
+    def projectPath1 = Path.path(":project1")
+    def projectPath2 = Path.path(":project2")
+    def projectId1 = ProjectIdentity.forSubproject(Path.ROOT, projectPath1)
+    def projectId2 = ProjectIdentity.forSubproject(Path.ROOT, projectPath2)
     def projectDep1 = Mock(ProjectDependencyInternal) { getTargetProjectIdentity() >> projectId1 }
     def projectDep2 = Mock(ProjectDependencyInternal) { getTargetProjectIdentity() >> projectId2 }
     def tasks1 = Mock(TaskContainerInternal)

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.dsl
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentSelector
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.project.ProjectIdentity
@@ -113,14 +112,11 @@ class ComponentSelectorParsersTest extends Specification {
 
     def "understands project input"() {
         when:
-        def buildId = new DefaultBuildIdentifier(Path.path(":build"))
+        def identity = ProjectIdentity.forSubproject(Path.path(":build"), Path.path(":bar"))
         def projectState = Mock(ProjectState) {
-            getIdentity() >> new ProjectIdentity(buildId, Path.path(":id:bar"), Path.path(":bar"), "name")
+            getIdentity() >> identity
         }
         def project = Mock(ProjectInternal) {
-            getIdentityPath() >> Path.path(":id:bar")
-            getProjectPath() >> Path.path(":bar")
-            getName() >> "name"
             getOwner() >> projectState
         }
         def v = multiParser().parseNotation(project) as List

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionCause
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
@@ -95,7 +94,7 @@ class DefaultDependencySubstitutionSpec extends Specification {
 
     def "can specify target project"() {
         def projectState = Mock(ProjectState)
-        projectState.identity >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.path(":id:path"), Path.path(":bar"), "bar")
+        projectState.identity >> ProjectIdentity.forSubproject(Path.path(":id"), Path.path(":bar"))
         def project = Mock(ProjectInternal)
         project.identityPath >> Path.path(":id:path")
         project.projectPath >> Path.path(":bar")

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.Action
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
@@ -49,8 +48,9 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         getProjects() >> Mock(BuildProjectRegistry) {
             getProject(_ as Path) >> { args ->
                 Path path = args[0]
+                ProjectIdentity id = path.name != null ? ProjectIdentity.forSubproject(Path.ROOT, path) : ProjectIdentity.forRootProject(Path.ROOT, "root")
                 return Mock(ProjectState) {
-                    getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, path, path, path.getName())
+                    getIdentity() >> id
                 }
             }
         }
@@ -180,7 +180,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
     def "cannot substitute with unversioned module selector"() {
         when:
         substitutions.with {
-            substitute project("foo") using module('group:name')
+            substitute project(":foo") using module('group:name')
         }
 
         then:

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverterTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencie
 import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.project.ProjectIdentity
@@ -44,8 +43,9 @@ class ProjectDependencyMetadataConverterTest extends AbstractDependencyDescripto
 
     def "test create from project dependency"() {
         given:
+        def projectId = ProjectIdentity.forRootProject(Path.ROOT, "foo")
         def projectState = Stub(ProjectState) {
-            getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "foo")
+            getIdentity() >> projectId
         }
 
         def projectDependency = new DefaultProjectDependency(projectState)
@@ -62,7 +62,7 @@ class ProjectDependencyMetadataConverterTest extends AbstractDependencyDescripto
         assertDependencyDescriptorHasCommonFixtureValues(dependencyMetaData, withArtifacts)
         !dependencyMetaData.changing
         !dependencyMetaData.force
-        dependencyMetaData.selector == new DefaultProjectComponentSelector(new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "root"), ImmutableAttributes.EMPTY, ImmutableSet.of())
+        dependencyMetaData.selector == new DefaultProjectComponentSelector(projectId, ImmutableAttributes.EMPTY, ImmutableSet.of())
 
         where:
         withArtifacts << [true, false]

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.AttributeContainer
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
@@ -205,7 +204,7 @@ class SelectorStateResolverTest extends Specification {
     }
 
     def 'short circuits for matching project selectors'() {
-        ProjectIdentity id = new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "projectA")
+        ProjectIdentity id = ProjectIdentity.forRootProject(Path.ROOT, "projectA")
         def projectId = new DefaultProjectComponentIdentifier(id)
         def nine = new TestProjectSelectorState(id)
         def otherNine = new TestProjectSelectorState(id)

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializerTest.groovy
@@ -18,11 +18,11 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.ProjectComponentIdentifierInternal
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.local.model.DefaultLibraryBinaryIdentifier
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier
@@ -69,7 +69,7 @@ class ComponentIdentifierSerializerTest extends SerializerSpec {
 
     def "serializes root ProjectComponentIdentifier"() {
         given:
-        def identifier = new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier(Path.path(":build")), Path.ROOT, Path.ROOT, "someProject")
+        def identifier = new DefaultProjectComponentIdentifier(ProjectIdentity.forRootProject(Path.ROOT, "root"))
 
         when:
         def result = serialize(identifier, serializer) as ProjectComponentIdentifierInternal
@@ -84,7 +84,7 @@ class ComponentIdentifierSerializerTest extends SerializerSpec {
 
     def "serializes root build ProjectComponentIdentifier"() {
         given:
-        def identifier = new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier(Path.path(":build")), Path.path(":a:b"), Path.path(":a:b"), "b")
+        def identifier = new DefaultProjectComponentIdentifier(ProjectIdentity.forSubproject(Path.ROOT, Path.path(":subproject")))
 
         when:
         def result = serialize(identifier, serializer) as ProjectComponentIdentifierInternal
@@ -99,7 +99,7 @@ class ComponentIdentifierSerializerTest extends SerializerSpec {
 
     def "serializes other build root ProjectComponentIdentifier"() {
         given:
-        def identifier = new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier(Path.path(":build")), Path.path(":prefix:someProject"), Path.ROOT, "someProject")
+        def identifier = new DefaultProjectComponentIdentifier(ProjectIdentity.forRootProject(Path.path(":build"), "root"))
 
         when:
         def result = serialize(identifier, serializer) as ProjectComponentIdentifierInternal
@@ -114,7 +114,7 @@ class ComponentIdentifierSerializerTest extends SerializerSpec {
 
     def "serializes other build ProjectComponentIdentifier"() {
         given:
-        def identifier = new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier(Path.path(":build")), Path.path(":prefix:a:b"), Path.path(":a:b"), "b")
+        def identifier = new DefaultProjectComponentIdentifier(ProjectIdentity.forSubproject(Path.path(":build"), Path.path(":subproject")))
 
         when:
         def result = serialize(identifier, serializer) as ProjectComponentIdentifierInternal
@@ -157,7 +157,7 @@ class ComponentIdentifierSerializerTest extends SerializerSpec {
     }
 
     void assertSameProjectId(ProjectComponentIdentifierInternal result, ProjectComponentIdentifierInternal selector) {
-        assert result.projectIdentity.buildIdentifier == selector.projectIdentity.buildIdentifier
+        assert result.projectIdentity.buildPath == selector.projectIdentity.buildPath
         assert result.projectIdentity.buildTreePath == selector.projectIdentity.buildTreePath
         assert result.projectIdentity.projectPath == selector.projectIdentity.projectPath
         assert result.projectIdentity.projectName == selector.projectIdentity.projectName

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -24,13 +24,13 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.artifacts.result.ResolvedVariantResult
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.resolver.ResolutionAccess
 import org.gradle.api.internal.artifacts.resolver.ResolutionOutputsInternal
 import org.gradle.api.internal.attributes.AttributeDesugaring
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvedDependencyEdge
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
@@ -140,10 +140,7 @@ class DefaultResolutionResultTest extends Specification {
 
     def "doesn't throw class cast exception when the source of the edge is a project"() {
         def projectId = new DefaultProjectComponentIdentifier(
-            DefaultBuildIdentifier.ROOT,
-            Stub(Path),
-            Stub(Path),
-            'test project'
+            ProjectIdentity.forRootProject(Path.ROOT, "bar")
         )
         def mid = DefaultModuleVersionIdentifier.newId("foo", "bar", "1.0")
         org.gradle.internal.Factory<String> broken = { "too bad" }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.notations
 
 import org.gradle.api.InvalidUserDataException
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
@@ -32,7 +31,7 @@ import spock.lang.Specification
 class ProjectDependencyFactoryTest extends Specification {
 
     def projectState = Mock(ProjectState) {
-        getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "foo")
+        getIdentity() >> ProjectIdentity.forRootProject(Path.ROOT, "foo")
     }
 
     def projectFinder = Mock(ProjectFinder) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/ProjectDerivedCapabilityTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/ProjectDerivedCapabilityTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.internal.component.external.model
 
 import org.gradle.api.capabilities.Capability
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
@@ -52,7 +51,7 @@ class ProjectDerivedCapabilityTest extends Specification {
             getName() >> name
             getVersion() >> version
             getOwner() >> Mock(ProjectState) {
-                getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, name)
+                getIdentity() >> ProjectIdentity.forRootProject(Path.ROOT, name)
             }
         }
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.internal.component.local.model
 
 import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.component.ProjectComponentSelector
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.capability.DefaultFeatureCapabilitySelector
@@ -36,13 +35,14 @@ class DefaultProjectComponentSelectorTest extends Specification {
 
     def "is instantiated with non-null constructor parameter values"() {
         when:
-        ProjectComponentSelector defaultBuildComponentSelector = new DefaultProjectComponentSelector(new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.path(":id:path"), Path.path(":project:path"), "projectName"), ImmutableAttributes.EMPTY, ImmutableSet.of())
+        ProjectIdentity id = ProjectIdentity.forSubproject(Path.path(":build"), Path.path(":path"))
+        ProjectComponentSelector defaultBuildComponentSelector = new DefaultProjectComponentSelector(id, ImmutableAttributes.EMPTY, ImmutableSet.of())
 
         then:
-        defaultBuildComponentSelector.projectPath == ":project:path"
-        defaultBuildComponentSelector.projectIdentity.projectName == "projectName"
-        defaultBuildComponentSelector.displayName == "project :id:path"
-        defaultBuildComponentSelector.toString() == "project :id:path"
+        defaultBuildComponentSelector.projectPath == ":path"
+        defaultBuildComponentSelector.projectIdentity == id
+        defaultBuildComponentSelector.displayName == "project :build:path"
+        defaultBuildComponentSelector.toString() == "project :build:path"
     }
 
     def "can compare with other instance (#projectPath)"() {
@@ -80,9 +80,14 @@ class DefaultProjectComponentSelectorTest extends Specification {
 
     def "matches id (#buildName #projectPath)"() {
         expect:
-        def selector = new DefaultProjectComponentSelector(new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.path(":id:path"), Path.path(":project:path"), "projectName"), ImmutableAttributes.EMPTY, ImmutableSet.of())
-        def sameIdPath = new DefaultProjectComponentIdentifier(DefaultBuildIdentifier.ROOT, Path.path(":id:path"), Path.path(":project:path"), "projectName")
-        def differentIdPath = new DefaultProjectComponentIdentifier(DefaultBuildIdentifier.ROOT, Path.path(":id:path2"), Path.path(":project:path"), "projectName")
+        ProjectIdentity id1 = ProjectIdentity.forSubproject(Path.ROOT, Path.path(":one"))
+        ProjectIdentity id2 = ProjectIdentity.forSubproject(Path.ROOT, Path.path(":two"))
+
+        def selector = new DefaultProjectComponentSelector(id1, ImmutableAttributes.EMPTY, ImmutableSet.of())
+
+        def sameIdPath = new DefaultProjectComponentIdentifier(id1)
+        def differentIdPath = new DefaultProjectComponentIdentifier(id2)
+
         selector.matchesStrictly(sameIdPath)
         !selector.matchesStrictly(differentIdPath)
     }
@@ -91,7 +96,7 @@ class DefaultProjectComponentSelectorTest extends Specification {
         def capabilities = ImmutableSet.of(
             new DefaultSpecificCapabilitySelector(new DefaultImmutableCapability("org", "blah", "1"))
         )
-        def identity = new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.path(":id:path"), Path.path(":project:path"), "projectName")
+        def identity = ProjectIdentity.forRootProject(Path.ROOT, "foo")
         ProjectComponentSelector selector = new DefaultProjectComponentSelector(identity, ImmutableAttributes.EMPTY, capabilities)
 
         expect:
@@ -105,7 +110,7 @@ class DefaultProjectComponentSelectorTest extends Specification {
         def capabilities = ImmutableSet.of(
             new DefaultFeatureCapabilitySelector("foo")
         )
-        def identity = new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.path(":id:path"), Path.path(":project:path"), "projectName")
+        def identity = ProjectIdentity.forRootProject(Path.ROOT, "foo")
         ProjectComponentSelector selector = new DefaultProjectComponentSelector(identity, ImmutableAttributes.EMPTY, capabilities)
 
         expect:

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -18,18 +18,17 @@ package org.gradle.internal.locking
 
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.DomainObjectContext
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.internal.resource.local.FileResourceListener
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.GradleVersion
 import org.gradle.util.Path
 import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Subject
-import org.gradle.util.GradleVersion
 
 class LockFileReaderWriterTest extends Specification {
     @Rule
@@ -40,7 +39,7 @@ class LockFileReaderWriterTest extends Specification {
     @Subject
     LockFileReaderWriter lockFileReaderWriter
     FileResolver resolver = Mock()
-    ProjectIdentity identity = new ProjectIdentity(new DefaultBuildIdentifier(Path.ROOT), Path.path("foo"), Path.path("foo"), "foo")
+    ProjectIdentity identity = ProjectIdentity.forSubproject(Path.ROOT, Path.path(":foo"))
     DomainObjectContext context = Mock() {
         identityPath(_) >> { String value -> Path.path(value) }
         getProjectIdentity() >> identity
@@ -269,7 +268,7 @@ empty=d
 
         then:
         def ex = thrown(IllegalStateException)
-        ex.getMessage().contains("Dependency locking cannot be used for project foo")
+        ex.getMessage().contains("Dependency locking cannot be used for project :foo")
     }
 
     def 'fails to read a legacy lockfile if root could not be determined'() {
@@ -282,7 +281,7 @@ empty=d
 
         then:
         def ex = thrown(IllegalStateException)
-        ex.getMessage().contains("Dependency locking cannot be used for project foo")
+        ex.getMessage().contains("Dependency locking cannot be used for project :foo")
     }
 
     def 'fails to write a unique lockfile if root could not be determined'() {
@@ -295,6 +294,6 @@ empty=d
 
         then:
         def ex = thrown(IllegalStateException)
-        ex.getMessage().contains("Dependency locking cannot be used for project foo")
+        ex.getMessage().contains("Dependency locking cannot be used for project :foo")
     }
 }

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/internal/component/local/model/TestComponentIdentifiers.java
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/internal/component/local/model/TestComponentIdentifiers.java
@@ -18,7 +18,6 @@ package org.gradle.internal.component.local.model;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.project.ProjectIdentity;
@@ -30,12 +29,8 @@ public class TestComponentIdentifiers {
     }
 
     public static ProjectComponentIdentifier newProjectId(String buildPath, String projectPath) {
-        Path path = Path.path(projectPath);
-        String name = path.getName();
-        if (name == null) {
-            name = "root";
-        }
-        return new DefaultProjectComponentIdentifier(new DefaultBuildIdentifier(Path.path(buildPath)), path, path, name);
+        ProjectIdentity id = projectIdFor(Path.path(buildPath), Path.path(projectPath));
+        return new DefaultProjectComponentIdentifier(id);
     }
 
     public static ProjectComponentSelector newSelector(String projectPath) {
@@ -43,11 +38,17 @@ public class TestComponentIdentifiers {
     }
 
     public static ProjectComponentSelector newSelector(String buildPath, String projectPath) {
-        Path path = Path.path(projectPath);
-        String name = path.getName();
-        if (name == null) {
-            name = "root";
+        ProjectIdentity id = projectIdFor(Path.path(buildPath), Path.path(projectPath));
+        return new DefaultProjectComponentSelector(id, ImmutableAttributes.EMPTY, ImmutableSet.of());
+    }
+
+    private static ProjectIdentity projectIdFor(Path buildPath, Path projectPath) {
+        ProjectIdentity id;
+        if (projectPath.getName() == null) {
+            id = ProjectIdentity.forRootProject(buildPath, "root");
+        } else {
+            id = ProjectIdentity.forSubproject(buildPath, projectPath);
         }
-        return new DefaultProjectComponentSelector(new ProjectIdentity(new DefaultBuildIdentifier(Path.path(buildPath)), path, path, name), ImmutableAttributes.EMPTY, ImmutableSet.of());
+        return id;
     }
 }

--- a/platforms/software/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/platforms/software/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
@@ -172,15 +171,14 @@ class DefaultIvyPublicationTest extends Specification {
     def "maps project dependency to ivy dependency"() {
         given:
         def publication = createPublication()
-        def buildTreePath = Mock(Path)
-        def projectIdentity = new ProjectIdentity(DefaultBuildIdentifier.ROOT, buildTreePath, buildTreePath, "foo")
+        def projectIdentity = ProjectIdentity.forSubproject(Path.path(":build"), Path.path(":subproject"))
         def projectDependency = Mock(ProjectDependencyInternal) {
             getTargetProjectIdentity() >> projectIdentity
         }
         def exclude = Mock(ExcludeRule)
 
         and:
-        projectDependencyResolver.resolveComponent(ModuleVersionIdentifier, buildTreePath) >> DefaultModuleVersionIdentifier.newId("pub-org", "pub-module", "pub-revision")
+        projectDependencyResolver.resolveComponent(ModuleVersionIdentifier, projectIdentity.getBuildTreePath()) >> DefaultModuleVersionIdentifier.newId("pub-org", "pub-module", "pub-revision")
         projectDependency.targetConfiguration >> "dep-configuration"
         projectDependency.artifacts >> []
         projectDependency.excludeRules >> [exclude]

--- a/platforms/software/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/platforms/software/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -28,7 +28,6 @@ import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.attributes.Category
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
@@ -423,8 +422,7 @@ class DefaultMavenPublicationTest extends Specification {
     def "maps project dependency to maven dependency"() {
         given:
         def publication = createPublication()
-        def buildTreePath = Mock(Path)
-        def projectIdentity = new ProjectIdentity(DefaultBuildIdentifier.ROOT, buildTreePath, buildTreePath, "foo")
+        def projectIdentity = ProjectIdentity.forSubproject(Path.path(":build"), Path.path(":subproject"))
         def projectDependency = Mock(ProjectDependencyInternal) {
             getTargetProjectIdentity() >> projectIdentity
         }
@@ -436,7 +434,7 @@ class DefaultMavenPublicationTest extends Specification {
         projectDependency.getArtifacts() >> []
         projectDependency.getGroup() >> "pub-group"
         projectDependency.getName() >> "pub-name"
-        projectDependencyResolver.resolveComponent(ModuleVersionIdentifier, buildTreePath) >> DefaultModuleVersionIdentifier.newId("pub-group", "pub-name", "pub-version")
+        projectDependencyResolver.resolveComponent(ModuleVersionIdentifier, projectIdentity.getBuildTreePath()) >> DefaultModuleVersionIdentifier.newId("pub-group", "pub-name", "pub-version")
 
         when:
         publication.from(componentWithDependency(projectDependency))
@@ -456,8 +454,7 @@ class DefaultMavenPublicationTest extends Specification {
     def "ignores self project dependency"() {
         given:
         def publication = createPublication()
-        def buildTreePath = Mock(Path)
-        def projectIdentity = new ProjectIdentity(DefaultBuildIdentifier.ROOT, buildTreePath, buildTreePath, "foo")
+        def projectIdentity = ProjectIdentity.forSubproject(Path.path(":build"), Path.path(":subproject"))
         def projectDependency = Mock(ProjectDependencyInternal) {
             getTargetProjectIdentity() >> projectIdentity
         }
@@ -467,7 +464,7 @@ class DefaultMavenPublicationTest extends Specification {
         projectDependency.getAttributes() >> ImmutableAttributes.EMPTY
         projectDependency.capabilitySelectors >> ([] as Set)
         projectDependency.getArtifacts() >> []
-        projectDependencyResolver.resolveComponent(ModuleVersionIdentifier, buildTreePath) >> DefaultModuleVersionIdentifier.newId("group", "name", "version")
+        projectDependencyResolver.resolveComponent(ModuleVersionIdentifier, projectIdentity.getBuildTreePath()) >> DefaultModuleVersionIdentifier.newId("group", "name", "version")
 
         when:
         publication.from(componentWithDependency(projectDependency))

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
@@ -17,7 +17,6 @@
 package org.gradle.composite.internal;
 
 import org.gradle.StartParameter;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.initialization.BuildCancellationToken;
@@ -67,8 +66,8 @@ public class BuildStateFactory {
         return new DefaultRootBuildState(buildDefinition, buildTreeState, listenerManager);
     }
 
-    public StandAloneNestedBuild createNestedBuild(BuildIdentifier buildIdentifier, Path identityPath, BuildDefinition buildDefinition, BuildState owner) {
-        DefaultNestedBuild build = new DefaultNestedBuild(buildIdentifier, identityPath, buildDefinition, owner, buildTreeState);
+    public StandAloneNestedBuild createNestedBuild(Path identityPath, BuildDefinition buildDefinition, BuildState owner) {
+        DefaultNestedBuild build = new DefaultNestedBuild(identityPath, buildDefinition, owner, buildTreeState);
         // Expose any contributions from the parent's settings
         build.getMutableModel().setClassLoaderScope(() -> owner.getMutableModel().getSettings().getClassLoaderScope());
         return build;
@@ -77,11 +76,10 @@ public class BuildStateFactory {
     public NestedBuildTree createNestedTree(
         BuildInvocationScopeId buildInvocationScopeId,
         BuildDefinition buildDefinition,
-        BuildIdentifier buildIdentifier,
         Path identityPath,
         BuildState owner
     ) {
-        return new DefaultNestedBuildTree(buildInvocationScopeId, buildDefinition, buildIdentifier, identityPath, owner, userHomeDirServiceRegistry, crossBuildSessionState, buildCancellationToken);
+        return new DefaultNestedBuildTree(buildInvocationScopeId, buildDefinition, identityPath, owner, userHomeDirServiceRegistry, crossBuildSessionState, buildCancellationToken);
     }
 
     public BuildDefinition buildDefinitionFor(File buildSrcDir, BuildState owner) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.DependencySubstitutions;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.tasks.TaskReference;
@@ -36,14 +35,14 @@ import org.gradle.util.Path;
 import java.io.File;
 
 public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState implements IncludedBuildState {
-    private final BuildIdentifier buildIdentifier;
+
     private final Path identityPath;
     private final BuildDefinition buildDefinition;
     private final boolean isImplicit;
     private final IncludedBuildImpl model;
 
     public DefaultIncludedBuild(
-        BuildIdentifier buildIdentifier,
+        Path identityPath,
         BuildDefinition buildDefinition,
         boolean isImplicit,
         BuildState owner,
@@ -52,16 +51,12 @@ public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState
     ) {
         // Use a defensive copy of the build definition, as it may be mutated during build execution
         super(buildTree, buildDefinition.newInstance(), owner);
-        this.buildIdentifier = buildIdentifier;
-        this.identityPath = Path.path(buildIdentifier.getBuildPath());
+        assert !identityPath.equals(Path.ROOT) : "An included build must not be located at the root path";
+
+        this.identityPath = identityPath;
         this.buildDefinition = buildDefinition;
         this.isImplicit = isImplicit;
         this.model = instantiator.newInstance(IncludedBuildImpl.class, this);
-    }
-
-    @Override
-    public BuildIdentifier getBuildIdentifier() {
-        return buildIdentifier;
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildFactory.java
@@ -17,13 +17,13 @@
 package org.gradle.composite.internal;
 
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.IncludedBuildFactory;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.util.Path;
 
 import java.io.File;
 
@@ -49,10 +49,10 @@ public class DefaultIncludedBuildFactory implements IncludedBuildFactory {
     }
 
     @Override
-    public IncludedBuildState createBuild(BuildIdentifier buildIdentifier, BuildDefinition buildDefinition, boolean isImplicit, BuildState owner) {
+    public IncludedBuildState createBuild(Path identityPath, BuildDefinition buildDefinition, boolean isImplicit, BuildState owner) {
         validateBuildDirectory(buildDefinition.getBuildRootDir());
         return new DefaultIncludedBuild(
-            buildIdentifier,
+            identityPath,
             buildDefinition,
             isImplicit,
             owner,

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -16,7 +16,6 @@
 
 package org.gradle.composite.internal;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.UncheckedException;
@@ -41,21 +40,19 @@ import java.util.List;
 import java.util.function.Function;
 
 class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedBuild {
+
     private final Path identityPath;
     private final BuildState owner;
-    private final BuildIdentifier buildIdentifier;
     private final BuildDefinition buildDefinition;
     private final BuildTreeLifecycleController buildTreeLifecycleController;
 
     DefaultNestedBuild(
-        BuildIdentifier buildIdentifier,
         Path identityPath,
         BuildDefinition buildDefinition,
         BuildState owner,
         BuildTreeState buildTree
     ) {
         super(buildTree, buildDefinition, owner);
-        this.buildIdentifier = buildIdentifier;
         this.identityPath = identityPath;
         this.buildDefinition = buildDefinition;
         this.owner = owner;
@@ -73,11 +70,6 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
             CompositeStoppable.stoppable().addFailure(t).add(buildScopeServices).stop();
             throw UncheckedException.throwAsUncheckedException(t);
         }
-    }
-
-    @Override
-    public BuildIdentifier getBuildIdentifier() {
-        return buildIdentifier;
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuildTree.java
@@ -16,7 +16,6 @@
 
 package org.gradle.composite.internal;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.initialization.BuildCancellationToken;
@@ -40,9 +39,9 @@ import org.gradle.util.Path;
 import java.util.function.Function;
 
 public class DefaultNestedBuildTree implements NestedBuildTree {
+
     private final BuildInvocationScopeId buildInvocationScopeId;
     private final BuildDefinition buildDefinition;
-    private final BuildIdentifier buildIdentifier;
     private final Path identityPath;
     private final BuildState owner;
     private final GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry;
@@ -52,7 +51,6 @@ public class DefaultNestedBuildTree implements NestedBuildTree {
     public DefaultNestedBuildTree(
         BuildInvocationScopeId buildInvocationScopeId,
         BuildDefinition buildDefinition,
-        BuildIdentifier buildIdentifier,
         Path identityPath,
         BuildState owner,
         GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry,
@@ -61,7 +59,6 @@ public class DefaultNestedBuildTree implements NestedBuildTree {
     ) {
         this.buildInvocationScopeId = buildInvocationScopeId;
         this.buildDefinition = buildDefinition;
-        this.buildIdentifier = buildIdentifier;
         this.identityPath = identityPath;
         this.owner = owner;
         this.userHomeDirServiceRegistry = userHomeDirServiceRegistry;
@@ -80,7 +77,7 @@ public class DefaultNestedBuildTree implements NestedBuildTree {
             // Let the nested build tree inherits the same invocation ID
             BuildTreeState buildTree = new BuildTreeState(buildInvocationScopeId, session.getServices(), modelServices);
             try {
-                RootOfNestedBuildTree rootBuild = new RootOfNestedBuildTree(buildDefinition, buildIdentifier, identityPath, owner, buildTree);
+                RootOfNestedBuildTree rootBuild = new RootOfNestedBuildTree(buildDefinition, identityPath, owner, buildTree);
                 rootBuild.attach();
                 return rootBuild.run(buildAction);
             } finally {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -17,11 +17,9 @@
 package org.gradle.composite.internal;
 
 import org.gradle.BuildResult;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.StartParameterInternal;
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.deployment.internal.DefaultDeploymentRegistry;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.RootBuildLifecycleListener;
@@ -79,11 +77,6 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
             CompositeStoppable.stoppable().addFailure(t).add(buildScopeServices).stop();
             throw UncheckedException.throwAsUncheckedException(t);
         }
-    }
-
-    @Override
-    public BuildIdentifier getBuildIdentifier() {
-        return DefaultBuildIdentifier.ROOT;
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -17,7 +17,6 @@
 package org.gradle.composite.internal;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
@@ -54,19 +53,17 @@ import java.util.Set;
 import java.util.function.Function;
 
 public class RootOfNestedBuildTree extends AbstractBuildState implements NestedRootBuild {
-    private final BuildIdentifier buildIdentifier;
+
     private final Path identityPath;
     private final BuildTreeLifecycleController buildTreeLifecycleController;
 
     public RootOfNestedBuildTree(
         BuildDefinition buildDefinition,
-        BuildIdentifier buildIdentifier,
         Path identityPath,
         BuildState owner,
         BuildTreeState buildTree
     ) {
         super(buildTree, buildDefinition, owner);
-        this.buildIdentifier = buildIdentifier;
         this.identityPath = identityPath;
 
         CloseableServiceRegistry buildServices = getBuildServices();
@@ -91,11 +88,6 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
     @Override
     public StartParameterInternal getStartParameter() {
         return getBuildController().getGradle().getStartParameter();
-    }
-
-    @Override
-    public BuildIdentifier getBuildIdentifier() {
-        return buildIdentifier;
     }
 
     @Override

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.composite.internal
 
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.DocumentationRegistry
@@ -118,20 +117,20 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         rootBuild.identityPath == Path.ROOT
         notifiedBuild.is(rootBuild)
 
-        registry.getBuild(rootBuild.buildIdentifier).is(rootBuild)
+        registry.getBuild(rootBuild.identityPath).is(rootBuild)
     }
 
     def "can add an included build"() {
         def dir = tmpDir.createDir("b1")
         def buildDefinition = build(dir)
         def includedBuild = Stub(IncludedBuildState)
-        def buildIdentifier = buildIdentifier(":b1")
-        includedBuild.buildIdentifier >> buildIdentifier
+        def identityPath = Path.path(":b1")
+        includedBuild.identityPath >> identityPath
         includedBuild.buildRootDir >> dir
 
         given:
         registry.attachRootBuild(rootBuild())
-        includedBuildFactory.createBuild(buildIdentifier, buildDefinition, false, _ as BuildState) >> includedBuild
+        includedBuildFactory.createBuild(identityPath, buildDefinition, false, _ as BuildState) >> includedBuild
 
         when:
         def result = registry.addIncludedBuild(buildDefinition, Stub(BuildState))
@@ -143,8 +142,7 @@ class DefaultIncludedBuildRegistryTest extends Specification {
 
         registry.includedBuilds as List == [includedBuild]
 
-        registry.getBuild(buildIdentifier).is(includedBuild)
-        registry.getIncludedBuild(buildIdentifier).is(includedBuild)
+        registry.getBuild(identityPath).is(includedBuild)
     }
 
     def "can add multiple included builds"() {
@@ -184,7 +182,7 @@ class DefaultIncludedBuildRegistryTest extends Specification {
 
         registry.includedBuilds as List == [includedBuild1, includedBuild2, includedBuild3]
 
-        registry.getBuild(buildIdentifier(":b1")).is(includedBuild1)
+        registry.getBuild(Path.path(":b1")).is(includedBuild1)
     }
 
     def "can add the same included build multiple times"() {
@@ -209,7 +207,7 @@ class DefaultIncludedBuildRegistryTest extends Specification {
 
         given:
         registry.attachRootBuild(rootBuild())
-        includedBuildFactory.createBuild(buildIdentifier(":b1"), buildDefinition, true, _ as BuildState) >> includedBuild
+        includedBuildFactory.createBuild(Path.path(":b1"), buildDefinition, true, _ as BuildState) >> includedBuild
 
         when:
         def result = registry.addImplicitIncludedBuild(buildDefinition)
@@ -242,14 +240,14 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         def nestedBuild = registry.getBuildSrcNestedBuild(rootBuild)
         nestedBuild != null
         nestedBuild.implicitBuild
-        nestedBuild.buildIdentifier == buildIdentifier(":buildSrc")
+        nestedBuild.buildIdentifier == new DefaultBuildIdentifier(Path.path(":buildSrc"))
         nestedBuild.identityPath == Path.path(":buildSrc")
 
         and:
         notifiedBuilds == [rootBuild, nestedBuild]
 
         and:
-        registry.getBuild(nestedBuild.buildIdentifier).is(nestedBuild)
+        registry.getBuild(nestedBuild.identityPath).is(nestedBuild)
     }
 
     def "can add multiple buildSrc builds with different levels of nesting"() {
@@ -270,12 +268,12 @@ class DefaultIncludedBuildRegistryTest extends Specification {
 
         expect:
         def nestedBuild1 = registry.getBuildSrcNestedBuild(rootBuild)
-        nestedBuild1.buildIdentifier == buildIdentifier(":buildSrc")
+        nestedBuild1.buildIdentifier == new DefaultBuildIdentifier(Path.path(":buildSrc"))
         nestedBuild1.identityPath == Path.path(":buildSrc")
 
         def nestedBuild2 = registry.getBuildSrcNestedBuild(parent)
         // Shows current behaviour, not necessarily desired behaviour
-        nestedBuild2.buildIdentifier == buildIdentifier(":parent:buildSrc")
+        nestedBuild2.buildIdentifier == new DefaultBuildIdentifier(Path.path(":parent:buildSrc"))
         nestedBuild2.identityPath == Path.path(":parent:buildSrc")
     }
 
@@ -297,7 +295,6 @@ class DefaultIncludedBuildRegistryTest extends Specification {
 
     IncludedBuildState expectIncludedBuildAdded(String name, BuildDefinition buildDefinition) {
         def idPath = Path.path(":$name")
-        def buildIdentifier = new DefaultBuildIdentifier(idPath)
 
         def gradle = Stub(GradleInternal)
         def services = Stub(ServiceRegistry)
@@ -305,14 +302,13 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         def includedBuild = Stub(IncludedBuildState)
         includedBuild.buildRootDir >> buildDefinition.buildRootDir
         includedBuild.identityPath >> idPath
-        includedBuild.buildIdentifier >> buildIdentifier
         includedBuild.mutableModel >> gradle
 
         gradle.services >> services
 
         services.get(PublicBuildPath) >> Stub(PublicBuildPath)
 
-        includedBuildFactory.createBuild(buildIdentifier, buildDefinition, false, _) >> includedBuild
+        includedBuildFactory.createBuild(idPath, buildDefinition, false, _) >> includedBuild
 
         return includedBuild
     }
@@ -332,7 +328,6 @@ class DefaultIncludedBuildRegistryTest extends Specification {
             it[0] in projects ? Stub(ProjectDescriptor) : null
         }
 
-        build.buildIdentifier >> DefaultBuildIdentifier.ROOT
         build.identityPath >> Path.ROOT
         build.loadedSettings >> settings
         build.mutableModel >> gradle
@@ -363,7 +358,4 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         return buildController
     }
 
-    private BuildIdentifier buildIdentifier(String path) {
-        new DefaultBuildIdentifier(Path.path(path))
-    }
 }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -271,20 +271,17 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
     TaskInternal task(BuildServices services, Node dependsOn) {
         def projectState = Stub(ProjectState)
+        def buildId = Path.path(services.identifier.buildPath)
+        def projectId = ProjectIdentity.forRootProject(buildId, "root")
         def project = Stub(ProjectInternal) {
-            getProjectIdentity() >> new ProjectIdentity(
-                services.identifier,
-                Path.ROOT,
-                Path.ROOT,
-                "root"
-            )
+            getProjectIdentity() >> projectId
         }
         def task = Stub(TaskInternal)
         def dependencies = Stub(TaskDependency)
         _ * dependencies.getDependencies(_) >> [dependsOn].toSet()
         _ * task.taskDependencies >> dependencies
         _ * task.project >> project
-        _ * task.identityPath >> Path.path(services.identifier.buildPath).child("task")
+        _ * task.identityPath >> projectId.buildTreePath.child("task")
         _ * task.taskIdentity >> TestTaskIdentities.create("task", DefaultTask, project)
         _ * task.destroyables >> Stub(TaskDestroyablesInternal)
         _ * task.localState >> Stub(TaskLocalStateInternal)

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.composite.internal
 
 import org.gradle.api.Transformer
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.GradleInternal
@@ -54,10 +53,7 @@ class DefaultIncludedBuildTest extends Specification {
         services.add(Stub(BuildTreeWorkGraphController))
         _ * buildTree.services >> services
 
-        def buildId = Stub(BuildIdentifier) {
-            buildPath >> Path.path(":a:b:c")
-        }
-        build = new DefaultIncludedBuild(buildId, buildDefinition, false, owningBuild, buildTree, Mock(Instantiator))
+        build = new DefaultIncludedBuild(Path.path(":a:b:c"), buildDefinition, false, owningBuild, buildTree, Mock(Instantiator))
     }
 
     def "can run action against build state"() {

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.composite.internal
 
-import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.GradleInternal
@@ -45,7 +44,6 @@ class DefaultNestedBuildTest extends Specification {
     def action = Mock(Function)
     def services = new DefaultServiceRegistry()
     def buildDefinition = Mock(BuildDefinition)
-    def buildIdentifier = Mock(BuildIdentifier)
     def exceptionAnalyzer = Mock(ExceptionAnalyser)
     def buildTreeController = Mock(BuildTreeLifecycleController)
     def buildTreeControllerFactory = Mock(BuildTreeLifecycleControllerFactory)
@@ -70,7 +68,7 @@ class DefaultNestedBuildTest extends Specification {
             buildTreeController
         }
 
-        return new DefaultNestedBuild(buildIdentifier, Path.path(":a:b:c"), buildDefinition, owningBuild, tree)
+        return new DefaultNestedBuild(Path.path(":a:b:c"), buildDefinition, owningBuild, tree)
     }
 
     def "runs action and does not finish build"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultBuildIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultBuildIdentifier.java
@@ -37,6 +37,10 @@ public class DefaultBuildIdentifier implements BuildIdentifier {
         return buildPath.toString();
     }
 
+    public Path getIdentityPath() {
+        return buildPath;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.util.Path;
@@ -26,14 +25,6 @@ public class DefaultProjectComponentIdentifier implements ProjectComponentIdenti
 
     public DefaultProjectComponentIdentifier(ProjectIdentity projectIdentity) {
         this.projectIdentity = projectIdentity;
-    }
-
-    /**
-     * Prefer {@link #DefaultProjectComponentIdentifier(ProjectIdentity)}.
-     */
-    @VisibleForTesting
-    public DefaultProjectComponentIdentifier(BuildIdentifier buildIdentifier, Path identityPath, Path projectPath, String projectName) {
-        this(new ProjectIdentity(buildIdentifier, identityPath, projectPath, projectName));
     }
 
     @Override
@@ -48,7 +39,7 @@ public class DefaultProjectComponentIdentifier implements ProjectComponentIdenti
 
     @Override
     public BuildIdentifier getBuild() {
-        return projectIdentity.getBuildIdentifier();
+        return new DefaultBuildIdentifier(projectIdentity.getBuildPath());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -101,8 +101,8 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         DefaultBuildProjectRegistry registry = projectsByBuild.get(build.getBuildIdentifier());
         if (registry != null) {
             for (ProjectStateImpl project : registry.projectsByPath.values()) {
-                projectsById.remove(project.identifier);
-                projectsByPath.remove(project.identityPath);
+                projectsById.remove(project.getComponentIdentifier());
+                projectsByPath.remove(project.getIdentityPath());
             }
             CompositeStoppable.stoppable(registry.projectsByPath.values()).stop();
             registry.projectsByPath.clear();
@@ -111,12 +111,19 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
     private ProjectState addProject(BuildState owner, DefaultBuildProjectRegistry projectRegistry, DefaultProjectDescriptor descriptor) {
         Path projectPath = descriptor.path();
-        Path identityPath = owner.calculateIdentityPathForProject(projectPath);
+
+        ProjectIdentity identity;
+        if (projectPath.equals(Path.ROOT)) {
+            identity = ProjectIdentity.forRootProject(owner.getIdentityPath(), descriptor.getName());
+        } else {
+            identity = ProjectIdentity.forSubproject(owner.getIdentityPath(), projectPath);
+        }
+
         ServiceRegistry buildServices = owner.getMutableModel().getServices();
         IProjectFactory projectFactory = buildServices.get(IProjectFactory.class);
         StateTransitionControllerFactory stateTransitionControllerFactory = buildServices.get(StateTransitionControllerFactory.class);
-        ProjectStateImpl projectState = new ProjectStateImpl(owner, identityPath, projectPath, descriptor.getName(), descriptor, projectFactory, stateTransitionControllerFactory, buildServices);
-        projectsByPath.put(identityPath, projectState);
+        ProjectStateImpl projectState = new ProjectStateImpl(owner, identity, descriptor, projectFactory, stateTransitionControllerFactory, buildServices);
+        projectsByPath.put(identity.getBuildTreePath(), projectState);
         projectsById.put(projectState.getComponentIdentifier(), projectState);
         projectRegistry.add(projectPath, projectState);
         return projectState;
@@ -241,13 +248,10 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     }
 
     private class ProjectStateImpl implements ProjectState, Closeable {
-        private final Path projectPath;
-        private final String projectName;
-        private final ProjectComponentIdentifier identifier;
+
         private final DefaultProjectDescriptor descriptor;
         private final IProjectFactory projectFactory;
         private final BuildState owner;
-        private final Path identityPath;
         private final ProjectIdentity identity;
         private final ResourceLock allProjectsLock;
         private final ResourceLock projectLock;
@@ -258,32 +262,27 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
         ProjectStateImpl(
             BuildState owner,
-            Path identityPath,
-            Path projectPath,
-            String projectName,
+            ProjectIdentity identity,
             DefaultProjectDescriptor descriptor,
             IProjectFactory projectFactory,
             StateTransitionControllerFactory stateTransitionControllerFactory,
             ServiceRegistry buildServices
         ) {
             this.owner = owner;
-            this.identityPath = identityPath;
-            this.projectPath = projectPath;
-            this.projectName = projectName;
             this.descriptor = descriptor;
             this.projectFactory = projectFactory;
-            this.identity = new ProjectIdentity(owner.getBuildIdentifier(), identityPath, projectPath, projectName);
-            this.identifier = new DefaultProjectComponentIdentifier(identity);
+            this.identity = identity;
             this.allProjectsLock = workerLeaseService.getAllProjectsLock(owner.getIdentityPath());
-            this.projectLock = workerLeaseService.getProjectLock(owner.getIdentityPath(), identityPath);
-            this.taskLock = workerLeaseService.getTaskExecutionLock(owner.getIdentityPath(), identityPath);
+            this.projectLock = workerLeaseService.getProjectLock(owner.getIdentityPath(), identity.getBuildTreePath());
+            this.taskLock = workerLeaseService.getTaskExecutionLock(owner.getIdentityPath(), identity.getBuildTreePath());
             this.controller = new ProjectLifecycleController(getDisplayName(), stateTransitionControllerFactory, buildServices);
         }
 
         @Override
         public DisplayName getDisplayName() {
+            Path identityPath = identity.getBuildTreePath();
             if (identityPath.equals(Path.ROOT)) {
-                return Describables.withTypeAndName("root project", projectName);
+                return Describables.withTypeAndName("root project", identity.getProjectName());
             } else {
                 return Describables.withTypeAndName("project", identityPath.getPath());
             }
@@ -302,6 +301,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         @Nullable
         @Override
         public ProjectState getParent() {
+            Path identityPath = identity.getBuildTreePath();
             return identityPath.getParent() == null ? null : projectsByPath.get(identityPath.getParent());
         }
 
@@ -311,10 +311,11 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
             if (descriptor.getParent() != null) {
                 // Identity path of parent can be different to identity path parent, if the names are tweaked in the settings file
                 // Ideally they would be exactly the same, always
-                Path parentPath = owner.calculateIdentityPathForProject(descriptor.getParent().path());
-                ProjectStateImpl parentState = projectsByPath.get(parentPath);
+                Path parentProjectPath = descriptor.getParent().path();
+                Path parentIdentityPath = ProjectIdentity.computeProjectIdentityPath(owner.getIdentityPath(), parentProjectPath);
+                ProjectStateImpl parentState = projectsByPath.get(parentIdentityPath);
                 if (parentState == null) {
-                    throw new IllegalStateException("Parent project " + parentPath + " is not registered for project " + identityPath);
+                    throw new IllegalStateException("Parent project " + parentIdentityPath + " is not registered for " + identity);
                 }
                 return parentState;
             } else {
@@ -342,17 +343,19 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         }
 
         private ProjectStateImpl getStateForChild(DefaultProjectDescriptor child) {
-            return projectsByPath.get(owner.calculateIdentityPathForProject(child.path()));
+            Path childProjectPath = child.path();
+            Path childIdentityPath = ProjectIdentity.computeProjectIdentityPath(owner.getIdentityPath(), childProjectPath);
+            return projectsByPath.get(childIdentityPath);
         }
 
         @Override
         public String getName() {
-            return projectName;
+            return identity.getProjectName();
         }
 
         @Override
         public Path getIdentityPath() {
-            return identityPath;
+            return identity.getBuildTreePath();
         }
 
         @Override
@@ -362,7 +365,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
         @Override
         public Path getProjectPath() {
-            return projectPath;
+            return identity.getProjectPath();
         }
 
         @Override
@@ -416,7 +419,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
         @Override
         public ProjectComponentIdentifier getComponentIdentifier() {
-            return identifier;
+            return new DefaultProjectComponentIdentifier(identity);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesController.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesController.java
@@ -76,7 +76,7 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
 
     @Override
     public void loadGradleProperties(ProjectIdentity projectId, File projectDir) {
-        LoadedBuildScopedState loadedBuildProperties = getOrCreateGradleProperties(projectId.getBuildIdentifier())
+        LoadedBuildScopedState loadedBuildProperties = getOrCreateGradleProperties(new DefaultBuildIdentifier(projectId.getBuildPath()))
             .checkLoaded();
         getOrCreateGradleProperties(projectId).loadProperties(loadedBuildProperties, projectDir);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -18,6 +18,7 @@ package org.gradle.internal.build;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.DisplayName;
@@ -41,8 +42,12 @@ public interface BuildState {
 
     /**
      * Returns the identifier for this build. The identifier is fixed for the lifetime of the build.
+     * <p>
+     * Prefer {@link #getIdentityPath()}.
      */
-    BuildIdentifier getBuildIdentifier();
+    default BuildIdentifier getBuildIdentifier() {
+        return new DefaultBuildIdentifier(getIdentityPath());
+    }
 
     /**
      * Returns an identifying path for this build in the build tree. This path is fixed for the lifetime of the build.
@@ -63,13 +68,6 @@ public interface BuildState {
      * Should this build be imported into an IDE? Some implicit builds, such as source dependency builds, are not intended to be imported into the IDE or editable by users.
      */
     boolean isImportableBuild();
-
-    /**
-     * Calculates the identity path for a project in this build.
-     */
-    default Path calculateIdentityPathForProject(Path projectPath) {
-        return getIdentityPath().append(projectPath);
-    }
 
     /**
      * Loads the projects for this build so that {@link #getProjects()} can be used, if not already done.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -56,20 +56,30 @@ public interface BuildStateRegistry {
     Collection<? extends IncludedBuildState> getIncludedBuilds();
 
     /**
-     * Locates an included build by {@link BuildIdentifier}, if present. Fails if not an included build.
-     */
-    IncludedBuildState getIncludedBuild(BuildIdentifier buildIdentifier) throws IllegalArgumentException;
-
-    /**
      * Locates a build. Fails if not present.
+     * <p>
+     * Prefer {@link #getBuild(Path)}.
      */
     BuildState getBuild(BuildIdentifier buildIdentifier) throws IllegalArgumentException;
 
     /**
      * Finds a build. Returns null if there's no build with the given identifier.
+     * <p>
+     * Prefer {@link #findBuild(Path)}.
      */
     @Nullable
     BuildState findBuild(BuildIdentifier buildIdentifier);
+
+    /**
+     * Locates a build. Fails if not present.
+     */
+    BuildState getBuild(Path identityPath) throws IllegalArgumentException;
+
+    /**
+     * Finds a build. Returns null if there's no build with the given identifier.
+     */
+    @Nullable
+    BuildState findBuild(Path identityPath);
 
     /**
      * Notification that the settings have been loaded for the root build.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildFactory.java
@@ -16,12 +16,12 @@
 
 package org.gradle.internal.build;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.util.Path;
 
 @ServiceScope(Scope.BuildTree.class)
 public interface IncludedBuildFactory {
-    IncludedBuildState createBuild(BuildIdentifier buildIdentifier, BuildDefinition buildDefinition, boolean isImplicit, BuildState owner);
+    IncludedBuildState createBuild(Path identityPath, BuildDefinition buildDefinition, boolean isImplicit, BuildState owner);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/DefaultProjectFinder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/DefaultProjectFinder.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.service.scopes;
 
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
-import org.gradle.api.internal.project.ProjectState;
+import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.util.Path;
 
 /**
@@ -25,16 +25,17 @@ import org.gradle.util.Path;
  */
 public class DefaultProjectFinder implements ProjectFinder {
 
-    private final ProjectState baseProject;
+    private final ProjectIdentity baseProjectId;
 
-    public DefaultProjectFinder(ProjectState baseProject) {
-        this.baseProject = baseProject;
+    public DefaultProjectFinder(ProjectIdentity baseProjectId) {
+        this.baseProjectId = baseProjectId;
     }
 
     @Override
     public Path resolveIdentityPath(String path) {
-        Path resolvedProjectPath = baseProject.getIdentity().getProjectPath().absolutePath(Path.path(path));
-        return baseProject.getOwner().calculateIdentityPathForProject(resolvedProjectPath);
+        Path buildPath = baseProjectId.getBuildPath();
+        Path resolvedProjectPath = baseProjectId.getProjectPath().absolutePath(Path.path(path));
+        return ProjectIdentity.computeProjectIdentityPath(buildPath, resolvedProjectPath);
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -302,7 +302,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected ProjectFinder createProjectFinder() {
-        return new DefaultProjectFinder(project.getOwner());
+        return new DefaultProjectFinder(project.getOwner().getIdentity());
     }
 
     @Provides

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifierTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifierTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.artifacts
 
-import org.gradle.api.artifacts.component.BuildIdentifier
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.util.Path
 import spock.lang.Specification
 
@@ -24,20 +24,21 @@ import static org.gradle.util.Matchers.strictlyEquals
 class DefaultProjectComponentIdentifierTest extends Specification {
     def "is instantiated with non-null constructor parameter values"() {
         when:
-        def id = new DefaultProjectComponentIdentifier(DefaultBuildIdentifier.ROOT, Path.path(":id:path"), Path.path(":project:path"), "projectName")
+        def id = new DefaultProjectComponentIdentifier(ProjectIdentity.forSubproject(Path.path(":build"), Path.path(":subproject")))
 
         then:
-        id.projectPath == ':project:path'
-        id.projectName == 'projectName'
-        id.displayName == 'project :id:path'
-        id.buildTreePath == ':id:path'
-        id.toString() == 'project :id:path'
+        id.projectPath == ':subproject'
+        id.projectName == 'subproject'
+        id.displayName == 'project :build:subproject'
+        id.buildTreePath == ':build:subproject'
+        id.toString() == 'project :build:subproject'
     }
 
     def "can compare with other instance (#projectPath)"() {
         expect:
-        def id1 = newProjectId(':myProjectPath1')
-        def id2 = newProjectId(projectPath)
+        def id1 = new DefaultProjectComponentIdentifier(ProjectIdentity.forSubproject(Path.ROOT, Path.path(":myProjectPath1")))
+        def id2 = new DefaultProjectComponentIdentifier(ProjectIdentity.forSubproject(Path.ROOT, Path.path(projectPath)))
+
         strictlyEquals(id1, id2) == equality
         (id1.hashCode() == id2.hashCode()) == hashCode
         (id1.toString() == id2.toString()) == stringRepresentation
@@ -46,14 +47,6 @@ class DefaultProjectComponentIdentifierTest extends Specification {
         projectPath       | equality | hashCode | stringRepresentation
         ':myProjectPath1' | true     | true     | true
         ':myProjectPath2' | false    | false    | false
-    }
-
-    private static newProjectId(String path) {
-        newProjectId(DefaultBuildIdentifier.ROOT, path)
-    }
-
-    private static newProjectId(BuildIdentifier build, String path) {
-        new DefaultProjectComponentIdentifier(build, Path.path(path), Path.path(path), "name")
     }
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.dependencies
 
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory
 import org.gradle.api.internal.project.ProjectIdentity
@@ -70,7 +69,7 @@ class DefaultProjectDependencyConstraintTest extends Specification {
 
     private DefaultProjectDependencyConstraint createProjectDependencyConstraint() {
         def projectState = Stub(ProjectState) {
-            getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "test-project")
+            getIdentity() >> ProjectIdentity.forRootProject(Path.ROOT, "foo")
         }
         def project = Mock(ProjectInternal) {
             getGroup() >> "org.example"

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.dependencies
 
 import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
@@ -34,7 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 class DefaultProjectDependencyTest extends Specification {
 
     ProjectState projectState = Stub(ProjectState) {
-        getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "test-project")
+        getIdentity() >> ProjectIdentity.forRootProject(Path.ROOT, "test-project")
     }
 
     private ProjectDependency projectDependency
@@ -137,7 +136,7 @@ class DefaultProjectDependencyTest extends Specification {
         differentConf.setTargetConfiguration("conf2")
 
         def otherProjectState = Mock(ProjectState) {
-            getIdentity() >> new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.path(":foo"), Path.path(":foo"), "foo")
+            getIdentity() >> ProjectIdentity.forSubproject(Path.ROOT, Path.path(":bar"))
         }
         def differentProject = new DefaultProjectDependency(otherProjectState)
         differentProject.setTargetConfiguration("conf1")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -26,7 +26,6 @@ import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.MutationGuard
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.file.DefaultFilePropertyFactory
 import org.gradle.api.internal.file.DefaultProjectLayout
 import org.gradle.api.internal.file.FileCollectionFactory
@@ -298,19 +297,20 @@ class DefaultProjectSpec extends Specification {
         build.services >> serviceRegistry
 
         def projectPath = parent == null ? Path.ROOT : parent.projectPath.child(name)
-        def buildIdentifier
+        def buildPath
         if (build.identityPath.getPath().isEmpty()) {
             // No identity path was configured
-            buildIdentifier = DefaultBuildIdentifier.ROOT
+            buildPath = Path.ROOT
         } else {
-            buildIdentifier = new DefaultBuildIdentifier(build.identityPath)
+            buildPath = build.identityPath
         }
-        def identity = new ProjectIdentity(
-            buildIdentifier,
-            Path.path(buildIdentifier.buildPath).append(projectPath),
-            projectPath,
-            name
-        )
+
+        ProjectIdentity identity
+        if (projectPath == Path.ROOT) {
+            identity = ProjectIdentity.forRootProject(buildPath, name)
+        } else {
+            identity = ProjectIdentity.forSubproject(buildPath, projectPath)
+        }
 
         def container = Mock(ProjectState)
         _ * container.projectPath >> identity.projectPath

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
@@ -711,8 +711,11 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
     }
 
     ProjectComponentIdentifier projectId(String name) {
-        def path = name == ':' ? Path.ROOT : Path.ROOT.child(name)
-        return new DefaultProjectComponentIdentifier(DefaultBuildIdentifier.ROOT, path, path, name)
+        def id = name == ':'
+            ? ProjectIdentity.forRootProject(Path.ROOT, "root")
+            : ProjectIdentity.forSubproject(Path.ROOT, Path.ROOT.child(name))
+
+        return new DefaultProjectComponentIdentifier(id)
     }
 
     ProjectInternal project(String name) {
@@ -736,7 +739,6 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         build.loadedSettings >> settings
         build.buildIdentifier >> DefaultBuildIdentifier.ROOT
         build.identityPath >> Path.ROOT
-        build.calculateIdentityPathForProject(_) >> { Path path -> path }
         def services = new DefaultServiceRegistry()
         services.add(projectFactory)
         services.add(TestUtil.stateTransitionControllerFactory())

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -39,7 +39,6 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.ProcessOperations
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory
 import org.gradle.api.internal.file.DefaultProjectLayout
@@ -105,6 +104,7 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Path
 import org.gradle.util.TestClosure
 import org.gradle.util.TestUtil
+import org.jspecify.annotations.Nullable
 import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.Specification
@@ -292,18 +292,19 @@ class DefaultProjectTest extends Specification {
     private DefaultProject defaultProject(
         String name,
         ProjectState owner,
-        ProjectInternal parent,
+        @Nullable ProjectInternal parent,
         File rootDir,
         ClassLoaderScope scope
     ) {
-        def identityPath = parent == null ? Path.ROOT : parent.identityPath.child(name)
-        def projectPath = parent == null ? Path.ROOT : parent.projectPath.child(name)
-        def identity = new ProjectIdentity(
-            DefaultBuildIdentifier.ROOT,
-            identityPath,
-            projectPath,
-            name
-        )
+        def identity
+        if (parent == null) {
+            identity = ProjectIdentity.forRootProject(Path.ROOT, name)
+        } else {
+            identity = ProjectIdentity.forSubproject(
+                parent.projectIdentity.buildPath,
+                parent.projectIdentity.projectPath.child(name)
+            )
+        }
 
         _ * owner.identity >> identity
         _ * owner.identityPath >> identity.buildTreePath

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/ProjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/ProjectFactoryTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.project
 
 import org.gradle.api.internal.GradleInternal
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.groovy.scripts.TextResourceScriptSource
 import org.gradle.initialization.DefaultProjectDescriptor
@@ -30,6 +29,7 @@ import org.gradle.internal.scripts.ProjectScopedScriptResolution
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.ServiceRegistryFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Path
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -42,10 +42,10 @@ class ProjectFactoryTest extends Specification {
     def serviceRegistryFactory = Stub(ServiceRegistryFactory)
     def projectRegistry = Mock(ProjectRegistry)
     def project = Stub(DefaultProject)
-    def buildId = DefaultBuildIdentifier.ROOT
+    def buildId = Path.ROOT
     def owner = Stub(BuildState)
     def projectState = Stub(ProjectState) {
-        getIdentity() >> { new ProjectIdentity(buildId, projectDescriptor.path(), projectDescriptor.path(), projectDescriptor.name) }
+        getIdentity() >> { ProjectIdentity.forRootProject(buildId, projectDescriptor.name) }
     }
     def scriptResolution = Stub(ProjectScopedScriptResolution) {
         resolveScriptsForProject(_, _) >> { project, action -> action.get() }
@@ -57,7 +57,7 @@ class ProjectFactoryTest extends Specification {
     def dependencyResolutionManagement = Mock(DependencyResolutionManagementInternal)
 
     def setup() {
-        owner.buildIdentifier >> buildId
+        owner.identityPath >> buildId
     }
 
     def "creates a project with build script"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.project.ProjectIdentity
@@ -920,7 +919,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
 
     private <T extends TaskInternal> T expectTaskCreated(String name, final Class<T> type, T task) {
         // We cannot just stub here as we want to return a different task each time.
-        def projectId = new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "root")
+        def projectId = ProjectIdentity.forRootProject(Path.ROOT, "root")
         def id = new TaskIdentity(type, name, projectId, 12)
         1 * delegate.create(id) >> task
         def createdTask = factory.create(id)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Task
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.reflect.ObjectInstantiationException
 import org.gradle.api.tasks.TaskInstantiationException
@@ -38,12 +37,7 @@ class TaskFactoryTest extends AbstractProjectBuilderSpec {
     def deserializeInstantiator = Mock(DeserializationInstantiator)
     ITaskFactory taskFactory
 
-    ProjectIdentity projectId = new ProjectIdentity(
-        DefaultBuildIdentifier.ROOT,
-        Path.ROOT,
-        Path.ROOT,
-        "root"
-    )
+    ProjectIdentity projectId = ProjectIdentity.forRootProject(Path.ROOT, "root")
 
     def setup() {
         taskFactory = new TaskFactory().createChild(project, instantiationScheme)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.UnknownTaskException
 import org.gradle.api.internal.AbstractPolymorphicDomainObjectContainerSpec
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.project.BuildOperationCrossProjectConfigurator
 import org.gradle.api.internal.project.ProjectIdentity
@@ -75,10 +74,8 @@ class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerS
         getServices() >> serviceRegistry
         getTaskDependencyFactory() >> TestFiles.taskDependencyFactory()
         getObjects() >> Stub(ObjectFactory)
-        getProjectIdentity() >> new ProjectIdentity(
-            DefaultBuildIdentifier.ROOT,
-            Path.path(":project"),
-            Path.path(":project"),
+        getProjectIdentity() >> ProjectIdentity.forRootProject(
+            Path.ROOT,
             "project"
         )
     } as ProjectInternal

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuterTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.execution
 import org.gradle.api.DefaultTask
 import org.gradle.api.execution.TaskExecutionListener
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.taskfactory.TaskIdentity
 import org.gradle.api.internal.tasks.TaskExecuter
@@ -40,10 +39,8 @@ class EventFiringTaskExecuterTest extends Specification {
     def taskListener = Mock(TaskListenerInternal)
     def delegate = Mock(TaskExecuter)
     def task = Mock(TaskInternal)
-    def projectId = new ProjectIdentity(
-        DefaultBuildIdentifier.ROOT,
-        Path.path(":a"),
-        Path.path(":a"),
+    def projectId = ProjectIdentity.forRootProject(
+        Path.ROOT,
         "root",
     )
     def taskIdentity = new TaskIdentity(DefaultTask, "foo", projectId, 0)

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.Task
 import org.gradle.api.internal.TaskInputsInternal
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.TaskOutputsInternal
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
@@ -67,16 +66,19 @@ abstract class AbstractExecutionPlanSpec extends Specification {
     protected ProjectInternal project(ProjectInternal parent = null, String name = "root") {
         def projectState = Mock(ProjectState)
 
+        def identity
+        if (parent == null) {
+            identity = ProjectIdentity.forRootProject(Path.ROOT, name)
+        } else {
+            identity = ProjectIdentity.forSubproject(
+                parent.projectIdentity.buildPath,
+                parent.projectIdentity.projectPath.child(name)
+            )
+        }
+
         def project = Mock(ProjectInternal, name: name)
-        _ * project.identityPath >> (parent == null ? Path.ROOT : Path.ROOT.child(name))
-        _ * project.projectPath(_) >> { taskName -> Path.ROOT.child(taskName) }
-        _ * project.identityPath(_) >> { taskName -> (parent == null ? Path.ROOT : Path.ROOT.child(name)).child(taskName) }
-        _ * project.projectIdentity >> new ProjectIdentity(
-            DefaultBuildIdentifier.ROOT,
-            project.identityPath,
-            project.identityPath,
-            name
-        )
+        _ * project.identityPath >> identity.buildTreePath
+        _ * project.projectIdentity >> identity
         _ * project.gradle >> thisBuild
         _ * project.owner >> projectState
         _ * project.services >> backing.services

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesControllerTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 class DefaultGradlePropertiesControllerTest extends Specification {
 
     private final rootBuildId = DefaultBuildIdentifier.ROOT
-    private final rootProjectId = new ProjectIdentity(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "root")
+    private final rootProjectId = ProjectIdentity.forRootProject(Path.ROOT, "root")
     private final buildRootDir = new File("buildRootDir")
 
     private final GradlePropertiesLoader gradlePropertiesLoader = Mock(GradlePropertiesLoader)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparerTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.internal.build
 import org.gradle.api.Task
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.taskfactory.TestTaskIdentities
@@ -41,12 +40,7 @@ class BuildOperationFiringBuildWorkPreparerTest extends Specification {
     def "build operation provides execution plan when queries with all node types"() {
         def project = Stub(ProjectInternal) {
             projectPath(_) >> { args -> Path.path(":" + args[0]) }
-            getProjectIdentity() >> new ProjectIdentity(
-                DefaultBuildIdentifier.ROOT,
-                Path.ROOT,
-                Path.ROOT,
-                "root"
-            )
+            getProjectIdentity() >> ProjectIdentity.forRootProject(Path.ROOT, "root")
         }
         def ti1 = TestTaskIdentities.create("t1", Task, project)
         def t = Stub(LocalTaskNode) {

--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameValidatorTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.artifacts.ConfigurationResolver
-import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationFactory
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyFactory
@@ -64,11 +63,9 @@ class NameValidatorTest extends Specification {
     def "tasks are not allowed to be named '#name'"() {
         when:
         def project = Mock(ProjectInternal) {
-            getProjectIdentity() >> new ProjectIdentity(
-                DefaultBuildIdentifier.ROOT,
-                Path.path(":build:foo:bar"),
-                Path.path(":build:foo:bar"),
-                "root"
+            getProjectIdentity() >> ProjectIdentity.forSubproject(
+                Path.path(":build"),
+                Path.path(":foo:bar")
             )
             getGradle() >> Mock(GradleInternal) {
                 getIdentityPath() >> Path.path(":build:foo:bar")


### PR DESCRIPTION
Enforce in ProjectIdentity the relationship between build path and project path, and how they relate to the project identity path. We enforce that the project identity path is by definition the project path appended to owning build's path.

Given this new enforced definition of the project identity path, we introduce two new restricted factory methods for ProjectIdentity that create identity instances for root projects and non-root projects. We need specialized methods for these, since the project path of a root project does not include the project name, and the project name for any subproject _must_ be the last element of the project path. The factory methods now enforce these invariants.

Given the enforced invariants, we can greatly simplify ComponentSelectorSerializer and ComponentIdentifierSerializer for the cases of serializing project ids/selectors.

Finally, since we are changing the way ProjectIdentity is constructed, we update ProjectIdentity to accept a Path for its owning build instead of a BuildIdentifier. BuildIdentifier is a dependency management type (in a DM package) and therefore should not be used in a type related to configuration/build structure. Furthermore, since 9.0, BuildIdentifier is now a simple wrapper around a Path, meaning it is pretty much useless now.

A large portion of the changes in this commit involve updating tests to use the new factory methods for ProjectIdentity

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
