### PR TITLE
Fix some CC-incompatible tests

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
@@ -22,7 +22,6 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Task
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.TaskCollection
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.gradle.test.fixtures.file.LeaksFileHandles
@@ -41,7 +40,6 @@ import java.util.jar.JarFile
 class GradleApiExtensionsIntegrationTest : AbstractKotlinIntegrationTest() {
 
     @Test
-    @ToBeFixedForConfigurationCache(because = "test captures script reference")
     fun `Kotlin chooses withType extension specialized to container type`() {
 
         withBuildScript(
@@ -53,23 +51,27 @@ class GradleApiExtensionsIntegrationTest : AbstractKotlinIntegrationTest() {
             inline fun <reified T> inferredTypeOf(value: T) = typeOf<T>().toString()
 
             task("test") {
-
-                doLast {
-
+                val types = buildList {
                     val ca = container(A::class)
                     val cb = ca.withType<B>()
-                    println(inferredTypeOf(ca))
-                    println(inferredTypeOf(cb))
+                    add(inferredTypeOf(ca))
+                    add(inferredTypeOf(cb))
 
                     val oca: DomainObjectCollection<A> = ca
                     val ocb = oca.withType<B>()
-                    println(inferredTypeOf(oca))
-                    println(inferredTypeOf(ocb))
+                    add(inferredTypeOf(oca))
+                    add(inferredTypeOf(ocb))
 
                     val tt = tasks.withType<Task>()
                     val td = tt.withType<Delete>()
-                    println(inferredTypeOf(tt))
-                    println(inferredTypeOf(td))
+                    add(inferredTypeOf(tt))
+                    add(inferredTypeOf(td))
+                }
+
+                doLast {
+                    types.forEach {
+                        println(it)
+                    }
                 }
             }
             """

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.workers.internal
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.precondition.Requires
@@ -134,7 +134,6 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         failureHasCause("Failed to run Gradle Worker Daemon")
     }
 
-    @ToBeFixedForConfigurationCache(because = "non-serializable fails configuration cache store earlier")
     def "produces a sensible error when a parameter can't be serialized to the worker in #isolationMode"() {
         def workAction = fixture.workActionThatCreatesFiles.writeToBuildSrc()
         def alternateExecution = fixture.alternateWorkAction.writeToBuildSrc()
@@ -148,8 +147,11 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
             task runInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
-                foo = new FooWithUnserializableBar()
                 finalizedBy runAgainInWorker
+                doFirst {
+                    // Storing non-serializable foo at configuration time breaks CC serialization
+                    foo = new FooWithUnserializableBar()
+                }
             }
         """.stripIndent()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.project.taskfactory
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import spock.lang.Issue
 
 class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
@@ -127,7 +126,6 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
         output.contains 'Output: outputFiles$2 [output2.txt]'
     }
 
-    @ToBeFixedForConfigurationCache(because = "task references another task")
     def "nested properties are discovered"() {
         buildFile << classesForNestedProperties()
         buildFile << """
@@ -159,7 +157,6 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
         output.contains "Output file property 'bean.outputDir'"
     }
 
-    @ToBeFixedForConfigurationCache(because = "task references another task")
     def "nested iterable properties have names"() {
         buildFile << printPropertiesTask()
         buildFile """
@@ -194,7 +191,6 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
         output.contains "Input property 'beans.\$1.secondInput'"
     }
 
-    @ToBeFixedForConfigurationCache(because = "task references another task")
     def "nested destroyables are discovered"() {
         buildFile << classesForNestedProperties()
         buildFile << """
@@ -225,7 +221,6 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
         output =~ /Destroys: '.*destroyed'/
     }
 
-    @ToBeFixedForConfigurationCache(because = "task references another task")
     def "nested local state is discovered"() {
         buildFile << classesForNestedProperties()
         buildFile << """
@@ -256,7 +251,6 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
         output =~ /Local state: '.*localState'/
     }
 
-    @ToBeFixedForConfigurationCache(because = "task references another task")
     def "unnamed file properties are named"() {
         buildFile << """
             import org.gradle.api.internal.tasks.*
@@ -288,7 +282,6 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/4085")
-    @ToBeFixedForConfigurationCache(because = "task references another task")
     def "can register more unnamed properties after properties have been queried"() {
         buildFile << """
             import org.gradle.api.internal.tasks.*
@@ -329,7 +322,6 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
             """.stripIndent()
     }
 
-    @ToBeFixedForConfigurationCache(because = "task references another task")
     def "input properties can be overridden"() {
         buildFile << classesForNestedProperties()
         buildFile """
@@ -397,7 +389,8 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
     }
 
     String printPropertiesTask() {
-        """
+        groovySnippet """
+            import org.gradle.api.internal.TaskInternal
             import org.gradle.api.internal.tasks.*
             import org.gradle.api.internal.tasks.properties.*
             import org.gradle.internal.fingerprint.*
@@ -410,35 +403,53 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
                 @Inject
                 abstract PropertyWalker getPropertyWalker()
                 @Internal
-                Task task
-                @TaskAction
-                void printInputsAndOutputs() {
-                    TaskPropertyUtils.visitProperties(propertyWalker, task, new PropertyVisitor() {
+                transient Task task
+
+                private final Provider<List<String>> inputsProvider = project.provider {
+                    def inputsList = new ArrayList<String>()
+                    TaskPropertyUtils.visitProperties(propertyWalker, task as TaskInternal, new PropertyVisitor() {
                         @Override
                         void visitInputProperty(String propertyName, PropertyValue value, boolean optional) {
-                            println "Input property '\${propertyName}'"
+                            inputsList.add "Input property '\${propertyName}'"
                         }
 
                         @Override
-                        void visitInputFileProperty(String propertyName, boolean optional, InputBehavior behavior, DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, @Nullable FileNormalizer fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
-                            println "Input file property '\${propertyName}'"
+                        void visitInputFileProperty(
+                            String propertyName,
+                            boolean optional,
+                            InputBehavior behavior,
+                            DirectorySensitivity directorySensitivity,
+                            LineEndingSensitivity lineEndingSensitivity,
+                            @Nullable FileNormalizer fileNormalizer,
+                            PropertyValue value,
+                            InputFilePropertyType filePropertyType
+                        ) {
+                            inputsList.add "Input file property '\${propertyName}'"
                         }
 
                         @Override
                         void visitOutputFileProperty(String propertyName, boolean optional, PropertyValue value, OutputFilePropertyType filePropertyType) {
-                            println "Output file property '\${propertyName}'"
+                            inputsList.add "Output file property '\${propertyName}'"
                         }
 
                         @Override
                         void visitDestroyableProperty(Object path) {
-                            println "Destroys: '\${path.call()}'"
+                            inputsList.add "Destroys: '\${path.call()}'"
                         }
 
                         @Override
                         void visitLocalStateProperty(Object value) {
-                            println "Local state: '\${value.call()}'"
+                            inputsList.add "Local state: '\${value.call()}'"
                         }
                     })
+                    return inputsList
+                }
+
+                @TaskAction
+                void printInputsAndOutputs() {
+                    inputsProvider.get().forEach {
+                        println it
+                    }
                 }
             }
         """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
@@ -17,13 +17,11 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue
 
-import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip.INVESTIGATE
 import static org.junit.Assert.assertTrue
 
 class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec implements UnreadableCopyDestinationFixture {
@@ -180,16 +178,15 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec implements 
     }
 
     @Requires(UnitTestPreconditions.FilePermissions)
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "file permissions can be modified in copy action"() {
         given:
         file("reference.txt") << 'test file"'
 
         and:
-        buildFile << """
+        buildFile """
             task copy {
                 doLast {
-                    copy {
+                    services.get(FileSystemOperations).copy {
                         from 'reference.txt'
                         into 'build/tmp'
                         filePermissions { unix($mode) }

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/worker/DefaultWorkerProcessBuilderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/worker/DefaultWorkerProcessBuilderIntegrationTest.groovy
@@ -18,54 +18,78 @@ package org.gradle.process.internal.worker
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
-
-import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip.INVESTIGATE
+import org.gradle.util.internal.TextUtil
 
 class DefaultWorkerProcessBuilderIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "test classpath does not contain nonexistent entries"() {
-        String integTestHomeDir = IntegrationTestBuildContext.INSTANCE.getGradleUserHomeDir().absolutePath
         given:
-        file("src/test/java/ClasspathTest.java") << """
-        import org.junit.Test;
+        def existingDir = TextUtil.escapeString(createDir("existing").absolutePath)
+        def nonExistingDir = TextUtil.escapeString(new File(existingDir, "Non exist path").absolutePath)
 
-        import static org.junit.Assert.assertTrue;
+        javaFile("src/test/java/ClasspathTest.java", """
+            import org.junit.Test;
+            import java.io.*;
+            import java.util.*;
+            import java.util.stream.*;
+            import java.util.regex.Pattern;
 
-        public class ClasspathTest {
-            @Test
-            public void test() {
-                String runtimeClasspath = System.getProperty("java.class.path");
-                System.out.println(runtimeClasspath);
-                assertTrue(runtimeClasspath.contains("${integTestHomeDir.replace("\\", "\\\\")}"));
-                assertTrue(!runtimeClasspath.contains("Non exist path"));
+            import static org.junit.Assert.*;
+
+            public class ClasspathTest {
+                private static final File EXISTING_DIR = new File("$existingDir");
+                private static final File NON_EXISTING_DIR = new File("$nonExistingDir");
+
+                @Test
+                public void test() {
+                    List<File> runtimeClasspath = Arrays.stream(
+                            System.getProperty("java.class.path").split(Pattern.quote(File.pathSeparator))
+                        ).map(File::new)
+                        .collect(Collectors.toList());
+
+                    runtimeClasspath.forEach(System.out::println);  // Help debugging
+
+                    assertTrue("Must contain existing dir: " + EXISTING_DIR, runtimeClasspath.contains(EXISTING_DIR));
+                    assertTrue("Must contain existing dir with star: " + EXISTING_DIR, runtimeClasspath.contains(new File(EXISTING_DIR, "*")));
+                    assertFalse("Must not contain non-existent path: " + NON_EXISTING_DIR, runtimeClasspath.contains(NON_EXISTING_DIR));
+                    assertFalse("Must not contain non-existent path with star: " + NON_EXISTING_DIR, runtimeClasspath.contains(new File(NON_EXISTING_DIR, "*")));
+                }
             }
-        }
+        """)
 
-        """
-        buildFile << """
-        plugins {
-            id "java-library"
-        }
-
-        repositories {
-            mavenCentral()
-        }
-
-        dependencies {
-            testImplementation 'junit:junit:4.13'
-        }
-
-        tasks.test {
-            doFirst {
-                classpath += files(System.getProperty("user.home"),
-                        System.getProperty("user.home") + File.separator + "*",
-                        System.getProperty("user.home") + File.separator + "Non exist path",
-                        System.getProperty("user.home") + File.separator + "Non exist path" + File.separator + "*")
+        buildFile """
+            plugins {
+                id "java-library"
             }
-        }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                testImplementation 'junit:junit:4.13'
+            }
+
+            tasks.test {
+                doNotTrackState("Non-existent inputs, skip fingerprint to avoid failure")
+
+                testLogging {
+                    showStandardStreams = true
+                    exceptionFormat = "full"
+                }
+
+                def existingDir = new File("$existingDir")
+                def nonExistingDir = new File("$nonExistingDir")
+
+                def extraClasspath = files(
+                    existingDir,
+                    new File(existingDir, "*"),
+                    nonExistingDir,
+                    new File(nonExistingDir, "*")
+                )
+
+                classpath += extraClasspath
+            }
         """
 
         expect:


### PR DESCRIPTION
Mostly trivial changes to isolate configuration-time-only data or get rid of captured script references 