### PR TITLE
Adjust all cross version test buckets

### DIFF
--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -29,21 +29,16 @@ val QUICK_CROSS_VERSION_BUCKETS =
 
 val ALL_CROSS_VERSION_BUCKETS =
     listOf(
-        listOf("0.0", "4.1"), // 0.0 <= version < 4.1
-        listOf("4.1", "4.5"), // 4.1 <=version < 4.5
-        listOf("4.5", "4.8"), // 4.5 <=version < 4.8
-        listOf("4.8", "5.0"), // 4.8 <=version < 5.0
-        listOf("5.0", "5.4"), // 5.0 <=version < 5.4
-        listOf("5.4", "6.1"), // 5.4 <=version < 6.1
-        listOf("6.1", "6.4"), // 6.1 <=version < 6.4
-        listOf("6.4", "6.7"), // 6.4 <=version < 6.7
-        listOf("6.7", "7.0"), // 6.7 <=version < 7.0
-        listOf("7.0", "7.3"), // 7.0 <=version < 7.3
+        listOf("0.0", "5.0"), // 0.0 <= version < 5.0
+        listOf("5.0", "7.3"), // 5.0 <=version < 7.3
         listOf("7.3", "7.6"), // 7.3 <=version < 7.6
         listOf("7.6", "8.2"), // 7.6 <=version < 8.2
-        listOf("8.2", "8.6"), // 8.2 <=version < 8.6
-        listOf("8.6", "8.10"), // 8.6 <=version < 8.10
-        listOf("8.10", "99.0"), // 8.10 <=version < 99.0
+        listOf("8.2", "8.4"), // 8.2 <=version < 8.4
+        listOf("8.4", "8.6"), // 8.4 <=version < 8.6
+        listOf("8.6", "8.8"), // 8.6 <=version < 8.8
+        listOf("8.8", "8.10"), // 8.8 <=version < 8.10
+        listOf("8.10", "8.13"), // 8.10 <=version < 8.13
+        listOf("8.13", "99.0"), // 8.13 <=version < 99.0
     )
 
 typealias BuildProjectToSubprojectTestClassTimes = Map<String, Map<String, List<TestClassTime>>>


### PR DESCRIPTION
As new versions are released, our cross-version test buckets have become more and more unbalanced. Currently, older buckets before 5.0 complete in ~10 minutes, while the latest bucket can take up to ~4 hours, leading to potential timeouts.

This PR adjusts the bucket split to make a more even distribution of test execution time, mitigating timeouts and improving overall CI efficiency.