### PR TITLE
Reverting new internal uses of ConfigurableFileCollection

### DIFF
--- a/platforms/jvm/plugins-jvm-test-suite/src/main/java/org/gradle/api/plugins/JvmTestSuitePlugin.java
+++ b/platforms/jvm/plugins-jvm-test-suite/src/main/java/org/gradle/api/plugins/JvmTestSuitePlugin.java
@@ -19,15 +19,11 @@ package org.gradle.api.plugins;
 import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
 import org.gradle.api.plugins.jvm.internal.DefaultJvmTestSuite;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.testing.base.TestingExtension;
 import org.gradle.testing.base.plugins.TestSuiteBasePlugin;
-
-import java.util.concurrent.Callable;
 
 /**
  * A {@link org.gradle.api.Plugin} that adds extensions for declaring, compiling and running {@link JvmTestSuite}s.
@@ -62,12 +58,8 @@ public abstract class JvmTestSuitePlugin implements Plugin<Project> {
         testing.getSuites().withType(JvmTestSuite.class).all(testSuite -> {
             testSuite.getTargets().all(target -> {
                 target.getTestTask().configure(test -> {
-                    ((ConfigurableFileCollection)test.getTestClassesDirs()).convention((Callable<FileCollection>) () ->
-                        testSuite.getSources().getOutput().getClassesDirs()
-                    );
-                    ((ConfigurableFileCollection)test.getClasspath()).convention((Callable<FileCollection>) () ->
-                        testSuite.getSources().getRuntimeClasspath()
-                    );
+                    test.getConventionMapping().map("testClassesDirs", () -> testSuite.getSources().getOutput().getClassesDirs());
+                    test.getConventionMapping().map("classpath", () -> testSuite.getSources().getRuntimeClasspath());
                 });
                 target.getBinaryResultsDirectory().convention(target.getTestTask().flatMap(Test::getBinaryResultsDirectory));
             });

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -171,10 +171,10 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
     private final ModularitySpec modularity;
     private final Property<JavaLauncher> javaLauncher;
 
-    private final ConfigurableFileCollection testClassesDirs = getObjectFactory().fileCollection();
+    private FileCollection testClassesDirs;
     private final PatternFilterable patternSet;
-    private final ConfigurableFileCollection classpath = getObjectFactory().fileCollection();
-    private final ConfigurableFileCollection stableClasspath = getObjectFactory().fileCollection();
+    private FileCollection classpath;
+    private final ConfigurableFileCollection stableClasspath;
     private final Property<TestFramework> testFramework;
     private boolean scanForTestClasses = true;
     private long forkEvery;
@@ -184,8 +184,16 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
     public Test() {
         ObjectFactory objectFactory = getObjectFactory();
         patternSet = getPatternSetFactory().createPatternSet();
+        testClassesDirs = objectFactory.fileCollection();
+        classpath = objectFactory.fileCollection();
         // Create a stable instance to represent the classpath, that takes care of conventions and mutations applied to the property
-        stableClasspath.from((Callable<Object>) this::getClasspath);
+        stableClasspath = objectFactory.fileCollection();
+        stableClasspath.from(new Callable<Object>() {
+            @Override
+            public Object call() {
+                return getClasspath();
+            }
+        });
         forkOptions = getForkOptionsFactory().newDecoratedJavaForkOptions();
         forkOptions.setEnableAssertions(true);
         forkOptions.setExecutable(null);
@@ -860,7 +868,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      * @since 4.0
      */
     public void setTestClassesDirs(FileCollection testClassesDirs) {
-        this.testClassesDirs.setFrom(testClassesDirs);
+        this.testClassesDirs = testClassesDirs;
     }
 
     /**
@@ -1110,7 +1118,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
     }
 
     public void setClasspath(FileCollection classpath) {
-        this.classpath.setFrom(classpath);
+        this.classpath = classpath;
     }
 
     /**

--- a/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -61,7 +61,7 @@ public abstract class AntlrPlugin implements Plugin<Project> {
         JavaPluginHelper.getJavaComponent(project).getMainFeature().getApiConfiguration().extendsFrom(antlrConfiguration);
 
         // Wire the antlr configuration into all antlr tasks
-        project.getTasks().withType(AntlrTask.class).configureEach(antlrTask -> antlrTask.antlrClasspath.convention(antlrConfiguration));
+        project.getTasks().withType(AntlrTask.class).configureEach(antlrTask -> antlrTask.getConventionMapping().map("antlrClasspath", () -> project.getConfigurations().getByName(ANTLR_CONFIGURATION_NAME)));
 
         project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets().all(
             new Action<SourceSet>() {

--- a/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.plugins.antlr;
 
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileType;
@@ -73,13 +72,12 @@ public abstract class AntlrTask extends SourceTask {
     private boolean traceTreeWalker;
     private List<String> arguments = new ArrayList<>();
 
-    ConfigurableFileCollection antlrClasspath = getProject().getObjects().fileCollection();
+    private FileCollection antlrClasspath;
 
     private File outputDirectory;
     private String maxHeapSize;
     private FileCollection sourceSetDirectories;
     private final FileCollection stableSources = getProject().files((Callable<Object>) this::getSource);
-
 
     /**
      * Specifies that all rules call {@code traceIn}/{@code traceOut}.
@@ -201,7 +199,7 @@ public abstract class AntlrTask extends SourceTask {
      * @param antlrClasspath The Ant task implementation classpath. Must not be null.
      */
     protected void setAntlrClasspath(FileCollection antlrClasspath) {
-        this.antlrClasspath.setFrom(antlrClasspath);
+        this.antlrClasspath = antlrClasspath;
     }
 
     @Inject

--- a/testing/architecture-test/src/changes/archunit-store/public-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-nullability.txt
@@ -165,6 +165,7 @@ Class <org.gradle.api.tasks.testing.AggregateTestReport> is not annotated (direc
 Class <org.gradle.api.tasks.testing.GroupTestEventReporter> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (GroupTestEventReporter.java:0)
 Class <org.gradle.api.tasks.testing.JUnitXmlReport> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (JUnitXmlReport.java:0)
 Class <org.gradle.api.tasks.testing.Test$1> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (Test.java:0)
+Class <org.gradle.api.tasks.testing.Test$2> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (Test.java:0)
 Class <org.gradle.api.tasks.testing.TestEventReporter> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (TestEventReporter.java:0)
 Class <org.gradle.api.tasks.testing.TestEventReporterFactory> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (TestEventReporterFactory.java:0)
 Class <org.gradle.api.tasks.testing.TestExecutionException> is not annotated (directly or via its package) with @org.jspecify.annotations.NullMarked in (TestExecutionException.java:0)


### PR DESCRIPTION
CFC isn't a drop-in replacement for a bean-style FileCollection property. Besides subtle differences, it introduces potential for circular evaluations and the user experience isn't great there (a stack overflow happens). It turns out, a self-referential assignments are quite common (like `classpath = classpath.plus(...).minus(...)`).

Improving the situation with circular evaluations in CFCs isn't trivial and cannot be done in a reasonable time frame between RCs. As we aren't trying to remove ConventionMapping anymore, we're reverting the implementation back to the latter.

Fixes #34132.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
