### PR TITLE
Ensure thread visibility of build operation listeners

### DIFF
--- a/platforms/core-runtime/build-operations/build.gradle.kts
+++ b/platforms/core-runtime/build-operations/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     api(libs.jspecify)
 
     implementation(libs.slf4jApi)
+    implementation(libs.guava)
 
     testFixturesImplementation(libs.guava)
 


### PR DESCRIPTION
Before, threads reading the field directly in `broadcaster` methods without acquiring the lock could see stale values, causing recently added listeners to be missed or removed listeners. The issue occurs in the reading of `DefaultBuildOperationListenerManager.this.listeners` within the anonymous `BuildOperationListener` implementation, where it accesses the field without proper synchronization. 

---

We still can't use CopyOnWriteArrayList directly, because the support
for thread-safe reverse iteration is only available in JDK 21

See: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/concurrent/CopyOnWriteArrayList.html#reversed()
