### PR TITLE
Fix testDistribution args in docsTest

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/DocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/DocsTest.kt
@@ -88,7 +88,7 @@ class DocsTest(
             arch = os.defaultArch,
             timeout = 60,
             extraParameters =
-                buildScanTagParam(docsTestType.docsTestName) +
+                buildScanTagParam(docsTestType.docsTestName) + " " +
                     parallelizationMethod.extraBuildParameters +
                     " -PenableConfigurationCacheForDocsTests=${docsTestType.ccEnabled}" +
                     " -PtestJavaVersion=${testJava.version.major}" +


### PR DESCRIPTION
`-Dscan.tag.DocsTest-DenableTestDistribution=true` -> `-Dscan.tag.DocsTest -DenableTestDistribution=true`