### PR TITLE
Produce only a single artifact set per variant in the graph

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvedDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvedDependency.java
@@ -16,9 +16,7 @@
 
 package org.gradle.api.internal.artifacts;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ListMultimap;
 import org.apache.commons.lang3.ObjectUtils;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -44,7 +42,6 @@ import java.util.TreeSet;
 public class DefaultResolvedDependency implements ResolvedDependency {
     private final Set<DefaultResolvedDependency> children = new LinkedHashSet<>();
     private final Set<ResolvedDependency> parents = new LinkedHashSet<>();
-    private final ListMultimap<ResolvedDependency, ResolvedArtifactSet> parentArtifacts = ArrayListMultimap.create();
     private final String variantName;
     private final ModuleVersionIdentifier moduleVersionId;
     private final BuildOperationExecutor buildOperationExecutor;
@@ -136,7 +133,7 @@ public class DefaultResolvedDependency implements ResolvedDependency {
         if (!parents.contains(parent)) {
             throw new InvalidUserDataException("Provided dependency (" + parent + ") must be a parent of: " + this);
         }
-        return CompositeResolvedArtifactSet.of(parentArtifacts.get(parent));
+        return ResolvedArtifactSet.EMPTY;
     }
 
     @Override
@@ -190,11 +187,6 @@ public class DefaultResolvedDependency implements ResolvedDependency {
     public void addChild(DefaultResolvedDependency child) {
         children.add(child);
         child.parents.add(this);
-    }
-
-    public void addParentSpecificArtifacts(ResolvedDependency parent, ResolvedArtifactSet artifacts) {
-        this.parentArtifacts.put(parent, artifacts);
-        moduleArtifacts.add(artifacts);
     }
 
     public void addModuleArtifacts(ResolvedArtifactSet artifacts) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolutionExecutor.java
@@ -376,7 +376,8 @@ public class ResolutionExecutor {
             artifactsVisitor,
             immutableArtifactTypeRegistry,
             variantArtifactSetCache,
-            calculatedValueContainerFactory
+            calculatedValueContainerFactory,
+            attributesFactory
         );
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultResolvedArtifactsBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultResolvedArtifactsBuilder.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
-import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,25 +34,14 @@ public class DefaultResolvedArtifactsBuilder implements DependencyArtifactsVisit
     }
 
     @Override
-    public void visitArtifacts(DependencyGraphNode from, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifacts) {
-        collectArtifacts(artifactSetId, artifacts);
-    }
-
-    @Override
-    public void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts) {
+    public void visitArtifacts(DependencyGraphNode from, int artifactSetId, ArtifactSet artifacts) {
         // Don't collect build dependencies if not required
         if (!buildProjectDependencies) {
             artifacts = new NoBuildDependenciesArtifactSet(artifacts);
         }
-        collectArtifacts(artifactSetId, artifacts);
-    }
-
-    private void collectArtifacts(int artifactSetId, ArtifactSet artifacts) {
         // Collect artifact sets in a list, using the id of the set as its index in the list
-        assert artifactSetsById.size() >= artifactSetId;
-        if (artifactSetsById.size() == artifactSetId) {
-            artifactSetsById.add(artifacts);
-        }
+        assert artifactSetsById.size() == artifactSetId;
+        artifactSetsById.add(artifacts);
     }
 
     public VisitedArtifactResults complete() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DependencyArtifactsVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DependencyArtifactsVisitor.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
-import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 
 public interface DependencyArtifactsVisitor {
     /**
@@ -27,17 +26,16 @@ public interface DependencyArtifactsVisitor {
     default void visitNode(DependencyGraphNode node) {}
 
     /**
-     * Visits the artifacts introduced by a particular edge in the graph. Called for every edge in the graph.
+     * Visits a particular edge in the graph. Called for every edge in the graph.
      * The nodes are visited in consumer-first order.
      */
-    default void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts) {}
+    default void visitEdge(DependencyGraphNode from, DependencyGraphNode to) {}
 
     /**
-     * Visits the artifacts introduce by a particular node in the graph. Called *zero or more* times for each node.
-     * Currently local files are treated differently to other dependencies.
+     * Visits the artifacts introduce by a particular node in the graph. Called once for each node.
      * The nodes are visited in consumer-first order
      */
-    default void visitArtifacts(DependencyGraphNode from, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifactSet) {}
+    default void visitArtifacts(DependencyGraphNode from, int artifactSetId, ArtifactSet artifactSet) {}
 
     /**
      * Completes visiting.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
@@ -26,11 +26,9 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.immutable.artifact.ImmutableArtifactTypeRegistry;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
-import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -125,21 +123,15 @@ public class ResolvedArtifactsGraphVisitor implements DependencyGraphVisitor {
         VariantGraphResolveState variant = node.getResolveState();
 
         ImmutableAttributes attributes = dependency.getAttributes();
-        List<IvyArtifactName> artifacts = dependency.getDependencyMetadata().getArtifacts();
-        ExcludeSpec exclusions = dependency.getExclusions();
         Set<CapabilitySelector> capabilitySelectors = dependency.getDependencyMetadata().getSelector().getCapabilitySelectors();
 
         // If all dependency modifiers are empty, this edge does not produce an adhoc artifact set.
-        if (artifacts.isEmpty() &&
-            attributes.isEmpty() &&
-            capabilitySelectors.isEmpty() &&
-            !exclusions.mayExcludeArtifacts()
-        ) {
+        if (attributes.isEmpty() && capabilitySelectors.isEmpty()) {
             return false;
         }
 
         int id = nextId++;
-        VariantResolvingArtifactSet artifactSet = new VariantResolvingArtifactSet(component, variant, attributes, artifacts, exclusions, capabilitySelectors);
+        VariantResolvingArtifactSet artifactSet = new VariantResolvingArtifactSet(component, variant, attributes, node, capabilitySelectors);
         artifactResults.visitArtifacts(dependency.getFrom(), node, id, artifactSet);
 
         return true;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantArtifactSetCache.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantArtifactSetCache.java
@@ -85,7 +85,6 @@ public class VariantArtifactSetCache {
             component,
             variant,
             ImmutableAttributes.EMPTY,
-            Collections.emptyList(),
             EXCLUDE_NOTHING,
             Collections.emptySet()
         );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/CompositeDependencyArtifactsVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/CompositeDependencyArtifactsVisitor.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor;
-import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 
 import java.util.List;
 
@@ -37,16 +36,16 @@ public class CompositeDependencyArtifactsVisitor implements DependencyArtifactsV
     }
 
     @Override
-    public void visitArtifacts(DependencyGraphNode from, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifactSet) {
+    public void visitArtifacts(DependencyGraphNode from, int artifactSetId, ArtifactSet artifactSet) {
         for (DependencyArtifactsVisitor visitor : visitors) {
-            visitor.visitArtifacts(from, fileDependency, artifactSetId, artifactSet);
+            visitor.visitArtifacts(from, artifactSetId, artifactSet);
         }
     }
 
     @Override
-    public void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts) {
+    public void visitEdge(DependencyGraphNode from, DependencyGraphNode to) {
         for (DependencyArtifactsVisitor visitor : visitors) {
-            visitor.visitArtifacts(from, to, artifactSetId, artifacts);
+            visitor.visitEdge(from, to);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphNode.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphNode.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.model.VariantGraphResolveMetadata;
 
@@ -45,4 +46,10 @@ public interface DependencyGraphNode extends ResolvedGraphVariant {
     boolean isSelected();
 
     ComponentResolutionState getComponent();
+
+    /**
+     * Get all excludes that apply to this node, including all excludes from
+     * the incoming edges and the node itself.
+     */
+    ExcludeSpec getAllExcludes();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -243,7 +243,7 @@ public class NodeState implements DependencyGraphNode {
         }
 
         // Determine the net exclusion for this node, by inspecting all transitive incoming edges
-        ExcludeSpec resolutionFilter = computeModuleResolutionFilter(incomingEdges);
+        ExcludeSpec resolutionFilter = getAllExcludes();
 
         // Virtual platforms require their constraints to be recomputed each time as each module addition can cause a shift in versions
         if (!isVirtualPlatformNeedsRefresh()) {
@@ -700,6 +700,11 @@ public class NodeState implements DependencyGraphNode {
         return isSelected() && !component.getModule().isVirtualPlatform();
     }
 
+    @Override
+    public ExcludeSpec getAllExcludes() {
+        return computeModuleResolutionFilter(incomingEdges);
+    }
+
     private ExcludeSpec computeModuleResolutionFilter(List<EdgeState> incomingEdges) {
         if (metadata.isExternalVariant()) {
             // If the current node represents an external variant, we must not consider its excludes
@@ -842,7 +847,7 @@ public class NodeState implements DependencyGraphNode {
     }
 
     private void collectOwnStrictVersions() {
-        List<DependencyState> dependencies = dependencies(computeModuleResolutionFilter(incomingEdges));
+        List<DependencyState> dependencies = dependencies(getAllExcludes());
         Set<ModuleIdentifier> constraintsSet = null;
         for (DependencyState dependencyState : dependencies) {
             constraintsSet = maybeCollectStrictVersions(constraintsSet, dependencyState);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/TransientConfigurationResultsBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/TransientConfigurationResultsBuilder.java
@@ -35,7 +35,6 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.cache.internal.BinaryStore;
 import org.gradle.cache.internal.Store;
-import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.time.Time;
@@ -116,17 +115,16 @@ public class TransientConfigurationResultsBuilder implements DependencyArtifacts
     }
 
     @Override
-    public void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts) {
+    public void visitEdge(DependencyGraphNode from, DependencyGraphNode to) {
         binaryStore.write(encoder -> {
             encoder.writeByte(EDGE);
             encoder.writeSmallLong(from.getNodeId());
             encoder.writeSmallLong(to.getNodeId());
-            encoder.writeSmallInt(artifactSetId);
         });
     }
 
     @Override
-    public void visitArtifacts(DependencyGraphNode from, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifactSet) {
+    public void visitArtifacts(DependencyGraphNode from, int artifactSetId, ArtifactSet artifactSet) {
         binaryStore.write(encoder -> {
             encoder.writeByte(NODE_ARTIFACTS);
             encoder.writeSmallLong(from.getNodeId());
@@ -203,8 +201,6 @@ public class TransientConfigurationResultsBuilder implements DependencyArtifacts
                             throw new IllegalStateException(String.format("Unexpected child dependency id %s. Seen ids: %s", childId, allDependencies.keySet()));
                         }
                         parent.addChild(child);
-                        artifacts = artifactResults.getArtifactsWithId(decoder.readSmallInt());
-                        child.addParentSpecificArtifacts(parent, artifacts);
                         break;
                     case NODE_ARTIFACTS:
                         id = decoder.readSmallLong();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/SpecificArtifactsVariantGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/SpecificArtifactsVariantGraphResolveState.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.Describables;
+import org.gradle.internal.component.external.model.ImmutableCapabilities;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A variant in the graph derived from another variant, which exposes specific artifacts
+ * during artifact resolution instead of the original variant's artifacts.
+ * <p>
+ * This is modeled as a separate variant instead of adding additional artifacts to the
+ * original variant during artifact selection, since the user-specified artifacts are
+ * _not_ part of the original variant. By requesting specific artifacts, the user has
+ * explicitly requested to create/select a new variant that only contains those artifacts.
+ */
+public class SpecificArtifactsVariantGraphResolveState implements VariantGraphResolveState {
+
+    private final long instanceId;
+    private final ComponentIdentifier componentIdentifier;
+    private final VariantGraphResolveState delegate;
+    private final List<IvyArtifactName> artifactNames;
+    private final ImmutableAttributes componentAttributes;
+    private final VariantGraphResolveMetadata metadata;
+
+    public SpecificArtifactsVariantGraphResolveState(
+        long instanceId,
+        ComponentIdentifier componentIdentifier,
+        VariantGraphResolveState delegate,
+        List<IvyArtifactName> artifactNames,
+        ImmutableAttributes componentAttributes
+    ) {
+        this.instanceId = instanceId;
+        this.componentIdentifier = componentIdentifier;
+        this.delegate = delegate;
+        this.artifactNames = artifactNames;
+        this.componentAttributes = componentAttributes;
+        this.metadata = new SpecificArtifactsVariantGraphResolveMetadata(delegate.getMetadata(), artifactNames, componentAttributes);
+    }
+
+    @Override
+    public long getInstanceId() {
+        return instanceId;
+    }
+
+    @Override
+    public String getName() {
+        return metadata.getName();
+    }
+
+    @Override
+    public ImmutableAttributes getAttributes() {
+        return metadata.getAttributes();
+    }
+
+    @Override
+    public ImmutableCapabilities getCapabilities() {
+        return metadata.getCapabilities();
+    }
+
+    @Override
+    public VariantGraphResolveMetadata getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public List<? extends DependencyMetadata> getDependencies() {
+        return delegate.getDependencies();
+    }
+
+    @Override
+    public List<? extends ExcludeMetadata> getExcludes() {
+        return delegate.getExcludes();
+    }
+
+    @Override
+    public VariantArtifactResolveState prepareForArtifactResolution() {
+        return new SpecificArtifactsVariantArtifactResolveState();
+    }
+
+    private static class SpecificArtifactsVariantGraphResolveMetadata implements VariantGraphResolveMetadata {
+
+        private final VariantGraphResolveMetadata delegate;
+        private final List<IvyArtifactName> artifactNames;
+        private final ImmutableAttributes componentAttributes;
+
+        public SpecificArtifactsVariantGraphResolveMetadata(
+            VariantGraphResolveMetadata delegate,
+            List<IvyArtifactName> artifactNames,
+            ImmutableAttributes componentAttributes
+        ) {
+            this.delegate = delegate;
+            this.artifactNames = artifactNames;
+            this.componentAttributes = componentAttributes;
+        }
+
+        @Override
+        public String getName() {
+            return delegate.getName() + " with artifacts " + artifactNames;
+        }
+
+        @Override
+        public VariantIdentifier getId() {
+            return new VariantWithSpecificArtifactsIdentifier(delegate.getId(), artifactNames);
+        }
+
+        @Override
+        public ImmutableAttributes getAttributes() {
+            // We do not know the attributes of the specific artifacts, so we fall back the component attributes.
+            return componentAttributes;
+        }
+
+        @Override
+        public ImmutableCapabilities getCapabilities() {
+            // We do not know the capabilities of the specific artifacts, so we do not declare any capabilities.
+            // This variant should not participate in capability conflict detection.
+            return ImmutableCapabilities.EMPTY;
+        }
+
+        @Override
+        public boolean isTransitive() {
+            return delegate.isTransitive();
+        }
+
+        @Override
+        public boolean isExternalVariant() {
+            return delegate.isExternalVariant();
+        }
+    }
+
+    /**
+     * Exposes the specific artifacts of this variant to artifact selection as a single adhoc artifact set.
+     */
+    private class SpecificArtifactsVariantArtifactResolveState implements VariantArtifactResolveState {
+
+        @Override
+        public ImmutableList<ComponentArtifactMetadata> getAdhocArtifacts(List<IvyArtifactName> dependencyArtifacts) {
+            return delegate.prepareForArtifactResolution().getAdhocArtifacts(dependencyArtifacts);
+        }
+
+        @Override
+        public Set<? extends VariantResolveMetadata> getArtifactVariants() {
+            ImmutableList<ComponentArtifactMetadata> artifacts = getAdhocArtifacts(artifactNames);
+
+            ImmutableList.Builder<ComponentArtifactIdentifier> allArtifactIds = ImmutableList.builderWithExpectedSize(artifacts.size());
+            for (ComponentArtifactMetadata artifact : artifacts) {
+                allArtifactIds.add(artifact.getId());
+            }
+
+            VariantResolveMetadata.Identifier identifier =
+                new SpecificArtifactsArtifactSetId(allArtifactIds.build());
+
+            return ImmutableSet.of(new DefaultVariantMetadata(
+                "adhoc",
+                identifier,
+                Describables.of("adhoc variant for", componentIdentifier),
+                componentAttributes,
+                artifacts,
+                ImmutableCapabilities.EMPTY
+            ));
+        }
+
+    }
+
+    /**
+     * Identifies an adhoc variant of a component that is derived from another variant, but
+     * instead provides the artifacts corresponding to the given artifact names.
+     */
+    public static class VariantWithSpecificArtifactsIdentifier implements VariantIdentifier {
+
+        private final VariantIdentifier delegate;
+        private final List<IvyArtifactName> artifactNames;
+        private final int hashCode;
+
+        public VariantWithSpecificArtifactsIdentifier(VariantIdentifier delegate, List<IvyArtifactName> artifactNames) {
+            this.delegate = delegate;
+            this.artifactNames = artifactNames;
+            this.hashCode = computeHashCode(artifactNames, delegate);
+        }
+
+        @Override
+        public ComponentIdentifier getComponentId() {
+            return delegate.getComponentId();
+        }
+
+        public VariantIdentifier getDelegate() {
+            return delegate;
+        }
+
+        public List<IvyArtifactName> getArtifactNames() {
+            return artifactNames;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return delegate.getDisplayName() + " with artifacts " + artifactNames;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            VariantWithSpecificArtifactsIdentifier that = (VariantWithSpecificArtifactsIdentifier) o;
+            return delegate.equals(that.delegate) && artifactNames.equals(that.artifactNames);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        private static int computeHashCode(List<IvyArtifactName> artifactNames, VariantIdentifier delegate) {
+            int result = delegate.hashCode();
+            result = 31 * result + artifactNames.hashCode();
+            return result;
+        }
+
+    }
+
+    /**
+     * Identifier for an adhoc variant artifact set with attributes identified by the given identifiers.
+     */
+    private static class SpecificArtifactsArtifactSetId implements VariantResolveMetadata.Identifier {
+
+        private final ImmutableList<ComponentArtifactIdentifier> artifactIds;
+        private final int hashCode;
+
+        public SpecificArtifactsArtifactSetId(ImmutableList<ComponentArtifactIdentifier> artifactIds) {
+            this.artifactIds = artifactIds;
+            this.hashCode = artifactIds.hashCode();
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null || obj.getClass() != getClass()) {
+                return false;
+            }
+            SpecificArtifactsArtifactSetId other = (SpecificArtifactsArtifactSetId) obj;
+            return artifactIds.equals(other.artifactIds);
+        }
+
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantArtifactResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantArtifactResolveState.java
@@ -33,6 +33,7 @@ public interface VariantArtifactResolveState {
      *
      * This is used to resolve artifacts declared as part of a dependency.
      */
+    // TODO: This should be a property of a component, not a variant.
     ImmutableList<ComponentArtifactMetadata> getAdhocArtifacts(List<IvyArtifactName> dependencyArtifacts);
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultVariantArtifactResolver.java
@@ -17,18 +17,15 @@
 package org.gradle.internal.resolve.resolver;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
-import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactBackedResolvedVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.immutable.artifact.ImmutableArtifactTypeRegistry;
-import org.gradle.internal.Describables;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
-import org.gradle.internal.component.model.DefaultVariantMetadata;
+import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.jspecify.annotations.Nullable;
 
@@ -45,24 +42,6 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
         this.artifactTypeRegistry = artifactTypeRegistry;
         this.artifactResolver = artifactResolver;
         this.resolvedVariantCache = resolvedVariantCache;
-    }
-
-    @Override
-    public ResolvedVariant resolveAdhocVariant(ComponentArtifactResolveMetadata component, VariantIdentifier sourceVariantId, ImmutableList<? extends ComponentArtifactMetadata> artifacts) {
-        VariantResolveMetadata.Identifier identifier = artifacts.size() == 1
-            ? new SingleArtifactVariantIdentifier(artifacts.iterator().next().getId())
-            : null;
-
-        VariantResolveMetadata adhoc = new DefaultVariantMetadata(
-            "adhoc",
-            identifier,
-            Describables.of("adhoc variant for", component.getId()),
-            component.getAttributes(),
-            artifacts,
-            ImmutableCapabilities.EMPTY
-        );
-
-        return resolveVariantArtifactSet(component, sourceVariantId, adhoc);
     }
 
     @Override
@@ -139,34 +118,6 @@ public class DefaultVariantArtifactResolver implements VariantArtifactResolver {
             return ImmutableCapabilities.of(DefaultImmutableCapability.defaultCapabilityForComponent(component.getModuleVersionId()));
         } else {
             return capabilities;
-        }
-    }
-
-    /**
-     * Identifier for adhoc variants with a single artifact
-     */
-    private static class SingleArtifactVariantIdentifier implements VariantResolveMetadata.Identifier {
-        private final ComponentArtifactIdentifier artifactIdentifier;
-
-        public SingleArtifactVariantIdentifier(ComponentArtifactIdentifier artifactIdentifier) {
-            this.artifactIdentifier = artifactIdentifier;
-        }
-
-        @Override
-        public int hashCode() {
-            return artifactIdentifier.hashCode();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (obj == null || obj.getClass() != getClass()) {
-                return false;
-            }
-            SingleArtifactVariantIdentifier other = (SingleArtifactVariantIdentifier) obj;
-            return artifactIdentifier.equals(other.artifactIdentifier);
         }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/VariantArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/VariantArtifactResolver.java
@@ -16,19 +16,12 @@
 
 package org.gradle.internal.resolve.resolver;
 
-import com.google.common.collect.ImmutableList;
-import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
-import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
+import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
 public interface VariantArtifactResolver {
-
-    /**
-     * Creates an adhoc resolved variant which resolves the provided artifacts of the component.
-     */
-    ResolvedVariant resolveAdhocVariant(ComponentArtifactResolveMetadata component, VariantIdentifier sourceVariantId, ImmutableList<? extends ComponentArtifactMetadata> artifacts);
 
     /**
      * Resolve the artifacts described by the given variant artifact metadata, owned by the given component.

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSetTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSetTest.groovy
@@ -55,7 +55,7 @@ class VariantResolvingArtifactSetTest extends Specification {
 
     def "returns empty set when component id does not match spec"() {
         when:
-        def artifactSet = new VariantResolvingArtifactSet(component, variant, ImmutableAttributes.EMPTY, [], noExcludes(), [] as Set)
+        def artifactSet = new VariantResolvingArtifactSet(component, variant, ImmutableAttributes.EMPTY, noExcludes(), [] as Set)
         def spec = new ArtifactSelectionSpec(ImmutableAttributes.EMPTY, { false }, selectFromAll, false, ResolutionStrategy.SortOrder.DEFAULT)
         def selected = artifactSet.select(services, spec)
 
@@ -77,7 +77,7 @@ class VariantResolvingArtifactSetTest extends Specification {
 
         when:
         def spec = new ArtifactSelectionSpec(ImmutableAttributes.EMPTY, { true }, false, false, ResolutionStrategy.SortOrder.DEFAULT)
-        def artifactSet = new VariantResolvingArtifactSet(component, variant, ImmutableAttributes.EMPTY, [], noExcludes(), [] as Set)
+        def artifactSet = new VariantResolvingArtifactSet(component, variant, ImmutableAttributes.EMPTY, noExcludes(), [] as Set)
         services.getArtifactVariantSelector() >> new ArtifactVariantSelector() {
             @Override
             ResolvedArtifactSet select(ResolvedVariantSet candidates, ImmutableAttributes requestAttributes, boolean allowNoMatchingVariants) {
@@ -104,7 +104,7 @@ class VariantResolvingArtifactSetTest extends Specification {
         }
 
         def artifacts = Stub(ResolvedArtifactSet)
-        def artifactSet = new VariantResolvingArtifactSet(component, variant, ImmutableAttributes.EMPTY, [], noExcludes(), [] as Set)
+        def artifactSet = new VariantResolvingArtifactSet(component, variant, ImmutableAttributes.EMPTY, noExcludes(), [] as Set)
 
         when:
         def spec = new ArtifactSelectionSpec(ImmutableAttributes.EMPTY, { true }, selectFromAll, false, ResolutionStrategy.SortOrder.DEFAULT)


### PR DESCRIPTION
The upcoming "Artifact Graph" functionality will allow users to navigate a graph of artifacts, where each node corresponds to the artifacts derived by a node in the dependency graph. 

Prior to this PR, we did not have a one-to-one mapping between nodes in the graph and artifact sets produced by that node. Instead, _incoming edges_ to a node produced artifacts. In many cases edges are identical and we could deduplicate results with the "implicit" artifact set for that node, but in some cases, we needed to use adhoc edge-specific artifact sets:
- Explicit requested artifacts on the edge
- Attributes on the edge
- Capabilities on the edge
- Excludes on the edge

This PR solves this in two ways
1. For artifacts on the edge, we introduce a new type of node in the graph that represents a node with its artifacts replaced. This node is identical to the source node, but with manually specified artifacts.
2. For attributes, capabilities, and excludes, we merge their values into an aggregate set of values that can be used to select a single artifact set. 


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
