### PR TITLE
Fix serialization of provider backed relative files/directories with configuration cache

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -99,6 +99,11 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
     }
 
     @Override
+    public PathToFileResolver getResolver() {
+        return fileResolver;
+    }
+
+    @Override
     public FileCollectionFactory forChildScope(FileCollectionObservationListener listener) {
         return new DefaultFileCollectionFactory(fileResolver, taskDependencyFactory, directoryFileTreeFactory, patternSetFactory, propertyHost, fileSystem, listener);
     }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -64,6 +64,16 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
     }
 
     @Override
+    public FilePropertyFactory withResolvers(FileResolver fileResolver, PathToFileResolver fileCollectionResolver) {
+        return new DefaultFilePropertyFactory(host, fileResolver, fileCollectionFactory.withResolver(fileCollectionResolver));
+    }
+
+    @Override
+    public FilePropertyFactory withResolver(FileResolver fileResolver) {
+        return new DefaultFilePropertyFactory(host, fileResolver, fileCollectionFactory);
+    }
+
+    @Override
     public Directory dir(File dir) {
         dir = fileResolver.resolve(dir);
         return new FixedDirectory(dir, fileResolver.newResolver(dir), fileCollectionFactory);
@@ -280,11 +290,15 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
     }
 
     public static class DefaultRegularFileVar extends AbstractFileVar<RegularFile, RegularFileProperty> implements RegularFileProperty, Managed {
-        private final PathToFileResolver fileResolver;
+        private final FileResolver fileResolver;
 
-        DefaultRegularFileVar(PropertyHost host, PathToFileResolver fileResolver) {
+        DefaultRegularFileVar(PropertyHost host, FileResolver fileResolver) {
             super(host, RegularFile.class);
             this.fileResolver = fileResolver;
+        }
+
+        public PathToFileResolver getFileResolver() {
+            return fileResolver;
         }
 
         @Override
@@ -343,6 +357,14 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         @Override
         public FileTree getAsFileTree() {
             return fileCollectionFactory.resolving(this).getAsFileTree();
+        }
+
+        public FileResolver getFileResolver() {
+            return resolver;
+        }
+
+        public PathToFileResolver getFileCollectionResolver() {
+            return fileCollectionFactory.getResolver();
         }
 
         @Override

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
@@ -46,6 +46,8 @@ public interface FileCollectionFactory {
      */
     FileCollectionFactory withResolver(PathToFileResolver fileResolver);
 
+    PathToFileResolver getResolver();
+
     FileCollectionFactory forChildScope(FileCollectionObservationListener listener);
 
     FileCollectionFactory forChildScope(PathToFileResolver fileResolver, TaskDependencyFactory taskDependencyFactory, PropertyHost propertyHost);

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -26,4 +27,14 @@ public interface FilePropertyFactory {
     DirectoryProperty newDirectoryProperty();
 
     RegularFileProperty newFileProperty();
+
+    /**
+     * Returns a new FilePropertyFactory configured with the given file resolver and file collection resolver.
+     */
+    FilePropertyFactory withResolvers(FileResolver fileResolver, PathToFileResolver fileCollectionResolver);
+
+    /**
+     * Returns a new FilePropertyFactory configured with the given file resolver.
+     */
+    FilePropertyFactory withResolver(FileResolver fileResolver);
 }


### PR DESCRIPTION
We now retain the configuration of file resolvers in provider-backed properties when the values contain relative directories.

Fixes #32992 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
