### PR TITLE
Fix flaky DefaultWorkerProcessBuilderIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/worker/DefaultWorkerProcessBuilderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/worker/DefaultWorkerProcessBuilderIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.process.internal.worker
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 
 import static org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache.Skip.INVESTIGATE
 
@@ -26,8 +27,9 @@ class DefaultWorkerProcessBuilderIntegrationTest extends AbstractIntegrationSpec
 
     @ToBeFixedForConfigurationCache(skip = INVESTIGATE)
     def "test classpath does not contain nonexistent entries"() {
+        String integTestHomeDir = IntegrationTestBuildContext.INSTANCE.getGradleUserHomeDir().absolutePath
         given:
-        file("src/test/java/ClasspathTest.java") << '''
+        file("src/test/java/ClasspathTest.java") << """
         import org.junit.Test;
 
         import static org.junit.Assert.assertTrue;
@@ -37,12 +39,12 @@ class DefaultWorkerProcessBuilderIntegrationTest extends AbstractIntegrationSpec
             public void test() {
                 String runtimeClasspath = System.getProperty("java.class.path");
                 System.out.println(runtimeClasspath);
-                assertTrue(runtimeClasspath.contains(System.getProperty("user.home")));
+                assertTrue(runtimeClasspath.contains("${integTestHomeDir.replace("\\", "\\\\")}"));
                 assertTrue(!runtimeClasspath.contains("Non exist path"));
             }
         }
 
-        '''
+        """
         buildFile << """
         plugins {
             id "java-library"


### PR DESCRIPTION
In the past, this test asserts the test class path includes current user home. This is true on Hetzner machines, because project directory is in user home (`/home/tcagent1/work/f63322e10dd6b396`), but not true on EC2 agents, because on EC2 agents the project directory is in `/mnt/tcagent1/work/f63322e10dd6b396`.

[Example](https://ge.gradle.org/s/sncrks4ihxvey/tests/task/:core:isolatedProjectsIntegTest/details/org.gradle.process.internal.worker.DefaultWorkerProcessBuilderIntegrationTest/test%20classpath%20does%20not%20contain%20nonexistent%20entries?top-execution=1)

This PR fixes this by getting correct gradle user home in integration context.