### PR TITLE
Add Best Practice: Do not use `gradle.properties` in subprojects

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_general.adoc
@@ -285,3 +285,57 @@ Now it can be executed using only `gradle run`, and the continue property will a
 === Tags
 
 <<tags_reference.adoc#tag:properties,`#properties`>>
+
+[[do_not_use_gradle_properties_in_subprojects]]
+== Do not use `gradle.properties` in subprojects
+
+Do not use `gradle.properties` in subprojects to set properties in your build.
+
+=== Explanation
+
+It's possible to have `gradle.properties` in both the root project and in any of the subprojects.
+Using it outside of the root project makes it difficult to trace what Gradle property values are set throughout the project, and understand where they were set or overriden.
+
+=== Example
+
+==== Don't Do This
+
+[source,text]
+----
+├── app
+│   ├── src
+│   ├── ⋮
+│   ├── build.gradle.kts
+│   └── gradle.properties
+├── utilities
+│   ├── src
+│   ├── ⋮
+│   ├── build.gradle.kts
+│   └── gradle.properties
+├── settings.gradle.kts
+└── gradle.properties
+----
+
+==== Do This Instead
+
+[source,text]
+----
+├── app
+│   ├── src
+│   ├── ⋮
+│   └── build.gradle.kts
+├── utilities
+│   ├── src
+│   ├── ⋮
+│   └── build.gradle.kts
+├── settings.gradle.kts
+└── gradle.properties
+----
+
+=== References
+
+- <<build_environment.adoc#sec:gradle_configuration_properties,Gradle properties>>
+
+=== Tags
+
+<<tags_reference.adoc#tag:properties,`#properties`>>

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_index.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_index.adoc
@@ -18,7 +18,7 @@
 The table below provides a complete list of documented Gradle Best Practices.
 
 ****
-There are currently *23 Best Practices*.
+There are currently *24 Best Practices*.
 ****
 
 Use this as a quick reference to track newly added recommendations, check adoption status, or explore areas for improving your build:
@@ -32,6 +32,7 @@ Use this as a quick reference to track newly added recommendations, check adopti
 | <<best_practices_general.adoc#use_the_plugins_block,Apply Plugins Using the plugins Block>> | General | 8.14
 | <<best_practices_general.adoc#do_not_use_internal_apis,Do Not Use Internal APIs>> | General | 8.14
 | <<best_practices_general.adoc#use_the_gradle_properties_file,Set build flags in gradle.properties>> | General | 9.0.0
+| <<best_practices_general.adoc#do_not_use_gradle_properties_in_subprojects,Do not use gradle.properties in subprojects>> | General | 9.1.0
 
 | <<best_practices_structuring_builds.adoc#modularize_builds,Modularize Your Builds>> | Structuring Builds | 9.0.0
 | <<best_practices_structuring_builds.adoc#no_source_in_root,Do Not Put Source Files in the Root Project>> | Structuring Builds | 9.0.0


### PR DESCRIPTION
Add Best Practice: Do not use `gradle.properties` in subprojects.