### PR TITLE
Allow class name filters to match on JUnit 5 nested classes

### DIFF
--- a/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -27,8 +27,6 @@ import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.time.Clock;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.TestDescriptor;
@@ -308,25 +306,28 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
         }
 
         private boolean classMatch(TestDescriptor descriptor) {
-            return classMatch(new MatchContext(descriptor));
-        }
-
-        private boolean classMatch(MatchContext context) {
+            TestDescriptor current = descriptor;
+            String methodName = null;
             while (true) {
-                TestDescriptor current = context.current;
+
                 Optional<TestDescriptor> parent = current.getParent();
                 if (!parent.isPresent()) {
                     break;
                 }
-                if (className(current).filter(className -> matcher.matchesTest(className, context.methodName)).isPresent()) {
+
+                // If the current descriptor is a class, check if it matches the test selection criteria
+                Optional<String> className = className(current);
+                if (className.isPresent() && matcher.matchesTest(className.get(), methodName)) {
                     return true;
                 }
+
                 // If the descriptor is a MethodSource, capture the method name to use when checking against parent class names
                 // (for instance, if the method is in a nested class).
-                current.getSource().filter(MethodSource.class::isInstance)
-                    .ifPresent(source -> context.methodName = ((MethodSource) source).getMethodName());
+                if (current.getSource().isPresent() && current.getSource().get() instanceof MethodSource) {
+                    methodName = ((MethodSource) current.getSource().get()).getMethodName();
+                }
 
-                context.current = parent.get();
+                current = parent.get();
             }
             return false;
         }
@@ -336,16 +337,6 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
                 .filter(ClassSource.class::isInstance)
                 .map(ClassSource.class::cast)
                 .map(ClassSource::getClassName);
-        }
-
-        @NullMarked
-        private static class MatchContext {
-            private TestDescriptor current;
-            @Nullable private String methodName;
-
-            private MatchContext(TestDescriptor current) {
-                this.current = current;
-            }
         }
     }
 

--- a/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/platforms/jvm/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -306,13 +306,20 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
         }
 
         private boolean classMatch(TestDescriptor descriptor) {
+            String methodName = null;
             while (true) {
                 Optional<TestDescriptor> parent = descriptor.getParent();
+                String finalMethodName = methodName;
                 if (!parent.isPresent()) {
                     break;
                 }
-                if (className(descriptor).filter(className -> matcher.matchesTest(className, null)).isPresent()) {
+                if (className(descriptor).filter(className -> matcher.matchesTest(className, finalMethodName)).isPresent()) {
                     return true;
+                }
+                // If the descriptor is a MethodSource, capture the method name to use when checking against parent class names
+                // (for instance, if the method is in a nested class).
+                if (descriptor.getSource().isPresent() && descriptor.getSource().get() instanceof MethodSource) {
+                    methodName = ((MethodSource) descriptor.getSource().get()).getMethodName();
                 }
                 descriptor = parent.get();
             }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterFilteringIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterFilteringIntegrationTest.groovy
@@ -30,18 +30,14 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
     def "nested classes are executed when filtering by class name"() {
         given:
         buildFile << """
-            apply plugin: 'java'
-            ${mavenCentralRepository()}
             dependencies {
-                ${testFrameworkDependencies}
                 testImplementation 'org.junit.jupiter:junit-jupiter:${version}'
             }
             test {
-                ${configureTestFramework}
                 ${maybeConfigureFilters(withConfiguredFilters)}
             }
         """
-
+\
         file("src/test/java/SampleTest.java") << """
             import static org.junit.jupiter.api.Assertions.fail;
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterFilteringIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterFilteringIntegrationTest.groovy
@@ -16,11 +16,95 @@
 
 package org.gradle.testing.junit.jupiter
 
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.AbstractTestFilteringIntegrationTest
+import spock.lang.Issue
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_JUPITER
 
 @TargetCoverage({ JUNIT_JUPITER })
 class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrationTest implements JUnitJupiterMultiVersionTest {
+    @Issue("https://github.com/gradle/gradle/issues/19808")
+    def "nested classes are executed when filtering by class name"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies {
+                ${testFrameworkDependencies}
+                testImplementation 'org.junit.jupiter:junit-jupiter:${version}'
+            }
+            test {
+                ${configureTestFramework} {
+                    useJUnitPlatform()
+                }
+                ${maybeConfigureFilters(withConfiguredFilters)}
+            }
+        """
+
+        file("src/test/java/SampleTest.java") << """
+            import static org.junit.jupiter.api.Assertions.fail;
+
+            import org.junit.jupiter.api.Nested;
+            import org.junit.jupiter.api.Test;
+            import org.junit.jupiter.params.ParameterizedTest;
+            import org.junit.jupiter.params.provider.ValueSource;
+
+            public class SampleTest {
+                @Test
+                public void regularTest() {
+                    fail();
+                }
+
+                @Nested
+                public class NestedTestClass {
+                    @Nested
+                    public class SubNestedTestClass {
+                        @Test
+                        public void subNestedTest() {
+                            fail();
+                        }
+
+                        @ParameterizedTest
+                        @ValueSource(strings = { "racecar", "radar", "able was I ere I saw elba" })
+                        public void palindromes(String candidate) {
+                            fail();
+                        }
+                    }
+
+                    @Test
+                    public void nestedTest() {
+                      fail();
+                    }
+                }
+            }
+        """
+
+        when:
+        fails "test", "--tests", commandLineFilter
+
+        then:
+        result.assertTaskExecuted(":test")
+        def testResult = new DefaultTestExecutionResult(testDirectory)
+        testResult.assertTestClassesExecuted(expectedTests as String[])
+        testResult.testClass('SampleTest$NestedTestClass$SubNestedTestClass').assertTestCount(4, 4, 0)
+
+        where:
+        commandLineFilter                                   | withConfiguredFilters | expectedTests
+        "SampleTest"                                        | false                 | ['SampleTest', 'SampleTest$NestedTestClass', 'SampleTest$NestedTestClass$SubNestedTestClass']
+        "SampleTest"                                        | true                  | ['SampleTest', 'SampleTest$NestedTestClass', 'SampleTest$NestedTestClass$SubNestedTestClass']
+        "SampleTest\$NestedTestClass"                       | false                 | ['SampleTest$NestedTestClass', 'SampleTest$NestedTestClass$SubNestedTestClass']
+        "SampleTest\$NestedTestClass"                       | true                  | ['SampleTest$NestedTestClass', 'SampleTest$NestedTestClass$SubNestedTestClass']
+        "SampleTest\$NestedTestClass\$SubNestedTestClass"   | false                 | ['SampleTest$NestedTestClass$SubNestedTestClass']
+        "SampleTest\$NestedTestClass\$SubNestedTestClass"   | true                  | ['SampleTest$NestedTestClass$SubNestedTestClass']
+    }
+
+    String maybeConfigureFilters(boolean withConfiguredFilters) {
+        return withConfiguredFilters ? """
+            filter {
+                excludeTestsMatching "*Something*"
+            }
+        """ : ""
+    }
 }


### PR DESCRIPTION
When a class is specified as a test filter (e.g. `--tests "SampleTest"`) this will now match on any JUnit 5 nested test classes associated with the matching class (e.g. `SampleTest$NestedTestClass`).

Fixes #19808 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
