### PR TITLE
Remove ResolveArtifactsBuildOperationType.Details.getConfigurationPath

### DIFF
--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/ResolveArtifactsBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/ResolveArtifactsBuildOperationType.java
@@ -27,16 +27,6 @@ public final class ResolveArtifactsBuildOperationType implements BuildOperationT
 
     public interface Details {
 
-        /**
-         * This method is not called on the Develocity side, at least in DV plugin &gt;= 3.0.
-         *
-         * @return An empty string.
-         *
-         * @deprecated This method will be removed in Gradle 9.0
-         */
-        @Deprecated
-        String getConfigurationPath();
-
     }
 
     public interface Result {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSetResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSetResolver.java
@@ -76,13 +76,7 @@ public class ResolvedArtifactSetResolver {
                 return BuildOperationDescriptor
                     .displayName(displayName)
                     .progressDisplayName(displayName)
-                    .details(new ResolveArtifactsBuildOperationType.Details() {
-                        @Override
-                        @Deprecated
-                        public String getConfigurationPath() {
-                            return "";
-                        }
-                    });
+                    .details(new ResolveArtifactsBuildOperationType.Details() {});
             }
         });
     }


### PR DESCRIPTION
Now that the minimum required Develocity plugin version is 3.13.1, we can remove the method.