### PR TITLE
cobexer/teamcity config for legacy releases

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -97,9 +97,6 @@
                 <groupId>com.github.gantsign.maven</groupId>
                 <artifactId>ktlint-maven-plugin</artifactId>
                 <version>3.5.0</version>
-                <configuration>
-                    <ktlintVersion>1.5.0</ktlintVersion>
-                </configuration>
                 <executions>
                     <execution>
                         <id>check</id>

--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -78,6 +78,8 @@ data class VersionedSettingsBranch(
         get() = branchName == MASTER_BRANCH
     val isRelease: Boolean
         get() = branchName == RELEASE_BRANCH
+    val isLegacyRelease: Boolean
+        get() = OLD_RELEASE_PATTERN.matchEntire(branchName) != null
     val isExperimental: Boolean
         get() = branchName == EXPERIMENTAL_BRANCH
 

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -376,7 +376,7 @@ data class CIBuildModel(
             ),
             Stage(
                 StageName.HISTORICAL_PERFORMANCE,
-                trigger = Trigger.WEEKLY,
+                trigger = if (VersionedSettingsBranch.fromDslContext().isLegacyRelease) Trigger.NEVER else Trigger.WEEKLY,
                 runsIndependent = true,
                 performanceTests =
                     listOf(


### PR DESCRIPTION
- **TeamCity: disable triggering `HistoricalPerformance` legacy release branches**
- **TeamCity: drop ignored `ktlintVersion` configuration parameter**
