### PR TITLE
docs(catalogs): Fix a typo in "buildSrc"

### DIFF
--- a/platforms/documentation/docs/src/snippets/dependencyManagement/catalogs-toml-buildSrc/kotlin/buildSrc/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/catalogs-toml-buildSrc/kotlin/buildSrc/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `kotlin-dsl`
-    alias(libs.plugins.versions) // Access version catalog in builSrc build file for plugin
+    alias(libs.plugins.versions) // Access version catalog in buildSrc build file for plugin
 }
 
 repositories {


### PR DESCRIPTION
### Context

This fixes a typo in the docs.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
