### PR TITLE
Add a preamble to CC report link in degradation mode

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -190,7 +190,8 @@ class Summary(
         val documentationRegistry = DocumentationRegistry()
         return StringBuilder().apply {
             // When build degrades gracefully, we keep the console output minimal but still want to see the report link
-            if (reportableProblemCount > 0) {
+            val hasReportableProblems = reportableProblemCount > 0
+            if (hasReportableProblems) {
                 appendLine()
                 appendSummaryHeader(cacheActionText, reportableProblemCount)
                 appendLine()
@@ -209,6 +210,10 @@ class Summary(
             }
             htmlReportFile?.let {
                 appendLine()
+                if (!hasReportableProblems) {
+                    append("Some tasks in this build are not compatible with the configuration cache.")
+                    appendLine()
+                }
                 append(buildSummaryReportLink(it))
             }
         }.toString()


### PR DESCRIPTION
"See the complete report" doesn't give any context about what report it is. When CC problems are present, there is an introductory text of "problem was found storing the configuration cache". This commit adds an alternative preamble for cases when there are no problems, assuming that it only happens when some tasks/features requested graceful degradation.