### PR TITLE
Fix multi string dependency notation test

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/MultiStringDependencyNotationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/MultiStringDependencyNotationIntegrationTest.groovy
@@ -672,15 +672,12 @@ class MultiStringDependencyNotationIntegrationTest extends AbstractIntegrationSp
 
         expect:
         2.times { expectMultiStringDeprecationWarning(notation.value) }
-        if (notation.key.contains("group")) {
-            succeeds("dependencies", "--configuration", "runtimeClasspath")
-        } else {
-            fails("dependencies", "--configuration", "runtimeClasspath") // Group is required for module component IDs
-        }
-
+        succeeds("dependencies", "--configuration", "runtimeClasspath")
 
         where:
-        notation << GROOVY_CONSTRAINT_NOTATIONS.entrySet()
+        notation << GROOVY_CONSTRAINT_NOTATIONS.entrySet().findAll {
+            it.key.contains("group") // Group is required for module component IDs
+        }
     }
 
     def "can declare constraint rules using multi-string notation"() {


### PR DESCRIPTION
The test was failing during forceRealizeIntegTest since the build did not fail as expected. Instead, the resolution failed,  but the dependencies task itself did not fail, which is normal behavior.

Instead, we just skip resolving these offending dependencies. In reality they are broken all the time if you don't include a group. The failure scenario just slightly changes with the different test type.

Fixes https://github.com/gradle/gradle-private/issues/4762

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
