### PR TITLE
Fix reference to IP property

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/isolated_projects.adoc
@@ -59,7 +59,7 @@ You will need Gradle 8.5 or later to use Isolated Projects, preferably a recent 
 You should also use the most recent version of IDEA or Android Studio.
 
 The feature is off by default.
-You can enable it by setting the `org.gradle.unsafe.isolated-projects` system property to `true`.
+You can enable it by setting the `org.gradle.unsafe.isolated-projects` Gradle property to `true`.
 For example:
 
 ----


### PR DESCRIPTION
According to the [Gradle properties reference][1], `org.gradle.unsafe.isolated-projects` is a Gradle property, not a system property.

[1]: https://docs.gradle.org/current/userguide/build_environment.html#gradle_properties_reference

### Context

The misnaming leads to confusion when the user tries to set it in `gradle.properties` based on the example, since in that case it'd be prefixed with `systemProp.` if it were a system property.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
