### PR TITLE
Justify `buildSrc` CC Graceful Degradation compatibility

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
@@ -22,8 +22,9 @@ import javax.inject.Inject
 
 class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
+    def configurationCache = newConfigurationCacheFixture()
+
     def "a task can require CC degradation"() {
-        def configurationCache = newConfigurationCacheFixture()
         buildFile """
             ${taskWithInjectedDegradationController()}
             tasks.register("a", DegradingTask) { task ->
@@ -54,7 +55,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
     }
 
     def "a task can require CC degradation for multiple reasons"() {
-        def configurationCache = newConfigurationCacheFixture()
         buildFile """
             ${taskWithInjectedDegradationController()}
             tasks.register("a", DegradingTask) { task ->
@@ -103,7 +103,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
     }
 
     def "CC problems in warning mode are not hidden by CC degradation"() {
-        def configurationCache = newConfigurationCacheFixture()
         buildFile """
             ${taskWithInjectedDegradationController()}
             tasks.register("foo", DegradingTask) { task ->
@@ -140,7 +139,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
     }
 
     def "a task in included build can require CC degradation"() {
-        def configurationCache = newConfigurationCacheFixture()
         buildFile("included/build.gradle", """
             ${taskWithInjectedDegradationController()}
             tasks.register("foo", DegradingTask) { task ->
@@ -174,7 +172,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
     }
 
     def "a buildSrc internal task that requires CC degradation does not introduce root build CC degradation"() {
-        def configurationCache = newConfigurationCacheFixture()
         file("buildSrc/src/main/java/MyClass.java") << "class MyClass {}"
         buildFile("buildSrc/build.gradle", """
             ${taskWithInjectedDegradationController()}
@@ -202,7 +199,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
     }
 
     def "depending on a CC degrading task from included build introduces CC degradation"() {
-        def configurationCache = newConfigurationCacheFixture()
         buildFile("included/build.gradle", """
             ${taskWithInjectedDegradationController()}
             tasks.register("foo", DegradingTask) { task ->
@@ -245,7 +241,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
     }
 
     def "a dependency task in #build build can require CC degradation for the non-root build"() {
-        def configurationCache = newConfigurationCacheFixture()
         buildFile("$build/build.gradle", """
             ${taskWithInjectedDegradationController()}
 
@@ -281,7 +276,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
     }
 
     def "no CC degradation if incompatible task is not presented in the task graph"() {
-        def configurationCache = newConfigurationCacheFixture()
         buildFile """
             ${taskWithInjectedDegradationController()}
             tasks.register("a", DegradingTask) { task ->
@@ -313,7 +307,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
     }
 
     def "ignore CC degradation requests at execution time"() {
-        def configurationCache = newConfigurationCacheFixture()
         buildFile """
             ${taskWithInjectedDegradationController()}
             tasks.register("foo", DegradingTask) { task ->
@@ -335,7 +328,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
     }
 
     def "tasks instantiated during execution have degradation requests ignored"() {
-        def configurationCache = newConfigurationCacheFixture()
         buildFile """
             ${taskWithInjectedDegradationController()}
             tasks.register("a", DegradingTask) { task ->
@@ -419,7 +411,6 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
 
     def "CC report link is present even when no problems were reported"() {
         given:
-        def configurationCache = newConfigurationCacheFixture()
         buildFile """
             ${taskWithInjectedDegradationController()}
             tasks.register("foo", DegradingTask) { task ->
@@ -468,6 +459,9 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         configurationCacheRunLenient("foo", "bar")
 
         then:
+        configurationCache.assertNoConfigurationCache()
+
+        and:
         assertConfigurationCacheDegradation(true)
     }
 


### PR DESCRIPTION
Follow up on https://github.com/gradle/gradle/pull/33894

The [PR](https://github.com/gradle/gradle/pull/33894) changed a way how the task graph is being traversed during making GD decision: https://github.com/gradle/gradle/pull/33894/files#diff-bf9bfb6023edab8e4aed49850149bcc9a49e161e93b247b9f0042ae76b0f76d3R80-R87

- It got rid of `rootBuild.gradle` in favour of `task.gradle`
- Used `taskGraph.allTasks` instead of `taskGraph.visitScheduledTasks`

As a side effect of the PR, an [integTest](https://github.com/gradle/gradle/pull/33894/files#diff-054b721e76a41a0ead7c0e6c1de8e2d26c879a08b66fd912eeaf06598566f5ebL35-L40) was fixed, surprisingly.

The test registers IDE plugin to the `buildSrc` build, and run `:buildSrc:idea`(or `buildSrc:eclipse`). IDE plugin registers bunch of CC degrading tasks and makes an "umbrella" `:idea` task to depend on them.

When `rootBuild.gradle` was in use, those CC degrading IDE tasks weren't presented in the `scheduledNodes`. It was only `other build task :buildSrc:idea`. Java doc for [visitScheduledNodes](https://github.com/gradle/gradle/blob/c77df1f03636048365483d361f5d0b699c1b4a34/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java#L66) says
` Returns all the work items in this graph scheduled for execution plus all dependencies from other builds.`
... apparently, not including transitive dependencies.
This is relevant only for `buildSrc` builds. Included builds are being handled correctly.

So changing `taskGraph` from the root one to the build-corresponded-one is fixing that issue if continue to use `visitScheduledNodes`, OR the usage of `allTasks` instead of `visitScheduledNodes` doing the same effect. 

This PR adds a dedicated test scenario to the CC GD test coverage.
