### PR TITLE
Avoid dependency map notation in tests

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
@@ -77,14 +77,12 @@ class SourceDistributionResolver(private val project: Project) : SourceDistribut
         configurations.detachedConfiguration(dependency)
 
     private
-    fun gradleSourceDependency() = dependencies.create(
-        group = "gradle",
-        name = "gradle",
-        version = dependencyVersion(gradleVersion),
-        configuration = null,
-        classifier = "src",
-        ext = "zip"
-    )
+    fun gradleSourceDependency() = dependencies.create("gradle:gradle:${dependencyVersion(gradleVersion)}") {
+        artifact {
+            classifier = "src"
+            type = "zip"
+        }
+    }
 
     private
     fun createSourceRepository() = ivy {

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_dependencies_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_dependencies_basics.adoc
@@ -28,17 +28,19 @@ There are three main types of dependencies in Gradle:
 === 1. Module dependencies
 
 Module dependencies are the most common dependencies.
-They refer to a dependency that is identified by module coordinates (group, name, and version):
+They refer to a dependency that is identified by module coordinates (group, name, and version).
+Module dependencies are declared using the String notation, where the group, name, and version are joined into a single string:
 
 ====
 include::sample[dir="snippets/artifacts/externalDependencies/kotlin",files="build.gradle.kts[tags=module-dependencies]"]
 include::sample[dir="snippets/artifacts/externalDependencies/groovy",files="build.gradle[tags=module-dependencies]"]
 ====
 
-Gradle offers multiple notations for declaring module dependencies, including string notation and map notation.
+Gradle also supports the Map notation, where each coordinate may be declared separately:
 
-- **String Notation:** Simplifies dependency declaration by combining the group, name, and version into a single string.
-- **Map Notation:** Allows for specifying each part of the coordinates separately.
+====
+include::sample[dir="snippets/artifacts/externalDependencies/kotlin",files="build.gradle.kts[tags=module-dependencies-map]"]
+include::sample[dir="snippets/artifacts/externalDependencies/groovy",files="build.gradle[tags=module-dependencies-map]"]
 
 Module dependencies use the link:{javadocPath}/org/gradle/api/artifacts/ExternalModuleDependency.html[`ExternalModuleDependency`] and link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyHandler.html[`DependencyHandler`] APIs.
 These APIs provide various properties and configuration methods for defining dependencies.

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_dependencies_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_dependencies_basics.adoc
@@ -36,7 +36,7 @@ include::sample[dir="snippets/artifacts/externalDependencies/kotlin",files="buil
 include::sample[dir="snippets/artifacts/externalDependencies/groovy",files="build.gradle[tags=module-dependencies]"]
 ====
 
-Gradle also supports the Map notation, where each coordinate may be declared separately:
+Gradle also supports the multi-string notation, where each coordinate may be declared separately:
 
 ====
 include::sample[dir="snippets/artifacts/externalDependencies/kotlin",files="build.gradle.kts[tags=module-dependencies-map]"]

--- a/platforms/documentation/docs/src/snippets/ant/useExternalAntTaskWithConfig/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/ant/useExternalAntTaskWithConfig/groovy/build.gradle
@@ -8,7 +8,7 @@ configurations {
 }
 
 dependencies {
-    pmd group: 'pmd', name: 'pmd', version: '4.2.5'
+    pmd("pmd:pmd:4.2.5")
 }
 // end::define-classpath[]
 

--- a/platforms/documentation/docs/src/snippets/artifacts/externalDependencies/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/artifacts/externalDependencies/groovy/build.gradle
@@ -24,22 +24,28 @@ tasks.register('listJars') {
 
 // tag::module-dependencies[]
 dependencies {
+    runtimeOnly("org.springframework:spring-core:2.5")
+    runtimeOnly("org.springframework:spring-core:2.5",
+                "org.springframework:spring-aop:2.5")
+    runtimeOnly("org.hibernate:hibernate:3.0.5") {
+        transitive = true
+    }
+}
+// end::module-dependencies[]
+
+// tag::module-dependencies-map[]
+dependencies {
     runtimeOnly group: 'org.springframework', name: 'spring-core', version: '2.5'
-    runtimeOnly 'org.springframework:spring-core:2.5',
-            'org.springframework:spring-aop:2.5'
     runtimeOnly(
         [group: 'org.springframework', name: 'spring-core', version: '2.5'],
         [group: 'org.springframework', name: 'spring-aop', version: '2.5']
     )
-    runtimeOnly('org.hibernate:hibernate:3.0.5') {
-        transitive = true
-    }
     runtimeOnly group: 'org.hibernate', name: 'hibernate', version: '3.0.5', transitive: true
     runtimeOnly(group: 'org.hibernate', name: 'hibernate', version: '3.0.5') {
         transitive = true
     }
 }
-// end::module-dependencies[]
+// end::module-dependencies-map[]
 
 // tag::file-dependencies[]
 dependencies {

--- a/platforms/documentation/docs/src/snippets/artifacts/externalDependencies/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/artifacts/externalDependencies/kotlin/build.gradle.kts
@@ -22,16 +22,21 @@ tasks.register("listJars") {
 
 // tag::module-dependencies[]
 dependencies {
-    runtimeOnly(group = "org.springframework", name = "spring-core", version = "2.5")
     runtimeOnly("org.springframework:spring-aop:2.5")
     runtimeOnly("org.hibernate:hibernate:3.0.5") {
         isTransitive = true
     }
+}
+// end::module-dependencies[]
+
+// tag::module-dependencies-map[]
+dependencies {
+    runtimeOnly(group = "org.springframework", name = "spring-core", version = "2.5")
     runtimeOnly(group = "org.hibernate", name = "hibernate", version = "3.0.5") {
         isTransitive = true
     }
 }
-// end::module-dependencies[]
+// end::module-dependencies-map[]
 
 // tag::file-dependencies[]
 dependencies {

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-resolutionStrategy/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-resolutionStrategy/kotlin/build.gradle.kts
@@ -45,7 +45,7 @@ configurations.all {
 configurations.all {
     resolutionStrategy.eachDependency {
         if (requested.name == "groovy-all") {
-            useTarget(mapOf("group" to requested.group, "name" to "groovy", "version" to requested.version))
+            useTarget("${requested.group}:groovy:${requested.version}")
             because("""prefer "groovy" over "groovy-all"""")
         }
         if (requested.name == "log4j") {

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/groovy/build.gradle
@@ -135,7 +135,7 @@ configurations {
 }
 
 dependencies {
-    sampleConfig group: 'org.sample', name: 'api', version: '1+'
+    sampleConfig("org.sample:api:1+")
 }
 
 tasks.register('resolveConfiguration') {

--- a/platforms/documentation/docs/src/snippets/ear/earCustomized/groovy/ear/build.gradle
+++ b/platforms/documentation/docs/src/snippets/ear/earCustomized/groovy/ear/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     // The following dependencies will become ear libs and will
     // be placed in a dir configured via the libDirName property
-    earlib group: 'log4j', name: 'log4j', version: '1.2.15', ext: 'jar'
+    earlib("log4j:log4j:1.2.15@jar")
 }
 
 tasks.named('ear') {

--- a/platforms/documentation/docs/src/snippets/ear/earCustomized/groovy/war/build.gradle
+++ b/platforms/documentation/docs/src/snippets/ear/earCustomized/groovy/war/build.gradle
@@ -16,5 +16,5 @@ configurations {
 }
 
 dependencies {
-    implementation group: 'log4j', name: 'log4j', version: '1.2.15', ext: 'jar'
+    implementation("log4j:log4j:1.2.15@jar")
 }

--- a/platforms/documentation/docs/src/snippets/ear/earWithWar/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/ear/earWithWar/groovy/build.gradle
@@ -11,5 +11,5 @@ repositories {
 dependencies {
     deploy project(path: ':war', configuration: 'war')
 
-    earlib group: 'log4j', name: 'log4j', version: '1.2.15', ext: 'jar'
+    earlib("log4j:log4j:1.2.15@jar")
 }

--- a/platforms/documentation/docs/src/snippets/ear/earWithWar/groovy/war/build.gradle
+++ b/platforms/documentation/docs/src/snippets/ear/earWithWar/groovy/war/build.gradle
@@ -16,5 +16,5 @@ configurations {
 }
 
 dependencies {
-    implementation group: 'log4j', name: 'log4j', version: '1.2.15', ext: 'jar'
+    implementation("log4j:log4j:1.2.15@jar")
 }

--- a/platforms/documentation/docs/src/snippets/java/quickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/java/quickstart/groovy/build.gradle
@@ -40,8 +40,8 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    implementation group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
-    testImplementation group: 'junit', name: 'junit', version: '4.+'
+    implementation("commons-collections:commons-collections:3.2.2")
+    testImplementation("junit:junit:4.+")
 }
 // end::dependencies[]
 

--- a/platforms/documentation/docs/src/snippets/tasks/incrementalBuild-incrementalBuildAdvanced/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/tasks/incrementalBuild-incrementalBuildAdvanced/groovy/build.gradle
@@ -14,8 +14,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
-    testImplementation group: 'junit', name: 'junit', version: '4.+'
+    implementation("commons-collections:commons-collections:3.2.2")
+    testImplementation("junit:junit:4.+")
 }
 
 // tag::custom-task-class[]

--- a/platforms/documentation/docs/src/snippets/tutorial/externalDependency/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/tutorial/externalDependency/groovy/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'commons-codec', name: 'commons-codec', version: '1.2'
+        classpath("commons-codec:commons-codec:1.2")
     }
 }
 // end::declare-classpath[]

--- a/platforms/documentation/docs/src/snippets/webApplication/quickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/webApplication/quickstart/groovy/build.gradle
@@ -9,6 +9,6 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'commons-io', name: 'commons-io', version: '1.4'
-    implementation group: 'log4j', name: 'log4j', version: '1.2.15', ext: 'jar'
+    implementation("commons-io:commons-io:1.4")
+    implementation("log4j:log4j:1.2.15@jar")
 }

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
@@ -216,7 +216,7 @@ class DeployedPortalIntegrationSpec extends AbstractIntegrationSpec {
                 }
 
                 dependencies {
-                    classpath group: 'com.android.tools', name: 'r8', version: '1.5.70'
+                    classpath("com.android.tools:r8:1.5.70")
                 }
 
             }

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaModuleIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaModuleIntegrationTest.groovy
@@ -621,12 +621,11 @@ configurations {
 }
 
 dependencies {
-    myPlusConfig group: 'myGroup', name: 'missing-extra-artifact', version: '1.0'
-    myPlusConfig group: 'myGroup', name: 'filtered-artifact', version: '1.0'
-    myMinusConfig group: 'myGroup', name: 'filtered-artifact', version: '1.0'
-    runtimeOnly group: 'myGroup', name: 'missing-artifact', version: '1.0'
-    implementation group: 'myGroup', name: 'existing-artifact', version: '1.0'
-
+    myPlusConfig("myGroup:missing-extra-artifact:1.0")
+    myPlusConfig("myGroup:filtered-artifact:1.0")
+    myMinusConfig("myGroup:filtered-artifact:1.0")
+    runtimeOnly("myGroup:missing-artifact:1.0")
+    implementation("myGroup:existing-artifact:1.0")
     idea {
         module {
             scopes.COMPILE.plus += [ configurations.myPlusConfig ]

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathIntegrationTest.groovy
@@ -95,12 +95,11 @@ configurations {
 }
 
 dependencies {
-    myPlusConfig group: 'myGroup', name: 'missing-extra-artifact', version: '1.0'
-    myPlusConfig group: 'myGroup', name: 'filtered-artifact', version: '1.0'
-    myMinusConfig group: 'myGroup', name: 'filtered-artifact', version: '1.0'
-    runtimeOnly  group: 'myGroup', name: 'missing-artifact', version: '1.0'
-    implementation  group: 'myGroup', name: 'existing-artifact', version: '1.0'
-
+    myPlusConfig("myGroup:missing-extra-artifact:1.0")
+    myPlusConfig("myGroup:filtered-artifact:1.0")
+    myMinusConfig("myGroup:filtered-artifact:1.0")
+    runtimeOnly("myGroup:missing-artifact:1.0")
+    implementation("myGroup:existing-artifact:1.0")
     eclipse {
         classpath {
             plusConfigurations += [ configurations.myPlusConfig ]

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencySubstitutionIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencySubstitutionIntegrationTest.groovy
@@ -34,7 +34,7 @@ allprojects {
 
 project(":project2") {
     dependencies {
-        implementation group: "junit", name: "junit", version: "4.7"
+        implementation("junit:junit:4.7")
     }
 
     configurations.all {

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencySubstitutionIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencySubstitutionIntegrationTest.groovy
@@ -36,7 +36,7 @@ allprojects {
 
 project(":project2") {
     dependencies {
-        implementation group: "junit", name: "junit", version: "4.7"
+        implementation("junit:junit:4.7")
     }
 
     configurations.all {

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocCachingIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocCachingIntegrationTest.groovy
@@ -35,8 +35,8 @@ class JavadocCachingIntegrationTest extends AbstractIntegrationSpec implements D
             ${mavenCentralRepository()}
 
             dependencies {
-                implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
-                implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.1'
+                implementation("org.apache.logging.log4j:log4j-api:2.17.1")
+                implementation("org.apache.logging.log4j:log4j-core:2.17.1")
             }
         """
         projectDir.file("src/main/java/Foo.java") << """

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
@@ -40,7 +40,7 @@ class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegration
             ${mavenCentralRepository()}
 
             dependencies {
-                implementation group: 'org.scala-lang', name: 'scala-library', version: '${ScalaCoverage.latestSupportedScala2Version}'
+                implementation("org.scala-lang:scala-library:${ScalaCoverage.latestSupportedScala2Version}")
             }
         """.stripIndent()
 
@@ -65,7 +65,7 @@ class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegration
             ${mavenCentralRepository()}
 
             dependencies {
-                implementation group: 'org.scala-lang', name: 'scala-library', version: '${ScalaCoverage.latestSupportedScala2Version}'
+                implementation("org.scala-lang:scala-library:${ScalaCoverage.latestSupportedScala2Version}")
             }
         """
         file('src/main/java/RequiredByScala.java') << """

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesGroovyDSLDependenciesIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesGroovyDSLDependenciesIntegrationTest.groovy
@@ -409,15 +409,15 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
             // production code requires commons-lang3 at runtime, which will leak into tests' runtime classpaths
             implementation 'org.apache.commons:commons-lang3:3.11'
 
-            testImplementation([group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'])
-            testCompileOnly([group: 'javax.servlet', name: 'servlet-api', version: '3.0-alpha-1'])
-            testRuntimeOnly([group: 'mysql', name: 'mysql-connector-java', version: '8.0.26'])
+            testImplementation("com.google.guava:guava:30.1.1-jre")
+            testCompileOnly("javax.servlet:servlet-api:3.0-alpha-1")
+            testRuntimeOnly("mysql:mysql-connector-java:8.0.26")
 
             // intentionally setting lower versions of the same dependencies on the `test` suite to show that no conflict resolution should be taking place
             integTestImplementation project
-            integTestImplementation([group: 'com.google.guava', name: 'guava', version: '29.0-jre'])
-            integTestCompileOnly([group: 'javax.servlet', name: 'servlet-api', version: '2.5'])
-            integTestRuntimeOnly([group: 'mysql', name: 'mysql-connector-java', version: '6.0.6'])
+            integTestImplementation("com.google.guava:guava:29.0-jre")
+            integTestCompileOnly("javax.servlet:servlet-api:2.5")
+            integTestRuntimeOnly("mysql:mysql-connector-java:6.0.6")
         }
 
         tasks.named('check') {
@@ -474,15 +474,14 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
             // production code requires commons-lang3 at runtime, which will leak into tests' runtime classpaths
             implementation 'org.apache.commons:commons-lang3:3.11'
 
-           testImplementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
-            testCompileOnly group: 'javax.servlet', name: 'servlet-api', version: '3.0-alpha-1'
-            testRuntimeOnly group: 'mysql', name: 'mysql-connector-java', version: '8.0.26'
-
+           testImplementation("com.google.guava:guava:30.1.1-jre")
+            testCompileOnly("javax.servlet:servlet-api:3.0-alpha-1")
+            testRuntimeOnly("mysql:mysql-connector-java:8.0.26")
             // intentionally setting lower versions of the same dependencies on the `test` suite to show that no conflict resolution should be taking place
             integTestImplementation project
-            integTestImplementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-            integTestCompileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.5'
-            integTestRuntimeOnly group: 'mysql', name: 'mysql-connector-java', version: '6.0.6'
+            integTestImplementation("com.google.guava:guava:29.0-jre")
+            integTestCompileOnly("javax.servlet:servlet-api:2.5")
+            integTestRuntimeOnly("mysql:mysql-connector-java:6.0.6")
         }
 
         tasks.named('check') {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
@@ -37,7 +37,7 @@ def someDependency = project.dependencies.create(files('foo.txt'))
 dependencies {
     conf someDependency
     conf "org.mockito:mockito-core:1.8"
-    conf group: 'org.spockframework', name: 'spock-core', version: '1.0'
+    conf("org.spockframework:spock-core:1.0")
     conf provider { "junit:junit:4.12" }
 
     conf('org.test:configured') {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -550,7 +550,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
             }
 
             dependencies {
-                subConf(group: "org.utils", name: "api", version: "1.5")
+                subConf("org.utils:api:1.5")
             }
 
             configurations.runtimeClasspath.resolutionStrategy.dependencySubstitution {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
@@ -107,7 +107,7 @@ class ForcedModulesIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
             dependencies {
-                implementation (group: 'org', name: 'foo', version:'1.4.4')
+                implementation("org:foo:1.4.4")
             }
         """
 
@@ -116,7 +116,7 @@ class ForcedModulesIntegrationTest extends AbstractIntegrationSpec {
                 id("java-library")
             }
             dependencies {
-                implementation (group: 'org', name: 'foo', version:'1.3.3')
+                implementation("org:foo:1.3.3")
             }
         """
 
@@ -164,7 +164,7 @@ class ForcedModulesIntegrationTest extends AbstractIntegrationSpec {
             version = '1.0'
 
             dependencies {
-                implementation (group: 'org', name: 'foo', version:'1.4.4')
+                implementation("org:foo:1.4.4")
             }
         """
 
@@ -177,7 +177,7 @@ class ForcedModulesIntegrationTest extends AbstractIntegrationSpec {
             version = '1.0'
 
             dependencies {
-                implementation (group: 'org', name: 'foo', version:'1.3.3')
+                implementation("org:foo:1.3.3")
             }
         """
 
@@ -240,7 +240,7 @@ class ForcedModulesIntegrationTest extends AbstractIntegrationSpec {
             }
 
             dependencies {
-                implementation (group: 'org', name: 'foo', version:'1.3.3')
+                implementation("org:foo:1.3.3")
             }
         """
 
@@ -250,7 +250,7 @@ class ForcedModulesIntegrationTest extends AbstractIntegrationSpec {
             }
 
             dependencies {
-                implementation (group: 'org', name: 'foo', version:'1.4.4')
+                implementation("org:foo:1.4.4")
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -249,7 +249,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         buildFile << """
             dependencies {
                 configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-                conf group: 'org', name: 'mavenCompile1', version: '1.0'
+                conf("org:mavenCompile1:1.0")
             }
         """
         expectChainInteractions(modules, modules)
@@ -281,7 +281,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         buildFile << """
             dependencies {
                 configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-                conf group: 'org', name: 'mavenCompile1', version: '1.0'
+                conf("org:mavenCompile1:1.0")
             }
         """
         expectChainInteractions(modules, modules)
@@ -316,7 +316,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         buildFile << """
             dependencies {
                 configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-                conf group: 'org', name: 'maven', version: '1.0'
+                conf("org:maven:1.0")
             }
         """
         expectChainInteractions(modules, modules, 'api')

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/MultiStringDependencyNotationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/MultiStringDependencyNotationIntegrationTest.groovy
@@ -1,0 +1,745 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.internal.ToBeImplemented
+
+/**
+ * Tests all APIs related to map notation in Groovy, and the corresponding
+ * named parameters APIs in Kotlin.
+ */
+class MultiStringDependencyNotationIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final List<String> GROOVY_CONSTRAINT_NOTATIONS = [
+        "name: 'foo'",
+        "group: 'org', name: 'foo'",
+        "group: 'org', name: 'foo', version: '1.0'",
+        "name: 'foo', version: '1.0'",
+        "group: 'org', name: 'foo', version: '1.0', classifier: 'cls'",
+        "group: 'org', name: 'foo', version: '1.0', ext: 'jar'",
+    ]
+
+    private static final List<String> GROOVY_DEPENDENCY_NOTATIONS = GROOVY_CONSTRAINT_NOTATIONS + [
+        "group: 'org', name: 'foo', version: '1.0', configuration: 'conf'",
+        "group: 'org', name: 'foo', version: '1.0', changing: true",
+        "group: 'org', name: 'foo', version: '1.0', transitive: false"
+    ]
+
+    private static final List<String> KOTLIN_DEPENDENCY_NOTATIONS = [
+        "group = \"org\", name = \"foo\"",
+        "group = \"org\", name = \"foo\", version = \"1.0\"",
+        "group = \"org\", name = \"foo\", version = \"1.0\", configuration = \"conf\"",
+        "group = \"org\", name = \"foo\", version = \"1.0\", classifier = \"cls\"",
+        "group = \"org\", name = \"foo\", version = \"1.0\", ext = \"jar\""
+    ]
+
+    def setup() {
+        ivyRepo.module("org", "foo", "1.0")
+            .configuration("conf")
+            .artifact(type: "jar")
+            .artifact(classifier: "cls")
+            .publish()
+    }
+
+    def "can create buildscript dependencies using multi-string notation"() {
+        given:
+        buildFile << """
+            buildscript {
+                dependencies {
+                    assert create(${notation}) instanceof Dependency
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_DEPENDENCY_NOTATIONS
+    }
+
+    def "can declare buildscript dependencies using multi-string notation"() {
+        given:
+        buildFile << """
+            buildscript {
+                repositories {
+                    ivy { url = uri("${ivyRepo.uri}") }
+                }
+                dependencies {
+                    classpath(${notation})
+                    classpath(${notation}) {}
+                }
+                ${assertDependencyCount("classpath", 1)}
+            }
+        """
+
+        expect:
+        if (!notation.contains("group") || !notation.contains("version")) {
+            // We can declare these dependencies but they will fail to resolve.
+            fails("help")
+            failure.assertHasCause("Could not resolve all artifacts for configuration 'classpath'.")
+        } else {
+            succeeds("help")
+        }
+
+        where:
+        notation << GROOVY_DEPENDENCY_NOTATIONS
+    }
+
+    def "can create dependencies using multi-string notation"() {
+        given:
+        buildFile << """
+            dependencies {
+                assert create(${notation}) instanceof Dependency
+            }
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_DEPENDENCY_NOTATIONS
+    }
+
+    def "can declare dependencies using multi-string notation"() {
+        given:
+        buildFile << """
+            configurations {
+                implementation
+            }
+            dependencies {
+                implementation(${notation})
+                implementation(${notation}) {}
+            }
+            ${assertDependencyCount("implementation", 1)}
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_DEPENDENCY_NOTATIONS
+    }
+
+    def "can add map provider to dependency handler"() {
+        given:
+        buildFile << """
+            configurations {
+                implementation
+            }
+            dependencies {
+                implementation(provider { [${notation}] })
+                implementation(provider { [${notation}] }) {}
+            }
+            new ArrayList<>(configurations.implementation.dependencies) // Copy to realize providers
+            ${assertDependencyCount("implementation", 1)}
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_DEPENDENCY_NOTATIONS
+    }
+
+    def "can create buildscript dependencies in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            buildscript {
+                dependencies {
+                    assert(create(${notation}) is Dependency)
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    def "can declare buildscript dependencies in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            buildscript {
+                repositories {
+                    ivy { url = uri("${ivyRepo.uri}") }
+                }
+                dependencies {
+                    classpath(${notation})
+                    classpath(${notation}) {}
+                }
+                ${assertDependencyCountKotlin("classpath", 1)}
+            }
+        """
+
+        expect:
+        if (!notation.contains("version")) {
+            // We can declare this dependency but it will fail to resolve.
+            fails("help")
+            failure.assertHasCause("Could not resolve all artifacts for configuration 'classpath'.")
+        } else {
+            succeeds("help")
+        }
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    def "can create dependencies in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            dependencies {
+                assert(create(${notation}) is Dependency)
+            }
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    def "can declare dependencies on generated accessors in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            plugins {
+                id("java-library")
+            }
+            dependencies {
+                implementation(${notation})
+                implementation(${notation}) {}
+            }
+            ${assertDependencyCountKotlin("implementation", 1)}
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    def "can declare dependencies using invoke on a configuration in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            val implementation: Configuration = configurations.create("implementation")
+            dependencies {
+                implementation(${notation})
+                implementation(${notation}) {}
+            }
+            ${assertDependencyCountKotlin("implementation", 1)}
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    def "can declare dependencies using invoke on a configuration provider in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            configurations.create("implementation")
+            val implementation = configurations.named("implementation")
+            dependencies {
+                implementation(${notation})
+                implementation(${notation}) {}
+            }
+            ${assertDependencyCountKotlin("implementation", 1)}
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    def "can declare dependencies using invoke on a dependency scope configuration provider in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            val implementation = configurations.dependencyScope("implementation")
+            dependencies {
+                implementation(${notation})
+                implementation(${notation}) {}
+            }
+            ${assertDependencyCountKotlin("implementation", 1)}
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    def "can declare dependencies using invoke on a String in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            configurations.create("implementation")
+            dependencies {
+                "implementation"(${notation})
+                "implementation"(${notation}) {}
+            }
+            ${assertDependencyCountKotlin("implementation", 1)}
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    def "can create buildscript constraints using multi-string notation"() {
+        given:
+        buildFile << """
+            buildscript {
+                dependencies {
+                    constraints {
+                        assert(create(${notation}) instanceof DependencyConstraint)
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_CONSTRAINT_NOTATIONS
+    }
+
+    def "can declare buildscript constraints using multi-string notation"() {
+        given:
+        buildFile << """
+            buildscript {
+                dependencies {
+                    constraints {
+                        classpath(${notation})
+                        classpath(${notation}) {}
+                    }
+                }
+                ${assertConstraintCount("classpath", 2)} // We automatically add a constraint for log4j-core
+            }
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_CONSTRAINT_NOTATIONS
+    }
+
+    def "can create constraints using multi-string notation"() {
+        given:
+        buildFile << """
+            dependencies {
+                constraints {
+                    assert(create(${notation}) instanceof DependencyConstraint)
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_CONSTRAINT_NOTATIONS
+    }
+
+    def "can declare declare constraints using multi-string notation"() {
+        given:
+        buildFile << """
+            configurations {
+                implementation
+            }
+            dependencies {
+                constraints {
+                    implementation(${notation})
+                    implementation(${notation}) {}
+                }
+            }
+            ${assertConstraintCount("implementation", 1)}
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_CONSTRAINT_NOTATIONS
+    }
+
+    def "can add map provider to constraint handler"() {
+        given:
+        buildFile << """
+            configurations {
+                implementation
+            }
+            dependencies {
+                constraints {
+                    implementation(provider { [${notation}] })
+                    implementation(provider { [${notation}] }) {}
+                }
+            }
+            new ArrayList<>(configurations.implementation.dependencies) // Copy to realize providers
+            ${assertConstraintCount("implementation", 1)}
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_CONSTRAINT_NOTATIONS
+    }
+
+    @ToBeImplemented("The `create` call erroneously resolves to the extension which creates a dependency. There is no extension to create a map notation constraint.")
+    def "can create buildscript constraints in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            buildscript {
+                dependencies {
+                    constraints {
+                        assert(create(${notation}) is DependencyConstraint)
+                    }
+                }
+            }
+        """
+
+        expect:
+        fails("help") // Should be success
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    @ToBeImplemented("The `classpath` call erroneously resolves to the extension which adds a dependency to the classpath. There is no extension to add a map constraint.")
+    def "can declare buildscript constraints in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            buildscript {
+                dependencies {
+                    constraints {
+                        classpath(${notation})
+                        classpath(${notation}) {}
+                    }
+                }
+                ${assertConstraintCountKotlin("classpath", 1)}
+            }
+        """
+
+        expect:
+        fails("help") // Should be success
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    @ToBeImplemented("The `create` call erroneously resolves to the extension which creates a dependency. There is no extension to create a map notation constraint.")
+    def "can create constraints in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            dependencies {
+                constraints {
+                    assert(create(${notation}) is DependencyConstraint)
+                }
+            }
+        """
+
+        expect:
+        fails("help") // Should be success
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    @ToBeImplemented("The invoke call erroneously resolves to the extension which adds a dependency. There is no extension to add a map notation constraint.")
+    def "can declare declare constraints using multi-string notation in Kotlin"() {
+        given:
+        buildKotlinFile << """
+            plugins {
+                id("java-library")
+            }
+            dependencies {
+                constraints {
+                    implementation(${notation})
+                    implementation(${notation}) {}
+                }
+            }
+            ${assertConstraintCountKotlin("implementation", 1)}
+        """
+
+        expect:
+        fails("help") // Should be success
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    @ToBeImplemented("The invoke call erroneously resolves to the extension which adds a dependency. There is no extension to add a map notation constraint.")
+    def "can declare constraints using invoke on a configuration in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            val implementation: Configuration = configurations.create("implementation")
+            dependencies {
+                constraints {
+                    implementation(${notation})
+                    implementation(${notation}) {}
+                }
+            }
+            ${assertConstraintCountKotlin("implementation", 1)}
+        """
+
+        expect:
+        fails("help") // Should be success
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    @ToBeImplemented("The invoke call erroneously resolves to the extension which adds a dependency. There is no extension to add a map notation constraint.")
+    def "can declare constraints using invoke on a configuration provider in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            configurations.create("implementation")
+            val implementation = configurations.named("implementation")
+            dependencies {
+                constraints {
+                    implementation(${notation})
+                    implementation(${notation}) {}
+                }
+            }
+            ${assertConstraintCountKotlin("implementation", 1)}
+        """
+
+        expect:
+        fails("help") // Should be success
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    @ToBeImplemented("The invoke call erroneously resolves to the extension which adds a dependency. There is no extension to add a map notation constraint.")
+    def "can declare constraints using invoke on a dependency scope configuration provider in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            val implementation = configurations.dependencyScope("implementation")
+            dependencies {
+                constraints {
+                    implementation(${notation})
+                    implementation(${notation}) {}
+                }
+            }
+            ${assertConstraintCountKotlin("implementation", 1)}
+        """
+
+        expect:
+        fails("help") // Should be success
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    @ToBeImplemented("The invoke call erroneously resolves to the extension which adds a dependency. There is no extension to add a map notation constraint.")
+    def "can declare constraints using invoke on a String in Kotlin using multi-string notation"() {
+        given:
+        buildKotlinFile << """
+            configurations.create("implementation")
+            dependencies {
+                constraints {
+                    "implementation"(${notation})
+                    "implementation"(${notation}) {}
+                }
+            }
+            ${assertConstraintCountKotlin("implementation", 1)}
+        """
+
+        expect:
+        fails("help") // Should be success
+
+        where:
+        notation << KOTLIN_DEPENDENCY_NOTATIONS
+    }
+
+    // This method is used to implement multi-string dependencies in Kotlin, but
+    // it is also technically part of the public API.
+    def "can call externalModuleDependencyFor in Kotlin"() {
+        buildKotlinFile << """
+            import org.gradle.kotlin.dsl.accessors.runtime.externalModuleDependencyFor
+            externalModuleDependencyFor(dependencies, "group", "name", null, null, null, null)
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    // This method is used to implement multi-string dependencies in Kotlin, but
+    // it is also technically part of the public API.
+    def "can call addExternalModuleDependencyTo in Kotlin"() {
+        buildKotlinFile << """
+            import org.gradle.kotlin.dsl.accessors.runtime.addExternalModuleDependencyTo
+            configurations.create("conf")
+            addExternalModuleDependencyTo(
+                dependencies,
+                "conf", "group", "name", null, null, null, null
+            ) {}
+        """
+
+        expect:
+        succeeds("help")
+    }
+
+    def "can declare dependency rules using multi-string notation"() {
+        given:
+        buildFile << """
+            dependencies {
+                components {
+                    all {
+                        allVariants {
+                            withDependencies { deps ->
+                                deps.add(${notation})
+                                deps.add(${notation}) {}
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_DEPENDENCY_NOTATIONS
+    }
+
+    def "can declare constraint rules using multi-string notation"() {
+        given:
+        buildFile << """
+            dependencies {
+                components {
+                    all {
+                        allVariants {
+                            withDependencyConstraints { constraints ->
+                                constraints.add(${notation})
+                                constraints.add(${notation}) {}
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << GROOVY_DEPENDENCY_NOTATIONS
+    }
+
+    def "can declare dependencies using multi-string notation in type-safe dependencies block"() {
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            testing.suites.test {
+                dependencies {
+                    implementation(module(${notation}))
+                    implementation(module(${notation})) {}
+                }
+            }
+        """
+
+        expect:
+        succeeds("help")
+
+        where:
+        notation << [
+            "name: 'foo'",
+            "group: 'org', name: 'foo'",
+            "group: 'org', name: 'foo', version: '1.0'",
+            "name: 'foo', version: '1.0'",
+        ]
+    }
+
+    def "can declare dependencies using multi-string notation in type-safe dependencies block in Kotlin"() {
+        buildKotlinFile << """
+            plugins {
+                id("java-library")
+            }
+
+            testing.suites.named<JvmTestSuite>("test") {
+                dependencies {
+                    implementation(module(${notation}))
+                    implementation(module(${notation})) {}
+                }
+            }
+        """
+
+
+        expect:
+        if (notation.contains("group") && notation.contains("name") && notation.contains("version")) {
+            succeeds("help")
+        } else {
+            fails("help") // Kotlin fails unless you provide all three parts
+        }
+
+        where:
+        notation << [
+            "name= \"foo\"",
+            "group= \"org\", name= \"foo\"",
+            "group= \"org\", name= \"foo\", version= \"1.0\"",
+            "name= \"foo\", version= \"1.0\"",
+        ]
+    }
+
+    def assertDependencyCount(String configuration, int count) {
+        return """
+            assert(new ArrayList<>(configurations.getByName("${configuration}").dependencies).size() == $count)
+        """
+    }
+
+    def assertConstraintCount(String configuration, int count) {
+        return """
+            assert(new ArrayList<>(configurations.getByName("${configuration}").dependencyConstraints).size() == $count)
+        """
+    }
+
+    def assertDependencyCountKotlin(String configuration, int count) {
+        return """
+            val size = ArrayList(configurations.getByName("$configuration").dependencies).size
+            if (size != $count) {
+                throw AssertionError("Expected $configuration to have $count dependencies, but found \$size")
+            }
+        """
+    }
+
+    def assertConstraintCountKotlin(String configuration, int count) {
+        return """
+            val size = ArrayList(configurations.getByName("$configuration").dependencyConstraints).size
+            if (size != $count) {
+                throw AssertionError("Expected $configuration to have $count constraints, but found \$size")
+            }
+        """
+    }
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/MultiStringDependencyNotationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/MultiStringDependencyNotationIntegrationTest.groovy
@@ -41,11 +41,11 @@ class MultiStringDependencyNotationIntegrationTest extends AbstractIntegrationSp
     ]
 
     private static final List<String> KOTLIN_DEPENDENCY_NOTATIONS = [
-        "group = \"org\", name = \"foo\"",
-        "group = \"org\", name = \"foo\", version = \"1.0\"",
-        "group = \"org\", name = \"foo\", version = \"1.0\", configuration = \"conf\"",
-        "group = \"org\", name = \"foo\", version = \"1.0\", classifier = \"cls\"",
-        "group = \"org\", name = \"foo\", version = \"1.0\", ext = \"jar\""
+        'group = "org", name = "foo"',
+        'group = "org", name = "foo", version = "1.0"',
+        'group = "org", name = "foo", version = "1.0", configuration = "conf"',
+        'group = "org", name = "foo", version = "1.0", classifier = "cls"',
+        'group = "org", name = "foo", version = "1.0", ext = "jar"'
     ]
 
     def setup() {
@@ -706,10 +706,10 @@ class MultiStringDependencyNotationIntegrationTest extends AbstractIntegrationSp
 
         where:
         notation << [
-            "name= \"foo\"",
-            "group= \"org\", name= \"foo\"",
-            "group= \"org\", name= \"foo\", version= \"1.0\"",
-            "name= \"foo\", version= \"1.0\"",
+            'name= "foo"',
+            'group= "org", name= "foo"',
+            'group= "org", name= "foo", version= "1.0"',
+            'name= "foo", version= "1.0"',
         ]
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
@@ -166,7 +166,7 @@ baz:1.0 requested
                             all {
                                 if (it.requested instanceof ModuleComponentSelector) {
                                     if (it.requested.module == 'leaf' && it.requested.version == '0.9') {
-                                        it.useTarget("substitute 0.9 with 1.0", group: 'org.test', name: it.requested.module, version: '1.0')
+                                        it.useTarget("org.test:\${it.requested.module}:1.0", "substitute 0.9 with 1.0")
                                     }
                                 }
                             }
@@ -182,7 +182,6 @@ baz:1.0 requested
             dependencies {
                 conf 'org.test:a:1.0'
                 conf 'org.test:b:1.0'
-
             }
         """
         resolve.prepare()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ArtifactCacheUnusedEntryCleanupIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ArtifactCacheUnusedEntryCleanupIntegrationTest.groovy
@@ -429,7 +429,7 @@ class ArtifactCacheUnusedEntryCleanupIntegrationTest extends AbstractHttpDepende
                 custom
             }
             dependencies {
-                custom group: '${module.groupId}', name: '${module.artifactId}', version: '${module.version}'
+                custom("${module.groupId}:${module.artifactId}:${module.version}")
             }
             task resolve {
                 def files = configurations.custom

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedDependencyResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedDependencyResolutionIntegrationTest.groovy
@@ -45,7 +45,9 @@ configurations.all {
 }
 
 dependencies {
-    compile group: "group", name: "projectA", version: "1.1", changing: true
+    compile("group:projectA:1.1") {
+        changing = true
+    }
 }
 
 task retrieve(type: Sync) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedMissingModulesIntegrationTest.groovy
@@ -79,7 +79,9 @@ configurations {
     }
 }
 dependencies {
-    missing group: 'group', name: 'projectA', version: '1.2', changing: true
+    missing("group:projectA:1.2") {
+        changing = true
+    }
 }
 task showMissing {
     def missing = configurations.missing

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/RecoverFromBrokenResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/RecoverFromBrokenResolutionIntegrationTest.groovy
@@ -214,7 +214,9 @@ class RecoverFromBrokenResolutionIntegrationTest extends AbstractHttpDependencyR
                   }
 
                   dependencies {
-                      compile group:'group', name:'projectA', version:'1.0', changing:true
+                      compile("group:projectA:1.0") {
+                          changing = true
+                      }
                   }
 
                   task retrieve(type: Sync) {
@@ -267,7 +269,7 @@ class RecoverFromBrokenResolutionIntegrationTest extends AbstractHttpDependencyR
                       resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'
                   }
                   dependencies {
-                      compile group:'group', name:'projectA', version:'1.+'
+                      compile("group:projectA:1.+")
                   }
 
                   task retrieve(type: Sync) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -44,7 +44,7 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
 
             configurations.api.outgoing {
                 capability 'test:b:unspecified'
-                capability group:'org', name:'capability', version:'1.0'
+                capability("org:capability:1.0")
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyChangingModuleRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyChangingModuleRemoteResolveIntegrationTest.groovy
@@ -38,7 +38,9 @@ configurations.all {
 }
 
 dependencies {
-    compile group: "group", name: "projectA", version: "1.1", changing: true
+    compile("group:projectA:1.1") {
+        changing = true
+    }
 }
 
 task retrieve(type: Copy) {
@@ -97,7 +99,9 @@ configurations { compile }
 configurations.compile.resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 
 dependencies {
-    compile group: "group", name: "projectA", version: "1.1", changing: isChanging
+    compile("group:projectA:1.1") {
+        changing = isChanging
+    }
 }
 
 task retrieve(type: Copy) {
@@ -147,7 +151,9 @@ configurations.all {
 }
 
 dependencies {
-    compile group: "group", name: "projectA", version: "1.1", changing: true
+    compile("group:projectA:1.1") {
+        changing = true
+    }
 }
 
 task retrieve(type: Copy) {
@@ -207,7 +213,9 @@ if (providers.gradleProperty('doNotCacheChangingModules').isPresent()) {
 }
 
 dependencies {
-    compile group: "group", name: "projectA", version: "1.1", changing: true
+    compile("group:projectA:1.1") {
+        changing = true
+    }
 }
 
 task retrieve(type: Copy) {
@@ -282,7 +290,9 @@ task retrieve(type: Copy) {
             }
 
             dependencies {
-                compile group: "group", name: "projectA", version: "1.1", changing: true
+                compile("group:projectA:1.1") {
+                    changing = true
+                }
             }
 
             task retrieve(type: Copy) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyCustomStatusLatestVersionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyCustomStatusLatestVersionIntegrationTest.groovy
@@ -222,7 +222,9 @@ repositories {
 }
 configurations { compile }
 dependencies {
-    compile group: "org.test", name: "projectA", version: "latest.release", changing: true
+    compile("org.test:projectA:latest.release") {
+        changing = true
+    }
 }
 
 configurations.all {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
@@ -43,7 +43,7 @@ class IvyDynamicRevisionRemoteResolveIntegrationTest extends AbstractHttpDepende
 configurations { compile }
 
 dependencies {
-    compile group: "group", name: "projectA", version: "1.+"
+    compile("group:projectA:1.+")
 }
 """
         when:
@@ -78,8 +78,8 @@ if (project.hasProperty('refreshDynamicVersions')) {
     }
 }
 dependencies {
-    compile group: "group", name: "projectA", version: "1.+"
-    compile group: "group", name: "projectB", version: "latest.integration"
+    compile("group:projectA:1.+")
+    compile("group:projectB:latest.integration")
 }
 """
         when:
@@ -154,8 +154,8 @@ repositories.all {
 }
 configurations { compile }
 dependencies {
-  compile group: "group", name: "projectA", version: "1.+"
-  compile group: "group", name: "projectB", version: "latest.integration"
+  compile("group:projectA:1.+")
+  compile("group:projectB:latest.integration")
 }
 """
 
@@ -196,7 +196,7 @@ def latestRevision = project.getProperty('latestRevision')
 configurations { compile }
 
 dependencies {
-    compile group: "group", name: "projectA", version: "latest.\${latestRevision}"
+    compile("group:projectA:latest.\${latestRevision}")
 }
 """
 
@@ -256,8 +256,8 @@ configurations {
     compile
 }
 dependencies {
-    staticVersions group: "group", name: "projectA", version: "1.1"
-    compile group: "group", name: "projectA", version: "latest.milestone"
+    staticVersions("group:projectA:1.1")
+    compile("group:projectA:latest.milestone")
 }
 task cache {
     def files = configurations.staticVersions
@@ -302,7 +302,7 @@ task cache {
         buildFile << """
     configurations { compile }
     dependencies {
-        compile group: "group", name: "projectA", version: "latest.milestone"
+        compile("group:projectA:latest.milestone")
     }
     """
 
@@ -344,7 +344,7 @@ if (project.hasProperty('addRepo2')) {
 
 configurations { compile }
 dependencies {
-    compile group: "group", name: "projectA", version: "1.+"
+    compile("group:projectA:1.+")
 }
 """
 
@@ -383,7 +383,7 @@ dependencies {
         buildFile << """
     configurations { compile }
     dependencies {
-        compile group: "group", name: "projectA", version: "1.+"
+        compile("group:projectA:1.+")
     }
     """
 
@@ -419,7 +419,7 @@ dependencies {
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "group", name: "projectA", version: "1.+"
+    compile("group:projectA:1.+")
 }
 """
 
@@ -450,8 +450,8 @@ dependencies {
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "org.test", name: "projectA", version: "1.+"
-    compile group: "org.test", name: "projectA", version: "latest.integration"
+    compile("org.test:projectA:1.+")
+    compile("org.test:projectA:latest.integration")
 }
 """
 
@@ -477,7 +477,7 @@ dependencies {
         and:
         buildFile << """
 dependencies {
-    compile group: "org.test", name: "projectA", version: "[1.0,2.0)"
+    compile("org.test:projectA:[1.0,2.0)")
 }
 """
 
@@ -505,8 +505,8 @@ configurations {
 configurations.fresh.resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'
 
 dependencies {
-    fresh group: "org.test", name: "projectA", version: "1.+"
-    stale group: "org.test", name: "projectA", version: "1.+"
+    fresh("org.test:projectA:1.+")
+    stale("org.test:projectA:1.+")
 }
 
 task resolveStaleThenFresh {
@@ -552,7 +552,7 @@ task resolveStaleThenFresh {
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "org.test", name: "projectA", version: "1.+"
+    compile("org.test:projectA:1.+")
 }
 """
 
@@ -585,7 +585,7 @@ dependencies {
         and:
         buildFile << """
 dependencies {
-    compile group: "org.test", name: "projectA", version: "2.+"
+    compile("org.test:projectA:2.+")
 }
 """
 
@@ -611,7 +611,7 @@ dependencies {
         and:
         buildFile << """
 dependencies {
-    compile group: "org.test", name: "projectA", version: "3.+"
+    compile("org.test:projectA:3.+")
 }
 """
 
@@ -638,7 +638,7 @@ dependencies {
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "group", name: "projectA", version: "1.+"
+    compile("group:projectA:1.+")
 }
 if (project.hasProperty('noDynamicRevisionCache')) {
     configurations.all {
@@ -679,7 +679,7 @@ if (project.hasProperty('noDynamicRevisionCache')) {
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "group", name: "main", version: "1.0"
+    compile("group:main:1.0")
 }
 
 if (project.hasProperty('noDynamicRevisionCache')) {
@@ -901,8 +901,8 @@ dependencies {
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "group", name: "main", version: "1.0"
-    compile group: "group", name: "projectA", version: "latest.integration"
+    compile("group:main:1.0")
+    compile("group:projectA:latest.integration")
 }
 configurations.all {
     resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'
@@ -963,7 +963,7 @@ configurations.all {
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "group", name: "projectA", version: "2.+"
+    compile("group:projectA:2.+")
 }
 """
 
@@ -1050,7 +1050,7 @@ Required by:
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "group", name: "projectA", version: "2.+"
+    compile("group:projectA:2.+")
 }
 """
 
@@ -1094,7 +1094,7 @@ Required by:
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "group", name: "projectA", version: "2.+"
+    compile("group:projectA:2.+")
 }
 """
 
@@ -1117,7 +1117,7 @@ dependencies {
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "group", name: "projectA", version: "2.+"
+    compile("group:projectA:2.+")
 }
 """
 
@@ -1148,7 +1148,7 @@ dependencies {
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "group", name: "projectA", version: "latest.release"
+    compile("group:projectA:latest.release")
 }
 """
 
@@ -1182,7 +1182,7 @@ Required by:
         buildFile << """
 configurations { compile }
 dependencies {
-    compile group: "group", name: "projectA", version: "latest.release"
+    compile("group:projectA:latest.release")
 }
 """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
@@ -645,7 +645,7 @@ Searched in the following locations:
         given:
         buildFile << """
 dependencies {
-    conf group: "org.test", name: "projectA", version: "[1.1]"
+    conf("org.test:projectA:[1.1]")
 }
 """
         and:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyFileRepoResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyFileRepoResolveIntegrationTest.groovy
@@ -77,9 +77,11 @@ configurations {
 }
 
 dependencies {
-    compile group: "group", name: "projectA", version: "1.+"
-    compile group: "group", name: "projectB", version: "latest.integration"
-    compile group: "group", name: "projectC", version: "1.0", changing: true
+    compile("group:projectA:1.+")
+    compile("group:projectB:latest.integration")
+    compile("group:projectC:1.0") {
+        changing = true
+    }
 }
 
 task retrieve(type: Sync) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
@@ -100,7 +100,9 @@ task retrieve(type: Sync) {
                 ivy { url = "${ivyRepo.uri}" }
             }
             dependencies {
-                compile group: 'test', name: 'target', version: '1.0', configuration: 'x86_windows'
+                compile("test:target:1.0") {
+                    targetConfiguration = 'x86_windows'
+                }
             }
             task retrieve(type: Sync) {
               from configurations.compile
@@ -130,7 +132,9 @@ repositories {
     ivy { url = "${ivyRepo.uri}" }
 }
 dependencies {
-    compile group: 'test', name: 'target', version: '1.0', configuration: 'something'
+    compile("test:target:1.0") {
+        targetConfiguration = 'something'
+    }
 }
 task retrieve(type: Sync) {
   from configurations.compile
@@ -153,7 +157,9 @@ dependencies {
     repositories {
         ivy { url = "${ivyHttpRepo.uri}" }
     }
-    compile group: 'ivy.configuration', name: 'projectA', version: '1.2', configuration: 'a'
+    compile("ivy.configuration:projectA:1.2") {
+        targetConfiguration = "a"
+    }
 }
 task retrieve(type: Sync) {
   from configurations.compile
@@ -348,7 +354,9 @@ task retrieve(type: Sync) {
         ivy { url = "${ivyRepo.uri}" }
     }
     dependencies {
-        compile group: 'ivy.configuration', name: 'projectA', version: '1.2', configuration: 'a'
+        compile("ivy.configuration:projectA:1.2") {
+            targetConfiguration = "a"
+        }
     }
     task retrieve(type: Sync) {
       from configurations.compile

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyResolveIntegrationTest.groovy
@@ -363,7 +363,9 @@ dependencies {
                     }
                 }
                 dependencies {
-                    implementation(group:"org", name:"foo", configuration:"alice")
+                    implementation("org:foo") {
+                        targetConfiguration = "alice"
+                    }
                 }
             }
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
@@ -34,8 +34,8 @@ repositories {
 configurations { compile }
 
 dependencies {
-    compile group: "org.test", name: "projectA", version: "1.+"
-    compile group: "org.test", name: "projectB", version: "1.+"
+    compile("org.test:projectA:1.+")
+    compile("org.test:projectB:1.+")
 }
 
 task retrieve(type: Sync) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
@@ -152,7 +152,7 @@ class MavenScopesAndProjectDependencySubstitutionIntegrationTest extends Abstrac
 
         file("child1/build.gradle") << """
             dependencies {
-                conf group: 'org.test', name: 'maven', version: '1.0'
+                conf("org.test:maven:1.0")
             }
             configurations.conf.resolutionStrategy.dependencySubstitution {
                 substitute module('org.test:replaced:1.0') using project(':child2')
@@ -202,7 +202,7 @@ class MavenScopesAndProjectDependencySubstitutionIntegrationTest extends Abstrac
 
         file("child1/build.gradle") << """
             dependencies {
-                conf group: 'org.test', name: 'maven', version: '1.0'
+                conf("org.test:maven:1.0")
             }
             configurations.conf.resolutionStrategy.dependencySubstitution {
                 substitute module('org.test:replaced:1.0') using project(':child2')

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
@@ -100,7 +100,9 @@ class MavenScopesIntegrationTest extends AbstractDependencyResolutionTest {
 
         buildFile << """
             dependencies {
-                conf group: 'test', name: 'target', version: '1.0', configuration: 'compile'
+                conf("test:target:1.0") {
+                    targetConfiguration = "compile"
+                }
             }
         """
 
@@ -120,7 +122,9 @@ class MavenScopesIntegrationTest extends AbstractDependencyResolutionTest {
 
         buildFile << """
             dependencies {
-                conf group: 'test', name: 'target', version: '1.0', configuration: 'x86_windows'
+                conf("test:target:1.0") {
+                    targetConfiguration = "x86_windows"
+                }
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -550,7 +550,7 @@ task retrieve(type: Sync) {
             }
 
             dependencies {
-                compile group: "group", name: "projectA", version: "1.1-SNAPSHOT"
+                compile("group:projectA:1.1-SNAPSHOT")
             }
 
             task retrieve(type: Copy) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
@@ -40,7 +40,7 @@ repositories {
 configurations { compile }
 
 dependencies {
-    compile group: "org.test", name: "projectA", version: "[1.1]"
+    compile("org.test:projectA:[1.1]")
 }
 """
         and:
@@ -78,7 +78,7 @@ repositories {
 configurations { compile }
 
 dependencies {
-    compile group: "org.test", name: "child", version: "1.0"
+    compile("org.test:child:1.0")
 }
 """
         and:
@@ -120,7 +120,7 @@ repositories {
 configurations { compile }
 
 dependencies {
-    compile group: "org.test", name: "child", version: "1.0"
+    compile("org.test:child:1.0")
 }
 """
         and:
@@ -167,7 +167,7 @@ repositories {
 configurations { compile }
 
 dependencies {
-    compile group: "org.test", name: "child", version: "1.0"
+    compile("org.test:child:1.0")
 }
 """
         and:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
@@ -113,7 +113,7 @@ dependencies {
 
         buildFile << """
 dependencies {
-    conf group: 'org.test', name: 'maven', version: '1.0'
+    conf("org.test:maven:1.0")
 }
 """
         expect:
@@ -189,7 +189,7 @@ dependencies {
 
         buildFile << """
 dependencies {
-    conf group: 'org.test', name: 'ivy', version: '1.0'
+    conf("org.test:ivy:1.0")
 }
 """
         expect:
@@ -236,7 +236,7 @@ dependencies {
 
         buildFile << """
 dependencies {
-    conf group: 'org.test', name: 'maven', version: '1.0'
+    conf("org.test:maven:1.0")
 }
 configurations.conf.resolutionStrategy.force('org.test:ivy:1.2')
 """
@@ -283,7 +283,7 @@ configurations.conf.resolutionStrategy.force('org.test:ivy:1.2')
 
         buildFile << """
 dependencies {
-    conf group: 'org.test', name: 'maven', version: '1.0'
+    conf("org.test:maven:1.0")
 }
 """
         expect:
@@ -315,7 +315,7 @@ dependencies {
 
         buildFile << """
 dependencies {
-    conf group: 'org.test', name: 'm4', version: '1.0'
+    conf("org.test:m4:1.0")
 }
 """
         expect:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/AbstractDependencyMetadataRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/AbstractDependencyMetadataRulesIntegrationTest.groovy
@@ -67,7 +67,9 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
         } else {
             buildFile << """
                 dependencies {
-                    $variantToTest group: 'org.test', name: 'moduleA', version: '1.0', configuration: '$variantToTest'
+                    $variantToTest("org.test:moduleA:1.0") {
+                        targetConfiguration = "$variantToTest"
+                    }
                 }
             """
         }
@@ -193,14 +195,14 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
         "dependencies"           | _
     }
 
-    def "#thing can be added and configured using #notation notation"() {
+    def "#thing can be added and configured"() {
         when:
         buildFile << """
             class ModifyRule implements ComponentMetadataRule {
                 void execute(ComponentMetadataContext context) {
                     context.details.withVariant("$variantToTest") {
                         with${toCamelCase(thing)} {
-                            add($declaration) {
+                            add('org.test:moduleB:1.0') {
                                 it.version { strictly '1.0' }
                             }
                         }
@@ -245,11 +247,7 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
         }
 
         where:
-        thing                    | notation | declaration
-        "dependency constraints" | "string" | "'org.test:moduleB:1.0'"
-        "dependency constraints" | "map"    | "group: 'org.test', name: 'moduleB', version: '1.0'"
-        "dependencies"           | "string" | "'org.test:moduleB:1.0'"
-        "dependencies"           | "map"    | "group: 'org.test', name: 'moduleB', version: '1.0'"
+        thing << ["dependency constraints", "dependencies"]
     }
 
     def "dependencies can be removed"() {
@@ -794,7 +792,11 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
             configurations { anotherConfiguration { attributes { attribute(Attribute.of('format', String), 'custom') } } }
 
             dependencies {
-                anotherConfiguration group: 'org.test', name: 'moduleA', version: '1.0' ${publishedModulesHaveAttributes || useMaven() ? "" : ", configuration: '$variantToTest'"}
+                anotherConfiguration("org.test:moduleA:1.0") {
+                    if (${!publishedModulesHaveAttributes && !useMaven()}) {
+                        targetConfiguration = "$variantToTest"
+                    }
+                }
             }
 
             dependencies {
@@ -847,7 +849,11 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
             }
 
             dependencies {
-                $variantToTest group: 'org.test', name: 'moduleB', version: '1.1' ${publishedModulesHaveAttributes || useMaven() ? "" : ", configuration: '$variantToTest'"}
+                $variantToTest("org.test:moduleB:1.1") {
+                    if (${!publishedModulesHaveAttributes && !useMaven()}) {
+                        targetConfiguration = "$variantToTest"
+                    }
+                }
 
                 components {
                     withModule('org.test:moduleA', ModifyRule)
@@ -912,7 +918,11 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
             }
 
             dependencies {
-                $variantToTest group: 'org.test', name: 'moduleB', version: '1.1' ${publishedModulesHaveAttributes || useMaven() ? "" : ", configuration: '$variantToTest'"}
+                $variantToTest("org.test:moduleB:1.1") {
+                    if (${!publishedModulesHaveAttributes && !useMaven()}) {
+                        targetConfiguration = "$variantToTest"
+                    }
+                }
 
                 components {
                     withModule('org.test:moduleA', ModifyRule)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
@@ -55,7 +55,11 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
         if (useIvy()) {
             buildFile << """
                 dependencies {
-                    $variantToTest group: 'org.test', name: 'moduleA', version: '1.0' ${publishedModulesHaveAttributes ? "" : ", configuration: '$variantToTest'"}
+                    $variantToTest("org.test:moduleA:1.0") {
+                        if (${!publishedModulesHaveAttributes}) {
+                            targetConfiguration = "$variantToTest"
+                        }
+                    }
                 }
             """
         } else {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
@@ -291,10 +291,6 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
     }
 
     def "file can be added to existing variant"() {
-        def dependencyDeclaration = (useMaven() || gradleMetadataPublished)
-            ? "'org.test:moduleA:1.0'" // variant matching
-            : "group: 'org.test', name: 'moduleA', version: '1.0', configuration: 'runtime'" // explicit configuration selection for pure ivy
-
         given:
         repository {
             'org.test:moduleA:1.0' {
@@ -307,7 +303,11 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         when:
         buildFile << """
             dependencies {
-                conf $dependencyDeclaration
+                conf("org.test:moduleA:1.0") {
+                    if (${!useMaven() && !gradleMetadataPublished}) {
+                        targetConfiguration = "runtime" // explicit configuration selection for pure ivy
+                    }
+                }
                 components {
                     withModule('org.test:moduleA', MissingFileRule) { params('-extraFeature', 'jar', '') }
                 }
@@ -396,10 +396,6 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
     }
 
     def "cannot add file with the same name multiple times"() {
-        def dependencyDeclaration = (useMaven() || gradleMetadataPublished)
-            ? "'org.test:moduleA:1.0'" // variant matching
-            : "group: 'org.test', name: 'moduleA', version: '1.0', configuration: 'runtime'" // explicit configuration selection for pure ivy
-
         given:
         repository {
             'org.test:moduleA:1.0' {
@@ -410,7 +406,11 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         when:
         buildFile << """
             dependencies {
-                conf $dependencyDeclaration
+                conf("org.test:moduleA:1.0") {
+                    if (${!useMaven() && !gradleMetadataPublished}) {
+                        targetConfiguration = "runtime" // explicit configuration selection for pure ivy
+                    }
+                }
                 components {
                     withModule('org.test:moduleA', MissingFileRule) { params('-extraFeature', 'jar', '') }
                     withModule('org.test:moduleA', MissingFileRule) { params('-extraFeature', 'jar', "../somewhere/some.jar") }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -1367,8 +1367,8 @@ group:projectB:2.2;release
           }
 
           dependencies {
-              conf group: "group", name: "projectA", version: "1.+"
-              conf group: "group", name: "projectB", version: "latest.release"
+              conf("group:projectA:1.+")
+              conf("group:projectB:latest.release")
           }
           """
     }

--- a/platforms/software/dependency-management/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/canHaveConfigurationHierarchy/build.gradle
+++ b/platforms/software/dependency-management/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/canHaveConfigurationHierarchy/build.gradle
@@ -9,9 +9,13 @@ dependencies {
             ivyPattern(projectDir.absolutePath + '/[module]-[revision]-ivy.xml')
         }
     }
-    compile group: 'test', name: 'projectA', version: '1.2', configuration: 'api'
-    runtime group: 'test', name: 'projectA', version: '1.2'
-    runtime group: 'test', name: 'projectB', version: '1.5', configuration: 'extraRuntime'
+    compile("test:projectA:1.2") {
+        targetConfiguration = "api"
+    }
+    runtime("test:projectA:1.2")
+    runtime("test:projectB:1.5") {
+        targetConfiguration = "extraRuntime"
+    }
 }
 
 file("projectA-1.2.jar").text = ''

--- a/platforms/software/dependency-management/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/canUseDynamicVersions/build.gradle
+++ b/platforms/software/dependency-management/src/integTest/resources/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest/canUseDynamicVersions/build.gradle
@@ -8,7 +8,7 @@ dependencies {
             ivyPattern(projectDir.absolutePath + '/[module]-[revision]-ivy.xml')
         }
     }
-    compile group: 'test', name: 'projectA', version: '1.+'
+    compile("test:projectA:1.+")
 }
 
 file("projectA-1.2.jar").text = ''

--- a/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishVersionRangeIntegTest.groovy
+++ b/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishVersionRangeIntegTest.groovy
@@ -90,8 +90,7 @@ class IvyPublishVersionRangeIntegTest extends AbstractIvyPublishIntegTest {
             }
 
             dependencies {
-                api "group:projectA"
-                api group:"group", name:"projectB", version:null
+                api("group:projectA")
             }
         """
 
@@ -100,7 +99,7 @@ class IvyPublishVersionRangeIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         ivyModule.assertPublishedAsJavaModule()
-        ivyModule.parsedIvy.assertDependsOn("group:projectA:", "group:projectB:")
+        ivyModule.parsedIvy.assertDependsOn("group:projectA:")
     }
 
 }

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
@@ -73,7 +73,7 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
     }
 
     @Issue("GRADLE-3233")
-    def "publishes POM dependency with #versionType version for Gradle dependency with null version"() {
+    def "publishes POM dependency with empty version for Gradle"() {
         given:
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
@@ -91,7 +91,7 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
             }
 
             dependencies {
-                api $dependencyNotation
+                api 'group:projectA'
                 api 'group:projectB:1.0'
             }
 
@@ -117,11 +117,6 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         dependency.groupId == "group"
         dependency.artifactId == "projectA"
         dependency.version == ""
-
-        where:
-        versionType | dependencyNotation
-        "empty"     | "'group:projectA'"
-        "null"      | "group:'group', name:'projectA', version:null"
     }
 
     void "defaultDependencies are included in published pom file"() {

--- a/platforms/software/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/ivy/IvySftpRepoDynamicRevisionIntegrationTest.groovy
+++ b/platforms/software/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/ivy/IvySftpRepoDynamicRevisionIntegrationTest.groovy
@@ -36,8 +36,8 @@ class IvySftpRepoDynamicRevisionIntegrationTest extends AbstractSftpDependencyRe
             configurations { compile }
 
             dependencies {
-                compile group: "group", name: "projectA", version: "1.+"
-                compile group: "group", name: "projectB", version: "latest.integration"
+                compile("group:projectA:1.+")
+                compile("group:projectB:latest.integration")
             }
 
             configurations.all {

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -767,7 +767,9 @@ compileClasspath - Compile classpath for source set 'main'.
 
             project(":impl") {
                 dependencies {
-                    compile group: 'org.utils', name: 'api', version: '1.3', configuration: 'compile'
+                    compile("org.utils:api:1.3") {
+                        targetConfiguration = "compile"
+                    }
                 }
 
                 configurations.compile.resolutionStrategy.dependencySubstitution {
@@ -808,7 +810,7 @@ compile
 
             project(":impl") {
                 dependencies {
-                    compile group: 'org.utils', name: 'api', version: '1.3'
+                    compile("org.utils:api:1.3")
                 }
 
                 configurations.compile.resolutionStrategy.eachDependency {
@@ -852,8 +854,8 @@ compile
 
             project(":impl") {
                 dependencies {
-                    compile group: 'org.utils', name: 'api', version: '1.3'
-                    compile group: 'org.original', name: 'original', version: '1.0'
+                    compile("org.utils:api:1.3")
+                    compile("org.original:original:1.0")
                 }
 
                 configurations.compile.resolutionStrategy.dependencySubstitution {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyArtifactsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyArtifactsIntegrationTest.groovy
@@ -245,7 +245,9 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         given:
         buildA.buildFile << """
             dependencies {
-                implementation group: 'org.test', name: 'buildB', version: '1.0', configuration: 'other'
+                implementation("org.test:buildB:1.0") {
+                    targetConfiguration = "other"
+                }
             }
 """
 
@@ -303,8 +305,8 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         given:
         buildA.buildFile << """
             dependencies {
-                implementation group: 'org.test', name: 'buildB', version: '1.0', classifier: 'my'
-                implementation(group: 'org.test', name: 'buildB', version: '1.0') {
+                implementation("org.test:buildB:1.0:my")
+                implementation("org.test:buildB:1.0") {
                     artifact {
                         name = 'another'
                         type = 'jar'
@@ -338,8 +340,10 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         given:
         buildA.buildFile << """
             dependencies {
-                implementation group: 'org.test', name: 'buildB', version: '1.0'
-                implementation group: 'org.test', name: 'buildB', version: '1.0', configuration: 'other'
+                implementation("org.test:buildB:1.0")
+                implementation("org.test:buildB:1.0") {
+                    targetConfiguration = "other"
+                }
             }
 """
 
@@ -423,8 +427,8 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
         given:
         buildA.buildFile << """
             dependencies {
-                implementation group: 'org.test', name: 'buildB', version: '1.0'
-                implementation group: 'org.test', name: 'buildC', version: '1.0'
+                implementation("org.test:buildB:1.0")
+                implementation("org.test:buildC:1.0")
             }
 """
 
@@ -432,7 +436,9 @@ class CompositeBuildDependencyArtifactsIntegrationTest extends AbstractComposite
             buildFile << """
                 apply plugin: 'java'
                 dependencies {
-                    implementation group: 'org.test', name: 'buildB', version: '1.0', configuration: 'other'
+                    implementation("org.test:buildB:1.0") {
+                        targetConfiguration = "other"
+                    }
                 }
 """
         }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -129,7 +129,9 @@ import java.util.Map;
  * dependencies {
  *   // Configuring dependency to specific configuration of the module
  *   // This notation should _only_ be used for Ivy dependencies
- *   implementation(group: "org.someOrg", name: "someModule", version: "1.0", configuration: "someConf")
+ *   implementation("org.someOrg:someModule:1.0") {
+ *       targetConfiguration = "someConf"
+ *   }
  *
  *   // Configuring dependency on 'someLib' module
  *   implementation(group: 'org.myorg', name: 'someLib', version:'1.0') {
@@ -161,17 +163,11 @@ import java.util.Map;
  *
  * <h3>External dependencies</h3>
  *
- * <p>There are two notations supported for declaring a dependency on an external module.
- * One is a string notation formatted this way:</p>
+ * <p>The following notation is used to declare a dependency on an external module:</p>
  *
- * <code><i>configurationName</i> "<i>group</i>:<i>name</i>:<i>version</i>:<i>classifier</i>@<i>extension</i>"</code>
+ * <code><i>configurationName</i>("<i>group</i>:<i>name</i>:<i>version</i>:<i>classifier</i>@<i>extension</i>")</code>
  *
- * <p>The other is a map notation:</p>
- *
- * <code><i>configurationName</i> group: <i>group</i>, name: <i>name</i>, version: <i>version</i>, classifier:
- * <i>classifier</i>, ext: <i>extension</i></code>
- *
- * <p>In both notations, all properties, except name, are optional.</p>
+ * <p>All properties, except name, are optional.</p>
  *
  * <p>External dependencies are represented by a {@link
  * org.gradle.api.artifacts.ExternalModuleDependency}.</p>

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -59,7 +59,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         buildFile << '''
             buildscript {
                 repositories { flatDir { dirs 'repo' }}
-                dependencies { classpath name: 'test', version: '1.3-BUILD-SNAPSHOT' }
+                dependencies { classpath ':test:1.3-BUILD-SNAPSHOT' }
             }
 
             task hello {
@@ -105,7 +105,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
     def "build script classloader copies only non-cached jar files to cache"() {
         given:
         createBuildFileThatPrintsClasspathURLs("""
-            classpath name: 'test', version: '1.3-BUILD-SNAPSHOT'
+            classpath(":test:1.3-BUILD-SNAPSHOT")
             classpath 'commons-io:commons-io:1.4@jar'
         """)
         ArtifactBuilder builder = artifactBuilder()
@@ -185,7 +185,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         buildFile << '''
             buildscript {
                 repositories { flatDir { dirs 'repo' }}
-                dependencies { classpath name: 'test', version: '1.3-BUILD-SNAPSHOT' }
+                dependencies { classpath ':test:1.3-BUILD-SNAPSHOT' }
             }
 
             task hello {
@@ -240,7 +240,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
 
         when:
         createBuildFileThatPrintsClasspathURLs("""
-            classpath name: 'a', version: '1'
+            classpath(":a:1")
         """)
         succeeds("showBuildscript")
 
@@ -263,7 +263,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
 
         when:
         createBuildFileThatPrintsClasspathURLs("""
-            classpath name: 'a', version: '1'
+            classpath(":a:1")
         """)
         succeeds("showBuildscript")
 

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/BuildScriptClasspathIntegrationTest.java
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/BuildScriptClasspathIntegrationTest.java
@@ -43,7 +43,7 @@ public class BuildScriptClasspathIntegrationTest extends AbstractIntegrationTest
 
         testFile("buildSrc/build.gradle").writelns(
                 "repositories { flatDir { dirs '../repo' } }",
-                "dependencies { implementation name: 'test', version: '1.3' }");
+                "dependencies { implementation(':test:1.3') }");
         testFile("buildSrc/src/main/java/BuildClass.java").writelns("public class BuildClass extends org.gradle.test.DepClass { }");
         testFile("build.gradle").writelns("new BuildClass()");
         inTestDirectory().withTasks("help").run();
@@ -113,7 +113,7 @@ public class BuildScriptClasspathIntegrationTest extends AbstractIntegrationTest
                 "    flatDir { dirs 'repo' }",
                 "  }",
                 "  dependencies {",
-                "    classpath name: 'test', version: '1.+'",
+                "    classpath(':test:1.+')",
                 "  }",
                 "}",
                 "task hello {",
@@ -188,7 +188,7 @@ public class BuildScriptClasspathIntegrationTest extends AbstractIntegrationTest
         testFile("build.gradle").writelns(
                 "buildscript {",
                 "    repositories { flatDir { dirs 'repo' }}",
-                "    dependencies { classpath name: 'test', version: '1.3' }",
+                "    dependencies { classpath(':test:1.3') }",
                 "}"
         );
         testFile("child/build.gradle").writelns(

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
@@ -38,12 +38,12 @@ class GradleVersionsPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         """
         file("sub1/build.gradle") << """
             dependencies {
-                implementation group: 'log4j', name: 'log4j', version: '1.2.14'
+                implementation("log4j:log4j:1.2.14")
             }
         """
         file("sub2/build.gradle") << """
             dependencies {
-                implementation group: 'junit', name: 'junit', version: '4.10'
+                implementation("junit:junit:4.10")
             }
         """
         settingsFile << """

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
@@ -49,7 +49,7 @@ class GrettySmokeTest extends AbstractPluginValidatingSmokeTest {
             ${mavenCentralRepository()}
 
             dependencies {
-                implementation group: 'log4j', name: 'log4j', version: '1.2.15', ext: 'jar'
+                implementation("log4j:log4j:1.2.15@jar")
             }
 
             gretty {

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringDependencyManagementPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringDependencyManagementPluginSmokeTest.groovy
@@ -33,7 +33,7 @@ class SpringDependencyManagementPluginSmokeTest extends AbstractPluginValidating
             dependencyManagement {
                 dependencies {
                     dependency 'org.springframework:spring-core:4.0.3.RELEASE'
-                    dependency group: 'commons-logging', name: 'commons-logging', version: '1.1.2'
+                    dependency("commons-logging:commons-logging:1.1.2")
                 }
             }
 


### PR DESCRIPTION
We plan to deprecate this notation. We update most tests that use it, and some documentation, and migrate them to the string notation.

This may miss a few of these instances, but the goal here is to convert most usages to reduce noise from the deprecation PR

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
