### PR TITLE
Adjust nullability of TAPI builders

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/tooling/provider/model/ParameterizedToolingModelBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/tooling/provider/model/ParameterizedToolingModelBuilder.java
@@ -17,6 +17,7 @@
 package org.gradle.tooling.provider.model;
 
 import org.gradle.api.Project;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A {@link ToolingModelBuilder} which can be parameterized by the client.
@@ -89,7 +90,8 @@ public interface ParameterizedToolingModelBuilder<T> extends ToolingModelBuilder
      * @param modelName The model name, usually the same as the name of the Java interface used by the client.
      * @param parameter The parameter received from the client.
      * @param project The project to create the model for.
-     * @return The model.
+     * @return The model, or null if not available.
      */
+    @Nullable
     Object buildAll(String modelName, T parameter, Project project);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/tooling/provider/model/ToolingModelBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/tooling/provider/model/ToolingModelBuilder.java
@@ -17,6 +17,7 @@
 package org.gradle.tooling.provider.model;
 
 import org.gradle.api.Project;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Responsible for building tooling models to return to the tooling API client.
@@ -50,7 +51,8 @@ public interface ToolingModelBuilder {
      *
      * @param modelName The model name, usually the same as the name of the Java interface used by the client.
      * @param project The project to create the model for.
-     * @return The model.
+     * @return The model, or null if not available.
      */
+    @Nullable
     Object buildAll(String modelName, Project project);
 }

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/BuildScopeModelBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/BuildScopeModelBuilder.java
@@ -20,6 +20,7 @@ import org.gradle.api.Project;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.build.BuildState;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
+import org.jspecify.annotations.Nullable;
 
 public interface BuildScopeModelBuilder extends ToolingModelBuilder {
     /**
@@ -34,9 +35,11 @@ public interface BuildScopeModelBuilder extends ToolingModelBuilder {
      * are cases when such builders can be used as regular builders (for example as part of larger build actions),
      * that's why they need extend {@code ToolingModelBuilder} too.
      */
+    @Nullable
     Object create(BuildState target);
 
     @Override
+    @Nullable
     default Object buildAll(String modelName, Project project) {
         BuildState targetBuild = ((GradleInternal) project.getGradle()).getOwner();
         return create(targetBuild);

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -4465,6 +4465,22 @@
             ]
         },
         {
+            "type": "org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder",
+            "member": "Method org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder.buildAll(java.lang.String,java.lang.Object,org.gradle.api.Project)",
+            "acceptation": "We actually support null returning tooling model builders",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.tooling.provider.model.ToolingModelBuilder",
+            "member": "Method org.gradle.tooling.provider.model.ToolingModelBuilder.buildAll(java.lang.String,org.gradle.api.Project)",
+            "acceptation": "We actually support null returning tooling model builders",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
             "type": "org.gradle.util.ClosureBackedAction",
             "member": "Class org.gradle.util.ClosureBackedAction",
             "acceptation": "Deprecated in 8.x",


### PR DESCRIPTION
Gradle actually supports TAPI builders returning null models.

In previous Gradle versions these were annotated as non-null with JSR-305. This was wrong.

This change reflects the effective possiblity of builders returning null models. annotations.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
