### PR TITLE
Fix release notes and upgrade guide for RC2 release

### DIFF
--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
@@ -37,8 +37,12 @@ public abstract class Documentation implements InternalDocLink {
         return new UserGuide(id, null);
     }
 
-    public static Documentation upgradeGuide(int majorVersion, String upgradeGuideSection) {
-        return new UpgradeGuide(majorVersion, upgradeGuideSection);
+    public static Documentation upgradeMinorGuide(int majorVersion, String upgradeGuideSection) {
+        return UpgradeGuide.forMinorVersion(majorVersion, upgradeGuideSection);
+    }
+
+    public static Documentation upgradeMajorGuide(int majorVersion, String upgradeGuideSection) {
+        return UpgradeGuide.forMajorVersion(majorVersion, upgradeGuideSection);
     }
 
     public static Documentation dslReference(Class<?> targetClass, String property) {
@@ -90,7 +94,7 @@ public abstract class Documentation implements InternalDocLink {
          */
         @CheckReturnValue
         public T withUpgradeGuideSection(int majorVersion, String upgradeGuideSection) {
-            return withDocumentation(Documentation.upgradeGuide(majorVersion, upgradeGuideSection));
+            return withDocumentation(Documentation.upgradeMinorGuide(majorVersion, upgradeGuideSection));
         }
     }
 
@@ -134,8 +138,16 @@ public abstract class Documentation implements InternalDocLink {
 
     private static class UpgradeGuide extends UserGuide {
 
-        private UpgradeGuide(int majorVersion, String section) {
-            super("upgrading_version_" + majorVersion, section);
+        private UpgradeGuide(String basePath, String section) {
+            super(basePath, section);
+        }
+
+        public static UpgradeGuide forMinorVersion(int majorVersion, String section) {
+            return new UpgradeGuide("upgrading_version_" + majorVersion, section);
+        }
+
+        public static UpgradeGuide forMajorVersion(int majorVersion, String section) {
+            return new UpgradeGuide("upgrading_major_version_" + majorVersion, section);
         }
 
         @Override

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecatedFeatureUsageTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecatedFeatureUsageTest.groovy
@@ -48,6 +48,6 @@ class DeprecatedFeatureUsageTest extends Specification {
         documentationReference                 | expected
         null                                   | null
         Documentation.userManual("foo", "bar") | "https://docs.gradle.org/${GradleVersion.current().version}/userguide/foo.html#bar"
-        Documentation.upgradeGuide(42, "bar")  | "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_42.html#bar"
+        Documentation.upgradeMinorGuide(42, "bar")  | "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_42.html#bar"
     }
 }

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/DocumentationTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/internal/deprecation/DocumentationTest.groovy
@@ -38,7 +38,7 @@ class DocumentationTest extends Specification {
 
     def "creates upgrade guide reference"() {
         when:
-        def documentationReference = Documentation.upgradeGuide(11, "section")
+        def documentationReference = Documentation.upgradeMinorGuide(11, "section")
 
         then:
         def expectedUrl = DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_11", "section")

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -211,7 +211,7 @@ Gradle’s [version information endpoint](https://services.gradle.org/versions/)
 
 #### Archive tasks produce reproducible archives by default
 
-Archive tasks such as `Jar`, `Ear`, `War`, `Zip`, `Tar`, and `AbstractArchiveTask` produce reproducible archives by default.
+Archive tasks such as `Jar`, `Ear`, `War`, `Zip`, `Tar`, and `AbstractArchiveTask` produce [reproducible archives by default](userguide/working_with_files.html#sec:reproducible_archives).
 This means that generated archives have reproducible file order and preconfigured file timestamps and permissions.
 As a result archives generated from the same inputs will be identical byte-for-byte.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -112,7 +112,7 @@ Additional updates for the [Configuration Cache](userguide/configuration_cache.h
 <a name="jvm-17"></a>
 ### Gradle requires Java Virtual Machine (JVM) version 17 or higher to run
 
-Gradle requires a Java Virtual Machine (JVM) version [17 or higher](userguide/upgrading_version_8.html#jvm-17) to start the Gradle daemon.
+Gradle requires a Java Virtual Machine (JVM) version [17 or higher](userguide/upgrading_major_version_9.html#jvm-17) to start the Gradle daemon.
 
 If you need to build with older JVM versions, you can specify a separate JDK toolchain in the build definition by using [toolchains](userguide/toolchains.html).  
 Gradle still supports compiling, testing and running other JVM-based tools with Java 8 and higher.
@@ -133,7 +133,7 @@ Gradle uses Kotlin for build logic, which includes:
 - Plugins
 
 As a result, some behavior has changed, most notably the new K2 compiler and [nullability annotations on APIs](#jspecify).
-If you're upgrading, review the [Gradle 8.x upgrade guide](userguide/upgrading_version_8.html#kotlin-2) for migration details.
+If you're upgrading, review the [Gradle 9.0.0 upgrade guide](userguide/upgrading_major_version_9.html#kotlin-2) for migration details.
 
 <a name="groovy-4"></a>
 ### Update to Groovy 4
@@ -148,7 +148,7 @@ Build scripts written in the Groovy DSL (`.gradle` files)
 Ant integration
 Plugins
 
-Some behavior has changed between Groovy 3.0 and 4.0. If you're upgrading, review the [Gradle 8.x upgrade guide](userguide/upgrading_version_8.html#groovy-4) for migration details.
+Some behavior has changed between Groovy 3.0 and 4.0. If you're upgrading, review the [Gradle 9.0.0 upgrade guide](userguide/upgrading_major_version_9.html#groovy-4) for migration details.
 
 <a name="sem-ver"></a>
 ### Semantic Versioning for Gradle releases
@@ -185,7 +185,7 @@ Since Gradle 5.0 we've been using annotations from [JSR-305](https://jcp.org/en/
 Starting with Gradle 9, the Gradle API is annotated using [JSpecify](https://jspecify.dev/) instead.
 
 Kotlin 2.1, when combined with JSpecify annotations in the Gradle API, introduces stricter nullability handling.
-For more details and potential breakages, see the dedicated [upgrading guide section](userguide/upgrading_version_8.html#jspecify).
+For more details and potential breakages, see the dedicated [upgrading guide section](userguide/upgrading_major_version_9.html#jspecify).
 
 <a name="sem-ver-wrapper"></a>
 #### Support for major and minor version specification in Gradle Wrapper
@@ -217,7 +217,7 @@ As a result archives generated from the same inputs will be identical byte-for-b
 
 This change may affect builds that rely on non-deterministic archive characteristics like file order, file system timestamps, or file system permissions, or file executable bit.
 
-For more information, see the [upgrading guide section](userguide/upgrading_version_8.html#reproducible_archives_by_default).
+For more information, see the [upgrading guide section](userguide/upgrading_major_version_9.html#reproducible_archives_by_default).
 
 #### Detached configurations can resolve dependencies on their own project
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
@@ -265,6 +265,64 @@ plugins {
 TIP: The `jvm-toolchains` plugin is automatically applied by the <<java_library_plugin.adoc#java_library_plugin,Java Library Plugin>> and other JVM-related plugins.
 If you are already applying one of those, no further action is needed.
 
+[[reproducible_archives_by_default]]
+==== Archive tasks (Jar, Ear, War, Zip, AbstractArchiveTask) produce reproducible archives by default
+
+NOTE: This change may affect existing builds that relied on the previous behavior of archive tasks, where file order was not deterministic, and file timestamps and permissions were taken from the file system.
+
+In Gradle 9.0, the default behavior of archive tasks (such as `Jar`, `Ear`, `War`, `Zip`, and `AbstractArchiveTask`) has changed to produce reproducible archives by default.
+That means that:
+
+- File order in the archive is now deterministic.
+- Files have fixed timestamps (timestamps depends on the archive type).
+- All directories have fixed permissions set to `0755`.
+- All files have fixed permissions set to `0644`.
+
+This change improves the reproducibility of builds and ensures that the generated archives are consistent across different environments.
+
+You can restore the previous behaviour for one or more properties for your task with the following configuration:
+
+====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+tasks.withType<AbstractArchiveTask>().configureEach {
+    // Make file order based on the file system
+    isReproducibleFileOrder = false
+    // Use file timestamps from the file system
+    isPreserveFileTimestamps = true
+    // Use permissions from the file system
+    useFileSystemPermissions()
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+tasks.withType(AbstractArchiveTask).configureEach {
+    // Makes file order non deterministic
+    reproducibleFileOrder = false
+    // Use file timestamps from the file system
+    preserveFileTimestamps = true
+    // Use permissions from the file system
+    useFileSystemPermissions()
+}
+----
+=====
+====
+
+You can also preserve the file system permissions across archives tasks by configuring a property:
+
+[source,properties]
+.gradle.properties
+----
+org.gradle.archives.use-file-system-permissions=true
+----
+
 === `test` task fails when no tests are discovered
 
 When test sources are present and no filters are applied, the `test` task will now fail with an error if it runs but doesn’t discover any tests.

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
@@ -863,7 +863,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem) {
             fqid == 'validation:missing-java-toolchain-plugin'
             contextualLabel == 'Using task ValidatePlugins without applying the Java Toolchain plugin is not supported.'
-            definition.documentationLink.url.endsWith("/userguide/upgrading_version_8.html#validate_plugins_without_java_toolchain_90")
+            definition.documentationLink.url.endsWith("/userguide/upgrading_major_version_9.html#validate_plugins_without_java_toolchain_90")
         }
     }
 }

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
@@ -107,7 +107,7 @@ public abstract class ValidatePlugins extends DefaultTask {
                     throw problemReporter.throwing(
                         exception,
                         problemReporter.create(problemId, problemSpec -> {
-                            problemSpec.documentedAt(Documentation.upgradeGuide(8, "validate_plugins_without_java_toolchain_90").getUrl());
+                            problemSpec.documentedAt(Documentation.upgradeMajorGuide(9, "validate_plugins_without_java_toolchain_90").getUrl());
                             problemSpec.contextualLabel(exception.getMessage());
                         })
                     );

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/component/DefaultAdhocSoftwareComponent.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/component/DefaultAdhocSoftwareComponent.java
@@ -106,7 +106,7 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
 
         @Override
         public List<String> getResolutions() {
-            return Collections.singletonList(Documentation.upgradeGuide(8, "gmm_modification_after_publication_populated").getConsultDocumentationMessage());
+            return Collections.singletonList(Documentation.upgradeMinorGuide(8, "gmm_modification_after_publication_populated").getConsultDocumentationMessage());
         }
     }
 }


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- [x] Fix removed section about default archives
- [x] Fix broken links due to new upgrade guide
- [x] Update test classes and groovy tests for user documentation now that the upgrade guides are split