### PR TITLE
verify M2 and Ivy patterns contain the required tokens in any pattern

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
@@ -31,16 +31,16 @@ import java.util.Map;
 abstract class AbstractResourcePattern implements ResourcePattern {
     public static final String CLASSIFIER_KEY = "classifier";
     private final ExternalResourceName pattern;
-    private final boolean revisionIsOptional;
-    private final boolean organisationIsOptional;
-    private final boolean artifactIsOptional;
+    protected final boolean revisionIsOptional;
+    protected final boolean organisationIsOptional;
+    protected final boolean artifactIsOptional;
+    protected final boolean moduleIsOptional;
     private final boolean classifierIsOptional;
     private final boolean extensionIsOptional;
     private final boolean typeIsOptional;
 
     public AbstractResourcePattern(String pattern) {
         this(new ExternalResourceName(pattern));
-
     }
 
     public AbstractResourcePattern(URI baseUri, String pattern) {
@@ -55,6 +55,7 @@ abstract class AbstractResourcePattern implements ResourcePattern {
         this.classifierIsOptional = isOptionalToken(CLASSIFIER_KEY);
         this.extensionIsOptional = isOptionalToken(PatternHelper.EXT_KEY);
         this.typeIsOptional = isOptionalToken(PatternHelper.TYPE_KEY);
+        this.moduleIsOptional = isOptionalToken(PatternHelper.MODULE_KEY);
     }
 
     @Override


### PR DESCRIPTION
Permit more flexible repository layout patterns.

Instead of strictly checking for an exact repository pattern, instead verify the patterns contain the required tokens.

- M2 patterns must contain: `organisation`, `module`, `artifact`.
- Ivy patterns must contain: `artifact`.

The existing checks already required these tokens. They are still required, but the position is not fixed.

Signed-off-by: Adam <897017+aSemy@users.noreply.github.com>

I've tested this against the example project in #33674 and it works.

Fix #33674

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] ~Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.~ Not possible due to https://github.com/gradle/gradle/issues/35063
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
