### PR TITLE
Fix public API overloads nullability

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DelegatingJavaExecSpec.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DelegatingJavaExecSpec.java
@@ -41,7 +41,6 @@ interface DelegatingJavaExecSpec extends DelegatingBaseExecSpec, JavaExecSpec {
         return getDelegate().getMainClass();
     }
 
-    @Nullable
     @Override
     default List<String> getArgs() {
         return getDelegate().getArgs();
@@ -60,13 +59,13 @@ interface DelegatingJavaExecSpec extends DelegatingBaseExecSpec, JavaExecSpec {
     }
 
     @Override
-    default JavaExecSpec setArgs(@Nullable List<String> args) {
+    default JavaExecSpec setArgs(List<String> args) {
         getDelegate().setArgs(args);
         return this;
     }
 
     @Override
-    default JavaExecSpec setArgs(@Nullable Iterable<?> args) {
+    default JavaExecSpec setArgs(Iterable<?> args) {
         getDelegate().setArgs(args);
         return this;
     }
@@ -153,19 +152,18 @@ interface DelegatingJavaExecSpec extends DelegatingBaseExecSpec, JavaExecSpec {
         getDelegate().setMaxHeapSize(heapSize);
     }
 
-    @Nullable
     @Override
     default List<String> getJvmArgs() {
         return getDelegate().getJvmArgs();
     }
 
     @Override
-    default void setJvmArgs(@Nullable List<String> arguments) {
+    default void setJvmArgs(List<String> arguments) {
         getDelegate().setJvmArgs(arguments);
     }
 
     @Override
-    default void setJvmArgs(@Nullable Iterable<?> arguments) {
+    default void setJvmArgs(Iterable<?> arguments) {
         getDelegate().setJvmArgs(arguments);
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -205,7 +205,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
     @Override
     @ToBeReplacedByLazyProperty
     public List<String> getJvmArgs() {
-        return javaExecSpec.getJvmArguments().getOrNull();
+        return javaExecSpec.getJvmArguments().get();
     }
 
     /**
@@ -317,6 +317,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     @ToBeReplacedByLazyProperty
+    @Nullable
     public String getMinHeapSize() {
         return javaExecSpec.getMinHeapSize();
     }
@@ -325,7 +326,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      * {@inheritDoc}
      */
     @Override
-    public void setMinHeapSize(String heapSize) {
+    public void setMinHeapSize(@Nullable String heapSize) {
         javaExecSpec.setMinHeapSize(heapSize);
     }
 
@@ -334,6 +335,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     @ToBeReplacedByLazyProperty
+    @Nullable
     public String getDefaultCharacterEncoding() {
         return javaExecSpec.getDefaultCharacterEncoding();
     }
@@ -342,7 +344,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      * {@inheritDoc}
      */
     @Override
-    public void setDefaultCharacterEncoding(String defaultCharacterEncoding) {
+    public void setDefaultCharacterEncoding(@Nullable String defaultCharacterEncoding) {
         javaExecSpec.setDefaultCharacterEncoding(defaultCharacterEncoding);
     }
 
@@ -351,6 +353,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     @ToBeReplacedByLazyProperty
+    @Nullable
     public String getMaxHeapSize() {
         return javaExecSpec.getMaxHeapSize();
     }
@@ -359,7 +362,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      * {@inheritDoc}
      */
     @Override
-    public void setMaxHeapSize(String heapSize) {
+    public void setMaxHeapSize(@Nullable String heapSize) {
         javaExecSpec.setMaxHeapSize(heapSize);
     }
 

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -362,6 +362,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      */
     @Override
     @ToBeReplacedByLazyProperty
+    @Nullable
     public String getMinHeapSize() {
         return forkOptions.getMinHeapSize();
     }
@@ -371,6 +372,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      */
     @Override
     @ToBeReplacedByLazyProperty
+    @Nullable
     public String getDefaultCharacterEncoding() {
         return forkOptions.getDefaultCharacterEncoding();
     }
@@ -379,7 +381,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      * {@inheritDoc}
      */
     @Override
-    public void setDefaultCharacterEncoding(String defaultCharacterEncoding) {
+    public void setDefaultCharacterEncoding(@Nullable String defaultCharacterEncoding) {
         forkOptions.setDefaultCharacterEncoding(defaultCharacterEncoding);
     }
 
@@ -387,7 +389,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      * {@inheritDoc}
      */
     @Override
-    public void setMinHeapSize(String heapSize) {
+    public void setMinHeapSize(@Nullable String heapSize) {
         forkOptions.setMinHeapSize(heapSize);
     }
 
@@ -396,6 +398,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      */
     @Override
     @ToBeReplacedByLazyProperty
+    @Nullable
     public String getMaxHeapSize() {
         return forkOptions.getMaxHeapSize();
     }
@@ -404,7 +407,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      * {@inheritDoc}
      */
     @Override
-    public void setMaxHeapSize(String heapSize) {
+    public void setMaxHeapSize(@Nullable String heapSize) {
         forkOptions.setMaxHeapSize(heapSize);
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
@@ -80,7 +80,7 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
      * Returns the arguments passed to the main class to be executed.
      */
     @ToBeReplacedByLazyProperty
-    @Nullable @Optional @Input
+    @Optional @Input
     List<String> getArgs();
 
     /**
@@ -109,7 +109,7 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
      * @return this
      * @since 4.0
      */
-    JavaExecSpec setArgs(@Nullable List<String> args);
+    JavaExecSpec setArgs(List<String> args);
 
     /**
      * Sets the args for the main class to be executed.
@@ -118,7 +118,7 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
      *
      * @return this
      */
-    JavaExecSpec setArgs(@Nullable Iterable<?> args);
+    JavaExecSpec setArgs(Iterable<?> args);
 
     /**
      * Argument providers for the application.

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -129,7 +129,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * @return The immutable list of arguments. Returns an empty list if there are no arguments.
      */
     @ToBeReplacedByLazyProperty
-    @Nullable @Optional @Input
+    @Optional @Input
     List<String> getJvmArgs();
 
     /**
@@ -139,7 +139,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * @param arguments The arguments. Must not be null.
      * @since 4.0
      */
-    void setJvmArgs(@Nullable List<String> arguments);
+    void setJvmArgs(List<String> arguments);
 
     /**
      * Sets the extra arguments to use to launch the JVM for the process. System properties
@@ -147,7 +147,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      *
      * @param arguments The arguments. Must not be null.
      */
-    void setJvmArgs(@Nullable Iterable<?> arguments);
+    void setJvmArgs(Iterable<?> arguments);
 
     /**
      * Adds some arguments to use to launch the JVM for the process.

--- a/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.TaskDestroyables;
 import org.gradle.api.tasks.TaskLocalState;
 import org.gradle.internal.extensibility.NoConventionMapping;
 import org.gradle.work.DisableCachingByDefault;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.time.Duration;
@@ -180,22 +181,24 @@ public abstract class DefaultTask extends org.gradle.api.internal.AbstractTask i
     }
 
     @Override
+    @Nullable
     public String getDescription() {
         return super.getDescription();
     }
 
     @Override
-    public void setDescription(String description) {
+    public void setDescription(@Nullable String description) {
         super.setDescription(description);
     }
 
     @Override
+    @Nullable
     public String getGroup() {
         return super.getGroup();
     }
 
     @Override
-    public void setGroup(String group) {
+    public void setGroup(@Nullable String group) {
         super.setGroup(group);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -133,8 +133,10 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private ExtensibleDynamicObject extensibleDynamicObject;
 
+    @Nullable
     private String description;
 
+    @Nullable
     private String group;
 
     private final Property<Duration> timeout;
@@ -600,23 +602,25 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Internal
     @Override
+    @Nullable
     public String getDescription() {
         return description;
     }
 
     @Override
-    public void setDescription(String description) {
+    public void setDescription(@Nullable String description) {
         this.description = description;
     }
 
     @Internal
     @Override
+    @Nullable
     public String getGroup() {
         return group;
     }
 
     @Override
-    public void setGroup(String group) {
+    public void setGroup(@Nullable String group) {
         this.group = group;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/ant/AntTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/ant/AntTarget.java
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.work.DisableCachingByDefault;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 
@@ -87,6 +88,7 @@ public abstract class AntTarget extends ConventionTask {
      */
     @Internal
     @Override
+    @Nullable
     @ToBeReplacedByLazyProperty
     public String getDescription() {
         return target == null ? null : target.getDescription();
@@ -96,7 +98,7 @@ public abstract class AntTarget extends ConventionTask {
      * {@inheritDoc}
      */
     @Override
-    public void setDescription(String description) {
+    public void setDescription(@Nullable String description) {
         if (target != null) {
             target.setDescription(description);
         }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecAction.java
@@ -75,7 +75,6 @@ public class DefaultJavaExecAction implements JavaExecAction {
         return javaExecHandleBuilder.getMainClass();
     }
 
-    @Nullable
     @Override
     public List<String> getArgs() {
         return javaExecHandleBuilder.getArgs();
@@ -94,13 +93,13 @@ public class DefaultJavaExecAction implements JavaExecAction {
     }
 
     @Override
-    public JavaExecSpec setArgs(@Nullable List<String> args) {
+    public JavaExecSpec setArgs(List<String> args) {
         javaExecHandleBuilder.setArgs(args);
         return this;
     }
 
     @Override
-    public JavaExecSpec setArgs(@Nullable Iterable<?> args) {
+    public JavaExecSpec setArgs(Iterable<?> args) {
         javaExecHandleBuilder.setArgs(args);
         return this;
     }
@@ -236,19 +235,18 @@ public class DefaultJavaExecAction implements JavaExecAction {
         javaExecHandleBuilder.setMaxHeapSize(heapSize);
     }
 
-    @Nullable
     @Override
     public List<String> getJvmArgs() {
         return javaExecHandleBuilder.getJvmArgs();
     }
 
     @Override
-    public void setJvmArgs(@Nullable List<String> arguments) {
+    public void setJvmArgs(List<String> arguments) {
         javaExecHandleBuilder.setJvmArgs(arguments);
     }
 
     @Override
-    public void setJvmArgs(@Nullable Iterable<?> arguments) {
+    public void setJvmArgs(Iterable<?> arguments) {
         javaExecHandleBuilder.setJvmArgs(arguments);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecSpec.java
@@ -27,7 +27,6 @@ import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaExecSpec;
-import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.io.InputStream;
@@ -100,18 +99,17 @@ public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaE
     }
 
     @Override
-    public JavaExecSpec setArgs(@Nullable List<String> arguments) {
+    public JavaExecSpec setArgs(List<String> arguments) {
         argumentsSpec.setArgs(arguments);
         return this;
     }
 
     @Override
-    public JavaExecSpec setArgs(@Nullable Iterable<?> arguments) {
+    public JavaExecSpec setArgs(Iterable<?> arguments) {
         argumentsSpec.setArgs(arguments);
         return this;
     }
 
-    @Nullable
     @Override
     public List<String> getArgs() {
         return argumentsSpec.getArgs();

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1747,7 +1747,7 @@
         {
             "type": "org.gradle.api.tasks.AbstractExecTask",
             "member": "Method org.gradle.api.tasks.AbstractExecTask.setArgs(java.lang.Iterable)",
-            "acceptation": "Setting parameter to null doesn\u0027t work",
+            "acceptation": "Setting parameter to null doesn't work",
             "changes": [
                 "Parameter 0 from null accepting to non-null accepting breaking change"
             ]
@@ -1763,7 +1763,7 @@
         {
             "type": "org.gradle.api.tasks.Exec",
             "member": "Method org.gradle.api.tasks.Exec.setArgs(java.lang.Iterable)",
-            "acceptation": "Setting parameter to null doesn\u0027t work",
+            "acceptation": "Setting parameter to null doesn't work",
             "changes": [
                 "Parameter 0 from null accepting to non-null accepting breaking change"
             ]
@@ -1834,6 +1834,14 @@
         },
         {
             "type": "org.gradle.api.tasks.JavaExec",
+            "member": "Method org.gradle.api.tasks.JavaExec.getDefaultCharacterEncoding()",
+            "acceptation": "Fix JavaForkOptions overrides nullability",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.JavaExec",
             "member": "Method org.gradle.api.tasks.JavaExec.getExecActionFactory()",
             "acceptation": "Making all injecting getters abstract",
             "changes": [
@@ -1846,6 +1854,22 @@
             "acceptation": "Making all injecting getters abstract",
             "changes": [
                 "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.JavaExec",
+            "member": "Method org.gradle.api.tasks.JavaExec.getMaxHeapSize()",
+            "acceptation": "Fix JavaForkOptions overrides nullability",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.JavaExec",
+            "member": "Method org.gradle.api.tasks.JavaExec.getMinHeapSize()",
+            "acceptation": "Fix JavaForkOptions overrides nullability",
+            "changes": [
+                "From non-null returning to null returning breaking change"
             ]
         },
         {
@@ -2619,6 +2643,14 @@
         },
         {
             "type": "org.gradle.api.tasks.testing.Test",
+            "member": "Method org.gradle.api.tasks.testing.Test.getDefaultCharacterEncoding()",
+            "acceptation": "Fix JavaForkOptions overrides nullability",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.testing.Test",
             "member": "Method org.gradle.api.tasks.testing.Test.getForkOptionsFactory()",
             "acceptation": "Making all injecting getters abstract",
             "changes": [
@@ -2639,6 +2671,22 @@
             "acceptation": "Making all injecting getters abstract",
             "changes": [
                 "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.testing.Test",
+            "member": "Method org.gradle.api.tasks.testing.Test.getMaxHeapSize()",
+            "acceptation": "Fix JavaForkOptions overrides nullability",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.testing.Test",
+            "member": "Method org.gradle.api.tasks.testing.Test.getMinHeapSize()",
+            "acceptation": "Fix JavaForkOptions overrides nullability",
+            "changes": [
+                "From non-null returning to null returning breaking change"
             ]
         },
         {
@@ -4437,11 +4485,43 @@
             ]
         },
         {
+            "type": "org.gradle.process.JavaExecSpec",
+            "member": "Method org.gradle.process.JavaExecSpec.setArgs(java.lang.Iterable)",
+            "acceptation": "Fix JavaForkOptions overrides nullability",
+            "changes": [
+                "Parameter 0 from null accepting to non-null accepting breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.process.JavaExecSpec",
+            "member": "Method org.gradle.process.JavaExecSpec.setArgs(java.util.List)",
+            "acceptation": "Fix JavaForkOptions overrides nullability",
+            "changes": [
+                "Parameter 0 from null accepting to non-null accepting breaking change"
+            ]
+        },
+        {
             "type": "org.gradle.process.JavaForkOptions",
             "member": "Method org.gradle.process.JavaForkOptions.getSystemProperties()",
             "acceptation": "Values of returned map can be null",
             "changes": [
                 "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.process.JavaForkOptions",
+            "member": "Method org.gradle.process.JavaForkOptions.setJvmArgs(java.lang.Iterable)",
+            "acceptation": "Fix JavaForkOptions overrides nullability",
+            "changes": [
+                "Parameter 0 from null accepting to non-null accepting breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.process.JavaForkOptions",
+            "member": "Method org.gradle.process.JavaForkOptions.setJvmArgs(java.util.List)",
+            "acceptation": "Fix JavaForkOptions overrides nullability",
+            "changes": [
+                "Parameter 0 from null accepting to non-null accepting breaking change"
             ]
         },
         {

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -65,6 +65,22 @@
             ]
         },
         {
+            "type": "org.gradle.api.DefaultTask",
+            "member": "Method org.gradle.api.DefaultTask.getDescription()",
+            "acceptation": "Fix Task.group and Task.description overloads nullability",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.DefaultTask",
+            "member": "Method org.gradle.api.DefaultTask.getGroup()",
+            "acceptation": "Fix Task.group and Task.description overloads nullability",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
             "type": "org.gradle.api.Project",
             "member": "Method org.gradle.api.Project.exec(groovy.lang.Closure)",
             "acceptation": "Remove deprecated method",
@@ -2054,6 +2070,14 @@
             "acceptation": "remove deprecated method",
             "changes": [
                 "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.ant.AntTarget",
+            "member": "Method org.gradle.api.tasks.ant.AntTarget.getDescription()",
+            "acceptation": "Fix Task.group and Task.description overloads nullability",
+            "changes": [
+                "From non-null returning to null returning breaking change"
             ]
         },
         {


### PR DESCRIPTION
* Fixes https://github.com/gradle/gradle/issues/34372
* Using IntelliJ Structural Search more missing nullability annotations were found for `JavaForkOptions`


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
