### PR TITLE
Deprecate dependency map notation

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
@@ -42,6 +42,7 @@ import org.gradle.kotlin.dsl.support.uncheckedCast
  *
  * @see [DependencyHandler.create]
  */
+@Deprecated("Use string notation instead")
 fun DependencyHandler.create(
     group: String,
     name: String,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -104,6 +104,7 @@ private constructor(
      *
      * @see [DependencyHandler.add]
      */
+    @Deprecated("Use string notation instead")
     operator fun String.invoke(
         group: String,
         name: String,
@@ -129,6 +130,7 @@ private constructor(
      * @see [DependencyHandler.create]
      * @see [DependencyHandler.add]
      */
+    @Deprecated("Use string notation instead")
     inline operator fun String.invoke(
         group: String,
         name: String,
@@ -238,6 +240,7 @@ private constructor(
      *
      * @see [DependencyHandler.add]
      */
+    @Deprecated("Use string notation instead")
     operator fun Configuration.invoke(
         group: String,
         name: String,
@@ -263,6 +266,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
+    @Deprecated("Use string notation instead")
     operator fun NamedDomainObjectProvider<Configuration>.invoke(
         group: String,
         name: String,
@@ -289,6 +293,7 @@ private constructor(
      */
     @Incubating
     @JvmName("invokeDependencyScope")
+    @Deprecated("Use string notation instead")
     operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(
         group: String,
         name: String,
@@ -314,6 +319,7 @@ private constructor(
      * @see [DependencyHandler.create]
      * @see [DependencyHandler.add]
      */
+    @Deprecated("Use string notation instead")
     inline operator fun Configuration.invoke(
         group: String,
         name: String,
@@ -342,6 +348,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
+    @Deprecated("Use string notation instead")
     inline operator fun NamedDomainObjectProvider<Configuration>.invoke(
         group: String,
         name: String,
@@ -372,6 +379,7 @@ private constructor(
      */
     @Incubating
     @JvmName("invokeDependencyScope")
+    @Deprecated("Use string notation instead")
     inline operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(
         group: String,
         name: String,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
@@ -123,6 +123,7 @@ open class ScriptHandlerScope(
      *
      * @see [DependencyHandler.add]
      */
+    @Deprecated("Use string notation instead")
     fun DependencyHandler.classpath(
         group: String,
         name: String,
@@ -149,6 +150,7 @@ open class ScriptHandlerScope(
      * @see [DependencyHandler.create]
      * @see [DependencyHandler.add]
      */
+    @Deprecated("Use string notation instead")
     inline fun DependencyHandler.classpath(
         group: String,
         name: String,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -411,7 +411,8 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                      *
                      * @see [DependencyHandler.create]
                      * @see [DependencyHandler.add]
-                     */$deprecationBlock
+                     */
+                    @Deprecated("Use string notation instead")
                     fun DependencyHandler.`$kotlinIdentifier`(
                         group: String,
                         name: String,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
@@ -73,6 +73,7 @@ fun addConfiguredDependencyTo(
 
 
 @Suppress("LongParameterList")
+@Deprecated("Use string notation instead")
 fun addExternalModuleDependencyTo(
     dependencyHandler: DependencyHandler,
     targetConfiguration: String,
@@ -96,7 +97,7 @@ fun addExternalModuleDependencyTo(
     dependencyHandler.add(targetConfiguration, it)
 }
 
-
+@Deprecated("Use string notation instead")
 fun externalModuleDependencyFor(
     dependencyHandler: DependencyHandler,
     group: String,

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_dependencies_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/declaring-dependencies/declaring_dependencies_basics.adoc
@@ -42,6 +42,8 @@ Gradle also supports the Map notation, where each coordinate may be declared sep
 include::sample[dir="snippets/artifacts/externalDependencies/kotlin",files="build.gradle.kts[tags=module-dependencies-map]"]
 include::sample[dir="snippets/artifacts/externalDependencies/groovy",files="build.gradle[tags=module-dependencies-map]"]
 
+NOTE: The map notation for module dependencies has been deprecated and will not be supported starting in Gradle 10.0.0. Use the string notation instead.
+
 Module dependencies use the link:{javadocPath}/org/gradle/api/artifacts/ExternalModuleDependency.html[`ExternalModuleDependency`] and link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyHandler.html[`DependencyHandler`] APIs.
 These APIs provide various properties and configuration methods for defining dependencies.
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMapNotationConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMapNotationConverter.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.notations;
 
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ModuleFactoryHelper;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.MapKey;
@@ -43,7 +44,13 @@ public class DependencyMapNotationConverter<T> extends MapNotationConverter<T> {
                          @MapKey("version") @Nullable String version,
                          @MapKey("configuration") @Nullable String configuration,
                          @MapKey("ext") @Nullable String ext,
-                         @MapKey("classifier") @Nullable String classifier) {
+                         @MapKey("classifier") @Nullable String classifier
+    ) {
+        DeprecationLogger.deprecateBehaviour("Declaring dependencies using map notation")
+            .willBecomeAnErrorInGradle9()
+            .withUpgradeGuideSection(9, "dependency_map_notation")
+            .nagUser();
+
         T dependency;
         if (configuration == null) {
             dependency = instantiator.newInstance(resultingType, group, name, version);


### PR DESCRIPTION
TODO: Add upgrade guide section

In order to avoid the notion that Gradle always has more than one way to do things, we have decided to deprecate the map notation for dependencies. It is the more verbose compared to the string notation and is arguably less discoverable as it relies on map entries.

TODO: Add tests verifying deprecation status

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
