### PR TITLE
Make read-only CC compatible with graceful degradation

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAction.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAction.kt
@@ -32,7 +32,8 @@ internal sealed class ConfigurationCacheAction {
     val isReadOnly: Boolean get() = when (this) {
         Store -> false
         is Update -> false
-        else -> true
+        SkipStore -> true
+        is Load -> true
     }
 
     /**


### PR DESCRIPTION
When trying out [read-only CC mode](https://github.com/gradle/gradle/issues/33525) with our build, I bumped into unexpected issues with the `KotlinCompile` task, because degradation evaluation reasons were being computed at execution time. 

```
java.lang.IllegalStateException: Cannot notify listeners of type TaskExecutionAccessListener as these listeners are already being notified. 
```

See: https://ge.gradle.org/s/fna2y36rtfxhm/failures#1

When read-only CC is enabled, we should ensure we evaluate degradation reasons at configuration time. Failure to do so may cause evaluation of degradation reasons to happen at execution time (if any degradation requests exist), which leads to the exception above, because the degradation controller itself accesses `Task.getProject()`:

https://github.com/gradle/gradle/blob/8303ab9bc17594b5eb36f4811c516e96cedbcca1/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt#L86

Note that with this fix, Gradle's own build still fails in read-only mode during input fingerprinting `KotlinCompile.disableMultiModuleIC`, 
only with a [different failure mode](https://ge.gradle.org/s/xr3hfr6neqsbu).

The potential CC incompatibility of that input property has already been reported (_without_ read-only CC) [here](https://youtrack.jetbrains.com/issue/KT-79047) (maybe due to graceful degradation, which also skips CC storing?)


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
