### PR TITLE
Update documentation by adding a link to the cookbook for the Sonatype blog

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/init_scripts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/init_scripts.adoc
@@ -141,7 +141,8 @@ include::{snippetsPath}/initScripts/externalDependency/tests-common/externalInit
 [[sec:init_script_plugins]]
 == Applying plugins
 
-TIP: If you want to learn about tips for Maven Publishing, head over to our link:https://cookbook.gradle.org/integrations/maven-central/repositories/[Cookbook].
+TIP: This section provides a basic sample about using init scripts.
+If you want to learn about Maven Central mirroring and caching in real scenarios, head over to our link:https://cookbook.gradle.org/integrations/maven-central/repositories/[Gradle Cookbook].
 
 Plugins can be applied to init scripts like a Gradle build script or a Gradle settings file.
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- [x] Link in Sonatype blog post points to Init Script, adding a better alternative