### PR TITLE
Suppress promo when there is no project to enable CC in

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
@@ -35,7 +35,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("greet")
 
         then:
-        postBuildOutputContains(PROMO_PREFIX)
+        assertHasPromo()
     }
 
 
@@ -51,9 +51,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         fails("run")
 
         then:
-        // TODO(https://github.com/gradle/gradle/issues/33857) post-build output scraping is broken for failed builds
-        outputDoesNotContain(PROMO_PREFIX)
-        postBuildOutputDoesNotContain(PROMO_PREFIX)
+        assertHasNoPromo()
     }
 
     def "shows no promo message if build fails at execution time"() {
@@ -66,9 +64,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         fails("fail")
 
         then:
-        // TODO(https://github.com/gradle/gradle/issues/33857) post-build output scraping is broken for failed builds
-        outputDoesNotContain(PROMO_PREFIX)
-        postBuildOutputDoesNotContain(PROMO_PREFIX)
+        assertHasNoPromo()
     }
 
     def "shows promo message when running with isolated projects disabled in command-line"() {
@@ -81,7 +77,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("greet", "-D${IsolatedProjectsOption.PROPERTY_NAME}=false")
 
         then:
-        postBuildOutputContains(PROMO_PREFIX)
+        assertHasPromo()
     }
 
     def "shows promo message when running with isolated projects disabled in properties files"() {
@@ -96,7 +92,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("greet")
 
         then:
-        postBuildOutputContains(PROMO_PREFIX)
+        assertHasPromo()
     }
 
     def "shows no promo message when #ccSwitch is given in command-line"() {
@@ -109,7 +105,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("greet", ccSwitch)
 
         then:
-        postBuildOutputDoesNotContain(PROMO_PREFIX)
+        assertHasNoPromo()
 
         where:
         ccSwitch << [
@@ -135,7 +131,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("greet")
 
         then:
-        postBuildOutputDoesNotContain(PROMO_PREFIX)
+        assertHasNoPromo()
 
         where:
         ccStateLine << [
@@ -161,7 +157,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("greet")
 
         then:
-        postBuildOutputDoesNotContain(PROMO_PREFIX)
+        assertHasNoPromo()
     }
 
     def "shows no promo message if execution is not cc compatible"() {
@@ -180,7 +176,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("greet")
 
         then:
-        postBuildOutputDoesNotContain(PROMO_PREFIX)
+        assertHasNoPromo()
     }
 
     def "shows no promo message if external process used at configuration time with #execMethod"() {
@@ -209,7 +205,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("greet")
 
         then:
-        postBuildOutputDoesNotContain(PROMO_PREFIX)
+        assertHasNoPromo()
 
         where:
         execMethod << ["execWithExecOperations", "execWithGroovyApi"]
@@ -245,7 +241,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("greet")
 
         then:
-        postBuildOutputContains(PROMO_PREFIX)
+        assertHasPromo()
 
         where:
         execMethod << ["execWithExecOperations", "execWithGroovyApi"]
@@ -290,7 +286,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
 
         then:
         outputContains("Hello")
-        postBuildOutputContains(PROMO_PREFIX)
+        assertHasPromo()
 
         where:
         execMethod << ["execWithExecOperations", "execWithGroovyApi"]
@@ -311,7 +307,7 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("greet")
 
         then:
-        postBuildOutputContains(PROMO_PREFIX)
+        assertHasPromo()
     }
 
     def "shows no promo message if a task in the graph is marked as cc incompatible"() {
@@ -336,25 +332,25 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("incompatible")
 
         then:
-        postBuildOutputDoesNotContain(PROMO_PREFIX)
+        assertHasNoPromo()
 
         when: "incompatible task runs as dependency"
         run("withIncompatibleDep")
 
         then:
-        postBuildOutputDoesNotContain(PROMO_PREFIX)
+        assertHasNoPromo()
 
         when: "incompatible task is a skipped dependency"
         run("withIncompatibleDep", "-Dskip.incompatible=true")
 
         then:
-        postBuildOutputDoesNotContain(PROMO_PREFIX)
+        assertHasNoPromo()
 
         when: "promo is present when incompatible task is excluded from the task graph"
         run("withIncompatibleDep", "-x", "incompatible")
 
         then:
-        postBuildOutputContains(PROMO_PREFIX)
+        assertHasPromo()
 
         where:
         incompatibleReason << [
@@ -378,12 +374,22 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         run("run")
 
         then:
-        postBuildOutputContains(PROMO_PREFIX)
+        assertHasPromo()
 
         where:
         incompatibleReason << [
             "notCompatibleWithConfigurationCache('reasons')",
             "services.get(${ConfigurationCacheDegradationController.name}).requireConfigurationCacheDegradation(task, provider { 'reasons' })"
         ]
+    }
+
+    private void assertHasPromo() {
+        postBuildOutputContains(PROMO_PREFIX)
+    }
+
+    private void assertHasNoPromo() {
+        // TODO(https://github.com/gradle/gradle/issues/33857) post-build output scraping is broken for failed builds
+        outputDoesNotContain(PROMO_PREFIX)
+        postBuildOutputDoesNotContain(PROMO_PREFIX)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
@@ -395,6 +395,14 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         assertHasNoPromo()
     }
 
+    def "shows no promo message when gradle init is invoked with project"() {
+        when:
+        fails("init", "--use-defaults")
+
+        then:
+        assertHasNoPromo()
+    }
+
     def "shows no promo message when gradle help is invoked without project"() {
         given:
         withEmptyProjectDirectory()
@@ -417,6 +425,17 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
 
         then:
         assertHasPromo()
+    }
+
+    def "shows no promo message when unsupported command is invoked without project"() {
+        given:
+        withEmptyProjectDirectory()
+
+        when:
+        fails("wrapper")
+
+        then:
+        assertHasNoPromo()
     }
 
     private void withEmptyProjectDirectory() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoIntegrationTest.groovy
@@ -383,6 +383,56 @@ class ConfigurationCachePromoIntegrationTest extends AbstractConfigurationCacheI
         ]
     }
 
+
+    def "shows no promo message when gradle init is invoked"() {
+        given:
+        withEmptyProjectDirectory()
+
+        when:
+        run("init", "--use-defaults")
+
+        then:
+        assertHasNoPromo()
+    }
+
+    def "shows no promo message when gradle help is invoked without project"() {
+        given:
+        withEmptyProjectDirectory()
+
+        when:
+        run("help")
+
+        then:
+        assertHasNoPromo()
+    }
+
+    def "shows promo message when gradle help is invoked with project"() {
+        given:
+        buildFile """
+            // Some non-empty build file
+        """
+
+        when:
+        run("help")
+
+        then:
+        assertHasPromo()
+    }
+
+    private void withEmptyProjectDirectory() {
+        settingsFile """
+            // This is here to prevent Gradle searching up to find the build's settings.gradle
+        """
+
+        def initDir = createDir("toInit")
+
+        executer.tap {
+            inDirectory(initDir)
+            withRepositoryMirrors()
+            ignoreMissingSettingsFile()
+        }
+    }
+
     private void assertHasPromo() {
         postBuildOutputContains(PROMO_PREFIX)
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -407,7 +407,7 @@ class ConfigurationCacheProblems(
         override fun afterStart() = Unit
 
         @Suppress("CyclomaticComplexMethod")
-        override fun beforeComplete() {
+        override fun beforeComplete(failure: Throwable?) {
             val summary = summarizer.get()
             val reportableProblemCount = summary.reportableProblemCount
             val deferredProblemCount = summary.deferredProblemCount

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
@@ -17,13 +17,11 @@
 package org.gradle.internal.cc.impl.promo
 
 import org.gradle.BuildResult
-import org.gradle.StartParameter
 import org.gradle.api.Task
 import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.logging.Logging
-import org.gradle.configuration.project.BuiltInCommand
 import org.gradle.initialization.RootBuildLifecycleListener
 import org.gradle.initialization.layout.ResolvedBuildLayout
 import org.gradle.internal.Factory
@@ -53,8 +51,6 @@ import org.gradle.internal.service.scopes.ServiceScope
  */
 @ServiceScope(Scope.BuildTree::class)
 internal class ConfigurationCachePromoHandler(
-    private val startParameter: StartParameter,
-    private val builtInCommands: List<BuiltInCommand>,
     private val buildRegistry: BuildStateRegistry,
     private val degradationController: DefaultConfigurationCacheDegradationController,
     private val documentationRegistry: DocumentationRegistry
@@ -138,9 +134,5 @@ internal class ConfigurationCachePromoHandler(
 
     private fun TaskExecutionGraph.hasIncompatibleTasks() = allTasks.any { !(it as TaskInternal).isCompatibleWithConfigurationCache }
 
-    private fun runWithoutBuildDefinition(): Boolean {
-        return builtInCommands.any {
-            it.wasInvoked(startParameter) && (it.requireEmptyBuildDefinition() || rootBuildLayout.isBuildDefinitionMissing)
-        }
-    }
+    private fun runWithoutBuildDefinition() = rootBuildLayout.isBuildDefinitionMissing
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
@@ -108,8 +108,11 @@ internal class ConfigurationCachePromoHandler(
         }
     }
 
-    override fun beforeComplete() {
-        if (problems.arePresent() || runWithoutBuildDefinition()) {
+    override fun beforeComplete(failure: Throwable?) {
+        // Order of checks is somewhat important.
+        // With an infra failure, it is unsafe to check the build definition presence, as the Settings may not be initialized.
+        // We don't show the promo if there is any failure, so we don't need to know the build definition anyway.
+        if (failure != null || problems.arePresent() || runWithoutBuildDefinition()) {
             return
         }
 

--- a/platforms/core-runtime/build-profile/build.gradle.kts
+++ b/platforms/core-runtime/build-profile/build.gradle.kts
@@ -13,13 +13,15 @@ dependencies {
     api(projects.coreApi)
     api(projects.enterpriseLogging)
 
+    api(libs.jspecify)
+
+
     implementation(projects.logging)
     implementation(projects.loggingApi)
     implementation(projects.reportRendering)
     implementation(projects.serviceLookup)
 
     implementation(libs.guava)
-    implementation(libs.jspecify)
 
     testImplementation(projects.internalTesting)
 

--- a/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/ProfileCoordinator.java
+++ b/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/ProfileCoordinator.java
@@ -20,6 +20,7 @@ import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.time.Clock;
+import org.jspecify.annotations.Nullable;
 
 @ServiceScope(Scope.BuildTree.class)
 public class ProfileCoordinator implements RootBuildLifecycleListener {
@@ -34,11 +35,7 @@ public class ProfileCoordinator implements RootBuildLifecycleListener {
     }
 
     @Override
-    public void afterStart() {
-    }
-
-    @Override
-    public void beforeComplete() {
+    public void beforeComplete(@Nullable Throwable failure) {
         profile.setBuildFinished(clock.getCurrentTime());
         generator.buildFinished(profile);
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -118,6 +118,7 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
         try {
             RootBuildLifecycleListener buildLifecycleListener = listenerManager.getBroadcaster(RootBuildLifecycleListener.class);
             buildLifecycleListener.afterStart();
+            Throwable failure = null;
             try {
                 GradleInternal gradle = getBuildController().getGradle();
                 DefaultDeploymentRegistry deploymentRegistry = gradle.getServices().get(DefaultDeploymentRegistry.class);
@@ -128,8 +129,11 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
                     }
                 });
                 return action.apply(buildTreeLifecycleController);
+            } catch (RuntimeException | Error e) {
+                failure = e;
+                throw e;
             } finally {
-                buildLifecycleListener.beforeComplete();
+                buildLifecycleListener.beforeComplete(failure);
             }
         } finally {
             completed = true;

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
@@ -95,7 +95,7 @@ class DefaultRootBuildStateTest extends Specification {
             '<result>'
         }
 
-        1 * lifecycleListener.beforeComplete()
+        1 * lifecycleListener.beforeComplete(null)
         0 * controller._
         0 * lifecycleListener._
     }
@@ -133,7 +133,7 @@ class DefaultRootBuildStateTest extends Specification {
         1 * buildTreeController.scheduleAndRunTasks()
 
         and:
-        1 * lifecycleListener.beforeComplete()
+        1 * lifecycleListener.beforeComplete(null)
         0 * lifecycleListener._
     }
 
@@ -150,7 +150,7 @@ class DefaultRootBuildStateTest extends Specification {
         and:
         1 * action.apply(!null) >> { BuildTreeLifecycleController controller -> throw failure }
         1 * lifecycleListener.afterStart()
-        1 * lifecycleListener.beforeComplete()
+        1 * lifecycleListener.beforeComplete(failure)
         0 * lifecycleListener._
     }
 
@@ -176,7 +176,7 @@ class DefaultRootBuildStateTest extends Specification {
         1 * buildTreeController.scheduleAndRunTasks() >> { throw failure }
 
         and:
-        1 * lifecycleListener.beforeComplete()
+        1 * lifecycleListener.beforeComplete(failure)
         0 * lifecycleListener._
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspector.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.changedetection.state;
 import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 
@@ -44,7 +45,7 @@ public class BuildSessionScopeFileTimeStampInspector extends FileTimeStampInspec
     }
 
     @Override
-    public void beforeComplete() {
+    public void beforeComplete(@Nullable Throwable failure) {
         updateOnFinishBuild();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/GradleUserHomeScopeFileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/GradleUserHomeScopeFileTimeStampInspector.java
@@ -20,6 +20,7 @@ import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory;
 import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -73,7 +74,7 @@ public class GradleUserHomeScopeFileTimeStampInspector extends FileTimeStampInsp
     }
 
     @Override
-    public void beforeComplete() {
+    public void beforeComplete(@Nullable Throwable failure) {
         updateOnFinishBuild();
         synchronized (lock) {
             try {

--- a/subprojects/core/src/main/java/org/gradle/initialization/RootBuildLifecycleListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/RootBuildLifecycleListener.java
@@ -19,6 +19,7 @@ package org.gradle.initialization;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.StatefulListener;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A listener that is notified when a root build is started and completed. No more than one root build may run at a given time.
@@ -33,10 +34,14 @@ public interface RootBuildLifecycleListener {
     /**
      * Called at the start of the root build, immediately after the creation of the root build services.
      */
-    void afterStart();
+    default void afterStart() {}
 
     /**
      * Called at the completion of the root build, immediately before destruction of the root build services.
+     * If some infrastructural problem has been encountered, the {@code failure} will be non-{@code null}.
+     * Note that {@code failure == null} doesn't mean that the build has succeeded, but most build failures propagate through other means.
+     *
+     * @param failure the exception thrown while running the root build if any, or {@code null}
      */
-    void beforeComplete();
+    default void beforeComplete(@Nullable Throwable failure) {}
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/file/DefaultFileSystemDefaultExcludesProvider.java
@@ -44,10 +44,6 @@ public class DefaultFileSystemDefaultExcludesProvider implements FileSystemDefau
                 currentDefaultExcludes = ImmutableList.copyOf(DirectoryScanner.getDefaultExcludes());
                 broadcast.getSource().onDefaultExcludesChanged(currentDefaultExcludes);
             }
-
-            @Override
-            public void beforeComplete() {
-            }
         });
 
         listenerManager.addListener(new BuildAdapter() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -98,6 +98,7 @@ import org.gradle.internal.watch.vfs.impl.DefaultWatchableFileSystemDetector;
 import org.gradle.internal.watch.vfs.impl.FileWatchingFilter;
 import org.gradle.internal.watch.vfs.impl.WatchingNotSupportedVirtualFileSystem;
 import org.gradle.internal.watch.vfs.impl.WatchingVirtualFileSystem;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.util.Optional;
@@ -188,7 +189,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
                 }
 
                 @Override
-                public void beforeComplete() {
+                public void beforeComplete(@Nullable Throwable failure) {
                     fileWatchingFilter.buildFinished();
                 }
             });

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspectorTest.groovy
@@ -46,7 +46,7 @@ class BuildSessionScopeFileTimeStampInspectorTest extends Specification {
         when:
         timestampInspector.afterStart()
         def afterStartTimestamp = timestampInspector.lastBuildTimestamp
-        timestampInspector.beforeComplete()
+        timestampInspector.beforeComplete(null)
         def beforeCompleteTimestamp = timestampInspector.lastBuildTimestamp
 
         then:
@@ -57,7 +57,7 @@ class BuildSessionScopeFileTimeStampInspectorTest extends Specification {
     def "last build timestamp is equal to minimum of timestamps of the marker file"() {
         given:
         timestampInspector.afterStart()
-        timestampInspector.beforeComplete()
+        timestampInspector.beforeComplete(null)
         def markerFile = new File(workDir, "last-build.bin")
         // File.lastModified() and Files.getLastModifiedTime() uses different resolution on some JDKs < 11
         def markerFileTimestamp = Math.min(markerFile.lastModified(), Files.getLastModifiedTime(markerFile.toPath()).toMillis())
@@ -73,7 +73,7 @@ class BuildSessionScopeFileTimeStampInspectorTest extends Specification {
     def "timestamp cannot be used to detect file changes if it's equal to the last build timestamp"() {
         given:
         timestampInspector.afterStart()
-        timestampInspector.beforeComplete()
+        timestampInspector.beforeComplete(null)
         def lastBuildTimestamp = timestampInspector.lastBuildTimestamp
 
         when:
@@ -87,7 +87,7 @@ class BuildSessionScopeFileTimeStampInspectorTest extends Specification {
     def "timestamp can be used to detect file changes if it's not equal to the last build timestamp"() {
         given:
         timestampInspector.afterStart()
-        timestampInspector.beforeComplete()
+        timestampInspector.beforeComplete(null)
         def lastBuildTimestamp = timestampInspector.lastBuildTimestamp
 
         when:


### PR DESCRIPTION
The `gradle init` requires no promo, because the created project has CC enabled already.

The `gradle help` is trickier, because it can be run within a project (and can even be redefined). We suppress the promo when no underlying project is detected, but keep it otherwise (CC can help with `help` too).

Fixes #34414.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
