### PR TITLE
Move exclude fix to 9.0.0

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ModuleDependencyExcludeResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ModuleDependencyExcludeResolveIntegrationTest.groovy
@@ -600,7 +600,7 @@ task check(type: Sync) {
      *
      * Exclude is applied to configuration conf
      */
-    def "ensure renamed dependencies are exclude correctly"() {
+    def "ensure renamed dependencies are excluded correctly"() {
         given:
         buildFile << """
             dependencies {
@@ -659,6 +659,7 @@ task check(type: Sync) {
         assertResolvedFiles(resolvedJars)
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/33924")
     def "node reentering the queue with a new incoming edge with fewer exclusions than all previous incoming edges properly propagates new transitive excludes"() {
         repository {
             id("org.hamcrest:hamcrest-junit:2.0.0.0")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ModuleDependencyExcludeResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ModuleDependencyExcludeResolveIntegrationTest.groovy
@@ -31,10 +31,6 @@ import static org.gradle.integtests.resolve.versions.AbstractVersionRangeResolve
 class ModuleDependencyExcludeResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
     def setup() {
         buildFile << """
-dependencies {
-    conf 'a:a:1.0'
-}
-
 task check(type: Sync) {
     from configurations.conf
     into 'libs'
@@ -73,6 +69,12 @@ task check(type: Sync) {
             'b:b:1.0' { expectResolve() }
             'c:c:1.0' { expectResolve() }
         }
+
+        buildFile << """
+            dependencies {
+                conf("a:a:1.0")
+            }
+        """
 
         when:
         succeeds "checkDep"
@@ -132,6 +134,12 @@ task check(type: Sync) {
             }
         }
 
+        buildFile << """
+            dependencies {
+                conf("a:a:1.0")
+            }
+        """
+
         when:
         succeedsDependencyResolution()
 
@@ -179,6 +187,12 @@ task check(type: Sync) {
             'b:b:1.0' { expectResolve() }
         }
 
+        buildFile << """
+            dependencies {
+                conf("a:a:1.0")
+            }
+        """
+
         when:
         succeeds "checkDep"
 
@@ -219,6 +233,12 @@ task check(type: Sync) {
                 "${it}:${it}:1.0" { expectResolve() }
             }
         }
+
+        buildFile << """
+            dependencies {
+                conf("a:a:1.0")
+            }
+        """
 
         when:
         succeedsDependencyResolution()
@@ -264,6 +284,11 @@ task check(type: Sync) {
             'b:b:1.0' { expectResolve() }
         }
 
+        buildFile << """
+            dependencies {
+                conf("a:a:1.0")
+            }
+        """
 
         when:
         succeeds "checkDep"
@@ -307,6 +332,12 @@ task check(type: Sync) {
             }
         }
 
+        buildFile << """
+            dependencies {
+                conf("a:a:1.0")
+            }
+        """
+
         when:
         succeedsDependencyResolution()
 
@@ -347,6 +378,12 @@ task check(type: Sync) {
             }
         }
 
+        buildFile << """
+            dependencies {
+                conf("a:a:1.0")
+            }
+        """
+
         when:
         succeedsDependencyResolution()
 
@@ -377,6 +414,12 @@ task check(type: Sync) {
             'a:a:1.0' { expectResolve() }
             'b:b:1.0' { expectResolve() }
         }
+
+        buildFile << """
+            dependencies {
+                conf("a:a:1.0")
+            }
+        """
 
         and: // Initial request to cache metadata
         succeeds "checkDeps"
@@ -425,6 +468,12 @@ task check(type: Sync) {
             'c:c:1.0' { expectResolve() }
             'd:d:1.0' { expectResolve() }
         }
+
+        buildFile << """
+            dependencies {
+                conf("a:a:1.0")
+            }
+        """
 
         when:
         succeeds "checkDep"
@@ -498,16 +547,13 @@ task check(type: Sync) {
         }
 
         buildFile << """
-            configurations {
-                conf.dependencies.clear()
-            }
-
             dependencies {
                 conf(platform('org.test:platform:1.0'))
                 conf 'org.test:depD:1.0'
                 conf 'org.test:depF:1.0'
             }
-"""
+        """
+
         when:
         succeeds 'checkDeps'
 
@@ -557,23 +603,27 @@ task check(type: Sync) {
     def "ensure renamed dependencies are exclude correctly"() {
         given:
         buildFile << """
-configurations {
-    conf {
-        exclude group: 'b', module: 'b'
-        resolutionStrategy {
-            dependencySubstitution {
-                all {
-                    if (it.requested instanceof ModuleComponentSelector) {
-                        if (it.requested.group == 'c' && it.requested.module == 'c') {
-                            it.useTarget group: 'b', name: 'b', version: '1.0'
+            dependencies {
+                conf("a:a:1.0")
+            }
+
+            configurations {
+                conf {
+                    exclude group: 'b', module: 'b'
+                    resolutionStrategy {
+                        dependencySubstitution {
+                            all {
+                                if (it.requested instanceof ModuleComponentSelector) {
+                                    if (it.requested.group == 'c' && it.requested.module == 'c') {
+                                        it.useTarget group: 'b', name: 'b', version: '1.0'
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
-        }
-    }
-}
-"""
+        """
 
         def expectResolved = ['a', 'f', 'g']
         repository {
@@ -607,5 +657,68 @@ configurations {
         then:
         def resolvedJars = expectResolved.collect { it + '-1.0.jar' }
         assertResolvedFiles(resolvedJars)
+    }
+
+    def "node reentering the queue with a new incoming edge with fewer exclusions than all previous incoming edges properly propagates new transitive excludes"() {
+        repository {
+            id("org.hamcrest:hamcrest-junit:2.0.0.0")
+            id("org:ut:2.0.0-BETA-4-JAVA7") {
+                dependsOn("org.hamcrest:hamcrest-junit:2.0.0.0")
+            }
+            id("org.slf4j:slf4j-api:1.7.36")
+            id("org:engine:1.4.1") {
+                dependsOn("org.slf4j:slf4j-api:1.7.36")
+                dependsOn("org:ut:2.0.0-BETA-4-JAVA7")
+            }
+            id("data:tools:27.9.67") {
+                dependsOn("org:engine:1.4.1")
+            }
+        }
+
+        repositoryInteractions {
+            id("org.hamcrest:hamcrest-junit:2.0.0.0") {
+                expectResolve()
+            }
+            id("org:ut:2.0.0-BETA-4-JAVA7") {
+                expectResolve()
+            }
+            id("org:engine:1.4.1") {
+                expectResolve()
+            }
+            id("org.slf4j:slf4j-api:1.7.36") {
+                expectResolve()
+            }
+            id("data:tools:27.9.67") {
+                expectResolve()
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf("org:engine:1.4.1") {
+                    exclude(group: "org.slf4j", module: "*")
+                    exclude(group: "org.hamcrest", module: "*")
+                }
+                conf("data:tools:27.9.67")
+            }
+        """
+
+        when:
+        succeeds(":checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org:engine:1.4.1") {
+                    module("org.slf4j:slf4j-api:1.7.36")
+                    module("org:ut:2.0.0-BETA-4-JAVA7") {
+                        module("org.hamcrest:hamcrest-junit:2.0.0.0")
+                    }
+                }
+                module("data:tools:27.9.67") {
+                    module("org:engine:1.4.1")
+                }
+            }
+        }
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
@@ -2533,9 +2533,7 @@ parentFirst
         resolve.expectGraph {
             root(":", ":test:") {
                 module("com.netflix.eureka:eureka-client:2.0.1") {
-                    module("com.netflix.netflix-commons:netflix-eventbus:0.3.0") {
-                        module("com.netflix.archaius:archaius-core:0.3.3")
-                    }
+                    module("com.netflix.netflix-commons:netflix-eventbus:0.3.0")
                 }
                 project(":indirect", "test:indirect:1.0") {
                     module("org.springframework.cloud:spring-cloud-netflix-dependencies:4.1.0") {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -54,12 +54,15 @@ class EdgeState implements DependencyGraphEdge {
     private final List<NodeState> targetNodes = new LinkedList<>();
     private final boolean isTransitive;
     private final boolean isConstraint;
-    private final int hashCode;
 
     private SelectorState selector;
     private ModuleVersionResolveException targetNodeSelectionFailure;
     private ImmutableAttributes cachedAttributes;
-    private ExcludeSpec transitiveExclusions;
+
+    /**
+     * The accumulated exclusions that apply to this edge based on the path from the root
+     */
+    private @Nullable ExcludeSpec transitiveExclusions;
     private ExcludeSpec cachedEdgeExclusions;
     private ExcludeSpec cachedExclusions;
 
@@ -67,25 +70,13 @@ class EdgeState implements DependencyGraphEdge {
     private boolean unattached;
     private boolean used;
 
-    EdgeState(NodeState from, DependencyState dependencyState, ExcludeSpec transitiveExclusions, ResolveState resolveState) {
+    EdgeState(NodeState from, DependencyState dependencyState, ResolveState resolveState) {
         this.from = from;
         this.dependencyState = dependencyState;
         this.dependencyMetadata = dependencyState.getDependency();
-        // The accumulated exclusions that apply to this edge based on the path from the root
-        this.transitiveExclusions = transitiveExclusions;
         this.resolveState = resolveState;
         this.isTransitive = from.isTransitive() && dependencyMetadata.isTransitive();
         this.isConstraint = dependencyMetadata.isConstraint();
-        this.hashCode = computeHashCode();
-    }
-
-    private int computeHashCode() {
-        int hashCode = from.hashCode();
-        hashCode = 31 * hashCode + dependencyState.hashCode();
-        if (transitiveExclusions != null) {
-            hashCode = 31 * hashCode + transitiveExclusions.hashCode();
-        }
-        return hashCode;
     }
 
     void computeSelector() {
@@ -493,17 +484,6 @@ class EdgeState implements DependencyGraphEdge {
         return selector.getTargetModule().getSelected();
     }
 
-    @Override
-    public boolean equals(Object o) {
-        return this == o;
-        // Edge states are deduplicated, this is a performance optimization
-    }
-
-    @Override
-    public int hashCode() {
-        return hashCode;
-    }
-
     DependencyState getDependencyState() {
         return dependencyState;
     }
@@ -515,8 +495,12 @@ class EdgeState implements DependencyGraphEdge {
         }
         transitiveExclusions = newResolutionFilter;
         cachedExclusions = null;
+    }
+
+    public void updateTransitiveExcludesAndRequeueTargetNodes(ExcludeSpec newResolutionFilter) {
+        updateTransitiveExcludes(newResolutionFilter);
         for (NodeState targetNode : targetNodes) {
-            targetNode.updateTransitiveExcludes();
+            targetNode.clearTransitiveExclusionsAndEnqueue();
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -60,7 +60,7 @@ class EdgeState implements DependencyGraphEdge {
     private ImmutableAttributes cachedAttributes;
 
     /**
-     * The accumulated exclusions that apply to this edge based on the path from the root
+     * The accumulated exclusions that apply to this edge based on the paths from the root
      */
     private @Nullable ExcludeSpec transitiveExclusions;
     private ExcludeSpec cachedEdgeExclusions;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -354,13 +354,10 @@ public class NodeState implements DependencyGraphNode {
         boolean sameDependencies = dependencies(newResolutionFilter).equals(oldDependencies);
 
         if (sameDependencies) {
-            // The excludes did change. Even if our direct filtered dependencies are the same,
-            // their transitive dependencies may be affected by the new excludes. So, we
-            // always update the outgoing edges to reflect the new resolution filter.
-
-            // If we return true here, we will short-circuit normal dependency traversal,
-            // which usually takes care of updating the transitive excludes. Do that here
-            // instead.
+            // If this method returns true, we are going to skip normal dependency traversal
+            // and instead short-circuit by only updating a subset of edges. Therefore, since
+            // the excludes changed, we need to update the resolution filter on our outgoing edges, as we
+            // are going to skip the normal dependency traversal logic that usually takes care of this.
             for (EdgeState outgoingEdge : outgoingEdges) {
                 outgoingEdge.updateTransitiveExcludesAndRequeueTargetNodes(newResolutionFilter);
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -342,8 +342,9 @@ public class NodeState implements DependencyGraphNode {
         // (it used to be) because if the filters are _equivalent_, we would
         // revisit all dependencies and possibly change the classpath order!
         boolean sameDependencies = dependencies(newResolutionFilter).equals(oldStates);
-        if (sameDependencies) {
-            // While there will be no change to this node, there might be changes to the nodes it brings as the exclude change could concern them
+        if (sameDependencies || previousTraversalExclusions != null) {
+            // If the dependencies are the same, there might be changes to the nodes it brings as the exclude change could concern them
+            // If the dependencies are different and there has been a previous traversal, we need to update the outgoing edges with the new excludes
             for (EdgeState outgoingEdge : outgoingEdges) {
                 outgoingEdge.updateTransitiveExcludes(newResolutionFilter);
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -92,35 +92,35 @@ public class NodeState implements DependencyGraphNode {
     ExcludeSpec previousTraversalExclusions;
 
     // In opposite to outgoing edges, virtual edges are for now pretty rare, so they are created lazily
-    private List<EdgeState> virtualEdges;
+    private @Nullable List<EdgeState> virtualEdges;
     private boolean queued;
     private boolean evicted;
     private int transitiveEdgeCount;
-    private Set<ModuleIdentifier> upcomingNoLongerPendingConstraints;
+    private @Nullable Set<ModuleIdentifier> upcomingNoLongerPendingConstraints;
     private boolean virtualPlatformNeedsRefresh;
-    private Set<EdgeState> edgesToRecompute;
-    private Multimap<ModuleIdentifier, DependencyState> potentiallyActivatedConstraints;
+    private @Nullable Set<EdgeState> edgesToRecompute;
+    private @Nullable Multimap<ModuleIdentifier, DependencyState> potentiallyActivatedConstraints;
 
     // caches
     private final Map<DependencyMetadata, DependencyState> dependencyStateCache = new HashMap<>();
     private final Map<DependencyState, EdgeState> edgesCache = new HashMap<>();
 
     // Caches the list of dependency states for dependencies
-    private List<DependencyState> cachedDependencyStates;
+    private @Nullable List<DependencyState> cachedDependencyStates;
 
     // Caches the list of dependency states which are NOT excluded
-    private List<DependencyState> cachedFilteredDependencyStates;
+    private @Nullable List<DependencyState> cachedFilteredDependencyStates;
 
     // exclusions optimizations
-    private ExcludeSpec cachedNodeExclusions;
+    private @Nullable ExcludeSpec cachedNodeExclusions;
     private int previousIncomingEdgeCount;
     private long previousIncomingHash;
     private long incomingHash;
-    private ExcludeSpec cachedModuleResolutionFilter;
+    private @Nullable ExcludeSpec cachedModuleResolutionFilter;
 
-    private StrictVersionConstraints ancestorsStrictVersionConstraints;
-    private StrictVersionConstraints ownStrictVersionConstraints;
-    private List<EdgeState> endorsesStrictVersionsFrom;
+    private @Nullable StrictVersionConstraints ancestorsStrictVersionConstraints;
+    private @Nullable StrictVersionConstraints ownStrictVersionConstraints;
+    private @Nullable List<EdgeState> endorsesStrictVersionsFrom;
     private boolean removingOutgoingEdges;
     private boolean findingExternalVariants;
 
@@ -267,11 +267,13 @@ public class NodeState implements DependencyGraphNode {
             potentiallyActivatedConstraints = null;
             ownStrictVersionConstraints = null;
         }
+
         // We are processing dependencies, anything in the previous state will be handled
         upcomingNoLongerPendingConstraints = null;
-
         visitDependencies(resolutionFilter, discoveredEdges);
         visitOwners(discoveredEdges);
+
+        previousTraversalExclusions = resolutionFilter;
     }
 
     private boolean canIgnoreExternalVariant() {
@@ -324,39 +326,39 @@ public class NodeState implements DependencyGraphNode {
     }
 
     private boolean excludesSameDependenciesAsPreviousTraversal(ExcludeSpec newResolutionFilter) {
-        List<DependencyState> oldStates = cachedFilteredDependencyStates;
-        if (previousTraversalExclusions == null || oldStates == null) {
+        if (previousTraversalExclusions == null) {
+            // There was no previous traversal. This traversal can't be the same.
             return false;
         }
         if (previousTraversalExclusions.equals(newResolutionFilter)) {
+            // The excludes did not change. The dependencies are the same.
             return true;
+        }
+        if (cachedFilteredDependencyStates == null) {
+            // We don't know which dependencies were excluded in the previous traversal.
+            // We are not sure if this traversal is the same.
+            return false;
         }
         if (doesNotHaveDependencies && !dependenciesMayChange) {
-            // whatever the exclude filter, there are no dependencies
+            // We have no dependencies, so the resolution filter does not matter.
             return true;
         }
-        cachedFilteredDependencyStates = null;
+
+        // The excludes did change. Even if our direct filtered dependencies are the same,
+        // their transitive dependencies may be affected by the new excludes. So, we
+        // always update the outgoing edges to reflect the new resolution filter.
+        for (EdgeState outgoingEdge : outgoingEdges) {
+            outgoingEdge.updateTransitiveExcludes(newResolutionFilter);
+        }
+
         // here, we need to check that applying the new resolution filter
         // we would actually exclude exactly the same dependencies as in
         // the previous visit. It is important that this is NOT a heuristic
         // (it used to be) because if the filters are _equivalent_, we would
         // revisit all dependencies and possibly change the classpath order!
-        boolean sameDependencies = dependencies(newResolutionFilter).equals(oldStates);
-        if (sameDependencies || previousTraversalExclusions != null) {
-            // If the dependencies are the same, there might be changes to the nodes it brings as the exclude change could concern them
-            // If the dependencies are different and there has been a previous traversal, we need to update the outgoing edges with the new excludes
-            for (EdgeState outgoingEdge : outgoingEdges) {
-                outgoingEdge.updateTransitiveExcludes(newResolutionFilter);
-            }
-        }
-        if (LOGGER.isDebugEnabled()) {
-            if (sameDependencies) {
-                LOGGER.debug("Filter {} excludes same dependencies as previous {}. Dependencies left = {}", newResolutionFilter, previousTraversalExclusions, oldStates);
-            } else {
-                LOGGER.debug("Filter {} doesn't exclude same dependencies as previous {}. Previous dependencies left = {} - New dependencies left = {}", newResolutionFilter, previousTraversalExclusions, oldStates, cachedFilteredDependencyStates);
-            }
-        }
-        return sameDependencies;
+        List<DependencyState> oldDependencies = cachedFilteredDependencyStates;
+        this.cachedFilteredDependencyStates = null; // Invalidate the cache so `dependencies` recomputes the value.
+        return dependencies(newResolutionFilter).equals(oldDependencies);
     }
 
     private void prepareToRecomputeEdge(EdgeState edgeToRecompute) {
@@ -435,7 +437,6 @@ public class NodeState implements DependencyGraphNode {
                     strictVersionsSet = maybeCollectStrictVersions(strictVersionsSet, dependencyState);
                 }
             }
-            previousTraversalExclusions = resolutionFilter;
         } finally {
             // If there are 'pending' dependencies that share a target with any of these outgoing edges,
             // then reset the state of the node that owns those dependencies.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
@@ -57,7 +57,8 @@ class PotentialEdge {
         if (exclusions == null) {
             exclusions = resolveState.getModuleExclusions().nothing();
         }
-        EdgeState edge = new EdgeState(from, dependencyState, exclusions, resolveState);
+        EdgeState edge = new EdgeState(from, dependencyState, resolveState);
+        edge.updateTransitiveExcludes(exclusions);
         edge.computeSelector();
         ModuleVersionIdentifier toModuleVersionId = DefaultModuleVersionIdentifier.newId(toSelector.getModuleIdentifier(), toSelector.getVersion());
         ComponentState version = resolveState.getModule(toSelector.getModuleIdentifier()).getVersion(toModuleVersionId, toComponent);


### PR DESCRIPTION
This moves the fix made in #33925 for Gradle 9.1.0 to 9.0.0 to not have a gap without the fix after 7.6.6 and 8.14.3 are released.