### PR TITLE
Fix incorrect stacktrace option documentation

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/running-builds/features/logging.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/features/logging.adoc
@@ -113,7 +113,7 @@ Stacktraces are useful for diagnosing issues during a build failure. You can con
 | CLI Option | Gradle Property | Stacktrace Shown
 
 | `--stacktrace` or `-s`
-| `org.gradle.logging.stacktrace=always`
+| `org.gradle.logging.stacktrace=all`
 | Truncated stacktraces are printed. We recommend this over full stacktraces. Groovy full stacktraces are extremely verbose due to the underlying dynamic invocation mechanisms. Yet they usually do not contain relevant information about what has gone wrong in _your_ code. This option renders stacktraces for deprecation warnings.
 
 | `--full-stacktrace` or `-S`


### PR DESCRIPTION
Fixes #33779

### Context
The issue above concerns [this documentation page](https://docs.gradle.org/8.14.2/userguide/logging.html#stacktraces), which states that `org.gradle.logging.stacktrace=always` is a valid property setting that corresponds to the CLI option `--stacktrace`.

As the author suspects, the correct property setting is actually `org.gradle.logging.stacktrace=all`. One can see that it corresponds to the CLI option `--stacktrace` in [LoggingConfigurationBuildOptions.java](https://github.com/gradle/gradle/blob/207bb70b44b59efb494ece83c81206423c3d4365/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java):

https://github.com/gradle/gradle/blob/207bb70b44b59efb494ece83c81206423c3d4365/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java#L132-L136

https://github.com/gradle/gradle/blob/207bb70b44b59efb494ece83c81206423c3d4365/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java#L169-L176

https://github.com/gradle/gradle/blob/207bb70b44b59efb494ece83c81206423c3d4365/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java#L143-L158

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
