### PR TITLE
Added assertAnyTasksExecuted(), assertNoTasksExecuted(), assertAnyTas…

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncludedBuildLogicIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheIncludedBuildLogicIntegrationTest.groovy
@@ -124,7 +124,7 @@ class ConfigurationCacheIncludedBuildLogicIntegrationTest extends AbstractConfig
         configurationCacheRun(":build-logic:classes")
 
         then:
-        result.assertTasksExecuted()
+        result.assertNoTasksExecuted()
         fixture.assertStateLoaded()
 
         when:

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -243,7 +243,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCacheFails 'broken'
 
         then:
-        failure.assertTasksExecuted()
+        failure.assertNoTasksExecuted()
 
         and:
         configurationCache.assertStateStoreFailed()
@@ -259,7 +259,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCacheFails WARN_PROBLEMS_CLI_OPT, 'broken'
 
         then:
-        failure.assertTasksExecuted()
+        failure.assertNoTasksExecuted()
 
         and:
         configurationCache.assertStateStoreFailed()
@@ -295,7 +295,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCacheFails 'broken'
 
         then:
-        failure.assertTasksExecuted()
+        failure.assertNoTasksExecuted()
 
         and:
         // TODO: why are we not discarding the state here, the same way we would have discarded it for the execution-time problems?
@@ -311,7 +311,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCacheFails WARN_PROBLEMS_CLI_OPT, 'broken'
 
         then:
-        failure.assertTasksExecuted()
+        failure.assertNoTasksExecuted()
 
         and:
         configurationCache.assertStateLoadFailed()
@@ -350,7 +350,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCacheFails 'problems', 'broken'
 
         then:
-        failure.assertTasksExecuted()
+        failure.assertNoTasksExecuted()
 
         and:
         configurationCache.assertStateStoreFailed()
@@ -375,7 +375,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCacheFails WARN_PROBLEMS_CLI_OPT, 'problems', 'broken'
 
         then:
-        failure.assertTasksExecuted()
+        failure.assertNoTasksExecuted()
 
         and:
         configurationCache.assertStateStoreFailed()

--- a/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioMultiProjectIntegrationTest.groovy
+++ b/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioMultiProjectIntegrationTest.groovy
@@ -422,7 +422,7 @@ class VisualStudioMultiProjectIntegrationTest extends AbstractVisualStudioIntegr
 
         then:
         resultUnbuildableSolution.size() == 1
-        resultUnbuildableSolution[0].assertTasksExecuted()
+        resultUnbuildableSolution[0].assertNoTasksExecuted()
         resultUnbuildableSolution[0].assertOutputContains('The project "exe" is not selected for building in solution configuration "unbuildable|Win32".')
         resultUnbuildableSolution[0].assertOutputContains('The project "libLib" is not selected for building in solution configuration "unbuildable|Win32".')
         installation('exe/build/install/main/debug').assertNotInstalled()
@@ -434,7 +434,7 @@ class VisualStudioMultiProjectIntegrationTest extends AbstractVisualStudioIntegr
                 .fails()
 
         then:
-        resultDebug.assertTasksExecuted()
+        resultDebug.assertNoTasksExecuted()
         resultDebug.assertHasCause("Could not resolve all dependencies for configuration ':exe:nativeRuntimeDebug'.")
         resultDebug.assertHasCause("Could not resolve project :lib.")
         installation('exe/build/install/main/debug').assertNotInstalled()

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
@@ -220,7 +220,7 @@ class PersistentCompositeDependencySubstitutionCrossVersionSpec extends ToolingA
 
         then:
         modelType.isInstance modelInstance
-        modelOperation.result.assertTasksExecuted()
+        modelOperation.result.assertNoTasksExecuted()
 
         where:
         modelType << [EclipseProject, IdeaProject]

--- a/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeLanguageComponentIntegrationTest.groovy
+++ b/platforms/native/language-native/src/testFixtures/groovy/org/gradle/language/AbstractNativeLanguageComponentIntegrationTest.groovy
@@ -71,7 +71,7 @@ abstract class AbstractNativeLanguageComponentIntegrationTest extends AbstractIn
 
         expect:
         fails taskNameToAssembleDevelopmentBinary
-        result.assertTasksExecuted()
+        result.assertNoTasksExecuted()
         failure.assertHasCause("No tool chain has support to build")
     }
 

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -239,7 +239,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec implements Ta
             executer.withTasks("d").withArguments("-x", "c").run().assertTasksExecuted(":d", ":sub:d")
             executer.withTasks("d").withArguments("-x", "sub:c").run().assertTasksExecuted(":a", ":b", ":c", ":d", ":sub:d")
             executer.withTasks("d").withArguments("-x", ":sub:c").run().assertTasksExecuted(":a", ":b", ":c", ":d", ":sub:d")
-            executer.withTasks("d").withArguments("-x", "d").run().assertTasksExecuted()
+            executer.withTasks("d").withArguments("-x", "d").run().assertNoTasksExecuted()
             // Project defaults
             executer.withArguments("-x", "b").run().assertTasksExecuted(":a", ":c", ":d", ":sub:c", ":sub:d")
             // Unknown task

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DelegatingExecutionResult.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DelegatingExecutionResult.java
@@ -146,6 +146,16 @@ public interface DelegatingExecutionResult extends ExecutionResult {
     }
 
     @Override
+    default ExecutionResult assertAnyTasksExecuted() {
+        return getDelegate().assertAnyTasksExecuted();
+    }
+
+    @Override
+    default ExecutionResult assertNoTasksExecuted() {
+        return getDelegate().assertNoTasksExecuted();
+    }
+
+    @Override
     default ExecutionResult assertTaskOrder(Object... taskPaths) {
         return getDelegate().assertTaskOrder(taskPaths);
     }
@@ -153,6 +163,16 @@ public interface DelegatingExecutionResult extends ExecutionResult {
     @Override
     default ExecutionResult assertTasksSkipped(Object... taskPaths) {
         return getDelegate().assertTasksSkipped(taskPaths);
+    }
+
+    @Override
+    default ExecutionResult assertAnyTasksExecutedAndNotSkipped() {
+        return getDelegate().assertAnyTasksExecutedAndNotSkipped();
+    }
+
+    @Override
+    default ExecutionResult assertNoTasksExecutedAndNotSkipped() {
+        return getDelegate().assertNoTasksExecutedAndNotSkipped();
     }
 
     @Override

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
@@ -164,6 +164,16 @@ public interface ExecutionResult {
     ExecutionResult assertTaskNotExecuted(String taskPath);
 
     /**
+     * Asserts that at least one task has been executed.
+     */
+    ExecutionResult assertAnyTasksExecuted();
+
+    /**
+     * Asserts that there are no tasks that have been executed.
+     */
+    ExecutionResult assertNoTasksExecuted();
+
+    /**
      * Asserts that the provided tasks were executed in the given order.  Each task path can be either a String
      * or a {@link TaskOrderSpec}.  See {@link TaskOrderSpecs} for common assertions and an explanation of their usage.
      * Defaults to a {@link TaskOrderSpecs#exact(Object[])} assertion.
@@ -184,6 +194,42 @@ public interface ExecutionResult {
      * Asserts that exactly the given set of tasks have not been skipped.
      */
     ExecutionResult assertTasksNotSkipped(Object... taskPaths);
+
+    /**
+     * Asserts that at least one task was executed and not skipped.
+     * Examples:
+     *
+     *  foo: SKIPPED
+     *  bar: SKIPPED -> false
+     *  ----------------------
+     *  NO TASKS EXECUTED -> false
+     *  ----------------------
+     *  foo:
+     *  bar: SKIPPED -> true
+     *  ----------------------
+     *
+     *  foo:
+     *  bar: -> true
+     */
+    ExecutionResult assertAnyTasksExecutedAndNotSkipped();
+
+    /**
+     * Asserts that no tasks were executed and none were skipped.
+     * Examples:
+     *
+     * foo: SKIPPED
+     * bar: SKIPPED -> true
+     * ----------------------
+     * NO TASKS EXECUTED -> true
+     * ----------------------
+     * foo:
+     * bar: SKIPPED -> false
+     * ----------------------
+     *
+     * foo:
+     * bar: -> false
+     */
+    ExecutionResult assertNoTasksExecutedAndNotSkipped();
 
     /**
      * Asserts that the given task has not been skipped.

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -107,6 +107,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -556,6 +558,34 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
             Set<String> expected = new TreeSet<>(flattenTaskPaths(taskPaths));
             assertThat(skippedTasks, equalTo(expected));
             delegate.assertTasksSkipped(expected);
+            return this;
+        }
+
+        @Override
+        public ExecutionResult assertNoTasksExecutedAndNotSkipped() {
+            assertThat(getNotSkippedTasks(), is(empty()));
+            delegate.assertNoTasksExecutedAndNotSkipped();
+            return this;
+        }
+
+        @Override
+        public ExecutionResult assertAnyTasksExecutedAndNotSkipped() {
+            assertThat(getNotSkippedTasks(), is(not(empty())));
+            delegate.assertAnyTasksExecutedAndNotSkipped();
+            return this;
+        }
+
+        @Override
+        public ExecutionResult assertNoTasksExecuted() {
+           assertThat(executedTasks, is(empty()));
+           delegate.assertNoTasksExecuted();
+           return this;
+        }
+
+        @Override
+        public ExecutionResult assertAnyTasksExecuted() {
+            assertThat(executedTasks, is(not(empty())));
+            delegate.assertAnyTasksExecuted();
             return this;
         }
 


### PR DESCRIPTION
Fixes #34047 

### Context
`ExecutionResult.assertTasksExecuted()` previously took empty `vararg` arguments and had confusing semantics. 
Added the following additional methods to make things more intuitive and clear. 

- Added `assertAnyTasksExecuted()`, `assertNoTasksExecuted()`, `assertAnyTasksExecutedAndNotSkipped()`, and `assertNoTasksExecutedAndNotSkipped()`
- Added test cases for each of the above
- Replaced instances of assertTasksExecuted() with new methods where appropriate
- Calling `assertTasksExecuted()` and `assertTasksExecutedAndNotSkipped()` now throw an `IllegalArgumentException` with suggested alternative methods. 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
