### PR TITLE
Restore disallowUnsafeRead and disallowChanges status from the CC

### DIFF
--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/serialize/StatelessPropertyHost.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/serialize/StatelessPropertyHost.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.base.serialize
+
+import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.provider.PropertyHost
+import org.gradle.internal.state.ModelObject
+
+class StatelessPropertyHost : PropertyHost {
+    override fun beforeRead(producer: ModelObject?): String? {
+        if (producer != null) {
+            val producerTask = producer.getTaskThatOwnsThisObject() as TaskInternal?
+            if (producerTask != null && producerTask.getState().isConfigurable()) {
+                // Currently cannot tell the difference between access from the producing task and access from outside, so assume
+                // all access after the task has started execution is ok
+                return producerTask.toString() + " has not completed yet"
+            }
+        }
+        return null
+    }
+}

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
@@ -45,6 +45,7 @@ import org.gradle.api.services.internal.BuildServiceProvider
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.cc.base.serialize.IsolateOwners
+import org.gradle.internal.cc.base.serialize.StatelessPropertyHost
 import org.gradle.internal.cc.base.serialize.readProjectRef
 import org.gradle.internal.cc.base.serialize.writeProjectRef
 import org.gradle.internal.configuration.problems.PropertyTrace
@@ -424,7 +425,7 @@ abstract class AbstractFileVarPropertyCodec<P: DefaultFilePropertyFactory.Abstra
             }
             host is ProjectBackedPropertyHost -> {
                 writeByte(2)
-                writeProjectRef(host.project)
+//                writeProjectRef(host.project)
             }
             else -> error("Unsupported host type: ${host::class.java.name}")
         }
@@ -440,8 +441,9 @@ abstract class AbstractFileVarPropertyCodec<P: DefaultFilePropertyFactory.Abstra
                 return PropertyHost.NO_OP
             }
             2.toByte() -> {
-                val project = readProjectRef()
-                return ProjectBackedPropertyHost(project)
+//                val project = readProjectRef()
+//                return ProjectBackedPropertyHost(project)
+                return StatelessPropertyHost()
             }
             else -> {
                 error("Unsupported host type: $discriminator")

--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyLifecycleIntegrationTest.groovy
@@ -249,7 +249,6 @@ task thing {
         output.count("prop = " + file("build/dir.out")) == 3
     }
 
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25513")
     def "cannot query strict task output file property until task starts execution"() {
         taskTypeWithOutputFileProperty()
         settingsFile << "rootProject.name = 'broken'"

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -59,8 +59,18 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
     }
 
     @Override
+    public DirectoryProperty newDirectoryProperty(PropertyHost customHost) {
+        return new DefaultDirectoryVar(customHost, fileResolver, fileCollectionFactory);
+    }
+
+    @Override
     public RegularFileProperty newFileProperty() {
         return new DefaultRegularFileVar(host, fileResolver);
+    }
+
+    @Override
+    public RegularFileProperty newFileProperty(PropertyHost customHost) {
+        return new DefaultRegularFileVar(customHost, fileResolver);
     }
 
     @Override

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -177,7 +177,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         }
     }
 
-    static abstract class AbstractFileVar<T extends FileSystemLocation, THIS extends FileSystemLocationProperty<T>> extends DefaultProperty<T> implements FileSystemLocationPropertyInternal<T> {
+    public static abstract class AbstractFileVar<T extends FileSystemLocation, THIS extends FileSystemLocationProperty<T>> extends DefaultProperty<T> implements FileSystemLocationPropertyInternal<T> {
 
         public AbstractFileVar(PropertyHost host, Class<T> type) {
             super(host, type);

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
@@ -18,12 +18,15 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.provider.PropertyHost;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 @ServiceScope({Scope.Global.class, Scope.Project.class})
 public interface FilePropertyFactory {
     DirectoryProperty newDirectoryProperty();
+    DirectoryProperty newDirectoryProperty(PropertyHost customHost);
 
     RegularFileProperty newFileProperty();
+    RegularFileProperty newFileProperty(PropertyHost customHost);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -79,6 +79,11 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         return state.isDisallowChanges();
     }
 
+    @Nullable
+    public PropertyHost getHost() {
+        return state.getHost();
+    }
+
     protected boolean isExplicit() {
         return state.isExplicit();
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -71,6 +71,14 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         return state.isFinalized();
     }
 
+    public boolean isDisallowUnsafeRead() {
+        return state.isDisallowUnsafeRead();
+    }
+
+    public boolean isDisallowChanges() {
+        return state.isDisallowChanges();
+    }
+
     protected boolean isExplicit() {
         return state.isExplicit();
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
@@ -176,6 +176,9 @@ public abstract class ValueState<S> {
 
     public abstract void warnOnUpgradedPropertyValueChanges();
 
+    @Nullable
+    public abstract PropertyHost getHost();
+
     private static class NonFinalizedValue<S> extends ValueState<S> {
         private final PropertyHost host;
         private final Function<S, S> copier;
@@ -190,6 +193,12 @@ public abstract class ValueState<S> {
         public NonFinalizedValue(PropertyHost host, Function<S, S> copier) {
             this.host = host;
             this.copier = copier;
+        }
+
+        @Override
+        @Nullable
+        public PropertyHost getHost() {
+            return host;
         }
 
         @Override
@@ -379,6 +388,12 @@ public abstract class ValueState<S> {
     }
 
     private static class FinalizedValue<S> extends ValueState<S> {
+        @Override
+        @Nullable
+        public PropertyHost getHost() {
+            return null; // Finalized value does not need or have a host, it can always be read safely
+        }
+
         @Override
         public boolean shouldFinalize(Describable displayName, @Nullable ModelObject producer) {
             return false;

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
@@ -73,9 +73,13 @@ public abstract class ValueState<S> {
 
     public abstract void disallowChanges();
 
+    public abstract boolean isDisallowChanges();
+
     public abstract void finalizeOnNextGet();
 
     public abstract void disallowUnsafeRead();
+
+    public abstract boolean isDisallowUnsafeRead();
 
     /**
      * Marks this value state as being explicitly assigned. Does not remember the given value in any way.
@@ -246,6 +250,11 @@ public abstract class ValueState<S> {
         }
 
         @Override
+        public boolean isDisallowChanges() {
+            return disallowChanges;
+        }
+
+        @Override
         public void finalizeOnNextGet() {
             finalizeOnNextGet = true;
         }
@@ -254,6 +263,11 @@ public abstract class ValueState<S> {
         public void disallowUnsafeRead() {
             disallowUnsafeRead = true;
             finalizeOnNextGet = true;
+        }
+
+        @Override
+        public boolean isDisallowUnsafeRead() {
+            return disallowUnsafeRead;
         }
 
         @Override
@@ -376,6 +390,11 @@ public abstract class ValueState<S> {
         }
 
         @Override
+        public boolean isDisallowChanges() {
+            return true;
+        }
+
+        @Override
         public void finalizeOnNextGet() {
             // Finalized already
         }
@@ -383,6 +402,11 @@ public abstract class ValueState<S> {
         @Override
         public void disallowUnsafeRead() {
             // Finalized already so read is safe
+        }
+
+        @Override
+        public boolean isDisallowUnsafeRead() {
+            return false;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectBackedPropertyHost.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectBackedPropertyHost.java
@@ -22,11 +22,15 @@ import org.gradle.api.internal.provider.PropertyHost;
 import org.gradle.internal.state.ModelObject;
 import org.jspecify.annotations.Nullable;
 
-class ProjectBackedPropertyHost implements PropertyHost {
+public class ProjectBackedPropertyHost implements PropertyHost {
     private final ProjectInternal project;
 
     public ProjectBackedPropertyHost(ProjectInternal project) {
         this.project = project;
+    }
+
+    public ProjectInternal getProject() {
+        return project;
     }
 
     @Nullable


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/25513

Serializes and restores some ValueState metadata
- Refactors file property codecs for metadata handling to do this by introducing an abstract base class for file property codecs to handle common metadata like `isDisallowUnsafeRead` and `isDisallowChanges`.  This requires exposing the AbstractFileVar type as public.
- Also adds new public getter methods for this metadata.
- Adds serialization support for `PropertyHost` in file properties,
allowing to persist the association between a property and its owning
project.  This ensures that properties retain their project context after
deserialization, which is crucial for unsafe read error reporting .
- Adds additional constructors to allow re-injecting serialized host.
