### PR TITLE
Avoid HasAttributes in internal attribute matching

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
@@ -17,8 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.Action;
-import org.gradle.api.attributes.HasAttributes;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.matching.AttributeMatchingCandidate;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.VariantResolveMetadata;
@@ -28,7 +27,8 @@ import org.jspecify.annotations.Nullable;
  * A set of artifacts that may be selected from a variant. This would be better named
  * {@code ResolvedVariantArtifactCollection}.
  */
-public interface ResolvedVariant extends HasAttributes {
+public interface ResolvedVariant extends AttributeMatchingCandidate {
+
     DisplayName asDescribable();
 
     /**
@@ -37,10 +37,8 @@ public interface ResolvedVariant extends HasAttributes {
      */
     VariantResolveMetadata.@Nullable Identifier getIdentifier();
 
-    @Override
-    ImmutableAttributes getAttributes();
-
     ResolvedArtifactSet getArtifacts();
 
     ImmutableCapabilities getCapabilities();
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -236,7 +236,7 @@ public class ConsumerProvidedVariantFinder {
         ) {
             List<ImmutableAttributes> variantAttributes = new ArrayList<>(sources.size());
             for (ResolvedVariant variant : sources) {
-                variantAttributes.add(variant.getAttributes().asImmutable());
+                variantAttributes.add(variant.getAttributes());
             }
             List<CachedVariant> cached = cache.computeIfAbsent(new CacheKey(variantAttributes, requested), key -> action.apply(key.variantAttributes, key.requested));
             List<TransformedVariant> output = new ArrayList<>(cached.size());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedVariant.java
@@ -16,15 +16,16 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.matching.AttributeMatchingCandidate;
 
 /**
  * Represents a variant which is produced as the result of applying an artifact transform chain
  * to a root producer variant.
  */
-public class TransformedVariant implements HasAttributes {
+public class TransformedVariant implements AttributeMatchingCandidate {
+
     private final ResolvedVariant root;
     private final VariantDefinition chain;
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/AttributeMatcher.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/AttributeMatcher.java
@@ -17,11 +17,9 @@
 package org.gradle.api.internal.attributes.matching;
 
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
-import java.util.Collection;
 import java.util.List;
 
 public interface AttributeMatcher {
@@ -50,8 +48,8 @@ public interface AttributeMatcher {
      * criteria attributes. Then, if there is more than one match, performs disambiguation to attempt
      * to reduce the set of matches to a more preferred subset.
      */
-    <T extends HasAttributes> List<T> matchMultipleCandidates(
-        Collection<? extends T> candidates,
+    <T extends AttributeMatchingCandidate> List<T> matchMultipleCandidates(
+        List<? extends T> candidates,
         ImmutableAttributes requested
     );
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/AttributeMatchingCandidate.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/AttributeMatchingCandidate.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes.matching;
+
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+import java.util.List;
+
+/**
+ * Something that can participate in multiple-candidate attribute matching. During multiple-candidate
+ * matching, candidates are compared based on their attributes and the best match is selected. Compatibility
+ * and disambiguation rules from attribute schemas are used to determine the best match.
+ *
+ * @see AttributeMatcher#matchMultipleCandidates(List, ImmutableAttributes)
+ */
+public interface AttributeMatchingCandidate {
+
+    /**
+     * Get the attributes that describe this candidate.
+     */
+    ImmutableAttributes getAttributes();
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/DefaultAttributeMatcher.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/DefaultAttributeMatcher.java
@@ -19,11 +19,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.HasAttributes;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.Cast;
 import org.gradle.internal.component.model.AttributeMatchingExplanationBuilder;
 import org.gradle.internal.model.InMemoryCacheFactory;
 import org.gradle.internal.model.InMemoryLoadingCache;
@@ -31,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -162,7 +159,10 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
     }
 
     @Override
-    public <T extends HasAttributes> List<T> matchMultipleCandidates(Collection<? extends T> candidates, ImmutableAttributes requested) {
+    public <T extends AttributeMatchingCandidate> List<T> matchMultipleCandidates(
+        List<? extends T> candidates,
+        ImmutableAttributes requested
+    ) {
         AttributeMatchingExplanationBuilder explanationBuilder = AttributeMatchingExplanationBuilder.logging();
 
         if (candidates.isEmpty()) {
@@ -172,16 +172,14 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
 
         if (candidates.size() == 1) {
             T candidate = candidates.iterator().next();
-            ImmutableAttributes candidateAttrs = ((AttributeContainerInternal) candidate.getAttributes()).asImmutable();
-            if (isMatchingCandidate(candidateAttrs, requested)) {
-                explanationBuilder.singleMatch(candidate, candidates, requested);
+            ImmutableAttributes candidateAttributes = candidate.getAttributes();
+            if (isMatchingCandidate(candidateAttributes, requested)) {
+                explanationBuilder.singleMatch(candidateAttributes, ImmutableList.of(candidateAttributes), requested);
                 return Collections.singletonList(candidate);
             }
-            explanationBuilder.candidateDoesNotMatchAttributes(candidate, requested);
+            explanationBuilder.candidateDoesNotMatchAttributes(candidateAttributes, requested);
             return ImmutableList.of();
         }
-
-        List<T> candidateList = (candidates instanceof List) ? Cast.uncheckedCast(candidates) : ImmutableList.copyOf(candidates);
 
         // Often times, collections of candidates will themselves differ even though their attributes are the same.
         // Disambiguating two different candidate lists which map to the same attribute lists in reality performs
@@ -189,30 +187,30 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
         // The result of this is a list of indices into the original candidate list from which the
         // attributes-to-disambiguate are derived. When retrieving a result from the cache, we use the resulting
         // indices to index back into the original candidates list.
-        CachedQuery query = CachedQuery.from(requested, candidateList);
+        CachedQuery query = CachedQuery.from(requested, candidates);
         int[] indices = cachedQueries.get(query);
-        return CachedQuery.getMatchesFromCandidateIndices(indices, candidateList);
+        return CachedQuery.getMatchesFromCandidateIndices(indices, candidates);
     }
 
     private int[] doMatchMultipleCandidates(CachedQuery key) {
         AttributeMatchingExplanationBuilder explanationBuilder = AttributeMatchingExplanationBuilder.logging();
-        int[] matches = new MultipleCandidateMatcher<>(schema, key.candidates, key.requestedAttributes, explanationBuilder).getMatches();
+        int[] matches = new MultipleCandidateMatcher(schema, key.candidates, key.requestedAttributes, explanationBuilder).getMatches();
         LOGGER.debug("Selected matches {} from candidates {} for {}", Ints.asList(matches), key.candidates, key.requestedAttributes);
         return matches;
     }
 
     private static class CachedQuery {
         private final ImmutableAttributes requestedAttributes;
-        private final List<ImmutableAttributes> candidates;
+        private final ImmutableAttributes[] candidates;
         private final int hashCode;
 
-        private CachedQuery(ImmutableAttributes requestedAttributes, List<ImmutableAttributes> candidates) {
+        private CachedQuery(ImmutableAttributes requestedAttributes, ImmutableAttributes[] candidates) {
             this.requestedAttributes = requestedAttributes;
             this.candidates = candidates;
             this.hashCode = computeHashCode(requestedAttributes, candidates);
         }
 
-        private static int computeHashCode(ImmutableAttributes requestedAttributes, List<ImmutableAttributes> candidates) {
+        private static int computeHashCode(ImmutableAttributes requestedAttributes, ImmutableAttributes[] candidates) {
             int hash = requestedAttributes.hashCode();
             for (ImmutableAttributes candidate : candidates) {
                 hash = 31 * hash + candidate.hashCode();
@@ -220,16 +218,17 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
             return hash;
         }
 
-        public static <T extends HasAttributes> CachedQuery from(ImmutableAttributes requestedAttributes, List<T> candidates) {
-            List<ImmutableAttributes> attributes = new ArrayList<>(candidates.size());
-            for (T candidate : candidates) {
-                attributes.add(((AttributeContainerInternal) candidate.getAttributes()).asImmutable());
+        public static <T extends AttributeMatchingCandidate> CachedQuery from(ImmutableAttributes requestedAttributes, List<T> candidates) {
+            int size = candidates.size();
+            ImmutableAttributes[] attributes = new ImmutableAttributes[size];
+            for (int i = 0; i < size; i++) {
+                attributes[i] = candidates.get(i).getAttributes();
             }
             return new CachedQuery(requestedAttributes, attributes);
         }
 
         @SuppressWarnings("MixedMutabilityReturnType")
-        private static <T extends HasAttributes> List<T> getMatchesFromCandidateIndices(int[] indices, List<? extends T> candidates) {
+        private static <T extends AttributeMatchingCandidate> List<T> getMatchesFromCandidateIndices(int[] indices, List<? extends T> candidates) {
             if (indices.length == 0) {
                 return Collections.emptyList();
             }
@@ -253,7 +252,7 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
             CachedQuery that = (CachedQuery) o;
             return hashCode == that.hashCode &&
                 requestedAttributes.equals(that.requestedAttributes) &&
-                candidates.equals(that.candidates);
+                Arrays.equals(candidates, that.candidates);
         }
 
         @Override
@@ -265,7 +264,7 @@ public class DefaultAttributeMatcher implements AttributeMatcher {
         public String toString() {
             return "CachedQuery{" +
                 "requestedAttributes=" + requestedAttributes +
-                ", candidates=" + candidates +
+                ", candidates=" + Arrays.toString(candidates) +
                 '}';
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/ImmutableAttributesBackedMatchingCandidate.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/ImmutableAttributesBackedMatchingCandidate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes.matching;
+
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+/**
+ * Wraps a standalone {@link ImmutableAttributes} so that it can participate in
+ * attribute matching.
+ */
+public class ImmutableAttributesBackedMatchingCandidate implements AttributeMatchingCandidate {
+
+    private final ImmutableAttributes attributes;
+
+    public ImmutableAttributesBackedMatchingCandidate(ImmutableAttributes attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public ImmutableAttributes getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ImmutableAttributesBackedMatchingCandidate)) {
+            return false;
+        }
+
+        ImmutableAttributesBackedMatchingCandidate that = (ImmutableAttributesBackedMatchingCandidate) o;
+        return attributes.equals(that.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return attributes.hashCode();
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/MultipleCandidateMatcher.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/matching/MultipleCandidateMatcher.java
@@ -18,8 +18,6 @@ package org.gradle.api.internal.attributes.matching;
 
 import com.google.common.collect.Sets;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.HasAttributes;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Cast;
@@ -68,11 +66,10 @@ import java.util.function.IntFunction;
  *
  * </p>
  */
-class MultipleCandidateMatcher<T extends HasAttributes> {
+class MultipleCandidateMatcher {
     private final AttributeSelectionSchema schema;
     private final ImmutableAttributes requested;
-    private final List<? extends T> candidates;
-    private final ImmutableAttributes[] candidateAttributeSets;
+    private final ImmutableAttributes[] candidates;
     private final AttributeMatchingExplanationBuilder explanationBuilder;
 
     private final List<Attribute<?>> requestedAttributes;
@@ -96,7 +93,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
 
     private BitSet remaining;
 
-    <E extends T> MultipleCandidateMatcher(AttributeSelectionSchema schema, List<E> candidates, ImmutableAttributes requested, AttributeMatchingExplanationBuilder explanationBuilder) {
+    MultipleCandidateMatcher(AttributeSelectionSchema schema, ImmutableAttributes[] candidates, ImmutableAttributes requested, AttributeMatchingExplanationBuilder explanationBuilder) {
         this.schema = schema;
         this.candidates = candidates;
         this.requested = requested;
@@ -105,11 +102,10 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         this.requestedAttributes = requested.keySet().asList();
         this.requestedAttributeValues = getRequestedValues(requestedAttributes, requested);
 
-        this.candidateAttributeSets = getCandidateAttributeSets(this.candidates);
-        this.candidateValues = new Object[candidates.size() * requestedAttributes.size()];
+        this.candidateValues = new Object[candidates.length * requestedAttributes.size()];
 
-        this.compatible = new BitSet(candidates.size());
-        compatible.set(0, candidates.size());
+        this.compatible = new BitSet(candidates.length);
+        compatible.set(0, candidates.length);
     }
 
     public int[] getMatches() {
@@ -118,7 +114,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
             return getCandidates(compatible);
         }
         if (longestMatchIsSuperSetOfAllOthers()) {
-            T o = candidates.get(candidateWithLongestMatch);
+            ImmutableAttributes o = candidates[candidateWithLongestMatch];
             explanationBuilder.candidateIsSuperSetOfAllOthers(o);
             return new int[] {candidateWithLongestMatch};
         }
@@ -135,20 +131,12 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         return requestedAttributeValues;
     }
 
-    private static ImmutableAttributes[] getCandidateAttributeSets(List<? extends HasAttributes> candidates) {
-        ImmutableAttributes[] candidateAttributeSets = new ImmutableAttributes[candidates.size()];
-        for (int i = 0; i < candidates.size(); i++) {
-            candidateAttributeSets[i] = ((AttributeContainerInternal) candidates.get(i).getAttributes()).asImmutable();
-        }
-        return candidateAttributeSets;
-    }
-
     private void findCompatibleCandidates() {
         if (requested.isEmpty()) {
             // Avoid iterating on candidates if there's no requested attribute
             return;
         }
-        for (int c = 0; c < candidates.size(); c++) {
+        for (int c = 0; c < candidates.length; c++) {
             matchCandidate(c);
         }
     }
@@ -176,11 +164,11 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
     private MatchResult recordAndMatchCandidateValue(int c, int a) {
         Object requestedValue = requestedAttributeValues[a];
         Attribute<?> attribute = requestedAttributes.get(a);
-        AttributeValue<?> candidateValue = candidateAttributeSets[c].findEntry(attribute.getName());
+        AttributeValue<?> candidateValue = candidates[c].findEntry(attribute.getName());
 
         if (!candidateValue.isPresent()) {
             setCandidateValue(c, a, null);
-            explanationBuilder.candidateAttributeMissing(candidates.get(c), attribute, requestedValue);
+            explanationBuilder.candidateAttributeMissing(candidates[c], attribute, requestedValue);
             return MatchResult.MISSING;
         }
 
@@ -190,7 +178,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         if (unsafeMatchValue(attribute, requestedValue, coercedValue)) {
             return MatchResult.MATCH;
         }
-        explanationBuilder.candidateAttributeDoesNotMatch(candidates.get(c), attribute, requestedValue, candidateValue);
+        explanationBuilder.candidateAttributeDoesNotMatch(candidates[c], attribute, requestedValue, candidateValue);
         return MatchResult.NO_MATCH;
     }
 
@@ -229,7 +217,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
     }
 
     private int[] disambiguateCompatibleCandidates() {
-        remaining = new BitSet(candidates.size());
+        remaining = new BitSet(candidates.length);
         remaining.or(compatible);
 
         disambiguateWithRequestedAttributeValues();
@@ -239,7 +227,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
             return getCandidates(remaining);
         }
 
-        Attribute<?>[] extraAttributes = schema.collectExtraAttributes(candidateAttributeSets, requested);
+        Attribute<?>[] extraAttributes = schema.collectExtraAttributes(candidates, requested);
         if (remaining.cardinality() > 1) {
             disambiguateWithExtraAttributes(extraAttributes);
         }
@@ -257,10 +245,10 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
             // We consider only extra attributes which are NOT on every candidate:
             // Because they are EXTRA attributes, we consider that a
             // candidate which does NOT provide this value is a better match
-            int candidateCount = candidateAttributeSets.length;
+            int candidateCount = candidates.length;
             BitSet any = new BitSet(candidateCount);
             for (int c = 0; c < candidateCount; c++) {
-                ImmutableAttributes candidateAttributeSet = candidateAttributeSets[c];
+                ImmutableAttributes candidateAttributeSet = candidates[c];
                 if (candidateAttributeSet.findEntry(extraAttribute.getName()).isPresent()) {
                     any.set(c);
                 }
@@ -455,7 +443,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
 
     @Nullable
     private <E> E getCandidateValue(int c, Attribute<E> attribute) {
-        AttributeValue<?> attributeValue = candidateAttributeSets[c].findEntry(attribute.getName());
+        AttributeValue<?> attributeValue = candidates[c].findEntry(attribute.getName());
         return attributeValue.isPresent() ? attributeValue.coerce(attribute) : null;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalComponentResolveMetadata.java
@@ -19,7 +19,6 @@ package org.gradle.internal.component.external.model;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
@@ -45,7 +44,7 @@ import java.util.List;
  * @see ComponentArtifactResolveState
  * @see ComponentArtifactResolveMetadata
  */
-public interface ExternalComponentResolveMetadata extends HasAttributes {
+public interface ExternalComponentResolveMetadata {
     List<String> DEFAULT_STATUS_SCHEME = Arrays.asList("integration", "milestone", "release");
 
     /**
@@ -87,6 +86,5 @@ public interface ExternalComponentResolveMetadata extends HasAttributes {
 
     ImmutableList<? extends VirtualComponentIdentifier> getPlatformOwners();
 
-    @Override
     ImmutableAttributes getAttributes();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatchingExplanationBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatchingExplanationBuilder.java
@@ -16,9 +16,9 @@
 package org.gradle.internal.component.model;
 
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeValue;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.Collection;
 
@@ -29,27 +29,27 @@ public interface AttributeMatchingExplanationBuilder {
         return LoggingAttributeMatchingExplanationBuilder.logging();
     }
 
-    default <T extends HasAttributes> void noCandidates(AttributeContainerInternal requested) {
+    default void noCandidates(ImmutableAttributes requested) {
 
     }
 
-    default <T extends HasAttributes> void singleMatch(T candidate, Collection<? extends T> candidates, AttributeContainerInternal requested) {
+    default void singleMatch(ImmutableAttributes candidate, Collection<ImmutableAttributes> candidates, AttributeContainerInternal requested) {
 
     }
 
-    default <T extends HasAttributes> void candidateDoesNotMatchAttributes(T candidate, AttributeContainerInternal requested) {
+    default void candidateDoesNotMatchAttributes(ImmutableAttributes candidate, AttributeContainerInternal requested) {
 
     }
 
-    default <T extends HasAttributes> void candidateAttributeDoesNotMatch(T candidate, Attribute<?> attribute, Object requestedValue, AttributeValue<?> candidateValue) {
+    default void candidateAttributeDoesNotMatch(ImmutableAttributes candidate, Attribute<?> attribute, Object requestedValue, AttributeValue<?> candidateValue) {
 
     }
 
-    default <T extends HasAttributes> void candidateAttributeMissing(T candidate, Attribute<?> attribute, Object requestedValue) {
+    default void candidateAttributeMissing(ImmutableAttributes candidate, Attribute<?> attribute, Object requestedValue) {
 
     }
 
-    default <T extends HasAttributes> void candidateIsSuperSetOfAllOthers(T candidate) {
+    default void candidateIsSuperSetOfAllOthers(ImmutableAttributes candidate) {
 
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -18,7 +18,6 @@ package org.gradle.internal.component.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
@@ -36,7 +35,7 @@ import java.util.Set;
  * @see VariantGraphResolveMetadata
  * @see ConfigurationGraphResolveMetadata
  */
-public interface ConfigurationMetadata extends HasAttributes {
+public interface ConfigurationMetadata {
     /**
      * The set of configurations that this configuration extends. Includes this configuration.
      *
@@ -50,10 +49,6 @@ public interface ConfigurationMetadata extends HasAttributes {
 
     DisplayName asDescribable();
 
-    /**
-     * Attributes are immutable on ConfigurationMetadata
-     */
-    @Override
     ImmutableAttributes getAttributes();
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/LoggingAttributeMatchingExplanationBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/LoggingAttributeMatchingExplanationBuilder.java
@@ -16,9 +16,9 @@
 package org.gradle.internal.component.model;
 
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeValue;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 
@@ -36,32 +36,32 @@ public class LoggingAttributeMatchingExplanationBuilder implements AttributeMatc
     }
 
     @Override
-    public <T extends HasAttributes> void noCandidates(AttributeContainerInternal requested) {
+    public void noCandidates(ImmutableAttributes requested) {
         LOGGER.debug("No candidates for {}. Select nothing.", requested);
     }
 
     @Override
-    public <T extends HasAttributes> void singleMatch(T candidate, Collection<? extends T> candidates, AttributeContainerInternal requested) {
+    public void singleMatch(ImmutableAttributes candidate, Collection<ImmutableAttributes> candidates, AttributeContainerInternal requested) {
         LOGGER.debug("Selected match {} from candidates {} for {}", candidate, candidates, requested);
     }
 
     @Override
-    public <T extends HasAttributes> void candidateDoesNotMatchAttributes(T candidate, AttributeContainerInternal requested) {
+    public void candidateDoesNotMatchAttributes(ImmutableAttributes candidate, AttributeContainerInternal requested) {
         LOGGER.debug("Candidate {} doesn't match attributes {}", candidate, requested);
     }
 
     @Override
-    public <T extends HasAttributes> void candidateAttributeDoesNotMatch(T candidate, Attribute<?> attribute, Object requestedValue, AttributeValue<?> candidateValue) {
+    public void candidateAttributeDoesNotMatch(ImmutableAttributes candidate, Attribute<?> attribute, Object requestedValue, AttributeValue<?> candidateValue) {
         LOGGER.debug("Candidate {} attribute {} value {} doesn't requested value {}", candidate, attribute, candidateValue, requestedValue);
     }
 
     @Override
-    public <T extends HasAttributes> void candidateAttributeMissing(T candidate, Attribute<?> attribute, Object requestedValue) {
+    public void candidateAttributeMissing(ImmutableAttributes candidate, Attribute<?> attribute, Object requestedValue) {
         LOGGER.debug("Candidate {} doesn't have attribute {}", candidate, attribute);
     }
 
     @Override
-    public <T extends HasAttributes> void candidateIsSuperSetOfAllOthers(T candidate) {
+    public void candidateIsSuperSetOfAllOthers(ImmutableAttributes candidate) {
         LOGGER.debug("Candidate {} selected because its attributes are a superset of all other candidate attributes", candidate);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantGraphResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantGraphResolveMetadata.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.component.model;
 
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 
@@ -27,7 +26,7 @@ import org.gradle.internal.component.external.model.ImmutableCapabilities;
  * of this variant, as they may be expensive to resolve. Expensive information about this variant
  * can be accessed via the methods of {@link VariantGraphResolveState}.
  */
-public interface VariantGraphResolveMetadata extends HasAttributes {
+public interface VariantGraphResolveMetadata {
 
     /**
      * Returns the name for this variant, which is unique for the variants of its owning component.
@@ -47,7 +46,6 @@ public interface VariantGraphResolveMetadata extends HasAttributes {
         return getName();
     }
 
-    @Override
     ImmutableAttributes getAttributes();
 
     ImmutableCapabilities getCapabilities();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/VariantGraphResolveState.java
@@ -16,8 +16,7 @@
 
 package org.gradle.internal.component.model;
 
-import org.gradle.api.attributes.HasAttributes;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.matching.AttributeMatchingCandidate;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 
 import java.util.List;
@@ -28,7 +27,7 @@ import java.util.List;
  * This state type manages expensive operations required to resolve a variant. These include
  * managing dependencies and artifacts, which may not be easily available from the metadata.
  */
-public interface VariantGraphResolveState extends HasAttributes {
+public interface VariantGraphResolveState extends AttributeMatchingCandidate {
 
     /**
      * A unique id for this variant within the current build tree. Note that this id is not stable across Gradle invocations.
@@ -36,9 +35,6 @@ public interface VariantGraphResolveState extends HasAttributes {
     long getInstanceId();
 
     String getName();
-
-    @Override
-    ImmutableAttributes getAttributes();
 
     ImmutableCapabilities getCapabilities();
 
@@ -63,4 +59,5 @@ public interface VariantGraphResolveState extends HasAttributes {
      * when required.
      */
     VariantArtifactResolveState prepareForArtifactResolution();
+
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributePrecedenceSchemaAttributeMatcherTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributePrecedenceSchemaAttributeMatcherTest.groovy
@@ -24,6 +24,8 @@ import org.gradle.api.attributes.MultipleCandidatesDetails
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema
 import org.gradle.api.internal.attributes.matching.AttributeMatcher
+import org.gradle.api.internal.attributes.matching.AttributeMatchingCandidate
+import org.gradle.api.internal.attributes.matching.ImmutableAttributesBackedMatchingCandidate
 import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
@@ -118,9 +120,11 @@ class AttributePrecedenceSchemaAttributeMatcherTest extends Specification {
     }
 
     private static ImmutableAttributes requested(String highestValue, String middleValue, String lowestValue) {
-        return candidate(highestValue, middleValue, lowestValue)
+        return candidate(highestValue, middleValue, lowestValue).attributes
     }
-    private static ImmutableAttributes candidate(String highestValue, String middleValue, String lowestValue) {
-        return AttributeTestUtil.attributes([highest: highestValue, middle: middleValue, lowest: lowestValue])
+
+    private static AttributeMatchingCandidate candidate(String highestValue, String middleValue, String lowestValue) {
+        def attributes = AttributeTestUtil.attributes([highest: highestValue, middle: middleValue, lowest: lowestValue])
+        new ImmutableAttributesBackedMatchingCandidate(attributes)
     }
 }

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/DefaultVersionMappingStrategy.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/DefaultVersionMappingStrategy.java
@@ -16,6 +16,7 @@
 package org.gradle.api.publish.internal.versionmapping;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
@@ -28,6 +29,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.api.internal.attributes.matching.AttributeMatcher;
+import org.gradle.api.internal.attributes.matching.ImmutableAttributesBackedMatchingCandidate;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.publish.VariantVersionMappingStrategy;
 
@@ -37,7 +39,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class DefaultVersionMappingStrategy implements VersionMappingStrategyInternal {
     private final ObjectFactory objectFactory;
@@ -47,8 +48,8 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     private final AttributeSchemaServices attributeSchemaServices;
 
     private final List<Action<? super VariantVersionMappingStrategy>> mappingsForAllVariants = new ArrayList<>(2);
-    private final Map<ImmutableAttributes, String> defaultConfigurations = new HashMap<>();
-    private final Multimap<ImmutableAttributes, Action<? super VariantVersionMappingStrategy>> attributeBasedMappings = ArrayListMultimap.create();
+    private final Map<ImmutableAttributesBackedMatchingCandidate, String> defaultConfigurations = new HashMap<>();
+    private final Multimap<ImmutableAttributesBackedMatchingCandidate, Action<? super VariantVersionMappingStrategy>> attributeBasedMappings = ArrayListMultimap.create();
 
     private AttributeMatcher matcher;
 
@@ -74,7 +75,8 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
 
     @Override
     public <T> void variant(Attribute<T> attribute, T attributeValue, Action<? super VariantVersionMappingStrategy> action) {
-        attributeBasedMappings.put(attributesFactory.of(attribute, attributeValue), action);
+        ImmutableAttributes attributes = attributesFactory.of(attribute, attributeValue);
+        attributeBasedMappings.put(new ImmutableAttributesBackedMatchingCandidate(attributes), action);
     }
 
     @Override
@@ -84,7 +86,8 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
 
     @Override
     public void defaultResolutionConfiguration(String usage, String defaultConfiguration) {
-        defaultConfigurations.put(attributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, usage)), defaultConfiguration);
+        ImmutableAttributes attributes = attributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, usage));
+        defaultConfigurations.put(new ImmutableAttributesBackedMatchingCandidate(attributes), defaultConfiguration);
     }
 
     @Override
@@ -97,8 +100,8 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
 
         // Then use attribute specific mapping
         if (!attributeBasedMappings.isEmpty()) {
-            Set<ImmutableAttributes> candidates = attributeBasedMappings.keySet();
-            List<ImmutableAttributes> matches = getMatcher().matchMultipleCandidates(candidates, variantAttributes);
+            List<ImmutableAttributesBackedMatchingCandidate> candidates = ImmutableList.copyOf(attributeBasedMappings.keySet());
+            List<ImmutableAttributesBackedMatchingCandidate> matches = getMatcher().matchMultipleCandidates(candidates, variantAttributes);
             if (matches.size() == 1) {
                 Collection<Action<? super VariantVersionMappingStrategy>> actions = attributeBasedMappings.get(matches.get(0));
                 for (Action<? super VariantVersionMappingStrategy> action : actions) {
@@ -116,9 +119,9 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
         if (!defaultConfigurations.isEmpty()) {
             // First need to populate the default variant version mapping strategy with the default values
             // provided by plugins
-            Set<ImmutableAttributes> candidates = defaultConfigurations.keySet();
-            List<ImmutableAttributes> matches = getMatcher().matchMultipleCandidates(candidates, variantAttributes);
-            for (ImmutableAttributes match : matches) {
+            List<ImmutableAttributesBackedMatchingCandidate> candidates = ImmutableList.copyOf(defaultConfigurations.keySet());
+            List<ImmutableAttributesBackedMatchingCandidate> matches = getMatcher().matchMultipleCandidates(candidates, variantAttributes);
+            for (ImmutableAttributesBackedMatchingCandidate match : matches) {
                 strategy.setDefaultResolutionConfiguration(configurations.getByName(defaultConfigurations.get(match)));
             }
         }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -30,7 +30,6 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
@@ -50,7 +49,9 @@ import org.gradle.api.tasks.diagnostics.internal.dependencies.MatchType;
 import org.gradle.api.tasks.diagnostics.internal.dsl.DependencyResultSpecNotationConverter;
 import org.gradle.api.tasks.diagnostics.internal.graph.DependencyGraphsRenderer;
 import org.gradle.api.tasks.diagnostics.internal.graph.NodeRenderer;
+import org.gradle.api.tasks.diagnostics.internal.graph.nodes.DependencyReportHeader;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependency;
+import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RequestedVersion;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.Section;
 import org.gradle.api.tasks.diagnostics.internal.insight.DependencyInsightReporter;
 import org.gradle.api.tasks.diagnostics.internal.text.StyledTable;
@@ -516,9 +517,11 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
         }
 
         private AttributeContainer getRequestedAttributes(RenderableDependency dependency) {
-            if (dependency instanceof HasAttributes) {
-                AttributeContainer dependencyAttributes = ((HasAttributes) dependency).getAttributes();
+            if (dependency instanceof DependencyReportHeader) {
+                AttributeContainer dependencyAttributes = ((DependencyReportHeader) dependency).getAttributes();
                 return concat(configurationAttributes, dependencyAttributes);
+            } else if (dependency instanceof RequestedVersion) {
+                return ((RequestedVersion) dependency).getAttributes();
             }
             return configurationAttributes;
         }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyReportHeader.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyReportHeader.java
@@ -21,14 +21,13 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
-public class DependencyReportHeader extends AbstractRenderableDependency implements HasAttributes {
+public class DependencyReportHeader extends AbstractRenderableDependency {
     private final DependencyEdge dependency;
     private final String description;
     private final List<ResolvedVariantResult> selectedVariants;
@@ -74,7 +73,6 @@ public class DependencyReportHeader extends AbstractRenderableDependency impleme
         return allVariants;
     }
 
-    @Override
     public AttributeContainer getAttributes() {
         ComponentSelector requested = dependency.getRequested();
         return requested instanceof ModuleComponentSelector

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RequestedVersion.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RequestedVersion.java
@@ -20,13 +20,12 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-public class RequestedVersion extends AbstractRenderableDependencyResult implements HasAttributes {
+public class RequestedVersion extends AbstractRenderableDependencyResult {
     private final ComponentSelector requested;
     private final ComponentIdentifier actual;
     private final boolean resolvable;
@@ -62,7 +61,6 @@ public class RequestedVersion extends AbstractRenderableDependencyResult impleme
         return children;
     }
 
-    @Override
     public AttributeContainer getAttributes() {
         return requested instanceof ModuleComponentSelector
             ? requested.getAttributes()


### PR DESCRIPTION
AttributeMatcher and MultipleCandidateMatcher relied on candidates implementing HasAttributes. There are two main problems with this interface:

1. It is public, so it only exposes AttributeContainer instead of ImmutableAttributes. Our attribute matching code needed a number of casts and copies in order to deal with this. This introduces clutter, but also seems to break some optimizations in the JVM due to the casting and extra method calls, as methods like DefaultAttributeMatcher.CachedQuery.from have come up as hot spots in flame graphs.
2. It hurts IDE navigability, as ctrl+clicking on any type that implements HasAttributes shows _all_ usages of the interface across the entire build, even if they are not related. Having such a wide-ranging interface like this almost always results in poor IDE experience. We should deprecate and remove HasAttributes in public types as well, but this is a start.

Since ImmutableAttributes does not implement AttributeMatchingCandidate directly, we also introduce ImmutableAttributesBackedMatchingCandidate. This wrapper makes the attribute matching done in publishing a bit more clumsy. But, this seems like a worthy trade-off

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
