### PR TITLE
TAPI: update javadoc with regards to Gradle version compatibility

### DIFF
--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/GradleConnector.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/GradleConnector.java
@@ -61,7 +61,7 @@ import java.net.URI;
  *
  * <p>The Tooling API is both forwards and backwards compatible with other versions of Gradle. It supports execution of Gradle builds that use older or newer versions of Gradle.  Each release of Gradle contains a new release of the Tooling API as well.</p>
  *
- * <p>The Tooling API supports running builds using Gradle version 3.0 and up.</p>
+ * <p>The Tooling API supports running builds using Gradle version 4.0 and up.</p>
  *
  * <p>You should note that not all features of the Tooling API are available for all versions of Gradle. Refer to the documentation for each class and method for more details.</p>
  *

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/ProjectConnection.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/ProjectConnection.java
@@ -96,7 +96,7 @@ public interface ProjectConnection extends Closeable {
     /**
      * Creates a test launcher which can be used to execute tests.
      *
-     * <p>Requires Gradle 3.0 or later.</p>
+     * <p>Requires Gradle 4.0 or later.</p>
      *
      * @return The launcher.
      * @since 2.6


### PR DESCRIPTION
Following #32936 the Javadoc should be consistent with the userguide.


