### PR TITLE
cobexer/merge release to master

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ProjectDelegate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ProjectDelegate.kt
@@ -213,7 +213,7 @@ abstract class ProjectDelegate : Project {
     override fun getProjectDir(): File =
         delegate.projectDir
 
-    override fun files(vararg paths: Any): ConfigurableFileCollection =
+    override fun files(vararg paths: Any?): ConfigurableFileCollection =
         delegate.files(*paths)
 
     override fun files(paths: Any, configureClosure: Closure<*>): ConfigurableFileCollection =
@@ -418,7 +418,7 @@ abstract class ProjectDelegate : Project {
     override fun tarTree(tarPath: Any): FileTree =
         delegate.tarTree(tarPath)
 
-    override fun delete(vararg paths: Any): Boolean =
+    override fun delete(vararg paths: Any?): Boolean =
         delegate.delete(*paths)
 
     override fun delete(action: Action<in DeleteSpec>): WorkResult =

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -59,11 +59,6 @@ For more, see the <<#minimum_daemon_jvm_version,Running Gradle on older JVMs>> s
 
 Gradle now embeds Kotlin 2.1.21, upgrading from the previously embedded version 2.0.21.
 
-This upgrade includes several important changes:
-
-* Support for Kotlin language versions 1.4 and 1.5 has been removed.
-* Kotlin language version 1.7 is now deprecated.
-
 For full details and potential breaking changes, consult the link:https://github.com/JetBrains/kotlin/releases/tag/v2.1.21[Kotlin release notes].
 
 ==== Kotlin DSL and plugins use the Kotlin language version 2.1
@@ -77,6 +72,11 @@ Users should review their code for compatibility with link:https://kotlinlang.or
 Due to changes in how the Kotlin 2 compiler handles script compilation, you can no longer refer to the script instance using labels like `this@Build_gradle`, `this@Settings_gradle`, or `this@Init_gradle`.
 If they are used to reference the DSL script target object, then use `project`, `settings`, or `gradle` instead.
 If they are used to reference a top-level symbol that happens to have the same name as a nested symbol, then use a different name, possibly by adding an intermediary variable.
+
+This upgrade also includes several important changes for build-logic and plugin authors:
+
+* Support for Kotlin language versions 1.4 and 1.5 has been removed.
+* Kotlin language version 1.7 is now deprecated.
 
 Read the link:#jspecify[JSpecify section] below to learn about potential breaking changes in Kotlin build logic code related to nullability.
 
@@ -489,6 +489,10 @@ For example if you have a Kotlin extension function on `Provider<T>` whose signa
 For example, you can't use `Property<String?>` anymore because the `T` in `Property<T>` is not nullable.
 +
 Another example is using a function from the Gradle API that takes a `Map<String, *>` parameter ; you could pass a map with nullable values before, you can't do that anymore.
+
+- Functions of the Gradle API that take varargs are now strict with regards to elements nullability.
++
+For example, functions of the Gradle API that take varargs with non-nullable elements only were accepting null elements in previous Gradle versions and will now fail to compile.
 
 NOTE: Plugins that use `javax.annotation` (JSR-305) annotations will continue to work in Gradle 9 as they did before.
 

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -212,8 +212,8 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
         eclipseProjects.add(eclipseProject);
     }
 
-    private void populate(Project project) {
-        ((ProjectInternal) project).getModel().applyToMutableState(state -> {
+    private void populate(Project p) {
+        ((ProjectInternal) p).getOwner().applyToMutableState(project -> {
             EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
 
             boolean projectDependenciesOnly = this.projectDependenciesOnly;
@@ -243,7 +243,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
             populateEclipseProjectJdt(eclipseProject, eclipseModel.getJdt());
         });
 
-        for (Project childProject : getChildProjectsForInternalUse(project)) {
+        for (Project childProject : getChildProjectsForInternalUse(p)) {
             populate(childProject);
         }
     }

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.ide.internal.tooling;
 
 import org.gradle.StartParameter;
 import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.plugins.ide.eclipse.EclipsePlugin;
@@ -73,15 +74,18 @@ public class RunBuildDependenciesTaskBuilder implements ParameterizedToolingMode
         return getRootGradle(parent);
     }
 
-    private List<TaskDependency> populate(Project project) {
-        project.getPluginManager().apply(EclipsePlugin.class);
-        EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
-        EclipseClasspath eclipseClasspath = eclipseModel.getClasspath();
+    private List<TaskDependency> populate(Project p) {
+        List<TaskDependency> currentElements = ((ProjectInternal) p).getOwner().fromMutableState(project -> {
+            project.getPluginManager().apply(EclipsePlugin.class);
+            EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
+            EclipseClasspath eclipseClasspath = eclipseModel.getClasspath();
 
-        EclipseModelBuilder.ClasspathElements elements = EclipseModelBuilder.gatherClasspathElements(projectOpenStatus, eclipseClasspath, false);
-        List<TaskDependency> buildDependencies = new ArrayList<>(elements.getBuildDependencies());
+            EclipseModelBuilder.ClasspathElements elements = EclipseModelBuilder.gatherClasspathElements(projectOpenStatus, eclipseClasspath, false);
+            return elements.getBuildDependencies();
+        });
 
-        for (Project childProject : getChildProjectsForInternalUse(project)) {
+        List<TaskDependency> buildDependencies = new ArrayList<>(currentElements);
+        for (Project childProject : getChildProjectsForInternalUse(p)) {
             buildDependencies.addAll(populate(childProject));
         }
         return buildDependencies;

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ParameterizedLoadCompositeEclipseModels.java
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ParameterizedLoadCompositeEclipseModels.java
@@ -31,7 +31,7 @@ public class ParameterizedLoadCompositeEclipseModels<T> implements BuildAction<C
     private final EclipseWorkspace workspace;
     private final Class<T> modelClass;
 
-    ParameterizedLoadCompositeEclipseModels(EclipseWorkspace workspace, Class<T> modelClass) {
+    public ParameterizedLoadCompositeEclipseModels(EclipseWorkspace workspace, Class<T> modelClass) {
         this.workspace = workspace;
         this.modelClass = modelClass;
     }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r900/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r900/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.tooling.r900
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.r56.DefaultEclipseWorkspace
+import org.gradle.integtests.tooling.r56.DefaultEclipseWorkspaceProject
+import org.gradle.integtests.tooling.r56.IntermediateResultHandlerCollector
+import org.gradle.integtests.tooling.r56.ParameterizedLoadCompositeEclipseModels
+import org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies
+
+@TargetGradleVersion('>=9.0.0')
+class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
+
+    def "can build RunClosedProjectBuildDependencies when --parallel is #parallel"() {
+        includeProjects("other")
+        [buildFile, file("other/build.gradle")].each {
+            it << """
+                plugins {
+                    id("java-library")
+                }
+            """
+        }
+
+        def workspace = new DefaultEclipseWorkspace(
+            temporaryFolder.file("workspace"),
+            [new DefaultEclipseWorkspaceProject("root", projectDir, true)]
+        )
+
+        expect:
+        succeeds { connection ->
+            def collector = new IntermediateResultHandlerCollector<Collection<RunClosedProjectBuildDependencies>>()
+
+            def builder = connection.action()
+                .projectsLoaded(new ParameterizedLoadCompositeEclipseModels(workspace, RunClosedProjectBuildDependencies), collector)
+                .build()
+
+            if (parallel) {
+                builder.withArguments("--parallel")
+            }
+
+            builder.run()
+            collector.result
+        }
+
+        where:
+        parallel << [true, false]
+    }
+
+}

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdExtension.java
@@ -215,7 +215,7 @@ public abstract class PmdExtension extends CodeQualityExtension {
      *
      * @param ruleSetFiles the rule set files to be added
      */
-    public void ruleSetFiles(Object... ruleSetFiles) {
+    public void ruleSetFiles(@Nullable Object... ruleSetFiles) {
         this.ruleSetFiles.from(ruleSetFiles);
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -307,7 +307,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      * {@inheritDoc}
      */
     @Override
-    public JavaExec bootstrapClasspath(Object... classpath) {
+    public JavaExec bootstrapClasspath(@Nullable Object... classpath) {
         javaExecSpec.bootstrapClasspath(classpath);
         return this;
     }
@@ -520,7 +520,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      * {@inheritDoc}
      */
     @Override
-    public JavaExec classpath(Object... paths) {
+    public JavaExec classpath(@Nullable Object... paths) {
         javaExecSpec.classpath(paths);
         return this;
     }

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -344,7 +344,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      * {@inheritDoc}
      */
     @Override
-    public Test bootstrapClasspath(Object... classpath) {
+    public Test bootstrapClasspath(@Nullable Object... classpath) {
         forkOptions.bootstrapClasspath(classpath);
         return this;
     }

--- a/platforms/jvm/war/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/platforms/jvm/war/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -156,7 +156,7 @@ public abstract class War extends Jar {
      * @param classpath The files to add. These are evaluated as per {@link org.gradle.api.Project#files(Object...)}
      */
     @SuppressWarnings("rawtypes")
-    public void classpath(Object... classpath) {
+    public void classpath(@Nullable Object... classpath) {
         FileCollection oldClasspath = getClasspath();
         this.classpath = getProject().files(oldClasspath != null ? oldClasspath : new ArrayList(), classpath);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -59,6 +59,7 @@ class EdgeState implements DependencyGraphEdge {
     private SelectorState selector;
     private ModuleVersionResolveException targetNodeSelectionFailure;
 
+
     /**
      * The accumulated exclusions that apply to this edge based on the paths from the root
      */

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -59,7 +59,6 @@ class EdgeState implements DependencyGraphEdge {
     private SelectorState selector;
     private ModuleVersionResolveException targetNodeSelectionFailure;
 
-
     /**
      * The accumulated exclusions that apply to this edge based on the paths from the root
      */

--- a/released-versions.json
+++ b/released-versions.json
@@ -1,7 +1,7 @@
 {
   "latestReleaseSnapshot": {
-    "version": "9.0.0-20250703012944+0000",
-    "buildTime": "20250703012944+0000"
+    "version": "9.0.0-20250704011203+0000",
+    "buildTime": "20250704011203+0000"
   },
   "latestRc": {
     "version": "9.0.0-rc-1",

--- a/subprojects/core-api/src/main/java/org/gradle/api/ActionConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/ActionConfiguration.java
@@ -17,6 +17,7 @@
 package org.gradle.api;
 
 import org.gradle.internal.instrumentation.api.annotations.NotToBeMigratedToLazy;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Allows specification of configuration for some action.
@@ -45,19 +46,19 @@ public interface ActionConfiguration {
      *
      * @param params - the parameters to use during construction
      */
-    void params(Object... params);
+    void params(@Nullable Object... params);
 
     /**
      * Sets any initialization parameters to use when constructing an instance of the implementation class.
      *
      * @param params - the parameters to use during construction
      */
-    void setParams(Object... params);
+    void setParams(@Nullable Object... params);
 
     /**
      * Gets the initialization parameters that will be used when constructing an instance of the implementation class.
      *
      * @return the parameters to use during construction
      */
-    Object[] getParams();
+    @Nullable Object[] getParams();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -798,10 +798,10 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * <p>This method can also be used to create an empty collection, which can later be mutated to add elements.</p>
      *
-     * @param paths The paths to the files. May be empty.
+     * @param paths The paths to the files. May be empty. {@code null} values are ignored.
      * @return The file collection. Never returns null.
      */
-    ConfigurableFileCollection files(Object... paths);
+    ConfigurableFileCollection files(@Nullable Object... paths);
 
     /**
      * <p>Creates a new {@code ConfigurableFileCollection} using the given paths. The paths are evaluated as per {@link
@@ -1046,7 +1046,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @param paths Any type of object accepted by {@link org.gradle.api.Project#files(Object...)}
      * @return true if anything got deleted, false otherwise
      */
-    boolean delete(Object... paths);
+    boolean delete(@Nullable Object... paths);
 
     /**
      * Deletes the specified files.  The given action is used to configure a {@link DeleteSpec}, which is then used to

--- a/subprojects/core-api/src/main/java/org/gradle/api/Script.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Script.java
@@ -26,6 +26,7 @@ import org.gradle.api.logging.LoggingManager;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.resources.ResourceHandler;
 import org.gradle.api.tasks.WorkResult;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.net.URI;
@@ -126,7 +127,7 @@ public interface Script {
      * @param paths The paths to the files. May be empty.
      * @return The file collection. Never returns null.
      */
-    ConfigurableFileCollection files(Object... paths);
+    ConfigurableFileCollection files(@Nullable Object... paths);
 
     /**
      * <p>Creates a new {@code ConfigurableFileCollection} using the given paths. The file collection is configured
@@ -302,7 +303,7 @@ public interface Script {
      * @param paths Any type of object accepted by {@link org.gradle.api.Project#files(Object...)}
      * @return true if anything got deleted, false otherwise
      */
-    boolean delete(Object... paths);
+    boolean delete(@Nullable Object... paths);
 
     /**
      * Returns the {@link org.gradle.api.logging.LoggingManager} which can be used to receive logging and to control the

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/FlatDirectoryArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/FlatDirectoryArtifactRepository.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.artifacts.repositories;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.File;
 import java.util.Set;
 
@@ -60,7 +62,7 @@ public interface FlatDirectoryArtifactRepository extends ArtifactRepository {
      *
      * @param dirs the directories.
      */
-    void dirs(Object... dirs);
+    void dirs(@Nullable Object... dirs);
 
     /**
      * Sets the directories where this repository will look for artifacts.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.java
@@ -17,6 +17,7 @@ package org.gradle.api.artifacts.repositories;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.attributes.Attribute;
+import org.jspecify.annotations.Nullable;
 
 /**
  * <p>Descriptor of a repository content, used to avoid reaching to
@@ -104,7 +105,7 @@ public interface RepositoryContentDescriptor extends InclusiveRepositoryContentD
      *
      * @param configurationNames the names of the configurations the repository will be used for
      */
-    void onlyForConfigurations(String... configurationNames);
+    void onlyForConfigurations(@Nullable String... configurationNames);
 
     /**
      * Declares that this repository should not be used for a specific
@@ -112,7 +113,7 @@ public interface RepositoryContentDescriptor extends InclusiveRepositoryContentD
      *
      * @param configurationNames the names of the configurations the repository will not be used for
      */
-    void notForConfigurations(String... configurationNames);
+    void notForConfigurations(@Nullable String... configurationNames);
 
     /**
      * Declares that this repository will only be searched if the consumer requires a

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -21,6 +21,7 @@ import org.gradle.api.model.ManagedType;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.HasConfigurableValue;
 import org.gradle.api.provider.SupportsConvention;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
 
@@ -53,7 +54,7 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      *
      * @param paths The paths. {@code null} values are ignored.
      */
-    void setFrom(Object... paths);
+    void setFrom(@Nullable Object... paths);
 
     /**
      * Specifies the value to use as the convention (default value) to be used when resolving this file collection,
@@ -83,7 +84,7 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * @since 8.8
      */
     @Incubating
-    ConfigurableFileCollection convention(Object... paths);
+    ConfigurableFileCollection convention(@Nullable Object... paths);
 
     /**
      * Adds a set of source paths to this collection. The given paths are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
@@ -91,7 +92,7 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * @param paths The files to add. {@code null} values are ignored.
      * @return this
      */
-    ConfigurableFileCollection from(Object... paths);
+    ConfigurableFileCollection from(@Nullable Object... paths);
 
     /**
      * Returns the set of tasks which build the files of this collection.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/CopySourceSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/CopySourceSpec.java
@@ -18,6 +18,7 @@ package org.gradle.api.file;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Specifies sources for a file copy.
@@ -29,7 +30,7 @@ public interface CopySourceSpec {
      *
      * @param sourcePaths Paths to source files for the copy
      */
-    CopySourceSpec from(Object... sourcePaths);
+    CopySourceSpec from(@Nullable Object... sourcePaths);
 
     /**
      * Specifies the source files or directories for a copy and creates a child {@code CopySourceSpec}. The given source

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/CopySpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/CopySpec.java
@@ -210,7 +210,7 @@ public interface CopySpec extends CopySourceSpec, CopyProcessingSpec, PatternFil
      * {@inheritDoc}
      */
     @Override
-    CopySpec from(Object... sourcePaths);
+    CopySpec from(@Nullable Object... sourcePaths);
 
     /**
      * {@inheritDoc}

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/DeleteSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/DeleteSpec.java
@@ -17,6 +17,7 @@
 package org.gradle.api.file;
 
 import org.gradle.internal.HasInternalProtocol;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A specification for deleting files from the filesystem.
@@ -29,7 +30,7 @@ public interface DeleteSpec {
      * @param files the list of files which should be deleted. Any type of object
      * accepted by {@link org.gradle.api.Project#files(Object...)}
      */
-    DeleteSpec delete(Object... files);
+    DeleteSpec delete(@Nullable Object... files);
 
     /**
      * Specifies whether or not symbolic links should be followed during deletion.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/Directory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/Directory.java
@@ -18,6 +18,7 @@ package org.gradle.api.file;
 
 import org.gradle.api.provider.Provider;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 
@@ -92,5 +93,5 @@ public interface Directory extends FileSystemLocation {
      * @return The file collection.
      * @since 6.0
      */
-    FileCollection files(Object... paths);
+    FileCollection files(@Nullable Object... paths);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
@@ -120,5 +120,5 @@ public interface DirectoryProperty extends FileSystemLocationProperty<Directory>
      * @return The file collection.
      * @since 6.0
      */
-    FileCollection files(Object... paths);
+    FileCollection files(@Nullable Object... paths);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
@@ -22,6 +22,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 
@@ -85,5 +86,5 @@ public interface ProjectLayout {
      * @return The file collection. Never returns null.
      * @since 4.8
      */
-    FileCollection files(Object... paths);
+    FileCollection files(@Nullable Object... paths);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeMigratedToLazy;
 import org.gradle.model.internal.core.UnmanagedStruct;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.util.Set;
@@ -67,7 +68,7 @@ public interface SourceDirectorySet extends FileTree, PatternFilterable, Named, 
      * @param srcPaths The source directories. These are evaluated as per {@link org.gradle.api.Project#files(Object...)}
      * @return this
      */
-    SourceDirectorySet srcDirs(Object... srcPaths);
+    SourceDirectorySet srcDirs(@Nullable Object... srcPaths);
 
     /**
      * Returns the source directories that make up this set.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskDestroyables.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskDestroyables.java
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks;
 
 import org.gradle.internal.HasInternalProtocol;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the files or directories that a {@link org.gradle.api.Task} destroys (removes).
@@ -32,5 +33,5 @@ public interface TaskDestroyables {
      *
      * @since 4.3
      */
-    void register(Object... paths);
+    void register(@Nullable Object... paths);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
@@ -49,7 +49,7 @@ public interface TaskInputs {
      * @param paths The input files. The given paths are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
      * @return a property builder to further configure the property.
      */
-    TaskInputFilePropertyBuilder files(Object... paths);
+    TaskInputFilePropertyBuilder files(@Nullable Object... paths);
 
     /**
      * Registers some input file for this task.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskLocalState.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskLocalState.java
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks;
 
 import org.gradle.internal.HasInternalProtocol;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the files or directories that represent the local state of a {@link org.gradle.api.Task}.
@@ -32,5 +33,5 @@ public interface TaskLocalState {
      *
      * @param paths The files that represent the local state. The given paths are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
      */
-    void register(Object... paths);
+    void register(@Nullable Object... paths);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputs.java
@@ -21,6 +21,7 @@ import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.HasInternalProtocol;
+import org.jspecify.annotations.Nullable;
 
 /**
  * <p>A {@code TaskOutputs} represents the outputs of a task.</p>
@@ -142,7 +143,7 @@ public interface TaskOutputs {
      *
      * @see CacheableTask
      */
-    TaskOutputFilePropertyBuilder files(Object... paths);
+    TaskOutputFilePropertyBuilder files(@Nullable Object... paths);
 
     /**
      * Registers some output directories for this task.
@@ -162,7 +163,7 @@ public interface TaskOutputs {
      *
      * @since 3.3
      */
-    TaskOutputFilePropertyBuilder dirs(Object... paths);
+    TaskOutputFilePropertyBuilder dirs(@Nullable Object... paths);
 
     /**
      * Registers some output file for this task.

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
@@ -136,7 +136,7 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
      *
      * @return this
      */
-    JavaExecSpec classpath(Object... paths);
+    JavaExecSpec classpath(@Nullable Object... paths);
 
     /**
      * Returns the classpath for executing the main class.

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -198,7 +198,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * @param classpath The classpath.
      * @return this
      */
-    JavaForkOptions bootstrapClasspath(Object... classpath);
+    JavaForkOptions bootstrapClasspath(@Nullable Object... classpath);
 
     /**
      * Returns true if assertions are enabled for the process.

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -238,7 +238,7 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
      * {@inheritDoc}
      */
     @Override
-    public AbstractCopyTask from(Object... sourcePaths) {
+    public AbstractCopyTask from(@Nullable Object... sourcePaths) {
         getMainSpec().from(sourcePaths);
         return this;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Delete.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Delete.java
@@ -25,6 +25,7 @@ import org.gradle.internal.file.Deleter;
 import org.gradle.internal.instrumentation.api.annotations.NotToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.work.DisableCachingByDefault;
+import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -127,7 +128,7 @@ public abstract class Delete extends ConventionTask implements DeleteSpec {
      * @param targets Any type of object accepted by {@link Project#files(Object...)}
      */
     @Override
-    public Delete delete(Object... targets) {
+    public Delete delete(@Nullable Object... targets) {
         paths.from(targets);
         return this;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.util.internal.PatternSetFactory;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.work.DisableCachingByDefault;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.util.Set;
@@ -97,7 +98,7 @@ public abstract class SourceTask extends ConventionTask implements PatternFilter
      * @param sources The source to add
      * @return this
      */
-    public SourceTask source(Object... sources) {
+    public SourceTask source(@Nullable Object... sources) {
         sourceFiles.from(sources);
         return this;
     }


### PR DESCRIPTION
- **Fix nullability for Project.files and ConfigurableFileCollection.from**
- **Ensure transitive excludes are updated**
- **Additional cleanup for NodeState**
- **Always update edge transitive excludes**
- **Address review comments**
- **Adjust Project.files() javadoc around passed null values**
- **Fix ActionConfiguration.params nullability contract**
- **Fix Exec-like types nullability contract**
- **Fix Delete-like types nullability contract**
- **Fix Copy-like types nullability contract**
- **Fix Task state related types nullability contract**
- **Fix file state related types nullability contract**
- **Fix repositories related types nullability contract**
- **Fix PmdExtension nullability contract**
- **Fix Groovy DSL Script nullability contract**
- **Fix Project nullability contract**
- **Add common breaking change to the upgrading guide for varargs elements nullability**
- **Refine upgrade guide around Kotlin language version support**
- **Acquire project lock when building eclipse model**
- **Publish version 9.0.0-20250704011203+0000**
