### PR TITLE
Fix Kotlin DSL new IDE templates file path pattern

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinGradleScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinGradleScriptTemplate.kt
@@ -32,7 +32,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
 
 
 class KotlinGradleScriptTemplateCompilationConfiguration : KotlinDslStandaloneScriptCompilationConfiguration({
-    filePathPattern.put("(?:.+\\.)?init\\.gradle\\.kts")
+    filePathPattern.put(".*/(?:.+\\.)?init\\.gradle\\.kts")
     baseClass(KotlinGradleScriptTemplate::class)
     implicitReceivers(Gradle::class)
 })

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinProjectScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinProjectScriptTemplate.kt
@@ -34,7 +34,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
 
 
 class KotlinProjectScriptTemplateCompilationConfiguration : KotlinDslStandaloneScriptCompilationConfiguration({
-    filePathPattern.put(".+(?<!(^|\\.)(init|settings))\\.gradle\\.kts")
+    filePathPattern.put(".*/.+(?<!(/|\\.)(init|settings))\\.gradle\\.kts")
     baseClass(KotlinProjectScriptTemplate::class)
     implicitReceivers(Project::class)
 })

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt
@@ -33,7 +33,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
 
 
 class KotlinSettingsScriptTemplateCompilationConfiguration : KotlinDslStandaloneScriptCompilationConfiguration({
-    filePathPattern.put("(?:.+\\.)?settings\\.gradle\\.kts")
+    filePathPattern.put(".*/(?:.+\\.)?settings\\.gradle\\.kts")
     baseClass(KotlinSettingsScriptTemplate::class)
     implicitReceivers(Settings::class)
 })


### PR DESCRIPTION
In legacy script templates, `scriptFilePattern` is matched against the script file name by IntelliJ.
In new script templates, `filePathPattern` is matched against the script normalized full path by IntelliJ.

This PR fixes the `filePathPattern` of all new IDE script templates to let IntelliJ match the right templates to the right files.

* Part of https://github.com/gradle/gradle/issues/26640

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
