### PR TITLE
Deprecate the archives configuration

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -41,4 +41,23 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Deprecations
 
+[[archives-configuration]]
+==== Deprecation of the `archives` configuration
+The `archives` configuration added by the `base` plugin has been deprecated and will be removed in Gradle 10.0.0.
+Adding artifacts to the `archives` configuration will now result in a deprecation warning.
+If you want the artifact built when running the `assemble` task, you should add the artifact (or the task that produces it) as a dependency of the `assemble` task directly.
+
+.build.gradle.kts
+[source,kotlin]
+----
+val specialJar = tasks.register<Jar>("specialJar") {
+    archiveBaseName.set("special")
+    from("build/special")
+}
+
+tasks.named("assemble") {
+    dependsOn(specialJar)
+}
+----
+
 === Potential breaking changes

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/variants/GradlePluginWithVariantsPublicationIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/variants/GradlePluginWithVariantsPublicationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.plugin.devel.variants
 
 import org.gradle.api.JavaVersion
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.plugins.UnknownPluginException
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException
@@ -156,7 +157,7 @@ class GradlePluginWithVariantsPublicationIntegrationTest extends AbstractIntegra
             version = "1.0"
 
             configurations.configureEach {
-                if (canBeConsumed && name != 'archives')  {
+                if (canBeConsumed && name != '${Dependency.ARCHIVES_CONFIGURATION}')  {
                     attributes {
                         attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named(GradlePluginApiVersion, '1000.0'))
                     }
@@ -333,7 +334,7 @@ class GradlePluginWithVariantsPublicationIntegrationTest extends AbstractIntegra
 
             def color = Attribute.of("color", String)
             configurations.configureEach {
-                if (name != 'archives') {
+                if (name != '${Dependency.ARCHIVES_CONFIGURATION}') {
                     if (canBeConsumed && name.startsWith(alternate.name))  {
                         attributes {
                             attribute(color, 'green')

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/variants/GradlePluginWithVariantsPublicationIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/variants/GradlePluginWithVariantsPublicationIntegrationTest.groovy
@@ -156,7 +156,7 @@ class GradlePluginWithVariantsPublicationIntegrationTest extends AbstractIntegra
             version = "1.0"
 
             configurations.configureEach {
-                if (canBeConsumed)  {
+                if (canBeConsumed && name != 'archives')  {
                     attributes {
                         attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named(GradlePluginApiVersion, '1000.0'))
                     }
@@ -333,13 +333,15 @@ class GradlePluginWithVariantsPublicationIntegrationTest extends AbstractIntegra
 
             def color = Attribute.of("color", String)
             configurations.configureEach {
-                if (canBeConsumed && name.startsWith(alternate.name))  {
-                    attributes {
-                        attribute(color, 'green')
-                    }
-                } else if (canBeConsumed && !name.startsWith(alternate.name))  {
-                    attributes {
-                        attribute(color, 'blue')
+                if (name != 'archives') {
+                    if (canBeConsumed && name.startsWith(alternate.name))  {
+                        attributes {
+                            attribute(color, 'green')
+                        }
+                    } else if (canBeConsumed && !name.startsWith(alternate.name))  {
+                        attributes {
+                            attribute(color, 'blue')
+                        }
                     }
                 }
             }

--- a/platforms/jvm/ear/build.gradle.kts
+++ b/platforms/jvm/ear/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(projects.execution)
     implementation(projects.fileCollections)
     implementation(projects.languageJava)
+    implementation(projects.logging)
     implementation(projects.platformBase)
     implementation(projects.pluginsJava)
     implementation(projects.pluginsJavaBase)

--- a/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -34,6 +34,7 @@ import org.gradle.api.plugins.internal.JavaPluginHelper;
 import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
 import org.gradle.plugins.ear.descriptor.internal.DefaultDeploymentDescriptor;
@@ -123,7 +124,11 @@ public abstract class EarPlugin implements Plugin<Project> {
             task.setDeploymentDescriptor(deploymentDescriptor);
         });
 
-        project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getArtifacts().add(new LazyPublishArtifact(ear, ((ProjectInternal) project).getFileResolver(), taskDependencyFactory));
+        DeprecationLogger.whileDisabled(() -> {
+            project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION)
+                .getArtifacts()
+                .add(new LazyPublishArtifact(ear, ((ProjectInternal) project).getFileResolver(), taskDependencyFactory));
+        });
     }
 
     private void wireEarTaskConventions(Project project) {

--- a/platforms/jvm/plugins-java/build.gradle.kts
+++ b/platforms/jvm/plugins-java/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(projects.core)
     implementation(projects.ivy)
     implementation(projects.languageJvm)
+    implementation(projects.logging)
     implementation(projects.maven)
     implementation(projects.modelCore)
     implementation(projects.platformBase)

--- a/platforms/jvm/plugins-java/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/platforms/jvm/plugins-java/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -47,6 +47,7 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.diagnostics.DependencyInsightReportTask;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.jvm.component.internal.DefaultJvmSoftwareComponent;
 import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
 import org.gradle.testing.base.TestingExtension;
@@ -266,8 +267,10 @@ public abstract class JavaPlugin implements Plugin<Project> {
         ((SoftwareComponentContainerInternal) project.getComponents()).getMainComponent().convention(javaComponent);
 
         // Build the main jar when running `assemble`.
-        project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getArtifacts()
-            .add(javaComponent.getMainFeature().getRuntimeElementsConfiguration().getArtifacts().iterator().next());
+        DeprecationLogger.whileDisabled(() -> {
+            project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getArtifacts()
+                .add(javaComponent.getMainFeature().getRuntimeElementsConfiguration().getArtifacts().iterator().next());
+        });
 
         configureTestTaskOrdering(project.getTasks());
         configureDiagnostics(project, javaComponent.getMainFeature());

--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
@@ -184,7 +184,7 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
             project(":ear") {
                 apply plugin: 'ear'
                 dependencies {
-                    deploy project(path: ':war', configuration: 'archives')
+                    deploy project(path: ':war')
                 }
             }
         """

--- a/platforms/jvm/war/build.gradle.kts
+++ b/platforms/jvm/war/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(projects.dependencyManagement)
     implementation(projects.fileCollections)
     implementation(projects.fileOperations)
+    implementation(projects.logging)
     implementation(projects.languageJava)
     implementation(projects.modelCore)
     implementation(projects.platformBase)

--- a/platforms/jvm/war/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/platforms/jvm/war/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -35,6 +35,7 @@ import org.gradle.api.plugins.jvm.JvmTestSuite;
 import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -84,7 +85,9 @@ public abstract class WarPlugin implements Plugin<Project> {
         });
 
         PublishArtifact warArtifact = new LazyPublishArtifact(war, ((ProjectInternal) project).getFileResolver(), ((ProjectInternal) project).getTaskDependencyFactory());
-        project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getArtifacts().add(warArtifact);
+        DeprecationLogger.whileDisabled(() -> {
+            project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getArtifacts().add(warArtifact);
+        });
         configureConfigurations(((ProjectInternal) project).getConfigurations(), mainFeature);
         configureComponent(project, warArtifact);
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginVariantResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginVariantResolveIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.api.JavaVersion
+import org.gradle.api.artifacts.Dependency
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
 
@@ -149,7 +150,7 @@ class PluginVariantResolveIntegrationTest extends AbstractIntegrationSpec {
             }
 
             configurations.all {
-                if (it.canBeConsumed && it.name != 'sourcesElements' && it.name != 'archives') {
+                if (it.canBeConsumed && it.name != 'sourcesElements' && it.name != '${Dependency.ARCHIVES_CONFIGURATION}') {
                     // let's pretend it was built with a newer Java version
                     attributes {
                         // This test is not Artic Code Vault safe

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginVariantResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginVariantResolveIntegrationTest.groovy
@@ -149,7 +149,7 @@ class PluginVariantResolveIntegrationTest extends AbstractIntegrationSpec {
             }
 
             configurations.all {
-                if (it.canBeConsumed && it.name != 'sourcesElements' ) {
+                if (it.canBeConsumed && it.name != 'sourcesElements' && it.name != 'archives') {
                     // let's pretend it was built with a newer Java version
                     attributes {
                         // This test is not Artic Code Vault safe

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -456,6 +456,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         """
 
         when: "the build fails"
+        executer.noDeprecationChecks()
         fails 'help'
 
         then:
@@ -487,6 +488,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         """
 
         when: "the build fails because the configuration is not allowed to change"
+        executer.noDeprecationChecks()
         fails 'help'
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -456,6 +456,8 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         """
 
         when: "the build fails"
+        // archives is now deprecated for all usages, so the error contains the word "deprecated", so we disable deprecation checks to avoid
+        // a post-execution error that a deprecation warning may appear in the output
         executer.noDeprecationChecks()
         fails 'help'
 
@@ -488,6 +490,8 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         """
 
         when: "the build fails because the configuration is not allowed to change"
+        // archives is now deprecated for all usages, so the error contains the word "deprecated", so we disable deprecation checks to avoid
+        // a post-execution error that a deprecation warning may appear in the output
         executer.noDeprecationChecks()
         fails 'help'
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.plugin.devel.variants
 
 import org.gradle.api.JavaVersion
+import org.gradle.api.artifacts.Dependency
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
@@ -134,7 +135,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
             version = "1.0"
 
             configurations.configureEach {
-                if (canBeConsumed && name != 'archives')  {
+                if (canBeConsumed && name != '${Dependency.ARCHIVES_CONFIGURATION}')  {
                     attributes {
                         attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, $tooHighJava)
                     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
@@ -134,7 +134,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
             version = "1.0"
 
             configurations.configureEach {
-                if (canBeConsumed)  {
+                if (canBeConsumed && name != 'archives')  {
                     attributes {
                         attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, $tooHighJava)
                     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -649,7 +649,7 @@ class DefaultConfigurationSpec extends Specification {
             ConfigurationRoles.ALL,
             ConfigurationRoles.RESOLVABLE,
             ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE
-        ] + ConfigurationRolesForMigration.ALL
+        ] + ConfigurationRolesForMigration.ALL - ConfigurationRolesForMigration.CONSUMABLE_TO_RETIRED
     }
 
     void "fails to copy non-resolvable configuration (#role)"() {

--- a/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -146,7 +146,6 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
             artifacts {
                 implementation extraJar
-                archives extraJar
                 it."default" extraJar
             }
 

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/ArchivesConfigurationDeprecationIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/ArchivesConfigurationDeprecationIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
-class ArchivesConfigurationDeprecationTest extends AbstractIntegrationSpec {
+class ArchivesConfigurationDeprecationIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile """
             plugins {
@@ -42,7 +42,7 @@ class ArchivesConfigurationDeprecationTest extends AbstractIntegrationSpec {
         executer.expectDocumentedDeprecationWarning(
             "The archives configuration has been deprecated for artifact declaration. " +
                 "This will fail with an error in Gradle 10. " +
-                "Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. " +
+                "Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#sec:archives-configuration"
         )
         succeeds("assemble")
@@ -90,7 +90,7 @@ class ArchivesConfigurationDeprecationTest extends AbstractIntegrationSpec {
         executer.expectDocumentedDeprecationWarning(
             "The archives configuration has been deprecated for artifact declaration. " +
                 "This will fail with an error in Gradle 10. " +
-                "Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. " +
+                "Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#sec:archives-configuration"
         )
         executer.expectDocumentedDeprecationWarning("The archives configuration has been deprecated for consumption. " +

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/ArchivesConfigurationDeprecationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/ArchivesConfigurationDeprecationTest.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class ArchivesConfigurationDeprecationTest extends AbstractIntegrationSpec {
+    def setup() {
+        buildFile """
+            plugins {
+                id("base")
+            }
+        """
+    }
+
+    def "deprecation when adding artifacts to the archives configuration"() {
+        buildFile """
+            task jar(type: Jar) {}
+
+            configurations {
+                archives {
+                    outgoing.artifact(tasks.jar)
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning(
+            "The archives configuration has been deprecated for artifact declaration. " +
+                "This will fail with an error in Gradle 10. " +
+                "Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#sec:archives-configuration"
+        )
+        succeeds("assemble")
+    }
+
+    def "deprecation when consuming artifacts from the archives configuration"() {
+        settingsFile """
+            rootProject.name = "root"
+            include(":sub")
+        """
+        buildFile """
+            task jar(type: Jar) {}
+
+            configurations {
+                resolvable("resolvableArchives") {
+                    extendsFrom archives
+                }
+                archives {
+                    outgoing.artifact(tasks.jar)
+                }
+            }
+        """
+        buildFile("sub/build.gradle", """
+            configurations {
+                dependencyScope("consumeArchives")
+                resolvable("resolvableArchives") {
+                    extendsFrom consumeArchives
+                }
+            }
+
+            dependencies {
+                consumeArchives project(path: ":", configuration: "archives")
+            }
+
+            task("resolve") {
+                def resolvableArchives = configurations.resolvableArchives
+                inputs.files resolvableArchives
+                doLast {
+                    resolvableArchives.files.each { println it }
+                }
+            }
+        """)
+
+        expect:
+        executer.expectDocumentedDeprecationWarning(
+            "The archives configuration has been deprecated for artifact declaration. " +
+                "This will fail with an error in Gradle 10. " +
+                "Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#sec:archives-configuration"
+        )
+        executer.expectDocumentedDeprecationWarning("The archives configuration has been deprecated for consumption. " +
+            "This will fail with an error in Gradle 10. " +
+            "For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation."
+        )
+        succeeds(":sub:resolve")
+    }
+
+    def "error when adding dependencies to the archives configuration"() {
+        settingsFile """
+            include(":sub")
+        """
+        buildFile """
+            dependencies {
+                archives project(":sub")
+            }
+        """
+        file("sub").createDir()
+
+        expect:
+        fails("assemble")
+        failure.assertHasCause("Dependencies can not be declared against the `archives` configuration.")
+    }
+
+    def "error when resolving the archives configuration"() {
+        buildFile """
+            task("resolve") {
+                def archives = configurations.archives
+                doLast {
+                    archives.files.each { println it }
+                }
+            }
+        """
+
+        expect:
+        fails("resolve")
+        failure.assertHasCause("Resolving dependency configuration 'archives' is not allowed")
+    }
+}

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
@@ -127,6 +127,12 @@ class BasePluginIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        executer.expectDocumentedDeprecationWarning(
+            "The archives configuration has been deprecated for artifact declaration. " +
+                "This will fail with an error in Gradle 10. " +
+                "Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#sec:archives-configuration"
+        )
         succeeds("assemble")
 
         executedAndNotSkipped(":jar2")

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
@@ -130,7 +130,7 @@ class BasePluginIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDocumentedDeprecationWarning(
             "The archives configuration has been deprecated for artifact declaration. " +
                 "This will fail with an error in Gradle 10. " +
-                "Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. " +
+                "Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#sec:archives-configuration"
         )
         succeeds("assemble")

--- a/platforms/software/platform-base/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/platforms/software/platform-base/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -85,7 +85,7 @@ public abstract class BasePlugin implements Plugin<Project> {
             artifacts.beforeCollectionChanges(artifact -> {
                 DeprecationLogger.deprecateConfiguration(ARCHIVES_CONFIGURATION)
                     .forArtifactDeclaration()
-                    .withAdvice("Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the " + ARCHIVES_CONFIGURATION + " configuration.")
+                    .withAdvice("Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the " + ARCHIVES_CONFIGURATION + " configuration.")
                     .willBecomeAnErrorInNextMajorGradleVersion()
                     .withUpgradeGuideSection(9, "sec:archives-configuration")
                     .nagUser();

--- a/platforms/software/platform-base/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/platforms/software/platform-base/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -20,11 +20,14 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.DomainObjectCollectionInternal;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
 import org.gradle.api.internal.plugins.BuildConfigurationRule;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.internal.DefaultBasePluginExtension;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.gradle.internal.Cast;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
@@ -78,7 +81,8 @@ public abstract class BasePlugin implements Plugin<Project> {
 
         final Configuration archivesConfiguration = configurations.migratingLocked(ARCHIVES_CONFIGURATION, CONSUMABLE_TO_RETIRED, conf -> {
             conf.setDescription("Configuration for archive artifacts.");
-            conf.getArtifacts().whenObjectAdded(artifact -> {
+            DomainObjectCollectionInternal<PublishArtifact> artifacts = Cast.uncheckedCast(conf.getArtifacts());
+            artifacts.beforeCollectionChanges(artifact -> {
                 DeprecationLogger.deprecateConfiguration(ARCHIVES_CONFIGURATION)
                     .forArtifactDeclaration()
                     .withAdvice("Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the " + ARCHIVES_CONFIGURATION + " configuration.")

--- a/platforms/software/plugins-distribution/build.gradle.kts
+++ b/platforms/software/plugins-distribution/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 
     implementation(projects.dependencyManagement)
     implementation(projects.fileCollections)
+    implementation(projects.logging)
     implementation(projects.modelCore)
     implementation(projects.platformBase)
 

--- a/platforms/software/plugins-distribution/src/main/java/org/gradle/api/distribution/plugins/DistributionBasePlugin.java
+++ b/platforms/software/plugins-distribution/src/main/java/org/gradle/api/distribution/plugins/DistributionBasePlugin.java
@@ -38,6 +38,7 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Tar;
 import org.gradle.api.tasks.bundling.Zip;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.internal.TextUtil;
 
@@ -125,8 +126,10 @@ public abstract class DistributionBasePlugin implements Plugin<Project> {
 
         // Build zips and tars by default when running the build-wide assemble task.
         PublishArtifactSet archivesArtifacts = project.getConfigurations().getByName(Dependency.ARCHIVES_CONFIGURATION).getArtifacts();
-        archivesArtifacts.add(new LazyPublishArtifact(zipTask, project.getFileResolver(), project.getTaskDependencyFactory()));
-        archivesArtifacts.add(new LazyPublishArtifact(tarTask, project.getFileResolver(), project.getTaskDependencyFactory()));
+        DeprecationLogger.whileDisabled(() -> {
+            archivesArtifacts.add(new LazyPublishArtifact(zipTask, project.getFileResolver(), project.getTaskDependencyFactory()));
+            archivesArtifacts.add(new LazyPublishArtifact(tarTask, project.getFileResolver(), project.getTaskDependencyFactory()));
+        });
     }
 
     /**

--- a/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningConfigurationsIntegrationSpec.groovy
+++ b/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningConfigurationsIntegrationSpec.groovy
@@ -114,24 +114,26 @@ class SigningConfigurationsIntegrationSpec extends SigningIntegrationSpec {
     def "duplicated inputs are handled"() {
         given:
         buildFile << """
+            configurations {
+                consumable("jars") {
+                    // Add the jar file as an artifact using both the task as well as a mapped file provider
+                    outgoing.artifact(tasks.named("jar"))
+                    outgoing.artifact(tasks.named("jar").map { it.archiveFile })
+                }
+            }
             signing {
                 ${signingConfiguration()}
-                sign configurations.archives
+                sign configurations.jars
             }
 
             ${keyInfo.addAsPropertiesScript()}
-
-            artifacts {
-                // depend directly on 'jar' task in addition to dependency through 'archives'
-                archives jar
-            }
         """
 
         when:
         run "buildSignatures"
 
         then:
-        executedAndNotSkipped ":signArchives"
+        executedAndNotSkipped ":signJars"
 
         and:
         file("build", "libs", "sign-1.0.jar.asc").text

--- a/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningIntegrationSpec.groovy
+++ b/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningIntegrationSpec.groovy
@@ -131,11 +131,10 @@ abstract class SigningIntegrationSpec extends AbstractIntegrationSpec {
         } else {
             javaPluginConfig + """
                 configurations {
-                    $configurationName
-                }
-
-                artifacts {
-                    $configurationName sourcesJar, javadocJar
+                    $configurationName {
+                        outgoing.artifact(tasks.named("sourcesJar"))
+                        outgoing.artifact(tasks.named("javadocJar"))
+                    }
                 }
             """
         }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -158,7 +158,7 @@ class ConfigurationOnDemandIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
 allprojects { apply plugin: 'java-library' }
 project(':impl') {
-    dependencies { implementation project(path: ':api', configuration: 'archives') }
+    dependencies { implementation project(':api') }
 }
 project(':api') {
     dependencies { runtimeOnly project(':impl') }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/TaskFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/TaskFilePropertiesIntegrationTest.groovy
@@ -153,7 +153,7 @@ class TaskFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
 
         buildFile('a/build.gradle', '''
             configurations.create("compile")
-            dependencies { compile project(path: ':b', configuration: 'archives') }
+            dependencies { compile project(path: ':b', configuration: 'producer') }
 
             task doStuff(type: InputTask) {
                 src = configurations.compile + fileTree('src/java')
@@ -179,12 +179,12 @@ class TaskFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
 
             configurations {
                 create("deps")
-                archives {
+                consumable("producer") {
                     extendsFrom deps
+                    outgoing.artifact(otherJar)
                 }
             }
             dependencies { deps files('b.jar') { builtBy jar } }
-            artifacts { archives otherJar }
         ''')
 
         when:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRoles.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRoles.java
@@ -45,6 +45,11 @@ public final class ConfigurationRoles {
     public static final ConfigurationRole ALL = createNonDeprecatedRole("Legacy", true, true, true);
 
     /**
+     * A configuration that is retired and not meant to be used for any purpose.  This is primarily useful in creating a migrating configuration role in {@link ConfigurationRolesForMigration}.
+     */
+    public static final ConfigurationRole NONE = createNonDeprecatedRole("Deprecated", false, false, false);
+
+    /**
      * Meant to be used only for consumption by other projects.
      */
     public static final ConfigurationRole CONSUMABLE = createNonDeprecatedRole("Consumable", true, false, false);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRoles.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRoles.java
@@ -45,11 +45,6 @@ public final class ConfigurationRoles {
     public static final ConfigurationRole ALL = createNonDeprecatedRole("Legacy", true, true, true);
 
     /**
-     * A configuration that is retired and not meant to be used for any purpose.  This is primarily useful in creating a migrating configuration role in {@link ConfigurationRolesForMigration}.
-     */
-    public static final ConfigurationRole NONE = createNonDeprecatedRole("Deprecated", false, false, false);
-
-    /**
      * Meant to be used only for consumption by other projects.
      */
     public static final ConfigurationRole CONSUMABLE = createNonDeprecatedRole("Consumable", true, false, false);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
@@ -62,12 +62,29 @@ public final class ConfigurationRolesForMigration {
     public static final ConfigurationRole LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE = difference(ConfigurationRoles.ALL, ConfigurationRoles.RESOLVABLE_DEPENDENCY_SCOPE);
 
     /**
+     * A consumable configuration that has been deprecated and will be removed in the next major version.
+     */
+    public static final ConfigurationRole CONSUMABLE_TO_RETIRED = difference(ConfigurationRoles.CONSUMABLE, ConfigurationRoles.NONE);
+
+    /**
+     * A resolvable configuration that has been deprecated and will be removed in the next major version.
+     */
+    public static final ConfigurationRole RESOLVABLE_TO_RETIRED = difference(ConfigurationRoles.RESOLVABLE, ConfigurationRoles.NONE);
+
+    /**
+     * A dependency scope configuration that has been deprecated and will be removed in the next major version.
+     */
+    public static final ConfigurationRole DEPENDENCY_SCOPE_TO_RETIRED = difference(ConfigurationRoles.DEPENDENCY_SCOPE, ConfigurationRoles.NONE);
+
+
+    /**
      * All known migration roles.
      */
     public static final Set<ConfigurationRole> ALL = ImmutableSet.of(
         RESOLVABLE_DEPENDENCY_SCOPE_TO_RESOLVABLE,
         RESOLVABLE_DEPENDENCY_SCOPE_TO_DEPENDENCY_SCOPE,
-        LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE
+        LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE,
+        CONSUMABLE_TO_RETIRED
     );
 
     /**
@@ -86,7 +103,7 @@ public final class ConfigurationRolesForMigration {
 
         /*
          * Since we're assuming strictly narrowing usage from a non-deprecated initial role, for each usage we want this migration
-         * role to deprecate a usage iff that usage will change from allowed -> disallowed when migrating from the initial role to the
+         * role to deprecate a usage if that usage will change from allowed -> disallowed when migrating from the initial role to the
          * eventual role.
          */
         boolean consumptionDeprecated = initialRole.isConsumable() && !eventualRole.isConsumable();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
@@ -41,6 +41,11 @@ public final class ConfigurationRolesForMigration {
     private ConfigurationRolesForMigration() { /* Private to prevent instantiation. */ }
 
     /**
+     * A configuration that is retired and not meant to be used for any purpose.  This is primarily useful in creating a migrating configuration role in {@link ConfigurationRolesForMigration}.
+     */
+    public static final ConfigurationRole NONE = new DefaultConfigurationRole("Deprecated", false, false, false, false, false, false);
+
+    /**
      * A resolvable dependency scope that will become a resolvable configuration in the next major version.
      */
     @SuppressWarnings("DeprecatedIsStillUsed")
@@ -64,18 +69,7 @@ public final class ConfigurationRolesForMigration {
     /**
      * A consumable configuration that has been deprecated and will be removed in the next major version.
      */
-    public static final ConfigurationRole CONSUMABLE_TO_RETIRED = difference(ConfigurationRoles.CONSUMABLE, ConfigurationRoles.NONE);
-
-    /**
-     * A resolvable configuration that has been deprecated and will be removed in the next major version.
-     */
-    public static final ConfigurationRole RESOLVABLE_TO_RETIRED = difference(ConfigurationRoles.RESOLVABLE, ConfigurationRoles.NONE);
-
-    /**
-     * A dependency scope configuration that has been deprecated and will be removed in the next major version.
-     */
-    public static final ConfigurationRole DEPENDENCY_SCOPE_TO_RETIRED = difference(ConfigurationRoles.DEPENDENCY_SCOPE, ConfigurationRoles.NONE);
-
+    public static final ConfigurationRole CONSUMABLE_TO_RETIRED = difference(ConfigurationRoles.CONSUMABLE, NONE);
 
     /**
      * All known migration roles.

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -44,6 +44,11 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_1_21,
                 "Declaring an 'is-' property with a Boolean type has been deprecated. Starting with Gradle 9.0, this property will be ignored by Gradle. The combination of method name and return type is not consistent with Java Bean property rules and will become unsupported in future versions of Groovy. Add a method named 'getMpp' with the same behavior and mark the old one with @Deprecated, or change the type of 'org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget.isMpp' (and the setter) to 'boolean'. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#groovy_boolean_properties",
             )
+            .expectDeprecationWarningIf(
+                kotlinVersionNumber.baseVersion > KotlinGradlePluginVersions.KOTLIN_2_1_20,
+                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
+                "https://youtrack.jetbrains.com/issue/KT-78620"
+            )
             .build()
 
         then:
@@ -77,6 +82,11 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
             .expectLegacyDeprecationWarningIf(
                 GradleContextualExecuter.notConfigCache && kotlinVersionNumber.baseVersion < KotlinGradlePluginVersions.KOTLIN_2_1_20,
                 "Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#task_project"
+            )
+            .expectDeprecationWarningIf(
+                kotlinVersionNumber.baseVersion > KotlinGradlePluginVersions.KOTLIN_2_1_20,
+                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
+                "https://youtrack.jetbrains.com/issue/KT-78620"
             )
             .build()
 
@@ -114,7 +124,13 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         def kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
 
         when:
-        def result = kgpRunner(false, kotlinVersionNumber, ':tasks').build()
+        def result = kgpRunner(false, kotlinVersionNumber, ':tasks')
+            .expectDeprecationWarningIf(
+                kotlinVersionNumber.baseVersion > KotlinGradlePluginVersions.KOTLIN_2_1_20,
+                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
+                "https://youtrack.jetbrains.com/issue/KT-78620"
+            )
+            .build()
 
         then:
         result.task(':tasks').outcome == SUCCESS
@@ -166,6 +182,11 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
 
         when:
         def testRunner = kgpRunner(false, kotlinVersionNumber, ':resolve', '--stacktrace')
+            .expectDeprecationWarningIf(
+                kotlinVersionNumber.baseVersion > KotlinGradlePluginVersions.KOTLIN_2_1_20,
+                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
+                "https://youtrack.jetbrains.com/issue/KT-78620"
+            )
         def result = testRunner.build()
 
         then:

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -46,7 +46,7 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
             )
             .expectDeprecationWarningIf(
                 kotlinVersionNumber.baseVersion > KotlinGradlePluginVersions.KOTLIN_2_1_20,
-                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
+                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
                 "https://youtrack.jetbrains.com/issue/KT-78620"
             )
             .build()
@@ -85,7 +85,7 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
             )
             .expectDeprecationWarningIf(
                 kotlinVersionNumber.baseVersion > KotlinGradlePluginVersions.KOTLIN_2_1_20,
-                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
+                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
                 "https://youtrack.jetbrains.com/issue/KT-78620"
             )
             .build()
@@ -127,7 +127,7 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         def result = kgpRunner(false, kotlinVersionNumber, ':tasks')
             .expectDeprecationWarningIf(
                 kotlinVersionNumber.baseVersion > KotlinGradlePluginVersions.KOTLIN_2_1_20,
-                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
+                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
                 "https://youtrack.jetbrains.com/issue/KT-78620"
             )
             .build()
@@ -184,7 +184,7 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         def testRunner = kgpRunner(false, kotlinVersionNumber, ':resolve', '--stacktrace')
             .expectDeprecationWarningIf(
                 kotlinVersionNumber.baseVersion > KotlinGradlePluginVersions.KOTLIN_2_1_20,
-                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as a direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
+                "The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#sec:archives-configuration",
                 "https://youtrack.jetbrains.com/issue/KT-78620"
             )
         def result = testRunner.build()


### PR DESCRIPTION
Deprecates the archives configuration in preparation for removal in Gradle 10.0.

Fixes #15639 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
