### PR TITLE
Polish `WorkExecutionTracker`

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -264,7 +264,7 @@ class ConfigurationCacheFingerprintWriter(
     fun isInputTrackingDisabled() = !inputTrackingState.isEnabledForCurrentThread()
 
     private
-    fun isExecutingWork() = workExecutionTracker.currentTask.isPresent || workExecutionTracker.isExecutingTransformAction
+    fun isExecutingWork() = workExecutionTracker.isExecutingTaskOrTransformAction
 
     override fun fileObserved(file: File) {
         fileObserved(file, null)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -192,5 +192,5 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     fun isInputTrackingDisabled() = !inputTrackingState.isEnabledForCurrentThread()
 
     private
-    fun isExecutingWork() = workExecutionTracker.currentTask.isPresent || workExecutionTracker.isExecutingTransformAction
+    fun isExecutingWork() = workExecutionTracker.isExecutingTaskOrTransformAction
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultWorkExecutionTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultWorkExecutionTracker.java
@@ -81,6 +81,14 @@ public class DefaultWorkExecutionTracker implements WorkExecutionTracker, Closea
     }
 
     @Override
+    public boolean isExecutingTaskOrTransformAction() {
+        return buildOperationAncestryTracker.findClosestMatchingAncestor(
+            currentBuildOperationRef.getId(),
+            operationListener::containsWork
+        ).isPresent();
+    }
+
+    @Override
     public void close() throws IOException {
         buildOperationListenerManager.removeListener(operationListener);
         assert !operationListener.hasRunningWork();
@@ -136,6 +144,10 @@ public class DefaultWorkExecutionTracker implements WorkExecutionTracker, Closea
 
         private static boolean isTransformAction(BuildOperationDescriptor buildOperation) {
             return UncategorizedBuildOperations.TRANSFORM_ACTION.equals(buildOperation.getMetadata());
+        }
+
+        public boolean containsWork(OperationIdentifier o) {
+            return runningTasks.containsKey(o) || runningTransformActions.contains(o);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultWorkExecutionTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultWorkExecutionTracker.java
@@ -29,8 +29,8 @@ import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.internal.operations.OperationProgressEvent;
 import org.gradle.internal.operations.OperationStartEvent;
 import org.gradle.internal.operations.UncategorizedBuildOperations;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultWorkExecutionTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/DefaultWorkExecutionTracker.java
@@ -75,18 +75,6 @@ public class DefaultWorkExecutionTracker implements WorkExecutionTracker, Closea
     }
 
     @Override
-    public boolean isExecutingTransformAction() {
-        Set<OperationIdentifier> runningTransformActions = operationListener.runningTransformActions;
-        if (runningTransformActions.isEmpty()) {
-            return false;
-        }
-        return buildOperationAncestryTracker.findClosestMatchingAncestor(
-            currentBuildOperationRef.getId(),
-            runningTransformActions::contains
-        ).isPresent();
-    }
-
-    @Override
     public boolean isExecutingTaskOrTransformAction() {
         if (!operationListener.hasRunningWork()) {
             return false;
@@ -148,7 +136,8 @@ public class DefaultWorkExecutionTracker implements WorkExecutionTracker, Closea
         }
 
         public boolean hasRunningWork() {
-            return !runningTasks.isEmpty() || !runningTransformActions.isEmpty();
+            return !runningTasks.isEmpty()
+                || !runningTransformActions.isEmpty();
         }
 
         private static boolean isTransformAction(BuildOperationDescriptor buildOperation) {

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/WorkExecutionTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/WorkExecutionTracker.java
@@ -45,4 +45,11 @@ public interface WorkExecutionTracker {
      * @return {@code true} if the current thread is executing a transform action
      */
     boolean isExecutingTransformAction();
+
+    /**
+     * Checks if the current thread is executing a Task or a {@link org.gradle.api.artifacts.transform.TransformAction}.
+     *
+     * @return {@code true} if the current thread is executing a task or a transform action
+     */
+    boolean isExecutingTaskOrTransformAction();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/WorkExecutionTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/WorkExecutionTracker.java
@@ -40,13 +40,6 @@ public interface WorkExecutionTracker {
     Optional<TaskInternal> getCurrentTask(OperationIdentifier id);
 
     /**
-     * Checks if the current thread is executing a {@link org.gradle.api.artifacts.transform.TransformAction}.
-     *
-     * @return {@code true} if the current thread is executing a transform action
-     */
-    boolean isExecutingTransformAction();
-
-    /**
      * Checks if the current thread is executing a Task or a {@link org.gradle.api.artifacts.transform.TransformAction}.
      *
      * @return {@code true} if the current thread is executing a task or a transform action


### PR DESCRIPTION
- Dedupe `isExecutingWork` check by moving logic to tracker
- Avoid traversing build operation hierarchy via cheap check

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
