### PR TITLE
Add Best Practice: Naming Root Projects

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -136,6 +136,7 @@ public class GradleBuildDocumentationPlugin implements Plugin<Project> {
             task.getPort().convention(webserverPort);
 
             task.dependsOn(extension.getRenderedDocumentation());
+            task.notCompatibleWithConfigurationCache("There are many CC problems with this task, which clutter the console output and make it hard to see docs generation issues.");
         });
 
         tasks.register("docs", task -> {

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -136,7 +136,6 @@ public class GradleBuildDocumentationPlugin implements Plugin<Project> {
             task.getPort().convention(webserverPort);
 
             task.dependsOn(extension.getRenderedDocumentation());
-            task.notCompatibleWithConfigurationCache("There are many CC problems with this task, which clutter the console output and make it hard to see docs generation issues.");
         });
 
         tasks.register("docs", task -> {

--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_general.adoc
@@ -194,7 +194,6 @@ include::sample[dir="snippets/bestPractices/avoidInternal-do/groovy",files="buil
 
 <<tags_reference.adoc#tag:upgrades,`#upgrades`>>
 
-
 [[use_the_gradle_properties_file]]
 == Set build flags in `gradle.properties`
 
@@ -285,3 +284,51 @@ Now it can be executed using only `gradle run`, and the continue property will a
 === Tags
 
 <<tags_reference.adoc#tag:properties,`#properties`>>
+
+
+[[name_your_root_project]]
+== Name Your Root Project
+
+Always name your root project in the `settings.gradle(.kts)` file.
+
+=== Explanation
+
+While an empty `settings.gradle(.kts)` file is all that is minimally necessary for a multi-project build, you should always set the `rootProject.name` property in it.
+
+Without setting a name explicitly, the root project's name implicitly defaults to the name of the directory containing the build.
+Some directory names may not be valid or suitable as project names, such as those containing spaces, Gradle logical path separators or other special characters.
+The paths to tasks in build should be able to be specified reliably regardless of where the build lives.
+
+Explicitly setting the root project's name also ensures that it referred to consistently.
+Project names are used in various places, such as error messages, logs, and reports.
+Builds may execute on a variety of machines or environments, such as CI servers, and should report the same root project name anywhere to make the project more comprehensible.
+
+=== Example
+
+==== Don't Do This
+
+====
+include::sample[dir="snippets/bestPractices/nameYourRootProject-avoid/kotlin",files="settings.gradle.kts[]"]
+include::sample[dir="snippets/bestPractices/nameYourRootProject-avoid/groovy",files="settings.gradle[]"]
+====
+
+In this build, the settings file is empty and the root project is unnamed.
+If you try running the `projects` report, you will see an implicit name used for the root project that is based on the build's current location.
+
+==== Do This Instead
+
+====
+include::sample[dir="snippets/bestPractices/nameYourRootProject-do/kotlin",files="settings.gradle.kts[]"]
+include::sample[dir="snippets/bestPractices/nameYourRootProject-do/groovy",files="settings.gradle[]"]
+====
+
+In this build, the root project is explicitly named.
+The explicit name `my-example-project` will be used in all reports, logs, and error messages.
+
+=== References
+
+- <<multi_project_builds.adoc#sec:naming_recommendations,Naming recommendations>>
+
+=== Tags
+
+<<tags_reference.adoc#tag:settings,`#settings`>>

--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_general.adoc
@@ -293,14 +293,14 @@ Always name your root project in the `settings.gradle(.kts)` file.
 
 === Explanation
 
-While an empty `settings.gradle(.kts)` file is all that is minimally necessary for a multi-project build, you should always set the `rootProject.name` property in it.
+While an empty `settings.gradle(.kts)` file is enough to create a multi-project build, you should always set the `rootProject.name` property.
 
-Without setting a name explicitly, the root project's name implicitly defaults to the name of the directory containing the build.
-Some directory names may not be valid or suitable as project names, such as those containing spaces, Gradle logical path separators or other special characters.
-The paths to tasks in build should be able to be specified reliably regardless of where the build lives.
+By default, the root project’s name is taken from the directory containing the build.
+This can be problematic if the directory name contains spaces, Gradle logical path separators, or other special characters.
+It also makes task paths dependent on the directory name, rather than being reliably defined.
 
-Explicitly setting the root project's name also ensures that it referred to consistently.
-Project names are used in various places, such as error messages, logs, and reports.
+Explicitly setting the root project's name ensures consistency across environments.
+Project names appear in error messages, logs, and reports, and builds often run on different machines, such as CI servers.
 Builds may execute on a variety of machines or environments, such as CI servers, and should report the same root project name anywhere to make the project more comprehensible.
 
 === Example
@@ -312,8 +312,8 @@ include::sample[dir="snippets/bestPractices/nameYourRootProject-avoid/kotlin",fi
 include::sample[dir="snippets/bestPractices/nameYourRootProject-avoid/groovy",files="settings.gradle[]"]
 ====
 
-In this build, the settings file is empty and the root project is unnamed.
-If you try running the `projects` report, you will see an implicit name used for the root project that is based on the build's current location.
+In this build, the settings file is empty and the root project has no explicit name.
+Running the `projects` report shows that Gradle assigns an implicit name to the root project, derived from the build’s current directory.
 
 ==== Do This Instead
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_general.adoc
@@ -315,6 +315,19 @@ include::sample[dir="snippets/bestPractices/nameYourRootProject-avoid/groovy",fi
 In this build, the settings file is empty and the root project has no explicit name.
 Running the `projects` report shows that Gradle assigns an implicit name to the root project, derived from the build’s current directory.
 
+Unfortunately that name varies based on where the project currently lives.
+For example, if the project is checked out into a directory named `some-directory-name`, the output of `./gradlew projects` will look like this:
+
+```
+> Task :projects
+
+Projects:
+
+------------------------------------------------------------
+Root project 'some-directory-name'
+------------------------------------------------------------
+```
+
 ==== Do This Instead
 
 ====
@@ -324,6 +337,11 @@ include::sample[dir="snippets/bestPractices/nameYourRootProject-do/groovy",files
 
 In this build, the root project is explicitly named.
 The explicit name `my-example-project` will be used in all reports, logs, and error messages.
+Regardless of where the project lives, the output of `./gradlew projects` will look like this:
+
+====
+include::sample[dir="snippets/bestPractices/nameYourRootProject-do/tests",files="nameYourRootProject-do.out[]"]
+====
 
 === References
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_index.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_index.adoc
@@ -18,7 +18,7 @@
 The table below provides a complete list of documented Gradle Best Practices.
 
 ****
-There are currently *27 Best Practices*.
+There are currently *0 Best Practices*.
 ****
 
 Use this as a quick reference to track newly added recommendations, check adoption status, or explore areas for improving your build:
@@ -32,6 +32,7 @@ Use this as a quick reference to track newly added recommendations, check adopti
 | <<best_practices_general.adoc#use_the_plugins_block,Apply Plugins Using the plugins Block>> | General | 8.14
 | <<best_practices_general.adoc#do_not_use_internal_apis,Do Not Use Internal APIs>> | General | 8.14
 | <<best_practices_general.adoc#use_the_gradle_properties_file,Set build flags in gradle.properties>> | General | 9.0.0
+| <<best_practices_general.adoc#name_your_root_project,Name Your Root Project>> | General | 9.2.0
 
 | <<best_practices_structuring_builds.adoc#modularize_builds,Modularize Your Builds>> | Structuring Builds | 9.0.0
 | <<best_practices_structuring_builds.adoc#no_source_in_root,Do Not Put Source Files in the Root Project>> | Structuring Builds | 9.0.0

--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_index.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_index.adoc
@@ -18,7 +18,7 @@
 The table below provides a complete list of documented Gradle Best Practices.
 
 ****
-There are currently *0 Best Practices*.
+There are currently *28 Best Practices*.
 ****
 
 Use this as a quick reference to track newly added recommendations, check adoption status, or explore areas for improving your build:

--- a/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-avoid/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-avoid/groovy/settings.gradle
@@ -1,0 +1,1 @@
+// Left empty

--- a/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-avoid/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-avoid/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+// Left empty

--- a/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-avoid/tests/nameYourRootProject-avoid.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-avoid/tests/nameYourRootProject-avoid.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: "projects"

--- a/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-do/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-do/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "my-example-project"

--- a/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-do/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-do/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "my-example-project"

--- a/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-do/tests/nameYourRootProject-do.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-do/tests/nameYourRootProject-do.out
@@ -1,0 +1,19 @@
+
+> Task :projects
+
+Projects:
+
+------------------------------------------------------------
+Root project 'my-example-project'
+------------------------------------------------------------
+
+Project hierarchy:
+
+Root project 'my-example-project'
+No sub-projects
+
+To see a list of the tasks of a project, run gradle <project-path>:tasks
+For example, try running gradle :tasks
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-do/tests/nameYourRootProject-do.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/nameYourRootProject-do/tests/nameYourRootProject-do.sample.conf
@@ -1,0 +1,5 @@
+executable: gradle
+args: "projects"
+expected-output-file: nameYourRootProject-do.out
+allow-additional-output: true
+allow-disordered-output: true


### PR DESCRIPTION
Recommends that root projects be explicitly named in settings files.

This ensures consistency and avoids potential issues with default naming based on directory names.

`./gradlew :docs:docsTest --tests "*snippet-best-practices-name-your-root-project*"`
