### PR TITLE
Address comments from prior PRs

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
@@ -276,7 +276,7 @@ Group
 BUILD SUCCESSFUL"""
     }
 
-    @ToBeFixedForIsolatedProjects
+    @ToBeFixedForIsolatedProjects(because = "Accesses project.task for another project")
     def "help for tasks same type different descriptions"() {
         setup:
         createDirs("someproj")
@@ -319,7 +319,7 @@ Group
 BUILD SUCCESSFUL"""
     }
 
-    @ToBeFixedForIsolatedProjects
+    @ToBeFixedForIsolatedProjects(because = "Accesses project.task for another project")
     def "help for tasks same type different groups"() {
         setup:
         createDirs("someproj1", "someproj2")
@@ -370,7 +370,7 @@ Groups
 BUILD SUCCESSFUL"""
     }
 
-    @ToBeFixedForIsolatedProjects
+    @ToBeFixedForIsolatedProjects(because = "Accesses project.task for another project")
     def "matchingTasksOfSameType"() {
         setup:
         createDirs("subproj1")
@@ -425,7 +425,7 @@ BUILD SUCCESSFUL"""
 
     }
 
-    @ToBeFixedForIsolatedProjects
+    @ToBeFixedForIsolatedProjects(because = "Accesses project.task for another project")
     def "multipleMatchingTasksOfDifferentType"() {
         setup:
         createDirs("subproj1")
@@ -557,7 +557,7 @@ BUILD SUCCESSFUL"""
         )
     }
 
-    @ToBeFixedForIsolatedProjects
+    @ToBeFixedForIsolatedProjects(because = "Accesses project.task for another project")
     def "listsEnumAndBooleanCmdOptionValues"() {
         createDirs("proj1", "proj2")
         when:
@@ -596,7 +596,7 @@ Group
 BUILD SUCCESSFUL"""
     }
 
-    @ToBeFixedForIsolatedProjects
+    @ToBeFixedForIsolatedProjects(because = "Accesses project.task for another project")
     def "listsCommonDynamicAvailableValues"() {
         createDirs("sub1", "sub2")
         when:

--- a/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ProjectReportTaskIntegrationTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ProjectReportTaskIntegrationTest.groovy
@@ -219,7 +219,7 @@ Root project 'my-root-project'
 """
     }
 
-    @ToBeFixedForIsolatedProjects
+    @ToBeFixedForIsolatedProjects(because = "Accesses project.description for another project")
     def "project project structure and software types for multi-project build using declarative dcl"() {
         given: "a build-logic build registering an ecosystem plugin defining several software types via several plugins"
         file("build-logic/src/main/java/com/example/restricted/LibraryExtension.java") << """

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
@@ -292,8 +292,8 @@ public abstract class TaskReportTask extends ConventionReportTask {
             .startsWith(relativeProjectIdentity.getBuildTreePath());
 
         return isParentProject
-            ? relativeProjectIdentity.getProjectPath().relativePath(taskId.projectPath)
-            : taskId.projectPath;
+            ? relativeProjectIdentity.getProjectPath().relativePath(taskId.getPath())
+            : taskId.getPath();
     }
 
     /**

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
@@ -90,7 +90,7 @@ class TaskNodeCodec(
             writeClass(taskType)
             writeProjectRef(task.project)
             writeString(taskName)
-            writeLong(task.taskIdentity.uniqueId)
+            writeLong(task.taskIdentity.id)
             writeNullableString(task.reasonTaskIsIncompatibleWithConfigurationCache.orElse(null))
 
             withDebugFrame({ taskType.name }) {

--- a/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
+++ b/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
@@ -97,15 +97,17 @@ public class ProfileEventAdapter implements ProfileService, InternalBuildListene
     @Override
     public void beforeExecute(TaskIdentity<?> taskIdentity) {
         long now = clock.getCurrentTime();
-        ProjectProfile projectProfile = buildProfile.getProjectProfile(taskIdentity.getProjectPath());
-        projectProfile.getTaskProfile(taskIdentity.getTaskPath()).setStart(now);
+        String projectPath = taskIdentity.getProjectIdentity().getProjectPath().getPath();
+        ProjectProfile projectProfile = buildProfile.getProjectProfile(projectPath);
+        projectProfile.getTaskProfile(taskIdentity.getPath().getPath()).setStart(now);
     }
 
     @Override
     public void afterExecute(TaskIdentity<?> taskIdentity, TaskState state) {
         long now = clock.getCurrentTime();
-        ProjectProfile projectProfile = buildProfile.getProjectProfile(taskIdentity.getProjectPath());
-        TaskExecution taskExecution = projectProfile.getTaskProfile(taskIdentity.getTaskPath());
+        String projectPath = taskIdentity.getProjectIdentity().getProjectPath().getPath();
+        ProjectProfile projectProfile = buildProfile.getProjectProfile(projectPath);
+        TaskExecution taskExecution = projectProfile.getTaskProfile(taskIdentity.getPath().getPath());
         taskExecution.setFinish(now);
         taskExecution.completed(state);
     }

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/RealizeTaskBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/RealizeTaskBuildOperationType.java
@@ -26,8 +26,15 @@ import org.gradle.internal.operations.BuildOperationType;
 public final class RealizeTaskBuildOperationType implements BuildOperationType<RealizeTaskBuildOperationType.Details, RealizeTaskBuildOperationType.Result> {
 
     public interface Details {
+
+        /**
+         * The path of the build this task belongs to.
+         */
         String getBuildPath();
 
+        /**
+         * Get the path of this task within the build.
+         */
         String getTaskPath();
 
         /**
@@ -38,6 +45,7 @@ public final class RealizeTaskBuildOperationType implements BuildOperationType<R
         boolean isReplacement();
 
         boolean isEager();
+
     }
 
     public interface Result {

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/RegisterTaskBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/RegisterTaskBuildOperationType.java
@@ -26,8 +26,15 @@ import org.gradle.internal.operations.BuildOperationType;
 public final class RegisterTaskBuildOperationType implements BuildOperationType<RegisterTaskBuildOperationType.Details, RegisterTaskBuildOperationType.Result> {
 
     public interface Details {
+
+        /**
+         * The path of the build this task belongs to.
+         */
         String getBuildPath();
 
+        /**
+         * Get the path of this task within the build.
+         */
         String getTaskPath();
 
         /**
@@ -36,6 +43,7 @@ public final class RegisterTaskBuildOperationType implements BuildOperationType<
         long getTaskId();
 
         boolean isReplacement();
+
     }
 
     public interface Result {

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationType.java
@@ -39,8 +39,14 @@ public final class ExecuteTaskBuildOperationType implements BuildOperationType<E
 
     public interface Details {
 
+        /**
+         * The path of the build this task belongs to.
+         */
         String getBuildPath();
 
+        /**
+         * Get the path of this task within the build.
+         */
         String getTaskPath();
 
         /**

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationType.java
@@ -30,17 +30,27 @@ import org.gradle.internal.operations.BuildOperationType;
  * @since 7.6
  */
 public final class ResolveTaskMutationsBuildOperationType implements BuildOperationType<ResolveTaskMutationsBuildOperationType.Details, ResolveTaskMutationsBuildOperationType.Result> {
+
     public interface Details {
+
+        /**
+         * The path of the build this task belongs to.
+         */
         String getBuildPath();
 
+        /**
+         * Get the path of this task within the build.
+         */
         String getTaskPath();
 
         /**
          * See {@code org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId}.
          */
         long getTaskId();
+
     }
 
     public interface Result {
     }
+
 }

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
@@ -56,8 +56,14 @@ public final class CalculateTaskGraphBuildOperationType implements BuildOperatio
      */
     public interface TaskIdentity extends NodeIdentity {
 
+        /**
+         * The path of the build this task belongs to.
+         */
         String getBuildPath();
 
+        /**
+         * The path of this task in the build.
+         */
         String getTaskPath();
 
         /**

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TaskIdentity.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TaskIdentity.java
@@ -18,16 +18,10 @@ package org.gradle.api.problems.internal;
 
 public class TaskIdentity {
 
-    private final String buildTreePath;
     private final String taskPath;
 
-    public TaskIdentity(String buildTreePath, String taskPath) {
-        this.buildTreePath = buildTreePath;
+    public TaskIdentity(String taskPath) {
         this.taskPath = taskPath;
-    }
-
-    public String getBuildTreePath() {
-        return buildTreePath;
     }
 
     public String getTaskPath() {

--- a/platforms/ide/problems/src/main/java/org/gradle/problems/internal/services/ProblemsBuildTreeServices.java
+++ b/platforms/ide/problems/src/main/java/org/gradle/problems/internal/services/ProblemsBuildTreeServices.java
@@ -99,7 +99,7 @@ public class ProblemsBuildTreeServices implements ServiceRegistrationProvider {
                 } else {
                     return workExecutionTracker
                         .getCurrentTask(id)
-                        .map(task -> new TaskIdentity(task.getTaskIdentity().getBuildPath(), task.getTaskIdentity().getTaskPath()))
+                        .map(task -> new TaskIdentity(task.getTaskIdentity().getPath().getPath()))
                         .orElse(null);
                 }
             }

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TaskOriginTracker.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TaskOriginTracker.java
@@ -47,7 +47,7 @@ class TaskOriginTracker implements BuildOperationTracker {
 
     @Nullable
     InternalPluginIdentifier getOriginPlugin(TaskIdentity<?> taskIdentity) {
-        return origins.get(taskIdentity.uniqueId);
+        return origins.get(taskIdentity.getId());
     }
 
     @Override

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProjectModuleIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProjectModuleIdentityIntegrationTest.groovy
@@ -28,9 +28,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 class ProjectModuleIdentityIntegrationTest extends AbstractIntegrationSpec {
 
     def "default group for root project is an empty string"() {
-        buildFile << """
+        buildFile("""
             assert group == ""
-        """
+        """)
 
         expect:
         succeeds("help")
@@ -38,27 +38,34 @@ class ProjectModuleIdentityIntegrationTest extends AbstractIntegrationSpec {
 
     def "default group for subproject is based on project structure"() {
         given:
-        settingsFile << """
+        settingsFile("""
             rootProject.name = "root"
             include(":sub")
             include(":sub:subsub")
-        """
+        """)
 
-        file("sub/build.gradle") << """
+        buildFile("sub/build.gradle", """
             assert group == "root"
-        """
-        file("sub/subsub/build.gradle") << """
+        """)
+        buildFile("sub/subsub/build.gradle", """
             assert group == "root.sub"
-        """
+        """)
 
         expect:
         succeeds("help")
     }
 
-    def "default version for root project is 'unspecified'"() {
-        buildFile << """
+    def "default version for project is 'unspecified'"() {
+        settingsFile("""
+            rootProject.name = "root"
+            include(":sub")
+        """)
+        buildFile("""
             assert version == "unspecified"
-        """
+        """)
+        buildFile("sub/build.gradle", """
+            assert version == "unspecified"
+        """)
 
         expect:
         succeeds("help")

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -181,7 +181,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         this.project = taskInfo.project;
 
         assert project != null;
-        assert identity.name != null;
+        assert identity.getName() != null;
         this.state = new TaskStateInternal();
         final TaskDependencyFactory taskDependencyFactory = project.getTaskDependencyFactory();
         this.mustRunAfter = taskDependencyFactory.configurableDependency();
@@ -207,7 +207,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private void assertDynamicObject() {
         if (extensibleDynamicObject == null) {
-            extensibleDynamicObject = new ExtensibleDynamicObject(this, identity.type, services.get(InstantiatorFactory.class).decorateLenient(services));
+            extensibleDynamicObject = new ExtensibleDynamicObject(this, identity.getTaskType(), services.get(InstantiatorFactory.class).decorateLenient(services));
         }
     }
 
@@ -242,7 +242,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     @Internal
     @Override
     public String getName() {
-        return identity.name;
+        return identity.getName();
     }
 
     @Override
@@ -472,12 +472,12 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     @Internal
     @Override
     public String getPath() {
-        return identity.projectPath.toString();
+        return identity.getPath().getPath();
     }
 
     @Override
     public Path getIdentityPath() {
-        return identity.identityPath;
+        return identity.getBuildTreePath();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -482,6 +482,12 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         return group;
     }
 
+    /**
+     * Constructs a default group for this project based on its hierarchy.
+     *
+     * For example, a project ":a:b:c" in a build with a root project named "root"
+     * will have a default group "root.a.b".
+     */
     private String getDefaultGroup() {
         ProjectInternal parent = getParent();
         if (parent == null) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -51,33 +51,33 @@ public class TaskFactory implements ITaskFactory {
     @Override
     @SuppressWarnings("deprecation")
     public <S extends Task> S create(final TaskIdentity<S> identity, @Nullable final Object[] constructorArgs) {
-        if (!Task.class.isAssignableFrom(identity.type)) {
+        if (!Task.class.isAssignableFrom(identity.getTaskType())) {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task '%s' of type '%s' as it does not implement the Task interface.",
-                identity.identityPath.toString(),
-                identity.type.getSimpleName()));
+                identity.getBuildTreePath().getPath(),
+                identity.getTaskType().getSimpleName()));
         }
 
-        NameValidator.validate(identity.name, "task name", "");
+        NameValidator.validate(identity.getName(), "task name", "");
 
         final Class<? extends DefaultTask> implType;
-        if (identity.type == Task.class) {
+        if (identity.getTaskType() == Task.class) {
             implType = DefaultTask.class;
-        } else if (DefaultTask.class.isAssignableFrom(identity.type)) {
-            implType = identity.type.asSubclass(DefaultTask.class);
-        } else if (identity.type == org.gradle.api.internal.AbstractTask.class || identity.type == TaskInternal.class) {
+        } else if (DefaultTask.class.isAssignableFrom(identity.getTaskType())) {
+            implType = identity.getTaskType().asSubclass(DefaultTask.class);
+        } else if (identity.getTaskType() == org.gradle.api.internal.AbstractTask.class || identity.getTaskType() == TaskInternal.class) {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task '%s' of type '%s' as this type is not supported for task registration.",
-                identity.identityPath.toString(),
-                identity.type.getSimpleName()));
+                identity.getBuildTreePath().getPath(),
+                identity.getTaskType().getSimpleName()));
         } else {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task '%s' of type '%s' as directly extending AbstractTask is not supported.",
-                identity.identityPath.toString(),
-                identity.type.getSimpleName()));
+                identity.getBuildTreePath().getPath(),
+                identity.getTaskType().getSimpleName()));
         }
 
-        Describable displayName = Describables.withTypeAndName("task", identity.getIdentityPath());
+        Describable displayName = Describables.withTypeAndName("task", identity.getBuildTreePath().getPath());
 
         return org.gradle.api.internal.AbstractTask.injectIntoNewInstance(project, identity, new Callable<S>() {
             @Override
@@ -89,9 +89,9 @@ public class TaskFactory implements ITaskFactory {
                     } else {
                         instance = instantiationScheme.deserializationInstantiator().newInstance(implType, org.gradle.api.internal.AbstractTask.class);
                     }
-                    return identity.type.cast(instance);
+                    return identity.getTaskType().cast(instance);
                 } catch (ObjectInstantiationException e) {
-                    throw new TaskInstantiationException(String.format("Could not create task of type '%s'.", identity.type.getSimpleName()),
+                    throw new TaskInstantiationException(String.format("Could not create task of type '%s'.", identity.getTaskType().getSimpleName()),
                         e.getCause());
                 }
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskIdentity.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskIdentity.java
@@ -24,16 +24,54 @@ import org.gradle.util.Path;
 @UsedByScanPlugin
 public final class TaskIdentity<T extends Task> {
 
-    public final Class<T> type;
-    public final String name;
-    public final Path projectPath; // path within its build (i.e. including project path)
-    public final Path identityPath; // path within the build tree (i.e. including project path)
-    public final Path buildPath; // path of the owning build
+    // TODO #34344: Remove these public fields and String-typed getters.
 
     /**
-     * Tasks can be replaced in Gradle, meaning there can be two different tasks with the same path/type.
-     * This allows identifying a precise instance.
+     * The type of the task.
+     *
+     * @deprecated Use {@link #getTaskType()} instead.
      */
+    @Deprecated
+    public final Class<T> type;
+
+    /**
+     * The name of the task.
+     *
+     * @deprecated Use {@link #getName()} instead.
+     */
+    @Deprecated
+    public final String name;
+
+    /**
+     * The path of the task within the build.
+     *
+     * @deprecated Use {@link #getPath()} instead.
+     */
+    @Deprecated
+    public final Path projectPath;
+
+    /**
+     * The path of the task within the build tree.
+     *
+     * @deprecated Use {@link #getBuildTreePath()} instead.
+     */
+    @Deprecated
+    public final Path identityPath;
+
+    /**
+     * The path of the owning build.
+     *
+     * @deprecated Use {@link #getProjectIdentity()} instead.
+     */
+    @Deprecated
+    public final Path buildPath;
+
+    /**
+     * A unique identifier for the task within the build.
+     *
+     * @deprecated Use {@link #getId()} instead.
+     */
+    @Deprecated
     public final long uniqueId;
 
     private final ProjectIdentity projectIdentity;
@@ -49,6 +87,19 @@ public final class TaskIdentity<T extends Task> {
         this.buildPath = projectIdentity.getBuildPath();
     }
 
+    /**
+     * Get the name of the task.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Get the unique identifier for the task within the build.
+     * <p>
+     * Tasks can be replaced in Gradle, meaning there can be two different tasks with the same path/type.
+     * This allows identifying a precise instance.
+     */
     public long getId() {
         return uniqueId;
     }
@@ -67,7 +118,7 @@ public final class TaskIdentity<T extends Task> {
 
     @Override
     public int hashCode() {
-        return (int) (uniqueId ^ uniqueId >>> 32);
+        return Long.hashCode(uniqueId);
     }
 
     @Override
@@ -75,27 +126,67 @@ public final class TaskIdentity<T extends Task> {
         return "TaskIdentity{path=" + identityPath + ", type=" + type + ", uniqueId=" + uniqueId + '}';
     }
 
+    /**
+     * Get the path of this task within the build.
+     */
+    public Path getPath() {
+        return projectPath;
+    }
+
+    /**
+     * Get the path of this task within the build tree.
+     */
+    public Path getBuildTreePath() {
+        return identityPath;
+    }
+
+    /**
+     * Get the path of this task within the build.
+     *
+     * @deprecated Use {@link #getPath()} instead.
+     */
+    @Deprecated
     public String getTaskPath() {
-        return projectPath.getPath();
+        return getPath().getPath();
     }
 
+    /**
+     * @deprecated Use {@link #getProjectIdentity()} instead.
+     */
+    @Deprecated
     public String getProjectPath() {
-        return projectPath.getParent().getPath();
+        return getProjectIdentity().getProjectPath().getPath();
     }
 
+    /**
+     * Get the path of this task within the build tree.
+     *
+     * @deprecated Use {@link #getBuildTreePath()} instead.
+     */
+    @Deprecated
     public String getIdentityPath() {
-        return identityPath.getPath();
+        return getBuildTreePath().getPath();
     }
-
+    /**
+     * @deprecated Use {@link #getProjectIdentity()} instead.
+     */
+    @Deprecated
     public String getBuildPath() {
-        return buildPath.getPath();
+        return getProjectIdentity().getBuildPath().getPath();
     }
 
+    /**
+     * Get the type of the task.
+     */
     public Class<T> getTaskType() {
         return type;
     }
 
+    /**
+     * Get the identity of the project that owns this task.
+     */
     public ProjectIdentity getProjectIdentity() {
         return projectIdentity;
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -240,7 +240,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
                     final Action<? super T> onCreate;
                     if (!taskProvider.getType().isAssignableFrom(task.getClass())) {
-                        throw new IllegalStateException("Replacing an existing task with an incompatible type is not supported.  Use a different name for this task ('" + name + "') or use a compatible type (" + ((TaskInternal) task).getTaskIdentity().type.getName() + ")");
+                        throw new IllegalStateException("Replacing an existing task with an incompatible type is not supported.  Use a different name for this task ('" + name + "') or use a compatible type (" + ((TaskInternal) task).getTaskIdentity().getTaskType().getName() + ")");
                     } else {
                         onCreate = Cast.uncheckedCast(taskProvider.getOnCreateActions().mergeFrom(getEventRegister().getAddActions()));
                     }
@@ -308,13 +308,13 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
             public T call(BuildOperationContext context) {
                 try {
                     T task = createTask(identity, constructorArgs);
-                    statistics.eagerTask(identity.type);
+                    statistics.eagerTask(identity.getTaskType());
                     addTask(task, false);
                     configureAction.execute(task);
                     context.setResult(REALIZE_RESULT);
                     return task;
                 } catch (Throwable t) {
-                    throw taskCreationException(identity.name, t);
+                    throw taskCreationException(identity.getName(), t);
                 }
             }
 
@@ -329,7 +329,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         if (constructorArgs != null) {
             for (int i = 0; i < constructorArgs.length; i++) {
                 if (constructorArgs[i] == null) {
-                    throw new NullPointerException(String.format("Received null for %s constructor argument #%s", identity.type.getName(), i + 1));
+                    throw new NullPointerException(String.format("Received null for %s constructor argument #%s", identity.getTaskType().getName(), i + 1));
                 }
             }
         }
@@ -670,7 +670,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         private Object[] constructorArgs;
 
         public TaskCreatingProvider(TaskIdentity<I> identity, @Nullable Action<? super I> configureAction, Object... constructorArgs) {
-            super(identity.name, identity.type, configureAction);
+            super(identity.getName(), identity.getTaskType(), configureAction);
             this.identity = identity;
             this.constructorArgs = constructorArgs;
             statistics.lazyTask();
@@ -730,12 +730,12 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     private static BuildOperationDescriptor.Builder realizeDescriptor(TaskIdentity<?> identity, boolean replacement, boolean eager) {
-        return BuildOperationDescriptor.displayName("Realize task " + identity.identityPath)
+        return BuildOperationDescriptor.displayName("Realize task " + identity.getBuildTreePath().getPath())
             .details(new RealizeDetails(identity, replacement, eager));
     }
 
     private static BuildOperationDescriptor.Builder registerDescriptor(TaskIdentity<?> identity) {
-        return BuildOperationDescriptor.displayName("Register task " + identity.identityPath)
+        return BuildOperationDescriptor.displayName("Register task " + identity.getBuildTreePath().getPath())
             .details(new RegisterDetails(identity));
     }
 
@@ -807,17 +807,17 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
         @Override
         public String getBuildPath() {
-            return identity.buildPath.toString();
+            return identity.getProjectIdentity().getBuildPath().getPath();
         }
 
         @Override
         public String getTaskPath() {
-            return identity.projectPath.toString();
+            return identity.getPath().getPath();
         }
 
         @Override
         public long getTaskId() {
-            return identity.uniqueId;
+            return identity.getId();
         }
 
         @Override
@@ -842,17 +842,17 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
         @Override
         public String getBuildPath() {
-            return identity.buildPath.toString();
+            return identity.getProjectIdentity().getBuildPath().getPath();
         }
 
         @Override
         public String getTaskPath() {
-            return identity.projectPath.toString();
+            return identity.getPath().getPath();
         }
 
         @Override
         public long getTaskId() {
-            return identity.uniqueId;
+            return identity.getId();
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationDetails.java
@@ -44,22 +44,22 @@ public class ExecuteTaskBuildOperationDetails implements ExecuteTaskBuildOperati
 
     @Override
     public String getBuildPath() {
-        return taskIdentity().buildPath.toString();
+        return taskIdentity().getProjectIdentity().getBuildPath().getPath();
     }
 
     @Override
     public String getTaskPath() {
-        return taskIdentity().projectPath.toString();
+        return taskIdentity().getPath().getPath();
     }
 
     @Override
     public long getTaskId() {
-        return taskIdentity().uniqueId;
+        return taskIdentity().getId();
     }
 
     @Override
     public Class<?> getTaskClass() {
-        return taskIdentity().type;
+        return taskIdentity().getTaskType();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ProblemsTaskPathTrackingTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ProblemsTaskPathTrackingTaskExecuter.java
@@ -37,7 +37,7 @@ public class ProblemsTaskPathTrackingTaskExecuter implements TaskExecuter {
     @Override
     public TaskExecuterResult execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
         try {
-            ProblemTaskIdentityTracker.setTaskIdentity(new TaskIdentity(task.getTaskIdentity().getBuildPath(), task.getTaskIdentity().getTaskPath()));
+            ProblemTaskIdentityTracker.setTaskIdentity(new TaskIdentity(task.getTaskIdentity().getPath().getPath()));
             return taskExecuter.execute(task, state, context);
         } finally {
             ProblemTaskIdentityTracker.clear();

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ResolveMutationsNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ResolveMutationsNode.java
@@ -103,7 +103,7 @@ public class ResolveMutationsNode extends Node implements SelfExecutingNode {
             @Override
             public BuildOperationDescriptor.Builder description() {
                 TaskIdentity<?> taskIdentity = node.getTask().getTaskIdentity();
-                return BuildOperationDescriptor.displayName("Resolve mutations for task " + taskIdentity.getIdentityPath())
+                return BuildOperationDescriptor.displayName("Resolve mutations for task " + taskIdentity.getBuildTreePath().getPath())
                     .details(new ResolveTaskMutationsDetails(taskIdentity));
             }
         });
@@ -118,12 +118,12 @@ public class ResolveMutationsNode extends Node implements SelfExecutingNode {
 
         @Override
         public String getBuildPath() {
-            return taskIdentity.getBuildPath();
+            return taskIdentity.getProjectIdentity().getBuildPath().getPath();
         }
 
         @Override
         public String getTaskPath() {
-            return taskIdentity.getTaskPath();
+            return taskIdentity.getPath().getPath();
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
@@ -65,12 +65,12 @@ public class ToPlannedTaskConverter implements ToPlannedNodeConverter {
 
         @Override
         public String getBuildPath() {
-            return delegate.getBuildPath();
+            return delegate.getProjectIdentity().getBuildPath().getPath();
         }
 
         @Override
         public String getTaskPath() {
-            return delegate.getTaskPath();
+            return delegate.getPath().getPath();
         }
 
         @Override
@@ -97,7 +97,7 @@ public class ToPlannedTaskConverter implements ToPlannedNodeConverter {
 
         @Override
         public String toString() {
-            return "Task " + delegate.getIdentityPath();
+            return "Task " + delegate.getBuildTreePath().getPath();
         }
     }
 


### PR DESCRIPTION
Add javadoc/example to DefaultProject.getDefaultGroup Use buildFile methods with syntax highligting in integ tets Verify default version of subprojects
Add reasons for broken tests in IP

Deprecate public fields on TaskIdentity in favor of new methods to expose the field values. Some of these public field are being used by Test Acceleration, so we cannot remove them at the moment.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
