### PR TITLE
Avoid duplicating exceptions in CC build failures

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -367,6 +367,10 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
             problemsWithStackTraceCount = 1
         }
 
+        // The interrupting problem cause must not be repeated in the aggregated CC build failure
+        // TODO: introduce a structured failure assert instead of checking all error output: https://github.com/gradle/gradle/issues/33985
+        failure.error.count("Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'") == 1
+
         when:
         configurationCacheFails WARN_PROBLEMS_CLI_OPT, 'problems', 'broken'
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblemsSummary.kt
@@ -119,7 +119,7 @@ class ConfigurationCacheProblemsSummary(
             }
             if (severity != ProblemSeverity.SuppressedSilently) {
                 val isNewCause = recordProblemCause(problem, severity)
-                if (isNewCause) {
+                if (isNewCause && severity != ProblemSeverity.Interrupting) {
                     collectOriginalException(problem)
                 }
             }


### PR DESCRIPTION
This is a port of https://github.com/gradle/gradle/pull/33986 to 9.0.0