### PR TITLE
Add Best Practice: Do not hardcode task names

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_index.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_index.adoc
@@ -75,6 +75,7 @@ Use this as a quick reference to track newly added recommendations, check adopti
 | <<best_practices_tasks.adoc#avoid_eager_file_collection_apis,Avoid using eager APIs on File Collections>> | Task | 9.1.0
 | <<best_practices_tasks.adoc#default_path_sensitivities,Prefer `@PathSensitivity.NONE` for file inputs and `@PathSensitivity.RELATIVE` for directories>> | Task | 9.2.0
 | <<best_practices_tasks.adoc#use_unique_output_files_and_directories,Use unique output files and directories>> | Task | 9.3.0
+| <<best_practices_tasks.adoc#dont_hardcode_task_names,Don't hardcode task names when referring to them>> | Task | 9.7.0
 
 | <<best_practices_performance.adoc#use_utf8_encoding,Enable UTF‑8>> | Performance | 9.0.0
 | <<best_practices_performance.adoc#use_build_cache,Use the Build Cache>> | Performance | 9.1.0

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
@@ -561,3 +561,57 @@ Now when running `consumer` task, then `greeterB`, the `consumer` task remains `
 === Tags
 
 `<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:inputs-and-outputs,#inputs-and-outputs>>`
+
+[[dont_hardcode_task_names]]
+== Don’t hardcode task names unless they are documented as public API
+
+Hardcoding task names can make a build fragile when upgrading Gradle or third-party plugins.
+
+=== Explanation
+
+Some task names in core Gradle are part of the <<public_apis.adoc#public_gradle_apis,Gradle public API>> and are stable.
+Most other task names in Gradle and third-party plugins are internal implementation details. They may be renamed or removed in future versions and should not be relied upon.
+Task types are also not guaranteed to remain stable; plugin authors may refactor them. In practice, configuring tasks by type is usually more robust than depending on specific names, especially in ecosystems like Android or Kotlin where many tasks are generated dynamically.
+
+Prefer, in order:
+
+  1. Plugin DSL - Future-proof and most stable.
+  2. Task types - Robust in many cases, but can change across plugin versions.
+  3. Task names - Use only when they are explicitly documented as <<public_apis.adoc#public_gradle_apis,public API>>.
+
+As a plugin author, provide a DSL extension for users to configure behavior declaratively. Internally wire the configuration into your tasks. Avoid exposing task names as part of your public API unless you are prepared to maintain them with deprecation cycles.
+
+=== Example
+
+==== Don't Do This
+
+====
+include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotlin",files="build.gradle.kts[tags=avoid-this]"]
+include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy",files="build.gradle[tags=avoid-this]"]
+====
+
+<1> *Using tasks.named to get `GenerateMavenPom`*: This relies on this task name and that's the only `GenerateMavenPom` task that needs configuring.
+
+==== Do This Instead
+
+The following is okay to use because this task namee is part of <<public_apis.adoc#public_gradle_apis,public API>>.
+
+====
+include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin",files="build.gradle.kts[tags=ok]"]
+include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/groovy",files="build.gradle[tags=ok]"]
+====
+
+<1> *Using tasks.named to get `JavaCompile`*: This uses a public constant to get `JavaCompile`.
+
+The best option is to use DSL where possible
+
+====
+include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin",files="build.gradle.kts[tags=best]"]
+include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/groovy",files="build.gradle[tags=best]"]
+====
+
+<1> *Using java DSL*: Entirely avoids implementation details of `java-library` plugin and sets `sourceCompatibility` for all `JavaCompile` tasks.
+<2> *Using publishing DSL*: Avoids hardcoding task names and ensures that generated pom has the expected URL.
+
+=== Tags
+`<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:upgrades,`#upgrades`>>`

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
@@ -597,6 +597,16 @@ include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-avoid/groov
 
 ==== Do This Instead
 
+++++
+<div style="text-align: right;">
+  <a class="download-project-link"
+     data-base-path="https://github.com/gradle/gradle/tree/master/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/"
+     href="https://download-directory.github.io/?url=https://github.com/gradle/gradle/tree/master/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin">
+    <img src="https://img.shields.io/badge/Download%20Project-GitHub-blue?logo=github&style=flat" alt="Download"/>
+  </a>
+</div>
+++++
+
 A better option for the `compileJava` configuration is to use a public constant — this task name is part of <<public_apis.adoc#public_gradle_apis,public API>>, so referencing it via the constant is safe:
 
 ====

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
@@ -563,21 +563,23 @@ Now when running `consumer` task, then `greeterB`, the `consumer` task remains `
 `<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:inputs-and-outputs,#inputs-and-outputs>>`
 
 [[dont_hardcode_task_names]]
-== Don’t hardcode task names unless they are documented as public API
+== Don’t Hardcode Task Names unless they are Documented as Public API
 
 Hardcoding task names can make a build fragile when upgrading Gradle or third-party plugins.
 
 === Explanation
 
-Some task names in core Gradle are part of the <<public_apis.adoc#public_gradle_apis,Gradle public API>> and are stable.
+Some task names in Gradle are part of the <<public_apis.adoc#public_gradle_apis,Gradle public API>> and are stable.
 Most other task names in Gradle and third-party plugins are internal implementation details. They may be renamed or removed in future versions and should not be relied upon.
-Task types are also not guaranteed to remain stable; plugin authors may refactor them. In practice, configuring tasks by type is usually more robust than depending on specific names, especially in ecosystems like Android or Kotlin where many tasks are generated dynamically.
+Task types are also not guaranteed to remain stable; plugin authors may refactor them. 
+
+In practice, configuring tasks by type is usually more robust than depending on specific names, especially in ecosystems like Android or Kotlin where many tasks are generated dynamically.
 
 Prefer, in order:
 
-  1. Plugin DSL - Future-proof and most stable.
-  2. Task types - Robust in many cases, but can change across plugin versions.
-  3. Task names - Use only when they are explicitly documented as <<public_apis.adoc#public_gradle_apis,public API>>.
+1. *Plugin DSL* - Future-proof and most stable.
+2. *Task types* - Robust in many cases, but can change across plugin versions.
+3. *Task names* - Use only when they are explicitly documented as <<public_apis.adoc#public_gradle_apis,public API>>.
 
 As a plugin author, provide a DSL extension for users to configure behavior declaratively. Internally wire the configuration into your tasks. Avoid exposing task names as part of your public API unless you are prepared to maintain them with deprecation cycles.
 
@@ -590,28 +592,29 @@ include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotli
 include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy",files="build.gradle[tags=avoid-this]"]
 ====
 
-<1> *Using tasks.named to get `GenerateMavenPom`*: This relies on this task name and that's the only `GenerateMavenPom` task that needs configuring.
+<1> Using `tasks.named` to get `GenerateMavenPom`: This relies on this task name and that's the only `GenerateMavenPom` task that needs configuring.
 
 ==== Do This Instead
 
-The following is okay to use because this task namee is part of <<public_apis.adoc#public_gradle_apis,public API>>.
+The following is okay to use because this task name is part of <<public_apis.adoc#public_gradle_apis,public API>>.
 
 ====
 include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin",files="build.gradle.kts[tags=ok]"]
 include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/groovy",files="build.gradle[tags=ok]"]
 ====
 
-<1> *Using tasks.named to get `JavaCompile`*: This uses a public constant to get `JavaCompile`.
+<1> Using `tasks.named` to get `JavaCompile`: This uses a public constant to get `JavaCompile`.
 
-The best option is to use DSL where possible
+The best option is to use DSL where possible:
 
 ====
 include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin",files="build.gradle.kts[tags=best]"]
 include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/groovy",files="build.gradle[tags=best]"]
 ====
 
-<1> *Using java DSL*: Entirely avoids implementation details of `java-library` plugin and sets `sourceCompatibility` for all `JavaCompile` tasks.
-<2> *Using publishing DSL*: Avoids hardcoding task names and ensures that generated pom has the expected URL.
+<1> Using Java DSL: Entirely avoids implementation details of `java-library` plugin and sets `sourceCompatibility` for all `JavaCompile` tasks.
+<2> Using publishing DSL: Avoids hardcoding task names and ensures that the generated POM has the expected URL.
 
 === Tags
-`<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:upgrades,`#upgrades`>>`
+
+`<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:upgrades,#upgrades>>`

--- a/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/best-practices/best_practices_tasks.adoc
@@ -563,7 +563,7 @@ Now when running `consumer` task, then `greeterB`, the `consumer` task remains `
 `<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:inputs-and-outputs,#inputs-and-outputs>>`
 
 [[dont_hardcode_task_names]]
-== Don’t Hardcode Task Names unless they are Documented as Public API
+== Don’t hardcode Task names unless they are documented as Public API
 
 Hardcoding task names can make a build fragile when upgrading Gradle or third-party plugins.
 
@@ -577,8 +577,8 @@ In practice, configuring tasks by type is usually more robust than depending on 
 
 Prefer, in order:
 
-1. *Plugin DSL* - Future-proof and most stable.
-2. *Task types* - Robust in many cases, but can change across plugin versions.
+1. *Plugin DSL* - Configure tasks via extension blocks provided by a plugin that are automatically wired to the tasks that plugin creates.  This is the most future-proof and stable option.
+2. *Task types* - More robust than names in many cases, but can still change across plugin versions, depending on the plugin's backwards compatibility policies.
 3. *Task names* - Use only when they are explicitly documented as <<public_apis.adoc#public_gradle_apis,public API>>.
 
 As a plugin author, provide a DSL extension for users to configure behavior declaratively. Internally wire the configuration into your tasks. Avoid exposing task names as part of your public API unless you are prepared to maintain them with deprecation cycles.
@@ -592,20 +592,21 @@ include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotli
 include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy",files="build.gradle[tags=avoid-this]"]
 ====
 
-<1> Using `tasks.named` to get `GenerateMavenPom`: This relies on this task name and that's the only `GenerateMavenPom` task that needs configuring.
+<1> Looking up `compileJava` by name: This relies on the hardcoded `"compileJava"` string.
+<2> Using `tasks.named` to get the `generatePomFileForMavenPublication` task: This unnecessarily relies on this task's name, even though it's the only `GenerateMavenPom` task that needs configuring.
 
 ==== Do This Instead
 
-The following is okay to use because this task name is part of <<public_apis.adoc#public_gradle_apis,public API>>.
+A better option for the `compileJava` configuration is to use a public constant — this task name is part of <<public_apis.adoc#public_gradle_apis,public API>>, so referencing it via the constant is safe:
 
 ====
 include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin",files="build.gradle.kts[tags=ok]"]
 include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/groovy",files="build.gradle[tags=ok]"]
 ====
 
-<1> Using `tasks.named` to get `JavaCompile`: This uses a public constant to get `JavaCompile`.
+<1> Using `tasks.named` with `JavaPlugin.COMPILE_JAVA_TASK_NAME`: Replaces the hardcoded string with a public constant.
 
-The best option is to use DSL where possible:
+The best option is to use the plugin DSL where possible — this avoids referring to tasks by name or type at all:
 
 ====
 include::sample[dir="snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin",files="build.gradle.kts[tags=best]"]

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy/build.gradle
@@ -1,0 +1,20 @@
+// tag::avoid-this[]
+plugins {
+    id("java-library")
+    id("maven-publish")
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from(components.java)
+        }
+    }
+}
+tasks.named("generatePomFileForMavenPublication") { // <1>
+    pom.url = "sample.gradle.org"
+}
+// end::avoid-this[]
+
+version = "1.0.0"
+group = "org.gradle.sample"

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy/build.gradle
@@ -4,6 +4,11 @@ plugins {
     id("maven-publish")
 }
 
+tasks.named("compileJava") { // <1>
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
+}
+
 publishing {
     publications {
         maven(MavenPublication) {
@@ -11,7 +16,8 @@ publishing {
         }
     }
 }
-tasks.named("generatePomFileForMavenPublication") { // <1>
+
+tasks.named("generatePomFileForMavenPublication") { // <2>
     pom.url = "sample.gradle.org"
 }
 // end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy/settings.gradle
@@ -1,0 +1,7 @@
+rootProject.name = "avoid-hardcoding-task-names"
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy/src/main/java/com/example/Example.java
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/groovy/src/main/java/com/example/Example.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Example {}

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotlin/build.gradle.kts
@@ -1,0 +1,21 @@
+// tag::avoid-this[]
+plugins {
+    id("java-library")
+    id("maven-publish")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+    }
+}
+
+tasks.named<GenerateMavenPom>("generatePomFileForMavenPublication").configure { // <1>
+    pom.url = "sample.gradle.org"
+}
+// end::avoid-this[]
+
+version = "1.0.0"
+group = "org.gradle.sample"

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotlin/build.gradle.kts
@@ -4,6 +4,11 @@ plugins {
     id("maven-publish")
 }
 
+tasks.named<JavaCompile>("compileJava").configure { // <1>
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
+}
+
 publishing {
     publications {
         create<MavenPublication>("maven") {
@@ -12,7 +17,7 @@ publishing {
     }
 }
 
-tasks.named<GenerateMavenPom>("generatePomFileForMavenPublication").configure { // <1>
+tasks.named<GenerateMavenPom>("generatePomFileForMavenPublication").configure { // <2>
     pom.url = "sample.gradle.org"
 }
 // end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotlin/settings.gradle.kts
@@ -1,0 +1,7 @@
+rootProject.name = "avoid-hardcoding-task-names"
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotlin/src/main/java/com/example/Example.java
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/kotlin/src/main/java/com/example/Example.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Example {}

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/tests/avoidHardcodingTaskNames.bad.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/tests/avoidHardcodingTaskNames.bad.out
@@ -1,0 +1,5 @@
+> Task :compileJava
+> Task :generatePomFileForMavenPublication
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/tests/avoidHardcodingTaskNames.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/tests/avoidHardcodingTaskNames.sample.conf
@@ -1,0 +1,5 @@
+commands: [{
+    executable: gradle
+    args: compileJava generatePomFileForMavenPublication
+    expected-output-file: avoidHardcodingTaskNames.bad.out
+}]

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/tests/avoidHardcodingTaskNames.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-avoid/tests/avoidHardcodingTaskNames.sample.conf
@@ -2,4 +2,5 @@ commands: [{
     executable: gradle
     args: compileJava generatePomFileForMavenPublication
     expected-output-file: avoidHardcodingTaskNames.bad.out
+    allow-disordered-output: true
 }]

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/groovy/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id("java-library")
+    id("maven-publish")
+}
+
+// tag::ok[]
+tasks.named(JavaPlugin.COMPILE_JAVA_TASK_NAME) { // <1>
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
+}
+// end::ok[]
+
+// tag::best[]
+java { // <1>
+    setSourceCompatibility(JavaVersion.VERSION_17)
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from(components.java)
+            pom.url = "sample.gradle.org" // <2>
+        }
+    }
+}
+// end::best[]
+
+version = "1.0.0"
+group = "org.gradle.sample"

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/groovy/settings.gradle
@@ -1,0 +1,7 @@
+rootProject.name = "avoid-hardcoding-task-names"
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/groovy/src/main/java/com/example/Example.java
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/groovy/src/main/java/com/example/Example.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Example {}

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin/build.gradle.kts
@@ -1,0 +1,30 @@
+// tag::do-this[]
+plugins {
+    id("java-library")
+    id("maven-publish")
+}
+
+// tag::ok[]
+tasks.named<JavaCompile>(JavaPlugin.COMPILE_JAVA_TASK_NAME) { // <1>
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
+}
+// end::ok[]
+
+// tag::best[]
+java { // <1>
+    setSourceCompatibility(JavaVersion.VERSION_17)
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+            pom.url = "sample.gradle.org" // <2>
+        }
+    }
+}
+// end::best[]
+
+version = "1.0.0"
+group = "org.gradle.sample"

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin/settings.gradle.kts
@@ -1,0 +1,7 @@
+rootProject.name = "avoid-hardcoding-task-names"
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin/src/main/java/com/example/Example.java
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/kotlin/src/main/java/com/example/Example.java
@@ -1,0 +1,3 @@
+package com.example;
+
+public class Example {}

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/tests/avoidHardcodingTaskNames.good.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/tests/avoidHardcodingTaskNames.good.out
@@ -1,0 +1,5 @@
+> Task :compileJava
+> Task :generatePomFileForMavenPublication
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/tests/avoidHardcodingTaskNames.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/tests/avoidHardcodingTaskNames.sample.conf
@@ -1,0 +1,5 @@
+commands: [{
+    executable: gradle
+    args: compileJava generatePomFileForMavenPublication
+    expected-output-file: avoidHardcodingTaskNames.good.out
+}]

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/tests/avoidHardcodingTaskNames.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidHardcodingTaskNames-do/tests/avoidHardcodingTaskNames.sample.conf
@@ -2,4 +2,5 @@ commands: [{
     executable: gradle
     args: compileJava generatePomFileForMavenPublication
     expected-output-file: avoidHardcodingTaskNames.good.out
+    allow-disordered-output: true
 }]


### PR DESCRIPTION
Docs tested with: `./gradlew serveDocs -PquickDocs`

Tests ran with `./gradlew :docs:docsTest --tests "*snippet-best-practices-avoid-hardcoding-*"`

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
