### PR TITLE
Deprecate Configuration.is/setVisible()

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncludedBuildLogicChangesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncludedBuildLogicChangesIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.cc.impl
 
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.internal.cc.impl.fixtures.BuildLogicChangeFixture
 
 class ConfigurationCacheIncludedBuildLogicChangesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
@@ -35,6 +36,7 @@ class ConfigurationCacheIncludedBuildLogicChangesIntegrationTest extends Abstrac
         """
 
         when:
+        maybeExpectDeprecations(fixtureSpec)
         configurationCacheRunLenient fixture.task
 
         then:
@@ -50,6 +52,7 @@ class ConfigurationCacheIncludedBuildLogicChangesIntegrationTest extends Abstrac
 
         when:
         fixture.applyChange()
+        maybeExpectDeprecations(fixtureSpec)
         configurationCacheRunLenient fixture.task
 
         then:
@@ -66,5 +69,12 @@ class ConfigurationCacheIncludedBuildLogicChangesIntegrationTest extends Abstrac
 
         where:
         fixtureSpec << BuildLogicChangeFixture.specs()
+    }
+
+    AbstractConfigurationCacheIntegrationTest maybeExpectDeprecations(BuildLogicChangeFixture.Spec fixtureSpec) {
+        if (fixtureSpec.language == BuildLogicChangeFixture.Language.KOTLIN) {
+            ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+        }
+        return this
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/AbstractUndeclaredBuildInputsIntegrationTest.groovy
@@ -32,12 +32,16 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
         return false
     }
 
+    protected AbstractConfigurationCacheIntegrationTest maybeExpectDeprecations() {
+        return this
+    }
+
     def "reports undeclared system property read using #propertyRead.groovyExpression prior to task execution from plugin"() {
         buildLogicApplication(propertyRead)
         def configurationCache = newConfigurationCacheFixture()
 
         when:
-        configurationCacheRunLenient "thing", "-DCI=$value"
+        maybeExpectDeprecations().configurationCacheRunLenient "thing", "-DCI=$value"
 
         then:
         configurationCache.assertStateStored()
@@ -59,7 +63,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
         outputContains("task = $value")
 
         when:
-        configurationCacheRun("thing", "-DCI=$newValue")
+        maybeExpectDeprecations().configurationCacheRun("thing", "-DCI=$newValue")
 
         then: 'undeclared properties are considered build inputs'
         configurationCache.assertStateStored()
@@ -88,7 +92,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
         def configurationCache = newConfigurationCacheFixture()
 
         when:
-        configurationCacheRun("thing", "-DCI=$value")
+        maybeExpectDeprecations().configurationCacheRun("thing", "-DCI=$value")
 
         then:
         configurationCache.assertStateStored()
@@ -110,7 +114,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
 
         when:
         EnvVariableInjection.environmentVariable("CI", value).setup(this)
-        configurationCacheRunLenient "thing"
+        maybeExpectDeprecations().configurationCacheRunLenient "thing"
 
         then:
         configurationCache.assertStateStored()
@@ -133,7 +137,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
 
         when:
         EnvVariableInjection.environmentVariable("CI", newValue).setup(this)
-        configurationCacheRun("thing")
+        maybeExpectDeprecations().configurationCacheRun("thing")
 
         then: 'undeclared properties are considered build inputs'
         configurationCache.assertStateStored()
@@ -159,7 +163,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
 
         when: "the file system entry used in configuration does not exist"
         assert !accessedFile.exists()
-        configurationCacheRunLenient()
+        maybeExpectDeprecations().configurationCacheRunLenient()
 
         then: "the file system entry is reported as an input"
         configurationCache.assertStateStored()
@@ -177,7 +181,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
 
         when: "there was no file system entry at the path used in configuration and a file is created at that path"
         assert accessedFile.createNewFile()
-        configurationCacheRunLenient()
+        maybeExpectDeprecations().configurationCacheRunLenient()
 
         then: "the cache entry is invalidated and the created file is reported"
         configurationCache.assertStateStored()
@@ -194,7 +198,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
         assert accessedFile.isFile()
         assert accessedFile.delete()
         assert accessedFile.mkdirs()
-        configurationCacheRunLenient()
+        maybeExpectDeprecations().configurationCacheRunLenient()
 
         then: "the cache entry is invalidated and the change of the file system entry is reported"
         configurationCache.assertStateStored()
@@ -202,7 +206,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
 
         when: "the file system entry used in configuration is deleted"
         assert accessedFile.deleteDir()
-        configurationCacheRunLenient()
+        maybeExpectDeprecations().configurationCacheRunLenient()
 
         then: "the cache entry is invalidated and the removal is reported"
         configurationCache.assertStateStored()
@@ -226,7 +230,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
 
         when: "an empty directory used in configuration is created"
         assert accessedFile.mkdirs()
-        configurationCacheRunLenient()
+        maybeExpectDeprecations().configurationCacheRunLenient()
 
         then: "it is reported as an input"
         configurationCache.assertStateStored()
@@ -243,7 +247,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
 
         when: "a file is created in the directory"
         assert new File(accessedFile, "test1").createNewFile()
-        configurationCacheRunLenient()
+        maybeExpectDeprecations().configurationCacheRunLenient()
 
         then: "the cache entry is invalidated and the change is reported"
         configurationCache.assertStateStored()
@@ -273,7 +277,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
 
         when: "the build uses a file content in configuration"
         accessedFile.text = "foo"
-        configurationCacheRunLenient()
+        maybeExpectDeprecations().configurationCacheRunLenient()
 
         then: "the file content input is reported"
         configurationCache.assertStateStored()
@@ -290,7 +294,7 @@ abstract class AbstractUndeclaredBuildInputsIntegrationTest extends AbstractConf
 
         when: "the file content is modified and the build is re-run"
         accessedFile.text = "bar"
-        configurationCacheRunLenient()
+        maybeExpectDeprecations().configurationCacheRunLenient()
 
         then: "the cache entry is invalidated and the change is reported"
         configurationCache.assertStateStored()

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/MethodReferenceInstrumentationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/MethodReferenceInstrumentationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.cc.impl.inputs.undeclared
 
 import groovy.transform.CompileStatic
 import groovy.transform.MapConstructor
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.internal.cc.impl.AbstractConfigurationCacheIntegrationTest
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.util.internal.ToBeImplemented
@@ -410,6 +411,7 @@ class MethodReferenceInstrumentationIntegrationTest extends AbstractConfiguratio
         """
 
         when:
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
         configurationCacheRun("echo", "-D${systemProperty().path}=${systemProperty().expectedValue}")
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/SystemPropertyInstrumentationInKotlinIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/SystemPropertyInstrumentationInKotlinIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl.inputs.undeclared
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.internal.cc.impl.AbstractConfigurationCacheIntegrationTest
 import org.gradle.test.fixtures.dsl.GradleDsl
 
@@ -52,6 +53,7 @@ class SystemPropertyInstrumentationInKotlinIntegrationTest extends AbstractConfi
         """)
 
         when:
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
         configurationCacheRun("-Dsome.property=some.value")
 
         then:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/UndeclaredBuildInputsKotlinBuildSrcIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/inputs/undeclared/UndeclaredBuildInputsKotlinBuildSrcIntegrationTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.internal.cc.impl.inputs.undeclared
 
 import org.gradle.integtests.fixtures.KotlinDslTestUtil
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
+import org.gradle.internal.cc.impl.AbstractConfigurationCacheIntegrationTest
 
 class UndeclaredBuildInputsKotlinBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements KotlinPluginImplementation {
     @Override
@@ -31,5 +33,11 @@ class UndeclaredBuildInputsKotlinBuildSrcIntegrationTest extends AbstractUndecla
         buildFile << """
             apply plugin: SneakyPlugin
         """
+    }
+
+    @Override
+    protected AbstractConfigurationCacheIntegrationTest maybeExpectDeprecations() {
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+        return super.maybeExpectDeprecations()
     }
 }

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -61,6 +61,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractKotlinIntegrationTest() {
                         $repositoriesBlock
                     """
                 )
+                usesKotlinDslPlugin()
                 withFile(
                     "src/main/kotlin/my-plugin.settings.gradle.kts",
                     """
@@ -102,6 +103,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractKotlinIntegrationTest() {
                         $repositoriesBlock
                     """
                 )
+                usesKotlinDslPlugin()
                 withFile(
                     "src/main/kotlin/base-plugin.settings.gradle.kts",
                     """
@@ -187,6 +189,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractKotlinIntegrationTest() {
                         }
                     """
                 )
+                usesKotlinDslPlugin()
                 withFile(
                     "src/main/kotlin/my-plugin.settings.gradle.kts",
                     """
@@ -277,6 +280,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractKotlinIntegrationTest() {
                 compileOnly(files("${normaliseFileSeparators(pluginJarV1.absolutePath)}"))
             }
         """)
+        usesKotlinDslPlugin()
         val precompiledScript = withFile("buildSrc/src/main/kotlin/my-precompiled-script.gradle.kts", """
             plugins {
                 id("my-plugin")

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
@@ -58,6 +58,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
             }
             """
         )
+        usesKotlinDslPlugin()
 
         withPrecompiledKotlinScript(
             "plugin-without-package.gradle.kts",
@@ -109,6 +110,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
             ${mavenCentralRepository(GradleDsl.KOTLIN)}
             """
         )
+        usesKotlinDslPlugin()
 
         withFile("$firstLocation/src/main/kotlin/plugin-without-package.gradle.kts")
         withFile(
@@ -160,6 +162,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
             plugins { `kotlin-dsl` }
             """
         )
+        usesKotlinDslPlugin()
 
         val fooScript = withFile("src/main/kotlin/foo.gradle.kts", "")
 
@@ -205,6 +208,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
                         }
                     """
                 )
+                usesKotlinDslPlugin()
 
                 withFile(
                     "producer/src/main/kotlin/producer-plugin.gradle.kts",

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -513,6 +513,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractKotlinIntegrationTest() {
             $repositoriesBlock
             """
         )
+        usesKotlinDslPlugin()
     }
 
     @Test
@@ -934,6 +935,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractKotlinIntegrationTest() {
             $repositoriesBlock
             """
         )
+        usesKotlinDslPlugin()
 
         withFile(
             "buildSrc/src/main/kotlin/foo/FooPlugin.kt",
@@ -995,6 +997,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractKotlinIntegrationTest() {
             $repositoriesBlock
             """
         )
+        usesKotlinDslPlugin()
 
         withFile(
             "buildSrc/src/main/kotlin/plugins/MyPlugin.kt",

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -355,6 +355,7 @@ class KotlinDslPluginTest : AbstractKotlinIntegrationTest() {
             $buildSrcScript
             """
         )
+        usesKotlinDslPlugin()
 
         withFile(
             "buildSrc/src/main/kotlin/my.kt",

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginIntegTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginIntegTest.kt
@@ -21,10 +21,16 @@ import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
 import org.junit.Test
 
 
 class EmbeddedKotlinPluginIntegTest : AbstractKotlinIntegrationTest() {
+
+    @Before
+    fun setup() {
+        usesEmbeddedKotlinPlugin()
+    }
 
     @Test
     fun `applies the kotlin plugin`() {

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorSettingEvaluationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorSettingEvaluationTest.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.kotlin.dsl.plugins.precompiled
 
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.kotlin.dsl.fixtures.normalisedPath
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.hamcrest.CoreMatchers
@@ -95,6 +96,7 @@ class PrecompiledScriptPluginAccessorSettingEvaluationTest : AbstractPrecompiled
         )
 
         // when: precompiled script plugin accessors are generated
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
         buildWithGradleUserHome(
             gradleUserHome,
             "generatePrecompiledScriptPluginAccessors",

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTemplatesTest.kt
@@ -26,6 +26,7 @@ import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.kotlin.dsl.fixtures.FoldersDslExpression
 import org.gradle.kotlin.dsl.fixtures.assertFailsWith
 import org.gradle.kotlin.dsl.fixtures.assertInstanceOf
@@ -261,6 +262,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
             }
         }
 
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
         executer.inDirectory(file("plugin")).withTasks("jar").run()
 
         val pluginJar = file("plugin/build/libs/plugin.jar")
@@ -454,7 +456,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
         )
 
         // Error message relies on Kotlin's Deprecated.HIDDEN
-        executer.noDeprecationChecks()
+        noDeprecationChecks()
         buildAndFail("classes").run {
             assertHasDescription(
                 "Execution failed for task ':compileKotlin'."
@@ -678,6 +680,7 @@ class PrecompiledScriptPluginTemplatesTest : AbstractPrecompiledScriptPluginTest
             }
         }
 
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
         build(
             existing("plugins"),
             "publish"

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/AbstractCompileAvoidanceIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/AbstractCompileAvoidanceIntegrationTest.kt
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl.compile
 
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
@@ -64,6 +65,7 @@ abstract class AbstractCompileAvoidanceIntegrationTest : AbstractKotlinIntegrati
         // and not to be reused from daemon's cache from other tests when daemon is in use
         withBuildScriptIn("buildSrc", scriptWithKotlinDslPlugin())
             .bustScriptCache()
+        usesKotlinDslPlugin()
     }
 
     private
@@ -127,12 +129,14 @@ abstract class AbstractCompileAvoidanceIntegrationTest : AbstractKotlinIntegrati
     protected
     fun configureProject(vararg tasks: String): BuildOperationsAssertions {
         val buildOperations = BuildOperationsFixture(executer, testDirectoryProvider)
+        setupDeprecationExpectations(tasks)
         val output = executer.withTasks(*tasks).run().normalizedOutput
         return BuildOperationsAssertions(buildOperations, output)
     }
 
     protected
     fun configureProjectAndExpectCompileFailure(@Suppress("SameParameterValue") expectedFailure: String) {
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
         val error = executer.runWithFailure().error
         MatcherAssert.assertThat(error, CoreMatchers.containsString(expectedFailure))
     }

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/BuildScriptCompileAvoidanceIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/BuildScriptCompileAvoidanceIntegrationTest.kt
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl.compile
 
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.kotlin.dsl.provider.KOTLIN_SCRIPT_COMPILATION_AVOIDANCE_ENABLED_PROPERTY
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -520,6 +521,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractCompileAvoidanceInteg
             """
         )
         val className = kotlinClassSourceFile(baseDir, classBody)
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
         build(existing(baseDir), "build")
         val jarPath = "$baseDir/build/libs/buildscript.jar"
         assertTrue(existing(jarPath).exists())

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/DeprecationInAccessorsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/compile/DeprecationInAccessorsIntegrationTest.kt
@@ -259,6 +259,7 @@ class DeprecationInAccessorsIntegrationTest : AbstractKotlinIntegrationTest() {
 
     private fun withPrecompiledScriptPluginInBuildSrc(pluginId: String, pluginSource: String) {
         withBuildScriptIn("buildSrc", scriptWithKotlinDslPlugin())
+        usesKotlinDslPlugin()
         withFile("buildSrc/src/main/kotlin/$pluginId.gradle.kts", pluginSource)
     }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/DclInterpreterIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/DclInterpreterIntegrationTest.kt
@@ -122,6 +122,7 @@ class DclInterpreterIntegrationTest : AbstractKotlinIntegrationTest() {
                 }
             """.trimIndent()
         )
+        usesKotlinDslPlugin()
 
         withFile(
             "settings.gradle.kts", """

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/DeprecationInDclAccessorsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/DeprecationInDclAccessorsIntegrationTest.kt
@@ -112,6 +112,7 @@ class DeprecationInDclAccessorsIntegrationTest : AbstractKotlinIntegrationTest()
                 }
             """.trimIndent()
         )
+        usesKotlinDslPlugin()
 
         withFile(
             "settings.gradle.kts", """

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/OptInDclAccessorsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/OptInDclAccessorsIntegrationTest.kt
@@ -131,6 +131,7 @@ class OptInDclAccessorsIntegrationTest : AbstractKotlinIntegrationTest() {
                 }
             """.trimIndent()
         )
+        usesKotlinDslPlugin()
 
         withFile(
             "settings.gradle.kts", """

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyKotlinInterOpIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyKotlinInterOpIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.provider
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
 @LeaksFileHandles
@@ -26,6 +27,7 @@ abstract class AbstractPropertyKotlinInterOpIntegrationTest extends AbstractProp
     def setup() {
         usesKotlin(pluginDir)
         executer.withStackTraceChecksDisabled()
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.provider
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.provider.AbstractLanguageInterOpIntegrationTest
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 
@@ -31,6 +32,10 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
     abstract void pluginSetsCalculatedValuesUsingMappedProvider()
 
     abstract void pluginDefinesTask()
+
+    AbstractPropertyLanguageInterOpIntegrationTest maybeExpectDeprecations() {
+        return this
+    }
 
     def "can define property and set value from language plugin"() {
         pluginSetsValues()
@@ -137,7 +142,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
                 map = provider { [3: true] }
             }
         """
-        run("someTask")
+        maybeExpectDeprecations().run("someTask")
 
         then:
         outputContains("flag = false")
@@ -184,7 +189,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractLa
                 map.set(provider { mapOf(3 to true) })
             }
         """
-        run("someTask")
+        maybeExpectDeprecations().run("someTask")
 
         then:
         outputContains("flag = false")

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ManagedPropertyKotlinInterOpIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ManagedPropertyKotlinInterOpIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.provider
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
 @LeaksFileHandles
@@ -58,5 +59,11 @@ class ManagedPropertyKotlinInterOpIntegrationTest extends AbstractPropertyKotlin
                 }
             }
         """
+    }
+
+    @Override
+    AbstractPropertyLanguageInterOpIntegrationTest maybeExpectDeprecations() {
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+        return super.maybeExpectDeprecations()
     }
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/NestedBeanKotlinInterOpIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/NestedBeanKotlinInterOpIntegrationTest.groovy
@@ -22,11 +22,13 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 
 class NestedBeanKotlinInterOpIntegrationTest extends AbstractNestedBeanLanguageInterOpIntegrationTest {
     def setup() {
         usesKotlin(pluginDir)
         executer.withStackTraceChecksDisabled()
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
         pluginDir.file("src/main/kotlin/Params.kt") << """
             import ${Property.name}
             import ${Internal.name}

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
 import javax.inject.Inject
@@ -63,5 +64,11 @@ class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyKotlinInterOp
                 }
             }
         """
+    }
+
+    @Override
+    AbstractPropertyLanguageInterOpIntegrationTest maybeExpectDeprecations() {
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+        return super.maybeExpectDeprecations()
     }
 }

--- a/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
+++ b/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.integtests
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.KotlinDslTestUtil
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
@@ -57,7 +59,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
             }
         """
         when:
-        withBuildCache().run "customTask"
+        runWithBuildCache "customTask"
         then:
         result.assertTaskNotSkipped(":customTask")
 
@@ -66,7 +68,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         file("buildSrc/.gradle").deleteDir()
         cleanBuildDir()
 
-        withBuildCache().run "customTask"
+        runWithBuildCache "customTask"
         then:
         result.groupedOutput.task(":customTask").outcome == "FROM-CACHE"
     }
@@ -85,7 +87,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
             }
         """
         when:
-        withBuildCache().run "customTask"
+        runWithBuildCache "customTask"
         then:
         result.assertTaskNotSkipped(":customTask")
         file("build/output.txt").text == "input"
@@ -94,7 +96,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         taskSourceFile.text = customKotlinTask(" modified")
 
         cleanBuildDir()
-        withBuildCache().run "customTask"
+        runWithBuildCache "customTask"
         then:
         result.assertTaskNotSkipped(":customTask")
         file("build/output.txt").text == "input modified"
@@ -129,4 +131,8 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         file("build").assertIsDir().deleteDir()
     }
 
+    private ExecutionResult runWithBuildCache(String... tasks) {
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+        return withBuildCache().run(tasks)
+    }
 }

--- a/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
+++ b/platforms/core-execution/execution-e2e-tests/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.integtests
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.KotlinDslTestUtil
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
@@ -228,5 +230,11 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractInt
                 }
             """
         }
+    }
+
+    @Override
+    protected ExecutionResult run(String... tasks) {
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+        return super.run(tasks)
     }
 }

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -41,4 +41,31 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Deprecations
 
+[[deprecate-visible-property]]
+==== The `Configuration.visible` property is now deprecated
+Prior to Gradle 9.0, the artifacts of any configuration where `isVisible()` returned true would be built whenever the `assemble` task was executed.
+This implicit behavior was removed in 9.0, and the `Configuration.visible` property no longer has any meaningful effect.
+This property is now deprecated and will be removed in Gradle 10.0.0.
+Any usage of this property can be removed.
+If the artifacts of the configuration should be built by the `assemble` task, create an explicit task dependency on the `assemble` task instead.
+
+.build.gradle.kts
+[source,kotlin]
+----
+val specialJar = tasks.register<Jar>("specialJar") {
+    archiveBaseName.set("special")
+    from("build/special")
+}
+
+configurations {
+    consumable("special") {
+        outgoing.artifact(specialJar)
+    }
+}
+
+tasks.named("assemble") {
+    dependsOn(specialJar)
+}
+----
+
 === Potential breaking changes

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiResolveIntegrationTest.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiResolveIntegrationTest.groovy
@@ -78,7 +78,6 @@ class ToolingApiResolveIntegrationTest extends AbstractIntegrationSpec {
                 sources {
                     extendsFrom runtimeClasspath
                     canBeConsumed = false
-                    visible = false
                     attributes {
                         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
                         attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))

--- a/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
+++ b/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
@@ -50,7 +50,6 @@ class CheckstylePluginTest extends AbstractProjectBuilderSpec {
 
         expect:
         config != null
-        !config.visible
         config.transitive
         config.description == 'The Checkstyle libraries to be used for this project.'
     }

--- a/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodeNarcPluginTest.groovy
+++ b/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodeNarcPluginTest.groovy
@@ -39,7 +39,6 @@ class CodeNarcPluginTest extends AbstractProjectBuilderSpec {
 
         expect:
         config != null
-        !config.visible
         config.transitive
         config.description == 'The CodeNarc libraries to be used for this project.'
     }

--- a/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -73,7 +73,6 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
 
         expect:
         config != null
-        !config.visible
         config.transitive
         config.description == 'The PMD libraries to be used for this project.'
     }

--- a/platforms/jvm/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
+++ b/platforms/jvm/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
@@ -65,14 +65,12 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         def configuration = project.configurations.getByName(EarPlugin.DEPLOY_CONFIGURATION_NAME)
 
         then:
-        !configuration.visible
         !configuration.transitive
 
         when:
         configuration = project.configurations.getByName(EarPlugin.EARLIB_CONFIGURATION_NAME)
 
         then:
-        !configuration.visible
         configuration.transitive
     }
 

--- a/platforms/jvm/plugins-groovy/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
+++ b/platforms/jvm/plugins-groovy/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
@@ -47,7 +47,6 @@ class GroovyPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         implementation.extendsFrom == [] as Set
-        !implementation.visible
         !implementation.canBeConsumed
         !implementation.canBeResolved
     }

--- a/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -231,7 +231,6 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         then:
         def implementation = project.configurations.customImplementation
-        !implementation.visible
         implementation.extendsFrom == [] as Set
         implementation.description == "Implementation only dependencies for source set 'custom'."
         !implementation.canBeConsumed
@@ -240,7 +239,6 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         and:
         def runtimeOnly = project.configurations.customRuntimeOnly
         runtimeOnly.transitive
-        !runtimeOnly.visible
         !runtimeOnly.canBeConsumed
         !runtimeOnly.canBeResolved
         runtimeOnly.extendsFrom == [] as Set
@@ -249,7 +247,6 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         and:
         def runtimeClasspath = project.configurations.customRuntimeClasspath
         runtimeClasspath.transitive
-        !runtimeClasspath.visible
         !runtimeClasspath.canBeConsumed
         runtimeClasspath.canBeResolved
         runtimeClasspath.extendsFrom == [runtimeOnly, implementation] as Set
@@ -258,14 +255,12 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         and:
         def compileOnly = project.configurations.customCompileOnly
         compileOnly.transitive
-        !compileOnly.visible
         compileOnly.extendsFrom == [] as Set
         compileOnly.description == "Compile only dependencies for source set 'custom'."
 
         and:
         def compileClasspath = project.configurations.customCompileClasspath
         compileClasspath.transitive
-        !compileClasspath.visible
         compileClasspath.extendsFrom == [compileOnly, implementation] as Set
         compileClasspath.description == "Compile classpath for source set 'custom'."
 

--- a/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmFeatureTest.groovy
+++ b/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmFeatureTest.groovy
@@ -91,7 +91,6 @@ class DefaultJvmFeatureTest extends AbstractProjectBuilderSpec {
 
         then:
         def configuration = project.configurations.getByName(JvmConstants.JAVADOC_ELEMENTS_CONFIGURATION_NAME)
-        !configuration.visible
         !configuration.canBeResolved
         configuration.canBeConsumed
         (configuration.attributes.getAttribute(Usage.USAGE_ATTRIBUTE) as Usage).name == Usage.JAVA_RUNTIME
@@ -111,7 +110,6 @@ class DefaultJvmFeatureTest extends AbstractProjectBuilderSpec {
 
         then:
         def configuration = project.configurations.getByName(JvmConstants.SOURCES_ELEMENTS_CONFIGURATION_NAME)
-        !configuration.visible
         !configuration.canBeResolved
         configuration.canBeConsumed
         (configuration.attributes.getAttribute(Usage.USAGE_ATTRIBUTE) as Usage).name == Usage.JAVA_RUNTIME

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmFeature.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmFeature.java
@@ -332,7 +332,6 @@ public class DefaultJvmFeature implements JvmFeatureInternal {
             ? project.getConfigurations().maybeCreateDependencyScopeLocked(configName, warnOnDuplicate)
             : project.getConfigurations().getByName(configName);
         configuration.setDescription(kind + " dependencies for the '" + name + "' feature.");
-        configuration.setVisible(false);
         return configuration;
     }
 

--- a/platforms/jvm/plugins-java-library/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/platforms/jvm/plugins-java-library/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -42,7 +42,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         def api = project.configurations.getByName(JvmConstants.API_CONFIGURATION_NAME)
 
         then:
-        !api.visible
         api.extendsFrom == [] as Set
         !api.canBeConsumed
         !api.canBeResolved
@@ -51,7 +50,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         def implementation = project.configurations.getByName(JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME)
 
         then:
-        !implementation.visible
         implementation.extendsFrom == [api] as Set
         !implementation.canBeConsumed
         !implementation.canBeResolved
@@ -61,7 +59,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         runtimeOnly.transitive
-        !runtimeOnly.visible
         !runtimeOnly.canBeConsumed
         !runtimeOnly.canBeResolved
         runtimeOnly.extendsFrom == [] as Set
@@ -71,7 +68,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         runtimeElements.transitive
-        !runtimeElements.visible
         runtimeElements.canBeConsumed
         !runtimeElements.canBeResolved
         runtimeElements.extendsFrom == [implementation, runtimeOnly] as Set
@@ -81,7 +77,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         runtimeClasspath.transitive
-        !runtimeClasspath.visible
         !runtimeClasspath.canBeConsumed
         runtimeClasspath.canBeResolved
         runtimeClasspath.extendsFrom == [runtimeOnly, implementation] as Set
@@ -91,7 +86,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         compileOnlyApi.extendsFrom == [] as Set
-        !compileOnlyApi.visible
         compileOnlyApi.transitive
         !compileOnlyApi.canBeConsumed
         !compileOnlyApi.canBeResolved
@@ -101,7 +95,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         compileOnly.extendsFrom == [compileOnlyApi] as Set
-        !compileOnly.visible
         compileOnly.transitive
 
         when:
@@ -109,14 +102,12 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         compileClasspath.extendsFrom == toSet(compileOnly, implementation)
-        !compileClasspath.visible
         compileClasspath.transitive
 
         when:
         def apiElements = project.configurations.getByName(JvmConstants.API_ELEMENTS_CONFIGURATION_NAME)
 
         then:
-        !apiElements.visible
         apiElements.extendsFrom == [api, compileOnlyApi] as Set
         apiElements.canBeConsumed
         !apiElements.canBeResolved
@@ -126,7 +117,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         testImplementation.extendsFrom == toSet(implementation)
-        !testImplementation.visible
         !testImplementation.canBeConsumed
         !testImplementation.canBeResolved
 
@@ -135,7 +125,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         testRuntimeOnly.transitive
-        !testRuntimeOnly.visible
         !testRuntimeOnly.canBeConsumed
         !testRuntimeOnly.canBeResolved
         testRuntimeOnly.extendsFrom == [runtimeOnly] as Set
@@ -145,7 +134,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         testCompileOnly.extendsFrom == toSet(compileOnlyApi)
-        !testCompileOnly.visible
         !testRuntimeOnly.canBeConsumed
         !testRuntimeOnly.canBeResolved
         testCompileOnly.transitive
@@ -155,7 +143,6 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         testCompileClasspath.extendsFrom == toSet(testCompileOnly, testImplementation)
-        !testCompileClasspath.visible
         testCompileClasspath.transitive
 
         when:

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -151,7 +151,6 @@ Artifacts
 
             // A resolvable configuration to collect source data
             def sourceElementsConfig = configurations.create("sourceElements") {
-                visible = true
                 assert canBeResolved
                 canBeConsumed = false
                 attributes {
@@ -242,7 +241,6 @@ Artifacts
 
             // A resolvable configuration to collect JaCoCo coverage data
             def sourceElementsConfig = configurations.create("sourceElements") {
-                visible = true
                 assert canBeResolved
                 canBeConsumed = false
                 extendsFrom(configurations.implementation)

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -51,7 +51,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         implementation.extendsFrom == toSet()
-        !implementation.visible
         !implementation.canBeConsumed
         !implementation.canBeResolved
 
@@ -60,7 +59,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         runtimeOnly.transitive
-        !runtimeOnly.visible
         !runtimeOnly.canBeConsumed
         !runtimeOnly.canBeResolved
         runtimeOnly.extendsFrom == [] as Set
@@ -70,7 +68,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         runtimeElements.transitive
-        !runtimeElements.visible
         runtimeElements.canBeConsumed
         !runtimeElements.canBeResolved
         runtimeElements.extendsFrom == [implementation, runtimeOnly] as Set
@@ -80,7 +77,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         runtimeClasspath.transitive
-        !runtimeClasspath.visible
         !runtimeClasspath.canBeConsumed
         runtimeClasspath.canBeResolved
         runtimeClasspath.extendsFrom == [runtimeOnly, implementation] as Set
@@ -90,7 +86,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         compileOnly.extendsFrom == [] as Set
-        !compileOnly.visible
         !compileOnly.canBeConsumed
         !compileOnly.canBeResolved
         compileOnly.transitive
@@ -100,7 +95,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         compileClasspath.extendsFrom == toSet(compileOnly, implementation)
-        !compileClasspath.visible
         compileClasspath.transitive
 
         when:
@@ -108,7 +102,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         annotationProcessor.extendsFrom == [] as Set
-        !annotationProcessor.visible
         annotationProcessor.transitive
         !annotationProcessor.canBeConsumed
         annotationProcessor.canBeResolved
@@ -118,7 +111,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         testImplementation.extendsFrom == toSet(implementation)
-        !testImplementation.visible
         testImplementation.transitive
 
         when:
@@ -126,7 +118,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         testRuntimeOnly.transitive
-        !testRuntimeOnly.visible
         !testRuntimeOnly.canBeConsumed
         !testRuntimeOnly.canBeResolved
         testRuntimeOnly.extendsFrom == [runtimeOnly] as Set
@@ -136,7 +127,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         testCompileOnly.extendsFrom == toSet()
-        !testCompileOnly.visible
         !testRuntimeOnly.canBeConsumed
         !testRuntimeOnly.canBeResolved
         testCompileOnly.transitive
@@ -146,7 +136,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         testCompileClasspath.extendsFrom == toSet(testCompileOnly, testImplementation)
-        !testCompileClasspath.visible
         testCompileClasspath.transitive
 
         when:
@@ -154,7 +143,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         testAnnotationProcessor.extendsFrom == [] as Set
-        !testAnnotationProcessor.visible
         testAnnotationProcessor.transitive
         !testAnnotationProcessor.canBeConsumed
         testAnnotationProcessor.canBeResolved
@@ -164,7 +152,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         testRuntimeClasspath.extendsFrom == toSet(testRuntimeOnly, testImplementation)
-        !testRuntimeClasspath.visible
         testRuntimeClasspath.transitive
         !testRuntimeClasspath.canBeConsumed
         testRuntimeClasspath.canBeResolved
@@ -173,7 +160,6 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         def apiElements = project.configurations.getByName(JvmConstants.API_ELEMENTS_CONFIGURATION_NAME)
 
         then:
-        !apiElements.visible
         apiElements.extendsFrom == [] as Set
         apiElements.canBeConsumed
         !apiElements.canBeResolved

--- a/platforms/jvm/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
+++ b/platforms/jvm/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
@@ -44,7 +44,6 @@ class ScalaBasePluginTest extends AbstractProjectBuilderSpec {
 
         then:
         configuration.extendsFrom.empty
-        !configuration.visible
         configuration.transitive
     }
 

--- a/platforms/jvm/war/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
+++ b/platforms/jvm/war/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
@@ -43,7 +43,6 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         providedCompileConfiguration.extendsFrom  == [] as Set
-        !providedCompileConfiguration.visible
         providedCompileConfiguration.transitive
 
         when:
@@ -51,7 +50,6 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         providedRuntimeConfiguration.extendsFrom == [providedCompileConfiguration] as Set
-        !providedRuntimeConfiguration.visible
         providedRuntimeConfiguration.transitive
 
     }

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.buildinit.InsecureProtocolOption
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpModule
@@ -58,6 +59,12 @@ abstract class MavenConversionIntegrationTest extends AbstractInitIntegrationSpe
         using m2
     }
 
+    def expectDeprecationsForKotlinDslPlugin() {
+        if (scriptDsl == BuildInitDsl.KOTLIN) {
+            ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+        }
+    }
+
     def "multiModule init with incubating"() {
         def dsl = dslFixtureFor(scriptDsl)
         def conventionPluginScript = targetDir.file("build-logic/src/main/${scriptDsl.name().toLowerCase()}/${scriptDsl.fileNameFor("buildlogic.java-conventions")}")
@@ -90,6 +97,7 @@ abstract class MavenConversionIntegrationTest extends AbstractInitIntegrationSpe
         apiSubprojectBuildFile.exists()
 
         when:
+        expectDeprecationsForKotlinDslPlugin()
         run 'clean', 'build'
 
         then: //smoke test the build artifacts
@@ -131,6 +139,7 @@ java {
     withJavadocJar()
 }'''))
         when:
+        expectDeprecationsForKotlinDslPlugin()
         run 'clean', 'build'
 
         then: //smoke test the build artifacts
@@ -141,6 +150,7 @@ java {
         new DefaultTestExecutionResult(targetDir.file("webinar-impl")).assertTestClassesExecuted('webinar.WebinarTest')
 
         when:
+        expectDeprecationsForKotlinDslPlugin()
         run 'projects'
 
         then:
@@ -189,6 +199,7 @@ java {
     withJavadocJar()
 }'''))
         when:
+        expectDeprecationsForKotlinDslPlugin()
         run 'clean', 'build'
 
         then: //smoke test the build artifacts
@@ -199,6 +210,7 @@ java {
         new DefaultTestExecutionResult(targetDir.file("webinar-impl")).assertTestClassesExecuted('webinar.WebinarTest')
 
         when:
+        expectDeprecationsForKotlinDslPlugin()
         run 'projects'
 
         then:
@@ -224,6 +236,7 @@ Root project 'webinar-parent'
         targetDir.file("webinar-war/" + dsl.buildFileName).exists()
 
         when:
+        expectDeprecationsForKotlinDslPlugin()
         run 'clean', 'build'
 
         then: //smoke test the build artifacts
@@ -255,6 +268,7 @@ Root project 'webinar-parent'
         targetDir.file("webinar-war/" + dsl.buildFileName).exists()
 
         when:
+        expectDeprecationsForKotlinDslPlugin()
         run 'clean', 'build'
 
         then: //smoke test the build artifacts
@@ -265,6 +279,7 @@ Root project 'webinar-parent'
         new DefaultTestExecutionResult(targetDir.file("webinar-impl")).assertTestClassesExecuted('webinar.WebinarTest')
 
         when:
+        expectDeprecationsForKotlinDslPlugin()
         run 'projects'
 
         then:
@@ -696,6 +711,7 @@ ${TextUtil.indent(configLines.join("\n"), "                    ")}
         libRequest(repo, "org.hamcrest", "hamcrest-core", 1.3)
         libRequest(repo, "org.apache.commons", "commons-parent", 17)
 
+        expectDeprecationsForKotlinDslPlugin()
         run 'clean', 'build'
 
         then: //smoke test the build artifacts
@@ -706,6 +722,7 @@ ${TextUtil.indent(configLines.join("\n"), "                    ")}
         new DefaultTestExecutionResult(targetDir.file("webinar-impl")).assertTestClassesExecuted('webinar.WebinarTest')
 
         when:
+        expectDeprecationsForKotlinDslPlugin()
         run 'projects'
 
         then:

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.buildinit.plugins.internal.modifiers.Language
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
@@ -57,6 +58,18 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest extends Abs
             files << file
         }
         return files
+    }
+
+    def expectDeprecationsForKotlinDslPlugin() {
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+    }
+
+    def expectDeprecationsForKotlinJvmPlugin() {
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+    }
+
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        return this
     }
 
     void assertBuildLogicSources(BuildInitDsl dsl, String language, TestFile buildLogicDir, String settingsFile, String buildFile, String javaMajorVersion) {
@@ -145,7 +158,7 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest1 extends Ab
         assertApplicationProjectsSources(buildFile, language, "org.example.", ext)
 
         when:
-        succeeds "build"
+        maybeExpectDeprecations().succeeds "build"
 
         then:
         assertTestPassed("app", "org.example.app.MessageUtilsTest", "testGetMessage")
@@ -155,7 +168,7 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest1 extends Ab
         assertTestPassed("list", "org.example.list.LinkedListTest", "testRemoveMissing")
 
         when:
-        succeeds "run"
+        maybeExpectDeprecations().succeeds "run"
 
         then:
         outputContains("Hello World!")
@@ -194,10 +207,10 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest2 extends Ab
         assertApplicationProjectsSources(buildFile, language, expectedPackagePrefix, ext)
 
         expect:
-        succeeds "build"
+        maybeExpectDeprecations().succeeds "build"
 
         when:
-        succeeds "run"
+        maybeExpectDeprecations().succeeds "run"
 
         then:
         outputContains("Hello World!")
@@ -245,7 +258,7 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest3 extends Ab
         }
 
         when:
-        succeeds "build"
+        maybeExpectDeprecations().succeeds "build"
 
         then:
         assertTestPassed("app", "org.example.app.MessageUtilsTest", "testGetMessage")
@@ -255,7 +268,7 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest3 extends Ab
         assertTestPassed("list", "org.example.list.LinkedListTest", "testRemoveMissing")
 
         when:
-        succeeds "run"
+        maybeExpectDeprecations().succeeds "run"
 
         then:
         outputContains("Hello World!")
@@ -310,6 +323,12 @@ class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest1 extends Abstrac
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
     }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinJvmPlugin()
+        return super.maybeExpectDeprecations()
+    }
 }
 
 @Requires(value = UnitTestPreconditions.KotlinSupportedJdk.class)
@@ -318,6 +337,12 @@ class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest2 extends Abstrac
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
     }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinJvmPlugin()
+        return super.maybeExpectDeprecations()
+    }
 }
 
 @Requires(value = UnitTestPreconditions.KotlinSupportedJdk.class)
@@ -325,6 +350,12 @@ class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest2 extends Abstrac
 class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest3 extends AbstractMultiProjectJvmApplicationInitIntegrationTest3 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.GROOVY, KOTLIN)
+    }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinJvmPlugin()
+        return super.maybeExpectDeprecations()
     }
 }
 
@@ -353,11 +384,23 @@ class KotlinDslMultiProjectJavaApplicationInitIntegrationTest1 extends AbstractM
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, JAVA)
     }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
+    }
 }
 
 class KotlinDslMultiProjectJavaApplicationInitIntegrationTest2 extends AbstractMultiProjectJvmApplicationInitIntegrationTest2 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, JAVA)
+    }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
     }
 }
 
@@ -365,11 +408,23 @@ class KotlinDslMultiProjectJavaApplicationInitIntegrationTest3 extends AbstractM
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, JAVA)
     }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
+    }
 }
 
 class KotlinDslMultiProjectGroovyApplicationInitIntegrationTest1 extends AbstractMultiProjectJvmApplicationInitIntegrationTest1 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, GROOVY)
+    }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
     }
 }
 
@@ -377,11 +432,23 @@ class KotlinDslMultiProjectGroovyApplicationInitIntegrationTest2 extends Abstrac
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, GROOVY)
     }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
+    }
 }
 
 class KotlinDslMultiProjectGroovyApplicationInitIntegrationTest3 extends AbstractMultiProjectJvmApplicationInitIntegrationTest3 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, GROOVY)
+    }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
     }
 }
 
@@ -391,6 +458,12 @@ class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest1 extends Abstrac
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)
     }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
+    }
 }
 
 @Requires(value = UnitTestPreconditions.KotlinSupportedJdk.class)
@@ -398,6 +471,12 @@ class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest1 extends Abstrac
 class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest2 extends AbstractMultiProjectJvmApplicationInitIntegrationTest2 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)
+    }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
     }
 }
 
@@ -407,12 +486,24 @@ class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest3 extends Abstrac
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, KOTLIN)
     }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
+    }
 }
 
 @Requires(value = UnitTestPreconditions.Jdk23OrEarlier, reason = "Scala cannot compile on Java 24 yet")
 class KotlinDslMultiProjectScalaApplicationInitIntegrationTest1 extends AbstractMultiProjectJvmApplicationInitIntegrationTest1 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, SCALA)
+    }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
     }
 }
 
@@ -421,11 +512,23 @@ class KotlinDslMultiProjectScalaApplicationInitIntegrationTest2 extends Abstract
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, SCALA)
     }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
+    }
 }
 
 @Requires(value = UnitTestPreconditions.Jdk23OrEarlier, reason = "Scala cannot compile on Java 24 yet")
 class KotlinDslMultiProjectScalaApplicationInitIntegrationTest3 extends AbstractMultiProjectJvmApplicationInitIntegrationTest3 {
     def setup() {
         setupDslAndLanguage(BuildInitDsl.KOTLIN, SCALA)
+    }
+
+    @Override
+    AbstractJvmLibraryInitIntegrationSpec maybeExpectDeprecations() {
+        expectDeprecationsForKotlinDslPlugin()
+        return super.maybeExpectDeprecations()
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -88,7 +88,6 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         op.details.buildPath == ":"
         op.details.scriptConfiguration == false
         op.details.configurationDescription ==~ /Compile classpath for source set 'main'.*/
-        op.details.configurationVisible == false
         op.details.configurationTransitive == true
 
         op.result.resolvedDependenciesCount == 4
@@ -169,7 +168,6 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         resolveOperations[0].details.buildPath == ":"
         resolveOperations[0].details.scriptConfiguration == false
         resolveOperations[0].details.configurationDescription ==~ /Compile classpath for source set 'main'.*/
-        resolveOperations[0].details.configurationVisible == false
         resolveOperations[0].details.configurationTransitive == true
         resolveOperations[0].result.resolvedDependenciesCount == 2
 
@@ -179,7 +177,6 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         resolveOperations[1].details.buildPath == ":my-composite-app"
         resolveOperations[1].details.scriptConfiguration == false
         resolveOperations[1].details.configurationDescription == "Compile classpath for source set 'main'."
-        resolveOperations[1].details.configurationVisible == false
         resolveOperations[1].details.configurationTransitive == true
         resolveOperations[1].result.resolvedDependenciesCount == 1
     }
@@ -224,7 +221,6 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             assert it.details.buildPath == ":"
             assert it.details.scriptConfiguration == true
             assert it.details.configurationDescription == null
-            assert it.details.configurationVisible == false
             assert it.details.configurationTransitive == true
             assert it.result.resolvedDependenciesCount == 2
         }
@@ -234,7 +230,6 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         resolveOperations[1].details.buildPath == ":my-composite-app"
         resolveOperations[1].details.scriptConfiguration == false
         resolveOperations[1].details.configurationDescription == "Compile classpath for source set 'main'."
-        resolveOperations[1].details.configurationVisible == false
         resolveOperations[1].details.configurationTransitive == true
         resolveOperations[1].result.resolvedDependenciesCount == 1
 
@@ -282,7 +277,6 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         resolveOperations[0].details.projectPath == null
         resolveOperations[0].details.scriptConfiguration == true
         resolveOperations[0].details.configurationDescription == null
-        resolveOperations[0].details.configurationVisible == false
         resolveOperations[0].details.configurationTransitive == true
         resolveOperations[0].result.resolvedDependenciesCount == 1
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/LazyAttributesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/LazyAttributesIntegrationTest.groovy
@@ -32,7 +32,6 @@ class LazyAttributesIntegrationTest extends AbstractIntegrationSpec {
 
             configurations {
                 sample {
-                    visible = false
                     canBeResolved = false
                     assert canBeConsumed
 
@@ -68,7 +67,6 @@ class LazyAttributesIntegrationTest extends AbstractIntegrationSpec {
 
             configurations {
                 sample {
-                    visible = false
                     canBeResolved = false
                     assert canBeConsumed
                     extendsFrom(configurations.implementation)
@@ -95,7 +93,6 @@ class LazyAttributesIntegrationTest extends AbstractIntegrationSpec {
 
             configurations {
                 sample {
-                    visible = false
                     canBeResolved = false
                     assert canBeConsumed
                     extendsFrom(configurations.implementation)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/KotlinDslVersionCatalogExtensionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/KotlinDslVersionCatalogExtensionIntegrationTest.groovy
@@ -134,6 +134,7 @@ class KotlinDslVersionCatalogExtensionIntegrationTest extends AbstractHttpDepend
         lib.artifact.expectGet()
 
         then:
+
         succeeds ':checkDeps'
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -342,13 +342,23 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     }
 
     @Override
+    @Deprecated
     public boolean isVisible() {
+        DeprecationLogger.deprecateProperty(Configuration.class, "visible")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecate-visible-property")
+            .nagUser();
         return visible;
     }
 
     @Override
+    @Deprecated
     public Configuration setVisible(boolean visible) {
         validateMutation(MutationType.BASIC_STATE);
+        DeprecationLogger.deprecateProperty(Configuration.class, "visible")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecate-visible-property")
+            .nagUser();
         this.visible = visible;
         return this;
     }
@@ -709,7 +719,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                         getDescription(),
                         domainObjectContext.getBuildPath().getPath(),
                         projectPathString,
-                        isVisible(),
+                        visible,
                         isTransitive(),
                         resolver.getAllRepositories()
                     ));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -360,7 +360,6 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         super.add(configuration);
         configureAction.execute(configuration);
         configuration.preventUsageMutation();
-        configuration.setVisible(false);
         return configuration;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
@@ -99,8 +99,6 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
             documentationRegistry,
             true
         );
-
-        setVisible(false);
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
@@ -99,8 +99,6 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
             documentationRegistry,
             true
         );
-
-        setVisible(false);
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
@@ -99,8 +99,6 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
             documentationRegistry,
             true
         );
-
-        setVisible(false);
     }
 
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -340,16 +340,6 @@ class DefaultConfigurationContainerTest extends Specification {
         "resolvableDependencyScopeLocked(String, Action)" | { resolvableDependencyScopeLocked("foo", it) }
     }
 
-    def "role locked configurations default to non-visible"() {
-        expect:
-        !configurationContainer.consumable("a").get().visible
-        !configurationContainer.consumable("b", {}).get().visible
-        !configurationContainer.resolvable("c").get().visible
-        !configurationContainer.resolvable("d", {}).get().visible
-        !configurationContainer.dependencyScope("e").get().visible
-        !configurationContainer.dependencyScope("f", {}).get().visible
-    }
-
     // withType when used with a class that is not a super-class of the container does not work with registered elements
     @ToBeImplemented
     def "can find all configurations even when they're registered"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -115,7 +115,6 @@ class DefaultConfigurationSpec extends Specification {
 
         then:
         configuration.name == "name"
-        configuration.visible
         configuration.extendsFrom.empty
         configuration.transitive
         configuration.description == null
@@ -142,12 +141,10 @@ class DefaultConfigurationSpec extends Specification {
 
         when:
         configuration.setDescription("description")
-        configuration.setVisible(false)
         configuration.setTransitive(false)
 
         then:
         configuration.description == "description"
-        !configuration.visible
         !configuration.transitive
     }
 
@@ -781,7 +778,6 @@ This method is only meant to be called on configurations which allow the (non-de
 
     private void checkCopiedConfiguration(Configuration original, Configuration copy, def resolutionStrategyInCopy, int copyCount = 1) {
         assert copy.name == original.name + "Copy${copyCount > 1 ? copyCount : ''}"
-        assert copy.visible == original.visible
         assert copy.transitive == original.transitive
         assert copy.description == original.description
         assert copy.allArtifacts as Set == original.allArtifacts as Set
@@ -1237,11 +1233,6 @@ This method is only meant to be called on configurations which allow the (non-de
 
         when:
         configuration.setTransitive(true)
-        then:
-        thrown(InvalidUserCodeException)
-
-        when:
-        configuration.setVisible(false)
         then:
         thrown(InvalidUserCodeException)
 

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
@@ -161,7 +161,7 @@ class BasePluginIntegrationTest extends AbstractIntegrationSpec {
         notExecuted(":jar1", ":jar2", ":jar3")
     }
 
-    def "artifacts on legacy configurations are not built by default even if visible is set"() {
+    def "artifacts on legacy configurations are not built by default"() {
         buildFile << """
             plugins {
                 id("base")
@@ -172,11 +172,9 @@ class BasePluginIntegrationTest extends AbstractIntegrationSpec {
 
             configurations {
                 foo {
-                    visible = true
                     outgoing.artifact(tasks.jar1)
                 }
                 bar {
-                    visible = false
                     outgoing.artifact(tasks.jar2)
                 }
             }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite.plugins
 
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.integtests.fixtures.resolve.ResolveFailureTestFixture
 
 class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
@@ -392,6 +393,9 @@ class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
         """
 
         then:
+        if (dsl == 'Kotlin') {
+            ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+        }
         succeeds("help")
 
         where:
@@ -614,6 +618,9 @@ class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
         """
 
         when:
+        if (dsl == 'Kotlin') {
+            ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+        }
         succeeds()
 
         then:

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -112,6 +112,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * The value of this property does not dictate in any way the "visibility" of
      * a configuration, or if it is accessible between projects.
      */
+    @Deprecated
     boolean isVisible();
 
     /**
@@ -120,6 +121,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      *
      * @param visible the value to set.
      */
+    @Deprecated
     Configuration setVisible(boolean visible);
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ProjectIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/ProjectIdentityIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.api.internal.project
 
 import org.gradle.api.Project
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
@@ -45,6 +47,12 @@ class ProjectIdentityIntegrationTest extends AbstractIntegrationSpec {
 
             ${mavenCentralRepository(GradleDsl.KOTLIN)}
         """
+    }
+
+    @Override
+    protected ExecutionResult run(String... tasks) {
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
+        return super.run(tasks)
     }
 
     @Requires(value = IntegTestPreconditions.NotIsolatedProjects, reason = "IP enables parallel configuration")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/invocation/GradleLifecycleIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.invocation
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 
 import static org.gradle.integtests.fixtures.KotlinDslTestUtil.getKotlinDslBuildSrcConfig
 
@@ -81,6 +82,7 @@ class GradleLifecycleIntegrationTest extends AbstractIntegrationSpec {
         }
 
         expect:
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
         configuredTaskRunsCorrectly()
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -44,6 +44,7 @@ import org.gradle.build.event.BuildEventsListenerRegistry
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
+import org.gradle.integtests.fixtures.configuration.ConfigurationAPIDeprecations
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecOperations
@@ -1783,6 +1784,7 @@ Hello, subproject1
         """
 
         expect:
+        ConfigurationAPIDeprecations.expectVisiblePropertyDeprecation(executer)
         succeeds("hello")
     }
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configuration/ConfigurationAPIDeprecations.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configuration/ConfigurationAPIDeprecations.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.configuration
+
+import org.gradle.integtests.fixtures.executer.GradleExecuter
+
+class ConfigurationAPIDeprecations {
+    static void expectVisiblePropertyDeprecation(GradleExecuter executer) {
+        executer.expectDocumentedDeprecationWarning(
+            "The Configuration.visible property has been deprecated. " +
+                "This is scheduled to be removed in Gradle 10. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate-visible-property"
+        )
+    }
+}


### PR DESCRIPTION
This flag no longer has a meaningful effect.  We're deprecating it in preparation for removal in 10.0.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
