### PR TITLE
Serializes and restores isDisallowChanges property metadata

### DIFF
--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyLifecycleIntegrationTest.groovy
@@ -698,7 +698,6 @@ task thing {
         def "cannot update file property marked disallowChanges"() {
             taskTypeWithOutputFileProperty()
 
-            settingsFile << "rootProject.name = 'broken'"
             buildFile """
                 tasks.register("producer", FileProducer) {
                     output = layout.buildDir.file("text.out")
@@ -722,7 +721,6 @@ task thing {
         def "cannot update directory property marked disallowChanges"() {
             taskTypeWithOutputDirectoryProperty()
 
-            settingsFile << "rootProject.name = 'broken'"
             buildFile """
                 tasks.register("producer", DirProducer) {
                     output = layout.buildDir.dir("dir.out")

--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyLifecycleIntegrationTest.groovy
@@ -690,51 +690,57 @@ task thing {
         output.count("prop = 123") == 1
     }
 
-    def "cannot update file property marked disallowChanges"() {
-        taskTypeWithOutputFileProperty()
+    /**
+     * These tests are to verify that when a property is marked as disallowChanges during configuration time,
+     * this setting is properly restored by the CC and honored at task execution time.
+     */
+    static class DisallowChangesIntegrationTests extends AbstractIntegrationSpec implements TasksWithInputsAndOutputs {
+        def "cannot update file property marked disallowChanges"() {
+            taskTypeWithOutputFileProperty()
 
-        settingsFile << "rootProject.name = 'broken'"
-        buildFile """
-        tasks.register("producer", FileProducer) {
-            output = layout.buildDir.file("text.out")
-            output.disallowChanges()
-            def other = file('ignore')
-            doFirst {
-                try {
-                    output = other
-                } catch(IllegalStateException e) {
-                    println("set failed: " + e.message)
-                }
-            }
-        }
-        """
-
-        expect:
-        succeeds("producer")
-        outputContains("set failed: The value for task ':producer' property 'output' is final and cannot be changed any further.")
-    }
-
-    def "cannot update directory property marked disallowChanges"() {
-        taskTypeWithOutputDirectoryProperty()
-
-        settingsFile << "rootProject.name = 'broken'"
-        buildFile """
-        tasks.register("producer", DirProducer) {
-                output = layout.buildDir.dir("dir.out")
-                output.disallowChanges()
-                def other = file('ignore')
-                doFirst {
-                    try {
-                        output = other
-                    } catch(IllegalStateException e) {
-                        println("set failed: " + e.message)
+            settingsFile << "rootProject.name = 'broken'"
+            buildFile """
+                tasks.register("producer", FileProducer) {
+                    output = layout.buildDir.file("text.out")
+                    output.disallowChanges()
+                    def other = file('ignore')
+                    doFirst {
+                        try {
+                            output = other
+                        } catch(IllegalStateException e) {
+                            println("set failed: " + e.message)
+                        }
                     }
                 }
-            }
-        """
+            """
 
-        expect:
-        succeeds("producer")
-        outputContains("set failed: The value for task ':producer' property 'output' is final and cannot be changed any further.")
+            expect:
+            succeeds("producer")
+            outputContains("set failed: The value for task ':producer' property 'output' is final and cannot be changed any further.")
+        }
+
+        def "cannot update directory property marked disallowChanges"() {
+            taskTypeWithOutputDirectoryProperty()
+
+            settingsFile << "rootProject.name = 'broken'"
+            buildFile """
+                tasks.register("producer", DirProducer) {
+                    output = layout.buildDir.dir("dir.out")
+                    output.disallowChanges()
+                    def other = file('ignore')
+                    doFirst {
+                        try {
+                            output = other
+                        } catch(IllegalStateException e) {
+                            println("set failed: " + e.message)
+                        }
+                    }
+                }
+            """
+
+            expect:
+            succeeds("producer")
+            outputContains("set failed: The value for task ':producer' property 'output' is final and cannot be changed any further.")
+        }
     }
 }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -289,9 +289,6 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         }
 
         public abstract FileResolver getFileResolver();
-
-        @Nullable
-        public abstract PathToFileResolver getFileCollectionResolver();
     }
 
     public static class DefaultRegularFileVar extends AbstractFileVar<RegularFile, RegularFileProperty> implements RegularFileProperty, Managed {
@@ -305,12 +302,6 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         @Override
         public FileResolver getFileResolver() {
             return fileResolver;
-        }
-
-        @Override
-        @Nullable
-        public PathToFileResolver getFileCollectionResolver() {
-            return null;
         }
 
         @Override
@@ -376,7 +367,6 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
             return resolver;
         }
 
-        @Override
         public PathToFileResolver getFileCollectionResolver() {
             return fileCollectionFactory.getResolver();
         }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -187,7 +187,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         }
     }
 
-    static abstract class AbstractFileVar<T extends FileSystemLocation, THIS extends FileSystemLocationProperty<T>> extends DefaultProperty<T> implements FileSystemLocationPropertyInternal<T> {
+    public static abstract class AbstractFileVar<T extends FileSystemLocation, THIS extends FileSystemLocationProperty<T>> extends DefaultProperty<T> implements FileSystemLocationPropertyInternal<T> {
 
         public AbstractFileVar(PropertyHost host, Class<T> type) {
             super(host, type);
@@ -287,6 +287,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
                 }
             };
         }
+
+        public abstract FileResolver getFileResolver();
+
+        @Nullable
+        public abstract PathToFileResolver getFileCollectionResolver();
     }
 
     public static class DefaultRegularFileVar extends AbstractFileVar<RegularFile, RegularFileProperty> implements RegularFileProperty, Managed {
@@ -297,8 +302,15 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
             this.fileResolver = fileResolver;
         }
 
-        public PathToFileResolver getFileResolver() {
+        @Override
+        public FileResolver getFileResolver() {
             return fileResolver;
+        }
+
+        @Override
+        @Nullable
+        public PathToFileResolver getFileCollectionResolver() {
+            return null;
         }
 
         @Override
@@ -359,10 +371,12 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
             return fileCollectionFactory.resolving(this).getAsFileTree();
         }
 
+        @Override
         public FileResolver getFileResolver() {
             return resolver;
         }
 
+        @Override
         public PathToFileResolver getFileCollectionResolver() {
             return fileCollectionFactory.getResolver();
         }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
@@ -560,8 +560,6 @@ task wrongPropertyElementTypeApi(type: MyTask) {
             given:
             buildFile """
                 class Setter extends DefaultTask {
-                    @Input
-                    final Property<String> content = project.objects.property(String).convention("content")
                     @Internal
                     final ListProperty<String> prop = project.objects.listProperty(String)
 
@@ -572,7 +570,7 @@ task wrongPropertyElementTypeApi(type: MyTask) {
                 }
 
                 tasks.register("setter", Setter) {
-                    prop.add(content)
+                    prop.add("original content")
                     prop.disallowChanges()
                 }
             """
@@ -586,8 +584,6 @@ task wrongPropertyElementTypeApi(type: MyTask) {
             given:
             buildFile """
                 class Setter extends DefaultTask {
-                    @Input
-                    final Property<String> content = project.objects.property(String).convention("content")
                     @Internal
                     final SetProperty<String> prop = project.objects.setProperty(String)
 
@@ -598,7 +594,7 @@ task wrongPropertyElementTypeApi(type: MyTask) {
                 }
 
                 tasks.register("setter", Setter) {
-                    prop.add(content)
+                    prop.add("original content")
                     prop.disallowChanges()
                 }
             """
@@ -612,8 +608,6 @@ task wrongPropertyElementTypeApi(type: MyTask) {
             given:
             buildFile """
                 class Setter extends DefaultTask {
-                    @Input
-                    final MapProperty<String, String> content = project.objects.mapProperty(String, String).convention(["key": "value"])
                     @Internal
                     final MapProperty<String, String> prop = project.objects.mapProperty(String, String)
 
@@ -624,7 +618,7 @@ task wrongPropertyElementTypeApi(type: MyTask) {
                 }
 
                 tasks.register("setter", Setter) {
-                    prop.set(content)
+                    prop.set(["key": "value"])
                     prop.disallowChanges()
                 }
             """

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
@@ -558,7 +558,6 @@ task wrongPropertyElementTypeApi(type: MyTask) {
     static class DisallowChangesIntegrationTests extends AbstractIntegrationSpec {
         def "cannot update list property marked disallowChanges"() {
             given:
-            settingsFile << "rootProject.name = 'broken'"
             buildFile """
                 class Setter extends DefaultTask {
                     @Input
@@ -585,7 +584,6 @@ task wrongPropertyElementTypeApi(type: MyTask) {
 
         def "cannot update set property marked disallowChanges"() {
             given:
-            settingsFile << "rootProject.name = 'broken'"
             buildFile """
                 class Setter extends DefaultTask {
                     @Input
@@ -612,7 +610,6 @@ task wrongPropertyElementTypeApi(type: MyTask) {
 
         def "cannot update map property marked disallowChanges"() {
             given:
-            settingsFile << "rootProject.name = 'broken'"
             buildFile """
                 class Setter extends DefaultTask {
                     @Input

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
@@ -550,4 +550,91 @@ task wrongPropertyElementTypeApi(type: MyTask) {
         "list" | "listProperty"
         "set" | "setProperty"
     }
+
+    /**
+     * These tests are to verify that when a property is marked as disallowChanges during configuration time,
+     * this setting is properly restored by the CC and honored at task execution time.
+     */
+    static class DisallowChangesIntegrationTests extends AbstractIntegrationSpec {
+        def "cannot update list property marked disallowChanges"() {
+            given:
+            settingsFile << "rootProject.name = 'broken'"
+            buildFile """
+                class Setter extends DefaultTask {
+                    @Input
+                    final Property<String> content = project.objects.property(String).convention("content")
+                    @Internal
+                    final ListProperty<String> prop = project.objects.listProperty(String)
+
+                    @TaskAction
+                    def run() {
+                        prop.add("new content")
+                    }
+                }
+
+                tasks.register("setter", Setter) {
+                    prop.add(content)
+                    prop.disallowChanges()
+                }
+            """
+
+            expect:
+            fails("setter")
+            failure.assertHasCause("The value for task ':setter' property 'prop' cannot be changed any further.")
+        }
+
+        def "cannot update set property marked disallowChanges"() {
+            given:
+            settingsFile << "rootProject.name = 'broken'"
+            buildFile """
+                class Setter extends DefaultTask {
+                    @Input
+                    final Property<String> content = project.objects.property(String).convention("content")
+                    @Internal
+                    final SetProperty<String> prop = project.objects.setProperty(String)
+
+                    @TaskAction
+                    def run() {
+                        prop.add("new content")
+                    }
+                }
+
+                tasks.register("setter", Setter) {
+                    prop.add(content)
+                    prop.disallowChanges()
+                }
+            """
+
+            expect:
+            fails("setter")
+            failure.assertHasCause("The value for task ':setter' property 'prop' cannot be changed any further.")
+        }
+
+        def "cannot update map property marked disallowChanges"() {
+            given:
+            settingsFile << "rootProject.name = 'broken'"
+            buildFile """
+                class Setter extends DefaultTask {
+                    @Input
+                    final MapProperty<String, String> content = project.objects.mapProperty(String, String).convention(["key": "value"])
+                    @Internal
+                    final MapProperty<String, String> prop = project.objects.mapProperty(String, String)
+
+                    @TaskAction
+                    def run() {
+                        prop.set(["key": "new value"])
+                    }
+                }
+
+                tasks.register("setter", Setter) {
+                    prop.set(content)
+                    prop.disallowChanges()
+                }
+            """
+
+            expect:
+            fails("setter")
+            failure.assertHasCause("The value for task ':setter' property 'prop' cannot be changed any further.")
+        }
+    }
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyLifecycleIntegrationTest.groovy
@@ -569,7 +569,6 @@ class PropertyLifecycleIntegrationTest extends AbstractIntegrationSpec {
          */
         def "cannot update property marked disallowChanges"() {
             given:
-            settingsFile << "rootProject.name = 'broken'"
             buildFile """
                 class Setter extends DefaultTask {
                     @Input

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyLifecycleIntegrationTest.groovy
@@ -571,8 +571,6 @@ class PropertyLifecycleIntegrationTest extends AbstractIntegrationSpec {
             given:
             buildFile """
                 class Setter extends DefaultTask {
-                    @Input
-                    final Property<String> content = project.objects.property(String).convention("content")
                     @Internal
                     final Property<String> prop = project.objects.property(String)
 
@@ -583,7 +581,7 @@ class PropertyLifecycleIntegrationTest extends AbstractIntegrationSpec {
                 }
 
                 tasks.register("setter", Setter) {
-                    prop = content
+                    prop = "original content"
                     prop.disallowChanges()
                 }
             """

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -71,6 +71,10 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         return state.isFinalized();
     }
 
+    public boolean isDisallowChanges() {
+        return state.isDisallowChanges();
+    }
+
     protected boolean isExplicit() {
         return state.isExplicit();
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
@@ -73,6 +73,8 @@ public abstract class ValueState<S> {
 
     public abstract void disallowChanges();
 
+    public abstract boolean isDisallowChanges();
+
     public abstract void finalizeOnNextGet();
 
     public abstract void disallowUnsafeRead();
@@ -246,6 +248,11 @@ public abstract class ValueState<S> {
         }
 
         @Override
+        public boolean isDisallowChanges() {
+            return disallowChanges;
+        }
+
+        @Override
         public void finalizeOnNextGet() {
             finalizeOnNextGet = true;
         }
@@ -373,6 +380,11 @@ public abstract class ValueState<S> {
         @Override
         public void disallowChanges() {
             // Finalized, so already cannot change
+        }
+
+        @Override
+        public boolean isDisallowChanges() {
+            return true;
         }
 
         @Override


### PR DESCRIPTION
Introduces serialization for `isDisallowChanges` and similar "metadata" attributes of file-based properties.

This ensures that properties configured with specific constraints, such as those preventing unsafe reads or modifications, retain these configurations after deserialization.

This is achieved by introducing an abstract base class for codecs handling file-based properties which extends `DefaultFilePropertyFactory.AbstractFileVar` and is responsible for encoding the property metadata fields, with the actual property recreation delegated to concrete subclasses.

Part 1 of addressing https://github.com/gradle/gradle/issues/25513