### PR TITLE
Remove direct JavaParser dependency

### DIFF
--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -185,7 +185,6 @@ abstract class ExternalModulesExtension(bundleGroovyMajor: Int) {
     val guice = "com.google.inject:guice"
     val httpmime = "org.apache.httpcomponents:httpmime"
     val jacksonKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin"
-    val javaParser = "com.github.javaparser:javaparser-core"
     val jetty = "org.eclipse.jetty:jetty-http"
     val jettySecurity = "org.eclipse.jetty:jetty-security"
     val jettyServer = "org.eclipse.jetty:jetty-server"

--- a/packaging/distributions-dependencies/build.gradle.kts
+++ b/packaging/distributions-dependencies/build.gradle.kts
@@ -195,7 +195,6 @@ dependencies {
         api(libs.equalsverifier)        { version { strictly("2.1.6") }}
         api(libs.guice)                 { version { strictly("5.1.0") }}
         api(libs.httpmime)              { version { strictly("4.5.10") }}
-        api(libs.javaParser)            { version { strictly("3.17.0") }}
         api(libs.jetty)                 { version { strictly(jettyVersion) }}
         api(libs.jettySecurity)         { version { strictly(jettyVersion) }}
         api(libs.jettyServer)           { version { strictly(jettyVersion) }}

--- a/platforms/jvm/language-groovy/build.gradle.kts
+++ b/platforms/jvm/language-groovy/build.gradle.kts
@@ -54,9 +54,6 @@ dependencies {
 
     integTestImplementation(testFixtures(projects.modelReflect))
     integTestImplementation(libs.commonsLang)
-    integTestImplementation(libs.javaParser) {
-        because("The Groovy docs inspects the dependencies at compile time")
-    }
     integTestImplementation(libs.nativePlatform) {
         because("Required for SystemInfo")
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DependencyHandlerApiResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DependencyHandlerApiResolveIntegrationTest.groovy
@@ -149,7 +149,7 @@ class DependencyHandlerApiResolveIntegrationTest extends AbstractIntegrationSpec
         def gradleBaseVersion = GradleVersion.current().baseVersion.version
         def groovyVersion = GroovySystem.version
         def kotlinVersion = getGradleKotlinVersion()
-        def groovyModules = ["groovy-${groovyVersion}.jar", "groovy-ant-${groovyVersion}.jar", "groovy-astbuilder-${groovyVersion}.jar", "groovy-datetime-${groovyVersion}.jar", "groovy-dateutil-${groovyVersion}.jar", "groovy-groovydoc-${groovyVersion}.jar", "groovy-json-${groovyVersion}.jar", "groovy-nio-${groovyVersion}.jar", "groovy-templates-${groovyVersion}.jar", "groovy-xml-${groovyVersion}.jar", "javaparser-core-3.17.0.jar"]
+        def groovyModules = ["groovy-${groovyVersion}.jar", "groovy-ant-${groovyVersion}.jar", "groovy-astbuilder-${groovyVersion}.jar", "groovy-datetime-${groovyVersion}.jar", "groovy-dateutil-${groovyVersion}.jar", "groovy-groovydoc-${groovyVersion}.jar", "groovy-json-${groovyVersion}.jar", "groovy-nio-${groovyVersion}.jar", "groovy-templates-${groovyVersion}.jar", "groovy-xml-${groovyVersion}.jar", "javaparser-core-3.26.3.jar"]
         def expectedGradleApiFiles = "gradle-api-${gradleVersion}.jar, ${groovyModules.join(", ")}, kotlin-stdlib-${kotlinVersion}.jar, kotlin-reflect-${kotlinVersion}.jar, gradle-installation-beacon-${gradleBaseVersion}.jar"
         def expectedGradleApiIds = { id ->
             "gradle-api-${gradleVersion}.jar ($id), ${groovyModules.collect({ it + " ($id)" }).join(", ")}, kotlin-stdlib-${kotlinVersion}.jar ($id), kotlin-reflect-${kotlinVersion}.jar ($id), gradle-installation-beacon-${gradleBaseVersion}.jar ($id)"

--- a/testing/integ-test/build.gradle.kts
+++ b/testing/integ-test/build.gradle.kts
@@ -51,9 +51,6 @@ dependencies {
     integTestImplementation(testFixtures(projects.scala))
     integTestImplementation(testFixtures(projects.platformNative))
     integTestImplementation(libs.jgit)
-    integTestImplementation(libs.javaParser) {
-        because("The Groovy compiler inspects the dependencies at compile time")
-    }
 
     integTestDistributionRuntimeOnly(projects.distributionsFull)
     crossVersionTestDistributionRuntimeOnly(projects.distributionsFull)

--- a/testing/internal-performance-testing/build.gradle.kts
+++ b/testing/internal-performance-testing/build.gradle.kts
@@ -65,10 +65,6 @@ dependencies {
     implementation(libs.mina)
     implementation(libs.slf4jApi)
 
-    compileOnly(libs.javaParser) {
-        because("The Groovy compiler inspects the dependencies at compile time")
-    }
-
     runtimeOnly(libs.jclToSlf4j)
     runtimeOnly(libs.jetty)
     runtimeOnly(libs.mySqlConnector)


### PR DESCRIPTION
Fixes #33692

We don't use this anymore, however it will still be pulled in by groovydoc which we may still need for Groovy-based Gradle plugin development. This commit simply allows the version to match whatever groovydoc requires.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
