### PR TITLE
Migrate away from variant names and components with module version Ids

### DIFF
--- a/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReport.out
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReport.out
@@ -2,7 +2,7 @@ log4j:log4j:1.2.16 FAILED
    Failures:
       - Could not resolve log4j:log4j:1.2.16.
           - Module 'log4j:log4j' has been rejected:
-               Cannot select module with conflict on capability 'log4j:log4j:1.2.16' also provided by [org.slf4j:log4j-over-slf4j:1.7.10(compile)]
+               Cannot select module with conflict on capability 'log4j:log4j:1.2.16' also provided by ['org.slf4j:log4j-over-slf4j:1.7.10' (compile)]
 
 log4j:log4j:1.2.16 FAILED
 \--- org.apache.zookeeper:zookeeper:3.4.9
@@ -12,7 +12,7 @@ org.slf4j:log4j-over-slf4j:1.7.10 FAILED
    Failures:
       - Could not resolve org.slf4j:log4j-over-slf4j:1.7.10.
           - Module 'org.slf4j:log4j-over-slf4j' has been rejected:
-               Cannot select module with conflict on capability 'log4j:log4j:1.7.10' also provided by [log4j:log4j:1.2.16(compile)]
+               Cannot select module with conflict on capability 'log4j:log4j:1.7.10' also provided by ['log4j:log4j:1.2.16' (compile)]
 
 org.slf4j:log4j-over-slf4j:1.7.10 FAILED
 \--- compileClasspath

--- a/platforms/documentation/docs/src/snippets/java-feature-variant/incompatible-variants/tests/runtimeClasspath.out
+++ b/platforms/documentation/docs/src/snippets/java-feature-variant/incompatible-variants/tests/runtimeClasspath.out
@@ -4,7 +4,7 @@ project :producer FAILED
    Failures:
       - Could not resolve project :producer.
           - Module 'org.gradle.demo:producer' has been rejected:
-               Cannot select module with conflict on capability 'org.gradle.demo:producer-db-support:1.0' also provided by [org.gradle.demo:producer:1.0(postgresSupportRuntimeElements), org.gradle.demo:producer:1.0(mysqlSupportRuntimeElements)]
+               Cannot select module with conflict on capability 'org.gradle.demo:producer-db-support:1.0' also provided by ['project :producer' (postgresSupportRuntimeElements), 'project :producer' (mysqlSupportRuntimeElements)]
 
 project :producer FAILED
 \--- runtimeClasspath

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -54,8 +54,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:foo:17'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' (runtime) --> 'org:foo:{strictly 15}' because of the following reason: what not""")
+   Dependency path: 'root project :' (conf) --> 'org:foo:17'
+   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{strictly 15}' because of the following reason: what not""")
 
     }
 
@@ -255,8 +255,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:foo:1.1'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' (runtime) --> 'org:foo:{require 1.0; reject 1.1}'""")
+   Dependency path: 'root project :' (conf) --> 'org:foo:1.1'
+   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{require 1.0; reject 1.1}'""")
     }
 
     void "honors multiple rejections #rejects using dynamic versions using dependency notation #rejects"() {
@@ -290,8 +290,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:foo:1.1'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' (runtime) --> 'org:foo:{require 1.0; reject ${rejects.join(' & ')}}'""")
+   Dependency path: 'root project :' (conf) --> 'org:foo:1.1'
+   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{require 1.0; reject ${rejects.join(' & ')}}'""")
 
         where:
         rejects << [
@@ -332,8 +332,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
-   Dependency path ':test:unspecified' --> 'org:foo:1.0'
-   Constraint path ':test:unspecified' --> 'org:bar:1.0' (runtime) --> 'org:foo:{reject all versions}'""")
+   Dependency path: 'root project :' (conf) --> 'org:foo:1.0'
+   Constraint path: 'root project :' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{reject all versions}'""")
 
     }
 
@@ -388,11 +388,11 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:a:1.0' (runtime) --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
-   Dependency path ':test:unspecified' --> 'org:c:1.0' (runtime) --> 'org:b:1.1'""")
+   Dependency path: 'root project :' (conf) --> 'org:a:1.0' (runtime) --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
+   Dependency path: 'root project :' (conf) --> 'org:c:1.0' (runtime) --> 'org:b:1.1'""")
 
         and:
-        failure.assertHasNoCause("Dependency path ':test:unspecified' --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
+        failure.assertHasNoCause("Dependency path: 'root project :' (conf) --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
     }
 
     def "handles dependency cycles"() {
@@ -447,11 +447,11 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:a:1.0' (runtime) --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
-   Dependency path ':test:unspecified' --> 'org:c:1.0' (runtime) --> 'org:b:1.1'""")
+   Dependency path: 'root project :' (conf) --> 'org:a:1.0' (runtime) --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
+   Dependency path: 'root project :' (conf) --> 'org:c:1.0' (runtime) --> 'org:b:1.1'""")
 
         and:
-        failure.assertHasNoCause("Dependency path ':test:unspecified' --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
+        failure.assertHasNoCause("Dependency path: 'root project :' (conf) --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
     }
 
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
@@ -163,8 +163,8 @@ class ForcingUsingStrictlyPlatformAlignmentTest extends AbstractAlignmentSpec {
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:databind' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:databind:{strictly 2.7.9}'
-   Constraint path ':test:unspecified' --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
+   Dependency path: 'root project :' (conf) --> 'org:databind:{strictly 2.7.9}'
+   Constraint path: 'root project :' (conf) --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
     }
 
     def "fails if forcing a virtual platform version by forcing multiple leaves with different versions, including transitively"() {
@@ -215,8 +215,8 @@ include 'other'
         then:
         def coreVariant = GradleMetadataResolveRunner.gradleMetadataPublished || GradleMetadataResolveRunner.useMaven() ? 'runtime' : 'default'
         failure.assertHasCause """Cannot find a version of 'org:databind' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:databind:{strictly 2.7.9}'
-   Constraint path ':test:unspecified' --> 'test:other:unspecified' (conf) --> 'org:core:2.9.4' ($coreVariant) --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
+   Dependency path: 'root project :' (conf) --> 'org:databind:{strictly 2.7.9}'
+   Constraint path: 'root project :' (conf) --> 'project :other' (conf) --> 'org:core:2.9.4' ($coreVariant) --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
     }
 
     def "succeeds if forcing a virtual platform version by forcing multiple leaves with same version"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -196,7 +196,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause("""Module 'org:test' has been rejected:
-   Cannot select module with conflict on capability 'org:test:1.0' also provided by [org:test:1.0(api), org:test:1.0(runtime)]""")
+   Cannot select module with conflict on capability 'org:test:1.0' also provided by ['org:test:1.0' (api), 'org:test:1.0' (runtime)]""")
     }
 
     @Unroll("can select distinct variants of the same component by using different attributes with capabilities (conflict=#conflict)")
@@ -257,7 +257,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         then:
         if (conflict) {
             failure.assertHasCause("""Module 'org:test' has been rejected:
-   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by [org:test:1.0(runtime), org:test:1.0(api)]""")
+   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by ['org:test:1.0' (runtime), 'org:test:1.0' (api)]""")
         } else {
             resolve.expectGraph {
                 root(":", ":test:") {
@@ -514,7 +514,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
-   Cannot select module with conflict on capability 'org:foo:1.1' also provided by [org:foo:1.1(runtime), org:foo:1.1(api)]""")
+   Cannot select module with conflict on capability 'org:foo:1.1' also provided by ['org:foo:1.1' (runtime), 'org:foo:1.1' (api)]""")
 
     }
 
@@ -679,9 +679,9 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
-   Cannot select module with conflict on capability 'org:foo:1.0' also provided by [org:bar:1.0(runtime)]""")
+   Cannot select module with conflict on capability 'org:foo:1.0' also provided by ['org:bar:1.0' (runtime)]""")
         failure.assertHasCause("""Module 'org:bar' has been rejected:
-   Cannot select module with conflict on capability 'org:foo:1.0' also provided by [org:foo:1.0(runtime)]""")
+   Cannot select module with conflict on capability 'org:foo:1.0' also provided by ['org:foo:1.0' (runtime)]""")
     }
 
     def "detects conflicts between 2 variants of 2 different components with the same capability"() {
@@ -728,9 +728,9 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
-   Cannot select module with conflict on capability 'org:blah:1.0' also provided by [org:bar:1.0(runtime)]""")
+   Cannot select module with conflict on capability 'org:blah:1.0' also provided by ['org:bar:1.0' (runtime)]""")
         failure.assertHasCause("""Module 'org:bar' has been rejected:
-   Cannot select module with conflict on capability 'org:blah:1.0' also provided by [org:foo:1.0(runtime)]""")
+   Cannot select module with conflict on capability 'org:blah:1.0' also provided by ['org:foo:1.0' (runtime)]""")
     }
 
     @ToBeImplemented("https://github.com/gradle/gradle/issues/8386")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
@@ -64,9 +64,9 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
         then:
         failure.assertHasCause("Could not resolve org.hamcrest:hamcrest-core:2.2")
         failure.assertHasCause("Module 'org.hamcrest:hamcrest-core' has been rejected")
-        failure.assertHasErrorOutput("Cannot select module with conflict on capability 'org.hamcrest:hamcrest:2.2' also provided by [org.hamcrest:hamcrest:2.2(runtime)]")
+        failure.assertHasErrorOutput("Cannot select module with conflict on capability 'org.hamcrest:hamcrest:2.2' also provided by ['org.hamcrest:hamcrest:2.2' (runtime)]")
         failure.assertHasCause("Module 'org.hamcrest:hamcrest' has been rejected")
-        failure.assertHasErrorOutput("Cannot select module with conflict on capability 'org.hamcrest:hamcrest:2.2' also provided by [org.hamcrest:hamcrest-core:2.2(runtime)]")
+        failure.assertHasErrorOutput("Cannot select module with conflict on capability 'org.hamcrest:hamcrest:2.2' also provided by ['org.hamcrest:hamcrest-core:2.2' (runtime)]")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/30969")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -53,7 +53,7 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
 
         then:
         failure.assertHasCause("""Module 'test:b' has been rejected:
-   Cannot select module with conflict on capability 'org:capability:1.0' also provided by [:test:unspecified(compileClasspath)]""")
+   Cannot select module with conflict on capability 'org:capability:1.0' also provided by ['root project :' (compileClasspath)]""")
     }
 
     def 'fails to resolve undeclared test fixture'() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
@@ -71,9 +71,9 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
             variant = 'default'
         }
         failure.assertHasCause("""Module 'cglib:cglib-nodep' has been rejected:
-   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib:3.2.5($variant)]""")
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by ['cglib:cglib:3.2.5' ($variant)]""")
         failure.assertHasCause("""Module 'cglib:cglib' has been rejected:
-   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib-nodep:3.2.5($variant)]""")
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by ['cglib:cglib-nodep:3.2.5' ($variant)]""")
     }
 
     def "implicit capability conflict is detected if implicit capability is discovered late"() {
@@ -130,9 +130,9 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
             variant = 'default'
         }
         failure.assertHasCause("""Module 'cglib:cglib-nodep' has been rejected:
-   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib:3.2.5($variant)]""")
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by ['cglib:cglib:3.2.5' ($variant)]""")
         failure.assertHasCause("""Module 'cglib:cglib' has been rejected:
-   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib-nodep:3.2.5($variant)]""")
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by ['cglib:cglib-nodep:3.2.5' ($variant)]""")
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
@@ -286,7 +286,7 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
 
         then:
         failure.assertHasCause("""Module 'org:test' has been rejected:
-   Cannot select module with conflict on capability 'org:capability:1.0' also provided by [:test:unspecified(conf)]""")
+   Cannot select module with conflict on capability 'org:capability:1.0' also provided by ['root project :' (conf)]""")
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -108,7 +108,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 variant = 'default'
             }
             failure.assertHasCause("""Module 'cglib:cglib-nodep' has been rejected:
-   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib:3.2.5($variant)]""")
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by ['cglib:cglib:3.2.5' ($variant)]""")
         }
 
         where:
@@ -223,11 +223,11 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 variant = 'default'
             }
             failure.assertHasCause("""Module 'org.apache:groovy' has been rejected:
-   Cannot select module with conflict on capability 'org.apache:groovy:1.0' also provided by [org.apache:groovy-all:1.0($variant)]""")
+   Cannot select module with conflict on capability 'org.apache:groovy:1.0' also provided by ['org.apache:groovy-all:1.0' ($variant)]""")
             failure.assertHasCause("""Module 'org.apache:groovy-json' has been rejected:
-   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by [org.apache:groovy-all:1.0($variant)]""")
+   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by ['org.apache:groovy-all:1.0' ($variant)]""")
             failure.assertHasCause("""Module 'org.apache:groovy-all' has been rejected:
-   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by [org.apache:groovy-json:1.0($variant)]""")
+   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by ['org.apache:groovy-json:1.0' ($variant)]""")
         }
 
         where:
@@ -346,11 +346,11 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 variant = 'default'
             }
             failure.assertHasCause("""Module 'org.apache:groovy' has been rejected:
-   Cannot select module with conflict on capability 'org.apache:groovy:1.0' also provided by [org.apache:groovy-all:1.0($variant)]""")
+   Cannot select module with conflict on capability 'org.apache:groovy:1.0' also provided by ['org.apache:groovy-all:1.0' ($variant)]""")
             failure.assertHasCause("""Module 'org.apache:groovy-json' has been rejected:
-   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by [org.apache:groovy-all:1.0($variant)]""")
+   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by ['org.apache:groovy-all:1.0' ($variant)]""")
             failure.assertHasCause("""Module 'org.apache:groovy-all' has been rejected:
-   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by [org.apache:groovy-json:1.0($variant)]""")
+   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by ['org.apache:groovy-json:1.0' ($variant)]""")
         }
 
         where:
@@ -496,9 +496,9 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
             }
         } else {
             failure.assertHasCause("""Module 'org:testA' has been rejected:
-   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by [org:testB:1.0(runtime)]""")
+   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by ['org:testB:1.0' (runtime)]""")
             failure.assertHasCause("""Module 'org:testB' has been rejected:
-   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by [org:testA:1.0(runtime)]""")
+   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by ['org:testA:1.0' (runtime)]""")
         }
 
         where:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
@@ -55,9 +55,9 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
 
         then:
         failure.assertHasCause("""Module 'cglib:cglib-nodep' has been rejected:
-   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib:3.2.5(runtime)]""")
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by ['cglib:cglib:3.2.5' (runtime)]""")
         failure.assertHasCause("""Module 'cglib:cglib' has been rejected:
-   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib-nodep:3.2.5(runtime)]""")
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by ['cglib:cglib-nodep:3.2.5' (runtime)]""")
     }
 
     def "can detect conflict with capability in different versions and upgrade to latest version (#rule)"() {
@@ -147,7 +147,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
 
         then:
         failure.assertHasCause("""Module 'org:test' has been rejected:
-   Cannot select module with conflict on capability 'org:capability:1.0' also provided by [:test:unspecified(conf)]""")
+   Cannot select module with conflict on capability 'org:capability:1.0' also provided by ['root project :' (conf)]""")
     }
 
     /**
@@ -191,9 +191,9 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
 
         then:
         failure.assertHasCause("""Module 'org:testA' has been rejected:
-   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by [org:testB:1.0(runtime)]""")
+   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by ['org:testB:1.0' (runtime)]""")
         failure.assertHasCause("""Module 'org:testB' has been rejected:
-   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by [org:testA:1.0(runtime)]""")
+   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by ['org:testA:1.0' (runtime)]""")
     }
 
     def "considers all candidates for conflict resolution"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
@@ -95,8 +95,8 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:foo:1.1'
-   Constraint path ':test:unspecified' --> 'org:foo:{strictly 1.0}' because of the following reason: version resolved in configuration ':other' by consistent resolution"""
+   Dependency path: 'root project :' (conf) --> 'org:foo:1.1'
+   Constraint path: 'root project :' (conf) --> 'org:foo:{strictly 1.0}' because of the following reason: version resolved in configuration ':other' by consistent resolution"""
     }
 
     def "first level dependency can be downgraded only if it's a preferred version"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -122,8 +122,8 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
 
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' (runtime) --> 'org:foo:1.1'
-   Constraint path ':test:unspecified' --> 'org:foo:{reject all versions}'""")
+   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:1.1'
+   Constraint path: 'root project :' (conf) --> 'org:foo:{reject all versions}'""")
     }
 
     void "dependency constraint is included into the result of resolution when a hard dependency is also added transitively"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractValidatingLockingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractValidatingLockingIntegrationTest.groovy
@@ -53,9 +53,9 @@ dependencies {
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':depLock:unspecified' --> 'org:foo:1.+'
-   Dependency path ':depLock:unspecified' --> 'org:foo:{strictly 1.1}'
-   Constraint path ':depLock:unspecified' --> 'org:foo:{strictly 1.0}' because of the following reason: Dependency version enforced by Dependency Locking"""
+   Dependency path: 'root project :' (lockedConf) --> 'org:foo:1.+'
+   Dependency path: 'root project :' (lockedConf) --> 'org:foo:{strictly 1.1}'
+   Constraint path: 'root project :' (lockedConf) --> 'org:foo:{strictly 1.0}' because of the following reason: Dependency version enforced by Dependency Locking"""
 
         where:
         unique << [true, false]
@@ -94,9 +94,9 @@ dependencies {
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':depLock:unspecified' --> 'org:foo:1.+'
-   Dependency path ':depLock:unspecified' --> 'org:foo:1.1'
-   Constraint path ':depLock:unspecified' --> 'org:foo:{strictly 1.0}' because of the following reason: Dependency version enforced by Dependency Locking"""
+   Dependency path: 'root project :' (lockedConf) --> 'org:foo:1.+'
+   Dependency path: 'root project :' (lockedConf) --> 'org:foo:1.1'
+   Constraint path: 'root project :' (lockedConf) --> 'org:foo:{strictly 1.0}' because of the following reason: Dependency version enforced by Dependency Locking"""
 
         where:
         unique << [true, false]

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/AbstractDependencyMetadataRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/AbstractDependencyMetadataRulesIntegrationTest.groovy
@@ -877,8 +877,8 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
         then:
         fails 'checkDep'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org.test:moduleB:1.1'
-   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' ($variantToTest) --> 'org.test:moduleB:{strictly 1.0}'"""
+   Dependency path: 'root project :' ($variantToTest) --> 'org.test:moduleB:1.1'
+   ${defineAsConstraint? 'Constraint' : 'Dependency'} path: 'root project :' ($variantToTest) --> 'org.test:moduleA:1.0' ($variantToTest) --> 'org.test:moduleB:{strictly 1.0}'"""
 
         where:
         thing                    | defineAsConstraint
@@ -952,8 +952,8 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
         then:
         fails 'checkDep'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org.test:moduleB:1.1'
-   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' ($variantToTest) --> 'org.test:moduleB:{require 1.+; reject 1.1 & 1.2}'"""
+   Dependency path: 'root project :' ($variantToTest) --> 'org.test:moduleB:1.1'
+   ${defineAsConstraint? 'Constraint' : 'Dependency'} path: 'root project :' ($variantToTest) --> 'org.test:moduleA:1.0' ($variantToTest) --> 'org.test:moduleB:{require 1.+; reject 1.1 & 1.2}'"""
 
         where:
         thing                    | defineAsConstraint

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
@@ -193,9 +193,9 @@ class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResol
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:foo'
-   Constraint path ':test:unspecified' --> 'org:platform-a:1.0' (runtime) --> 'org:foo:{strictly 1.0}'
-   Constraint path ':test:unspecified' --> 'org:platform-b:1.0' (runtime) --> 'org:foo:{strictly 2.0}'"""
+   Dependency path: 'root project :' (conf) --> 'org:foo'
+   Constraint path: 'root project :' (conf) --> 'org:platform-a:1.0' (runtime) --> 'org:foo:{strictly 1.0}'
+   Constraint path: 'root project :' (conf) --> 'org:platform-b:1.0' (runtime) --> 'org:foo:{strictly 2.0}'"""
     }
 
     def "a module from which strict versions are endorsed can itself be influenced by strict versions endorsed form elsewhere"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
@@ -275,9 +275,9 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:c' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:c:2.0'
-   Dependency path ':test:unspecified' --> 'org:a:1.0' (runtime) --> 'org:c:{strictly 1.0}'
-   Dependency path ':test:unspecified' --> 'org:a:1.0' (runtime) --> 'org:b:1.0' (runtime) --> 'org:c:2.0'"""
+   Dependency path: 'root project :' (conf) --> 'org:c:2.0'
+   Dependency path: 'root project :' (conf) --> 'org:a:1.0' (runtime) --> 'org:c:{strictly 1.0}'
+   Dependency path: 'root project :' (conf) --> 'org:a:1.0' (runtime) --> 'org:b:1.0' (runtime) --> 'org:c:2.0'"""
     }
 
     def "strict from selected and later evicted modules are ignored"() {
@@ -548,8 +548,8 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'project :foo'
-   Constraint path ':test:unspecified' --> 'org:foo:{strictly 1.0}'""")
+   Dependency path: 'root project :' (conf) --> 'project :foo'
+   Constraint path: 'root project :' (conf) --> 'org:foo:{strictly 1.0}'""")
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
@@ -596,8 +596,8 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:x1:1.0' (runtime) --> 'org:bar:1.0' (runtime) --> 'org:foo:2.0'
-   Constraint path ':test:unspecified' --> 'org:x1:1.0' (runtime) --> 'org:foo:{strictly 1.0}'"""
+   Dependency path: 'root project :' (conf) --> 'org:x1:1.0' (runtime) --> 'org:bar:1.0' (runtime) --> 'org:foo:2.0'
+   Constraint path: 'root project :' (conf) --> 'org:x1:1.0' (runtime) --> 'org:foo:{strictly 1.0}'"""
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -313,9 +313,9 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         def platformVariant = platformType == MODULE ? 'runtime' : 'apiElements'
         (platformType == ENFORCED_PLATFORM && !failed) || failure.assertHasCause(
             """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
-   Constraint path ':test:unspecified' --> 'org:platform:1.1' (${platformVariant}) --> 'org:foo:{strictly 3.1.1; reject 3.1 & 3.2}'
-   Constraint path ':test:unspecified' --> 'org:foo:3.2'""")
+   Dependency path: 'root project :' (conf) --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
+   Constraint path: 'root project :' (conf) --> 'org:platform:1.1' (${platformVariant}) --> 'org:foo:{strictly 3.1.1; reject 3.1 & 3.2}'
+   Constraint path: 'root project :' (conf) --> 'org:foo:3.2'""")
 
         where:
         platformType << PlatformType.values()
@@ -372,9 +372,9 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         then:
         if (platformType == ENFORCED_PLATFORM) {
             failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
-   Constraint path ':test:unspecified' --> 'org:platform:1.1' (enforcedApiElements) --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2}'
-   Constraint path ':test:unspecified' --> 'org:foo:{strictly 3.2}'"""
+   Dependency path: 'root project :' (conf) --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
+   Constraint path: 'root project :' (conf) --> 'org:platform:1.1' (enforcedApiElements) --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2}'
+   Constraint path: 'root project :' (conf) --> 'org:foo:{strictly 3.2}'"""
         } else {
             resolve.expectGraph {
                 root(':', ':test:') {
@@ -464,16 +464,16 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         then:
         if (platformType == ENFORCED_PLATFORM) {
             failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
-   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:platform:1.1' (enforcedApiElements) --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2}'
-   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:foo:{strictly 3.2}'"""
+   Dependency path: 'root project :' (conf) --> 'project :recklessLibrary' (conf) --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
+   Constraint path: 'root project :' (conf) --> 'project :recklessLibrary' (conf) --> 'org:platform:1.1' (enforcedApiElements) --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2}'
+   Constraint path: 'root project :' (conf) --> 'project :recklessLibrary' (conf) --> 'org:foo:{strictly 3.2}'"""
         } else {
             def platformVariant = platformType == MODULE ? 'runtime' : 'apiElements'
             failure.assertHasCause(
                 """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
-   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:platform:1.1' (${platformVariant}) --> 'org:foo:{strictly 3.1.1; reject 3.1 & 3.2}'
-   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' (conf) --> 'org:foo:{strictly 3.2}'""")
+   Dependency path: 'root project :' (conf) --> 'project :recklessLibrary' (conf) --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
+   Constraint path: 'root project :' (conf) --> 'project :recklessLibrary' (conf) --> 'org:platform:1.1' (${platformVariant}) --> 'org:foo:{strictly 3.1.1; reject 3.1 & 3.2}'
+   Constraint path: 'root project :' (conf) --> 'project :recklessLibrary' (conf) --> 'org:foo:{strictly 3.2}'""")
         }
 
         where:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/AbstractRichVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/AbstractRichVersionConstraintsIntegrationTest.groovy
@@ -524,8 +524,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:foo:17'
-   Dependency path ':test:unspecified' --> 'test:other:unspecified' (conf) --> 'org:foo:{strictly 15}'""")
+   Dependency path: 'root project :' (conf) --> 'org:foo:17'
+   Dependency path: 'root project :' (conf) --> 'project :other' (conf) --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -566,8 +566,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:foo:{strictly 17}'
-   Dependency path ':test:unspecified' --> 'org:foo:{strictly 15}'""")
+   Dependency path: 'root project :' (conf) --> 'org:foo:{strictly 17}'
+   Dependency path: 'root project :' (conf) --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -608,8 +608,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:foo:17'
-   Dependency path ':test:unspecified' --> 'org:bar:1' (runtime) --> 'org:foo:{strictly 15}'""")
+   Dependency path: 'root project :' (conf) --> 'org:foo:17'
+   Dependency path: 'root project :' (conf) --> 'org:bar:1' (runtime) --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -707,8 +707,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:foo:15'
-   Dependency path ':test:unspecified' --> 'org:foo:{strictly [0,1]}'""")
+   Dependency path: 'root project :' (conf) --> 'org:foo:15'
+   Dependency path: 'root project :' (conf) --> 'org:foo:{strictly [0,1]}'""")
     }
 
     void "can reject dependency versions of an external component"() {
@@ -845,8 +845,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
         then:
         def selected = GradleMetadataResolveRunner.gradleMetadataPublished || GradleMetadataResolveRunner.useMaven() ? 'runtime' : 'default'
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path ':test:unspecified' --> 'org:foo:{require 1.0; reject 1.1}'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' ($selected) --> 'org:foo:1.1'""")
+   Dependency path: 'root project :' (conf) --> 'org:foo:{require 1.0; reject 1.1}'
+   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' ($selected) --> 'org:foo:1.1'""")
     }
 
     def "can reject a version range"() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -48,6 +48,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
@@ -377,14 +378,14 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
 
     }
 
-    private String formatCapabilityRejectMessage(ModuleIdentifier id, Pair<Capability, Collection<NodeState>> capabilityConflict) {
-        StringBuilder sb = new StringBuilder("Module '");
-        sb.append(id).append("' has been rejected:\n");
-        sb.append("   Cannot select module with conflict on ");
-        Capability capability = capabilityConflict.left;
-        sb.append("capability '").append(capability.getGroup()).append(":").append(capability.getName()).append(":").append(capability.getVersion()).append("' also provided by ");
-        sb.append(capabilityConflict.getRight());
-        return sb.toString();
+    private static String formatCapabilityRejectMessage(ModuleIdentifier id, Pair<Capability, Collection<NodeState>> capabilityConflict) {
+        return "Module '" + id + "' has been rejected:\n" +
+            "   Cannot select module with conflict on capability '" + formatCapability(capabilityConflict.left) + "' also provided by " +
+            capabilityConflict.getRight().stream().map(NodeState::getDisplayName).collect(Collectors.toList());
+    }
+
+    private static String formatCapability(Capability capability) {
+        return capability.getGroup() + ":" + capability.getName() + ":" + capability.getVersion();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -66,7 +66,7 @@ class EdgeState implements DependencyGraphEdge {
     private ExcludeSpec cachedEdgeExclusions;
     private ExcludeSpec cachedExclusions;
 
-    private NodeState resolvedVariant;
+    private @Nullable NodeState resolvedVariant;
     private boolean unattached;
     private boolean used;
 
@@ -410,10 +410,6 @@ class EdgeState implements DependencyGraphEdge {
         return selectedComponent != null && selectedComponent.getModule().isVirtualPlatform();
     }
 
-    boolean hasSelectedVariant() {
-        return resolvedVariant != null || !findTargetNodes().isEmpty();
-    }
-
     @Nullable
     @Override
     public Long getSelectedVariant() {
@@ -431,18 +427,7 @@ class EdgeState implements DependencyGraphEdge {
         if (resolvedVariant != null) {
             return resolvedVariant;
         }
-        List<NodeState> targetNodes = findTargetNodes();
-        assert !targetNodes.isEmpty();
-        for (NodeState targetNode : targetNodes) {
-            if (targetNode.isSelected()) {
-                resolvedVariant = targetNode;
-                return resolvedVariant;
-            }
-        }
-        return null;
-    }
 
-    private List<NodeState> findTargetNodes() {
         List<NodeState> targetNodes = this.targetNodes;
         if (targetNodes.isEmpty()) {
             // TODO: This code is not correct. At the end of graph traversal,
@@ -454,7 +439,18 @@ class EdgeState implements DependencyGraphEdge {
                 targetNodes = targetComponent.getNodes();
             }
         }
-        return targetNodes;
+
+        assert !targetNodes.isEmpty();
+
+        for (NodeState targetNode : targetNodes) {
+            // TODO: The target node should _always_ be selected. By definition, since we are an edge
+            // and the node is our target, the node is selected.
+            if (targetNode.isSelected()) {
+                resolvedVariant = targetNode;
+                return resolvedVariant;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesMessageBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleDependencyAttributesMessageBuilder.java
@@ -24,8 +24,6 @@ import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.Set;
 
-import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.MessageBuilderHelper.pathTo;
-
 class IncompatibleDependencyAttributesMessageBuilder {
     static String buildMergeErrorMessage(ModuleResolveState module, AttributeMergingException e) {
         Attribute<?> attribute = e.getAttribute();
@@ -39,7 +37,7 @@ class IncompatibleDependencyAttributesMessageBuilder {
         incomingEdges.addAll(module.getUnattachedEdges());
         for (EdgeState incomingEdge : incomingEdges) {
             SelectorState selector = incomingEdge.getSelector();
-            for (String path : pathTo(incomingEdge, false)) {
+            for (String path : MessageBuilderHelper.formattedPathsTo(incomingEdge)) {
                 String requestedAttribute = formatAttributeQuery(selector, attribute);
                 fmt.node(path + " " + requestedAttribute);
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformGraphResolveState.java
@@ -361,7 +361,7 @@ public class LenientPlatformGraphResolveState extends AbstractComponentGraphReso
             return ImmutableSet.of(new DefaultVariantMetadata(
                 name,
                 new ComponentConfigurationIdentifier(componentId, name),
-                Describables.of(componentId, "variant", name),
+                Describables.of(componentId, "variant", variant.getDisplayName()),
                 variant.getAttributes(),
                 ImmutableList.of(),
                 variant.getCapabilities()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
@@ -31,10 +31,7 @@ abstract class MessageBuilderHelper {
             String header = Iterables.getLast(path).getSelector().getDependencyMetadata().isConstraint() ? "Constraint" : "Dependency";
             String formattedPath = path.stream()
                 .map(EdgeState::getFrom)
-                .map(node -> {
-                    String id = node.getComponent().getComponentId().getDisplayName();
-                    return "'" + id + "' (" + node.getMetadata().getName() + ")";
-                })
+                .map(NodeState::getDisplayName)
                 .collect(Collectors.joining(" --> "));
 
             return header + " path: " + formattedPath;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
@@ -15,81 +15,52 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
-import com.google.common.collect.Iterators;
-import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.jspecify.annotations.Nullable;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 abstract class MessageBuilderHelper {
 
-    static Collection<String> pathTo(EdgeState edge) {
-        return pathTo(edge, true);
+    public static List<String> formattedPathsTo(EdgeState edge) {
+        return findPathsTo(edge).stream().map(path -> {
+            String header = Iterables.getLast(path).getSelector().getDependencyMetadata().isConstraint() ? "Constraint" : "Dependency";
+            String formattedPath = path.stream()
+                .map(EdgeState::getFrom)
+                .map(node -> {
+                    String id = node.getComponent().getComponentId().getDisplayName();
+                    return "'" + id + "' (" + node.getMetadata().getName() + ")";
+                })
+                .collect(Collectors.joining(" --> "));
+
+            return header + " path: " + formattedPath;
+        }).collect(Collectors.toList());
     }
 
-    static Collection<String> pathTo(EdgeState edge, boolean includeLast) {
+    private static List<List<EdgeState>> findPathsTo(EdgeState edge) {
         List<List<EdgeState>> acc = new ArrayList<>(1);
         pathTo(edge, new ArrayList<>(), acc, new HashSet<>());
-        List<String> result = new ArrayList<>(acc.size());
-        for (List<EdgeState> path : acc) {
-            EdgeState target = Iterators.getLast(path.iterator());
-            StringBuilder sb = new StringBuilder();
-            if (target.getSelector().getDependencyMetadata().isConstraint()) {
-                sb.append("Constraint path ");
+        return acc;
+    }
+
+    private static void pathTo(EdgeState edge, List<EdgeState> currentPath, List<List<EdgeState>> accumulator, Set<NodeState> alreadySeen) {
+        NodeState from = edge.getFrom();
+        if (alreadySeen.add(from)) {
+            currentPath.add(edge);
+
+            List<EdgeState> incomingEdges = from.getIncomingEdges();
+            if (!incomingEdges.isEmpty()) {
+                for (EdgeState dependent : incomingEdges) {
+                    List<EdgeState> otherPath = new ArrayList<>(currentPath);
+                    pathTo(dependent, otherPath, accumulator, alreadySeen);
+                }
             } else {
-                sb.append("Dependency path ");
-            }
-            boolean first = true;
-            String variantDetails = null;
-            for (EdgeState e : path) {
-                if (!first) {
-                    sb.append(" --> ");
-                }
-                first = false;
-                ModuleVersionIdentifier id = e.getFrom().getComponent().getModuleVersion();
-                sb.append('\'').append(id).append('\'');
-                if (variantDetails != null) {
-                    sb.append(variantDetails);
-                }
-                variantDetails = variantDetails(e);
-            }
-            if (includeLast) {
-                sb.append(" --> ");
-                SelectorState selector = edge.getSelector();
-                ModuleIdentifier moduleId = selector.getTargetModule().getId();
-                sb.append('\'').append(moduleId.getGroup()).append(':').append(moduleId.getName()).append('\'');
-                if (variantDetails != null) {
-                    sb.append(variantDetails);
-                }
-            }
-            result.add(sb.toString());
-        }
-        return result;
-    }
-
-    @Nullable
-    private static String variantDetails(EdgeState e) {
-        String selectedVariantName = e.hasSelectedVariant() ? e.getSelectedNode().getMetadata().getName() : null;
-        if (selectedVariantName != null) {
-            return " (" + selectedVariantName + ")";
-        }
-        return null;
-    }
-
-    static void pathTo(EdgeState component, List<EdgeState> currentPath, List<List<EdgeState>> accumulator, Set<NodeState> alreadySeen) {
-        if (alreadySeen.add(component.getFrom())) {
-            currentPath.add(0, component);
-            for (EdgeState dependent : component.getFrom().getIncomingEdges()) {
-                List<EdgeState> otherPath = new ArrayList<>(currentPath);
-                pathTo(dependent, otherPath, accumulator, alreadySeen);
-            }
-            if (component.getFrom().isRoot()) {
-                accumulator.add(currentPath);
+                // We've hit the root of the path
+                accumulator.add(Lists.reverse(currentPath));
             }
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -254,7 +254,7 @@ public class ModuleResolveState implements CandidateModule {
         assert this.selected == null;
         assert selected != null;
 
-        if (!selected.getId().getModule().equals(getId())) {
+        if (!selected.getModule().getId().equals(getId())) {
             this.overriddenSelection = true;
         }
         this.selected = selected;
@@ -269,7 +269,7 @@ public class ModuleResolveState implements CandidateModule {
 
     private boolean computeReplaced(ComponentState selected) {
         // This module might be resolved to a different module, through replacedBy
-        return !selected.getId().getModule().equals(getId());
+        return !selected.getModule().getId().equals(getId());
     }
 
     private void doRestart(ComponentState selected) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -206,15 +206,11 @@ public class NodeState implements DependencyGraphNode {
 
     @Override
     public String toString() {
-        return String.format("%s(%s)", component, metadata.getName());
+        return getDisplayName();
     }
 
-    public String getSimpleName() {
-        return component.getId().toString();
-    }
-
-    public String getNameWithVariant() {
-        return component.getId() + " variant " + metadata.getName();
+    public String getDisplayName() {
+        return String.format("'%s' (%s)", component.getComponentId().getDisplayName(), metadata.getName());
     }
 
     public boolean isTransitive() {
@@ -1285,14 +1281,14 @@ public class NodeState implements DependencyGraphNode {
 
     private String computePathToRoot() {
         TreeFormatter formatter = new TreeFormatter();
-        formatter.node(getSimpleName());
+        formatter.node(getDisplayName());
         NodeState from = this;
         int depth = 0;
         do {
             from = getFromNode(from);
             if (from != null) {
                 formatter.startChildren();
-                formatter.node(from.getSimpleName());
+                formatter.node(getDisplayName());
                 depth++;
             }
         } while (from != null && !(from instanceof RootNode));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -210,7 +210,7 @@ public class NodeState implements DependencyGraphNode {
     }
 
     public String getDisplayName() {
-        return String.format("'%s' (%s)", component.getComponentId().getDisplayName(), metadata.getName());
+        return String.format("'%s' (%s)", component.getComponentId().getDisplayName(), metadata.getDisplayName());
     }
 
     public boolean isTransitive() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -52,7 +52,7 @@ class RejectedModuleMessageBuilder {
     private void renderEdges(StringBuilder sb, Set<EdgeState> incomingEdges) {
         for (EdgeState incomingEdge : incomingEdges) {
             SelectorState selector = incomingEdge.getSelector();
-            for (String path : MessageBuilderHelper.pathTo(incomingEdge, false)) {
+            for (String path : MessageBuilderHelper.formattedPathsTo(incomingEdge)) {
                 sb.append("   ").append(path);
                 sb.append(" --> ");
                 renderSelector(sb, selector);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RootNode.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RootNode.java
@@ -51,7 +51,7 @@ class RootNode extends NodeState implements RootGraphNode {
     @Override
     void addIncomingEdge(EdgeState dependencyEdge) {
         throw new InvalidUserCodeException(
-            "Cannot select root node '" + getMetadata().getName() + "' as a variant. " +
+            "Cannot select root node '" + getMetadata().getDisplayName() + "' as a variant. " +
                 "Configurations should not act as both a resolution root and a variant simultaneously. " +
                 "Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them."
         );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -72,7 +72,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
             ModuleIdentifier rootId = null;
             for (NodeState ns : tracker) {
                 if (ns.isRoot()) {
-                    rootId = ns.getComponent().getId().getModule();
+                    rootId = ns.getComponent().getModule().getId();
                 }
             }
 
@@ -85,7 +85,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
                 // allow 2 modules to have the same capability, so we filter the nodes coming
                 // from transitive dependencies
                 ModuleIdentifier rootModuleId = rootId;
-                candidatesForConflict.removeIf(n -> !n.isRoot() && n.getComponent().getId().getModule().equals(rootModuleId));
+                candidatesForConflict.removeIf(n -> !n.isRoot() && n.getComponent().getModule().getId().equals(rootModuleId));
             }
 
             // For a conflict we want at least 2 nodes, and at least one of them should not be rejected
@@ -99,7 +99,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
                     @Override
                     public void withParticipatingModules(Action<ModuleIdentifier> action) {
                         for (NodeState node : candidatesForConflict) {
-                            action.execute(node.getComponent().getId().getModule());
+                            action.execute(node.getComponent().getModule().getId());
                         }
                     }
 
@@ -278,7 +278,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
             seen.add(winningModule);
 
             for (NodeState node : conflict.nodes) {
-                ModuleIdentifier module = node.getComponent().getId().getModule();
+                ModuleIdentifier module = node.getComponent().getModule().getId();
                 if (seen.add(module)) {
                     action.execute(module);
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolutionResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolutionResult.java
@@ -44,9 +44,9 @@ class DefaultConflictResolutionResult implements ConflictResolutionResult {
     public DefaultConflictResolutionResult(Collection<? extends ModuleIdentifier> participatingModules, Object selected) {
         this.selected = findComponent(selected);
         this.participatingModules = participatingModules.stream().sorted((first, second) -> {
-            if (this.selected.getId().getModule().equals(first)) {
+            if (this.selected.getModule().getId().equals(first)) {
                 return -1;
-            } else if (this.selected.getId().getModule().equals(second)) {
+            } else if (this.selected.getModule().getId().equals(second)) {
                 return 1;
             }
             return 0;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
@@ -114,7 +114,7 @@ public abstract class AbstractComponentGraphResolveState<T extends ComponentGrap
         VariantGraphResolveMetadata metadata = variant.getMetadata();
         return new DefaultResolvedVariantResult(
             getId(),
-            Describables.of(metadata.getName()),
+            Describables.of(metadata.getDisplayName()),
             attributeDesugaring.desugar(metadata.getAttributes()),
             capabilitiesFor(metadata.getCapabilities()),
             externalVariant

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantGraphResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantGraphResolveMetadata.java
@@ -35,8 +35,17 @@ public interface VariantGraphResolveMetadata extends HasAttributes {
      * In general, this method should be avoided. The internal engine should not need to know the name of a node and
      * should instead identify nodes based on their integer node ID. This method should only be used for
      * diagnostics/reporting and for implementing existing public API methods that require this field.
+     *
+     * Prefer {@link #getDisplayName()}.
      */
     String getName();
+
+    /**
+     * Get a name for this variant to be used when displaying it.
+     */
+    default String getDisplayName() {
+        return getName();
+    }
 
     @Override
     ImmutableAttributes getAttributes();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionCandidateAssessor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionCandidateAssessor.java
@@ -69,14 +69,14 @@ public final class ResolutionCandidateAssessor {
             .map(VariantGraphResolveState::getMetadata)
             .map(variant -> {
                 ImmutableCapabilities capabilities = variant.getCapabilities().orElse(defaultCapabilityForComponent);
-                return assessCandidate(variant.getName(), capabilities, variant.getAttributes().asImmutable());
+                return assessCandidate(variant.getDisplayName(), capabilities, variant.getAttributes().asImmutable());
             }).sorted(Comparator.comparing(AssessedCandidate::getDisplayName))
             .collect(Collectors.toList());
     }
 
     public List<AssessedCandidate> assessNodeMetadatas(Set<VariantGraphResolveMetadata> nodes) {
         return nodes.stream()
-            .map(variant -> assessCandidate(variant.getName(), variant.getCapabilities(), variant.getAttributes().asImmutable()))
+            .map(variant -> assessCandidate(variant.getDisplayName(), variant.getCapabilities(), variant.getAttributes().asImmutable()))
             .sorted(Comparator.comparing(AssessedCandidate::getDisplayName))
             .collect(Collectors.toList());
     }
@@ -84,13 +84,13 @@ public final class ResolutionCandidateAssessor {
     public List<AssessedCandidate> assessGraphSelectionCandidates(GraphSelectionCandidates candidates) {
         return candidates.getVariantsForAttributeMatching().stream()
             .map(VariantGraphResolveState::getMetadata)
-            .map(variantMetadata -> assessCandidate(variantMetadata.getName(), variantMetadata.getCapabilities(), variantMetadata.getAttributes()))
+            .map(variantMetadata -> assessCandidate(variantMetadata.getDisplayName(), variantMetadata.getCapabilities(), variantMetadata.getAttributes()))
             .sorted(Comparator.comparing(AssessedCandidate::getDisplayName))
             .collect(Collectors.toList());
     }
 
     public AssessedCandidate assessCandidate(
-        String candidateName,
+        String candidateDisplayName,
         ImmutableCapabilities candidateCapabilities,
         ImmutableAttributes candidateAttributes
     ) {
@@ -104,7 +104,7 @@ public final class ResolutionCandidateAssessor {
             .sorted(Comparator.comparing(Attribute::getName))
             .forEach(attribute -> classifyAttribute(requestedAttributes, candidateAttributes, attributeMatcher, attribute, alreadyAssessed, compatible, incompatible, onlyOnConsumer, onlyOnProducer));
 
-        return new AssessedCandidate(candidateName, candidateAttributes, candidateCapabilities, compatible.build(), incompatible.build(), onlyOnConsumer.build(), onlyOnProducer.build());
+        return new AssessedCandidate(candidateDisplayName, candidateAttributes, candidateCapabilities, compatible.build(), incompatible.build(), onlyOnConsumer.build(), onlyOnProducer.build());
     }
 
     private static <T> void classifyAttribute(
@@ -140,7 +140,7 @@ public final class ResolutionCandidateAssessor {
      * that produced it, in order to remain configuration cache compatible - the assessor is not serializable.
      */
     public static final class AssessedCandidate implements Describable {
-        private final String name;
+        private final String displayName;
         private final ImmutableAttributes candidateAttributes;
         private final ImmutableCapabilities candidateCapabilities;
 
@@ -149,8 +149,16 @@ public final class ResolutionCandidateAssessor {
         private final ImmutableList<AssessedAttribute<?>> onlyOnRequest;
         private final ImmutableList<AssessedAttribute<?>> onlyOnCandidate;
 
-        private AssessedCandidate(String name, AttributeContainerInternal attributes, ImmutableCapabilities candidateCapabilities, ImmutableList<AssessedAttribute<?>> compatible, ImmutableList<AssessedAttribute<?>> incompatible, ImmutableList<AssessedAttribute<?>> onlyOnRequest, ImmutableList<AssessedAttribute<?>> onlyOnCandidate) {
-            this.name = name;
+        private AssessedCandidate(
+            String displayName,
+            AttributeContainerInternal attributes,
+            ImmutableCapabilities candidateCapabilities,
+            ImmutableList<AssessedAttribute<?>> compatible,
+            ImmutableList<AssessedAttribute<?>> incompatible,
+            ImmutableList<AssessedAttribute<?>> onlyOnRequest,
+            ImmutableList<AssessedAttribute<?>> onlyOnCandidate
+        ) {
+            this.displayName = displayName;
             this.candidateAttributes = attributes.asImmutable();
             this.candidateCapabilities = candidateCapabilities;
             this.compatible = compatible;
@@ -161,7 +169,7 @@ public final class ResolutionCandidateAssessor {
 
         @Override
         public String getDisplayName() {
-            return name;
+            return displayName;
         }
 
         public ImmutableAttributes getAllCandidateAttributes() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandlerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandlerTest.groovy
@@ -97,7 +97,9 @@ class DefaultCapabilitiesConflictHandlerTest extends Specification {
             getId() >> mvi
             getComponentId() >> DefaultModuleComponentIdentifier.newId(mvi)
             isCandidateForConflictResolution() >> true
-            getModule() >> Mock(ModuleResolveState)
+            getModule() >> Mock(ModuleResolveState) {
+                getId() >> mvi.module
+            }
             isSelected() >> true
         }
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/GraphVariantSelectorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/GraphVariantSelectorTest.groovy
@@ -331,7 +331,7 @@ Configuration 'bar':
             getAttributes() >> attributes
             getCapabilities() >> ImmutableCapabilities.EMPTY
             getMetadata() >> Stub(VariantGraphResolveMetadata) {
-                getName() >> name
+                getDisplayName() >> name
                 getAttributes() >> attributes
             }
         }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -458,9 +458,9 @@ org:foo:1.0 FAILED
    Failures:
       - Could not resolve org:foo:{strictly 1.0}.
           - Cannot find a version of 'org:foo' that satisfies the version constraints:
-               Dependency path ':insight-test:unspecified' --> 'org:foo:1.+'
-               Constraint path ':insight-test:unspecified' --> 'org:foo:1.1'
-               Constraint path ':insight-test:unspecified' --> 'org:foo:{strictly 1.0}' because of the following reason: Dependency version enforced by Dependency Locking
+               Dependency path: 'root project :' (lockedConf) --> 'org:foo:1.+'
+               Constraint path: 'root project :' (lockedConf) --> 'org:foo:1.1'
+               Constraint path: 'root project :' (lockedConf) --> 'org:foo:{strictly 1.0}' because of the following reason: Dependency version enforced by Dependency Locking
 
 org:foo:{strictly 1.0} -> 1.0 FAILED
 \\--- lockedConf
@@ -2597,8 +2597,8 @@ org:bar: FAILED
    Failures:
       - Could not resolve org:bar:{reject all versions}.
           - Module 'org:bar' has been rejected:
-               Dependency path ':insight-test:unspecified' --> 'org:bar:[1.0,)'
-               Constraint path ':insight-test:unspecified' --> 'org:bar:{reject all versions}' because of the following reason: Nope, you won't use this
+               Dependency path: 'root project :' (compileClasspath) --> 'org:bar:[1.0,)'
+               Constraint path: 'root project :' (compileClasspath) --> 'org:bar:{reject all versions}' because of the following reason: Nope, you won't use this
 
 org:bar:{reject all versions} FAILED
 \\--- compileClasspath
@@ -2614,8 +2614,8 @@ org:foo: (by constraint) FAILED
    Failures:
       - Could not resolve org:foo:{reject 1.0 & 1.1 & 1.2}.
           - Cannot find a version of 'org:foo' that satisfies the version constraints:
-               Dependency path ':insight-test:unspecified' --> 'org:foo:[1.0,)'
-               Constraint path ':insight-test:unspecified' --> 'org:foo:{reject 1.0 & 1.1 & 1.2}'
+               Dependency path: 'root project :' (compileClasspath) --> 'org:foo:[1.0,)'
+               Constraint path: 'root project :' (compileClasspath) --> 'org:foo:{reject 1.0 & 1.1 & 1.2}'
 
 org:foo:{reject 1.0 & 1.1 & 1.2} FAILED
 \\--- compileClasspath


### PR DESCRIPTION
Small nudges away from components being required to have module version IDs and from variants being required to have names. 

Reduce usage of using variant name, migrate toward variant display name.
Reduce usage of component module version id, migrate toward using the module's id
Use more consistent display names everywhere, which now use component id instead of module version id.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
