### PR TITLE
Suppress CC promo if build starts processes at configuration time

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl.promo
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
 import org.gradle.initialization.StartParameterBuildOptions.IsolatedProjectsOption
 import org.gradle.internal.cc.impl.AbstractConfigurationCacheIntegrationTest
+import org.gradle.process.ShellScript
 
 import static org.gradle.integtests.fixtures.logging.ConfigurationCacheOutputNormalizer.PROMO_PREFIX
 
@@ -160,6 +161,41 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
 
         then:
         postBuildOutputDoesNotContain(PROMO_PREFIX)
+    }
+
+    def "shows no promo message if external process used at configuration time with #execMethod"() {
+        given:
+        def script = ShellScript.builder().printText("Hello").writeTo(testDirectory, "script")
+
+        buildFile """
+            interface Ops {
+                @Inject ExecOperations getExecOps()
+            }
+
+            def execWithExecOperations() {
+                def ops = objects.newInstance(Ops)
+                ops.execOps.exec { commandLine(${ShellScript.cmdToVarargLiterals(script.commandLine)}) }
+            }
+
+            def execWithGroovyApi() {
+                [${ShellScript.cmdToVarargLiterals(script.commandLine)}].execute().waitForProcessOutput(System.out, System.err)
+            }
+
+            $execMethod()
+
+            tasks.register("greet") {}
+        """
+
+        executer.noDeprecationChecks()
+
+        when:
+        run("greet")
+
+        then:
+        postBuildOutputDoesNotContain(PROMO_PREFIX)
+
+        where:
+        execMethod << ["execWithExecOperations", "execWithGroovyApi"]
     }
 
     def "shows promo message if configuration-only calls are used correctly"() {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheInputsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheInputsListener.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.internal.configuration.inputs.InstrumentedInputsListener
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
+
+@ServiceScope(Scope.BuildTree::class)
+internal interface ConfigurationCacheInputsListener : InstrumentedInputsListener

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
@@ -66,7 +66,6 @@ class ConfigurationCacheServices : AbstractGradleModuleServices() {
             add(DeprecatedFeaturesListener::class.java)
             add(InputTrackingState::class.java)
             add(InstrumentedExecutionAccessListener::class.java)
-            add(ConfigurationCacheInputsListener::class.java, InstrumentedInputAccessListener::class.java)
             addProvider(IgnoredConfigurationInputsProvider)
             addProvider(RemoteScriptUpToDateCheckerProvider)
             addProvider(ExecutionAccessCheckerProvider)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
@@ -66,7 +66,7 @@ class ConfigurationCacheServices : AbstractGradleModuleServices() {
             add(DeprecatedFeaturesListener::class.java)
             add(InputTrackingState::class.java)
             add(InstrumentedExecutionAccessListener::class.java)
-            add(InstrumentedInputAccessListener::class.java)
+            add(ConfigurationCacheInputsListener::class.java, InstrumentedInputAccessListener::class.java)
             addProvider(IgnoredConfigurationInputsProvider)
             addProvider(RemoteScriptUpToDateCheckerProvider)
             addProvider(ExecutionAccessCheckerProvider)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -53,6 +53,7 @@ import org.gradle.internal.cc.impl.initialization.VintageInjectedClasspathInstru
 import org.gradle.internal.cc.impl.models.DefaultToolingModelParameterCarrierFactory
 import org.gradle.internal.cc.impl.problems.ConfigurationCacheProblems
 import org.gradle.internal.cc.impl.promo.ConfigurationCachePromoHandler
+import org.gradle.internal.cc.impl.promo.PromoInputsListener
 import org.gradle.internal.cc.impl.services.ConfigurationCacheBuildTreeModelSideEffectExecutor
 import org.gradle.internal.cc.impl.services.DefaultBuildModelParameters
 import org.gradle.internal.cc.impl.services.DefaultDeferredRootBuildGradle
@@ -266,6 +267,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
             registration.addProvider(ConfigurationCacheBuildTreeProvider())
             registration.add(ConfigurationCacheBuildTreeModelSideEffectExecutor::class.java)
             registration.add(DefaultDeferredRootBuildGradle::class.java)
+            registration.add(ConfigurationCacheInputsListener::class.java, InstrumentedInputAccessListener::class.java)
         } else {
             registration.add(InjectedClasspathInstrumentationStrategy::class.java, VintageInjectedClasspathInstrumentationStrategy::class.java)
             registration.add(BuildTreeLifecycleControllerFactory::class.java, BarrierAwareBuildTreeLifecycleControllerFactory::class.java)
@@ -274,6 +276,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
             registration.add(ProjectScopedScriptResolution::class.java, ProjectScopedScriptResolution.NO_OP)
             registration.addProvider(VintageBuildTreeProvider())
             registration.add(BuildTreeModelSideEffectExecutor::class.java, DefaultBuildTreeModelSideEffectExecutor::class.java)
+            registration.add(ConfigurationCacheInputsListener::class.java, PromoInputsListener::class.java)
         }
         if (modelParameters.isIntermediateModelCache) {
             registration.addProvider(ConfigurationCacheModelProvider())

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -41,6 +41,8 @@ import org.gradle.internal.buildtree.RunTasksRequirements
 import org.gradle.internal.cc.base.logger
 import org.gradle.internal.cc.base.problems.IgnoringProblemsListener
 import org.gradle.internal.cc.base.services.ConfigurationCacheEnvironmentChangeTracker
+import org.gradle.internal.cc.impl.barrier.BarrierAwareBuildTreeLifecycleControllerFactory
+import org.gradle.internal.cc.impl.barrier.VintageConfigurationTimeActionRunner
 import org.gradle.internal.cc.impl.fingerprint.ConfigurationCacheFingerprintController
 import org.gradle.internal.cc.impl.initialization.ConfigurationCacheInjectedClasspathInstrumentationStrategy
 import org.gradle.internal.cc.impl.initialization.ConfigurationCacheProblemsListener
@@ -266,7 +268,8 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
             registration.add(DefaultDeferredRootBuildGradle::class.java)
         } else {
             registration.add(InjectedClasspathInstrumentationStrategy::class.java, VintageInjectedClasspathInstrumentationStrategy::class.java)
-            registration.add(BuildTreeLifecycleControllerFactory::class.java, VintageBuildTreeLifecycleControllerFactory::class.java)
+            registration.add(BuildTreeLifecycleControllerFactory::class.java, BarrierAwareBuildTreeLifecycleControllerFactory::class.java)
+            registration.add(VintageConfigurationTimeActionRunner::class.java)
             registration.add(EnvironmentChangeTracker::class.java, VintageEnvironmentChangeTracker::class.java)
             registration.add(ProjectScopedScriptResolution::class.java, ProjectScopedScriptResolution.NO_OP)
             registration.addProvider(VintageBuildTreeProvider())

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -82,7 +82,7 @@ class DefaultConfigurationCache internal constructor(
     private val problems: ConfigurationCacheProblems,
     private val scopeRegistryListener: ConfigurationCacheClassLoaderScopeRegistryListener,
     private val cacheRepository: ConfigurationCacheRepository,
-    private val instrumentedInputAccessListener: InstrumentedInputAccessListener,
+    private val inputsAccessListener: ConfigurationCacheInputsListener,
     private val configurationTimeBarrier: ConfigurationTimeBarrier,
     private val buildActionModelRequirements: BuildActionModelRequirements,
     private val buildStateRegistry: BuildStateRegistry,
@@ -559,7 +559,7 @@ class DefaultConfigurationCache internal constructor(
     fun prepareForWork() {
         prepareConfigurationTimeBarrier()
         startCollectingCacheFingerprint()
-        InstrumentedInputs.setListener(instrumentedInputAccessListener)
+        InstrumentedInputs.setListener(inputsAccessListener)
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/InstrumentedInputAccessListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/InstrumentedInputAccessListener.kt
@@ -16,9 +16,8 @@
 
 package org.gradle.internal.cc.impl
 
-import org.gradle.internal.cc.impl.initialization.ConfigurationCacheProblemsListener
 import org.gradle.internal.cc.base.services.ConfigurationCacheEnvironmentChangeTracker
-import org.gradle.internal.configuration.inputs.InstrumentedInputsListener
+import org.gradle.internal.cc.impl.initialization.ConfigurationCacheProblemsListener
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
@@ -69,7 +68,7 @@ class InstrumentedInputAccessListener(
     configurationCacheProblemsListener: ConfigurationCacheProblemsListener,
     private val environmentChangeTracker: ConfigurationCacheEnvironmentChangeTracker,
     private val ignoredConfigurationInputs: IgnoredConfigurationInputs
-) : InstrumentedInputsListener {
+) : ConfigurationCacheInputsListener {
 
     private
     val undeclaredInputBroadcast = listenerManager.getBroadcaster(UndeclaredBuildInputListener::class.java)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/BarrierAwareBuildTreeLifecycleControllerFactory.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/BarrierAwareBuildTreeLifecycleControllerFactory.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.barrier
+
+import org.gradle.StartParameter
+import org.gradle.composite.internal.BuildTreeWorkGraphController
+import org.gradle.internal.build.BuildLifecycleController
+import org.gradle.internal.build.BuildStateRegistry
+import org.gradle.internal.buildtree.BuildModelParameters
+import org.gradle.internal.buildtree.BuildTreeFinishExecutor
+import org.gradle.internal.buildtree.BuildTreeLifecycleController
+import org.gradle.internal.buildtree.BuildTreeWorkExecutor
+import org.gradle.internal.cc.impl.VintageBuildTreeLifecycleControllerFactory
+import org.gradle.internal.model.StateTransitionControllerFactory
+import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.BuildOperationRunner
+import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
+
+/**
+ * An extension of [VintageBuildTreeLifecycleControllerFactory] that adds configuration time barrier management to vintage mode.
+ */
+internal class BarrierAwareBuildTreeLifecycleControllerFactory(
+    private val runner: VintageConfigurationTimeActionRunner,
+    buildModelParameters: BuildModelParameters,
+    taskGraph: BuildTreeWorkGraphController,
+    buildOperationExecutor: BuildOperationExecutor,
+    stateTransitionControllerFactory: StateTransitionControllerFactory,
+    startParameter: StartParameter,
+    parameterCarrierFactory: ToolingModelParameterCarrier.Factory,
+    buildStateRegistry: BuildStateRegistry,
+    buildOperationRunner: BuildOperationRunner
+) : VintageBuildTreeLifecycleControllerFactory(
+    buildModelParameters,
+    taskGraph,
+    buildOperationExecutor,
+    stateTransitionControllerFactory,
+    startParameter,
+    parameterCarrierFactory,
+    buildStateRegistry,
+    buildOperationRunner
+) {
+    override fun createRootBuildController(
+        targetBuild: BuildLifecycleController,
+        workExecutor: BuildTreeWorkExecutor,
+        finishExecutor: BuildTreeFinishExecutor
+    ): BuildTreeLifecycleController {
+        return createControllerImpl(
+            BarrierAwareBuildTreeWorkPreparer(runner, createWorkPreparer(targetBuild)),
+            BarrierAwareBuildTreeModelCreator(runner, createModelCreator(targetBuild)),
+            targetBuild,
+            workExecutor,
+            finishExecutor
+        )
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/BarrierAwareBuildTreeModelCreator.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/BarrierAwareBuildTreeModelCreator.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.cc.impl.barrier
+
+import org.gradle.internal.buildtree.BuildTreeModelAction
+import org.gradle.internal.buildtree.BuildTreeModelCreator
+
+/**
+ * Prepares models while managing the configuration time barrier in the vintage mode.
+ */
+internal class BarrierAwareBuildTreeModelCreator(
+    private val runner: VintageConfigurationTimeActionRunner,
+    private val delegate: BuildTreeModelCreator
+) : BuildTreeModelCreator {
+    override fun <T : Any> beforeTasks(action: BuildTreeModelAction<out T>) {
+        runner.runConfigurationTimeAction {
+            delegate.beforeTasks(action)
+        }
+    }
+
+    override fun <T : Any> fromBuildModel(action: BuildTreeModelAction<out T>): T? {
+        return runner.runConfigurationTimeAction {
+            delegate.fromBuildModel(action)
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/BarrierAwareBuildTreeWorkPreparer.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/BarrierAwareBuildTreeWorkPreparer.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.cc.impl.barrier
+
+import org.gradle.execution.EntryTaskSelector
+import org.gradle.internal.buildtree.BuildTreeWorkGraph
+import org.gradle.internal.buildtree.BuildTreeWorkPreparer
+
+/**
+ * Builds task graph while managing the configuration time barrier in the vintage mode.
+ */
+internal class BarrierAwareBuildTreeWorkPreparer(
+    private val runner: VintageConfigurationTimeActionRunner,
+    private val delegate: BuildTreeWorkPreparer
+) : BuildTreeWorkPreparer {
+    override fun scheduleRequestedTasks(
+        graph: BuildTreeWorkGraph,
+        selector: EntryTaskSelector?
+    ): BuildTreeWorkGraph.FinalizedGraph {
+        return runner.runConfigurationTimeAction {
+            delegate.scheduleRequestedTasks(graph, selector)
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/VintageConfigurationTimeActionRunner.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/VintageConfigurationTimeActionRunner.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.barrier
+
+import org.gradle.api.internal.provider.ConfigurationTimeBarrier
+import org.gradle.api.internal.provider.DefaultConfigurationTimeBarrier
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
+
+/**
+ * Runs parts of the vintage build with the expected state of the [ConfigurationTimeBarrier] and other auxiliary CC-related machinery.
+ *
+ * This class is not intended to be used with CC enabled.
+ */
+@ServiceScope(Scope.BuildTree::class)
+internal class VintageConfigurationTimeActionRunner(
+    configurationTimeBarrier: ConfigurationTimeBarrier
+) {
+    private val configurationTimeBarrier = configurationTimeBarrier as DefaultConfigurationTimeBarrier
+
+    fun <T> runConfigurationTimeAction(action: () -> T): T {
+        configurationTimeBarrier.prepare()
+        try {
+            return action()
+        } finally {
+            configurationTimeBarrier.cross()
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/VintageConfigurationTimeActionRunner.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/VintageConfigurationTimeActionRunner.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.barrier
 
+import org.gradle.api.configuration.BuildFeatures
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier
 import org.gradle.api.internal.provider.DefaultConfigurationTimeBarrier
 import org.gradle.internal.cc.impl.ConfigurationCacheInputsListener
@@ -30,11 +31,16 @@ import org.gradle.internal.service.scopes.ServiceScope
  */
 @ServiceScope(Scope.BuildTree::class)
 internal class VintageConfigurationTimeActionRunner(
+    buildFeatures: BuildFeatures,
     configurationTimeBarrier: ConfigurationTimeBarrier,
     private val inputsListener: ConfigurationCacheInputsListener
 ) {
     private val configurationTimeBarrier = configurationTimeBarrier as DefaultConfigurationTimeBarrier
-
+    init {
+        require(!buildFeatures.configurationCache.active.get()) {
+            "This class should not be used with the configuration cache enabled."
+        }
+    }
     fun <T> runConfigurationTimeAction(action: () -> T): T {
         configurationTimeBarrier.prepare()
         InstrumentedInputs.setListener(inputsListener)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/package-info.md
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/barrier/package-info.md
@@ -1,0 +1,7 @@
+# Package org.gradle.internal.cc.impl.barrier
+
+This package provides support of integrating `ConfigurationTimeBarrier` functionality into Vintage (non-CC) mode.
+The barrier management here should not be used with CC enabled, because it may interfere with CC's own 
+management routines.
+
+Ideally, this all should move away as we fold the vintage mode into CC more and more.

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/PromoInputsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/PromoInputsListener.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.promo
+
+import org.gradle.api.internal.ExternalProcessStartedListener
+import org.gradle.internal.cc.impl.ConfigurationCacheInputsListener
+import org.gradle.internal.cc.impl.Workarounds
+import org.gradle.internal.cc.impl.initialization.ConfigurationCacheProblemsListener
+import java.io.File
+
+/**
+ * This class is used to intercept instrumented calls when configuration cache is not enabled.
+ * It is a lightweight alternative to the InstrumentedInputAccessListener because only the functionality used by the Promo controller is supported.
+ */
+internal class PromoInputsListener(
+    configurationCacheProblemsListener: ConfigurationCacheProblemsListener,
+) : ConfigurationCacheInputsListener {
+    // TODO(mlopatkin): fold it into InstrumentedInputAccessListener if its overhead is reduced?
+    private val externalProcessListener: ExternalProcessStartedListener = configurationCacheProblemsListener
+
+    override fun systemPropertyQueried(key: String, value: Any?, consumer: String) = Unit
+
+    override fun systemPropertyChanged(key: Any, value: Any?, consumer: String) = Unit
+
+    override fun systemPropertyRemoved(key: Any, consumer: String) = Unit
+
+    override fun systemPropertiesCleared(consumer: String) = Unit
+
+    override fun envVariableQueried(key: String, value: String?, consumer: String) = Unit
+
+    override fun externalProcessStarted(command: String, consumer: String) {
+        if (Workarounds.canStartExternalProcesses(consumer)) {
+            return
+        }
+        externalProcessListener.onExternalProcessStarted(command, consumer)
+    }
+
+    override fun fileOpened(file: File, consumer: String) = Unit
+
+    override fun fileObserved(file: File, consumer: String) = Unit
+
+    override fun fileSystemEntryObserved(file: File, consumer: String) = Unit
+
+    override fun directoryContentObserved(file: File, consumer: String) = Unit
+}


### PR DESCRIPTION
This PR adds the proper ConfigurationTimeBarrier management and bytecode interception to Vintage mode.

Part of #33526.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
