### PR TITLE
docs(userguide): Remove a superfluous "Step" prefix

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/dep-man/how-to/how_to_upgrade_transitive_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/how-to/how_to_upgrade_transitive_dependencies.adoc
@@ -26,7 +26,7 @@ There are many reasons to upgrade a version of a dependency:
 * *Performance improvements* make builds faster and more efficient.
 * *New features* provide additional functionality and better compatibility.
 
-== Step 1: Setting Dependency Constraints on Transitive Dependencies
+== Setting Dependency Constraints on Transitive Dependencies
 
 <<dependency_constraints.adoc#dependency-constraints,Dependency constraints>> allow you to define the **version** or **version range** of both direct dependencies and transitive dependencies.
 


### PR DESCRIPTION
There is no second step, so omit the "Step 1" prefix for simplicity.

### Context

Improvement to the public userguide.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
