### PR TITLE
Fix unexpected redirects in userguide_single.adoc

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/userguide_single.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/userguide_single.adoc
@@ -86,7 +86,6 @@ include::service_injection.adoc[leveloffset=+2]
 == STRUCTURING BUILDS
 
 include::multi_project_builds.adoc[leveloffset=+2]
-include::declaring_dependencies_between_subprojects.adoc[leveloffset=+2]
 include::sharing_build_logic_between_subprojects.adoc[leveloffset=+2]
 include::composite_builds.adoc[leveloffset=+2]
 include::multi_project_configuration_and_execution.adoc[leveloffset=+2]
@@ -190,15 +189,12 @@ include::dependency_caching.adoc[leveloffset=+2]
 
 == UNDERSTANDING DEPENDENCY RESOLUTION
 
-include::dependency_resolution_model.adoc[leveloffset=+2]
-include::variant_model.adoc[leveloffset=+2]
 include::component_capabilities.adoc[leveloffset=+2]
 include::variant_attributes.adoc[leveloffset=+2]
 
 == CONTROLLING DEPENDENCY RESOLUTION
 
-include::dependency_resolution_basics.adoc[leveloffset=+2]
-include::dependency_graph_resolution.adoc[leveloffset=+2]
+include::graph_resolution.adoc[leveloffset=+2]
 include::artifact_resolution.adoc[leveloffset=+2]
 include::artifact_views.adoc[leveloffset=+2]
 include::artifact_transforms.adoc[leveloffset=+2]
@@ -215,8 +211,8 @@ include::publishing_ivy.adoc[leveloffset=+2]
 == OTHER TOPICS
 
 include::dependency_verification.adoc[leveloffset=+2]
-include::dependency_version_alignment.adoc[leveloffset=+2]
-include::feature_variants.adoc[leveloffset=+2]
+include::how_to_align_dependency_versions.adoc[leveloffset=+2]
+include::how_to_create_feature_variants_of_a_library.adoc[leveloffset=+2]
 
 [[part:platforms]]
 == **PLATFORMS**
@@ -266,7 +262,7 @@ include::plugin_reference.adoc[leveloffset=2]
 
 == HOW TO GUIDES
 
-include::cross_project_publications.adoc[leveloffset=2]
+include::how_to_share_outputs_between_projects.adoc[leveloffset=2]
 
 == **LICENSE INFORMATION**
 


### PR DESCRIPTION
⚠️ The diffs are identical to this PR (https://github.com/gradle/gradle/pull/33612), but the base is set to `release` intentionally according to this comment: https://github.com/gradle/gradle/pull/33612#issuecomment-2922649593 

### Context

Replaced or removed obsolete document references that were causing unexpected redirects in the single-page user guide.

#### Tests

I checked that obsolete links are not included anymore using the following shell script.

<details>
<summary>shell script</summary>

```check.sh
#!/bin/bash

# Script to check if files under /platforms/documentation/docs/src/docs/userguide/redirects/ 
# are included in userguide_single.adoc

set -euo pipefail

# Colors for output
RED='\033[0;31m'
GREEN='\033[0;32m'
YELLOW='\033[1;33m'
BLUE='\033[0;34m'
NC='\033[0m' # No Color

# Paths
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
PROJECT_ROOT="$(cd "$SCRIPT_DIR" && pwd)"
REDIRECTS_DIR="$PROJECT_ROOT/platforms/documentation/docs/src/docs/userguide/redirects"
USERGUIDE_SINGLE="$PROJECT_ROOT/platforms/documentation/docs/src/docs/userguide/userguide_single.adoc"

# Check if directories and files exist
if [[ ! -d "$REDIRECTS_DIR" ]]; then
    echo -e "${RED}Error: Redirects directory not found: $REDIRECTS_DIR${NC}"
    exit 1
fi

if [[ ! -f "$USERGUIDE_SINGLE" ]]; then
    echo -e "${RED}Error: userguide_single.adoc not found: $USERGUIDE_SINGLE${NC}"
    exit 1
fi

echo -e "${BLUE}Checking if redirect files are included in userguide_single.adoc...${NC}"
echo -e "${BLUE}Redirects directory: $REDIRECTS_DIR${NC}"
echo -e "${BLUE}User guide file: $USERGUIDE_SINGLE${NC}"
echo

# Get all .adoc files in the redirects directory
redirect_files=($(find "$REDIRECTS_DIR" -name "*.adoc" -type f | sort))

if [[ ${#redirect_files[@]} -eq 0 ]]; then
    echo -e "${YELLOW}No .adoc files found in redirects directory.${NC}"
    exit 0
fi

echo -e "${BLUE}Found ${#redirect_files[@]} redirect files to check:${NC}"

# Arrays to track results
included_files=()
not_included_files=()

# Check each redirect file
for redirect_file in "${redirect_files[@]}"; do
    # Get just the filename without path
    filename=$(basename "$redirect_file")
    
    # Check if this file is included in userguide_single.adoc
    # Look for include:: statements that reference this file
    if grep -q "include::.*${filename}" "$USERGUIDE_SINGLE"; then
        included_files+=("$filename")
        echo -e "  ${GREEN}✓${NC} $filename - ${GREEN}INCLUDED${NC}"
    else
        not_included_files+=("$filename")
        echo -e "  ${RED}✗${NC} $filename - ${RED}NOT INCLUDED${NC}"
    fi
done

echo
echo -e "${BLUE}Summary:${NC}"
echo -e "  ${GREEN}Included files: ${#included_files[@]}${NC}"
echo -e "  ${RED}Not included files: ${#not_included_files[@]}${NC}"
echo -e "  ${BLUE}Total redirect files: ${#redirect_files[@]}${NC}"

if [[ ${#included_files[@]} -gt 0 ]]; then
    echo
    echo -e "${YELLOW}WARNING: The following redirect files are included in userguide_single.adoc:${NC}"
    for file in "${included_files[@]}"; do
        echo -e "  ${YELLOW}- $file${NC}"
        # Show the actual include line(s)
        echo -e "    ${BLUE}Include line(s):${NC}"
        grep -n "include::.*${file}" "$USERGUIDE_SINGLE" | sed 's/^/      /'
    done
    echo
    echo -e "${YELLOW}Redirect files should typically NOT be included in the main user guide${NC}"
    echo -e "${YELLOW}as they are meant to redirect old URLs to new locations.${NC}"
fi

if [[ ${#not_included_files[@]} -eq ${#redirect_files[@]} ]]; then
    echo
    echo -e "${GREEN}✓ Good! No redirect files are included in userguide_single.adoc${NC}"
    exit 0
else
    echo
    echo -e "${RED}⚠ Warning: Some redirect files are included in userguide_single.adoc${NC}"
    exit 1
fi
```

</details>

|before|after|
|---|---|
|![スクリーンショット 2025-05-26 15 53 21](https://github.com/user-attachments/assets/cbf1f5d0-78da-46cd-9cab-2fce15a3dabb)|![スクリーンショット 2025-05-26 15 53 05](https://github.com/user-attachments/assets/42795885-fe04-46db-abed-899dcdc3a91a)|

Also, I confirmed the following test cases by running `./gradlew serveDocs` locally and checking the preview.

- [x] I checked that redirects does not occur in `userguide_single.html` anymore.
- [x] I checked that `graph_resolution.adoc` appears correctly in the single page.
- [x] I checked that `how_to_align_dependency_versions.adoc` appears correctly in the single page.
- [x] I checked that `how_to_create_feature_variants_of_a_library.adoc` appears correctly in the single page.
- [x] I checked that `how_to_share_outputs_between_projects.adoc` appears correctly in the single page.

<img width="1511" alt="スクリーンショット 2025-05-26 15 34 03" src="https://github.com/user-attachments/assets/5131fe4a-8793-43e6-93de-38cfc9480e09" />

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
