### PR TITLE
Improve error message for missing `@Inject`

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/InjectUtil.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/InjectUtil.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 class InjectUtil {
+
     /**
      * Selects the single injectable constructor for the given type.
      * The type must either have only one public or package-private default constructor,
@@ -47,13 +48,15 @@ class InjectUtil {
                 TreeFormatter formatter = new TreeFormatter();
                 formatter.node("The constructor for type ");
                 formatter.appendType(reportAs);
-                formatter.append(" should be public or package protected or annotated with @Inject.");
+                formatter.append(" should be public or package protected or ");
+                appendAnnotatedWithInject(formatter);
                 throw new IllegalArgumentException(formatter.toString());
             } else {
                 TreeFormatter formatter = new TreeFormatter();
                 formatter.node("The constructor for type ");
                 formatter.appendType(reportAs);
-                formatter.append(" should be annotated with @Inject.");
+                formatter.append(" should be ");
+                appendAnnotatedWithInject(formatter);
                 throw new IllegalArgumentException(formatter.toString());
             }
         }
@@ -68,17 +71,25 @@ class InjectUtil {
         if (injectConstructors.isEmpty()) {
             TreeFormatter formatter = new TreeFormatter();
             formatter.node(reportAs);
-            formatter.append(" has no constructor that is annotated with @Inject.");
+            formatter.append(" has no constructor that is ");
+            appendAnnotatedWithInject(formatter);
             throw new IllegalArgumentException(formatter.toString());
         }
         if (injectConstructors.size() > 1) {
             TreeFormatter formatter = new TreeFormatter();
             formatter.node(reportAs);
-            formatter.append(" has multiple constructors that are annotated with @Inject.");
+            formatter.append(" has multiple constructors that are ");
+            appendAnnotatedWithInject(formatter);
             throw new IllegalArgumentException(formatter.toString());
         }
 
         return injectConstructors.get(0);
+    }
+
+    private static void appendAnnotatedWithInject(TreeFormatter formatter) {
+        formatter.append("annotated with @Inject (");
+        formatter.append(Inject.class.getName());
+        formatter.append(") for dependency injection.");
     }
 
     private static boolean isPublicOrPackageScoped(Class<?> type, ClassGenerator.GeneratedConstructor<?> constructor) {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectingInstantiatorTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectingInstantiatorTest.groovy
@@ -172,7 +172,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasNoInjectConstructor has no constructor that is annotated with @Inject."
+        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasNoInjectConstructor has no constructor that is annotated with @Inject (javax.inject.Inject) for dependency injection."
     }
 
     def "fails when class has multiple constructors with different visibilities and none are annotated"() {
@@ -181,7 +181,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasMixedConstructors has no constructor that is annotated with @Inject."
+        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasMixedConstructors has no constructor that is annotated with @Inject (javax.inject.Inject) for dependency injection."
     }
 
     def "fails when class has multiple constructors that are annotated"() {
@@ -190,7 +190,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasMultipleInjectConstructors has multiple constructors that are annotated with @Inject."
+        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasMultipleInjectConstructors has multiple constructors that are annotated with @Inject (javax.inject.Inject) for dependency injection."
     }
 
     def "fails when class has multiple constructors with different visibilities that are annotated"() {
@@ -199,7 +199,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasMixedInjectConstructors has multiple constructors that are annotated with @Inject."
+        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasMixedInjectConstructors has multiple constructors that are annotated with @Inject (javax.inject.Inject) for dependency injection."
     }
 
     def "fails when class has non-public zero args constructor that is not annotated"() {
@@ -211,7 +211,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "The constructor for type DependencyInjectingInstantiatorTest.HasNonPublicNoArgsConstructor should be public or package protected or annotated with @Inject."
+        e.cause.message == "The constructor for type DependencyInjectingInstantiatorTest.HasNonPublicNoArgsConstructor should be public or package protected or annotated with @Inject (javax.inject.Inject) for dependency injection."
     }
 
     def "fails when class has public constructor with args and that is not annotated"() {
@@ -223,7 +223,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "The constructor for type DependencyInjectingInstantiatorTest.HasSingleConstructorWithArgsAndNoAnnotation should be annotated with @Inject."
+        e.cause.message == "The constructor for type DependencyInjectingInstantiatorTest.HasSingleConstructorWithArgsAndNoAnnotation should be annotated with @Inject (javax.inject.Inject) for dependency injection."
     }
 
     def "fails when class has private constructor with args and that is not annotated"() {
@@ -232,7 +232,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "The constructor for type DependencyInjectingInstantiatorTest.HasPrivateArgsConstructor should be annotated with @Inject."
+        e.cause.message == "The constructor for type DependencyInjectingInstantiatorTest.HasPrivateArgsConstructor should be annotated with @Inject (javax.inject.Inject) for dependency injection."
     }
 
     def "fails when null passed as constructor argument value"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -1161,7 +1161,7 @@ All of them match the consumer attributes:
         failure.assertHasCause("Could not resolve project :b.")
         failure.assertHasCause("Could not determine whether value paid is compatible with value free using FlavorCompatibilityRule.")
         failure.assertHasCause("Could not create an instance of type FlavorCompatibilityRule.")
-        failure.assertHasCause("The constructor for type FlavorCompatibilityRule should be annotated with @Inject.")
+        failure.assertHasCause("The constructor for type FlavorCompatibilityRule should be annotated with @Inject (javax.inject.Inject) for dependency injection.")
     }
 
     def "user receives reasonable error message when compatibility rule fails"() {
@@ -1297,7 +1297,7 @@ All of them match the consumer attributes:
         failure.assertHasCause("Could not resolve project :b.")
         failure.assertHasCause("Could not select value from candidates [free, paid] using FlavorSelectionRule.")
         failure.assertHasCause("Could not create an instance of type FlavorSelectionRule.")
-        failure.assertHasCause("The constructor for type FlavorSelectionRule should be annotated with @Inject.")
+        failure.assertHasCause("The constructor for type FlavorSelectionRule should be annotated with @Inject (javax.inject.Inject) for dependency injection.")
     }
 
     def "user receives reasonable error message when disambiguation rule fails"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PluginServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PluginServiceInjectionIntegrationTest.groovy
@@ -78,7 +78,7 @@ class PluginServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
         fails()
         failure.assertHasCause("Failed to apply plugin class 'CustomPlugin'")
         failure.assertHasCause("Could not create plugin of type 'CustomPlugin'.")
-        failure.assertHasCause("The constructor for type CustomPlugin should be annotated with @Inject.")
+        failure.assertHasCause("The constructor for type CustomPlugin should be annotated with @Inject (javax.inject.Inject) for dependency injection.")
     }
 
     def "fails when plugin constructor requests unknown service"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
@@ -563,7 +563,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause('Could not create an instance of type Thing.')
-        failure.assertHasCause('The constructor for type Thing should be annotated with @Inject.')
+        failure.assertHasCause('The constructor for type Thing should be annotated with @Inject (javax.inject.Inject) for dependency injection.')
     }
 
     def "object creation fails with ObjectInstantiationException when type has multiple constructors not annotated"() {
@@ -587,7 +587,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause('Could not create an instance of type Thing.')
-        failure.assertHasCause('Class Thing has no constructor that is annotated with @Inject.')
+        failure.assertHasCause('Class Thing has no constructor that is annotated with @Inject (javax.inject.Inject) for dependency injection.')
     }
 
     def "plugin can create SourceDirectorySet instances"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskServiceInjectionIntegrationTest.groovy
@@ -161,7 +161,7 @@ class TaskServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Could not create task of type 'CustomTask'.")
-        failure.assertHasCause("The constructor for type CustomTask should be annotated with @Inject.")
+        failure.assertHasCause("The constructor for type CustomTask should be annotated with @Inject (javax.inject.Inject) for dependency injection.")
     }
 
     def "task creation fails when service getter is not public or protected"() {


### PR DESCRIPTION
The message has been improved to include the fully qualified name of the `Inject` annotation.

This helps users who might not be familiar with `javax.inject.Inject` to understand which annotation is required for dependency injection.

Relates to #20183

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
