### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ systemProp.develocity.internal.testacceleration.enableCustomValues=true
 # If enabled, the build logs whenever a WorkerReadyMessage is received. This should help analyzing the problem of remote executors being in wrong state.
 systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 # Default performance baseline
-defaultPerformanceBaselines=9.0.0-commit-c635dee1c5e
+defaultPerformanceBaselines=9.1.0-commit-ac3cee521d1
 #-----------------------------------------till here^
 systemProp.dependency.analysis.test.analysis=false
 


### PR DESCRIPTION
I observed performance test failures in docs test, which is a sign that we should rebaseline.