### PR TITLE
Remove "JetBrains Kotlin plugin" in "Writing Build Scripts" section

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_build_scripts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_build_scripts.adoc
@@ -189,7 +189,7 @@ include::sample[dir="snippets/plugins/simple/kotlin/sub-project-a", files="build
 include::sample[dir="snippets/plugins/simple/groovy/sub-project-a", files="build.gradle[tags=repo]"]
 ====
 
-In the example, the `guava` library and the JetBrains Kotlin plugin (`org.jetbrains.kotlin.jvm`) will be downloaded from the link:https://repo.maven.apache.org/maven2/[Maven Central Repository].
+In the example, the `guava` library will be downloaded from the link:https://repo.maven.apache.org/maven2/[Maven Central Repository].
 
 === 3. Add dependencies
 


### PR DESCRIPTION
### Context

This PR removes "JetBrains Kotlin plugin" in "Writing Build Scripts" section as the example doesn't include it.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
