### PR TITLE
Fix asterisk escape

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -262,7 +262,7 @@ Only the root project's `gradle.properties` file will be checked for properties 
 [[sec:gradle_configuration_properties]]
 == Gradle properties
 
-Gradle properties configure Gradle itself and usually have the name `org.gradle.\*`.
+Gradle properties configure Gradle itself and usually have the name `org.gradle.*`.
 Gradle properties should not be used in build logic, their values should not be read/retrieved in build scripts.
 
 === Setting a Gradle property


### PR DESCRIPTION
Otherwise, it's rendered incorrectly:

<img width="224" height="72" alt="image" src="https://github.com/user-attachments/assets/4075dd0a-6bbc-49c9-b3ba-b63b5dc12fb5" />