### PR TITLE
RemovesBuildClientMetaData from ReportGenerator

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ConventionReportTask.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ConventionReportTask.java
@@ -124,7 +124,6 @@ public abstract class ConventionReportTask extends ConventionTask {
     ReportGenerator reportGenerator() {
         return new ReportGenerator(
             getRenderer(),
-            getClientMetaData(),
             getOutputFile(),
             getTextOutputFactory()
         );

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
@@ -76,7 +76,7 @@ public abstract class TaskReportTask extends ConventionReportTask {
     @ToBeReplacedByLazyProperty
     public ReportRenderer getRenderer() {
         if (renderer == null) {
-            renderer = new TaskReportRenderer();
+            renderer = new TaskReportRenderer(getClientMetaData());
         }
         return renderer;
     }

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/ReportGenerator.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/ReportGenerator.java
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks.diagnostics.internal;
 
 import org.gradle.api.Project;
-import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.jspecify.annotations.Nullable;
@@ -31,18 +30,15 @@ import java.util.function.Function;
 public final class ReportGenerator {
 
     private final ReportRenderer renderer;
-    private final BuildClientMetaData buildClientMetaData;
-    private final File outputFile;
+    private final @Nullable File outputFile;
     private final StyledTextOutputFactory textOutputFactory;
 
     public ReportGenerator(
         ReportRenderer renderer,
-        BuildClientMetaData buildClientMetaData,
         @Nullable File outputFile,
         StyledTextOutputFactory textOutputFactory
     ) {
         this.renderer = renderer;
-        this.buildClientMetaData = buildClientMetaData;
         this.outputFile = outputFile;
         this.textOutputFactory = textOutputFactory;
     }
@@ -85,7 +81,6 @@ public final class ReportGenerator {
     ) {
         try {
             ReportRenderer renderer = getRenderer();
-            renderer.setClientMetaData(getClientMetaData());
             File outputFile = getOutputFile();
             if (outputFile != null) {
                 renderer.setOutputFile(outputFile);
@@ -108,10 +103,6 @@ public final class ReportGenerator {
 
     private ReportRenderer getRenderer() {
         return renderer;
-    }
-
-    private BuildClientMetaData getClientMetaData() {
-        return buildClientMetaData;
     }
 
     /**

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/ReportRenderer.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/ReportRenderer.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.tasks.diagnostics.internal;
 
-import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.internal.logging.text.StyledTextOutput;
 
 import java.io.File;
@@ -25,13 +24,6 @@ import java.io.IOException;
  * Renders the model of a project report.
  */
 public interface ReportRenderer {
-
-    /**
-     * Set the build client metadata.
-     *
-     * @param clientMetaData the build client metadata, never null
-     */
-    void setClientMetaData(BuildClientMetaData clientMetaData);
 
     /**
      * Sets the text output for the report. This method must be called before any other methods on this renderer.

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/TaskReportRenderer.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/TaskReportRenderer.java
@@ -35,6 +35,11 @@ public class TaskReportRenderer extends TextReportRenderer {
     private boolean hasContent;
     private boolean detail;
     private boolean showTypes;
+    private final BuildClientMetaData buildClientMetaData;
+
+    public TaskReportRenderer(BuildClientMetaData buildClientMetaData) {
+        this.buildClientMetaData = buildClientMetaData;
+    }
 
     @Override
     public void startProject(ProjectDetails project) {
@@ -145,15 +150,14 @@ public class TaskReportRenderer extends TextReportRenderer {
     public void complete() {
         if (!detail) {
             StyledTextOutput output = getTextOutput();
-            BuildClientMetaData clientMetaData = getClientMetaData();
 
             output.println();
             output.text("To see all tasks and more detail, run ");
-            clientMetaData.describeCommand(output.withStyle(UserInput), "tasks --all");
+            buildClientMetaData.describeCommand(output.withStyle(UserInput), "tasks --all");
             output.println();
             output.println();
             output.text("To see more detail about a task, run ");
-            clientMetaData.describeCommand(output.withStyle(UserInput), "help --task <task>");
+            buildClientMetaData.describeCommand(output.withStyle(UserInput), "help --task <task>");
             output.println();
         }
         super.complete();

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/TextReportRenderer.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/TextReportRenderer.java
@@ -19,10 +19,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.tasks.diagnostics.internal.text.DefaultTextReportBuilder;
 import org.gradle.api.tasks.diagnostics.internal.text.TextReportBuilder;
-import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.logging.text.StreamingStyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutput;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,19 +33,13 @@ import java.nio.file.Files;
  * <p>A basic {@link ReportRenderer} which writes out a text report.
  */
 public class TextReportRenderer implements ReportRenderer {
-    private BuildClientMetaData clientMetaData;
-    private FileResolver fileResolver;
-    private StyledTextOutput textOutput;
-    private TextReportBuilder builder;
+    private @Nullable FileResolver fileResolver;
+    private @Nullable StyledTextOutput textOutput;
+    private @Nullable TextReportBuilder builder;
     private boolean close;
 
     public void setFileResolver(FileResolver fileResolver) {
         this.fileResolver = fileResolver;
-    }
-
-    @Override
-    public void setClientMetaData(BuildClientMetaData clientMetaData) {
-        this.clientMetaData = clientMetaData;
     }
 
     @Override
@@ -59,6 +53,7 @@ public class TextReportRenderer implements ReportRenderer {
         setWriter(new StreamingStyledTextOutput(Files.newBufferedWriter(file.toPath(), Charset.defaultCharset())), true);
     }
 
+    @SuppressWarnings("DataFlowIssue")
     @Override
     public void startProject(ProjectDetails project) {
         String header = createHeader(project);
@@ -87,6 +82,7 @@ public class TextReportRenderer implements ReportRenderer {
     private void cleanupWriter() {
         try {
             if (close) {
+                //noinspection DataFlowIssue
                 CompositeStoppable.stoppable(textOutput).stop();
             }
         } finally {
@@ -94,16 +90,13 @@ public class TextReportRenderer implements ReportRenderer {
         }
     }
 
-    public BuildClientMetaData getClientMetaData() {
-        return clientMetaData;
-    }
-
+    @Nullable
     public StyledTextOutput getTextOutput() {
         return textOutput;
     }
 
+    @Nullable
     public TextReportBuilder getBuilder() {
         return builder;
     }
-
 }

--- a/platforms/core-configuration/base-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/ReportGeneratorTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/ReportGeneratorTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks.diagnostics.internal
 
 import org.gradle.api.Project
-import org.gradle.initialization.BuildClientMetaData
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -26,14 +25,13 @@ import org.gradle.util.TestUtil
 class ReportGeneratorTest extends AbstractProjectBuilderSpec {
 
     ReportRenderer renderer = Mock(ReportRenderer)
-    BuildClientMetaData buildClientMetaData = Mock(BuildClientMetaData)
     ReportGenerator.ReportAction<Project> projectReportGenerator = Mock(ReportGenerator.ReportAction)
     StyledTextOutput styledTextOutput = Mock(StyledTextOutput)
 
     def createReportGenerator(File file = null) {
         StyledTextOutputFactory textOutputFactory = Mock(StyledTextOutputFactory)
         textOutputFactory.create(_) >> styledTextOutput
-        return new ReportGenerator(renderer, buildClientMetaData, file, textOutputFactory)
+        return new ReportGenerator(renderer, file, textOutputFactory)
     }
 
     def 'completes renderer at end of generation'() {
@@ -42,9 +40,6 @@ class ReportGeneratorTest extends AbstractProjectBuilderSpec {
 
         when:
         generator.generateReport([project] as Set, projectReportGenerator)
-
-        then:
-        1 * renderer.setClientMetaData(buildClientMetaData)
 
         then:
         1 * renderer.setOutput(styledTextOutput)
@@ -70,9 +65,6 @@ class ReportGeneratorTest extends AbstractProjectBuilderSpec {
 
         when:
         generator.generateReport([project] as Set, projectReportGenerator)
-
-        then:
-        1 * renderer.setClientMetaData(buildClientMetaData)
 
         then:
         1 * renderer.setOutputFile(file)
@@ -104,7 +96,6 @@ class ReportGeneratorTest extends AbstractProjectBuilderSpec {
         generator.generateReport(project.getAllprojects(), projectReportGenerator)
 
         then:
-        1 * renderer.setClientMetaData(buildClientMetaData)
         1 * renderer.setOutput(styledTextOutput)
 
         then:

--- a/platforms/core-configuration/base-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/TaskReportRendererTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/TaskReportRendererTest.groovy
@@ -16,11 +16,12 @@
 
 package org.gradle.api.tasks.diagnostics.internal
 
+import org.gradle.initialization.BuildClientMetaData
 import org.gradle.internal.logging.text.TestStyledTextOutput
 
 class TaskReportRendererTest extends AbstractTaskModelSpec {
     private final TestStyledTextOutput writer = new TestStyledTextOutput().ignoreStyle()
-    private final TaskReportRenderer renderer = new TaskReportRenderer()
+    private final TaskReportRenderer renderer = new TaskReportRenderer(Mock(BuildClientMetaData))
 
     def setup() {
         renderer.output = writer

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractReportTask.java
@@ -79,7 +79,6 @@ public abstract class AbstractReportTask extends ConventionTask {
     ReportGenerator reportGenerator() {
         return new ReportGenerator(
             getRenderer(),
-            getClientMetaData(),
             getOutputFile(),
             getTextOutputFactory()
         );

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/BuildEnvironmentReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/BuildEnvironmentReportTask.java
@@ -80,6 +80,8 @@ public abstract class BuildEnvironmentReportTask extends DefaultTask {
         return getProject().getBuildscript().getConfigurations().getByName(ScriptHandler.CLASSPATH_CONFIGURATION);
     }
 
+    // TODO: Remove this in Gradle 10.0.0?  There is no need for it, but no easy way to warn users about the removal.
+    @Deprecated
     @Inject
     protected abstract BuildClientMetaData getClientMetaData();
 
@@ -108,6 +110,6 @@ public abstract class BuildEnvironmentReportTask extends DefaultTask {
     }
 
     private ReportGenerator reportGenerator() {
-        return new ReportGenerator(renderer, getClientMetaData(), null, getTextOutputFactory());
+        return new ReportGenerator(renderer, null, getTextOutputFactory());
     }
 }

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/AbstractReportTaskTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/AbstractReportTaskTest.groovy
@@ -50,7 +50,6 @@ class AbstractReportTaskTest extends Specification {
         task.generate()
 
         then:
-        1 * renderer.setClientMetaData(_)
         1 * renderer.setOutput(_ as StyledTextOutput)
         1 * renderer.startProject(projectDetails)
         1 * generator.run()
@@ -66,7 +65,6 @@ class AbstractReportTaskTest extends Specification {
         task.generate()
 
         then:
-        1 * renderer.setClientMetaData(_)
         1 * renderer.setOutputFile(file)
         1 * renderer.startProject(projectDetails)
         1 * generator.run()
@@ -83,7 +81,6 @@ class AbstractReportTaskTest extends Specification {
         task.generate()
 
         then:
-        1 * renderer.setClientMetaData(_)
         1 * renderer.setOutput(_ as StyledTextOutput)
         [project, child1, child2].each {
             final ProjectDetails p = ProjectDetails.of(it)


### PR DESCRIPTION
Refactor the report generation process by removing the `BuildClientMetaData` dependency from the `ReportGenerator`.

The `BuildClientMetaData` is only used by `TaskReportRenderer`, so it is now passed only to its constructor. This simplifies the `ReportGenerator` and removes the need to pass this instance to many intermediate types that don't use it.

This also deprecates the `getClientMetaData()` property on `BuildEnvironmentReportTask`, as it isn't used any more.
