### PR TITLE
Fix CC integration test asserting the html report

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheReportIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheReportIntegrationTest.groovy
@@ -38,11 +38,12 @@ class ConfigurationCacheReportIntegrationTest extends AbstractConfigurationCache
 
     def "report with problem loads successfully"() {
         given:
-        buildFile '''
+        buildFile """
+            def capturedProject = project
             tasks.register('notOk') {
-                doLast { println project.name }
+                doLast { println capturedProject.name }
             }
-        '''
+        """
 
         when:
         configurationCacheFails 'notOk'


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4701

The test was already flaky, so when it became entirely failing after this change (https://github.com/gradle/gradle/pull/33753), it still slipped through the CI.

FWIW, the failure was not Windows-specific. We only run this test on Windows, because it's test dependencies are unavailable or unstable under other platforms (see test's javadoc).