### PR TITLE
Accessors for `compileOnly` plugin dependencies in precompiled Kotlin scripts

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -10,7 +10,6 @@ import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.util.internal.TextUtil.normaliseFileSeparators
-import org.gradle.util.internal.ToBeImplemented
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -249,8 +248,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractKotlinIntegrationTest() {
     }
 
     @Test
-    @Issue("https://github.com/gradle/gradle/issues/23576")
-    @ToBeImplemented
+    @Requires(IntegTestPreconditions.NotEmbeddedExecutor::class)
     fun `can compile precompiled scripts with compileOnly dependency`() {
 
         fun withPluginJar(fileName: String, versionString: String): File =
@@ -277,7 +275,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractKotlinIntegrationTest() {
                 compileOnly(files("${normaliseFileSeparators(pluginJarV1.absolutePath)}"))
             }
         """)
-        val precompiledScript = withFile("buildSrc/src/main/kotlin/my-precompiled-script.gradle.kts", """
+        withFile("buildSrc/src/main/kotlin/my-precompiled-script.gradle.kts", """
             plugins {
                 id("my-plugin")
             }
@@ -294,16 +292,9 @@ class PrecompiledScriptPluginIntegrationTest : AbstractKotlinIntegrationTest() {
             }
         """)
 
-        buildAndFail("action").apply {
-            assertHasFailure("Plugin [id: 'my-plugin'] was not found in any of the following sources") {
-                assertHasErrorOutput("Precompiled script plugin '${precompiledScript.absolutePath}' line: 1")
-            }
-        }
-
-        // Once implemented:
-        // build("action").apply {
-        //     assertOutputContains("Applied plugin 2.0")
-        // }
+         build("action").apply {
+             assertOutputContains("Applied plugin 2.0")
+         }
     }
 
     @Test

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -216,6 +216,12 @@ fun Project.enableScriptCompilationOf(
             outputDir = compiledPluginsBlocks
         )
 
+        val accessorsGenerationClasspath = configurations.resolvable("precompiledScriptPluginAccessorsGenerationClasspath") {
+            // We use both compile and runtime classpath to include compileOnly, implementation and runtimeOnly dependencies
+            it.extendsFrom(configurations["compileClasspath"])
+            it.extendsFrom(configurations["runtimeClasspath"])
+        }
+
         val (generatePrecompiledScriptPluginAccessors, _) =
             codeGenerationTask<GeneratePrecompiledScriptPluginAccessors>(
                 "accessors",
@@ -224,7 +230,7 @@ fun Project.enableScriptCompilationOf(
             ) {
                 dependsOn(compilePluginsBlocks)
                 classPathFiles.from(compileClasspath)
-                runtimeClassPathArtifactCollection.set(configurations["runtimeClasspath"].incoming.artifacts)
+                accessorsGenerationClassPathArtifactCollection.set(accessorsGenerationClasspath.get().incoming.artifacts)
                 sourceCodeOutputDir.set(it)
                 metadataOutputDir.set(accessorsMetadata)
                 compiledPluginsBlocksDir.set(compiledPluginsBlocks)
@@ -397,10 +403,11 @@ fun Task.validateKotlinCompilerArguments() {
 
 private
 fun configureKotlinCompilerArgumentsEagerly() {
-    throw PrecompiledScriptException("Using the `kotlin-dsl` plugin together with Kotlin Gradle Plugin < 1.8.0. " +
-        "Please let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic. " +
-        "Or use version $expectedKotlinDslPluginsVersion which is the expected version for this Gradle release. " +
-        "If you explicitly declare which version of the Kotlin Gradle Plugin to use for your build logic, update it to >= 1.8.0."
+    throw PrecompiledScriptException(
+        "Using the `kotlin-dsl` plugin together with Kotlin Gradle Plugin < 1.8.0. " +
+            "Please let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic. " +
+            "Or use version $expectedKotlinDslPluginsVersion which is the expected version for this Gradle release. " +
+            "If you explicitly declare which version of the Kotlin Gradle Plugin to use for your build logic, update it to >= 1.8.0."
     )
 }
 

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -113,15 +113,15 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
 
     @get:InputFiles
     @get:Classpath
-    val runtimeClassPathFiles: FileCollection
-        get() = runtimeClassPathArtifactCollection.get().artifactFiles
+    val accessorsGenerationClassPathFiles: FileCollection
+        get() = accessorsGenerationClassPathArtifactCollection.get().artifactFiles
 
     /**
-     * Tracked via [runtimeClassPathFiles].
+     * Tracked via [accessorsGenerationClassPathFiles].
      */
     @get:Internal
     internal
-    abstract val runtimeClassPathArtifactCollection: Property<ArtifactCollection>
+    abstract val accessorsGenerationClassPathArtifactCollection: Property<ArtifactCollection>
 
     @get:OutputDirectory
     abstract val metadataOutputDir: DirectoryProperty
@@ -437,7 +437,7 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
         configurations: ConfigurationContainer,
         fileCollectionFactory: FileCollectionFactory
     ): Configuration {
-        val dependencies = runtimeClassPathArtifactCollection.get().artifacts.map {
+        val dependencies = accessorsGenerationClassPathArtifactCollection.get().artifacts.map {
             when (val componentIdentifier = it.id.componentIdentifier) {
                 is OpaqueComponentIdentifier -> DefaultFileCollectionDependency(
                     componentIdentifier,

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -114,6 +114,30 @@ assert(bar.getAttribute(color) == "orange") // `color` gets overwritten again
 assert(bar.getAttribute(shape) == "square") // `shape` remains the same
 ```
 
+#### Accessors for `compileOnly` plugin dependencies in precompiled Kotlin scripts
+
+Previously, it was not possible to use a plugin coming from a `compileOnly` dependency in a [precompiled Kotlin script](userguide/implementing_gradle_plugins_precompiled.html).
+Now, one can and [type-safe accessors](userguide/kotlin_dsl.html#type-safe-accessors) for model elements contributed by the plugin are available in the precompiled Kotlin scripts.
+
+As an example, the following `buildSrc/build.gradle.kts` build script declares a `compileOnly` dependency to a third party plugin: 
+```kotlin
+plugins {
+    `kotlin-dsl`
+}
+dependencies {
+    compileOnly("com.android.tools.build:gradle:x.y.z")
+}
+```
+And a convention precompiled Kotlin script in `buildSrc/src/main/kotlin/my-convention-plugin.gradle.kts` applies it, and can now use type-safe accessors to configure the third party plugin:
+```kotlin
+plugins {
+    id("com.android.application")
+}
+android {
+    // The accessor to the `android` extension registered by the Android plugin is available
+}
+```
+
 ### Configuration Improvements
 
 #### Simpler target package configuration for Antlr 4

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -117,7 +117,7 @@ assert(bar.getAttribute(shape) == "square") // `shape` remains the same
 #### Accessors for `compileOnly` plugin dependencies in precompiled Kotlin scripts
 
 Previously, it was not possible to use a plugin coming from a `compileOnly` dependency in a [precompiled Kotlin script](userguide/implementing_gradle_plugins_precompiled.html).
-Now, one can and [type-safe accessors](userguide/kotlin_dsl.html#type-safe-accessors) for model elements contributed by the plugin are available in the precompiled Kotlin scripts.
+Now it is supported, and [​type-safe accessors​]​(​userguide/kotlin_dsl.html#type-safe-accessors​) for plugins from such dependencies are available in the precompiled Kotlin scripts.
 
 As an example, the following `buildSrc/build.gradle.kts` build script declares a `compileOnly` dependency to a third party plugin: 
 ```kotlin

--- a/testing/architecture-test/src/changes/archunit-store/explicit-properties.txt
+++ b/testing/architecture-test/src/changes/archunit-store/explicit-properties.txt
@@ -107,7 +107,7 @@ Method <org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks.CompilePrecompi
 Method <org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks.CompilePrecompiledScriptPluginPlugins.getSourceFiles()> is not abstract
 Method <org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks.ExtractPrecompiledScriptPluginPlugins.getScriptFiles$kotlin_dsl_provider_plugins()> is not abstract
 Method <org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks.GenerateExternalPluginSpecBuilders.getPluginEntries()> is not abstract
-Method <org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks.GeneratePrecompiledScriptPluginAccessors.getRuntimeClassPathFiles()> is not abstract
+Method <org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks.GeneratePrecompiledScriptPluginAccessors.getAccessorsGenerationClassPathFiles()> is not abstract
 Method <org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks.GeneratePrecompiledScriptPluginAccessors.getScriptFiles$kotlin_dsl_provider_plugins()> is not abstract
 Method <org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks.GenerateScriptPluginAdapters.getScriptFiles$kotlin_dsl_provider_plugins()> is not abstract
 Method <org.gradle.kotlin.dsl.tooling.builders.GenerateSourceRootsFile.getDestinationFile()> is not abstract


### PR DESCRIPTION
Let the task that generates type-safe accessors for precompiled Kotlin scripts use both the compile and runtime classpath to discover the schema of contributed model elements. This allows to generate type-safe accessors for plugins that are declared as `compileOnly` dependencies.

* Fixes https://github.com/gradle/gradle/issues/23576#issuecomment-3057999235

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
