### PR TITLE
Fix synthetic property access for Exec.args

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecKotlinDSLIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecKotlinDSLIntegrationTest.groovy
@@ -51,6 +51,23 @@ class ExecKotlinDSLIntegrationTest extends AbstractIntegrationSpec {
         "its setter"    | "setArgs(listOf(${echoArguments}))"
     }
 
+    def "can execute command without setting any value for Exec.args"() {
+        buildKotlinFile << """
+            import org.gradle.internal.jvm.Jvm
+
+            tasks.register<Exec>("execTask") {
+                executable = Jvm.current().getJavaExecutable().absolutePath
+                setIgnoreExitValue(true)
+            }
+        """
+
+        when:
+        run "execTask"
+
+        then:
+        errorOutput.contains("Usage: java")
+    }
+
     String getEchoArguments() {
         return """ "-cp", sourceSets["main"].runtimeClasspath.asPath, "Echo", "foo", "bar" """
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecKotlinDSLIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecKotlinDSLIntegrationTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+class ExecKotlinDSLIntegrationTest extends AbstractIntegrationSpec {
+
+    @Issue("https://github.com/gradle/gradle/issues/33861")
+    def "can configure Exec.args using #method"() {
+        given:
+        file("src/main/java/Echo.java") << echoClass
+        buildKotlinFile << """
+            import org.gradle.internal.jvm.Jvm
+
+            plugins {
+                id("java")
+            }
+
+            tasks.register<Exec>("execTask") {
+                dependsOn(sourceSets["main"].runtimeClasspath)
+                executable = Jvm.current().getJavaExecutable().absolutePath
+                ${expression}
+            }
+        """
+
+        when:
+        run "execTask"
+
+        then:
+        outputContains("foo+bar")
+
+        where:
+        method          | expression
+        "a property"    | "args = listOf(${echoArguments})"
+        "its setter"    | "setArgs(listOf(${echoArguments}))"
+    }
+
+    String getEchoArguments() {
+        return """ "-cp", sourceSets["main"].runtimeClasspath.asPath, "Echo", "foo", "bar" """
+    }
+
+    String getEchoClass() {
+        return """
+            class Echo {
+                public static void main(String[] args) {
+                    System.out.println(String.join("+", args));
+                }
+            }
+        """
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
@@ -117,7 +117,7 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
      * {@inheritDoc}
      */
     @Override
-    public T setArgs(@Nullable Iterable<?> arguments) {
+    public T setArgs(Iterable<?> arguments) {
         execSpec.setArgs(arguments);
         return taskType.cast(this);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
@@ -125,7 +125,6 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
     /**
      * {@inheritDoc}
      */
-    @Nullable
     @Optional
     @Input
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Exec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Exec.java
@@ -17,7 +17,6 @@ package org.gradle.api.tasks;
 
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.work.DisableCachingByDefault;
-import org.jspecify.annotations.Nullable;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -72,7 +71,7 @@ public abstract class Exec extends AbstractExecTask<Exec> {
      * {@inheritDoc}
      */
     @Override
-    public Exec setArgs(@Nullable Iterable<?> arguments) {
+    public Exec setArgs(Iterable<?> arguments) {
         return super.setArgs(arguments);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Exec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Exec.java
@@ -55,7 +55,6 @@ public abstract class Exec extends AbstractExecTask<Exec> {
      * {@inheritDoc}
      */
     @Override
-    @Nullable
     @ToBeReplacedByLazyProperty
     public List<String> getArgs() {
         return super.getArgs();

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1585,11 +1585,27 @@
             ]
         },
         {
+            "type": "org.gradle.api.tasks.AbstractExecTask",
+            "member": "Method org.gradle.api.tasks.AbstractExecTask.setArgs(java.lang.Iterable)",
+            "acceptation": "Setting parameter to null doesn't work",
+            "changes": [
+                "Parameter 0 from null accepting to non-null accepting breaking change"
+            ]
+        },
+        {
             "type": "org.gradle.api.tasks.Delete",
             "member": "Method org.gradle.api.tasks.Delete.getDeleter()",
             "acceptation": "Making all injecting getters abstract",
             "changes": [
                 "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.Exec",
+            "member": "Method org.gradle.api.tasks.Exec.setArgs(java.lang.Iterable)",
+            "acceptation": "Setting parameter to null doesn't work",
+            "changes": [
+                "Parameter 0 from null accepting to non-null accepting breaking change"
             ]
         },
         {

--- a/testing/architecture-test/src/changes/archunit-store/public-api-symmetrical-accessors-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-symmetrical-accessors-nullability.txt
@@ -1,9 +1,7 @@
 Accessors for org.gradle.StartParameter.currentDir don't use symmetrical @Nullable
 Accessors for org.gradle.StartParameter.gradleUserHomeDir don't use symmetrical @Nullable
 Accessors for org.gradle.StartParameter.taskNames don't use symmetrical @Nullable
-Accessors for org.gradle.api.tasks.AbstractExecTask.args don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.AbstractExecTask.executable don't use symmetrical @Nullable
-Accessors for org.gradle.api.tasks.Exec.args don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.JavaExec.executable don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.SourceSetOutput.resourcesDir don't use symmetrical @Nullable
 Accessors for org.gradle.api.tasks.bundling.War.classpath don't use symmetrical @Nullable


### PR DESCRIPTION
Nullability was preventing Kotlin from seeing `setArgs(List<String>)` as a corresponding setter for `getArgs()`, so a synthetic property was never exposed.

Turns out that setting args to null doesn't work anyways since it causes a null pointer exception elsewhere, so we just remove it from `getArgs()` and synthetic property access works again.

* Fixes #33861
* Follows up #24767 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
