### PR TITLE
JGit: Polish workaround to avoid deprecated, internal API usage.

### DIFF
--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/git/internal/GitVersionControlSystem.java
@@ -23,7 +23,6 @@ import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.JGitInternalException;
-import org.eclipse.jgit.internal.storage.file.WindowCache;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.RepositoryCache;
@@ -151,14 +150,13 @@ public class GitVersionControlSystem implements VersionControlSystem {
         }
     }
 
-    @SuppressWarnings("deprecation")
     public static void closeGit(@Nullable Git git) {
         if (git != null) {
             git.close();
         }
         // https://github.com/eclipse-jgit/jgit/issues/155
         RepositoryCache.clear();
-        WindowCache.reconfigure(new WindowCacheConfig());
+        new WindowCacheConfig().install();
     }
 
     private static void updateSubModules(Git git) throws IOException, GitAPIException {

--- a/testing/internal-integ-testing/src/main/java/org/gradle/integtests/fixtures/GitUtility.java
+++ b/testing/internal-integ-testing/src/main/java/org/gradle/integtests/fixtures/GitUtility.java
@@ -19,7 +19,6 @@ package org.gradle.integtests.fixtures;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.ConfigInvalidException;
-import org.eclipse.jgit.internal.storage.file.WindowCache;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.RepositoryCache;
 import org.eclipse.jgit.lib.StoredConfig;
@@ -72,10 +71,9 @@ public class GitUtility {
         }
     }
 
-    @SuppressWarnings("deprecation")
     private static void cleanup() {
         // https://github.com/eclipse-jgit/jgit/issues/155
         RepositoryCache.clear();
-        WindowCache.reconfigure(new WindowCacheConfig());
+        new WindowCacheConfig().install();
     }
 }


### PR DESCRIPTION
Polish #33786

`install()` calls `WindowCache.reconfigure(this)` internally

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
