### PR TITLE
Fix LoggingBuildOperationProgressIntegTest (attempt 2)

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -435,9 +435,10 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
 
     def int getNumberOfExpectedEvents() {
         // when configuration cache is enabled also "Configuration cache entry reused." and "Parallel Configuration Cache is an incubating feature."
-        def configCacheOffset = GradleContextualExecuter.configCache ? 2 : 0
-        // 13 tasks + "\n" + "BUILD SUCCESSFUL" + "2 actionable tasks: 2 executed"
-        return 15 + configCacheOffset
+        // when CC is not enabled, "Consider enabling configuration cache to speed up this build"
+        def configCacheOffset = GradleContextualExecuter.configCache ? 2 : 1
+        // 11 tasks + "\n" + "BUILD SUCCESSFUL" + "3 actionable tasks: 3 executed"
+        return 14 + configCacheOffset
     }
 
     private void assertNestedTaskOutputTracked(String projectPath = ':nested') {


### PR DESCRIPTION
Fix `LoggingBuildOperationProgressIntegTest` when CC enabled: https://ge.gradle.org/s/k76nsjeh2va62/tests/task/:core:configCacheIntegTest/details/org.gradle.internal.operations.logging.LoggingBuildOperationProgressIntegTest/filters%20non%20supported%20output%20events?top-execution=1