### PR TITLE
TeamCity: fix automatic splitting of test buckets

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -376,7 +376,7 @@ data class CIBuildModel(
             ),
             Stage(
                 StageName.HISTORICAL_PERFORMANCE,
-                trigger = if (VersionedSettingsBranch.fromDslContext().isLegacyRelease) Trigger.NEVER else Trigger.WEEKLY,
+                trigger = if (branch.isLegacyRelease) Trigger.NEVER else Trigger.WEEKLY,
                 runsIndependent = true,
                 performanceTests =
                     listOf(


### PR DESCRIPTION
VersionedSettingsBranch.fromDslContext doesn't work outside of TeamCity as it's not initialized there
