### PR TITLE
Fix a typo in docs/userguide/optimizing-builds/performance.adoc

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/performance.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/performance.adoc
@@ -771,7 +771,7 @@ include::sample[dir="snippets/performance/parallelTestExecution/kotlin",files="b
 include::sample[dir="snippets/performance/parallelTestExecution/groovy",files="build.gradle[tags=fork-every]"]
 ====
 
-WARNING: Forking a VVM is an expensive operation. Setting `forkEvery` too low can increase test time due to excessive process startup overhead.
+WARNING: Forking a JVM is an expensive operation. Setting `forkEvery` too low can increase test time due to excessive process startup overhead.
 
 ==== C. Disable test reports
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

Hello 👋
Thanks for providing such a nice documentation, it really makes Gradle user friendly and working solution in our field!

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
I found a typo at https://docs.gradle.org/current/userguide/performance.html#b_fork_tests_into_multiple_processes
and I thought that fixing it may benefit to all Gradle users.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
