### PR TITLE
Add `--add-open` for `java.time`

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -85,7 +85,8 @@ public class JpmsConfiguration {
             "--add-opens=java.base/java.net=ALL-UNNAMED", // required by JavaObjectSerializationCodec
             "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED", // required by AccessTrackingProperties
             "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED", // serialized from org.gradle.internal.file.StatStatistics$Collector
-            "--add-opens=java.xml/javax.xml.namespace=ALL-UNNAMED" // serialized from IvyDescriptorFileGenerator.Model
+            "--add-opens=java.xml/javax.xml.namespace=ALL-UNNAMED", // serialized from IvyDescriptorFileGenerator.Model
+            "--add-opens=java.base/java.time=ALL-UNNAMED"
         ));
         gradleDaemonJvmArgs.addAll(configurationCacheJpmsArgs);
 


### PR DESCRIPTION
Fixes #25680 

JPMS configuration is being picked for embedded executer from deamon, which is mean that we need to have updated wrapper before we can have some test coverage for the change, running with embedded executer.

This PR is needed for milestone promotion.

The test coverage will be landed in next PR, together with the wrapper update.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
