### PR TITLE
Fix flaky docsTest with "Timed out waiting ... Discarding connection"

### DIFF
--- a/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/bucket/Buckets.java
+++ b/platforms/documentation/docs/src/docsTest/java/org/gradle/docs/samples/bucket/Buckets.java
@@ -28,6 +28,7 @@ import org.gradle.integtests.fixtures.logging.ArtifactResolutionOmittingOutputNo
 import org.gradle.integtests.fixtures.logging.ConfigurationCacheOutputCleaner;
 import org.gradle.integtests.fixtures.logging.ConfigurationCacheOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.DependencyInsightOutputNormalizer;
+import org.gradle.integtests.fixtures.logging.DiscardingConnectionMessageRemovalOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.EmbeddedKotlinOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.EmptyLineRemovalOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.EmptyLineTrimmerOutputNormalizer;
@@ -61,6 +62,7 @@ import org.gradle.integtests.fixtures.mirror.SetMirrorsSampleModifier;
     EmptyLineTrimmerOutputNormalizer.class,
     RepositoryMirrorOutputNormalizer.class,
     EmptyLineRemovalOutputNormalizer.class,
+    DiscardingConnectionMessageRemovalOutputNormalizer.class
 })
 @SampleModifiers({
     SetMirrorsSampleModifier.class,

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/DiscardingConnectionMessageRemovalOutputNormalizer.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/DiscardingConnectionMessageRemovalOutputNormalizer.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.logging
+
+import org.gradle.exemplar.executor.ExecutionMetadata
+import org.gradle.exemplar.test.normalizer.OutputNormalizer
+
+/**
+ * Remove lines like:
+ * Timed out waiting for finished message from client socket connection from /127.0.0.1:35693 to /127.0.0.1:57026. Discarding connection.
+ */
+class DiscardingConnectionMessageRemovalOutputNormalizer implements OutputNormalizer {
+    @Override
+    String normalize(String commandOutput, ExecutionMetadata executionMetadata) {
+        return commandOutput.readLines()
+            .findAll { !isDiscardingConnectionMessage(it) }
+            .join(System.getProperty("line.separator"))
+    }
+
+    private static boolean isDiscardingConnectionMessage(String line) {
+        line = line.trim()
+        return line.startsWith("Timed out waiting for finished message from client socket connection") &&
+            line.endsWith("Discarding connection.")
+    }
+}


### PR DESCRIPTION
There are [quite some flaky docsTest like this](https://ge.gradle.org/scans/tests?search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.docs.samples.bucket.Bucket28):


```
Caused by: java.lang.RuntimeException: java.lang.AssertionError: Extra text at line 1. 
Expected:
Actual: Timed out waiting for finished message from client socket connection from /127.0.0.1:35693 to /127.0.0.1:57026. Discarding connection. 
Actual output:
  Timed out waiting for finished message from client socket connection from /127.0.0.1:35693 to /127.0.0.1:57026. Discarding connection.
```

This is probably caused by parallel execution. Let's ignore these error lines.
