### PR TITLE
Honor the platform's default keystore type when encrypting the Configuration Cache

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -28,7 +28,6 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.test.preconditions.UnitTestPreconditions
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
-import org.spockframework.lang.Wildcard
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileVisitOption
@@ -54,17 +53,11 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         encryptionKeyAsBase64 = Base64.encoder.encodeToString(encryptionKeyText.getBytes(StandardCharsets.UTF_8))
     }
 
-    def "configuration cache can be loaded without errors from #source using #encryptionTransformation and #keystoreType"() {
+    def "configuration cache can be loaded without errors from #source using #encryptionTransformation"() {
         given:
         def additionalOpts = [
             "-Dorg.gradle.configuration-cache.internal.encryption-alg=${encryptionTransformation}"
         ]
-        if (keystoreType != Wildcard.INSTANCE) {
-            file "security.properties" << """
-            keystore.type=${keystoreType}
-            """
-            additionalOpts << "-Djava.security.properties=security.propertie"
-        }
         def configurationCache = newConfigurationCacheFixture()
         runWithEncryption(source, ["help"], additionalOpts)
 
@@ -75,15 +68,11 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         configurationCache.assertStateLoaded()
 
         where:
-        encryptionTransformation | keystoreType | source
-        "AES/CTR/NoPadding"      | _            | EncryptionKind.KEYSTORE
-        "AES/CTR/NoPadding"      | "jceks"      | EncryptionKind.KEYSTORE
-        "AES/CTR/NoPadding"      | "pkcs12"     | EncryptionKind.KEYSTORE
-        "AES/CTR/NoPadding"      | _            | EncryptionKind.ENV_VAR
-        "AES/GCM/NoPadding"      | _            | EncryptionKind.KEYSTORE
-        "AES/GCM/NoPadding"      | "jceks"      | EncryptionKind.KEYSTORE
-        "AES/GCM/NoPadding"      | "pkcs12"     | EncryptionKind.KEYSTORE
-        "AES/GCM/NoPadding"      | _            | EncryptionKind.ENV_VAR
+        encryptionTransformation | source
+        "AES/CTR/NoPadding"      | EncryptionKind.KEYSTORE
+        "AES/CTR/NoPadding"      | EncryptionKind.ENV_VAR
+        "AES/GCM/NoPadding"      | EncryptionKind.KEYSTORE
+        "AES/GCM/NoPadding"      | EncryptionKind.ENV_VAR
     }
 
     def "configuration cache encryption enablement is #enabled if kind=#kind"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -271,9 +271,9 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
     def "encryption service honors default keystore type"() {
         def defaultKeystoreType = KeyStore.defaultType
         buildFile """
-        def encryptionService = services.get(org.gradle.internal.encryption.EncryptionConfiguration)
-        // ensure encryption service is triggered
-        assert encryptionService.encrypting
+            def encryptionService = services.get(org.gradle.internal.encryption.EncryptionConfiguration)
+            // ensure encryption service is triggered
+            assert encryptionService.encrypting
         """
         when:
         run("help", "-i")
@@ -285,13 +285,13 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
     @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "Test sets a custom security properties file")
     def "encryption service attempts to honor explicitly requested keystore type"() {
         buildFile """
-        def encryptionService = services.get(org.gradle.internal.encryption.EncryptionConfiguration)
-        // ensure encryption service is triggered
-        assert encryptionService.encrypting
-        assert java.security.KeyStore.getDefaultType() == "$requestedType"
+            def encryptionService = services.get(org.gradle.internal.encryption.EncryptionConfiguration)
+            // ensure encryption service is triggered
+            assert encryptionService.encrypting
+            assert java.security.KeyStore.getDefaultType() == "$requestedType"
         """
         def customPropertiesFile = file("security.properties") << """
-        keystore.type=${requestedType}
+            keystore.type=${requestedType}
         """
 
         when:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -279,7 +279,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         run("help", "-i")
 
         then:
-        outputContains("Encryption key source: default Gradle configuration cache keystore (${defaultKeystoreType})")
+        outputContains("Encryption key source: default Gradle keystore (${defaultKeystoreType})")
     }
 
     @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "Test sets a custom security properties file")
@@ -299,7 +299,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         succeeds("help", "-i")
 
         then:
-        outputContains("Encryption key source: default Gradle configuration cache keystore (${actualType})")
+        outputContains("Encryption key source: default Gradle keystore (${actualType})")
 
         where:
         requestedType   | actualType

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -25,8 +25,10 @@ import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.test.preconditions.UnitTestPreconditions
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
+import org.spockframework.lang.Wildcard
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileVisitOption
@@ -52,11 +54,17 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         encryptionKeyAsBase64 = Base64.encoder.encodeToString(encryptionKeyText.getBytes(StandardCharsets.UTF_8))
     }
 
-    def "configuration cache can be loaded without errors from #source using #encryptionTransformation"() {
+    def "configuration cache can be loaded without errors from #source using #encryptionTransformation and #keystoreType"() {
         given:
         def additionalOpts = [
             "-Dorg.gradle.configuration-cache.internal.encryption-alg=${encryptionTransformation}"
         ]
+        if (keystoreType != Wildcard.INSTANCE) {
+            file "security.properties" << """
+            keystore.type=${keystoreType}
+            """
+            additionalOpts << "-Djava.security.properties=security.propertie"
+        }
         def configurationCache = newConfigurationCacheFixture()
         runWithEncryption(source, ["help"], additionalOpts)
 
@@ -67,11 +75,15 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         configurationCache.assertStateLoaded()
 
         where:
-        encryptionTransformation | source
-        "AES/CTR/NoPadding"      | EncryptionKind.KEYSTORE
-        "AES/CTR/NoPadding"      | EncryptionKind.ENV_VAR
-        "AES/GCM/NoPadding"      | EncryptionKind.KEYSTORE
-        "AES/GCM/NoPadding"      | EncryptionKind.ENV_VAR
+        encryptionTransformation | keystoreType | source
+        "AES/CTR/NoPadding"      | _            | EncryptionKind.KEYSTORE
+        "AES/CTR/NoPadding"      | "jceks"      | EncryptionKind.KEYSTORE
+        "AES/CTR/NoPadding"      | "pkcs12"     | EncryptionKind.KEYSTORE
+        "AES/CTR/NoPadding"      | _            | EncryptionKind.ENV_VAR
+        "AES/GCM/NoPadding"      | _            | EncryptionKind.KEYSTORE
+        "AES/GCM/NoPadding"      | "jceks"      | EncryptionKind.KEYSTORE
+        "AES/GCM/NoPadding"      | "pkcs12"     | EncryptionKind.KEYSTORE
+        "AES/GCM/NoPadding"      | _            | EncryptionKind.ENV_VAR
     }
 
     def "configuration cache encryption enablement is #enabled if kind=#kind"() {
@@ -155,15 +167,6 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         EncryptionKind.ENV_VAR  | true    | false
     }
 
-    private boolean isFoundInDirectory(File startDir, byte[] toFind) {
-        try (Stream<Path> tree = Files.walk(startDir.toPath(), FileVisitOption.FOLLOW_LINKS)) {
-            return tree.filter { it.toFile().file }
-                .anyMatch {
-                    isSubArray(Files.readAllBytes(it), toFind)
-                }
-        }
-    }
-
     def "new configuration cache entry if keystore is not found"() {
         given:
         def configurationCache = newConfigurationCacheFixture()
@@ -186,7 +189,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         and:
         def keyStoreFile = findRequiredKeystoreFile()
 
-        KeyStore ks = KeyStore.getInstance(KeyStoreKeySource.KEYSTORE_TYPE)
+        KeyStore ks = KeyStore.getInstance(KeyStoreKeySource.DEFAULT_KEYSTORE_TYPE)
         keyStoreFile.withInputStream { ks.load(it, new char[]{'c', 'c'}) }
         ks.deleteEntry("gradle-secret")
         keyStoreFile.withOutputStream { ks.store(it, new char[]{'c', 'c'}) }
@@ -214,37 +217,6 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
 
         cleanup:
         fs.chmod(keyStoreDir, 0666)
-    }
-
-    void runWithEncryption(
-        EncryptionKind kind = EncryptionKind.KEYSTORE,
-        List<String> tasks = ["help"],
-        List<String> additionalArgs = [],
-        Map<String, String> envVars = [:],
-        Closure<Void> runner = this::configurationCacheRun
-    ) {
-        def allArgs = tasks + getEncryptionOptions(kind) + additionalArgs + ["-s"]
-        // envVars overrides encryption env vars
-        def allVars = getEncryptionEnvVars(kind) + envVars
-        executer.withEnvironmentVars(allVars)
-        runner(*allArgs)
-    }
-
-    private List<String> getEncryptionOptions(EncryptionKind kind = EncryptionKind.KEYSTORE) {
-        switch (kind) {
-            case EncryptionKind.KEYSTORE:
-                return [
-                    "-Dorg.gradle.configuration-cache.internal.key-store-dir=${keyStoreDir}",
-                ]
-            case EncryptionKind.ENV_VAR:
-                // the env var is all that is required
-                return []
-            default:
-                // NONE
-                return [
-                    "-Dorg.gradle.configuration-cache.internal.encryption=false"
-                ]
-        }
     }
 
     def "build fails if key is provided via env var but invalid"() {
@@ -305,6 +277,88 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
 
         then:
         configurationCache.assertStateStored()
+    }
+
+    def "encryption service honors default keystore type"() {
+        def defaultKeystoreType = KeyStore.defaultType
+        buildFile """
+        def encryptionService = services.get(org.gradle.internal.encryption.EncryptionConfiguration)
+        // ensure encryption service is triggered
+        assert encryptionService.encrypting
+        """
+        when:
+        run("help", "-i")
+
+        then:
+        outputContains("Encryption key source: default Gradle configuration cache keystore (${defaultKeystoreType})")
+    }
+
+    @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "Test sets a custom security properties file")
+    def "encryption service attempts to honor explicitly requested keystore type"() {
+        buildFile """
+        def encryptionService = services.get(org.gradle.internal.encryption.EncryptionConfiguration)
+        // ensure encryption service is triggered
+        assert encryptionService.encrypting
+        assert java.security.KeyStore.getDefaultType() == "$requestedType"
+        """
+        def customPropertiesFile = file("security.properties") << """
+        keystore.type=${requestedType}
+        """
+
+        when:
+        executer.withArguments("-Djava.security.properties=${customPropertiesFile}")
+        succeeds("help", "-i")
+
+        then:
+        outputContains("Encryption key source: default Gradle configuration cache keystore (${actualType})")
+
+        where:
+        requestedType   | actualType
+        "pkcs12"        | "pkcs12"
+        "jceks"         | "jceks"
+        // unsupported types should fall back to a supported default type
+        "dks"           | "pkcs12"
+        "jks"           | "pkcs12"
+    }
+
+    private boolean isFoundInDirectory(File startDir, byte[] toFind) {
+        try (Stream<Path> tree = Files.walk(startDir.toPath(), FileVisitOption.FOLLOW_LINKS)) {
+            return tree.filter { it.toFile().file }
+                .anyMatch {
+                    isSubArray(Files.readAllBytes(it), toFind)
+                }
+        }
+    }
+
+    private void runWithEncryption(
+        EncryptionKind kind = EncryptionKind.KEYSTORE,
+        List<String> tasks = ["help"],
+        List<String> additionalArgs = [],
+        Map<String, String> envVars = [:],
+        Closure<Void> runner = this::configurationCacheRun
+    ) {
+        def allArgs = tasks + getEncryptionOptions(kind) + additionalArgs + ["-s"]
+        // envVars overrides encryption env vars
+        def allVars = getEncryptionEnvVars(kind) + envVars
+        executer.withEnvironmentVars(allVars)
+        runner(*allArgs)
+    }
+
+    private List<String> getEncryptionOptions(EncryptionKind kind = EncryptionKind.KEYSTORE) {
+        switch (kind) {
+            case EncryptionKind.KEYSTORE:
+                return [
+                    "-Dorg.gradle.configuration-cache.internal.key-store-dir=${keyStoreDir}",
+                ]
+            case EncryptionKind.ENV_VAR:
+                // the env var is all that is required
+                return []
+            default:
+                // NONE
+                return [
+                    "-Dorg.gradle.configuration-cache.internal.encryption=false"
+                ]
+        }
     }
 
     private Map<String, String> getEncryptionEnvVars(EncryptionKind kind = EncryptionKind.KEYSTORE) {

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
@@ -60,7 +60,6 @@ class DefaultEncryptionService(
     fun produceSecretKey(encryptionKind: EncryptionKind) =
         secretKeySource(encryptionKind).let { keySource ->
             try {
-                logger.info("Encryption key source: {}", keySource.sourceDescription)
                 secretKeyFrom(keySource)?.also { key ->
                     assertKeyLength(key)
                 }

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
@@ -49,6 +49,9 @@ class DefaultEncryptionService(
     val keystoreDirOption: String? = options.getInternalString("org.gradle.configuration-cache.internal.key-store-dir", null)
 
     private
+    val keystoreTypeOption: String? = options.getInternalString("org.gradle.configuration-cache.internal.key-store-type", null)
+
+    private
     val encryptionAlgorithmOption: String = options.getInternalString("org.gradle.configuration-cache.internal.encryption-alg", SupportedEncryptionAlgorithm.getDefault().transformation)
 
     private
@@ -60,6 +63,7 @@ class DefaultEncryptionService(
     fun produceSecretKey(encryptionKind: EncryptionKind) =
         secretKeySource(encryptionKind).let { keySource ->
             try {
+                logger.info("Encryption key source: {}", keySource.sourceDescription)
                 secretKeyFrom(keySource)?.also { key ->
                     assertKeyLength(key)
                 }
@@ -120,6 +124,7 @@ class DefaultEncryptionService(
                 KeyStoreKeySource(
                     encryptionAlgorithm = encryptionAlgorithm.algorithm,
                     customKeyStoreDir = keystoreDirOption?.let { File(it) },
+                    customKeyStoreType = keystoreTypeOption,
                     keyAlias = "gradle-secret",
                     cacheBuilderFactory = cacheBuilderFactory,
                     fileSystem = fileSystem
@@ -132,5 +137,7 @@ class DefaultEncryptionService(
 
             EncryptionKind.NONE ->
                 NoEncryptionKeySource()
+        }.apply {
+            logger.info("Encryption key source: $sourceDescription")
         }
 }

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
@@ -49,9 +49,6 @@ class DefaultEncryptionService(
     val keystoreDirOption: String? = options.getInternalString("org.gradle.configuration-cache.internal.key-store-dir", null)
 
     private
-    val keystoreTypeOption: String? = options.getInternalString("org.gradle.configuration-cache.internal.key-store-type", null)
-
-    private
     val encryptionAlgorithmOption: String = options.getInternalString("org.gradle.configuration-cache.internal.encryption-alg", SupportedEncryptionAlgorithm.getDefault().transformation)
 
     private
@@ -124,7 +121,6 @@ class DefaultEncryptionService(
                 KeyStoreKeySource(
                     encryptionAlgorithm = encryptionAlgorithm.algorithm,
                     customKeyStoreDir = keystoreDirOption?.let { File(it) },
-                    customKeyStoreType = keystoreTypeOption,
                     keyAlias = "gradle-secret",
                     cacheBuilderFactory = cacheBuilderFactory,
                     fileSystem = fileSystem

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/KeyStoreKeySource.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/KeyStoreKeySource.kt
@@ -45,8 +45,8 @@ class KeyStoreKeySource(
     }
 
     override val sourceDescription: String
-        get() = customKeyStoreDir?.let { "custom Java keystore (${keyStore.type}) at $it" }
-            ?: "default Gradle configuration cache keystore (${keyStore.type})"
+        get() = customKeyStoreDir?.let { "custom Gradle keystore (${keyStore.type}) at $it" }
+            ?: "default Gradle keystore (${keyStore.type})"
 
     private
     fun createKeyStoreAndGenerateKey(keyStoreFile: File): SecretKey {

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/KeyStoreKeySource.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/KeyStoreKeySource.kt
@@ -31,7 +31,6 @@ internal
 class KeyStoreKeySource(
     val encryptionAlgorithm: String,
     val customKeyStoreDir: File?,
-    val customKeyStoreType: String?,
     val keyAlias: String,
     val cacheBuilderFactory: GlobalScopedCacheBuilderFactory,
     val fileSystem: FileSystem

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/KeyStoreKeySource.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/KeyStoreKeySource.kt
@@ -31,6 +31,7 @@ internal
 class KeyStoreKeySource(
     val encryptionAlgorithm: String,
     val customKeyStoreDir: File?,
+    val customKeyStoreType: String?,
     val keyAlias: String,
     val cacheBuilderFactory: GlobalScopedCacheBuilderFactory,
     val fileSystem: FileSystem
@@ -41,12 +42,12 @@ class KeyStoreKeySource(
 
     private
     val keyStore by lazy {
-        KeyStore.getInstance(KEYSTORE_TYPE)
+        KeyStore.getInstance(DEFAULT_KEYSTORE_TYPE)
     }
 
     override val sourceDescription: String
-        get() = customKeyStoreDir?.let { "custom Java keystore at $it" }
-            ?: "default Gradle configuration cache keystore"
+        get() = customKeyStoreDir?.let { "custom Java keystore (${keyStore.type}) at $it" }
+            ?: "default Gradle configuration cache keystore (${keyStore.type})"
 
     private
     fun createKeyStoreAndGenerateKey(keyStoreFile: File): SecretKey {
@@ -122,11 +123,16 @@ class KeyStoreKeySource(
     fun PersistentCache.keyStoreFile(): File =
         File(baseDir, "gradle.keystore")
 
+    private
     companion object {
-        // JKS does not support non-PrivateKeys
-        const val KEYSTORE_TYPE = "pkcs12"
-        private val KEYSTORE_PASSWORD = charArrayOf('c', 'c')
+        // the known type we should fall back to if the JVM's default is unsupported
+        const val FALLBACK_TYPE = "pkcs12"
+        // these known types do not support symmetric keys
+        val UNSUPPORTED_TYPES = arrayOf("jks", "dks")
+        // this may differ from the JVM's default if the JVM's default is not supported
+        val DEFAULT_KEYSTORE_TYPE = KeyStore.getDefaultType().takeUnless(UNSUPPORTED_TYPES::contains) ?: FALLBACK_TYPE
+        val KEYSTORE_PASSWORD = charArrayOf('c', 'c')
         // Keystore should only be readable by owner
-        private val KEYSTORE_FILE_PERMISSIONS = "0600".toInt(8)
+        val KEYSTORE_FILE_PERMISSIONS = "0600".toInt(8)
     }
 }


### PR DESCRIPTION
Issue: #31377


### Context

Note that now that Gradle honors custom security properties, this has been changed to use the standard `KeyStore.getDefaultType()`, if possible.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
