### PR TITLE
Fix documentation about limitations of using the Kotlin DSL together with Configure-on-Demand

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/migrating/migrating_from_groovy_to_kotlin_dsl.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/migrating/migrating_from_groovy_to_kotlin_dsl.adoc
@@ -50,7 +50,6 @@ Builds with slow configuration time might affect the IDE responsiveness, please 
 * Knowledge of Kotlin syntax and basic language features is very helpful. The link:{kotlin-reference}[Kotlin reference documentation] and link:https://kotlinlang.org/docs/tutorials/koans.html[Kotlin Koans] should be useful to you.
 * Use of the `plugins {}` block to declare Gradle plugins significantly improves the editing experience, and is highly recommended. Consider adopting it in your Groovy build scripts before converting them to Kotlin.
 * The Kotlin DSL will not support `model {}` elements. This is part of the link:https://blog.gradle.org/state-and-future-of-the-gradle-software-model[discontinued Gradle Software Model].
-* Enabling the incubating configuration on demand feature is not recommended as it can lead to very hard-to-diagnose problems.
 
 Read more in the <<kotlin_dsl.adoc#kotdsl:kotlin_dsl,Gradle Kotlin DSL Primer>>.
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- [x] https://github.com/gradle/gradle/issues/30047