### PR TITLE
Compile :configuration-cache to java 17

### DIFF
--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -121,6 +121,14 @@ dependencies {
     crossVersionTestDistributionRuntimeOnly(projects.distributionsCore)
 }
 
+jvmCompile {
+    compilations {
+        named("main") {
+            targetJvmVersion = 17
+        }
+    }
+}
+
 packageCycles {
     excludePatterns.add("org/gradle/internal/cc/**")
 }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/AbstractInstrumentationProcessor.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/AbstractInstrumentationProcessor.java
@@ -36,7 +36,6 @@ import org.jspecify.annotations.NonNull;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -66,7 +65,6 @@ import java.util.stream.Stream;
 
 import static org.gradle.internal.instrumentation.processor.modelreader.impl.TypeUtils.getExecutableElementsFromElements;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public abstract class AbstractInstrumentationProcessor extends AbstractProcessor {
 
     public static final String PROJECT_NAME_OPTIONS = "org.gradle.annotation.processing.instrumented.project";
@@ -81,6 +79,11 @@ public abstract class AbstractInstrumentationProcessor extends AbstractProcessor
     @Override
     public Set<String> getSupportedAnnotationTypes() {
         return getSupportedAnnotations().stream().map(Class::getName).collect(Collectors.toSet());
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
 
     private Set<Class<? extends Annotation>> getSupportedAnnotations() {

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/ConfigurationCacheInstrumentationProcessor.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/ConfigurationCacheInstrumentationProcessor.java
@@ -18,14 +18,14 @@ package org.gradle.internal.instrumentation.processor;
 
 import org.gradle.internal.instrumentation.api.annotations.InterceptGroovyCalls;
 import org.gradle.internal.instrumentation.api.annotations.InterceptJvmCalls;
+import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 import org.gradle.internal.instrumentation.api.annotations.SpecificGroovyCallInterceptors;
 import org.gradle.internal.instrumentation.api.annotations.SpecificJvmCallInterceptors;
-import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.internal.instrumentation.api.annotations.VisitForInstrumentation;
+import org.gradle.internal.instrumentation.extensions.property.InstrumentedPropertiesResourceGenerator;
 import org.gradle.internal.instrumentation.extensions.property.PropertyUpgradeAnnotatedMethodReader;
 import org.gradle.internal.instrumentation.extensions.property.PropertyUpgradeClassSourceGenerator;
-import org.gradle.internal.instrumentation.extensions.property.InstrumentedPropertiesResourceGenerator;
 import org.gradle.internal.instrumentation.extensions.types.InstrumentedTypesResourceGenerator;
 import org.gradle.internal.instrumentation.model.RequestExtra;
 import org.gradle.internal.instrumentation.processor.codegen.groovy.InterceptGroovyCallsGenerator;
@@ -41,15 +41,12 @@ import org.gradle.internal.instrumentation.processor.features.withstaticreferenc
 import org.gradle.internal.instrumentation.processor.features.withstaticreference.WithExtensionReferencesReader;
 import org.gradle.internal.instrumentation.processor.modelreader.impl.AnnotationCallInterceptionRequestReaderImpl;
 
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import java.util.Arrays;
 import java.util.Collection;
 
 import static org.gradle.internal.instrumentation.processor.AddGeneratedClassNameFlagFromClassLevelAnnotation.ifHasAnnotation;
 import static org.gradle.internal.instrumentation.processor.AddGeneratedClassNameFlagFromClassLevelAnnotation.ifHasExtraOfType;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class ConfigurationCacheInstrumentationProcessor extends AbstractInstrumentationProcessor {
 
     @Override

--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -81,6 +81,14 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-full"))
 }
 
+jvmCompile {
+    compilations {
+        named("main") {
+            targetJvmVersion = 17
+        }
+    }
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)

--- a/platforms/enterprise/enterprise/build.gradle.kts
+++ b/platforms/enterprise/enterprise/build.gradle.kts
@@ -58,3 +58,11 @@ dependencies {
 
     integTestDistributionRuntimeOnly(projects.distributionsFull)
 }
+
+jvmCompile {
+    compilations {
+        named("main") {
+            targetJvmVersion = 17
+        }
+    }
+}

--- a/testing/internal-integ-testing/build.gradle.kts
+++ b/testing/internal-integ-testing/build.gradle.kts
@@ -147,7 +147,7 @@ dependencies {
     implementation(libs.sshdSftp)
     implementation(platform(libs.sshdSftp))
 
-    compileOnly(projects.configurationCache) {
+    compileOnly(libs.kotlinStdlib) {
         because("""Fixes:
             compiler message file broken: key=compiler.misc.msg.bug arguments=11.0.21, {1}, {2}, {3}, {4}, {5}, {6}, {7}
             java.lang.AssertionError: typeSig ERROR""")

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjectsRule.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForIsolatedProjectsRule.groovy
@@ -17,7 +17,7 @@
 package org.gradle.integtests.fixtures
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.jetbrains.annotations.NotNull
+import org.jspecify.annotations.NullMarked
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -25,10 +25,11 @@ import org.junit.runners.model.Statement
 /**
  * JUnit Rule supporting the {@link ToBeFixedForIsolatedProjects} annotation.
  */
+@NullMarked
 class ToBeFixedForIsolatedProjectsRule implements TestRule {
 
     @Override
-    Statement apply(@NotNull Statement base, @NotNull Description description) {
+    Statement apply(Statement base, Description description) {
         def annotation = description.getAnnotation(ToBeFixedForIsolatedProjects.class)
         if (GradleContextualExecuter.isNotIsolatedProjects() || annotation == null) {
             return base


### PR DESCRIPTION
Compiles :configuration-cache, :docs, and :enterprise to Java 17.

:configuration-cache since it is only used in the daemon.
:docs since it runs against the entire distribution (to generate javadoc)
:enterprise since it only runs in the daemon and depends on :configuration-cache

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
