### PR TITLE
Fix allow integers as valid attribute values in metadata specification

### DIFF
--- a/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md
+++ b/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md
@@ -77,7 +77,7 @@ The following statements must hold for the variants:
 ### `attributes` value
 
 This value, nested in `variants` or elements of `dependencies` or `dependencyConstraints` nodes, must contain an object with a value for each attribute.
-The attribute value must be a string or boolean.
+The value of each attribute must be a string, a boolean, or an integer.
 
 ### `capabilities` value
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #33634  -->

### Context

The Gradle Module Metadata specification currently states that attribute values must be either strings or booleans.  
However, attributes like `org.gradle.jvm.version` use an integer value in real-world metadata (e.g., [spring-core-6.2.7.module](https://repo1.maven.org/maven2/org/springframework/spring-core/6.2.7/spring-core-6.2.7.module)).

This PR updates the spec to reflect that integers are also valid attribute values.  
This clarification helps plugin authors and tool integrators better understand the supported attribute types.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] All commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff).
- [x] The contribution complies with the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] "Allow edit from maintainers" option is checked in this PR.

<!-- The following are not applicable for this documentation-only change -->
- [ ] Provide integration tests
- [ ] Provide unit tests
- [ ] Update User Guide, DSL Reference, and Javadoc
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with:
- ❌ ❓ **must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things