### PR TITLE
Remove all traces of JCenter

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/BaseRepositoryFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/BaseRepositoryFactory.java
@@ -37,8 +37,6 @@ public interface BaseRepositoryFactory {
 
     MavenArtifactRepository createMavenLocalRepository();
 
-    MavenArtifactRepository createJCenterRepository();
-
     MavenArtifactRepository createMavenCentralRepository();
 
     MavenArtifactRepository createGoogleRepository();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -49,8 +49,6 @@ import static org.gradle.util.internal.CollectionUtils.flattenCollections;
 public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer implements RepositoryHandlerInternal {
 
     public static final String GRADLE_PLUGIN_PORTAL_REPO_NAME = "Gradle Central Plugin Repository";
-    public static final String DEFAULT_BINTRAY_JCENTER_REPO_NAME = "BintrayJCenter";
-    public static final String BINTRAY_JCENTER_URL = "https://jcenter.bintray.com/";
     public static final String GOOGLE_REPO_NAME = "Google";
 
     public static final String FLAT_DIR_DEFAULT_NAME = "flatDir";

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -26,7 +26,6 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.artifacts.BaseRepositoryFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
-import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
@@ -151,13 +150,6 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
         MavenArtifactRepository mavenRepository = instantiator.newInstance(DefaultMavenLocalArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, versionParser);
         File localMavenRepository = localMavenRepositoryLocator.getLocalMavenRepository();
         mavenRepository.setUrl(localMavenRepository);
-        return mavenRepository;
-    }
-
-    @Override
-    public MavenArtifactRepository createJCenterRepository() {
-        MavenArtifactRepository mavenRepository = createMavenRepository(new NamedMavenRepositoryDescriber(DefaultRepositoryHandler.BINTRAY_JCENTER_URL));
-        mavenRepository.setUrl(DefaultRepositoryHandler.BINTRAY_JCENTER_URL);
         return mavenRepository;
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -103,19 +103,6 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
         repo.url == repoDir.toURI()
     }
 
-    def testCreateJCenterRepo() {
-        given:
-        def jcenterUrl = new URI(DefaultRepositoryHandler.BINTRAY_JCENTER_URL)
-
-        when:
-        fileResolver.resolveUri(DefaultRepositoryHandler.BINTRAY_JCENTER_URL) >> jcenterUrl
-
-        then:
-        def repo = factory.createJCenterRepository()
-        repo instanceof DefaultMavenArtifactRepository
-        repo.url == jcenterUrl
-    }
-
     def testCreateMavenCentralRepo() {
         given:
         def centralUrl = new URI(RepositoryHandler.MAVEN_CENTRAL_URL)


### PR DESCRIPTION
When the public API was removed, internal methods were not.