### PR TITLE
Update deprecation timeline in some javadocs

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
@@ -145,7 +145,7 @@ abstract class GradleDelegate : Gradle {
         delegate.removeListener(listener)
 
     @Suppress("DEPRECATION")
-    @Deprecated("Will be removed in Gradle 9. Logging customization through listeners is no longer supported.")
+    @Deprecated("Will be removed in Gradle 10. Logging customization through listeners is no longer supported.")
     override fun useLogger(logger: Any) =
         delegate.useLogger(logger)
 

--- a/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/ExecHandleBuilder.java
+++ b/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/ExecHandleBuilder.java
@@ -23,7 +23,7 @@ import org.gradle.process.ProcessForkOptions;
 /**
  * Deprecated. Use {@link ClientExecHandleBuilder} instead. Kept for now since it's used by the Kotlin plugin.
  *
- * Can be merged with {@link ClientExecHandleBuilder} in Gradle 9.0.
+ * Can be merged with {@link ClientExecHandleBuilder} in Gradle 10.
  */
 @Deprecated
 public interface ExecHandleBuilder extends ProcessForkOptions, BaseExecSpec, ExecSpec {

--- a/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/ExecHandleFactory.java
+++ b/platforms/core-runtime/process-services/src/main/java/org/gradle/process/internal/ExecHandleFactory.java
@@ -19,7 +19,7 @@ package org.gradle.process.internal;
 /**
  * Deprecated. Use {@link ClientExecHandleBuilderFactory} instead. Kept for now since it's used by the Kotlin plugin.
  *
- * Can be merged with {@link ClientExecHandleBuilderFactory} in Gradle 9.0.
+ * Can be merged with {@link ClientExecHandleBuilderFactory} in Gradle 10.
  */
 @Deprecated
 public interface ExecHandleFactory {

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -352,7 +352,7 @@ public interface Gradle extends PluginAware, ExtensionAware {
      * provides with your own implementation, for certain types of events.
      *
      * @param logger The logger to use.
-     * @deprecated Will be removed in Gradle 9. Logging customization through listeners is no longer supported.
+     * @deprecated Will be removed in Gradle 10. Logging customization through listeners is no longer supported.
      */
     @Deprecated
     void useLogger(Object logger);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -102,7 +102,7 @@ import java.util.stream.Collectors;
 import static org.gradle.internal.UncheckedException.uncheckedCall;
 
 /**
- * @deprecated This class will be removed in Gradle 9.0. Please use {@link org.gradle.api.DefaultTask} instead.
+ * @deprecated This class will be removed in Gradle 10. Please use {@link org.gradle.api.DefaultTask} instead.
  */
 @Deprecated
 @DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")

--- a/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Deprecated. Will be removed in Gradle 9.0. Kept for now it's subclass is used by the Kotlin plugin.
+ * Deprecated. Will be removed in Gradle 10. Kept for now it's subclass is used by the Kotlin plugin.
  */
 @Deprecated
 public abstract class AbstractExecHandleBuilder implements BaseExecSpec {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecAction.java
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * Use {@link ExecActionFactory} (for core code) or {@link org.gradle.process.ExecOperations} (for plugin code) instead.
  *
- * TODO: We should remove setters and have abstract getters in Gradle 9.0 and configure builder in execute() method.
+ * TODO: We should remove setters and have abstract getters in Gradle 10 and configure builder in execute() method.
  */
 public class DefaultExecAction implements ExecAction {
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandleBuilder.java
@@ -28,7 +28,7 @@ import java.util.Map;
 /**
  * Deprecated. Use {@link ClientExecHandleBuilder} instead. Kept for now since it's used by the Kotlin plugin.
  *
- * Can be merged with {@link ClientExecHandleBuilder} in Gradle 9.0.
+ * Can be merged with {@link ClientExecHandleBuilder} in Gradle 10.
  */
 @SuppressWarnings("DeprecatedIsStillUsed")
 @Deprecated

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecAction.java
@@ -39,7 +39,7 @@ import java.util.Map;
 /**
  * Use {@link ExecActionFactory} (for core code) or {@link org.gradle.process.ExecOperations} (for plugin code) instead.
  *
- * TODO: We should remove setters and have abstract getters in Gradle 9.0 and configure builder in execute() method.
+ * TODO: We should remove setters and have abstract getters in Gradle 10 and configure builder in execute() method.
  */
 public class DefaultJavaExecAction implements JavaExecAction {
 


### PR DESCRIPTION
All these were postponed until Gradle 10 for various reasons.