### PR TITLE
Avoid duplicating exceptions in CC build failures

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -367,6 +367,10 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
             problemsWithStackTraceCount = 1
         }
 
+        // The interrupting problem cause must not be repeated in the aggregated CC build failure
+        // TODO: introduce a structured failure assert instead of checking all error output: https://github.com/gradle/gradle/issues/33985
+        failure.error.count("Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'") == 1
+
         when:
         configurationCacheFails WARN_PROBLEMS_CLI_OPT, 'problems', 'broken'
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -119,7 +119,7 @@ class ConfigurationCacheProblemsSummary(
             }
             if (severity != ProblemSeverity.SuppressedSilently) {
                 val isNewCause = recordProblemCause(problem, severity)
-                if (isNewCause) {
+                if (isNewCause && severity != ProblemSeverity.Interrupting) {
                     collectOriginalException(problem)
                 }
             }


### PR DESCRIPTION
### Context

Each interrupting CC problem results in a separate build failure. The build failure carries the original exception causing the interrupting problem. By default, the exception message is shown in the console, when the build failure is displayed. With `--info` or in build scans, the entire stacktrace is shown as well.

There is also the aggregating CC build failure that can be issued at the end of the build, if there were any _deferred_ problems. This build failure carries a summary of all CC problems, including the interrupting ones, even though the interrupting problems never cause the aggregating failure by themselves.

Before this change, we have been collecting some exceptions attached to problems to include as sub-causes, *regardless* of the problem severity. For interrupting problems this results in the exception messages or stacktraces being duplicated in console and build scans. This can create a wrong impression that those exceptions also played a role in issuing the aggregated build failure.

### Example

Here is an example of the output with the duplicated error message (with some output redacted for clarity):
```
FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* Where:
Build file '/Users/asemin/projects/gradle/build-tool/cc2/platforms/core-configuration/configuration-cache/build/tmp/teŝt files/Configurati.Test/l028p/build.gradle' line: 4

* What went wrong:
Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'
> BOOM

==============================================================================

2: Task failed with an exception.
-----------
* Where:
Build file '/Users/asemin/projects/gradle/build-tool/cc2/platforms/core-configuration/configuration-cache/build/tmp/teŝt files/Configurati.Test/l028p/build.gradle' line: 4

* What went wrong:
Configuration cache problems found in this build.

3 problems were found storing the configuration cache, 2 of which seem unique.
- Task `:problems` of type `org.gradle.api.DefaultTask`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.1.0-20250623220000+0000/userguide/configuration_cache_requirements.html#config_cache:requirements:disallowed_types
- Task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'

See the complete report at file:///Users/asemin/projects/gradle/build-tool/cc2/platforms/core-configuration/configuration-cache/build/tmp/te%C5%9Dt%20files/Configurati.Test/l028p/build/reports/configuration-cache/40slljk1spnazp4e4i1z8nzk2/41omz680p466lson4d21rf6m0/configuration-cache-report.html
> Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'
   > BOOM
```

The ``Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'`` failure is duplicated with its causes.

### Change

The change excludes interrupting problem exceptions from being collected into the summary. However, the exception and its stacktrace is still included in the CC report.