### PR TITLE
docs: Improve context for Finalizer tasks section

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/controlling_task_execution.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/controlling_task_execution.adoc
@@ -248,6 +248,9 @@ Note that `taskY.mustRunAfter(taskX)` or `taskY.shouldRunAfter(taskX)` does not 
 [[sec:finalizer_tasks]]
 == Finalizer tasks
 
+Finalizer tasks are useful when the build creates a resource that must be cleaned up, regardless of whether the build fails or succeeds.
+An example of such a resource is a web container that is started before an integration test task and must be shut down, even if some tests fail.
+
 Finalizer tasks are automatically added to the task graph when the finalized task is scheduled to run.
 
 To specify a finalizer task, you use the link:{javadocPath}/org/gradle/api/Task.html#finalizedBy-java.lang.Object...-[Task.finalizedBy(java.lang.Object...)] method.
@@ -274,9 +277,6 @@ $ gradle -q taskX
 include::{snippetsPath}/tasks/finalizersWithFailure/tests-groovy/taskFinalizersWithFailureGroovy.out[]
 ----
 ====
-
-Finalizer tasks are useful when the build creates a resource that must be cleaned up, regardless of whether the build fails or succeeds.
-An example of such a resource is a web container that is started before an integration test task and must be shut down, even if some tests fail.
 
 [[sec:skipping_tasks]]
 == Skipping tasks


### PR DESCRIPTION
Moved the explanatory paragraph to the beginning of the section to provide better context and clarity about why Finalizer tasks are useful.

<!--- The issue this PR addresses -->
Fixes #34225

### Context
The "Finalizer tasks" section previously started without context, making it harder for readers to understand their purpose and why they are important.
This PR moves the explanatory paragraph to the beginning of the section, improving readability and comprehension for users who are learning about Gradle task execution.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective. *(Not applicable for docs change)*
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic. *(Not applicable for docs change)*
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`. *(Docs change, should pass)*
- [x] Ensure that tests pass locally: `./gradlew :docs:quickTest`.

### Reviewing cheatsheet
Before merging the PR, comments starting with:
- ❌ ❓ **must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things