### PR TITLE
Fix UpdateWrapper task

### DIFF
--- a/.teamcity/scripts/update_wrapper_and_create_pr.sh
+++ b/.teamcity/scripts/update_wrapper_and_create_pr.sh
@@ -46,10 +46,10 @@ main() {
     : "${GITHUB_TOKEN:?GITHUB_TOKEN environment variable is required}"
 
     if [[ "$TRIGGERED_BY" == *"Release - Final"* ]]; then
-        source version-info-final-release/version-info.properties
+        source version-info-final-release/promote-projects/gradle/build/version-info.properties
         export WRAPPER_VERSION="$promotedVersion"
     elif [[ "$TRIGGERED_BY" == *"Release - Release Candidate"* ]]; then
-        source version-info-release-candidate/version-info.properties
+        source version-info-release-candidate/promote-projects/gradle/build/version-info.properties
         export WRAPPER_VERSION="$promotedVersion"
     fi
 


### PR DESCRIPTION
The path of dependency artifacts were wrong:

```
# ls version-info-release-candidate/version-info.properties
ls: cannot access 'version-info-release-candidate/version-info.properties': No such file or directory
# cat version-info-release-candidate/promote-projects/gradle/build/version-info.properties
#Uploaded version information
buildTimestamp=20250728151002+0000
commitId=a0a6deb6f9937f9e9894a4460f4158267a13ad03
downloadUrl=https\://services.gradle.org/distributions/gradle-9.0.0-rc-4-all.zip
hasBeenReleased=true
isSnapshot=false
promotedVersion=9.0.0-rc-4
versionBase=9.0.0
```