### PR TITLE
Consistently throw AttributeMergingException for safeConcat

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
@@ -189,9 +189,7 @@ public final class DefaultAttributesFactory implements AttributesFactory {
             if (entry.isPresent()) {
                 Object currentAttribute = entry.get();
                 Object existingAttribute = attributes1.getAttribute(attribute);
-                if (!currentAttribute.equals(existingAttribute) &&
-                    entry.getAttribute().equals(attribute) // We check types later, don't throw here if the types are different
-                ) {
+                if (!currentAttribute.equals(existingAttribute)) {
                     String message = "An attribute named '" + attribute.getName() + "' of type '" + attribute.getType().getName() + "' already exists in this container";
                     throw new AttributeMergingException(attribute, existingAttribute, currentAttribute, message);
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesFactoryTest.groovy
@@ -16,14 +16,13 @@
 
 package org.gradle.api.internal.attributes
 
-
 import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
 import static org.gradle.api.internal.attributes.immutable.TestAttributes.BAR
 import static org.gradle.api.internal.attributes.immutable.TestAttributes.BAZ
-import static org.gradle.api.internal.attributes.immutable.TestAttributes.FOO
 import static org.gradle.api.internal.attributes.immutable.TestAttributes.BOOLEAN_BAR
+import static org.gradle.api.internal.attributes.immutable.TestAttributes.FOO
 import static org.gradle.api.internal.attributes.immutable.TestAttributes.OBJECT_BAR
 
 /**
@@ -213,8 +212,11 @@ class DefaultAttributesFactoryTest extends Specification {
         factory.safeConcat(set1, set2)
 
         then:
-        IllegalArgumentException e = thrown()
-        e.message == "Cannot have two attributes with the same name but different types. This container already has an attribute named 'bar' of type 'java.lang.String' and you are trying to store another one of type 'java.lang.Boolean'"
+        AttributeMergingException e = thrown()
+        e.attribute == BOOLEAN_BAR
+        e.leftValue == true
+        e.rightValue == "bar2"
+        e.message == "An attribute named 'bar' of type 'java.lang.Boolean' already exists in this container"
     }
 
     def "safeConcat can detect incompatible attributes with different types when merging; different value and different compatible types"() {
@@ -226,8 +228,11 @@ class DefaultAttributesFactoryTest extends Specification {
         factory.safeConcat(set1, set2)
 
         then:
-        IllegalArgumentException e = thrown()
-        e.message == "Cannot have two attributes with the same name but different types. This container already has an attribute named 'bar' of type 'java.lang.String' and you are trying to store another one of type 'java.lang.Object'"
+        AttributeMergingException e = thrown()
+        e.attribute == OBJECT_BAR
+        e.leftValue == "bar1"
+        e.rightValue == "bar2"
+        e.message == "An attribute named 'bar' of type 'java.lang.Object' already exists in this container"
     }
 
     def "safeConcat can detect incompatible attributes with different types when merging; same value and different compatible types"() {


### PR DESCRIPTION
We have code in EdgeState that specifically catches a certain exception type in order to present a more contextualized error message to the user. In some cases, for example when a component is loaded from the cache, its variant's attrbutes will have the desugared type instead of the sugared type. This previously caused different exception types to be emitted. We remove a special case and now this exception type is always thrown in both cases of same attribute type and different attribute type.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
