### PR TITLE
Suppress deprecations during degradations collecting

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
@@ -87,9 +87,9 @@ internal class ConfigurationCachePromoHandler(
             // Collecting degradation reasons may be somewhat expensive, let's skip it if the build is already incompatible.
             // We can only collect the reasons before the start of the execution phase. CC does that too.
 
+            val hasDegradationReasons = DeprecationLogger.whileDisabled(
             // Collecting degradation reasons uses Task.project call internally, which is deprecated at execution time.
             // We disable deprecations for the computation until we'll have a proper build lifecycle callback.
-            val hasDegradationReasons = DeprecationLogger.whileDisabled(
                 Factory {
                     degradationController.collectDegradationReasons()
                     degradationController.hasDegradationReasons


### PR DESCRIPTION
Follow up at #34188 

After https://github.com/gradle/gradle/pull/34188 was merged, `EclipseMultiBuildIntegrationTest.buildSrc project can apply IDE plugin` became flaky. See https://ge.gradle.org/scans/tests?search.timeZoneId=Australia%2FBrisbane&tests.container=org.gradle.plugins.ide.eclipse.EclipseMultiBuildIntegrationTest&tests.test=buildSrc%20project%20can%20apply%20IDE%20plugin

The reason is that after #34188 we started to call degradations collecting at execution time, which is deprecated. This PR suppresses deprecations for this process during CC promo handling as a workaround for RC.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
