### PR TITLE
Mention develocity during failures

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/reporting_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/reporting_problems.adoc
@@ -87,7 +87,7 @@ Execution failed for task ':sample-project:myFailingTask'.
 
 * Try:
 > Remove the Problems.throwing() method call from the task action
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 
 BUILD FAILED in 0ms
 ----

--- a/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
+++ b/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
@@ -24,6 +24,7 @@ import org.gradle.exemplar.test.runner.SamplesOutputNormalizers;
 import org.gradle.integtests.fixtures.executer.DependencyReplacingSampleModifier;
 import org.gradle.integtests.fixtures.executer.MoreMemorySampleModifier;
 import org.gradle.integtests.fixtures.logging.ArtifactResolutionOmittingOutputNormalizer;
+import org.gradle.integtests.fixtures.logging.BuildScanRecommendationOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.ConfigurationCacheOutputCleaner;
 import org.gradle.integtests.fixtures.logging.ConfigurationCacheOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.DependencyInsightOutputNormalizer;
@@ -54,7 +55,8 @@ import org.gradle.integtests.fixtures.mirror.SetMirrorsSampleModifier;
     PlatformInOutputNormalizer.class,
     SpringBootWebAppTestOutputNormalizer.class,
     EmptyLineTrimmerOutputNormalizer.class,
-    RepositoryMirrorOutputNormalizer.class
+    RepositoryMirrorOutputNormalizer.class,
+    BuildScanRecommendationOutputNormalizer.class
 })
 @SampleModifiers({
     SetMirrorsSampleModifier.class,

--- a/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-avoid/tests/useTheGradlePropertiesFile-avoid.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-avoid/tests/useTheGradlePropertiesFile-avoid.out
@@ -13,5 +13,5 @@ Execution failed for task ':first'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.

--- a/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-do/tests/useTheGradlePropertiesFile-do.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-do/tests/useTheGradlePropertiesFile-do.out
@@ -13,5 +13,5 @@ Execution failed for task ':first'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.

--- a/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-groovy/taskExecutionEvents.groovy.out
+++ b/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-groovy/taskExecutionEvents.groovy.out
@@ -15,7 +15,7 @@ Execution failed for task ':broken'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-kotlin/taskExecutionEvents.kotlin.out
+++ b/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-kotlin/taskExecutionEvents.kotlin.out
@@ -12,7 +12,7 @@ Execution failed for task ':broken'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/configurationCache/problemsGroovy/tests/fail.out
+++ b/platforms/documentation/docs/src/snippets/configurationCache/problemsGroovy/tests/fail.out
@@ -11,7 +11,7 @@ See the complete report at file:///home/user/gradle/samples/build/reports/config
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/configurationCache/problemsKotlin/tests/fail.out
+++ b/platforms/documentation/docs/src/snippets/configurationCache/problemsKotlin/tests/fail.out
@@ -11,7 +11,7 @@ See the complete report at file:///home/user/gradle/samples/build/reports/config
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.out
+++ b/platforms/documentation/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.out
@@ -24,4 +24,4 @@ Execution failed for task ':compileJava'.
 
 * Try:
 > Check your code and dependencies to fix the compilation error(s)
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).

--- a/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/completeCUnitExample.out
+++ b/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/completeCUnitExample.out
@@ -12,7 +12,7 @@ Execution failed for task ':runOperatorsTestFailingCUnitExe'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-groovy/taskFinalizersWithFailureGroovy.out
+++ b/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-groovy/taskFinalizersWithFailureGroovy.out
@@ -13,7 +13,7 @@ Execution failed for task ':taskX'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-kotlin/taskFinalizersWithFailureKotlin.out
+++ b/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-kotlin/taskFinalizersWithFailureKotlin.out
@@ -10,7 +10,7 @@ Execution failed for task ':taskX'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -417,7 +417,7 @@ public class BuildExceptionReporter implements Action<Throwable> {
     }
 
     private void addBuildScanMessage(ContextImpl context) {
-        context.appendResolution(output -> runWithOption(output, LONG_OPTION, " to get full insights."));
+        context.appendResolution(output -> runWithOption(output, LONG_OPTION, " to generate a Build Scan® (Powered by Develocity®)."));
     }
 
     private boolean isGradleEnterprisePluginApplied() {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -36,6 +36,7 @@ import org.gradle.internal.logging.text.BufferingStyledTextOutput;
 import org.gradle.internal.logging.text.LinePrefixingStyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.problems.failure.Failure;
 import org.gradle.internal.problems.failure.FailureFactory;
 import org.gradle.problems.internal.rendering.ProblemRenderer;
@@ -417,7 +418,14 @@ public class BuildExceptionReporter implements Action<Throwable> {
     }
 
     private void addBuildScanMessage(ContextImpl context) {
-        context.appendResolution(output -> runWithOption(output, LONG_OPTION, " to generate a Build Scan® (Powered by Develocity®)."));
+        String message;
+        if (OperatingSystem.current().isWindows()) {
+            // The default windows code page do not support the registered trademark symbol, so we use the text version.
+            message = " to generate a Build Scan (Powered by Develocity). Build Scan and Develocity are registered trademarks of Gradle, Inc.";
+        } else {
+            message = " to generate a Build Scan® (Powered by Develocity®).";
+        }
+        context.appendResolution(output -> runWithOption(output, LONG_OPTION, message));
     }
 
     private boolean isGradleEnterprisePluginApplied() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -55,7 +55,7 @@ class BuildExceptionReporterTest extends Specification {
     static final String LOCATION = "<location>"
     static final String STACKTRACE = "{info}> {normal}Run with {userinput}--stacktrace{normal} option to get the stack trace."
     static final String INFO_OR_DEBUG = "{info}> {normal}Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output."
-    static final String TRY_SCAN = "{info}> {normal}Run with {userinput}--scan{normal} to get full insights."
+    static final String TRY_SCAN = "{info}> {normal}Run with {userinput}--scan{normal} to generate a Build Scan® (Powered by Develocity®)."
     static final String GET_HELP = "{info}> {normal}Get more help at {userinput}https://help.gradle.org{normal}."
 
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutput
 import org.gradle.internal.problems.failure.DefaultFailureFactory
 import org.gradle.internal.problems.failure.FailureFactory
+import org.gradle.internal.os.OperatingSystem
 import spock.lang.Specification
 
 import java.lang.reflect.Field
@@ -49,15 +50,15 @@ class BuildExceptionReporterTest extends Specification {
     final FailureFactory failureFactory = DefaultFailureFactory.withDefaultClassifier()
     final BuildExceptionReporter reporter = new BuildExceptionReporter(factory, configuration, clientMetaData, gradleEnterprisePluginManager, failureFactory)
 
-
     static final String MESSAGE = "<message>"
     static final String FAILURE = '<failure>'
     static final String LOCATION = "<location>"
     static final String STACKTRACE = "{info}> {normal}Run with {userinput}--stacktrace{normal} option to get the stack trace."
     static final String INFO_OR_DEBUG = "{info}> {normal}Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output."
-    static final String TRY_SCAN = "{info}> {normal}Run with {userinput}--scan{normal} to generate a Build Scan® (Powered by Develocity®)."
+    static final String TRY_SCAN = OperatingSystem.current().isWindows()
+        ? "{info}> {normal}Run with {userinput}--scan{normal} to generate a Build Scan (Powered by Develocity). Build Scan and Develocity are registered trademarks of Gradle, Inc."
+        : "{info}> {normal}Run with {userinput}--scan{normal} to generate a Build Scan® (Powered by Develocity®)."
     static final String GET_HELP = "{info}> {normal}Get more help at {userinput}https://help.gradle.org{normal}."
-
 
     def setup() {
         factory.create(BuildExceptionReporter.class, LogLevel.ERROR) >> output

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SuggestionsMessages.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SuggestionsMessages.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.integtests.fixtures
 
+import org.gradle.internal.os.OperatingSystem
+
 /**
  * A collection of suggestions to be displayed to the user when a build fails.
  * These where repeated all over the test code, so they are now centralized here.
@@ -25,7 +27,9 @@ class SuggestionsMessages {
 
     public static final String INFO_DEBUG = "Run with --info or --debug option to get more log output."
     public static final String DEBUG = "Run with --debug option to get more log output."
-    public static final String SCAN = "Run with --scan to generate a Build Scan® (Powered by Develocity®)."
+    public static final String SCAN = OperatingSystem.current().isWindows()
+        ? "Run with --scan to generate a Build Scan (Powered by Develocity). Build Scan and Develocity are registered trademarks of Gradle, Inc."
+        : "Run with --scan to generate a Build Scan® (Powered by Develocity®)."
     public static final String GET_HELP = "Get more help at https://help.gradle.org."
     public static final String STACKTRACE_MESSAGE = "Run with --stacktrace option to get the stack trace."
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SuggestionsMessages.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SuggestionsMessages.groovy
@@ -25,7 +25,7 @@ class SuggestionsMessages {
 
     public static final String INFO_DEBUG = "Run with --info or --debug option to get more log output."
     public static final String DEBUG = "Run with --debug option to get more log output."
-    public static final String SCAN = "Run with --scan to get full insights."
+    public static final String SCAN = "Run with --scan to generate a Build Scan® (Powered by Develocity®)."
     public static final String GET_HELP = "Get more help at https://help.gradle.org."
     public static final String STACKTRACE_MESSAGE = "Run with --stacktrace option to get the stack trace."
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/BuildScanRecommendationOutputNormalizer.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/BuildScanRecommendationOutputNormalizer.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.logging
+
+import org.gradle.exemplar.executor.ExecutionMetadata
+import org.gradle.exemplar.test.normalizer.OutputNormalizer
+import org.gradle.internal.os.OperatingSystem
+
+/**
+ * Windows consoles do not support registered trademark symbols, so we output a different message for the --scan recommendation on Windows.
+ * We use this normalizer so out samples tests don't need to care about this.
+ */
+class BuildScanRecommendationOutputNormalizer implements OutputNormalizer {
+    @Override
+    String normalize(String commandOutput, ExecutionMetadata executionMetadata) {
+        if (OperatingSystem.current().isWindows()) {
+            return commandOutput.replace(
+                "> Run with --scan to generate a Build Scan (Powered by Develocity). Build Scan and Develocity are registered trademarks of Gradle, Inc.",
+                "> Run with --scan to generate a Build Scan® (Powered by Develocity®)."
+            )
+        }
+
+        return commandOutput;
+    }
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/BuildScanRecommendationOutputNormalizer.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/BuildScanRecommendationOutputNormalizer.groovy
@@ -22,7 +22,7 @@ import org.gradle.internal.os.OperatingSystem
 
 /**
  * Windows consoles do not support registered trademark symbols, so we output a different message for the --scan recommendation on Windows.
- * We use this normalizer so out samples tests don't need to care about this.
+ * We use this normalizer so our samples tests don't need to care about this.
  */
 class BuildScanRecommendationOutputNormalizer implements OutputNormalizer {
     @Override


### PR DESCRIPTION
We already recommend runing --scan during failures. In this commit, we additionally mention Build Scans, and Develocity.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
