### PR TITLE
Update documentation links to point to Kotlin DSL reference docs

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
@@ -448,7 +448,7 @@ When using a hierarchical directory structure to organize your Gradle projects, 
 
 === Explanation
 
-When you use the link:{groovyDslPath}/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.Iterable)[`Settings.include()`] method to include a project in your Gradle settings file, you typically include projects by supplying the directory name like `include("featureA")`.
+When you use the link:{kotlinDslPath}/gradle/org.gradle.api.initialization/-settings/include.html[`Settings.include()`] method to include a project in your Gradle settings file, you typically include projects by supplying the directory name like `include("featureA")`.
 This usage assumes that `featureA` is located at the root of your build.
 
 You can include projects located in subdirectories using hierarchical paths, with `:` as the separator.
@@ -460,7 +460,7 @@ In the example above, Gradle will generate projects for `:subs`, `:subs:features
 Unless those intermediate projects are intentional, this can slow down your build, clutter reports, and make your build structure harder to understand.
 Additional projects - even if empty - will slow down your build, clutter reporting, and make your build harder to understand.
 
-To avoid this, be sure to explicitly set the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:projectDir[`Project.projectDir`] property of any projects included in nested directories: `project(':my-web-module').projectDir = file("subs/web/my-web-module")`.
+To avoid this, be sure to explicitly set the link:{kotlinDslPath}/gradle/org.gradle.api/-project/get-project-dir.html[`Project.projectDir`] property of any projects included in nested directories: `project(':my-web-module').projectDir = file("subs/web/my-web-module")`.
 
 As an added benefit, this will allow you to reference the project by the shorter name `:my-web-module` instead of the full logical path `:subs:web:my-web-module`.
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_structuring_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_structuring_builds.adoc
@@ -226,9 +226,9 @@ Do not put source files in your root project; instead, put them in a separate pr
 
 === Explanation
 
-The root project is a special link:{groovyDslPath}/org.gradle.api.Project.html[Project] in Gradle that serves as the entry point for your build.
+The root project is a special link:{kotlinDslPath}/gradle/org.gradle.api/-project/index.html[Project] in Gradle that serves as the entry point for your build.
 
-It is the place to configure some settings and conventions that apply globally to the entire build, that are not configured via link:{groovyDslPath}/org.gradle.api.initialization.Settings.html[Settings].
+It is the place to configure some settings and conventions that apply globally to the entire build, that are not configured via link:{kotlinDslPath}/gradle/org.gradle.api.initialization/-settings/index.html[Settings].
 For example, you can _declare_ (but not apply) plugins here to ensure the same plugin version is consistently available across all projects and define other configurations shared by all projects within the build.
 
 NOTE: Be careful not to apply plugins unnecessarily in the root project - many plugins only affect source code and should only be applied to the projects that contain source code.
@@ -499,7 +499,7 @@ When using a hierarchical directory structure to organize your Gradle projects, 
 
 === Explanation
 
-When you use the link:{groovyDslPath}/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.Iterable)[Settings.include()] method to include a project in your Grade settings file, you typically include projects by supplying the directory name like `include("featureA")`.
+When you use the link:{kotlinDslPath}/gradle/org.gradle.api.initialization/-settings/include.html[Settings.include()] method to include a project in your Grade settings file, you typically include projects by supplying the directory name like `include("featureA")`.
 This usage assumes that `featureA` is located at the root of your build.
 
 You can also include projects located in subdirectories using hierarchical paths with the `:` charactor as a separator.
@@ -511,7 +511,7 @@ In the example above, Gradle will create a project named `:subs`, a project name
 This probably isn't intended, as you likely only want to include the `search` project.
 Additional projects - even if empty - will slow down your build, clutter reporting, and make your build harder to understand.
 
-To avoid this, be sure to explicitly set the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:projectDir[Project.projectDir] property of any projects included in nested directories: `project(':my-web-module').projectDir = file("subs/web/my-web-module"`).
+To avoid this, be sure to explicitly set the link:{kotlinDslPath}/gradle/org.gradle.api/-project/get-project-dir.html[Project.projectDir] property of any projects included in nested directories: `project(':my-web-module').projectDir = file("subs/web/my-web-module"`).
 
 As ab added benefit, this will allow you to reference the project by the shorter name `:my-web-module` instead of the full logical path `:subs:web:my-web-module`.
 

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
@@ -150,7 +150,7 @@ include::sample[dir="snippets/bestPractices/useCacheabilityAnnotations-do/groovy
 `<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:caching,#caching>>`
 
 [[avoid_provider_get_outside_task_action]]
-== Do not call `get()`` on a Provider outside a Task action
+== Do not call `get()` on a Provider outside a Task action
 
 When configuring tasks and extensions do not call link:{javadocPath}/org/gradle/api/provider/Provider.html#get()[`get()`] on a provider, use link:{javadocPath}/org/gradle/api/provider/Provider.html#map(org.gradle.api.Transformer)[`map()`], or link:{javadocPath}/org/gradle/api/provider/Provider.html#flatMap(org.gradle.api.Transformer)[`flatMap()`] instead.
 


### PR DESCRIPTION
Updates documentation links to use the Kotlin DSL versions of the Gradle API.