### PR TITLE
Introduce OnDemandEagerRelease mode for file caches

### DIFF
--- a/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/BuildCacheClientModule.java
+++ b/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/BuildCacheClientModule.java
@@ -37,9 +37,8 @@ import org.gradle.cache.internal.DefaultFileLockManager;
 import org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup;
 import org.gradle.cache.internal.ProcessMetaDataProvider;
 import org.gradle.cache.internal.SingleDepthFilesFinder;
-import org.gradle.cache.internal.locklistener.DefaultFileLockContentionHandler;
 import org.gradle.cache.internal.locklistener.FileLockContentionHandler;
-import org.gradle.cache.internal.locklistener.InetAddressProvider;
+import org.gradle.cache.internal.locklistener.RejectingFileLockContentionHandler;
 import org.gradle.caching.internal.controller.BuildCacheController;
 import org.gradle.caching.internal.controller.DefaultBuildCacheController;
 import org.gradle.caching.internal.controller.service.BuildCacheServicesConfiguration;
@@ -99,9 +98,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.util.function.Supplier;
 
@@ -162,22 +158,8 @@ class BuildCacheClientModule extends AbstractModule {
     }
 
     @Provides
-    FileLockContentionHandler createFileLockContentionHandler(ExecutorFactory executorFactory) {
-        return new DefaultFileLockContentionHandler(executorFactory, new InetAddressProvider() {
-            @Override
-            public InetAddress getWildcardBindingAddress() {
-                return new InetSocketAddress(0).getAddress();
-            }
-
-            @Override
-            public InetAddress getCommunicationAddress() {
-                try {
-                    return InetAddress.getByName(null);
-                } catch (UnknownHostException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
+    FileLockContentionHandler createFileLockContentionHandler() {
+        return new RejectingFileLockContentionHandler();
     }
 
     @Provides

--- a/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/BuildCacheClientModule.java
+++ b/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/BuildCacheClientModule.java
@@ -105,7 +105,7 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.util.function.Supplier;
 
-import static org.gradle.cache.FileLockManager.LockMode.OnDemand;
+import static org.gradle.cache.FileLockManager.LockMode.OnDemandEagerRelease;
 import static org.gradle.internal.snapshot.CaseSensitivity.CASE_SENSITIVE;
 
 @SuppressWarnings("CloseableProvides")
@@ -222,7 +222,7 @@ class BuildCacheClientModule extends AbstractModule {
             return new DefaultCacheBuilder(cacheFactory, buildCacheDir)
                 .withCleanupStrategy(cacheCleanupStrategy)
                 .withDisplayName("Build cache")
-                .withInitialLockMode(OnDemand)
+                .withInitialLockMode(OnDemandEagerRelease)
                 .open();
         }
 

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
@@ -64,7 +64,7 @@ public interface CacheBuilder {
      * <ul>
      *     <li>Using {@link org.gradle.cache.FileLockManager.LockMode#Exclusive} will lock the cache on open() in the exclusive mode and keep it locked until {@link PersistentCache#close()} is called.</li>
      *     <li>Using {@link org.gradle.cache.FileLockManager.LockMode#Shared} will lock the cache on open() in the shared mode and keep it locked until {@link PersistentCache#close()} is called.</li>
-     *     <li>Using {@link org.gradle.cache.FileLockManager.LockMode#OnDemand} will <em>not</em> lock the cache on open().</li>
+     *     <li>Using {@link org.gradle.cache.FileLockManager.LockMode#OnDemand} or {@link org.gradle.cache.FileLockManager.LockMode#OnDemandEagerRelease} will <em>not</em> lock the cache on open().</li>
      * </ul>
      *
      * @return The cache.

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
@@ -82,6 +82,21 @@ public interface FileLockManager {
         OnDemand,
 
         /**
+         * On demand, single writer, no readers (on demand exclusive mode).
+         * <br><br>
+         *
+         * Only one process can access the cache at a time.
+         * <br><br>
+         *
+         * For {@link PersistentCache} the file lock is created with {@link PersistentCache#useCache} or {@link PersistentCache#withFileLock} method.
+         * Lock is released when no longer needed, see {@link org.gradle.cache.internal.DefaultFileLockManager.DefaultFileLock#lock(org.gradle.cache.FileLockManager.LockMode)}.
+         * <br><br>
+         *
+         * Not supported by {@link FileLockManager}.
+         */
+        OnDemandEagerRelease,
+
+        /**
          * Multiple readers, no writers.
          * <br><br>
          *

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheCoordinator.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheCoordinator.java
@@ -105,6 +105,19 @@ public class DefaultCacheCoordinator implements CacheCreationCoordinator, Exclus
                 crossProcessCacheAccess = new LockOnDemandCrossProcessCacheAccess(cacheDisplayName, lockTarget, lockOptions.copyWithMode(Exclusive), lockManager, stateLock, initializationAction, onFileLockAcquireAction, onFileLockReleaseAction);
                 fileAccess = new UnitOfWorkFileAccess();
                 break;
+            case OnDemandEagerRelease:
+                crossProcessCacheAccess = new LockOnDemandEagerReleaseCrossProcessCacheAccess(
+                    cacheDisplayName,
+                    lockTarget,
+                    lockOptions.copyWithMode(Exclusive),
+                    lockManager,
+                    stateLock,
+                    initializationAction,
+                    onFileLockAcquireAction,
+                    onFileLockReleaseAction
+                );
+                fileAccess = new UnitOfWorkFileAccess();
+                break;
             case None:
                 crossProcessCacheAccess = new NoLockingCacheAccess(this::notifyFinish);
                 fileAccess = TransparentFileAccess.INSTANCE;

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -417,9 +417,9 @@ public class DefaultFileLockManager implements FileLockManager {
                     if (lockOutcome.isLockWasAcquired()) {
                         return ExponentialBackoff.Result.successful(lockOutcome);
                     }
-                    if (port != -1) { //we don't like the assumption about the port very much
+                    if (port != FileLockContentionHandler.INVALID_PORT) { //we don't like the assumption about the port very much
                         LockInfo lockInfo = readInformationRegion(backoff);
-                        if (lockInfo.port != -1) {
+                        if (lockInfo.port != FileLockContentionHandler.INVALID_PORT) {
                             if (lockInfo.port != lastLockHolderPort) {
                                 backoff.restartTimer();
                                 lastLockHolderPort = lockInfo.port;

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/LockOnDemandEagerReleaseCrossProcessCacheAccess.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/LockOnDemandEagerReleaseCrossProcessCacheAccess.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal;
+
+import org.gradle.cache.FileLock;
+import org.gradle.cache.FileLockManager;
+import org.gradle.cache.LockOptions;
+import org.gradle.internal.UncheckedException;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
+import java.io.File;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class LockOnDemandEagerReleaseCrossProcessCacheAccess extends AbstractCrossProcessCacheAccess {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LockOnDemandEagerReleaseCrossProcessCacheAccess.class);
+    private final String cacheDisplayName;
+    private final File lockTarget;
+    private final LockOptions lockOptions;
+    private final FileLockManager lockManager;
+    private final Lock stateLock;
+    private final Consumer<FileLock> onOpen;
+    private final Consumer<FileLock> onClose;
+    private final Runnable unlocker;
+    @GuardedBy("stateLock")
+    private int lockCount;
+    @GuardedBy("stateLock")
+    private @Nullable FileLock fileLock;
+    private final CacheInitializationAction initAction;
+
+    /**
+     * Actions are notified when lock is opened or closed. Actions are called while holding state lock, so that no other threads are working with cache while these are running.
+     *
+     * @param stateLock Lock to hold while mutating state.
+     * @param onOpen Action to run when the lock is opened. Action is called while holding state lock
+     * @param onClose Action to run when the lock is closed. Action is called while holding state lock
+     */
+    public LockOnDemandEagerReleaseCrossProcessCacheAccess(
+        String cacheDisplayName,
+        File lockTarget,
+        LockOptions lockOptions,
+        FileLockManager lockManager,
+        Lock stateLock,
+        CacheInitializationAction initAction,
+        Consumer<FileLock> onOpen,
+        Consumer<FileLock> onClose
+    ) {
+        this.cacheDisplayName = cacheDisplayName;
+        this.lockTarget = lockTarget;
+        this.lockOptions = lockOptions;
+        this.lockManager = lockManager;
+        this.stateLock = stateLock;
+        this.initAction = initAction;
+        this.onOpen = onOpen;
+        this.onClose = onClose;
+        this.unlocker = this::decrementLockCount;
+    }
+
+    @Override
+    public void open() {
+        // Don't need to do anything
+    }
+
+    @Override
+    public void close() {
+        stateLock.lock();
+        try {
+            if (lockCount != 0) {
+                throw new IllegalStateException(String.format("Cannot close cache access for %s as it is currently in use for %s operations.", cacheDisplayName, lockCount));
+            }
+            releaseLockIfHeld();
+        } finally {
+            stateLock.unlock();
+        }
+    }
+
+    @Override
+    public <T> T withFileLock(Supplier<T> factory) {
+        incrementLockCount();
+        try {
+            return factory.get();
+        } finally {
+            decrementLockCount();
+        }
+    }
+
+    private void incrementLockCount() {
+        stateLock.lock();
+        try {
+            if (fileLock == null) {
+                if (lockCount != 0) {
+                    throw new IllegalStateException("Mismatched lock count.");
+                }
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Acquiring file lock for {}", cacheDisplayName);
+                }
+                fileLock = lockManager.lock(lockTarget, lockOptions, cacheDisplayName, "");
+                try {
+                    if (initAction.requiresInitialization(fileLock)) {
+                        FileLock theLock = fileLock; // To pass the GuardedBy check, because the lambda below is called synchronously.
+                        fileLock.writeFile(() -> initAction.initialize(theLock));
+                    }
+                    onOpen.accept(fileLock);
+                } catch (Exception e) {
+                    fileLock.close();
+                    fileLock = null;
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+            }
+            lockCount++;
+        } finally {
+            stateLock.unlock();
+        }
+    }
+
+    private void decrementLockCount() {
+        stateLock.lock();
+        try {
+            if (lockCount <= 0 || fileLock == null) {
+                throw new IllegalStateException("Mismatched lock count.");
+            }
+            lockCount--;
+            if (lockCount == 0) {
+                releaseLockIfHeld();
+            } // otherwise, keep lock open
+        } finally {
+            stateLock.unlock();
+        }
+    }
+
+    @GuardedBy("stateLock")
+    private void releaseLockIfHeld() {
+        if (fileLock == null) {
+            return;
+        }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Releasing file lock for {}", cacheDisplayName);
+        }
+        try {
+            onClose.accept(fileLock);
+        } finally {
+            fileLock.close();
+            fileLock = null;
+        }
+    }
+
+    @Override
+    public Runnable acquireFileLock() {
+        incrementLockCount();
+        return unlocker;
+    }
+}

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/filelock/LockInfo.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/filelock/LockInfo.java
@@ -15,8 +15,10 @@
  */
 package org.gradle.cache.internal.filelock;
 
+import org.gradle.cache.internal.locklistener.FileLockContentionHandler;
+
 public class LockInfo {
-    public int port = -1;
+    public int port = FileLockContentionHandler.INVALID_PORT;
     public long lockId;
     public String pid = "unknown";
     public String operation = "unknown";

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockContentionHandler.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockContentionHandler.java
@@ -25,6 +25,8 @@ import java.util.function.Consumer;
 
 @ServiceScope(Scope.Global.class)
 public interface FileLockContentionHandler {
+    int INVALID_PORT = -1;
+
     void start(long lockId, Consumer<FileLockReleasedSignal> whenContended);
 
     void stop(long lockId);

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/RejectingFileLockContentionHandler.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/RejectingFileLockContentionHandler.java
@@ -37,8 +37,7 @@ public class RejectingFileLockContentionHandler implements FileLockContentionHan
 
     @Override
     public int reservePort() {
-        // This is a special value recognized by File
-        return -1;
+        return INVALID_PORT;
     }
 
     @Override

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/RejectingFileLockContentionHandler.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/RejectingFileLockContentionHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal.locklistener;
+
+import org.gradle.cache.FileLockReleasedSignal;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+/**
+ * A special contention handler that doesn't support communicating contention.
+ */
+@NullMarked
+public class RejectingFileLockContentionHandler implements FileLockContentionHandler {
+    @Override
+    public void start(long lockId, Consumer<FileLockReleasedSignal> whenContended) {
+        throw new UnsupportedOperationException("Cannot listen for contention signals");
+    }
+
+    @Override
+    public void stop(long lockId) {}
+
+    @Override
+    public int reservePort() {
+        // This is a special value recognized by File
+        return -1;
+    }
+
+    @Override
+    public boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed, @Nullable FileLockReleasedSignal signal) {
+        throw new UnsupportedOperationException("Cannot ping owners");
+    }
+
+    @Override
+    public boolean isRunning() {
+        return true;
+    }
+}

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionTest.groovy
@@ -136,17 +136,15 @@ class DefaultFileLockManagerContentionTest extends ConcurrentSpec {
         createLock(Exclusive, file, manager, null)
     }
 
-    def "cannot create lock with contention handling when using rejecting handler"() {
+    def "can create lock with contention handling when using rejecting handler"() {
         FileLockManager manager = new DefaultFileLockManager(Stub(ProcessMetaDataProvider), 2000, new RejectingFileLockContentionHandler())
         def file = tmpDir.file("lock-file.bin")
-
+        Consumer<FileLockReleasedSignal> whenContended = Mock()
         when:
-        createLock(Exclusive, file, manager) { FileLockReleasedSignal signal ->
-            signal.trigger()
-        }
+        createLock(Exclusive, file, manager, whenContended)
 
         then:
-        thrown(UnsupportedOperationException)
+        1 * whenContended.accept(_)
     }
 
     FileLock createLock(FileLockManager.LockMode lockMode, File file, FileLockManager lockManager = manager, Consumer<FileLockReleasedSignal> whenContended = null) {

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreConcurrencyTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreConcurrencyTest.groovy
@@ -29,6 +29,7 @@ import org.junit.Rule
 import spock.lang.Issue
 
 import static org.gradle.cache.FileLockManager.LockMode.OnDemand
+import static org.gradle.cache.FileLockManager.LockMode.OnDemandEagerRelease
 import static org.gradle.cache.internal.filelock.DefaultLockOptions.mode
 
 class DefaultPersistentDirectoryStoreConcurrencyTest extends ConcurrentSpec {
@@ -47,7 +48,7 @@ class DefaultPersistentDirectoryStoreConcurrencyTest extends ConcurrentSpec {
 
     @Issue("GRADLE-3206")
     def "can create new caches and access them in parallel"() {
-        def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", mode(OnDemand), null, lockManager, executorFactory)
+        def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", mode(lockMode), null, lockManager, executorFactory)
         store.open()
 
         when:
@@ -65,5 +66,8 @@ class DefaultPersistentDirectoryStoreConcurrencyTest extends ConcurrentSpec {
 
         cleanup:
         store.close()
+
+        where:
+        lockMode << [OnDemand, OnDemandEagerRelease]
     }
 }

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
@@ -33,6 +33,7 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import static org.gradle.cache.FileLockManager.LockMode.OnDemand
+import static org.gradle.cache.FileLockManager.LockMode.OnDemandEagerRelease
 import static org.gradle.cache.FileLockManager.LockMode.Shared
 import static org.gradle.cache.internal.filelock.DefaultLockOptions.mode
 
@@ -124,7 +125,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
     }
 
     def "open does not lock cache directory when None mode requested"() {
-        final store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", mode(OnDemand), null, lockManager, Mock(ExecutorFactory))
+        final store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", mode(lockMode), null, lockManager, Mock(ExecutorFactory))
 
         when:
         store.open()
@@ -137,6 +138,9 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
 
         then:
         0 * _._
+
+        where:
+        lockMode << [OnDemand, OnDemandEagerRelease]
     }
 
     def "runs cleanup action when it is due"() {

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/LockOnDemandEagerReleaseCrossProcessCacheAccessTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/LockOnDemandEagerReleaseCrossProcessCacheAccessTest.groovy
@@ -417,38 +417,6 @@ class LockOnDemandEagerReleaseCrossProcessCacheAccessTest extends ConcurrentSpec
         0 * _
     }
 
-    def "notifies handler when lock released on contention"() {
-        def action = Mock(Supplier)
-        def onOpen = Mock(Consumer)
-        def onClose = Mock(Consumer)
-        def lock = Mock(FileLock)
-
-        def cacheAccess = newCacheAccess(onOpen, onClose)
-
-        when:
-        cacheAccess.withFileLock(action)
-
-        then:
-        1 * lockManager.lock(file, _, _, _) >> lock
-
-        then:
-        1 * onOpen.accept(lock)
-
-        then:
-        1 * action.get() >> "result"
-
-        then:
-        1 * onClose.accept(lock)
-        1 * lock.close()
-        0 * _
-
-        when:
-        cacheAccess.close()
-
-        then:
-        0 * _
-    }
-
     def "releases lock when acquire handler fails"() {
         def action = Mock(Supplier)
         def onOpen = Mock(Consumer)


### PR DESCRIPTION
This is intended to be used by Maven cache extension. It is similar to OnDemand in that it never acquires lock until actually trying to run a cache operation, but unlike OnDemand, it releases the lock immediately after the operation is complete. No convincing the holder over the network to release the lock is needed.

Fixes #33788.