### PR TITLE
Deprecate ResolvedDependency parent artifact methods

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -41,4 +41,21 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Deprecations
 
+==== Deprecated parent-specific artifact method on ResolvedDependency
+
+The following methods on link:{javadocPath}/org/gradle/api/artifacts/ResolvedDependency.html[`ResolvedDependency`] will be removed in Gradle 10.0.0 without replacement:
+
+- getParentArtifacts(ResolvedDependency)
+- getArtifacts(ResolvedDependency)
+- getAllArtifacts(ResolvedDependency)
+
+These methods return artifacts of a dependency which are only provided from a specific parent.
+In order to reduce complexity, Gradle will stop tracking the extra data needed to provide this information.
+Since in most cases all parents resolve the same artifacts from child nodes, the deprecated methods can likely be replaced by:
+
+- getModuleArtifacts()
+- getAllModuleArtifacts()
+
+NOTE: The `ResolvedDependency` API is in maintenance mode. Prefer <<artifact_views.adoc#artifact-views,Artifact View>> for rich artifact querying and processing.
+
 === Potential breaking changes

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolvedDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolvedDependency.java
@@ -65,7 +65,7 @@ public interface ResolvedDependency {
 
     /**
      * Returns the module artifacts belonging to this ResolvedDependency. A module artifact is an artifact that belongs
-     * to a ResolvedDependency independent of a particular parent. Returns never null. 
+     * to a ResolvedDependency independent of a particular parent. Returns never null.
      */
     Set<ResolvedArtifact> getModuleArtifacts();
 
@@ -81,7 +81,10 @@ public interface ResolvedDependency {
      *
      * @param parent A parent of the ResolvedDependency. Must not be null.
      * @throws org.gradle.api.InvalidUserDataException If the parent is unknown or null
+     *
+     * @deprecated This method will be removed in Gradle 10.0.0
      */
+    @Deprecated
     Set<ResolvedArtifact> getParentArtifacts(ResolvedDependency parent);
 
     /**
@@ -89,7 +92,10 @@ public interface ResolvedDependency {
      *
      * @param parent A parent of the ResolvedDependency. Must not be null.
      * @throws org.gradle.api.InvalidUserDataException If the parent is unknown or null
+     *
+     * @deprecated This method will be removed in Gradle 10.0.0
      */
+    @Deprecated
     Set<ResolvedArtifact> getArtifacts(ResolvedDependency parent);
 
     /**
@@ -97,6 +103,9 @@ public interface ResolvedDependency {
      *
      * @param parent A parent of the ResolvedDependency. Must not be null.
      * @throws org.gradle.api.InvalidUserDataException If the parent is unknown or null
+     *
+     * @deprecated This method will be removed in Gradle 10.0.0
      */
+    @Deprecated
     Set<ResolvedArtifact> getAllArtifacts(ResolvedDependency parent);
 }


### PR DESCRIPTION
ResolvedDependency exposes method that allow dependencies from a certain parent node to be individually requested. Some edges from a given parent may have different dependencies if it has different attributes, excludes, target configurations, or capabilities.

ArtifactView operates on a node-by-node basis and does not operate on edges. We are planning to implement improvements to ArtifactView that will replace ResolvedConfiguration, LenientConfiguration, and ResolvedDependency, but that improvement will remain node-aware and not edge aware.

This commit prepares us for this by deprecating APIs that require data that will not be tracked in future versions of Gradle.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
