### PR TITLE
Use repo.grdev.net as AndroidStudio downloading mirror

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioProvisioningPlugin.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioProvisioningPlugin.kt
@@ -61,7 +61,7 @@ class AndroidStudioProvisioningPlugin : Plugin<Project> {
             repositories {
                 ivy {
                     // Url of Android Studio archive
-                    url = uri("https://redirector.gvt1.com/edgedl/android/studio/${if (androidStudioFileName.endsWith("dmg")) "install" else "ide-zips"}")
+                    url = uri("https://repo.grdev.net/artifactory/android-studio/${if (androidStudioFileName.endsWith("dmg")) "install" else "ide-zips"}")
                     patternLayout {
                         artifact("[revision]/[artifact]-[revision]-[ext]")
                     }


### PR DESCRIPTION
To avoid the upstream 503 error.