### PR TITLE
Replace usages of `Enum.values()` by `entries` following Kotlin upgrade

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -827,7 +827,7 @@ class ConfigurationCacheState(
     private
     suspend fun WriteContext.writePreviewFlags(gradle: GradleInternal) {
         val featureFlags = gradle.serviceOf<FeatureFlags>()
-        val enabledFeatures = FeaturePreviews.Feature.values().filter { featureFlags.isEnabledWithApi(it) }
+        val enabledFeatures = FeaturePreviews.Feature.entries.filter { featureFlags.isEnabledWithApi(it) }
         writeCollection(enabledFeatures)
     }
 

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/UserTypesCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/UserTypesCodecTest.kt
@@ -55,7 +55,7 @@ class UserTypesCodecTest : AbstractUserTypeCodecTest() {
 
     @Test
     fun `can handle anonymous enum subtypes`() {
-        EnumSuperType.values().forEach {
+        EnumSuperType.entries.forEach {
             assertThat(
                 configurationCacheRoundtripOf(it),
                 sameInstance(it)

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluatorTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluatorTest.kt
@@ -1243,8 +1243,8 @@ class PartialEvaluatorTest {
 
     @Test
     fun `Stage1 only Program is unsupported`() {
-        ProgramTarget.values().forEach { programTarget ->
-            ProgramKind.values().forEach { programKind ->
+        ProgramTarget.entries.forEach { programTarget ->
+            ProgramKind.entries.forEach { programKind ->
                 try {
                     partialEvaluationOf(object : Program.Stage1() {}, programKind, programTarget)
                     fail("Should have failed")


### PR DESCRIPTION

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
