### PR TITLE
Adopt graceful degradation from jar task

### DIFF
--- a/platforms/jvm/language-jvm/src/integTest/groovy/org/gradle/api/tasks/bundling/JarEncodingIntegrationTest.groovy
+++ b/platforms/jvm/language-jvm/src/integTest/groovy/org/gradle/api/tasks/bundling/JarEncodingIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks.bundling
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.archives.TestFileSystemSensitiveArchives
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
@@ -136,8 +135,8 @@ class JarEncodingIntegrationTest extends AbstractIntegrationSpec {
         manifest.contains('moji: bak€')
     }
 
-    @ToBeFixedForConfigurationCache
     @Issue('GRADLE-3374')
+    @Issue("https://github.com/gradle/gradle/issues/31838")
     @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "requires daemon with explicit default charset")
     def "write manifests using a user defined character set"() {
         given:


### PR DESCRIPTION
Adopt graceful degradation for Jar task

...when a custom manifest encoding is used.

Issue: #31838