### PR TITLE
Remove problematic ClasspathFingerprintingStrategy and ZipHasher fallback strategy

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest.groovy
@@ -16,8 +16,14 @@
 
 package org.gradle.api.tasks.compile
 
+
+import org.apache.commons.io.FileUtils
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildCacheOperationFixtures
+import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
+import org.gradle.test.fixtures.dsl.GradleDsl
+import spock.lang.Issue
 
 class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
@@ -62,6 +68,72 @@ class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractI
         executedAndNotSkipped ':b:jar', ':a:compileJava'
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/32464")
+    def "kotlin library on build script classpath and Java classpath doesn't affect Java compilation build cache key"() {
+        given:
+        file("a/build.gradle.kts") << """
+            plugins {
+                `java-library`
+            }
+            ${mavenCentralRepository(GradleDsl.KOTLIN)}
+            dependencies {
+                // We need a Kotlin library with inlined methods
+                implementation("com.squareup.okhttp3:okhttp:4.12.0")
+            }
+        """
+        file("a/settings.gradle.kts") << """
+            rootProject.name = "a"
+        """
+        file('a/src/main/java/A.java') << '''
+            public class A {
+                public void foo() {
+                }
+            }
+        '''
+        file("a/gradle/init.gradle.kts") << """
+            initscript {
+                ${mavenCentralRepository(GradleDsl.KOTLIN)}
+                dependencies {
+                    classpath("com.squareup.okhttp3:okhttp:4.12.0")
+                }
+            }
+
+            // We need to have this line to force the body script to be compiled and classpath snapshotted
+            println("Script body")
+        """
+        def aRelocated = file("a-relocated")
+        FileUtils.copyDirectory(file("a"), aRelocated)
+
+        when:
+        def firstOperations = new BuildCacheOperationFixtures(new BuildOperationsFixture(executer, testDirectoryProvider, "first-operations"))
+        result = executer
+            .withGradleUserHomeDir(testDirectoryProvider.getTestDirectory().file("first-user-home"))
+            .inDirectory(file("a"))
+            .withArgument("--init-script")
+            .withArgument("gradle/init.gradle.kts")
+            .withBuildCacheEnabled()
+            .withTasks("compileJava")
+            .run()
+
+        then:
+        executedAndNotSkipped ':compileJava'
+        def firstCacheKey = firstOperations.getCacheKeyForTask(":compileJava")
+
+        when:
+        def secondOperations = new BuildCacheOperationFixtures(new BuildOperationsFixture(executer, testDirectoryProvider, "second-operations"))
+        result = executer
+            .withGradleUserHomeDir(testDirectoryProvider.getTestDirectory().file("second-user-home"))
+            .inDirectory(aRelocated)
+            .withBuildCacheEnabled()
+            .withTasks("compileJava")
+            .run()
+
+        then:
+        executedAndNotSkipped ':compileJava'
+        def secondCacheKey = secondOperations.getCacheKeyForTask(":compileJava")
+        firstCacheKey == secondCacheKey
+    }
+
     void make_abi_compatible_change_on_b() {
         file('b/src/main/java/B.java').text = '''
             public class B {
@@ -89,9 +161,9 @@ class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractI
                 apply plugin: 'java'
             }
         '''
-        file('a/build.gradle') << '''
+        file('a/build.gradle.kts') << '''
             dependencies {
-                implementation project(':b')
+                implementation(project(":b"))
             }
         '''
 

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest.groovy
@@ -81,8 +81,10 @@ class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractI
         def repo = publishKotlinLibraryWithInlineFunctionToRemote()
         def kotlinLibraryWithInlineFunction = "com.example:kotlin-library:1.0.0"
 
-        setupBaseProjectA()
         file("a/build.gradle") << """
+            plugins {
+                id("java-library")
+            }
             repositories {
                 maven { url = uri("${repo.uri}") }
             }
@@ -90,6 +92,15 @@ class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractI
                 implementation("$kotlinLibraryWithInlineFunction")
             }
         """
+        file("a/settings.gradle") << """
+            rootProject.name = "a"
+        """
+        file('a/src/main/java/A.java') << '''
+            public class A {
+                public void foo() {
+                }
+            }
+        '''
         file("a/gradle/init.gradle.kts") << """
             initscript {
                 repositories {
@@ -185,22 +196,6 @@ class JavaCompileAvoidanceWithBuildCacheServiceIntegrationTest extends AbstractI
         '''
     }
 
-    void setupBaseProjectA() {
-        file("a/build.gradle") << """
-            plugins {
-                id("java-library")
-            }
-        """
-        file("a/settings.gradle") << """
-            rootProject.name = "a"
-        """
-        file('a/src/main/java/A.java') << '''
-            public class A {
-                public void foo() {
-                }
-            }
-        '''
-    }
 
     def publishKotlinLibraryWithInlineFunctionToRemote() {
         file("kotlin-library/build.gradle.kts") << """

--- a/platforms/jvm/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
+++ b/platforms/jvm/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
@@ -57,21 +57,11 @@ public class ZipHasher implements RegularFileSnapshotContextHasher, Configurable
     }
 
     private final ResourceHasher resourceHasher;
-    private final ZipHasher fallbackZipHasher;
     private final HashingExceptionReporter hashingExceptionReporter;
 
     public ZipHasher(ResourceHasher resourceHasher) {
-        this(
-            resourceHasher,
-            null,
-            (s, e) -> LOGGER.debug("Malformed archive '{}'. Falling back to full content hash instead of entry hashing.", s.getName(), e)
-        );
-    }
-
-    public ZipHasher(ResourceHasher resourceHasher, @Nullable ZipHasher fallbackZipHasher, HashingExceptionReporter hashingExceptionReporter) {
         this.resourceHasher = resourceHasher;
-        this.fallbackZipHasher = fallbackZipHasher;
-        this.hashingExceptionReporter = hashingExceptionReporter;
+        this.hashingExceptionReporter = (s, e) -> LOGGER.debug("Malformed archive '{}'. Falling back to full content hash instead of entry hashing.", s.getName(), e);
     }
 
     @Nullable
@@ -98,9 +88,6 @@ public class ZipHasher implements RegularFileSnapshotContextHasher, Configurable
             return hasher.hash();
         } catch (Exception e) {
             hashingExceptionReporter.report(zipFileSnapshot, e);
-            if (fallbackZipHasher != null) {
-                return fallbackZipHasher.hashZipContents(zipFileSnapshot);
-            }
             return zipFileSnapshot.getHash();
         }
     }

--- a/platforms/jvm/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/platforms/jvm/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -119,18 +119,6 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
         return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
     }
 
-    public static ClasspathFingerprintingStrategy compileClasspathFallbackToRuntimeClasspath(
-        ResourceHasher classpathResourceHasher,
-        ResourceHasher runtimeClasspathResourceHasher,
-        ResourceSnapshotterCacheService cacheService,
-        Interner<String> stringInterner,
-        ZipHasher.HashingExceptionReporter hashingExceptionReporter
-    ) {
-        ZipHasher fallbackZipHasher = new ZipHasher(runtimeClasspathResourceHasher);
-        ZipHasher zipHasher = new ZipHasher(classpathResourceHasher, fallbackZipHasher, hashingExceptionReporter);
-        return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
-    }
-
     public static ResourceHasher runtimeClasspathResourceHasher(
         RuntimeClasspathResourceHasher runtimeClasspathResourceHasher,
         LineEndingSensitivity lineEndingSensitivity,


### PR DESCRIPTION
Relates to https://github.com/gradle/gradle/issues/32464

Due to a bug in ZipHasher it can happen that when we use a fallback ZipHasher we could potentially poison fingerprint cache. See https://github.com/gradle/gradle/issues/32464#issuecomment-3044602295.
We could fix it, but since fallback is not used anymore we can just remove it.

This happens only with remote Kotlin libraries with inline function that are present on build script and Java compile classpath. 

This PR also adds a test that fails with 8.14.3.