### PR TITLE
Acquire project lock when building eclipse model

### DIFF
--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -212,8 +212,8 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
         eclipseProjects.add(eclipseProject);
     }
 
-    private void populate(Project project) {
-        ((ProjectInternal) project).getModel().applyToMutableState(state -> {
+    private void populate(Project p) {
+        ((ProjectInternal) p).getOwner().applyToMutableState(project -> {
             EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
 
             boolean projectDependenciesOnly = this.projectDependenciesOnly;
@@ -243,7 +243,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
             populateEclipseProjectJdt(eclipseProject, eclipseModel.getJdt());
         });
 
-        for (Project childProject : getChildProjectsForInternalUse(project)) {
+        for (Project childProject : getChildProjectsForInternalUse(p)) {
             populate(childProject);
         }
     }

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.ide.internal.tooling;
 
 import org.gradle.StartParameter;
 import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.plugins.ide.eclipse.EclipsePlugin;
@@ -73,15 +74,18 @@ public class RunBuildDependenciesTaskBuilder implements ParameterizedToolingMode
         return getRootGradle(parent);
     }
 
-    private List<TaskDependency> populate(Project project) {
-        project.getPluginManager().apply(EclipsePlugin.class);
-        EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
-        EclipseClasspath eclipseClasspath = eclipseModel.getClasspath();
+    private List<TaskDependency> populate(Project p) {
+        List<TaskDependency> currentElements = ((ProjectInternal) p).getOwner().fromMutableState(project -> {
+            project.getPluginManager().apply(EclipsePlugin.class);
+            EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
+            EclipseClasspath eclipseClasspath = eclipseModel.getClasspath();
 
-        EclipseModelBuilder.ClasspathElements elements = EclipseModelBuilder.gatherClasspathElements(projectOpenStatus, eclipseClasspath, false);
-        List<TaskDependency> buildDependencies = new ArrayList<>(elements.getBuildDependencies());
+            EclipseModelBuilder.ClasspathElements elements = EclipseModelBuilder.gatherClasspathElements(projectOpenStatus, eclipseClasspath, false);
+            return elements.getBuildDependencies();
+        });
 
-        for (Project childProject : getChildProjectsForInternalUse(project)) {
+        List<TaskDependency> buildDependencies = new ArrayList<>(currentElements);
+        for (Project childProject : getChildProjectsForInternalUse(p)) {
             buildDependencies.addAll(populate(childProject));
         }
         return buildDependencies;

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ParameterizedLoadCompositeEclipseModels.java
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ParameterizedLoadCompositeEclipseModels.java
@@ -31,7 +31,7 @@ public class ParameterizedLoadCompositeEclipseModels<T> implements BuildAction<C
     private final EclipseWorkspace workspace;
     private final Class<T> modelClass;
 
-    ParameterizedLoadCompositeEclipseModels(EclipseWorkspace workspace, Class<T> modelClass) {
+    public ParameterizedLoadCompositeEclipseModels(EclipseWorkspace workspace, Class<T> modelClass) {
         this.workspace = workspace;
         this.modelClass = modelClass;
     }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r900/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r900/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.tooling.r900
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.r56.DefaultEclipseWorkspace
+import org.gradle.integtests.tooling.r56.DefaultEclipseWorkspaceProject
+import org.gradle.integtests.tooling.r56.IntermediateResultHandlerCollector
+import org.gradle.integtests.tooling.r56.ParameterizedLoadCompositeEclipseModels
+import org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies
+
+@TargetGradleVersion('>=9.0.0')
+class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
+
+    def "can build RunClosedProjectBuildDependencies when --parallel is #parallel"() {
+        includeProjects("other")
+        [buildFile, file("other/build.gradle")].each {
+            it << """
+                plugins {
+                    id("java-library")
+                }
+            """
+        }
+
+        def workspace = new DefaultEclipseWorkspace(
+            temporaryFolder.file("workspace"),
+            [new DefaultEclipseWorkspaceProject("root", projectDir, true)]
+        )
+
+        expect:
+        succeeds { connection ->
+            def collector = new IntermediateResultHandlerCollector<Collection<RunClosedProjectBuildDependencies>>()
+
+            def builder = connection.action()
+                .projectsLoaded(new ParameterizedLoadCompositeEclipseModels(workspace, RunClosedProjectBuildDependencies), collector)
+                .build()
+
+            if (parallel) {
+                builder.withArguments("--parallel")
+            }
+
+            builder.run()
+            collector.result
+        }
+
+        where:
+        parallel << [true, false]
+    }
+
+}


### PR DESCRIPTION
In 9.0, we are more strict when resolving configurations, requiring the project lock for the configuration being resolved to be held when resolving that configuration.

RunBuildDependenciesTaskBuilder resolves configurations for subprojects of the current project, but did not properly acquire project locks when doing so. Now it does.


Fixes https://github.com/gradle/gradle/issues/34064

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
