### PR TITLE
Add some leniency to `IsolatedProjectsIdeSyncFixture`

### DIFF
--- a/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/IsolatedProjectsGradleceptionSyncTest.groovy
+++ b/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/IsolatedProjectsGradleceptionSyncTest.groovy
@@ -33,7 +33,9 @@ class IsolatedProjectsGradleceptionSyncTest extends AbstractIdeSyncTest {
 
         then:
         fixture.assertHtmlReportHasProblems {
-            totalProblemsCount = 211
+            // In gradle/gradle total problems count depends on amount of subprojects.
+            // We want to avoid useless test failures
+            ignoreTotalProblemsCount = true
             withLocatedProblem("Build file 'testing/architecture-test/build.gradle.kts'", "Project ':architecture-test' cannot access 'Project.tasks' functionality on another project ':'")
             withLocatedProblem("Plugin class 'JetGradlePlugin'", "Project ':' cannot access 'Project.extensions' functionality on subprojects via 'allprojects'")
         }

--- a/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/fixtures/HasConfigurationCacheProblemsInReportSpec.groovy
+++ b/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/fixtures/HasConfigurationCacheProblemsInReportSpec.groovy
@@ -29,6 +29,8 @@ class HasConfigurationCacheProblemsInReportSpec {
     @Nullable
     Integer totalProblemsCount
 
+    boolean ignoreTotalProblemsCount
+
     void validateSpec() {
         def totalCount = totalProblemsCount ?: locationsWithProblems.size()
         if (totalCount < locationsWithProblems.size()) {

--- a/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/fixtures/IsolatedProjectsIdeSyncFixture.groovy
+++ b/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/fixtures/IsolatedProjectsIdeSyncFixture.groovy
@@ -59,7 +59,9 @@ class IsolatedProjectsIdeSyncFixture {
             Pair.of(location, message)
         }.unique()
 
-        assert jsModel.totalProblemCount == spec.totalProblemsCount
+        if (!spec.ignoreTotalProblemsCount) {
+            assert jsModel.totalProblemCount == spec.totalProblemsCount
+        }
         assert actualLocationsWithProblems.size() == spec.locationsWithProblems.size()
         assert actualLocationsWithProblems.every { actualLocation ->
             spec.locationsWithProblems.any { expectedLocation ->


### PR DESCRIPTION
Total problems count during IP sync for gradle/gradle depends on amount of subprojects. 

This PR adding an API for `IPSyncFixture` for ignoring total problems count

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
