### PR TITLE
Only run `docs:checkSamples` in the first batch

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/DocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/DocsTest.kt
@@ -105,7 +105,10 @@ class TeamCityParallelDocsTest(
         os,
         testJava,
         docsTestType,
-        TeamCityParallelTests(parallelism).extraBuildParameters + " -PteamCityParallelTestsBatch=%teamCityParallelTestsBatch%",
+        listOf(
+            TeamCityParallelTests(parallelism).extraBuildParameters,
+            "-PteamCityParallelTestsCurrentBatch=%teamCityParallelTestsCurrentBatch%",
+        ).joinToString(" "),
     ) {
     init {
         features {
@@ -115,10 +118,9 @@ class TeamCityParallelDocsTest(
         }
 
         params {
-            // Could be "1/1" (for initial run) or "1/4", "2/4", "3/4", "4/4" (for batched run)
             text(
-                "teamCityParallelTestsBatch",
-                "%teamcity.build.parallelTests.currentBatch%/%teamcity.build.parallelTests.totalBatches%",
+                "teamCityParallelTestsCurrentBatch",
+                "teamcity.build.parallelTests.currentBatch",
                 allowEmpty = true,
             )
         }

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -56,7 +56,7 @@ import gradlebuild.basics.BuildParams.RUN_ANDROID_STUDIO_IN_HEADLESS_MODE
 import gradlebuild.basics.BuildParams.RUN_BROKEN_CONFIGURATION_CACHE_DOCS_TESTS
 import gradlebuild.basics.BuildParams.SKIP_BUILD_LOGIC_TESTS
 import gradlebuild.basics.BuildParams.STUDIO_HOME
-import gradlebuild.basics.BuildParams.TEAMCITY_PARALLEL_TESTS_BATCH
+import gradlebuild.basics.BuildParams.TEAMCITY_PARALLEL_TESTS_CURRENT_BATCH
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_DOGFOODING_TAG
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_ENABLED
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_PARTITION_SIZE
@@ -125,7 +125,7 @@ object BuildParams {
     const val RERUN_ALL_TESTS = "rerunAllTests"
     const val SKIP_BUILD_LOGIC_TESTS = "skipBuildLogicTests"
     const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
-    const val TEAMCITY_PARALLEL_TESTS_BATCH = "teamCityParallelTestsBatch"
+    const val TEAMCITY_PARALLEL_TESTS_CURRENT_BATCH = "teamCityParallelTestsBatch"
     const val TEST_DISTRIBUTION_DOGFOODING_TAG = "testDistributionDogfoodingTag"
     const val TEST_DISTRIBUTION_ENABLED = "enableTestDistribution"
     const val TEST_DISTRIBUTION_PARTITION_SIZE = "testDistributionPartitionSizeInSeconds"
@@ -341,25 +341,8 @@ val Project.gradleInstallPath: Provider<String>
 val Project.rerunAllTests: Provider<Boolean>
     get() = gradleProperty(RERUN_ALL_TESTS).map { true }.orElse(false)
 
-// It could be lik "1/1" (for initial run) or "1/3", "2/3", "3/3" for batched run.
-// Return null if anything goes wrong.
-private
-fun Project.parseTeamCityBatchInfo(): Pair<Int, Int>? {
-    val batchProperty = gradleProperty(TEAMCITY_PARALLEL_TESTS_BATCH).orNull
-    return if (batchProperty?.matches("\\d+/\\d+".toRegex()) == true) {
-        val current = batchProperty.substringBefore("/").toInt()
-        val total = batchProperty.substringAfter("/").toInt()
-        current to total
-    } else {
-        null
-    }
-}
-
-val Project.teamCityParallelTestsCurrentBatch: Int?
-    get() = parseTeamCityBatchInfo()?.first
-
-val Project.teamCityParallelTestsTotalBatches: Int?
-    get() = parseTeamCityBatchInfo()?.second
+val Project.teamCityParallelTestsCurrentBatch: Int
+    get() = gradleProperty(TEAMCITY_PARALLEL_TESTS_CURRENT_BATCH).getOrElse("1").toInt()
 
 val Project.testJavaVendor: Provider<JvmVendorSpec>
     get() = propertyFromAnySource(TEST_JAVA_VENDOR).map { vendorName -> VENDOR_MAPPING.getOrElse(vendorName) { -> JvmVendorSpec.matching(vendorName) } }

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -125,7 +125,7 @@ object BuildParams {
     const val RERUN_ALL_TESTS = "rerunAllTests"
     const val SKIP_BUILD_LOGIC_TESTS = "skipBuildLogicTests"
     const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
-    const val TEAMCITY_PARALLEL_TESTS_CURRENT_BATCH = "teamCityParallelTestsBatch"
+    const val TEAMCITY_PARALLEL_TESTS_CURRENT_BATCH = "teamCityParallelTestsCurrentBatch"
     const val TEST_DISTRIBUTION_DOGFOODING_TAG = "testDistributionDogfoodingTag"
     const val TEST_DISTRIBUTION_ENABLED = "enableTestDistribution"
     const val TEST_DISTRIBUTION_PARTITION_SIZE = "testDistributionPartitionSizeInSeconds"

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -4,7 +4,6 @@ import gradlebuild.basics.repoRoot
 import gradlebuild.basics.runBrokenForConfigurationCacheDocsTests
 import gradlebuild.integrationtests.model.GradleDistribution
 import gradlebuild.basics.teamCityParallelTestsCurrentBatch
-import gradlebuild.basics.teamCityParallelTestsTotalBatches
 import org.asciidoctor.gradle.jvm.AsciidoctorTask
 import org.gradle.docs.internal.tasks.CheckLinks
 import org.gradle.docs.samples.internal.tasks.InstallSample
@@ -602,7 +601,7 @@ tasks.named("checkAsciidoctorSampleContents") {
 }
 
 tasks.named("checkSamples") {
-    enabled = (project.teamCityParallelTestsTotalBatches == null) || (project.teamCityParallelTestsTotalBatches != null && teamCityParallelTestsCurrentBatch == 1)
+    enabled = (teamCityParallelTestsCurrentBatch == 1)
 }
 
 // exclude (unused and non-existing) wrapper of development Gradle version, as well as README, because the timestamp in the Gradle version break the cache

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -3,6 +3,8 @@ import gradlebuild.basics.googleApisJs
 import gradlebuild.basics.repoRoot
 import gradlebuild.basics.runBrokenForConfigurationCacheDocsTests
 import gradlebuild.integrationtests.model.GradleDistribution
+import gradlebuild.basics.teamCityParallelTestsCurrentBatch
+import gradlebuild.basics.teamCityParallelTestsTotalBatches
 import org.asciidoctor.gradle.jvm.AsciidoctorTask
 import org.gradle.docs.internal.tasks.CheckLinks
 import org.gradle.docs.samples.internal.tasks.InstallSample
@@ -597,6 +599,10 @@ tasks.named<Wrapper>("generateWrapperForSamples") {
 // TODO: The rich console to plain text is flaky
 tasks.named("checkAsciidoctorSampleContents") {
     enabled = false
+}
+
+tasks.named("checkSamples") {
+    enabled = (project.teamCityParallelTestsTotalBatches == null) || (project.teamCityParallelTestsTotalBatches != null && teamCityParallelTestsCurrentBatch == 1)
 }
 
 // exclude (unused and non-existing) wrapper of development Gradle version, as well as README, because the timestamp in the Gradle version break the cache


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/4717

In the past, we use TeamCity parallel tests feature for Wiindows/Mac docs test, which run `docs:checkSamples` in all batches. This PR does:

1. Pass the batch information into the build like `-PteamCityParallelTestsBatch=1/4`.
2. Only run `docs:checkSamples` if current build is batch 1.