### PR TITLE
Add missing space in upgrading_version_8.adoc

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -3794,7 +3794,7 @@ Starting in Gradle 9.0, this method will be removed without replacement.
 [[test_task_default_classpath]]
 ==== Relying on conventions for custom Test tasks
 
-By default, when applying the link:java_plugin.html[`java`] plugin, the `testClassesDirs`and `classpath` of all `Test` tasks have the same convention.
+By default, when applying the link:java_plugin.html[`java`] plugin, the `testClassesDirs` and `classpath` of all `Test` tasks have the same convention.
 Unless otherwise changed, the default behavior is to execute the tests from the default `test` link:jvm_test_suite_plugin.html[`TestSuite`] by configuring the task with the `classpath` and `testClassesDirs` from the `test` suite.
 This behavior will be removed in Gradle 9.0.
 


### PR DESCRIPTION
Add missing white space to not only fix the wording but also fix the broken backticks markdown rendering.