### PR TITLE
Fix flaky CacheConfigurationsIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
@@ -124,7 +124,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
                     snapshotWrappers.removeUnusedEntriesOlderThan = ${snapshotDistTimestamp}
                     downloadedResources.removeUnusedEntriesOlderThan = ${downloadedResourcesTimestamp}
                     createdResources.removeUnusedEntriesOlderThan = ${createdResourcesTimestamp}
-                    buildCache.removeUnusedEntriesOlderThan = ${createdResourcesTimestamp}
+                    buildCache.removeUnusedEntriesOlderThan = ${buildCacheResourcesTimestamp}
                 }
             }
         """


### PR DESCRIPTION
This is obviously a copy-paste error - the variable is duplicate with previous line. 