### PR TITLE
doc: reduce boilerplate in `exec-op-inject` sample

### DIFF
--- a/platforms/documentation/docs/src/snippets/providers/services/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/providers/services/groovy/build.gradle
@@ -239,11 +239,11 @@ interface InjectedExecOps {
     ExecOperations getExecOps()
 }
 
-tasks.register('myAdHocExecOperationsTask') {
-    def injected = project.objects.newInstance(InjectedExecOps)
+def execOps = project.objects.newInstance(InjectedExecOps).execOps
 
+tasks.register('myAdHocExecOperationsTask') {
     doLast {
-        injected.execOps.exec {
+        execOps.exec {
             commandLine 'ls', '-la'
         }
     }

--- a/platforms/documentation/docs/src/snippets/providers/services/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/providers/services/kotlin/build.gradle.kts
@@ -202,11 +202,11 @@ interface InjectedExecOps {
     @get:Inject val execOps: ExecOperations
 }
 
-tasks.register("myAdHocExecOperationsTask") {
-    val injected = project.objects.newInstance<InjectedExecOps>()
+val execOps = project.objects.newInstance<InjectedExecOps>().execOps
 
+tasks.register("myAdHocExecOperationsTask") {
     doLast {
-        injected.execOps.exec {
+        execOps.exec {
             commandLine("ls", "-la")
         }
     }


### PR DESCRIPTION
You don't need to instantiate a new injected `ExecOperations` object in every custom task; you can do it just once at the top of the build script, and then use the injected `ExecOperations` object at execution time.

This commit doesn't directly reduce the lines of code here in the sample, but if there were multiple tasks using `execOps.exec`, the tasks would be able to skip the instantiation line.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->Related to #34483

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
