### PR TITLE
Fix documentation broken links in Gradle 7, 8, and 9 upgrade guide

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_major_version_9.adoc
@@ -422,10 +422,10 @@ By making the description a `Property<String>`, secondary variants have a user c
 
 === New subtypes of `ComponentIdentifier` introduced
 
-Gradle 9.0.0 introduces link:{javadocPath}/org/gradle/api/artifacts/component/RootComponentIdentifier.html)[`RootComponentIdentifier`], a new subtype of link:{javadocPath}/org/gradle/api/artifacts/component/ComponentIdentifier.html)[`ComponentIdentifier`].
+Gradle 9.0.0 introduces link:{javadocPath}/org/gradle/api/artifacts/component/RootComponentIdentifier.html[`RootComponentIdentifier`], a new subtype of link:{javadocPath}/org/gradle/api/artifacts/component/ComponentIdentifier.html[`ComponentIdentifier`].
 
 APIs which return instances of `ComponentIdentifier` may now return identifier instances of this new type.
-For example, the link:{javadocPath}/org/gradle/api/artifacts/result/ComponentResult.html)[`ComponentResult`], link:{javadocPath}/org/gradle/api/artifacts/result/ResolvedVariantResult.html)[`ResolvedVariantResult`], and link:{javadocPath}/org/gradle/api/artifacts/ArtifactView.ViewConfiguration.html)[`ArtifactView`] APIs, among others, are affected.
+For example, the link:{javadocPath}/org/gradle/api/artifacts/result/ComponentResult.html[`ComponentResult`], link:{javadocPath}/org/gradle/api/artifacts/result/ResolvedVariantResult.html[`ResolvedVariantResult`], and link:{javadocPath}/org/gradle/api/artifacts/ArtifactView.ViewConfiguration.html[`ArtifactView`] APIs, among others, are affected.
 
 In future Gradle versions, additional subtypes of `ComponentIdentifier` may be introduced.
 Build logic should remain resilient to unknown `ComponentIdentifier` subtypes returned by Gradle APIs.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_7.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_7.adoc
@@ -806,7 +806,7 @@ The default version of CodeNarc has been updated to https://github.com/CodeNarc/
 
 ==== Upgrade to PMD 6.48.0
 
-PMD has been updated to https://pmd.github.io/pmd-6.48.0/pmd_release_notes.html[PMD 6.48.0].
+PMD has been updated to https://github.com/pmd/pmd/releases/tag/pmd_releases%2F6.48.0[PMD 6.48.0].
 
 ==== Configuring a non-existing executable now fails
 
@@ -865,7 +865,7 @@ Other syntax effected by this change includes:
 - You cannot use a bundle as a dependency declaration directly (`implementation(libs.bundles.testing)`).
 Use `implementation.bundle(libs.bundles.testing)` instead.
 
-For more information, see the updated <<jvm_test_suite_plugin.adoc#sec:declare_an_additional_test_suite, declare an additional test suite>> example in the JVM Test Suite Plugin section of the user guide and the link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyAdder.html[`DependencyAdder`] page in the DSL reference.
+For more information, see the updated <<jvm_test_suite_plugin.adoc#sec:declare_an_additional_test_suite, declare an additional test suite>> example in the JVM Test Suite Plugin section of the user guide.
 
 === Deprecations
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -709,7 +709,7 @@ link:{javadocPath}/org/gradle/api/artifacts/ConfigurationContainer.html#detached
 
 This behavior has been deprecated and will become an error in Gradle 9.0.
 
-To create extension relationships between configurations, you should change to using non-detached configurations created via the other factory methods present in the project's `link:{javadocPath}/org/gradle/api/artifacts/ConfigurationContainer.html)[ConfigurationContainer]`.
+To create extension relationships between configurations, you should change to using non-detached configurations created via the other factory methods present in the project's `link:{javadocPath}/org/gradle/api/artifacts/ConfigurationContainer.html[ConfigurationContainer]`.
 
 [[deprecated_use_logger]]
 ==== Deprecated customized Gradle logging
@@ -973,7 +973,7 @@ For the following use cases, consider these alternatives when replacing a `befor
 
 In an ongoing effort to simplify the Gradle API, the following methods that support filtering based on declared dependencies have been deprecated:
 
-On link:{javadocPath}/org/gradle/api/artifacts/Configuration.html--[Configuration]:
+On link:{javadocPath}/org/gradle/api/artifacts/Configuration.html[Configuration]:
 
 - `files(Dependency...)`
 - `files(Spec)`
@@ -982,12 +982,12 @@ On link:{javadocPath}/org/gradle/api/artifacts/Configuration.html--[Configuratio
 - `fileCollection(Spec)`
 - `fileCollection(Closure)`
 
-On link:{javadocPath}/org/gradle/api/artifacts/ResolvedConfiguration.html--[ResolvedConfiguration]:
+On link:{javadocPath}/org/gradle/api/artifacts/ResolvedConfiguration.html[ResolvedConfiguration]:
 
 - `getFiles(Spec)`
 - `getFirstLevelModuleDependencies(Spec)`
 
-On link:{javadocPath}/org/gradle/api/artifacts/LenientConfiguration.html--[LenientConfiguration]:
+On link:{javadocPath}/org/gradle/api/artifacts/LenientConfiguration.html[LenientConfiguration]:
 
 - `getFirstLevelModuleDependencies(Spec)`
 - `getFiles(Spec)`
@@ -1224,7 +1224,7 @@ Apache SSHD has been updated from 2.0.0 to https://mina.apache.org/sshd-project/
 
 ==== Replacement and upgrade of JSch
 
-http://www.jcraft.com/jsch/[JSch] has been replaced by https://github.com/mwiede/jsch[`com.github.mwiede:jsch`] and updated from 0.1.55 to https://github.com/mwiede/jsch/releases/tag/jsch-0.2.16[0.2.16]
+JSch has been replaced by https://github.com/mwiede/jsch[`com.github.mwiede:jsch`] and updated from 0.1.55 to https://github.com/mwiede/jsch/releases/tag/jsch-0.2.16[0.2.16]
 
 ==== Upgrade to Eclipse JGit 5.13.3
 
@@ -2255,7 +2255,7 @@ Since the previous version was 3.0.15, the https://groovy-lang.org/changelogs/ch
 
 ==== Upgrade to Ant 1.10.13
 
-Ant has been updated to https://archive.apache.org/dist/ant/RELEASE-NOTES-1.10.13.html[Ant 1.10.13].
+Ant has been updated to https://ant.apache.org/index.html[Ant 1.10.13].
 
 Since the previous version was 1.10.11, the https://github.com/apache/ant/blob/rel/1.10.12/WHATSNEW[1.10.12] changes are also included.
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- Broken links for javadocs and other items fix in the Upgrade Guides