### PR TITLE
Fix flaky ResolveConfigurationDependenciesBuildOperationIntegrationTest

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -79,12 +79,14 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
 
         when:
         fails "checkDeps"
+        operations.debugTree()
 
         then:
         failedResolve.assertFailurePresent(failure)
-        def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
+        def op = operations.first(ResolveConfigurationDependenciesBuildOperationType) {
+            it.details.projectPath == ":"
+        }
         op.details.configurationName == "compileClasspath"
-        op.details.projectPath == ":"
         op.details.buildPath == ":"
         op.details.scriptConfiguration == false
         op.details.configurationDescription ==~ /Compile classpath for source set 'main'.*/


### PR DESCRIPTION
It's been very flaky: https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Australia%2FBrisbane&tests.container=org.gradle.integtests.resolve.ResolveConfigurationDependenciesBuildOperationIntegrationTest&tests.test=resolved%20configurations%20are%20exposed%20via%20build%20operation

<img width="980" height="318" alt="image" src="https://github.com/user-attachments/assets/06e767d3-003f-4fdc-bc19-44f04231d5d0" />

It seems like a concurrency issue: the root project `:compileClasspath` and child project `:child:compileClasspath` are resolved at the same time, and when resolving `:child:compileClasspath` happens first, it fails.

This PR fixes by filtering the root project resolution operation.