### PR TITLE
Revert "Bump mszostok/codeowners-validator from 0.7.2 to 0.7.4"

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -35,7 +35,7 @@ jobs:
       # downgrading to 0.7.2 for owners check to avoid issues with token permissions check,
       # see https://github.com/mszostok/codeowners-validator/issues/224
       - name: GitHub CODEOWNERS Validator
-        uses: mszostok/codeowners-validator@v0.7.4
+        uses: mszostok/codeowners-validator@v0.7.2
         if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           checks: "owners"


### PR DESCRIPTION
This reverts commit da958bb23cc3c6b3af0d55aa254b420433be5ddb.

The comment says 

>      # downgrading to 0.7.2 for owners check to avoid issues with token permissions check,
>      # see https://github.com/mszostok/codeowners-validator/issues/224