### PR TITLE
Update CC compatibility matrix after graceful degradation adopted

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
@@ -139,7 +139,7 @@ See link:{gradle-issues}13510[gradle/gradle#13510].
 === Source Dependencies
 
 Support for link:https://blog.gradle.org/introducing-source-dependencies[source dependencies] is not yet implemented.
-When using this feature, the build will not fail and no problems will be reported, but the configuration cache will be automatically disabled.
+When using this feature, the build will not fail, and no problems will be reported, but the Configuration Cache will be automatically disabled.
 
 See link:{gradle-issues}13506[gradle/gradle#13506].
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
@@ -139,7 +139,7 @@ See link:{gradle-issues}13510[gradle/gradle#13510].
 === Source Dependencies
 
 Support for link:https://blog.gradle.org/introducing-source-dependencies[source dependencies] is not yet implemented.
-With the Configuration Cache enabled, no problem will be reported and the build will fail.
+When using this feature, the build will not fail and no problems will be reported, but the configuration cache will be automatically disabled.
 
 See link:{gradle-issues}13506[gradle/gradle#13506].
 

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-builds/configuration-cache/configuration_cache_status.adoc
@@ -67,8 +67,8 @@ a|
 link:{gradle-issues}13463[[.green]#✓#]:: <<application_plugin.adoc#application_plugin,Application>>
 link:{gradle-issues}13466[[.green]#✓#]:: <<war_plugin.adoc#war_plugin,WAR>>
 link:{gradle-issues}13467[[.green]#✓#]:: <<ear_plugin.adoc#ear_plugin,EAR>>
-link:{gradle-issues}24329[[.yellow]#⚠#]:: <<publishing_maven.adoc#publishing_maven,Maven Publish>>
-link:{gradle-issues}24328[[.yellow]#⚠#]:: <<publishing_ivy.adoc#publishing_ivy,Ivy Publish>>
+link:{gradle-issues}24329[[.yellow]#⚠*#]:: <<publishing_maven.adoc#publishing_maven,Maven Publish>>
+link:{gradle-issues}24328[[.yellow]#⚠*#]:: <<publishing_ivy.adoc#publishing_ivy,Ivy Publish>>
 link:{gradle-issues}13464[[.green]#✓#]:: <<distribution_plugin.adoc#distribution_plugin,Distribution>>
 link:{gradle-issues}13465[[.green]#✓#]:: <<java_library_distribution_plugin.adoc#java_library_distribution_plugin,Java Library Distribution>>
 
@@ -87,8 +87,8 @@ link:{gradle-issues}13476[[.green]#✓#]:: <<pmd_plugin.adoc#pmd_plugin,PMD>>
 
 a|
 [horizontal]
-link:{gradle-issues}13479[[.red]#✖#]:: <<eclipse_plugin.adoc#eclipse_plugin,Eclipse>>
-link:{gradle-issues}13480[[.red]#✖#]:: <<idea_plugin.adoc#idea_plugin,IntelliJ IDEA>>
+link:{gradle-issues}13479[[.yellow]#⚠#]:: <<eclipse_plugin.adoc#eclipse_plugin,Eclipse>>
+link:{gradle-issues}13480[[.yellow]#⚠#]:: <<idea_plugin.adoc#idea_plugin,IntelliJ IDEA>>
 link:{gradle-issues}13482[[.green]#✓#]:: <<visual_studio_plugin.adoc#visual_studio_plugin,Visual Studio>>
 link:{gradle-issues}13483[[.green]#✓#]:: <<xcode_plugin.adoc#xcode_plugin,Xcode>>
 
@@ -106,9 +106,12 @@ link:{gradle-issues}13473[[.green]#✓#]:: <<project_report_plugin.adoc#project_
 
 [horizontal]
 [.green]#✓#:: Supported plugin
-[.yellow]#⚠#:: Partially supported plugin
+[.yellow]#⚠#:: Partially supported plugin (tasks always disable configuration caching)
+[.yellow]#⚠*#:: Partially supported plugin (some features may disable configuration caching)
+////
+// no unsupported plug-ins atm
 [.red]#✖#:: Unsupported plugin
-
+////
 [[config_cache:plugins:community]]
 === Community Plugins
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/eclipse_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/eclipse_plugin.adoc
@@ -15,7 +15,7 @@
 [[eclipse_plugin]]
 = The Eclipse Plugins
 
-WARNING: The Eclipse Plugins are not fully compatible with the <<configuration_cache_status.adoc#config_cache:plugins:core,configuration cache>>. When they are applied, the configuration cache is disabled.
+WARNING: The Eclipse Plugins are not fully compatible with the <<configuration_cache_status.adoc#config_cache:plugins:core,Configuration Cache>>. When applied, the Configuration Cache is automatically disabled.
 
 The Eclipse plugins generate files that are used by the http://eclipse.org[Eclipse IDE], thus making it possible to import the project into Eclipse (`File` - `Import...` - `Existing Projects into Workspace`).
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/eclipse_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/eclipse_plugin.adoc
@@ -15,7 +15,7 @@
 [[eclipse_plugin]]
 = The Eclipse Plugins
 
-WARNING: The Eclipse Plugins are not compatible with the <<configuration_cache_status.adoc#config_cache:plugins:core,configuration cache>>.
+WARNING: The Eclipse Plugins are not fully compatible with the <<configuration_cache_status.adoc#config_cache:plugins:core,configuration cache>>. When they are applied, the configuration cache is disabled.
 
 The Eclipse plugins generate files that are used by the http://eclipse.org[Eclipse IDE], thus making it possible to import the project into Eclipse (`File` - `Import...` - `Existing Projects into Workspace`).
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/idea_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/idea_plugin.adoc
@@ -15,7 +15,7 @@
 [[idea_plugin]]
 = The IDEA Plugin
 
-WARNING: The IDEA Plugin is not compatible with the <<configuration_cache_status.adoc#config_cache:plugins:core,configuration cache>>.
+WARNING: The IDEA Plugin is not fully compatible with the <<configuration_cache_status.adoc#config_cache:plugins:core,configuration cache>>. When it is applied, the configuration cache is disabled.
 
 The IDEA plugin generates files that are used by http://www.jetbrains.com/idea/[IntelliJ IDEA], thus making it possible to open the project from IDEA (`File` - `Open Project`). Both external dependencies (including associated source and Javadoc files) and project dependencies are considered.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/idea_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/idea_plugin.adoc
@@ -15,7 +15,7 @@
 [[idea_plugin]]
 = The IDEA Plugin
 
-WARNING: The IDEA Plugin is not fully compatible with the <<configuration_cache_status.adoc#config_cache:plugins:core,configuration cache>>. When it is applied, the configuration cache is disabled.
+WARNING: The IDEA Plugin is not fully compatible with the <<configuration_cache_status.adoc#config_cache:plugins:core,Configuration Cache>>. When applied, the Configuration Cache is automatically disabled.
 
 The IDEA plugin generates files that are used by http://www.jetbrains.com/idea/[IntelliJ IDEA], thus making it possible to open the project from IDEA (`File` - `Open Project`). Both external dependencies (including associated source and Javadoc files) and project dependencies are considered.
 


### PR DESCRIPTION
Related: #33740

I chose to distinguish fully degrading and partially degrading with an asterisk.

![image](https://github.com/user-attachments/assets/eff89012-7449-4e62-9788-630205e9b1f4)


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things

