### PR TITLE
Update documentation by adding info about the new artifactTransforms task

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_transforms.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_transforms.adoc
@@ -490,8 +490,10 @@ This will produce output listing all registered transforms, including details su
 
 This report is especially helpful if you encounter issues with artifact selection or resolution errors related to transforms.
 
-It is important to note that this task is applied to a single project.
-For example, to view transforms in the `app` subproject:
+It’s important to note that the `artifactTransforms` task operates on a single project.
+If you run it on a subproject, it will report the transforms registered only in that specific project.
+
+For example, to view the artifact transforms in the `app` subproject, you would run:
 
 [source, text]
 ----
@@ -532,7 +534,7 @@ To Attributes:
 Some artifact transforms are not cacheable.  This can have negative performance impacts.
 ----
 
-Running the task on the root project will not work:
+Because the task only inspects the current project, running it on the root project, where no transforms are registered, will produce empty output:
 
 [source, text]
 ----

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_transforms.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_transforms.adoc
@@ -488,9 +488,16 @@ This will produce output listing all registered transforms, including details su
 * Attributes required for the transform to apply
 * Implementation details of custom transforms
 
+This report is especially helpful if you encounter issues with artifact selection or resolution errors related to transforms.
+
+It is important to note that this task is applied to a single project.
+For example, to view transforms in the `app` subproject:
+
 [source, text]
 ----
-> Task :artifactTransforms
+$ ./gradlew :app:artifactTransforms
+
+> Task :app:artifactTransforms
 
 --------------------------------------------------
 CopyTransform
@@ -525,4 +532,13 @@ To Attributes:
 Some artifact transforms are not cacheable.  This can have negative performance impacts.
 ----
 
-This report is especially helpful if you encounter issues with artifact selection or resolution errors related to transforms.
+Running the task on the root project will not work:
+
+[source, text]
+----
+$ ./gradlew artifactTransforms
+
+> Task :artifactTransforms
+
+There are no transforms registered in root project 'gradle'.
+----

--- a/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_transforms.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/controlling-dependency-resolution/artifact_transforms.adoc
@@ -468,3 +468,61 @@ It's important to remember that Artifact Transforms:
 If there are no artifacts present in an input variant to a transform, that transform will be skipped.
 This can happen in the middle of a chain of actions, resulting in all subsequent transforms being skipped.
 ====
+
+[[sec:debugging-artifact-transforms]]
+== Debugging Artifact Transforms
+
+You can use the `artifactTransforms` task to inspect the artifact transforms registered in your build.
+This task makes it easier to debug unexpected transform behavior, understand which transforms are applied, and see how artifacts flow through your build.
+
+To generate the report, run:
+
+[source, bash]
+----
+$ ./gradlew artifactTransforms
+----
+
+This will produce output listing all registered transforms, including details such as:
+
+* The input and output artifact types for each transform
+* Attributes required for the transform to apply
+* Implementation details of custom transforms
+
+[source, text]
+----
+> Task :artifactTransforms
+
+--------------------------------------------------
+CopyTransform
+--------------------------------------------------
+Type: dagger.hilt.android.plugin.transform.CopyTransform
+Cacheable: No
+From Attributes:
+    - artifactType = android-classes
+To Attributes:
+    - artifactType = jar-for-dagger
+
+--------------------------------------------------
+CopyTransform
+--------------------------------------------------
+Type: dagger.hilt.android.plugin.transform.CopyTransform
+Cacheable: No
+From Attributes:
+    - artifactType = directory
+To Attributes:
+    - artifactType = jar-for-dagger
+
+--------------------------------------------------
+AggregatedPackagesTransform
+--------------------------------------------------
+Type: dagger.hilt.android.plugin.transform.AggregatedPackagesTransform
+Cacheable: Yes
+From Attributes:
+    - artifactType = jar-for-dagger
+To Attributes:
+    - artifactType = aggregated-jar-for-hilt
+
+Some artifact transforms are not cacheable.  This can have negative performance impacts.
+----
+
+This report is especially helpful if you encounter issues with artifact selection or resolution errors related to transforms.


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
The `artifactTransforms` task is not mentioned in the user guide. 
It is documented in the [8.13 release notes](https://docs.gradle.org/8.13/release-notes.html#new-artifacttransforms-report-task). The task is also [in the DSL docs](https://docs.gradle.org/8.13/dsl/org.gradle.api.tasks.diagnostics.ArtifactTransformsReportTask.html), but there is no usage example in our docs.