### PR TITLE
Fix enableConfigurationCacheForDocsTests property to work

### DIFF
--- a/build-logic-commons/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
+++ b/build-logic-commons/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
@@ -93,6 +93,7 @@ fun Project.buildTimestamp(): Provider<String> =
             runningOnCi = buildRunningOnCi
             runningInstallTask = provider { isRunningInstallTask() }
             runningDocsTestTask = provider { isRunningDocsTestTask() }
+            enableConfigurationCacheForDocsTests = providers.gradleProperty("enableConfigurationCacheForDocsTests").map { it.toBoolean() }
         }
     }
 

--- a/build-logic-commons/module-identity/src/main/kotlin/gradlebuild/identity/provider/BuildTimestampValueSource.kt
+++ b/build-logic-commons/module-identity/src/main/kotlin/gradlebuild/identity/provider/BuildTimestampValueSource.kt
@@ -36,6 +36,9 @@ abstract class BuildTimestampValueSource : ValueSource<String, BuildTimestampVal
         @get:Optional
         val buildTimestampFromGradleProperty: Property<String>
 
+        @get:Optional
+        val enableConfigurationCacheForDocsTests: Property<Boolean>
+
         val runningOnCi: Property<Boolean>
 
         val runningInstallTask: Property<Boolean>
@@ -43,6 +46,14 @@ abstract class BuildTimestampValueSource : ValueSource<String, BuildTimestampVal
     }
 
     override fun obtain(): String? = parameters.run {
+        if (enableConfigurationCacheForDocsTests.getOrElse(false)) {
+            // If the CC is enabled for docs tests, use a static dummy timestamp (the Epoch) so that we get hits,
+            // otherwise we'll use the current timestamp by default and miss
+            val formatter = SimpleDateFormat("yyyyMMddHHmmssZ").apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
+            return formatter.format(Date(0L))
+        }
 
         val buildTimestampFromReceipt = buildTimestampFromBuildReceipt.orNull
         if (buildTimestampFromReceipt != null) {


### PR DESCRIPTION
When configuration cache is enabled for documentation tests via the enableConfigurationCacheForDocsTests property, supplies a static dummy timestamp (the Epoch) for the buildTimestamp

This ensures configuration cache hits during documentation tests, improving performance.  otherwise the buildTimestamp would use the current timestamp, which changes, causing a miss.

After this change you can add `-PenableConfigurationCacheForDocsTests=true` to the command line or add `enableConfigurationCacheForDocsTests=true` to your `gradle.properties` and have a much better testing experience when iterating on snippets/samples.  