### PR TITLE
Correct 'can not' to 'cannot' in Kotlin DSL error message

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Lexer.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Lexer.kt
@@ -39,7 +39,7 @@ class UnexpectedDuplicateBlock(val identifier: TopLevelBlockId, override val loc
 
 internal
 class UnexpectedBlockOrder(val identifier: TopLevelBlockId, override val location: IntRange, expectedFirstIdentifier: TopLevelBlockId) :
-    UnexpectedBlock("Unexpected `$identifier` block found. `$identifier` can not appear before `$expectedFirstIdentifier`.")
+    UnexpectedBlock("Unexpected `$identifier` block found. `$identifier` cannot appear before `$expectedFirstIdentifier`.")
 
 
 data class Packaged<T>(

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TopLevelBlockExtractionTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TopLevelBlockExtractionTest.kt
@@ -124,7 +124,7 @@ class TopLevelBlockExtractionTest {
         } catch (unexpectedBlock: UnexpectedBlockOrder) {
             assertThat(unexpectedBlock.identifier, equalTo(plugins))
             assertThat(unexpectedBlock.location, equalTo(0..9))
-            assertThat(unexpectedBlock.message, equalTo("Unexpected `plugins` block found. `plugins` can not appear before `pluginManagement`."))
+            assertThat(unexpectedBlock.message, equalTo("Unexpected `plugins` block found. `plugins` cannot appear before `pluginManagement`."))
         }
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #33904  -->


### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
- Fixes #33904 

This change corrects a minor but important typo in an error message within the Kotlin DSL. The phrase "can not" has been updated to "cannot" for improved clarity and adherence to standard English spelling. This benefits users by providing grammatically correct and clearer error messages, enhancing the overall developer experience.

### Question Regarding Typo Consistency / Further Improvements

During the course of correcting the "can not" typo in the `kotlin-dsl` module (addressed by #33904), I noticed that similar "can not" occurrences also exist in `ModelTypeInitializationException.java`, located at `platform/core-configuration/model-core/src/main/java/org/gradle/model/internal/core`.

Examples include:
* `"A model element of type: '%s' can not be constructed.%n"`
* `"A managed collection can not contain '%s's%n"`
* `"Its property '%s %s' can not be constructed%n"`

Given that the original issue was specifically labeled `in:kotlin-dsl`, I understand the scope of that issue was limited to the Kotlin DSL module. However, these instances of "can not" in `ModelTypeInitializationException.java` also contribute to inconsistent messaging within Gradle's error reporting.

My question is:
1.  **Was the `in:kotlin-dsl` label applied because the initial report specifically targeted a Kotlin DSL-related message, or is there a broader intent to fix all such typos across the codebase?**
2.  **Should these "can not" instances in the `model-core` module also be corrected to "cannot" for consistency?**

If these corrections are desired, I would be happy to include them in this Pull Request if they are deemed within scope, or I can open a separate issue to track these specific typos in the `model-core` module. Please let me know the preferred approach.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
