### PR TITLE
Correct file labels and extensions in single-project layout example

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/organizing_gradle_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/organizing_gradle_projects.adoc
@@ -89,10 +89,10 @@ The project contains a single subproject called `app`:
 [source, kotlin]
 ----
 .   // <1>
-├── settings.gradle // <2>
-└── app/                // <3>
-    ├── build.gradle       // <4>
-    └── src/            // <5>
+├── settings.gradle.kts // <2>
+└── app/                   // <3>
+    ├── build.gradle.kts       // <4>
+    └── src/               // <5>
 ----
 =====
 [.multi-language-sample]
@@ -100,16 +100,16 @@ The project contains a single subproject called `app`:
 [source, groovy]
 ----
 .   // <1>
-├── settings.gradle.kts // <2>
-└── app/                    // <3>
-    ├── build.gradle.kts        // <4>
-    └── src/                // <5>
+├── settings.gradle // <2>
+└── app/                 // <3>
+    ├── build.gradle        // <4>
+    └── src/             // <5>
 ----
 =====
 <1> Root project
-<2> Subproject
-<3> Subproject build file
-<4> Settings file
+<2> Settings file
+<3> Subproject
+<4> Subproject build file
 <5> Source code and more
 
 This is the recommended project structure for starting any Gradle project.


### PR DESCRIPTION
Correct file labels and extensions in single-project layout example (#34301)

The example in the "Structuring & Organizing Gradle Projects / Single-Project Build" section contained mislabeled the numbered file references:

 - 2 was labeled "Subproject" but pointed to settings.gradle
 - 4 was labeled "Settings file" but pointed to app/build.gradle

Also, the Kotlin example used Groovy-style files, and vice versa.

This commit updates the directory structure diagram and associated annotations to match the actual layout and semantics.

Resolves: #34301

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
| Before | After |
|--------|-------|
| ![](https://github.com/user-attachments/assets/9bba5465-6dbe-45d2-a0c9-93130c76a183) <br> ![](https://github.com/user-attachments/assets/7c0f2460-62fb-41e9-9ede-a6d4390a060b) | ![](https://github.com/user-attachments/assets/ecf1d0f2-f9d8-499d-b9f7-adfc70a7078a) <br> ![](https://github.com/user-attachments/assets/e9798ff1-4b3d-4404-8972-1b24ea4a2754) |





### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
