### PR TITLE
Implement EAR Deployment Descriptor for Jakarta EE 11

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -74,6 +74,20 @@ ADD RELEASE FEATURES BELOW
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
 
+<a name="ear-plugin"></a>
+### Ear Plugin
+
+It is now possible to generate valid deployment descriptors for Jakarta EE 11
+by specifying the corresponding version in the `deploymentDescriptor` instead of having to use a custom descriptor file.
+
+```kotlin
+tasks.ear {
+    deploymentDescriptor {  // custom entries for application.xml:
+        version = "11"
+    }
+}
+```
+
 <a name="cli"></a>
 ### CLI improvement
 

--- a/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/DeploymentDescriptor.java
+++ b/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/DeploymentDescriptor.java
@@ -40,7 +40,7 @@ public interface DeploymentDescriptor {
     void setFileName(String fileName);
 
     /**
-     * The version of application.xml. Required. Valid versions are "1.3", "1.4", "5", "6", "7", "8", "9" and "10". Defaults to "6".
+     * The version of application.xml. Required. Valid versions are "1.3", "1.4", "5", "6", "7", "8", "9", "10" and "11". Defaults to "6".
      */
     @ToBeReplacedByLazyProperty
     String getVersion();

--- a/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
+++ b/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
@@ -381,7 +381,7 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
             rootAttributes.put("xsi:schemaLocation", "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_" + version + ".xsd");
         } else if ("7".equals(version) || "8".equals(version)) {
             rootAttributes.put("xsi:schemaLocation", "http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_" + version + ".xsd");
-        } else if ("9".equals(version) || "10".equals(version)) {
+        } else if ("9".equals(version) || "10".equals(version) || "11".equals(version)) {
             rootAttributes.put("xsi:schemaLocation", "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_" + version + ".xsd");
         }
         if (applicationName != null) {
@@ -437,7 +437,7 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
             return new QName("http://java.sun.com/xml/ns/javaee", name);
         } else if ("7".equals(version) || "8".equals(version)) {
             return new QName("http://xmlns.jcp.org/xml/ns/javaee", name);
-        } else if ("9".equals(version) || "10".equals(version)) {
+        } else if ("9".equals(version) || "10".equals(version) || "11".equals(version)) {
             return new QName("https://jakarta.ee/xml/ns/jakartaee", name);
         } else {
             return new QName(name);

--- a/platforms/jvm/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
+++ b/platforms/jvm/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
@@ -72,6 +72,7 @@ class DefaultDeploymentDescriptorTest extends Specification {
         '8'     | _
         '9'     | _
         '10'    | _
+        '11'    | _
         acceptableDescriptors = defaultDescriptorForVersion(version)
     }
 
@@ -217,6 +218,8 @@ class DefaultDeploymentDescriptorTest extends Specification {
         '9'     | 'asElement'        | { it.asElement() }
         '10'    | 'asNode'           | { it.asNode() }
         '10'    | 'asElement'        | { it.asElement() }
+        '11'    | 'asNode'           | { it.asNode() }
+        '11'    | 'asElement'        | { it.asElement() }
         acceptableDescriptors = defaultDescriptorForVersion(version)
     }
 


### PR DESCRIPTION
Support Jakarta EE 11 in ear Descriptor by correctly handling Value "11" in property `ear.deploymentDescriptor.version`.
Fixes #34342

<!--- The issue this PR addresses -->
<!-- Fixes #34342 -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
