### PR TITLE
CC Graceful Degradation

### DIFF
--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/problems/AbstractProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/problems/AbstractProblemsListener.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.base.problems
 
+import org.gradle.api.Task
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyTrace
 
@@ -23,4 +24,6 @@ import org.gradle.internal.configuration.problems.PropertyTrace
 abstract class AbstractProblemsListener : ProblemsListener {
 
     override fun forIncompatibleTask(trace: PropertyTrace, reason: String): ProblemsListener = this
+
+    override fun forTask(task: Task): ProblemsListener = this
 }

--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/problems/IgnoringProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/problems/IgnoringProblemsListener.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.base.problems
 
+import org.gradle.api.Task
 import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyProblem
 import org.gradle.internal.configuration.problems.PropertyTrace
@@ -33,6 +34,8 @@ object IgnoringProblemsListener : ProblemsListener {
     override fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) = Unit
 
     override fun forIncompatibleTask(trace: PropertyTrace, reason: String): ProblemsListener = this
+
+    override fun forTask(task: Task): ProblemsListener = this
 
     override fun onExecutionTimeProblem(problem: PropertyProblem) = Unit
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
@@ -353,6 +353,26 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         assertConfigurationCacheDegradation()
     }
 
+    def "degradation controller is available in vintage"() {
+        given:
+        buildFile """
+            ${taskWithInjectedDegradationController()}
+
+            tasks.register("foo", DegradingTask) { task ->
+                getDegradationController().requireConfigurationCacheDegradation(task, provider { "Because reasons" })
+                doLast {
+                    println("Hello")
+                }
+            }
+        """
+
+        when:
+        succeeds(":foo")
+
+        then:
+        outputContains("Hello")
+    }
+
     private static String taskWithInjectedDegradationController() {
         """
             abstract class DegradingTask extends DefaultTask {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
@@ -381,7 +381,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         result.assertTaskExecuted(":foo")
     }
 
-    def "CC report link is present even not problems were reported"() {
+    def "CC report link is present even when no problems were reported"() {
         given:
         def configurationCache = newConfigurationCacheFixture()
         buildFile """

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
@@ -86,10 +86,14 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         }
 
         where:
-        args                                                          | expectedOutputs                                               | expectedProblems                                                                                                | degradationReason
-        ["-DaccessTaskProject=true"]                                  | ["Task's project accessed!"]                                  | ["Build file 'build.gradle': line 10: invocation of 'Task.project' at execution time is unsupported."]          | "Project access."
-        ["-DaccessTaskProject=true", "-DaccessTaskDependencies=true"] | ["Task's project accessed!", "Task's dependencies accessed!"] | ["Build file 'build.gradle': line 10: invocation of 'Task.project' at execution time is unsupported.",
-                                                                                                                                         "Build file 'build.gradle': line 14: invocation of 'Task.taskDependencies' at execution time is unsupported."] | "Project access, TaskDependencies access."
+        expectedProblems                                                                                                | _
+        ["Build file 'build.gradle': line 10: invocation of 'Task.project' at execution time is unsupported."]          | _
+        ["Build file 'build.gradle': line 10: invocation of 'Task.project' at execution time is unsupported.",
+         "Build file 'build.gradle': line 14: invocation of 'Task.taskDependencies' at execution time is unsupported."] | _
+        __
+        args                                                          | expectedOutputs                                               | degradationReason
+        ["-DaccessTaskProject=true"]                                  | ["Task's project accessed!"]                                  | "Project access."
+        ["-DaccessTaskProject=true", "-DaccessTaskDependencies=true"] | ["Task's project accessed!", "Task's dependencies accessed!"] | "Project access, TaskDependencies access."
     }
 
     def "CC problems in incompatible tasks are not hidden by CC degradation"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
@@ -276,7 +276,8 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         outputContains("Hello from B")
     }
 
-    def "cannot require CC degradation at execution time"() {
+    def "ignore CC degradation requests at execution time"() {
+        def configurationCache = newConfigurationCacheFixture()
         buildFile """
             ${taskWithInjectedDegradationController()}
             tasks.register("foo", DegradingTask) { task ->
@@ -288,10 +289,13 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         """
 
         when:
-        configurationCacheFails ":foo"
+        configurationCacheRun ":foo", "-d"
 
         then:
-        failureCauseContains("Configuration cache degradation requests are accepted only at configuration time")
+        configurationCache.assertStateStored()
+
+        and:
+        outputContains("Configuration cache degradation request of task :foo is ignored at execution time")
     }
 
     def "tasks instantiated during execution have degradation requests ignored"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.cc.impl
 
 import org.gradle.api.internal.ConfigurationCacheDegradationController
+import org.junit.Ignore
 
 import javax.inject.Inject
 
@@ -96,6 +97,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         ["-DaccessTaskProject=true", "-DaccessTaskDependencies=true"] | ["Task's project accessed!", "Task's dependencies accessed!"] | "Project access, TaskDependencies access."
     }
 
+    @Ignore("CC problems became interrupting failures in 9.0")
     def "CC problems in incompatible tasks are not hidden by CC degradation"() {
         def configurationCache = newConfigurationCacheFixture()
         buildFile """

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
@@ -383,6 +383,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
     }
 
     private void assertConfigurationCacheDegradation() {
-        postBuildOutputContains("Configuration caching disabled because incompatible task")
+        postBuildOutputContains("Configuration cache disabled because incompatible task")
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.api.internal.ConfigurationCacheDegradationController
+
+import javax.inject.Inject
+
+class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def "a task can require CC degradation"() {
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile """
+            ${taskWithInjectedDegradationController()}
+            tasks.register("a", DegradingTask) { task ->
+               getDegradationController().requireConfigurationCacheDegradation(task, provider { "Project access" })
+               doLast {
+                   println("Project path is \${project.path}")
+               }
+            }
+        """
+
+        when:
+        configurationCacheRun "a"
+
+        then:
+        configurationCache.assertNoConfigurationCache()
+        problems.assertResultHtmlReportHasProblems(result) {
+            totalProblemsCount = 1
+            withProblem("Build file 'build.gradle': line 5: invocation of 'Task.project' at execution time is unsupported.")
+            withIncompatibleTask(":a", "Project access.")
+        }
+
+        and:
+        outputContains("Project path is :")
+        assertConfigurationCacheDegradation("task `:a` of type `DegradingTask`")
+    }
+
+    def "a task can require CC degradation for multiple reasons"() {
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile """
+            ${taskWithInjectedDegradationController()}
+            tasks.register("a", DegradingTask) { task ->
+                def shouldAccessTaskProjectProvider = providers.systemProperty("accessTaskProject").map { Boolean.parseBoolean(it) }.orElse(false)
+                def shouldAccessTaskDependenciesProvider = providers.systemProperty("accessTaskDependencies").map { Boolean.parseBoolean(it) }.orElse(false)
+
+                getDegradationController().requireConfigurationCacheDegradation(task, shouldAccessTaskProjectProvider.map { it ? "Project access" : null })
+                getDegradationController().requireConfigurationCacheDegradation(task, shouldAccessTaskDependenciesProvider.map { it ? "TaskDependencies access" : null })
+
+                doLast {
+                    if (shouldAccessTaskProjectProvider.get()) {
+                        it.project
+                        println "Task's project accessed!"
+                    }
+                    if (shouldAccessTaskDependenciesProvider.get()) {
+                        it.taskDependencies
+                        println "Task's dependencies accessed!"
+                    }
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun("a", *args)
+
+        then:
+        configurationCache.assertNoConfigurationCache()
+        problems.assertResultHtmlReportHasProblems(result) {
+            totalProblemsCount = expectedProblems.size()
+            expectedProblems.forEach { withProblem(it) }
+            withIncompatibleTask(":a", degradationReason)
+        }
+
+        where:
+        args                                                          | expectedOutputs                                               | expectedProblems                                                                                                | degradationReason
+        ["-DaccessTaskProject=true"]                                  | ["Task's project accessed!"]                                  | ["Build file 'build.gradle': line 10: invocation of 'Task.project' at execution time is unsupported."]          | "Project access."
+        ["-DaccessTaskProject=true", "-DaccessTaskDependencies=true"] | ["Task's project accessed!", "Task's dependencies accessed!"] | ["Build file 'build.gradle': line 10: invocation of 'Task.project' at execution time is unsupported.",
+                                                                                                                                         "Build file 'build.gradle': line 14: invocation of 'Task.taskDependencies' at execution time is unsupported."] | "Project access, TaskDependencies access."
+    }
+
+    def "CC problems in incompatible tasks are not hidden by CC degradation"() {
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile """
+            ${taskWithInjectedDegradationController()}
+            tasks.register("foo", DegradingTask) { task ->
+                getDegradationController().requireConfigurationCacheDegradation(task, provider { "Project access" })
+                doLast {
+                    println "Hello from foo \${project.path}"
+                }
+            }
+
+            tasks.register("bar") {
+                doLast {
+                    println "Hello from bar \${project.path}"
+                }
+            }
+        """
+
+        when:
+        configurationCacheFails "foo", "bar"
+
+        then:
+        configurationCache.assertNoConfigurationCache()
+        problems.assertFailureHtmlReportHasProblems(failure) {
+            totalProblemsCount = 2
+            withProblem("Build file 'build.gradle': line 11: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("Build file 'build.gradle': line 5: invocation of 'Task.project' at execution time is unsupported.")
+            withIncompatibleTask(":foo", "Project access.")
+        }
+    }
+
+    def "a task in included build can require CC degradation"() {
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("included/build.gradle", """
+            ${taskWithInjectedDegradationController()}
+            tasks.register("foo", DegradingTask) { task ->
+                getDegradationController().requireConfigurationCacheDegradation(task, provider { "Project access" })
+                doLast {
+                    println "Hello from included build \${project.path}"
+                }
+            }
+        """)
+        settingsFile """
+            includeBuild("included")
+        """
+
+        when:
+        configurationCacheRun ":included:foo"
+
+        then:
+        configurationCache.assertNoConfigurationCache()
+        problems.assertResultHtmlReportHasProblems(result) {
+            totalProblemsCount = 1
+            withProblem("Build file 'included/build.gradle': line 5: invocation of 'Task.project' at execution time is unsupported.")
+            withIncompatibleTask(":included:foo", "Project access.")
+        }
+
+        and:
+        outputContains("Hello from included build :")
+        assertConfigurationCacheDegradation("task `:included:foo` of type `DegradingTask`")
+    }
+
+    def "a buildSrc internal task that requires CC degradation does not introduce root build CC degradation"() {
+        def configurationCache = newConfigurationCacheFixture()
+        file("buildSrc/src/main/java/MyClass.java") << "class MyClass {}"
+        buildFile("buildSrc/build.gradle", """
+            ${taskWithInjectedDegradationController()}
+            def fooTask = tasks.register("foo", DegradingTask) { task ->
+                getDegradationController().requireConfigurationCacheDegradation(task, provider { "Project access" })
+                doLast {
+                    println "Hello from foo \${project.path}"
+                }
+            }
+            tasks.withType(JavaCompile).configureEach {
+                dependsOn(fooTask)
+            }
+        """)
+
+        when:
+        configurationCacheRun "help"
+
+        then:
+        configurationCache.assertStateStored()
+
+        and:
+        result.assertTaskExecuted(":buildSrc:compileJava")
+        result.assertTaskExecuted(":buildSrc:foo")
+        result.assertTaskExecuted(":help")
+    }
+
+    def "depending on a CC degrading task from included build introduces CC degradation"() {
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("included/build.gradle", """
+            ${taskWithInjectedDegradationController()}
+            tasks.register("foo", DegradingTask) { task ->
+                getDegradationController().requireConfigurationCacheDegradation(task, provider { "Project access" })
+                doLast {
+                    println "Hello from included build \${project.path}"
+                }
+            }
+        """)
+        settingsFile """
+            includeBuild("included")
+        """
+        buildFile """
+            tasks.register("bar") {
+                dependsOn gradle.includedBuild("included").task(":foo")
+                doLast {
+                    println "Hello from root build"
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun "bar"
+
+        then:
+        configurationCache.assertNoConfigurationCache()
+        problems.assertResultHtmlReportHasProblems(result) {
+            totalProblemsCount = 1
+            withProblem("Build file 'included/build.gradle': line 5: invocation of 'Task.project' at execution time is unsupported.")
+            withIncompatibleTask(":included:foo", "Project access.")
+        }
+
+        and:
+        outputContains("Hello from included build :")
+        outputContains("Hello from root build")
+        assertConfigurationCacheDegradation("task `:included:foo` of type `DegradingTask`")
+    }
+
+    def "no CC degradation if incompatible task is not presented in the task graph"() {
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile """
+            ${taskWithInjectedDegradationController()}
+            tasks.register("a", DegradingTask) { task ->
+                getDegradationController().requireConfigurationCacheDegradation(task, provider { "Project access" })
+                doLast {
+                    println("Project path is \${project.path}")
+                }
+            }
+
+            tasks.register("b") {
+                doLast {
+                    println "Hello from B"
+                }
+            }
+
+            tasks.all {
+                println "\$it configured"
+            }
+        """
+
+        when:
+        configurationCacheRun "b"
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("task ':a' configured")
+        outputContains("task ':b' configured")
+        outputContains("Hello from B")
+    }
+
+    def "cannot require CC degradation at execution time"() {
+        buildFile """
+            ${taskWithInjectedDegradationController()}
+            tasks.register("foo", DegradingTask) { task ->
+                def reason = provider { "Misconfiguration!" }
+                doLast {
+                    getDegradationController().requireConfigurationCacheDegradation(task, reason)
+                }
+            }
+        """
+
+        when:
+        configurationCacheFails ":foo"
+
+        then:
+        failureCauseContains("Expected state of CC degradation to be in state CollectingDegradationRequests but is in state DegradationDecisionMade.")
+    }
+
+    private static String taskWithInjectedDegradationController() {
+        """
+            abstract class DegradingTask extends DefaultTask {
+                @${Inject.name}
+                abstract ${ConfigurationCacheDegradationController.name} getDegradationController()
+            }
+        """
+    }
+
+    private assertConfigurationCacheDegradation(String... tasks) {
+        postBuildOutputContains("Configuration caching disabled because degradation was requested.")
+        tasks.each { task ->
+            postBuildOutputContains("\t- $task")
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
@@ -66,7 +66,6 @@ class ConfigurationCacheServices : AbstractGradleModuleServices() {
             add(DeprecatedFeaturesListener::class.java)
             add(InputTrackingState::class.java)
             add(InstrumentedExecutionAccessListener::class.java)
-            add(InstrumentedInputAccessListener::class.java)
             add(DefaultConfigurationCacheDegradationController::class.java)
             addProvider(IgnoredConfigurationInputsProvider)
             addProvider(RemoteScriptUpToDateCheckerProvider)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
@@ -66,6 +66,8 @@ class ConfigurationCacheServices : AbstractGradleModuleServices() {
             add(DeprecatedFeaturesListener::class.java)
             add(InputTrackingState::class.java)
             add(InstrumentedExecutionAccessListener::class.java)
+            add(InstrumentedInputAccessListener::class.java)
+            add(DefaultConfigurationCacheDegradationController::class.java)
             addProvider(IgnoredConfigurationInputsProvider)
             addProvider(RemoteScriptUpToDateCheckerProvider)
             addProvider(ExecutionAccessCheckerProvider)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -242,6 +242,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
 
         // This was originally only for the configuration cache, but now used for configuration cache and problems reporting
         registration.add(ProblemFactory::class.java, DefaultProblemFactory::class.java)
+        registration.add(DefaultDeferredRootBuildGradle::class.java)
 
         registration.add(ConfigurationCacheProblemsListener::class.java, DefaultConfigurationCacheProblemsListener::class.java)
         // Set up CC problem reporting pipeline and promo, based on the build configuration
@@ -266,7 +267,6 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
             registration.add(ConfigurationCacheFingerprintController::class.java)
             registration.addProvider(ConfigurationCacheBuildTreeProvider())
             registration.add(ConfigurationCacheBuildTreeModelSideEffectExecutor::class.java)
-            registration.add(DefaultDeferredRootBuildGradle::class.java)
             registration.add(ConfigurationCacheInputsListener::class.java, InstrumentedInputAccessListener::class.java)
         } else {
             registration.add(InjectedClasspathInstrumentationStrategy::class.java, VintageInjectedClasspathInstrumentationStrategy::class.java)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -610,7 +610,6 @@ class DefaultConfigurationCache internal constructor(
             }
             WorkGraphStoreResult(stateStoreResult.accessedFiles, stateStoreResult.value)
         }
-
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -239,7 +239,8 @@ class DefaultConfigurationCache internal constructor(
         } else {
             runWorkThatContributesToCacheEntry {
                 val finalizedGraph = scheduler(graph)
-                saveWorkGraph()
+                degradeGracefullyOr { saveWorkGraph() }
+                crossConfigurationTimeBarrier()
                 BuildTreeConfigurationCache.WorkGraphResult(
                     finalizedGraph,
                     wasLoadedFromCache = false,
@@ -270,8 +271,17 @@ class DefaultConfigurationCache internal constructor(
 
         return runWorkThatContributesToCacheEntry {
             val model = creator()
+            // Graceful degradation. We don't care about the models saving at the moment since it's happening
+            // only when Isolated Projects enabled. That's it, there is no model saving in CC + noIP mode.
             saveModel(model)
             model
+        }
+    }
+
+    private
+    fun degradeGracefullyOr(action: () -> Unit) {
+        if (!problems.shouldDegradeGracefully()) {
+            action()
         }
     }
 
@@ -601,7 +611,6 @@ class DefaultConfigurationCache internal constructor(
             WorkGraphStoreResult(stateStoreResult.accessedFiles, stateStoreResult.value)
         }
 
-        crossConfigurationTimeBarrier()
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
@@ -53,7 +53,7 @@ internal class DefaultConfigurationCacheDegradationController(
             deferredRootBuildGradle.gradle.taskGraph.visitScheduledNodes { scheduledNodes, _ ->
                 scheduledNodes.filterIsInstance<TaskNode>().map { it.task }.forEach { task ->
                     val taskDegradationReasons = tasksDegradationRequests[task]
-                        ?.mapNotNull { it.orNull }
+                        ?.mapNotNull { evaluateDegradationReason(it) }
                         ?.sorted()
 
                     if (!taskDegradationReasons.isNullOrEmpty()) {
@@ -63,5 +63,12 @@ internal class DefaultConfigurationCacheDegradationController(
             }
         }
         return result
+    }
+
+    // Request is represented by the user code, which can throw. We evaluate such requests to valid degradation reasons.
+    private fun evaluateDegradationReason(request: Provider<String>): String? = try {
+        request.orNull
+    } catch (e: Exception) {
+        e.message ?: e::class.qualifiedName
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.api.Task
+import org.gradle.api.internal.ConfigurationCacheDegradationController
+import org.gradle.api.provider.Provider
+import org.gradle.execution.plan.TaskNode
+import org.gradle.internal.Describables
+import org.gradle.internal.cc.impl.services.DeferredRootBuildGradle
+import org.gradle.internal.model.StateTransitionController
+import org.gradle.internal.model.StateTransitionControllerFactory
+import org.gradle.internal.service.scopes.Scope.BuildTree
+import org.gradle.internal.service.scopes.ServiceScope
+import java.util.function.Supplier
+
+@ServiceScope(BuildTree::class)
+internal class DefaultConfigurationCacheDegradationController(
+    private val deferredRootBuildGradle: DeferredRootBuildGradle,
+    stateTransitionControllerFactory: StateTransitionControllerFactory
+) : ConfigurationCacheDegradationController {
+
+    private val stateTransitionController = stateTransitionControllerFactory.newController(
+        Describables.of("state of CC degradation"),
+        State.CollectingDegradationRequests
+    )
+
+    private enum class State : StateTransitionController.State {
+        CollectingDegradationRequests,
+        DegradationDecisionMade
+    }
+
+    private val tasksDegradationRequests = HashMap<Task, List<Provider<String>>>()
+    val degradationReasons by lazy(::collectDegradationReasons)
+
+    override fun requireConfigurationCacheDegradation(task: Task, reason: Provider<String>) {
+        stateTransitionController.inState(State.CollectingDegradationRequests) {
+            tasksDegradationRequests.compute(task) { _, reasons -> reasons?.plus(reason) ?: listOf(reason) }
+        }
+    }
+
+    private fun collectDegradationReasons(): Map<Task, List<String>> =
+        stateTransitionController.transition(State.CollectingDegradationRequests, State.DegradationDecisionMade, Supplier {
+            val result = mutableMapOf<Task, List<String>>()
+            if (tasksDegradationRequests.isNotEmpty()) {
+                deferredRootBuildGradle.gradle.taskGraph.visitScheduledNodes { scheduledNodes, _ ->
+                    scheduledNodes.filterIsInstance<TaskNode>().map { it.task }.forEach { task ->
+                        val taskDegradationReasons = tasksDegradationRequests[task]
+                            ?.mapNotNull { it.orNull }
+                            ?.sorted()
+
+                        if (!taskDegradationReasons.isNullOrEmpty()) {
+                            result[task] = taskDegradationReasons
+                        }
+                    }
+                }
+            }
+            result
+        })
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.cc.impl
 
-import com.google.common.collect.ImmutableMap
 import org.gradle.api.Task
 import org.gradle.api.internal.ConfigurationCacheDegradationController
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier
@@ -26,6 +25,7 @@ import org.gradle.execution.plan.TaskNode
 import org.gradle.internal.cc.impl.services.DeferredRootBuildGradle
 import org.gradle.internal.service.scopes.Scope.BuildTree
 import org.gradle.internal.service.scopes.ServiceScope
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 
 @ServiceScope(BuildTree::class)
@@ -39,7 +39,7 @@ internal class DefaultConfigurationCacheDegradationController(
     private val collectedDegradationReasons = mutableMapOf<Task, List<String>>()
 
     val degradationReasons: Map<Task, List<String>>
-        get() = ImmutableMap.copyOf(collectedDegradationReasons)
+        get() = Collections.unmodifiableMap(collectedDegradationReasons)
 
     override fun requireConfigurationCacheDegradation(task: Task, reason: Provider<String>) {
         if (!configurationTimeBarrier.isAtConfigurationTime) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -146,9 +146,12 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     fun locationForTask(task: TaskInternal) = PropertyTrace.Task(GeneratedSubclasses.unpackType(task), task.identityPath.path)
 
     private
-    fun problemsListenerFor(task: TaskInternal): ProblemsListener = when {
-        task.isCompatibleWithConfigurationCache -> problems
-        else -> problems.forIncompatibleTask(locationForTask(task), task.reasonTaskIsIncompatibleWithConfigurationCache.get())
+    fun problemsListenerFor(task: TaskInternal): ProblemsListener {
+        val trace = locationForTask(task)
+        return when {
+            !task.isCompatibleWithConfigurationCache -> problems.forIncompatibleTask(trace, task.reasonTaskIsIncompatibleWithConfigurationCache.get())
+            else -> problems.forTask(task)
+        }
     }
 
     override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -166,7 +166,6 @@ class Summary(
     /**
      * Number of problems which shouldn't be reported in the console.
      */
-    private
     val suppressedSilentlyProblemCount: Int,
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -103,7 +103,7 @@ class ConfigurationCacheProblemsSummary(
             when (severity) {
                 ProblemSeverity.Deferred -> deferredProblemCount += 1
                 ProblemSeverity.Suppressed -> suppressedProblemCount += 1
-                ProblemSeverity.Interrupting -> {}
+                ProblemSeverity.Interrupting, ProblemSeverity.DegradationRequested -> {}
             }
             if (overflowed) {
                 return false
@@ -200,6 +200,8 @@ class Summary(
         problemCauses.entries.stream()
             .collect(Comparators.least(MAX_CONSOLE_PROBLEMS, consoleComparatorForProblemCauseWithSeverity()))
             .asSequence()
+            // we don't print degradation problems in the console
+            .filter { it.value != ProblemSeverity.DegradationRequested }
             .map { it.key }
 
     private
@@ -259,8 +261,9 @@ fun consoleComparatorForSeverity(): Comparator<ProblemSeverity> =
     Comparator.comparingInt { it: ProblemSeverity ->
         when (it) {
             ProblemSeverity.Deferred -> 1
-            ProblemSeverity.Suppressed -> 2
-            ProblemSeverity.Interrupting -> 3
+            ProblemSeverity.DegradationRequested -> 2
+            ProblemSeverity.Suppressed -> 3
+            ProblemSeverity.Interrupting -> 4
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -166,6 +166,7 @@ class Summary(
     /**
      * Number of problems which shouldn't be reported in the console.
      */
+    private
     val suppressedSilentlyProblemCount: Int,
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl.promo
 
+import org.gradle.api.Task
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.logging.Logging
 import org.gradle.initialization.RootBuildLifecycleListener
@@ -59,6 +60,8 @@ class ConfigurationCachePromoHandler(
     }
 
     override fun forIncompatibleTask(trace: PropertyTrace, reason: String): ProblemsListener = this
+
+    override fun forTask(task: Task): ProblemsListener = this
 
     override fun onExecutionTimeProblem(problem: PropertyProblem) = onProblem(problem)
 }

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummaryTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummaryTest.kt
@@ -46,7 +46,7 @@ class ConfigurationCacheProblemsSummaryTest {
             subject.onProblem(buildLogicProblem("build.gradle", "another failure"), ProblemSeverity.Deferred)
         )
         assertThat(
-            subject.get().problemCauseCount,
+            subject.get().reportableProblemCauseCount,
             equalTo(2)
         )
     }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
@@ -46,5 +46,5 @@ enum class ProblemSeverity {
     /**
      * A problem produced by a task, requested Configuration Cache[degradation][org.gradle.api.internal.ConfigurationCacheDegradationController.requireConfigurationCacheDegradation].
      */
-    DegradationRequested
+    SuppressedSilently
 }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/cc/impl/problems/ProblemSeverity.kt
@@ -42,4 +42,9 @@ enum class ProblemSeverity {
      * A problem produced by a task marked as [notCompatibleWithConfigurationCache][org.gradle.api.Task.notCompatibleWithConfigurationCache].
      */
     Suppressed,
+
+    /**
+     * A problem produced by a task, requested Configuration Cache[degradation][org.gradle.api.internal.ConfigurationCacheDegradationController.requireConfigurationCacheDegradation].
+     */
+    DegradationRequested
 }

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemsListener.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemsListener.kt
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.configuration.problems
 
+import org.gradle.api.Task
+
 
 interface ProblemsListener {
 
@@ -33,6 +35,8 @@ interface ProblemsListener {
     fun onExecutionTimeProblem(problem: PropertyProblem)
 
     fun forIncompatibleTask(trace: PropertyTrace, reason: String): ProblemsListener
+
+    fun forTask(task: Task): ProblemsListener
 }
 
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/ConfigurationCacheDegradationController.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/ConfigurationCacheDegradationController.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal;
+
+import org.gradle.api.Task;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scope.BuildTree.class)
+public interface ConfigurationCacheDegradationController {
+    /**
+     * Registers a Configuration Cache degradation request for a given {@code task}. Each task can have multiple reasons for degradation registered.
+     * <p>
+     * If the {@code task} is present in the task graph and the {@code reason} is present, then all Configuration Cache problems triggered by the task will
+     * be suppressed and Configuration Cache will be disabled, switching the build to the vintage execution mode.
+     * <p>
+     * The reasons are evaluated immediately before the serialization of the task graph and effectively prevent serialization if they are present.
+     * <p>
+     * Adding a degradation is thread-safe.
+     */
+    void requireConfigurationCacheDegradation(Task task, Provider<String> reason);
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -228,7 +228,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
     @Override
     public FinalizedExecutionPlan finalizePlan() {
         if (scheduledNodes == null) {
-            throw new IllegalStateException("Nodes have node been scheduled yet.");
+            throw new IllegalStateException("Nodes have not been scheduled yet.");
         }
         if (finalizedPlan == null) {
             dependencyResolver.clear();
@@ -288,7 +288,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
     @Override
     public ScheduledNodes getScheduledNodes() {
         if (scheduledNodes == null) {
-            throw new IllegalStateException("Nodes have node been scheduled yet.");
+            throw new IllegalStateException("Nodes have not been scheduled yet.");
         }
         for (Node node : scheduledNodes) {
             if (node instanceof TaskNode) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -181,6 +181,44 @@ final class ConfigurationCacheProblemsFixture {
         assertIncompatibleTasks(result.output, rootDir, spec)
     }
 
+    void assertFailureHtmlReportHasProblems(
+        ExecutionFailure failure,
+        @DelegatesTo(value = HasConfigurationCacheProblemsSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> specClosure
+    ) {
+        assertFailureHtmlReportHasProblems(failure, ConfigureUtil.configureUsing(specClosure))
+    }
+
+    void assertFailureHtmlReportHasProblems(
+        ExecutionFailure failure,
+        Action<HasConfigurationCacheProblemsSpec> specAction = {}
+    ) {
+        assertHtmlReportHasProblems(failure.error, newProblemsSpec(specAction))
+    }
+
+    void assertResultHtmlReportHasProblems(
+        ExecutionResult result,
+        @DelegatesTo(value = HasConfigurationCacheProblemsSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> specClosure
+    ) {
+        assertResultHtmlReportHasProblems(result, ConfigureUtil.configureUsing(specClosure))
+    }
+
+    void assertResultHtmlReportHasProblems(
+        ExecutionResult result,
+        Action<HasConfigurationCacheProblemsSpec> specAction = {}
+    ) {
+        assertHtmlReportHasProblems(result.output, newProblemsSpec(specAction))
+    }
+
+    private void assertHtmlReportHasProblems(
+        String output,
+        HasConfigurationCacheProblemsSpec spec
+    ) {
+        assertProblemsHtmlReport(output, rootDir, spec)
+        assertInputs(output, rootDir, spec)
+        assertIncompatibleTasks(output, rootDir, spec)
+    }
+
+
     HasConfigurationCacheProblemsSpec newProblemsSpec(
         @DelegatesTo(value = HasConfigurationCacheProblemsSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> specClosure
     ) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -329,7 +329,8 @@ final class ConfigurationCacheProblemsFixture {
             output,
             totalProblemCount,
             spec.uniqueProblems.size(),
-            spec.problemsWithStackTraceCount == null ? totalProblemCount : spec.problemsWithStackTraceCount
+            spec.problemsWithStackTraceCount == null ? totalProblemCount : spec.problemsWithStackTraceCount,
+            spec.incompatibleTasks instanceof ItemSpec.ExpectingSome
         )
     }
 
@@ -426,9 +427,10 @@ final class ConfigurationCacheProblemsFixture {
         String output,
         int totalProblemCount,
         int uniqueProblemCount,
-        int problemsWithStackTraceCount
+        int problemsWithStackTraceCount,
+        boolean expectIncompatibleTasks
     ) {
-        def expectReport = totalProblemCount > 0 || uniqueProblemCount > 0
+        def expectReport = totalProblemCount > 0 || uniqueProblemCount > 0 || expectIncompatibleTasks
         def reportDir = resolveConfigurationCacheReportDirectory(rootDir, output)
         if (expectReport) {
             Map<String, Object> jsModel = readJsModelFromReportDir(reportDir)

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -45,6 +45,7 @@ import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.CoreMatchers.nullValue
 import static org.hamcrest.CoreMatchers.startsWith
 import static org.hamcrest.MatcherAssert.assertThat
+import static org.junit.Assert.assertThrows
 import static org.junit.Assert.assertTrue
 
 final class ConfigurationCacheProblemsFixture {
@@ -209,6 +210,26 @@ final class ConfigurationCacheProblemsFixture {
         assertHtmlReportHasProblems(result.output, newProblemsSpec(specAction))
     }
 
+    void assertResultConsoleSummaryHasNoProblems(ExecutionResult result) {
+        assertThrows(AssertionFailedError) {
+            extractSummary(result.output)
+        }
+    }
+
+    void assertResultHasConsoleSummary(
+        ExecutionResult result,
+        @DelegatesTo(value = HasConfigurationCacheProblemsSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> specClosure
+    ) {
+        assertResultHasConsoleSummary(result, ConfigureUtil.configureUsing(specClosure))
+    }
+
+    void assertResultHasConsoleSummary(
+        ExecutionResult result,
+        Action<HasConfigurationCacheProblemsSpec> specAction = {}
+    ) {
+        assertHasConsoleSummary(result.output, newProblemsSpec(specAction))
+    }
+
     private void assertHtmlReportHasProblems(
         String output,
         HasConfigurationCacheProblemsSpec spec
@@ -217,7 +238,6 @@ final class ConfigurationCacheProblemsFixture {
         assertInputs(output, rootDir, spec)
         assertIncompatibleTasks(output, rootDir, spec)
     }
-
 
     HasConfigurationCacheProblemsSpec newProblemsSpec(
         @DelegatesTo(value = HasConfigurationCacheProblemsSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> specClosure
@@ -367,9 +387,9 @@ final class ConfigurationCacheProblemsFixture {
             }
         }
         if (!(spec instanceof ItemSpec.IgnoreUnexpected)) {
-            assert unexpectedItems.isEmpty() : "Unexpected '$kind' items $unexpectedItems found in the report, expecting $expectedItems"
+            assert unexpectedItems.isEmpty(): "Unexpected '$kind' items $unexpectedItems found in the report, expecting $expectedItems"
         }
-        assert expectedItems.isEmpty() : "Expecting $expectedItems in the report, found $unexpectedItems"
+        assert expectedItems.isEmpty(): "Expecting $expectedItems in the report, found $unexpectedItems"
     }
 
     static String formatItemForAssert(Map<String, Object> item, String kind) {
@@ -394,7 +414,7 @@ final class ConfigurationCacheProblemsFixture {
             case "Field": return trace['name']
             case "InputProperty": return trace['name']
             case "OutputProperty": return trace['name']
-            // Build file 'build.gradle'
+                // Build file 'build.gradle'
             case "BuildLogic": return trace['location'].toString().capitalize()
             case "BuildLogicClass": return trace['type']
             default: return "Gradle runtime"
@@ -529,7 +549,7 @@ ${text}
         return new ProblemsSummary(totalProblems, problems.size(), problems)
     }
 
-    @ToString(includeNames=true)
+    @ToString(includeNames = true)
     private static class ProblemsSummary {
         final int totalProblems
         final int uniqueProblems


### PR DESCRIPTION
As a part of `CC as a preferred mode of the execution`, the PR is Introducing an internal service for requiring CC graceful degradation by tasks.

`Graceful degradation` means that in presence of CC incompatible tasks, which explicitly declared its incompatibility with CC, Gradle will switch the build to the vintage execution mode instead of failing.

The `CCDegradationController` service intended to be used by Gradle core tasks and plugins which still not CC compatible and will not be before Gradle 9.0.

Implementation details:

- Task's degradation request is represented by `Provider<String>`. It gives a dynamic nature to the degradation state in favour of increasing CC hit rates. If provider's value is not present, then the task's presence shouldn't imply CC degradation
- A task can have multiple degradation requests
- Evaluation of the degradation requests is happening right before Work Graph serialization. If any of degradation requests evaluated to a degradation reason, then Work Graph serialization skipped, making the build running in vintage mode
- CC Degradation culprits are being printed in post build output, but excluded from regular problem reporting in the console
- CC Degradation culprits are being included to CC report in the `incompatibleTasks` tab