### PR TITLE
Deprecate org.gradle.daemon.debug

### DIFF
--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
@@ -155,7 +155,16 @@ public class DefaultDaemonStarter implements DaemonStarter {
         daemonArgs.add("-cp");
         daemonArgs.add(CollectionUtils.join(File.pathSeparator, classpath.getAsFiles()));
 
+        // TODO: remove in Gradle 10
         if (Boolean.getBoolean("org.gradle.daemon.debug")) {
+            // NOTE: DeprecationLogger is not initialized yet, so we cannot use it here.
+            LOGGER.warn(
+                "The org.gradle.daemon.debug launcher system property has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 10. " +
+                    "Please use the org.gradle.debug daemon system property instead. " +
+                    "For more information, please refer to https://docs.gradle.org/{}/userguide/command_line_interface.html#sec:command_line_debugging in the Gradle documentation.",
+                GradleVersion.current().getVersion()
+            );
             daemonArgs.add(JvmOptions.getDebugArgument(true, true, "5005"));
         }
 


### PR DESCRIPTION
This property is problematic for a couple of reasons:

1. It's a property for launcher, not daemon (as opposed to `org.gradle.debug` and others). This may be confusing to users.
2. It duplicates functionality for `org.gradle.debug` and others.
3. It's not flexible: it can't be combined with other  `org.gradle.debug` options:
    ```
    GRADLE_OPTS='-Dorg.gradle.daemon.debug=true' gradle help --task=help -Dorg.gradle.debug.server=false -Dorg.gradle.debug.suspend=false
    ```
   will hang despite `org.gradle.debug.suspend=false`
4. Apparently, it's not widely used - it's hard to find [recent mentions on the internet](https://duckduckgo.com/?q=%22-Dorg.gradle.daemon.debug%3Dtrue%22&t=h_&df=2020-01-01..2025-07-02&ia=web).

See relevant documentation:
* https://docs.gradle.org/9.0.0-rc-1/userguide/command_line_interface.html#sec:command_line_debugging


See also a PR to remove it from the docs:
* https://github.com/gradle/gradle/pull/34091

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
