### PR TITLE
TeamCity: create `extraParameters` from joining lists

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/CheckLinks.kt
+++ b/.teamcity/src/main/kotlin/configurations/CheckLinks.kt
@@ -17,6 +17,10 @@ class CheckLinks(
             model,
             this,
             ":docs:checkLinks",
-            extraParameters = buildScanTagParam("CheckLinks") + " " + "-Porg.gradle.java.installations.auto-download=false",
+            extraParameters =
+                listOf(
+                    buildScanTagParam("CheckLinks"),
+                    "-Porg.gradle.java.installations.auto-download=false",
+                ).joinToString(""),
         )
     })

--- a/.teamcity/src/main/kotlin/configurations/DocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/DocsTest.kt
@@ -88,10 +88,12 @@ class DocsTest(
             arch = os.defaultArch,
             timeout = 60,
             extraParameters =
-                buildScanTagParam(docsTestType.docsTestName) + " " +
-                    parallelizationMethod.extraBuildParameters +
-                    " -PenableConfigurationCacheForDocsTests=${docsTestType.ccEnabled}" +
-                    " -PtestJavaVersion=${testJava.version.major}" +
-                    " -PtestJavaVendor=${testJava.vendor.name.lowercase()}",
+                listOf(
+                    buildScanTagParam(docsTestType.docsTestName),
+                    parallelizationMethod.extraBuildParameters,
+                    "-PenableConfigurationCacheForDocsTests=${docsTestType.ccEnabled}",
+                    "-PtestJavaVersion=${testJava.version.major}",
+                    "-PtestJavaVendor=${testJava.vendor.name.lowercase()}",
+                ).joinToString(" "),
         )
     })


### PR DESCRIPTION
To reduce the chances of introducing space errors.
This is a followup to #33840

Signed-off-by: Christoph Obexer <cobexer@gradle.com>
