### PR TITLE
Split `ClassLoaderScopeSpec` encoding from `Class` encoding

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
@@ -22,6 +22,7 @@ import org.gradle.internal.buildtree.BuildTreeWorkGraph
 import org.gradle.internal.cc.impl.cacheentry.EntryDetails
 import org.gradle.internal.cc.impl.cacheentry.ModelKey
 import org.gradle.internal.cc.impl.serialize.Codecs
+import org.gradle.internal.serialize.graph.ClassEncoder
 import org.gradle.internal.serialize.graph.CloseableReadContext
 import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.internal.serialize.graph.MutableReadContext
@@ -73,6 +74,7 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
         outputStream: () -> OutputStream,
         profile: () -> String,
         specialEncoders: SpecialEncoders = SpecialEncoders(),
+        customClassEncoder: ClassEncoder? = null
     ): Pair<CloseableWriteContext, Codecs>
 
     fun <R> withReadContextFor(
@@ -106,9 +108,18 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
         stateFile: ConfigurationCacheStateFile,
         profile: () -> String,
         specialEncoders: SpecialEncoders = SpecialEncoders(),
+        customClassEncoder: ClassEncoder? = null,
         writeOperation: suspend WriteContext.(Codecs) -> R
     ): R =
-        withWriteContextFor(stateFile.stateFile.name, stateFile.stateType, stateFile::outputStream, profile, specialEncoders, writeOperation)
+        withWriteContextFor(
+            stateFile.stateFile.name,
+            stateFile.stateType,
+            stateFile::outputStream,
+            profile,
+            specialEncoders,
+            customClassEncoder,
+            writeOperation
+        )
 
     fun <R> withWriteContextFor(
         name: String,
@@ -116,6 +127,7 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
         outputStream: () -> OutputStream,
         profile: () -> String,
         specialEncoders: SpecialEncoders,
+        customClassEncoder: ClassEncoder?,
         writeOperation: suspend WriteContext.(Codecs) -> R
     ): R
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
@@ -22,6 +22,7 @@ import org.gradle.internal.buildtree.BuildTreeWorkGraph
 import org.gradle.internal.cc.impl.cacheentry.EntryDetails
 import org.gradle.internal.cc.impl.cacheentry.ModelKey
 import org.gradle.internal.cc.impl.serialize.Codecs
+import org.gradle.internal.serialize.graph.ClassDecoder
 import org.gradle.internal.serialize.graph.ClassEncoder
 import org.gradle.internal.serialize.graph.CloseableReadContext
 import org.gradle.internal.serialize.graph.CloseableWriteContext
@@ -80,6 +81,7 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
     fun <R> withReadContextFor(
         stateFile: ConfigurationCacheStateFile,
         specialDecoders: SpecialDecoders = SpecialDecoders(),
+        customClassDecoder: ClassDecoder? = null,
         readOperation: suspend MutableReadContext.(Codecs) -> R
     ): R =
         withReadContextFor(
@@ -87,6 +89,7 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
             stateFile.stateType,
             stateFile::inputStream,
             specialDecoders,
+            customClassDecoder,
             readOperation
         )
 
@@ -95,6 +98,7 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
         stateType: StateType,
         inputStream: () -> InputStream,
         specialDecoders: SpecialDecoders = SpecialDecoders(),
+        customClassDecoder: ClassDecoder? = null,
         readOperation: suspend MutableReadContext.(Codecs) -> R
     ): R
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheBuildTreeIO.kt
@@ -80,7 +80,13 @@ interface ConfigurationCacheBuildTreeIO : ConfigurationCacheOperationIO {
         specialDecoders: SpecialDecoders = SpecialDecoders(),
         readOperation: suspend MutableReadContext.(Codecs) -> R
     ): R =
-        withReadContextFor(stateFile.stateFile.name, stateFile.stateType, stateFile::inputStream, specialDecoders, readOperation)
+        withReadContextFor(
+            stateFile.stateFile.name,
+            stateFile.stateType,
+            stateFile::inputStream,
+            specialDecoders,
+            readOperation
+        )
 
     fun <R> withReadContextFor(
         name: String,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderScopeRegistryListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheClassLoaderScopeRegistryListener.kt
@@ -24,6 +24,7 @@ import org.gradle.initialization.ClassLoaderScopeOrigin
 import org.gradle.initialization.ClassLoaderScopeRegistryListener
 import org.gradle.initialization.ClassLoaderScopeRegistryListenerManager
 import org.gradle.internal.buildtree.BuildTreeLifecycleListener
+import org.gradle.internal.cc.impl.serialize.ClassLoaderRole
 import org.gradle.internal.cc.impl.serialize.ClassLoaderScopeSpec
 import org.gradle.internal.cc.impl.serialize.ScopeLookup
 import org.gradle.internal.cc.impl.serialize.describeClassLoader
@@ -31,7 +32,6 @@ import org.gradle.internal.cc.impl.serialize.describeKnownClassLoaders
 import org.gradle.internal.classloader.DelegatingClassLoader
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.serialize.graph.ClassLoaderRole
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.ServiceScope
 import java.io.Closeable
@@ -90,6 +90,7 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
     override fun scopeFor(classLoader: ClassLoader?): Pair<ClassLoaderScopeSpec, ClassLoaderRole>? {
         synchronized(lock) {
             assertNotDisposed("scopeFor")
+            // TODO:configuration-cache assert the spec can no longer change after it has been observed
             return loaders[classLoader]
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheRepository.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheRepository.kt
@@ -243,9 +243,10 @@ class ConfigurationCacheRepository(
 
         override fun <T> useForStore(action: Layout.() -> T): ConfigurationCacheStateStore.StateAccessResult<T> =
             withExclusiveAccessToCache(baseDir) { cacheDir ->
-                // TODO GlobalCache require(!cacheDir.isDirectory)
-                Files.createDirectories(cacheDir.toPath())
-                chmod(cacheDir, 448) // octal 0700
+                if (!cacheDir.isDirectory) {
+                    Files.createDirectories(cacheDir.toPath())
+                    chmod(cacheDir, 448) // octal 0700
+                }
                 markAccessed(cacheDir)
                 // this needs to be thread-safe as we may have multiple adding threads
                 val stateFiles = Collections.synchronizedList(mutableListOf<File>())

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheServices.kt
@@ -78,7 +78,11 @@ class ConfigurationCacheServices : AbstractGradleModuleServices() {
             add(RelevantProjectsRegistry::class.java)
             addProvider(TaskExecutionAccessCheckerProvider)
             add(ConfigurationCacheHost::class.java, DefaultConfigurationCacheHost::class.java)
-            add(ConfigurationCacheBuildTreeIO::class.java, ConfigurationCacheIncludedBuildIO::class.java, DefaultConfigurationCacheIO::class.java)
+            add(
+                ConfigurationCacheBuildTreeIO::class.java,
+                ConfigurationCacheIncludedBuildIO::class.java,
+                DefaultConfigurationCacheIO::class.java
+            )
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -102,7 +102,7 @@ enum class StateType(val encryptable: Boolean = false) {
     Work(true),
 
     /**
-     * Contains work-related state that is meant to be shared for the entire build.
+     * Contains work-related state meant to be shared for the entire build.
      */
     WorkShared(true),
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -341,7 +341,13 @@ class DefaultConfigurationCache internal constructor(
             val usedModels = intermediateModels.collectAccessedValues()
             val usedMetadata = projectMetadata.collectAccessedValues()
             val sideEffects = buildTreeModelSideEffects.collectSideEffects()
-            cacheIO.writeCacheEntryDetailsTo(buildStateRegistry, usedModels, usedMetadata, sideEffects, fileFor(StateType.Entry))
+            cacheIO.writeCacheEntryDetailsTo(
+                buildStateRegistry,
+                usedModels,
+                usedMetadata,
+                sideEffects,
+                fileFor(StateType.Entry)
+            )
         }
         updateMostRecentEntry(entryId)
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -702,8 +702,8 @@ class DefaultConfigurationCache internal constructor(
     private
     fun startCollectingCacheFingerprint() {
         cacheFingerprintController.maybeStartCollectingFingerprint(
-            entryStore.assignSpoolFile(StateType.BuildFingerprint),
-            entryStore.assignSpoolFile(StateType.ProjectFingerprint)
+            { entryStore.assignSpoolFile(StateType.BuildFingerprint) },
+            { entryStore.assignSpoolFile(StateType.ProjectFingerprint) }
         ) { stateFile ->
             cacheFingerprintWriteContextFor(stateFile.stateType, stateFile.file::outputStream) {
                 profileNameFor(stateFile)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -549,7 +549,10 @@ class DefaultConfigurationCache internal constructor(
         cacheIO.readCacheEntryDetailsFrom(fileFor(StateType.Entry))
             ?.let { entryDetails ->
                 // TODO:configuration-cache read only rootDirs at this point
-                EntrySearchResult(entryDetails.buildInvocationScopeId, checkFingerprint(candidateEntry, entryDetails.rootDirs))
+                EntrySearchResult(
+                    entryDetails.buildInvocationScopeId,
+                    checkFingerprint(candidateEntry, entryDetails.rootDirs)
+                )
             } ?: EntrySearchResult(null, CheckedFingerprint.NotFound)
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -43,6 +43,7 @@ import org.gradle.internal.cc.base.serialize.IsolateOwners
 import org.gradle.internal.cc.base.serialize.service
 import org.gradle.internal.cc.impl.extensions.withMostRecentEntry
 import org.gradle.internal.cc.impl.fingerprint.ConfigurationCacheFingerprintController
+import org.gradle.internal.cc.impl.fingerprint.ConfigurationCacheFingerprintStartParameters
 import org.gradle.internal.cc.impl.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.cc.impl.metadata.ProjectMetadataController
 import org.gradle.internal.cc.impl.models.BuildTreeModelSideEffectStore
@@ -702,13 +703,15 @@ class DefaultConfigurationCache internal constructor(
     private
     fun startCollectingCacheFingerprint() {
         cacheFingerprintController.maybeStartCollectingFingerprint(
-            { entryStore.assignSpoolFile(StateType.BuildFingerprint) },
-            { entryStore.assignSpoolFile(StateType.ProjectFingerprint) }
-        ) { stateFile ->
-            cacheFingerprintWriteContextFor(stateFile.stateType, stateFile.file::outputStream) {
-                profileNameFor(stateFile)
+            object : ConfigurationCacheFingerprintStartParameters {
+                override fun assignBuildScopedSpoolFile() = entryStore.assignSpoolFile(StateType.BuildFingerprint)
+                override fun assignProjectScopedSpoolFile() = entryStore.assignSpoolFile(StateType.ProjectFingerprint)
+                override fun writeContextForOutputStream(stateFile: ConfigurationCacheStateStore.StateFile) =
+                    cacheFingerprintWriteContextFor(stateFile.stateType, stateFile.file::outputStream) {
+                        profileNameFor(stateFile)
+                    }
             }
-        }
+        )
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -697,7 +697,10 @@ class DefaultConfigurationCache internal constructor(
                 }
             }
         }
-        cacheFingerprintController.commitFingerprintTo(fileFor(StateType.BuildFingerprint), fileFor(StateType.ProjectFingerprint))
+        cacheFingerprintController.commitFingerprintTo(
+            fileFor(StateType.BuildFingerprint),
+            fileFor(StateType.ProjectFingerprint)
+        )
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -523,7 +523,8 @@ class DefaultConfigurationCacheIO internal constructor(
                 context.writeWith(codecs, writeOperation)
             }
 
-    private fun readContextFor(
+    private
+    fun readContextFor(
         stateFile: ConfigurationCacheStateFile,
         specialDecoders: SpecialDecoders = SpecialDecoders()
     ) = readContextFor(
@@ -533,7 +534,8 @@ class DefaultConfigurationCacheIO internal constructor(
         specialDecoders
     )
 
-    private fun readContextFor(
+    private
+    fun readContextFor(
         name: String,
         stateType: StateType,
         inputStream: () -> InputStream,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -518,14 +518,23 @@ class DefaultConfigurationCacheIO internal constructor(
     private fun readContextFor(
         stateFile: ConfigurationCacheStateFile,
         specialDecoders: SpecialDecoders = SpecialDecoders()
-    ) = readContextFor(stateFile.stateFile.name, stateFile.stateType, stateFile::inputStream, specialDecoders)
+    ) = readContextFor(
+        stateFile.stateFile.name,
+        stateFile.stateType,
+        stateFile::inputStream,
+        specialDecoders
+    )
 
     private fun readContextFor(
         name: String,
         stateType: StateType,
         inputStream: () -> InputStream,
         specialDecoders: SpecialDecoders
-    ) = readContextFor(name, decoderFor(stateType, inputStream), specialDecoders)
+    ) = readContextFor(
+        name,
+        decoderFor(stateType, inputStream),
+        specialDecoders
+    )
 
     override fun <T> runReadOperation(decoder: Decoder, readOperation: suspend ReadContext.(codecs: Codecs) -> T): T {
         val (context, codecs) = readContextFor("unnamed", decoder, SpecialDecoders())

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -59,7 +59,6 @@ import org.gradle.internal.hash.HashCode
 import org.gradle.internal.instrumentation.agent.AgentStatus
 import org.gradle.internal.scripts.ProjectScopedScriptResolution
 import org.gradle.internal.scripts.ScriptFileResolverListeners
-import org.gradle.internal.serialize.graph.CloseableWriteContext
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.service.scopes.ParallelListener
 import org.gradle.internal.service.scopes.Scope
@@ -123,11 +122,7 @@ class ConfigurationCacheFingerprintController internal constructor(
     private
     abstract class WritingState {
 
-        open fun maybeStart(
-            buildScopedSpoolFile: () -> StateFile,
-            projectScopedSpoolFile: () -> StateFile,
-            writeContextForOutputStream: (StateFile) -> CloseableWriteContext
-        ): WritingState =
+        open fun maybeStart(parameters: ConfigurationCacheFingerprintStartParameters): WritingState =
             illegalStateFor("start")
 
         open fun pause(): WritingState =
@@ -161,18 +156,14 @@ class ConfigurationCacheFingerprintController internal constructor(
 
     private
     inner class Idle : WritingState() {
-        override fun maybeStart(
-            buildScopedSpoolFile: () -> StateFile,
-            projectScopedSpoolFile: () -> StateFile,
-            writeContextForOutputStream: (StateFile) -> CloseableWriteContext
-        ): WritingState {
 
-            val buildScopedFile = buildScopedSpoolFile()
-            val projectScopedFile = projectScopedSpoolFile()
+        override fun maybeStart(parameters: ConfigurationCacheFingerprintStartParameters): WritingState {
+            val buildScopedFile = parameters.assignBuildScopedSpoolFile()
+            val projectScopedFile = parameters.assignProjectScopedSpoolFile()
             val fingerprintWriter = ConfigurationCacheFingerprintWriter(
                 CacheFingerprintWriterHost(),
-                writeContextForOutputStream(buildScopedFile),
-                writeContextForOutputStream(projectScopedFile),
+                parameters.writeContextForOutputStream(buildScopedFile),
+                parameters.writeContextForOutputStream(projectScopedFile),
                 fileCollectionFactory,
                 directoryFileTreeFactory,
                 workExecutionTracker,
@@ -181,7 +172,11 @@ class ConfigurationCacheFingerprintController internal constructor(
                 buildStateRegistry
             )
             addListener(fingerprintWriter)
-            return Writing(fingerprintWriter, buildScopedFile, projectScopedFile)
+            return Writing(
+                fingerprintWriter,
+                buildScopedFile,
+                projectScopedFile
+            )
         }
 
         override fun <T> resolveScriptsForProject(project: ProjectIdentity, action: () -> T): T {
@@ -199,11 +194,8 @@ class ConfigurationCacheFingerprintController internal constructor(
         private val buildScopedSpoolFile: StateFile,
         private val projectScopedSpoolFile: StateFile
     ) : WritingState() {
-        override fun maybeStart(
-            buildScopedSpoolFile: () -> StateFile,
-            projectScopedSpoolFile: () -> StateFile,
-            writeContextForOutputStream: (StateFile) -> CloseableWriteContext
-        ): WritingState {
+
+        override fun maybeStart(parameters: ConfigurationCacheFingerprintStartParameters): WritingState {
             return this
         }
 
@@ -234,11 +226,8 @@ class ConfigurationCacheFingerprintController internal constructor(
         private val buildScopedSpoolFile: StateFile,
         private val projectScopedSpoolFile: StateFile
     ) : WritingState() {
-        override fun maybeStart(
-            buildScopedSpoolFile: () -> StateFile,
-            projectScopedSpoolFile: () -> StateFile,
-            writeContextForOutputStream: (StateFile) -> CloseableWriteContext
-        ): WritingState {
+
+        override fun maybeStart(parameters: ConfigurationCacheFingerprintStartParameters): WritingState {
             addListener(fingerprintWriter)
             // Continue with the current spool file, rather than starting a new one
             return Writing(fingerprintWriter, this.buildScopedSpoolFile, this.projectScopedSpoolFile)
@@ -264,12 +253,8 @@ class ConfigurationCacheFingerprintController internal constructor(
 
         override fun dispose(): WritingState {
             closeStreams()
-            if (buildScopedSpoolFile.file.exists()) {
-                Files.delete(buildScopedSpoolFile.file.toPath())
-            }
-            if (projectScopedSpoolFile.file.exists()) {
-                Files.delete(projectScopedSpoolFile.file.toPath())
-            }
+            buildScopedSpoolFile.delete()
+            projectScopedSpoolFile.delete()
             return Idle()
         }
 
@@ -316,15 +301,11 @@ class ConfigurationCacheFingerprintController internal constructor(
             controller.writingState.projectObserved(consumingProjectPath, targetProjectPath)
     }
 
-    // Start fingerprinting if not already started and not already committed
-    // This should be strict but currently this method may be called multiple times when a
+    // Start fingerprinting if not already started and not already committed,
+    // This should be strict, but currently this method may be called multiple times when a
     // build invocation both runs tasks and queries models
-    fun maybeStartCollectingFingerprint(
-        buildScopedSpoolFile: () -> StateFile,
-        projectScopedSpoolFile: () -> StateFile,
-        writeContextForOutputStream: (StateFile) -> CloseableWriteContext
-    ) {
-        writingState = writingState.maybeStart(buildScopedSpoolFile, projectScopedSpoolFile, writeContextForOutputStream)
+    fun maybeStartCollectingFingerprint(parameters: ConfigurationCacheFingerprintStartParameters) {
+        writingState = writingState.maybeStart(parameters)
     }
 
     fun stopCollectingFingerprint() {
@@ -535,4 +516,11 @@ class ConfigurationCacheFingerprintController internal constructor(
     private
     val rootDirectory
         get() = startParameter.rootDirectory
+
+    private
+    fun StateFile.delete() {
+        if (file.exists()) {
+            Files.delete(file.toPath())
+        }
+    }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintStartParameters.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintStartParameters.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.fingerprint
+
+import org.gradle.internal.cc.impl.ConfigurationCacheStateStore
+import org.gradle.internal.serialize.graph.CloseableWriteContext
+
+
+internal
+interface ConfigurationCacheFingerprintStartParameters {
+    fun assignBuildScopedSpoolFile(): ConfigurationCacheStateStore.StateFile
+    fun assignProjectScopedSpoolFile(): ConfigurationCacheStateStore.StateFile
+    fun writeContextForOutputStream(stateFile: ConfigurationCacheStateStore.StateFile): CloseableWriteContext
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -545,7 +545,9 @@ class ConfigurationCacheFingerprintWriter(
 
     fun <T> runCollectingFingerprintForProject(project: ProjectIdentity, action: () -> T): T {
         val previous = projectForThread.get()
-        val projectSink = sinksForProject.computeIfAbsent(project.buildTreePath) { ProjectScopedSink(host, project, projectScopedWriter) }
+        val projectSink = sinksForProject.computeIfAbsent(project.buildTreePath) {
+            ProjectScopedSink(host, project, projectScopedWriter)
+        }
         projectForThread.set(projectSink)
         try {
             return action()
@@ -891,11 +893,18 @@ class ConfigurationCacheFingerprintWriter(
         project: ProjectIdentity,
         private val writer: ScopedFingerprintWriter<ProjectSpecificFingerprint>
     ) : Sink(host) {
+
         private
         val projectIdentityPath = project.buildTreePath
 
         init {
-            writer.write(ProjectSpecificFingerprint.ProjectIdentity(project.buildTreePath, Path.path(project.buildIdentifier.buildPath), project.projectPath))
+            writer.write(
+                ProjectSpecificFingerprint.ProjectIdentity(
+                    project.buildTreePath,
+                    Path.path(project.buildIdentifier.buildPath),
+                    project.projectPath
+                )
+            )
         }
 
         override fun write(value: ConfigurationCacheFingerprint, trace: PropertyTrace?) {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassLoaderScopes.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassLoaderScopes.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.serialize
+
+import org.gradle.initialization.ClassLoaderScopeOrigin
+import org.gradle.internal.Describables
+import org.gradle.internal.classpath.ClassPath
+import org.gradle.internal.hash.HashCode
+import org.gradle.internal.serialize.Decoder
+import org.gradle.internal.serialize.Encoder
+import org.gradle.internal.serialize.graph.ReadIdentities
+import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.graph.WriteIdentities
+import org.gradle.internal.serialize.graph.decodePreservingIdentity
+import org.gradle.internal.serialize.graph.encodePreservingIdentityOf
+
+
+internal
+interface ScopeLookup {
+    fun scopeFor(classLoader: ClassLoader?): Pair<ClassLoaderScopeSpec, ClassLoaderRole>?
+    val knownClassLoaders: Set<ClassLoader>
+}
+
+
+internal
+data class ClassLoaderScopeSpec(
+    val parent: ClassLoaderScopeSpec?,
+    val name: String,
+    val origin: ClassLoaderScopeOrigin?
+) {
+    var localClassPath: ClassPath = ClassPath.EMPTY
+    var localImplementationHash: HashCode? = null
+    var exportClassPath: ClassPath = ClassPath.EMPTY
+
+    override fun toString(): String {
+        return if (parent != null) {
+            "$parent:$name"
+        } else {
+            name
+        }
+    }
+}
+
+
+@JvmInline
+internal
+value class ClassLoaderRole(val local: Boolean)
+
+
+internal
+interface ClassLoaderScopeSpecEncoder {
+    fun WriteContext.encodeScope(scope: ClassLoaderScopeSpec)
+}
+
+
+internal
+interface ClassLoaderScopeSpecDecoder {
+    fun Decoder.decodeScope(): ClassLoaderScopeSpec
+}
+
+
+internal
+class InlineClassLoaderScopeSpecEncoder : ClassLoaderScopeSpecEncoder {
+
+    private
+    val scopes = WriteIdentities()
+
+    override fun WriteContext.encodeScope(scope: ClassLoaderScopeSpec) {
+        encodePreservingIdentityOf(scopes, scope) { newScope ->
+            when (val parent = newScope.parent) {
+                null -> {
+                    writeBoolean(false)
+                }
+
+                else -> {
+                    writeBoolean(true)
+                    encodeScope(parent)
+                }
+            }
+            writeString(newScope.name)
+            writeOrigin(newScope.origin)
+            writeClassPath(newScope.localClassPath)
+            writeHashCode(newScope.localImplementationHash)
+            writeClassPath(newScope.exportClassPath)
+        }
+    }
+
+    private
+    fun WriteContext.writeOrigin(origin: ClassLoaderScopeOrigin?) {
+        when (origin) {
+            is ClassLoaderScopeOrigin.Script -> {
+                writeBoolean(true)
+                origin.let {
+                    writeString(it.fileName)
+                    writeString(it.longDisplayName.displayName)
+                    writeString(it.shortDisplayName.displayName)
+                }
+            }
+
+            else -> {
+                writeBoolean(false)
+            }
+        }
+    }
+
+    private
+    fun Encoder.writeHashCode(hashCode: HashCode?) {
+        if (hashCode == null) {
+            writeBoolean(false)
+        } else {
+            writeBoolean(true)
+            writeBinary(hashCode.toByteArray())
+        }
+    }
+}
+
+
+internal
+class InlineClassLoaderScopeSpecDecoder : ClassLoaderScopeSpecDecoder {
+
+    private
+    val scopes = ReadIdentities()
+
+    override fun Decoder.decodeScope(): ClassLoaderScopeSpec = decodePreservingIdentity(scopes) { id ->
+        val parent = if (readBoolean()) {
+            decodeScope()
+        } else {
+            null
+        }
+
+        val name = readString()
+        val origin = readOrigin()
+        val localClassPath = readClassPath()
+        val localImplementationHash = readHashCode()
+        val exportClassPath = readClassPath()
+
+        val newScope = ClassLoaderScopeSpec(parent, name, origin).apply {
+            this.localClassPath = localClassPath
+            this.localImplementationHash = localImplementationHash
+            this.exportClassPath = exportClassPath
+        }
+        scopes.putInstance(id, newScope)
+        newScope
+    }
+
+    private
+    fun Decoder.readOrigin() = if (readBoolean()) {
+        ClassLoaderScopeOrigin.Script(
+            readString(),
+            Describables.of(readString()),
+            Describables.of(readString())
+        )
+    } else {
+        null
+    }
+
+    private
+    fun Decoder.readHashCode() = if (readBoolean()) {
+        HashCode.fromBytes(readBinary())
+    } else {
+        null
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassPathEncodingExtensions.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassPathEncodingExtensions.kt
@@ -20,14 +20,14 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.classpath.TransformedClassPath
 import org.gradle.internal.serialize.Decoder
-import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.graph.readFile
-import org.gradle.internal.serialize.graph.writeCollection
+import org.gradle.internal.serialize.graph.writeCollectionUnchecked
 import org.gradle.internal.serialize.graph.writeFile
 
 
 internal
-fun WriteContext.writeClassPath(classPath: ClassPath) {
+fun Encoder.writeClassPath(classPath: ClassPath) {
     // Ensure that the proper type is going to be restored,
     // because it is important for the equality checks.
     if (classPath is TransformedClassPath) {
@@ -41,18 +41,22 @@ fun WriteContext.writeClassPath(classPath: ClassPath) {
 
 
 private
-fun WriteContext.writeDefaultClassPath(classPath: ClassPath) {
-    writeCollection(classPath.asFiles) {
-        writeFile(it)
+fun Encoder.writeDefaultClassPath(classPath: ClassPath) {
+    classPath.asFiles.let { files ->
+        writeCollectionUnchecked(files, files.size) {
+            writeFile(it)
+        }
     }
 }
 
 
 private
-fun WriteContext.writeTransformedClassPath(classPath: TransformedClassPath) {
-    writeCollection(classPath.asFiles.zip(classPath.asTransformedFiles)) {
-        writeFile(it.first)
-        writeFile(it.second)
+fun Encoder.writeTransformedClassPath(classPath: TransformedClassPath) {
+    classPath.asFiles.zip(classPath.asTransformedFiles).let { files ->
+        writeCollectionUnchecked(files, files.size) {
+            writeFile(it.first)
+            writeFile(it.second)
+        }
     }
 }
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -324,7 +324,7 @@ inline fun <T : Any> ReadContext.decodePreservingSharedIdentity(decode: ReadCont
     }
 
 
-inline fun <T> ReadContext.decodePreservingIdentity(identities: ReadIdentities, decode: ReadContext.(Int) -> T): T {
+inline fun <T, C : Decoder> C.decodePreservingIdentity(identities: ReadIdentities, decode: C.(Int) -> T): T {
     val id = readSmallInt()
     val previousValue = identities.getInstance(id)
     return when {

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -60,7 +60,7 @@ interface WriteContext : MutableIsolateContext, Encoder {
 
     suspend fun write(value: Any?)
 
-    suspend fun <T: Any> writeSharedObject(value: T, encode: suspend WriteContext.(T) -> Unit)
+    suspend fun <T : Any> writeSharedObject(value: T, encode: suspend WriteContext.(T) -> Unit)
 
     fun writeClass(type: Class<*>)
 
@@ -109,7 +109,7 @@ interface ReadContext : IsolateContext, MutableIsolateContext, Decoder {
 
     suspend fun read(): Any?
 
-    suspend fun <T: Any> readSharedObject(decode: suspend ReadContext.() -> T): T
+    suspend fun <T : Any> readSharedObject(decode: suspend ReadContext.() -> T): T
 
     fun readClass(): Class<*>
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Combinators.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Combinators.kt
@@ -360,7 +360,7 @@ fun WriteContext.reportCollectionWriteFailure(collectionKind: String, size: Int,
     onError(ConcurrentModificationException("Collection corrupted or changed while iterating")) {
         text("The $collectionKind size() is $size, but $totalWritten entries were available when iterating over it. ")
         if (sizeAfterIteration != size) {
-            text("The size changed to ${sizeAfterIteration} after iterating.")
+            text("The size changed to $sizeAfterIteration after iterating.")
         } else {
             text("The $collectionKind is likely broken or corrupted because of a data race.")
         }

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Combinators.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Combinators.kt
@@ -256,14 +256,20 @@ fun Decoder.readStringsSet(): Set<String> =
     }
 
 
-inline fun <T> WriteContext.writeCollection(collection: Collection<T>, writeElement: (T) -> Unit) {
-    val size = collection.size
+inline fun <T, C : Encoder> C.writeCollectionUnchecked(collection: Collection<T>, size: Int, writeElement: (T) -> Unit): Int {
     writeSmallInt(size)
     var totalWritten = 0
     for (element in collection) {
         writeElement(element)
         ++totalWritten
     }
+    return totalWritten
+}
+
+
+inline fun <T> WriteContext.writeCollection(collection: Collection<T>, writeElement: (T) -> Unit) {
+    val size = collection.size
+    val totalWritten = writeCollectionUnchecked(collection, size, writeElement)
     if (size != totalWritten) {
         reportCollectionWriteFailure("collection", size, totalWritten, collection.size)
     }

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -133,10 +133,6 @@ class DefaultWriteContext(
 }
 
 
-@JvmInline
-value class ClassLoaderRole(val local: Boolean)
-
-
 interface ClassEncoder {
     fun WriteContext.encodeClass(type: Class<*>)
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -205,17 +205,17 @@ object InlineStringDecoder : StringDecoder {
 
 //TODO-RC consider making the implementations auto-closeable
 interface SharedObjectEncoder : AutoCloseable {
-    suspend fun <T: Any> write(writeContext: WriteContext, value: T, encode: suspend WriteContext.(T) -> Unit)
+    suspend fun <T : Any> write(writeContext: WriteContext, value: T, encode: suspend WriteContext.(T) -> Unit)
 }
 
 
 interface SharedObjectDecoder : AutoCloseable {
-    suspend fun <T: Any> read(readContext: ReadContext, decode: suspend ReadContext.() -> T): T
+    suspend fun <T : Any> read(readContext: ReadContext, decode: suspend ReadContext.() -> T): T
 }
 
 
 object InlineSharedObjectDecoder : SharedObjectDecoder {
-    override suspend fun <T: Any> read(readContext: ReadContext, decode: suspend ReadContext.() -> T): T =
+    override suspend fun <T : Any> read(readContext: ReadContext, decode: suspend ReadContext.() -> T): T =
         readContext.decode()
 
     override fun close() = Unit

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -150,6 +150,12 @@ object NullClassEncoder : ClassEncoder {
 }
 
 
+object NullClassDecoder : ClassDecoder {
+    override fun Decoder.decodeClass(): Class<*> =
+        error("Cannot decode class in this context.")
+}
+
+
 interface ClassDecoder {
     fun Decoder.decodeClass(): Class<*>
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -143,6 +143,13 @@ interface ClassEncoder {
 }
 
 
+object NullClassEncoder : ClassEncoder {
+    override fun WriteContext.encodeClass(type: Class<*>) {
+        error("$type cannot be encoded in this context.")
+    }
+}
+
+
 interface ClassDecoder {
     fun Decoder.decodeClass(): Class<*>
 

--- a/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
+++ b/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
@@ -62,11 +62,11 @@ public class DefaultClassPath implements ClassPath, Serializable {
         }
     }
 
-    public static ClassPath of(@Nullable File... files) {
+    public static ClassPath of(File... files) {
         if (files == null || files.length == 0) {
             return EMPTY;
         } else {
-            return of(Arrays.asList(files));
+            return new DefaultClassPath(ImmutableUniqueList.of(Arrays.asList(files)));
         }
     }
 


### PR DESCRIPTION
In preparation to encoding `ClassLoaderScopeSpec` values to a separate fingerprint file so the required classpaths can be checked.

This is the first step towards fixing #28727 and #27390.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
