### PR TITLE
Use graceful degradation for software model tasks in CC mode

### DIFF
--- a/platforms/core-configuration/base-diagnostics/build.gradle.kts
+++ b/platforms/core-configuration/base-diagnostics/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(projects.concurrent)
     implementation(projects.functional)
     implementation(projects.loggingApi)
+    implementation(projects.serviceLookup)
 
     implementation(libs.commonsLang)
     implementation(libs.guava)

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/reporting/model/ModelReport.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/reporting/model/ModelReport.java
@@ -17,7 +17,9 @@
 package org.gradle.api.reporting.model;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.internal.ConfigurationCacheDegradationController;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.reporting.model.internal.ModelNodeRenderer;
 import org.gradle.api.reporting.model.internal.TextModelReportRenderer;
 import org.gradle.api.tasks.Console;
@@ -57,6 +59,11 @@ public abstract class ModelReport extends DefaultTask {
 
     private boolean showHidden;
     private Format format = Format.FULL;
+
+    @Inject
+    public ModelReport() {
+        getServices().get(ConfigurationCacheDegradationController.class).requireConfigurationCacheDegradation(this, Providers.of("Task is not compatible with the Configuration Cache"));
+    }
 
     @Option(option = "showHidden", description = "Show hidden model elements.")
     public void setShowHidden(boolean showHidden) {

--- a/platforms/core-configuration/base-diagnostics/src/test/groovy/org/gradle/api/reporting/model/ModelReportParserTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/test/groovy/org/gradle/api/reporting/model/ModelReportParserTest.groovy
@@ -51,7 +51,7 @@ BUILD SUCCESSFUsL
 """)
         then:
         def ex = thrown(AssertionError)
-        ex.message.startsWith "Expected to find an end of report marker '${ModelReportParser.END_OF_REPORT_MARKER}'"
+        ex.message.startsWith "Expected to find an end of report marker"
     }
 
     def "fails when missing the header marker"() {
@@ -198,5 +198,35 @@ BUILD SUCCESSFUL
 
         expect:
         modelReport.reportNode.'**'.primaryCredentials.@username == ['uname']
+    }
+
+    def "can parse end of report marker from #description build"() {
+        setup:
+        def modelReport = ModelReportParser.parse(""":model
+
+---------
+My Report
+---------
+
+1
+2
+3
+
+$marker
+""")
+
+        expect:
+        modelReport.nodeOnlyLines == ["1", "2", "3"]
+
+        where:
+        [marker, description] << [
+            ["BUILD SUCCESSFUL in 1s", "vintage"],
+            [
+                """Some tasks in this build are not compatible with the configuration cache.
+See the complete report at file:///root/build/reports/configuration-cache/hash1/hash2/configuration-cache-report.html
+BUILD SUCCESSFUL in 1s""",
+                "configuration cache"
+            ]
+        ]
     }
 }

--- a/platforms/core-configuration/base-diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/model/ModelReportParser.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/model/ModelReportParser.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.reporting.model
 import com.google.common.annotations.VisibleForTesting
 
 import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 class ModelReportParser {
 
@@ -26,8 +27,8 @@ class ModelReportParser {
     public static final int FIRST_NODE_LINE_NUMBER = 4
     public static final String NODE_LEFT_PADDING = '    '
     public static final String NODE_SYMBOL = '+'
-    public static final String END_OF_REPORT_MARKER = 'BUILD SUCCESSFUL'
     public static final LinkedHashMap<String, String> NODE_ATTRIBUTES = ['Value': 'nodeValue', 'Type': 'type', 'Creator': 'creator']
+    private static final Pattern END_OF_REPORT_MARKER = ~/BUILD SUCCESSFUL|Some tasks in this build are not compatible with the configuration cache/
 
     static ParsedModelReport parse(String text) {
         validate(text)
@@ -51,7 +52,7 @@ class ModelReportParser {
         assert text: 'Report text must not be blank'
         def reportLines = text.readLines()
         assert reportLines.size() >= 5: "Should have at least 5 lines"
-        assert text.contains(END_OF_REPORT_MARKER): "Expected to find an end of report marker '${END_OF_REPORT_MARKER}'"
+        assert text.find(END_OF_REPORT_MARKER): "Expected to find an end of report marker"
     }
 
     private static String getTitle(List<String> reportLines) {
@@ -144,7 +145,7 @@ class ModelReportParser {
     }
 
     private static List<String> nodeOnlyLines(List<String> nodeLines) {
-        int successMarker = nodeLines.findIndexOf { line -> line.startsWith(END_OF_REPORT_MARKER) }
+        int successMarker = nodeLines.findIndexOf { line -> line.find(END_OF_REPORT_MARKER) }
         if (successMarker == 0) {
             return []
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -190,7 +190,8 @@ class Summary(
         val documentationRegistry = DocumentationRegistry()
         return StringBuilder().apply {
             // When build degrades gracefully, we keep the console output minimal but still want to see the report link
-            if (reportableProblemCount > 0) {
+            val hasReportableProblems = reportableProblemCount > 0
+            if (hasReportableProblems) {
                 appendLine()
                 appendSummaryHeader(cacheActionText, reportableProblemCount)
                 appendLine()
@@ -209,6 +210,10 @@ class Summary(
             }
             htmlReportFile?.let {
                 appendLine()
+                if (!hasReportableProblems) {
+                    append("Some tasks in this build are not compatible with the configuration cache.")
+                    appendLine()
+                }
                 append(buildSummaryReportLink(it))
             }
         }.toString()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -211,6 +211,7 @@ class Summary(
             htmlReportFile?.let {
                 appendLine()
                 if (!hasReportableProblems) {
+                    // Some tests parse this line.
                     append("Some tasks in this build are not compatible with the configuration cache.")
                     appendLine()
                 }
@@ -231,6 +232,7 @@ class Summary(
         cacheAction: String,
         reportableProblemCount: Int
     ) {
+        // Some tests parse this header.
         append(reportableProblemCount)
         append(if (reportableProblemCount == 1) " problem was found " else " problems were found ")
         append(cacheAction)

--- a/platforms/software/software-diagnostics/build.gradle.kts
+++ b/platforms/software/software-diagnostics/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
     implementation(projects.functional)
     implementation(projects.loggingApi)
+    implementation(projects.serviceLookup)
 
     implementation(libs.commonsLang)
     implementation(libs.groovyJson)

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/components/DiagnosticsComponentReportIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/components/DiagnosticsComponentReportIntegrationTest.groovy
@@ -16,13 +16,12 @@
 
 package org.gradle.api.reporting.components
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 
 class DiagnosticsComponentReportIntegrationTest extends AbstractNativeComponentReportIntegrationTest {
 
     @RequiresInstalledToolChain
-    @ToBeFixedForConfigurationCache(because = ":components")
     def "informs the user when project has no components defined"() {
         given:
         buildFile << """
@@ -42,7 +41,6 @@ No components defined for this project.
     }
 
     @RequiresInstalledToolChain
-    @ToBeFixedForConfigurationCache(because = ":components")
     def "shows details of multiple components"() {
         given:
         buildFile << """

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/DetailedModelReportIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/DetailedModelReportIntegrationTest.groovy
@@ -17,13 +17,11 @@
 package org.gradle.api.reporting.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.junit.Rule
 
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
-@UnsupportedWithConfigurationCache(because = "software model")
 class DetailedModelReportIntegrationTest extends AbstractIntegrationSpec {
 
     @Rule

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -17,9 +17,7 @@
 package org.gradle.api.reporting.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
-@UnsupportedWithConfigurationCache(because = "software model")
 class ModelReportIntegrationTest extends AbstractIntegrationSpec {
 
     @Override

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportTaskIntegrationTest.groovy
@@ -17,9 +17,7 @@
 package org.gradle.api.reporting.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
-@UnsupportedWithConfigurationCache(because = "software model")
 class ModelReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
     def "should display the model report task options"() {
@@ -29,7 +27,7 @@ class ModelReportTaskIntegrationTest extends AbstractIntegrationSpec {
                 id 'model-reporting-tasks'
             }
         """
-        
+
         when:
         run "help", "--task", "model"
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/reporting/components/ComponentReport.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/reporting/components/ComponentReport.java
@@ -17,8 +17,10 @@
 package org.gradle.api.reporting.components;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.internal.ConfigurationCacheDegradationController;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.reporting.components.internal.ComponentReportRenderer;
 import org.gradle.api.reporting.components.internal.TypeAwareBinaryRenderer;
 import org.gradle.api.tasks.TaskAction;
@@ -58,6 +60,11 @@ public abstract class ComponentReport extends DefaultTask {
 
     @Inject
     protected abstract TypeAwareBinaryRenderer getBinaryRenderer();
+
+    @Inject
+    public ComponentReport() {
+        getServices().get(ConfigurationCacheDegradationController.class).requireConfigurationCacheDegradation(this, Providers.of("Task is not compatible with the Configuration Cache"));
+    }
 
     @TaskAction
     public void report() {

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/reporting/dependents/DependentComponentsReport.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/reporting/dependents/DependentComponentsReport.java
@@ -20,7 +20,9 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.internal.ConfigurationCacheDegradationController;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.reporting.dependents.internal.TextDependentComponentsReportRenderer;
 import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.TaskAction;
@@ -54,8 +56,9 @@ public abstract class DependentComponentsReport extends DefaultTask {
     private boolean showTestSuites;
     private List<String> components;
 
-    {
-        notCompatibleWithConfigurationCache("Requires access to the component model at execution time.");
+    @Inject
+    public DependentComponentsReport() {
+        getServices().get(ConfigurationCacheDegradationController.class).requireConfigurationCacheDegradation(this, Providers.of("Task is not compatible with the Configuration Cache"));
     }
 
     /**

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -50,12 +50,24 @@ public class GroupedOutputFixture {
     private final static String EMBEDDED_BUILD_START = "> :\\w* > [:\\w]+";
     private final static String BUILD_STATUS_FOOTER = "BUILD SUCCESSFUL";
     private final static String BUILD_FAILED_FOOTER = "BUILD FAILED";
+    private final static String CONFIGURATION_CACHE_PROBLEMS_FOOTER = "\\d+ (problem was|problems were) found storing the configuration cache";
+    private final static String CONFIGURATION_CACHE_INCOMPATIBLE_TASKS_FOOTER = "Some tasks in this build are not compatible with the configuration cache.";
     private final static String ACTIONABLE_TASKS = "[0-9]+ actionable tasks?:";
 
     /**
      * Various patterns to detect the end of the task output
      */
-    private final static String END_OF_GROUPED_OUTPUT = TASK_HEADER + "|" + TRANSFORM_HEADER + "|" + BUILD_STATUS_FOOTER + "|" + BUILD_FAILED_FOOTER + "|" + EMBEDDED_BUILD_START + "|" + ACTIONABLE_TASKS + "|\\z";
+    private final static String END_OF_GROUPED_OUTPUT = String.join("|",
+        TASK_HEADER,
+        TRANSFORM_HEADER,
+        BUILD_STATUS_FOOTER,
+        BUILD_FAILED_FOOTER,
+        EMBEDDED_BUILD_START,
+        ACTIONABLE_TASKS,
+        CONFIGURATION_CACHE_PROBLEMS_FOOTER,
+        CONFIGURATION_CACHE_INCOMPATIBLE_TASKS_FOOTER,
+        "\\z"
+    );
 
     /**
      * Pattern to extract task output.

--- a/testing/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
+++ b/testing/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
@@ -545,4 +545,23 @@ eggs
 """)
     }
     // endregion assertOutputContains
+
+    def "can parse #description as end of task output"() {
+        given:
+        def consoleOutput = """> Task :example1
+toast
+$endMarker
+"""
+        GroupedOutputFixture groupedOutput = new GroupedOutputFixture(LogContent.of(consoleOutput))
+
+        expect:
+        groupedOutput.task(":example1").output == "toast"
+        where:
+        description                     | endMarker
+        "start of another task"         | "> Task :example2"
+        "end of build"                  | "BUILD SUCCESSFUL in 2s"
+        "configuration cache problem"   | "1 problem was found storing the configuration cache."
+        "configuration cache problems"  | "2 problems were found storing the configuration cache."
+        "cc-incompatible tasks summary" | "Some tasks in this build are not compatible with the configuration cache."
+    }
 }


### PR DESCRIPTION
This provides better user experience compared to `notCompatibleWithCC`, because there is no serialization step.

Fixes #31088.
