### PR TITLE
Mark TestResult#getAssumptionFailure as nullable

### DIFF
--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/tasks/testing/TestResult.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/tasks/testing/TestResult.java
@@ -74,6 +74,7 @@ public interface TestResult {
      * @since 8.14
      */
     @Incubating
+    @Nullable
     TestFailure getAssumptionFailure();
 
     /**

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/DefaultTestResult.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/DefaultTestResult.java
@@ -20,12 +20,14 @@ import org.gradle.api.tasks.testing.TestFailure;
 import org.gradle.api.tasks.testing.TestResult;
 import org.gradle.internal.InternalTransformer;
 import org.gradle.util.internal.CollectionUtils;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
 import java.util.List;
 
 public class DefaultTestResult implements TestResult, Serializable {
     private final List<TestFailure> failures;
+    @Nullable
     private final TestFailure assumptionFailure;
     private final ResultType resultType;
     private final long startTime;
@@ -38,7 +40,7 @@ public class DefaultTestResult implements TestResult, Serializable {
         this(state.resultType, state.getStartTime(), state.getEndTime(), state.testCount, state.successfulCount, state.failedCount, state.failures, state.assumptionFailure);
     }
 
-    public DefaultTestResult(ResultType resultType, long startTime, long endTime, long testCount, long successfulCount, long failedCount, List<TestFailure> failures, TestFailure assumptionFailure) {
+    public DefaultTestResult(ResultType resultType, long startTime, long endTime, long testCount, long successfulCount, long failedCount, List<TestFailure> failures, @Nullable TestFailure assumptionFailure) {
         this.resultType = resultType;
         this.startTime = startTime;
         this.endTime = endTime;
@@ -60,6 +62,7 @@ public class DefaultTestResult implements TestResult, Serializable {
     }
 
     @Override
+    @Nullable
     public TestFailure getAssumptionFailure() {
         return assumptionFailure;
     }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/TestState.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/TestState.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 import org.gradle.api.internal.tasks.testing.TestStartEvent;
 import org.gradle.api.tasks.testing.TestFailure;
 import org.gradle.api.tasks.testing.TestResult;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +33,7 @@ public class TestState {
     private final Map<Object, TestState> executing;
     public boolean failedChild;
     public List<TestFailure> failures = new ArrayList<TestFailure>();
+    @Nullable
     public TestFailure assumptionFailure = null;
     public long testCount;
     public long successfulCount;

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,3 +1,12 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.tasks.testing.TestResult",
+            "member": "Method org.gradle.api.tasks.testing.TestResult.getAssumptionFailure()",
+            "acceptation": "Was always nullable, this is correctly reflecting the state of the code",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
### Context
I found this whilst working on #32672.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
