### PR TITLE
Mention develocity during failures

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/reporting_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/reporting_problems.adoc
@@ -87,7 +87,7 @@ Execution failed for task ':sample-project:myFailingTask'.
 
 * Try:
 > Remove the Problems.throwing() method call from the task action
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 
 BUILD FAILED in 0ms
 ----

--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/reporting_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/plugins/reporting_problems.adoc
@@ -87,7 +87,7 @@ Execution failed for task ':sample-project:myFailingTask'.
 
 * Try:
 > Remove the Problems.throwing() method call from the task action
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).
 
 BUILD FAILED in 0ms
 ----

--- a/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-avoid/tests/useTheGradlePropertiesFile-avoid.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-avoid/tests/useTheGradlePropertiesFile-avoid.out
@@ -13,5 +13,5 @@ Execution failed for task ':first'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.

--- a/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-avoid/tests/useTheGradlePropertiesFile-avoid.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-avoid/tests/useTheGradlePropertiesFile-avoid.out
@@ -13,5 +13,5 @@ Execution failed for task ':first'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).
 > Get more help at https://help.gradle.org.

--- a/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-do/tests/useTheGradlePropertiesFile-do.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-do/tests/useTheGradlePropertiesFile-do.out
@@ -13,5 +13,5 @@ Execution failed for task ':first'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.

--- a/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-do/tests/useTheGradlePropertiesFile-do.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/useTheGradlePropertiesFile-do/tests/useTheGradlePropertiesFile-do.out
@@ -13,5 +13,5 @@ Execution failed for task ':first'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).
 > Get more help at https://help.gradle.org.

--- a/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-groovy/taskExecutionEvents.groovy.out
+++ b/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-groovy/taskExecutionEvents.groovy.out
@@ -15,7 +15,7 @@ Execution failed for task ':broken'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-groovy/taskExecutionEvents.groovy.out
+++ b/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-groovy/taskExecutionEvents.groovy.out
@@ -15,7 +15,7 @@ Execution failed for task ':broken'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-kotlin/taskExecutionEvents.kotlin.out
+++ b/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-kotlin/taskExecutionEvents.kotlin.out
@@ -12,7 +12,7 @@ Execution failed for task ':broken'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-kotlin/taskExecutionEvents.kotlin.out
+++ b/platforms/documentation/docs/src/snippets/buildlifecycle/taskExecutionEvents/tests-kotlin/taskExecutionEvents.kotlin.out
@@ -12,7 +12,7 @@ Execution failed for task ':broken'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/configurationCache/problemsGroovy/tests/fail.out
+++ b/platforms/documentation/docs/src/snippets/configurationCache/problemsGroovy/tests/fail.out
@@ -21,7 +21,7 @@ Execution failed for task ':someTask'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/configurationCache/problemsGroovy/tests/fail.out
+++ b/platforms/documentation/docs/src/snippets/configurationCache/problemsGroovy/tests/fail.out
@@ -21,7 +21,7 @@ Execution failed for task ':someTask'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/configurationCache/problemsKotlin/tests/fail.out
+++ b/platforms/documentation/docs/src/snippets/configurationCache/problemsKotlin/tests/fail.out
@@ -18,7 +18,7 @@ Execution failed for task ':someTask'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/configurationCache/problemsKotlin/tests/fail.out
+++ b/platforms/documentation/docs/src/snippets/configurationCache/problemsKotlin/tests/fail.out
@@ -18,7 +18,7 @@ Execution failed for task ':someTask'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.out
+++ b/platforms/documentation/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.out
@@ -24,4 +24,4 @@ Execution failed for task ':compileJava'.
 
 * Try:
 > Check your code and dependencies to fix the compilation error(s)
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).

--- a/platforms/documentation/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.out
+++ b/platforms/documentation/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.out
@@ -24,4 +24,4 @@ Execution failed for task ':compileJava'.
 
 * Try:
 > Check your code and dependencies to fix the compilation error(s)
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).

--- a/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/completeCUnitExample.out
+++ b/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/completeCUnitExample.out
@@ -12,7 +12,7 @@ Execution failed for task ':runOperatorsTestFailingCUnitExe'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/completeCUnitExample.out
+++ b/platforms/documentation/docs/src/snippets/native-binaries/cunit/tests/completeCUnitExample.out
@@ -12,7 +12,7 @@ Execution failed for task ':runOperatorsTestFailingCUnitExe'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-groovy/taskFinalizersWithFailureGroovy.out
+++ b/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-groovy/taskFinalizersWithFailureGroovy.out
@@ -13,7 +13,7 @@ Execution failed for task ':taskX'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-groovy/taskFinalizersWithFailureGroovy.out
+++ b/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-groovy/taskFinalizersWithFailureGroovy.out
@@ -13,7 +13,7 @@ Execution failed for task ':taskX'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-kotlin/taskFinalizersWithFailureKotlin.out
+++ b/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-kotlin/taskFinalizersWithFailureKotlin.out
@@ -10,7 +10,7 @@ Execution failed for task ':taskX'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to get full insights.
+> Run with --scan to generate a Build Scan® (Powered by Develocity®).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-kotlin/taskFinalizersWithFailureKotlin.out
+++ b/platforms/documentation/docs/src/snippets/tasks/finalizersWithFailure/tests-kotlin/taskFinalizersWithFailureKotlin.out
@@ -10,7 +10,7 @@ Execution failed for task ':taskX'.
 * Try:
 > Run with --stacktrace option to get the stack trace.
 > Run with --info or --debug option to get more log output.
-> Run with --scan to generate a Build Scan® (Powered by Develocity®).
+> Run with --scan to generate a Build Scan (Powered by Develocity).
 > Get more help at https://help.gradle.org.
 
 BUILD FAILED in 0s

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/GradleHelpIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/GradleHelpIntegrationTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class GradleHelpIntegrationTest extends AbstractIntegrationSpec {
+    def "gradle -h is useful"() {
+        // This test doesn't actually start a daemon, but we need to require a daemon to avoid the in-process executer
+        executer.requireDaemon().requireIsolatedDaemons()
+
+        when:
+        succeeds("-h")
+        then:
+        output == """
+To see help contextual to the project, use gradle help
+
+To see more detail about a task, run gradle help --task <task>
+
+To see a list of available tasks, run gradle tasks
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+--no-build-cache                   Disables the Gradle build cache.
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds.
+--no-configuration-cache           Disables the configuration cache.
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail.
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+--no-continue                      Stop task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--no-parallel                      Disables parallel execution to build projects.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--problems-report                  (Experimental) enables HTML problems report
+--no-problems-report               (Experimental) disables HTML problems report
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+--property-upgrade-report          (Experimental) Runs build with experimental property upgrade report.
+-q, --quiet                        Log errors only.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Generate a Build Scan (Powered by Develocity).
+                                   Build Scan and Develocity are registered trademarks of Gradle, Inc.
+                                   For more information, please visit https://gradle.com/develocity/product/build-scan/.
+--no-scan                          Disables the creation of a Build Scan.
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+-U, --refresh-dependencies         Refresh the state of dependencies.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--no-watch-fs                      Disables watching the file system.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+
+"""
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -339,8 +339,10 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
         public BuildScanOption() {
             super(null, BooleanCommandLineOptionConfiguration.create(LONG_OPTION,
-                "Creates a Build Scan. Gradle will emit a warning if the Develocity plugin has not been applied. (https://gradle.com/develocity/product/build-scan/)",
-                "Disables the creation of a Build Scan. For more information about a Build Scan, please visit https://gradle.com/develocity/product/build-scan/."));
+                "Generate a Build Scan (Powered by Develocity).\n" +
+                    "                                   Build Scan and Develocity are registered trademarks of Gradle, Inc.\n" +
+                    "                                   For more information, please visit https://gradle.com/develocity/product/build-scan/.",
+                "Disables the creation of a Build Scan."));
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -417,7 +417,7 @@ public class BuildExceptionReporter implements Action<Throwable> {
     }
 
     private void addBuildScanMessage(ContextImpl context) {
-        context.appendResolution(output -> runWithOption(output, LONG_OPTION, " to get full insights."));
+        context.appendResolution(output -> runWithOption(output, LONG_OPTION, " to generate a Build Scan® (Powered by Develocity®)."));
     }
 
     private boolean isGradleEnterprisePluginApplied() {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -417,7 +417,7 @@ public class BuildExceptionReporter implements Action<Throwable> {
     }
 
     private void addBuildScanMessage(ContextImpl context) {
-        context.appendResolution(output -> runWithOption(output, LONG_OPTION, " to generate a Build Scan® (Powered by Develocity®)."));
+        context.appendResolution(output -> runWithOption(output, LONG_OPTION, " to generate a Build Scan (Powered by Develocity)."));
     }
 
     private boolean isGradleEnterprisePluginApplied() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -55,7 +55,7 @@ class BuildExceptionReporterTest extends Specification {
     static final String LOCATION = "<location>"
     static final String STACKTRACE = "{info}> {normal}Run with {userinput}--stacktrace{normal} option to get the stack trace."
     static final String INFO_OR_DEBUG = "{info}> {normal}Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output."
-    static final String TRY_SCAN = "{info}> {normal}Run with {userinput}--scan{normal} to generate a Build Scan® (Powered by Develocity®)."
+    static final String TRY_SCAN = "{info}> {normal}Run with {userinput}--scan{normal} to generate a Build Scan (Powered by Develocity)."
     static final String GET_HELP = "{info}> {normal}Get more help at {userinput}https://help.gradle.org{normal}."
 
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -55,7 +55,7 @@ class BuildExceptionReporterTest extends Specification {
     static final String LOCATION = "<location>"
     static final String STACKTRACE = "{info}> {normal}Run with {userinput}--stacktrace{normal} option to get the stack trace."
     static final String INFO_OR_DEBUG = "{info}> {normal}Run with {userinput}--info{normal} or {userinput}--debug{normal} option to get more log output."
-    static final String TRY_SCAN = "{info}> {normal}Run with {userinput}--scan{normal} to get full insights."
+    static final String TRY_SCAN = "{info}> {normal}Run with {userinput}--scan{normal} to generate a Build Scan® (Powered by Develocity®)."
     static final String GET_HELP = "{info}> {normal}Get more help at {userinput}https://help.gradle.org{normal}."
 
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SuggestionsMessages.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SuggestionsMessages.groovy
@@ -25,7 +25,7 @@ class SuggestionsMessages {
 
     public static final String INFO_DEBUG = "Run with --info or --debug option to get more log output."
     public static final String DEBUG = "Run with --debug option to get more log output."
-    public static final String SCAN = "Run with --scan to generate a Build Scan® (Powered by Develocity®)."
+    public static final String SCAN = "Run with --scan to generate a Build Scan (Powered by Develocity)."
     public static final String GET_HELP = "Get more help at https://help.gradle.org."
     public static final String STACKTRACE_MESSAGE = "Run with --stacktrace option to get the stack trace."
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SuggestionsMessages.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/SuggestionsMessages.groovy
@@ -25,7 +25,7 @@ class SuggestionsMessages {
 
     public static final String INFO_DEBUG = "Run with --info or --debug option to get more log output."
     public static final String DEBUG = "Run with --debug option to get more log output."
-    public static final String SCAN = "Run with --scan to get full insights."
+    public static final String SCAN = "Run with --scan to generate a Build Scan® (Powered by Develocity®)."
     public static final String GET_HELP = "Get more help at https://help.gradle.org."
     public static final String STACKTRACE_MESSAGE = "Run with --stacktrace option to get the stack trace."
 


### PR DESCRIPTION
We already recommend runing --scan during failures. In this commit, we additionally
mention Build Scans, and Develocity.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
