### PR TITLE
Fix flaky docsTest

### DIFF
--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidInternal-do/tests/avoidInternal.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidInternal-do/tests/avoidInternal.out
@@ -1,26 +1,17 @@
-
 > Configure project :
 Good map
 org.gradle.usage -> java-runtime
 org.gradle.category -> library
-
 > Task :projects
-
 Projects:
-
 ------------------------------------------------------------
 Root project 'avoid-internal-do'
 ------------------------------------------------------------
-
 Location: /home/user/gradle/samples
-
 Project hierarchy:
-
 Root project 'avoid-internal-do'
 No sub-projects
-
 To see a list of the tasks of a project, run gradle <project-path>:tasks
 For example, try running gradle :tasks
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/platforms/documentation/docs/src/snippets/java/multiproject/tests/listProjects.out
+++ b/platforms/documentation/docs/src/snippets/java/multiproject/tests/listProjects.out
@@ -1,28 +1,20 @@
-
 Projects:
-
 ------------------------------------------------------------
 Root project 'multiproject'
 ------------------------------------------------------------
-
 Location: /home/user/gradle/samples
-
 Project hierarchy:
-
 Root project 'multiproject'
 +--- Project ':api'
 +--- Project ':services'
 |    +--- Project ':services:shared'
 |    \--- Project ':services:webservice'
 \--- Project ':shared'
-
 Project locations:
-
 project ':api' - /api
 project ':services' - /services
 project ':services:shared' - /services/shared
 project ':services:webservice' - /services/webservice
 project ':shared' - /shared
-
 To see a list of the tasks of a project, run gradle <project-path>:tasks
 For example, try running gradle :api:tasks

--- a/platforms/documentation/docs/src/snippets/mavenMigration/multiModule/tests/projects.out
+++ b/platforms/documentation/docs/src/snippets/mavenMigration/multiModule/tests/projects.out
@@ -1,22 +1,14 @@
-
 Projects:
-
 ------------------------------------------------------------
 Root project 'simple-multi-module'
 ------------------------------------------------------------
-
 Location: /home/user/gradle/samples
-
 Project hierarchy:
-
 Root project 'simple-multi-module'
 +--- Project ':simple-weather'
 \--- Project ':simple-webapp'
-
 Project locations:
-
 project ':simple-weather' - /simple-weather
 project ':simple-webapp' - /simple-webapp
-
 To see a list of the tasks of a project, run gradle <project-path>:tasks
 For example, try running gradle :simple-weather:tasks

--- a/platforms/documentation/docs/src/snippets/multiproject/basic-multiproject/tests/projects.out
+++ b/platforms/documentation/docs/src/snippets/multiproject/basic-multiproject/tests/projects.out
@@ -1,20 +1,12 @@
-
 Projects:
-
 ------------------------------------------------------------
 Root project 'my-project'
 ------------------------------------------------------------
-
 Location: /home/user/gradle/samples
-
 Project hierarchy:
-
 Root project 'my-project'
 \--- Project ':app'
-
 Project locations:
-
 project ':app' - /app
-
 To see a list of the tasks of a project, run gradle <project-path>:tasks
 For example, try running gradle :app:tasks

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/EmptyLineRemovalOutputNormalizer.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/EmptyLineRemovalOutputNormalizer.groovy
@@ -20,9 +20,20 @@ import org.gradle.exemplar.executor.ExecutionMetadata
 import org.gradle.exemplar.test.normalizer.OutputNormalizer
 
 class EmptyLineRemovalOutputNormalizer implements OutputNormalizer {
+    private static final List<String> SAMPLES_IGNORING_EMPTY_LINE = [
+        "useCacheabilityAnnotations",
+        "avoidInternal",
+        "multiproject-basic-multiproject_groovy_test",
+        "multiproject-basic-multiproject_kotlin_test",
+        "multiproject_kotlin_listProjects",
+        "multiproject_groovy_listProjects",
+        "maven-migration-multi-module_kotlin_project",
+        "maven-migration-multi-module_groovy_projects"
+    ]
+
     @Override
     String normalize(String commandOutput, ExecutionMetadata executionMetadata) {
-        if (executionMetadata.tempSampleProjectDir.name.contains('useCacheabilityAnnotations')) {
+        if (SAMPLES_IGNORING_EMPTY_LINE.any { executionMetadata.tempSampleProjectDir.name.contains(it) }) {
             return commandOutput.readLines()
                 .collect { it.trim() }
                 .findAll { !it.isEmpty() }


### PR DESCRIPTION
Several sample tests are observed to be flaky because of empty lines. This PR fixes them by ignoring the empty lines when comparing.