### PR TITLE
Let CC report `ExtraPropertiesExtension` as unsupported

### DIFF
--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/UnsupportedTypesCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/UnsupportedTypesCodecs.kt
@@ -48,6 +48,7 @@ import org.gradle.api.attributes.CompatibilityRuleChain
 import org.gradle.api.attributes.DisambiguationRuleChain
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
+import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.project.IsolatedProject
 import org.gradle.api.publish.Publication
 import org.gradle.api.services.BuildService
@@ -101,6 +102,7 @@ fun BindingsBuilder.unsupportedTypes() {
     bind(unsupported<TaskDependency>())
     bind(unsupported<SourceSetContainer>())
     bind(unsupported<SourceSet>())
+    bind(unsupported<ExtraPropertiesExtension>())
 
     // Dependency Resolution Types
     bind(unsupported<ConfigurationContainer>())


### PR DESCRIPTION
Extra properties were never meant to be capture by CC and it gets in the way of finer grained project property tracking.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
