### PR TITLE
Fine-grained Gradle property lookup

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/Codecs.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/Codecs.kt
@@ -67,6 +67,7 @@ import org.gradle.internal.serialize.codecs.core.FileTreeCodec
 import org.gradle.internal.serialize.codecs.core.FileValueSnapshotCodec
 import org.gradle.internal.serialize.codecs.core.FixedValueReplacingProviderCodec
 import org.gradle.internal.serialize.codecs.core.FlowProvidersCodec
+import org.gradle.internal.serialize.codecs.core.GradlePropertiesCodec
 import org.gradle.internal.serialize.codecs.core.IntegerValueSnapshotCodec
 import org.gradle.internal.serialize.codecs.core.IntersectionPatternSetCodec
 import org.gradle.internal.serialize.codecs.core.IsolateContextSource
@@ -237,6 +238,7 @@ class Codecs(
             bind(DestinationRootCopySpecCodec(fileResolver))
 
             bind(TaskReferenceCodec)
+            bind(GradlePropertiesCodec)
 
             bind(CachedEnvironmentStateCodec)
 

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/GradlePropertiesCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/GradlePropertiesCodec.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.codecs.core
+
+import org.gradle.api.internal.properties.GradleProperties
+import org.gradle.initialization.properties.DefaultGradleProperties
+import org.gradle.internal.Cast.uncheckedNonnullCast
+import org.gradle.internal.serialize.graph.Codec
+import org.gradle.internal.serialize.graph.ReadContext
+import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.graph.decodePreservingSharedIdentity
+import org.gradle.internal.serialize.graph.encodePreservingSharedIdentityOf
+import org.gradle.internal.serialize.graph.readMapInto
+import org.gradle.internal.serialize.graph.writeMap
+
+
+object GradlePropertiesCodec : Codec<GradleProperties> {
+    override suspend fun WriteContext.encode(value: GradleProperties) {
+        encodePreservingSharedIdentityOf(value) {
+            writeMap(value.properties)
+        }
+    }
+
+    override suspend fun ReadContext.decode(): GradleProperties? {
+        return decodePreservingSharedIdentity {
+            val properties = readMapInto { mutableMapOf() }
+            DefaultGradleProperties(uncheckedNonnullCast(properties))
+        }
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/plugins/ExtraPropertiesExtensionInternal.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/plugins/ExtraPropertiesExtensionInternal.java
@@ -16,13 +16,12 @@
 
 package org.gradle.api.internal.plugins;
 
+import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
-
-import java.util.Map;
 
 /**
  * Internal protocol for the initialization of extra properties.
  */
 public interface ExtraPropertiesExtensionInternal extends ExtraPropertiesExtension {
-    void setGradleProperties(Map<String, Object> properties);
+    void setGradleProperties(GradleProperties gradleProperties);
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/EnvironmentVariablesPrefixedByValueSource.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/EnvironmentVariablesPrefixedByValueSource.java
@@ -17,14 +17,13 @@
 package org.gradle.api.internal.provider.sources;
 
 import java.util.Map;
-import java.util.stream.Stream;
 
 public abstract class EnvironmentVariablesPrefixedByValueSource extends MapWithPrefixedKeysValueSource<EnvironmentVariablesPrefixedByValueSource.Parameters> {
     public interface Parameters extends MapWithPrefixedKeysValueSource.Parameters {
     }
 
     @Override
-    protected Stream<Map.Entry<String, String>> itemsToFilter() {
-        return System.getenv().entrySet().stream();
+    protected Map<String, String> collectItems(String prefix) {
+        return collectWithKeyPrefix(prefix, System.getenv().entrySet().stream());
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/GradlePropertiesPrefixedByValueSource.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/GradlePropertiesPrefixedByValueSource.java
@@ -20,7 +20,6 @@ import org.gradle.api.internal.properties.GradleProperties;
 
 import javax.inject.Inject;
 import java.util.Map;
-import java.util.stream.Stream;
 
 public abstract class GradlePropertiesPrefixedByValueSource extends MapWithPrefixedKeysValueSource<GradlePropertiesPrefixedByValueSource.Parameters> {
     public interface Parameters extends MapWithPrefixedKeysValueSource.Parameters {
@@ -30,7 +29,7 @@ public abstract class GradlePropertiesPrefixedByValueSource extends MapWithPrefi
     protected abstract GradleProperties getGradleProperties();
 
     @Override
-    protected Stream<Map.Entry<String, String>> itemsToFilter() {
-        return getGradleProperties().getProperties().entrySet().stream();
+    protected Map<String, String> collectItems(String prefix) {
+        return getGradleProperties().getPropertiesWithPrefix(prefix);
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/MapWithPrefixedKeysValueSource.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/MapWithPrefixedKeysValueSource.java
@@ -34,11 +34,14 @@ public abstract class MapWithPrefixedKeysValueSource<P extends MapWithPrefixedKe
     @Override
     public Map<String, String> obtain() {
         String prefix = getParameters().getPrefix().getOrElse("");
+        return collectItems(prefix);
+    }
 
-        return itemsToFilter()
+    protected abstract Map<String, String> collectItems(String prefix);
+
+    protected Map<String, String> collectWithKeyPrefix(String prefix, Stream<Map.Entry<String, String>> items) {
+        return items
             .filter(e -> e.getKey().startsWith(prefix))
             .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
-
-    protected abstract Stream<Map.Entry<String, String>> itemsToFilter();
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/SystemPropertiesPrefixedByValueSource.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/sources/SystemPropertiesPrefixedByValueSource.java
@@ -24,7 +24,11 @@ public abstract class SystemPropertiesPrefixedByValueSource extends MapWithPrefi
     }
 
     @Override
-    protected Stream<Map.Entry<String, String>> itemsToFilter() {
+    protected Map<String, String> collectItems(String prefix) {
+        return collectWithKeyPrefix(prefix, itemsToFilter());
+    }
+
+    private static Stream<Map.Entry<String, String>> itemsToFilter() {
         return System.getProperties().entrySet().stream()
             .filter(e -> e.getKey() instanceof String && e.getValue() instanceof String)
             .map(e -> {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/DefaultExtraPropertiesExtension.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/DefaultExtraPropertiesExtension.java
@@ -46,7 +46,7 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
         }
 
         if (gradleProperties != null) {
-            return gradleProperties.find(name) != null;
+            return gradleProperties.findUnsafe(name) != null;
         }
 
         return false;
@@ -72,7 +72,7 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
         }
 
         if (gradleProperties != null) {
-            return gradleProperties.find(name);
+            return gradleProperties.findUnsafe(name);
         }
 
         return null;
@@ -101,7 +101,7 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
         }
 
         if (gradleProperties != null) {
-            Object value = gradleProperties.find(name);
+            Object value = gradleProperties.findUnsafe(name);
             if (value != null) {
                 return value;
             }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/DefaultExtraPropertiesExtension.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/DefaultExtraPropertiesExtension.java
@@ -16,21 +16,25 @@
 
 package org.gradle.internal.extensibility;
 
-import com.google.common.collect.ImmutableMap;
 import groovy.lang.Closure;
 import groovy.lang.GroovyObjectSupport;
 import groovy.lang.MissingPropertyException;
 import groovy.lang.ReadOnlyPropertyException;
 import org.gradle.api.internal.plugins.ExtraPropertiesExtensionInternal;
+import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.gradle.internal.Cast.uncheckedNonnullCast;
+
 public class DefaultExtraPropertiesExtension extends GroovyObjectSupport implements ExtraPropertiesExtensionInternal {
 
-    private ImmutableMap<String, Object> gradleProperties = ImmutableMap.of();
+    @Nullable
+    private GradleProperties gradleProperties;
 
     @Nullable
     private Map<String, Object> storage = null;
@@ -40,9 +44,12 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
         if (storage != null && storage.containsKey(name)) {
             return true;
         }
-        // TODO:configuration-cache track Gradle property lookup
-//        onGradlePropertyLookup(name);
-        return gradleProperties.containsKey(name);
+
+        if (gradleProperties != null) {
+            return gradleProperties.find(name) != null;
+        }
+
+        return false;
     }
 
     @Override
@@ -63,9 +70,12 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
                 return value;
             }
         }
-        // TODO:configuration-cache track Gradle property lookup
-//        onGradlePropertyLookup(name);
-        return gradleProperties.get(name);
+
+        if (gradleProperties != null) {
+            return gradleProperties.find(name);
+        }
+
+        return null;
     }
 
     @Override
@@ -90,10 +100,11 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
             }
         }
 
-        // TODO:configuration-cache track Gradle property lookup
-//        onGradlePropertyLookup(name);
-        if (gradleProperties.containsKey(name)) {
-            return gradleProperties.get(name);
+        if (gradleProperties != null) {
+            Object value = gradleProperties.find(name);
+            if (value != null) {
+                return value;
+            }
         }
 
         throw new MissingPropertyException(UnknownPropertyException.createMessage(name), name, null);
@@ -109,21 +120,24 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
 
     @Override
     public Map<String, Object> getProperties() {
-        // Must return a mutable map to preserve contract
-        // TODO:configuration-cache use a tracking map here
+        // Must return a mutable map to preserve the contract
+        // TODO:configuration-cache introduce a lazy mutable map that does not force eager reading of all Gradle properties
         if (storage == null) {
-            return new HashMap<>(gradleProperties);
+            return new HashMap<>(getGradlePropertiesAsMap());
         }
-        Map<String, Object> properties = new HashMap<>(storage.size() + gradleProperties.size());
+        Map<String, Object> gradlePropertiesMap = getGradlePropertiesAsMap();
+        Map<String, Object> properties = new HashMap<>(storage.size() + gradlePropertiesMap.size());
         properties.putAll(storage);
-        for (Map.Entry<String, Object> entry : gradleProperties.entrySet()) {
+        for (Map.Entry<String, Object> entry : gradlePropertiesMap.entrySet()) {
             if (!storage.containsKey(entry.getKey())) {
-                // TODO:configuration-cache track Gradle property lookup
-//                onGradlePropertyLookup(entry.getKey());
                 properties.put(entry.getKey(), entry.getValue());
             }
         }
         return properties;
+    }
+
+    private Map<String, Object> getGradlePropertiesAsMap() {
+        return gradleProperties == null ? Collections.emptyMap() : uncheckedNonnullCast(gradleProperties.getProperties());
     }
 
     @SuppressWarnings("rawtypes")
@@ -138,7 +152,7 @@ public class DefaultExtraPropertiesExtension extends GroovyObjectSupport impleme
     }
 
     @Override
-    public void setGradleProperties(Map<String, Object> properties) {
-        gradleProperties = ImmutableMap.copyOf(properties);
+    public void setGradleProperties(GradleProperties gradleProperties) {
+        this.gradleProperties = gradleProperties;
     }
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/extensibility/DefaultExtraPropertiesExtensionTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/extensibility/DefaultExtraPropertiesExtensionTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.extensibility
 
+import org.gradle.initialization.properties.DefaultGradleProperties
+
 class DefaultExtraPropertiesExtensionTest extends ExtraPropertiesExtensionTest<DefaultExtraPropertiesExtension> {
 
     DefaultExtraPropertiesExtension createExtension() {
@@ -26,7 +28,7 @@ class DefaultExtraPropertiesExtensionTest extends ExtraPropertiesExtensionTest<D
 
         DefaultExtraPropertiesExtension createExtension() {
             new DefaultExtraPropertiesExtension().tap {
-                it.setGradleProperties([:])
+                it.setGradleProperties(new DefaultGradleProperties([:]))
             }
         }
     }

--- a/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
+++ b/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
@@ -77,5 +77,10 @@ public class TestBuildScopeServices extends BuildScopeServices {
         public Map<String, String> getPropertiesWithPrefix(String prefix) {
             return Collections.emptyMap();
         }
+
+        @Override
+        public @Nullable Object findUnsafe(String propertyName) {
+            return null;
+        }
     }
 }

--- a/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
+++ b/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/TestBuildScopeServices.java
@@ -72,5 +72,10 @@ public class TestBuildScopeServices extends BuildScopeServices {
         public Map<String, String> getProperties() {
             return Collections.emptyMap();
         }
+
+        @Override
+        public Map<String, String> getPropertiesWithPrefix(String prefix) {
+            return Collections.emptyMap();
+        }
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/properties/GradleProperties.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/properties/GradleProperties.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.properties;
 
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.jspecify.annotations.Nullable;
@@ -23,15 +24,41 @@ import org.jspecify.annotations.Nullable;
 import java.util.Map;
 
 /**
- * Immutable set of Gradle properties loaded at the start of the build.
+ * Gradle properties of a build or a project. Only build-scoped properties when injected as a service.
+ * <p>
+ * See {@link org.gradle.initialization.GradlePropertiesController GradlePropertiesController} on how these properties
+ * are loaded and what contributes to their values at each scope.
+ * <p>
+ * Build-scoped properties are accessible by users via {@link ProviderFactory#gradleProperty(String)}.
+ * Currently, properties accessed this way do not take project-scoped Gradle properties into account,
+ * even if the provider factory was injected in the project.
+ * <p>
+ * Build-scoped properties are also accessible via extra-properties of the Settings instance.
+ * This includes any access to these extra-properties, including the dynamic lookup in the settings script.
+ * <p>
+ * Project-scoped properties are only accessible via extra-properties of the Project instance.
+ * This includes any access to these extra-properties, including the dynamic lookup in the build script.
  */
 @ServiceScope(Scope.Build.class)
 public interface GradleProperties {
 
+    /**
+     * Returns the value of the property or null if not found.
+     * <p>
+     * The actual value of a property can never be null. Therefore, if null is returned, then the property was not specified.
+     */
     @Nullable
     String find(String propertyName);
 
+    /**
+     * Returns all properties as a map.
+     */
     Map<String, String> getProperties();
 
+    /**
+     * Returns all properties, whose name starts with a given prefix, as a map.
+     * <p>
+     * The returned map is never null. An empty map is returned if nothing is found.
+     */
     Map<String, String> getPropertiesWithPrefix(String prefix);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/properties/GradleProperties.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/properties/GradleProperties.java
@@ -61,4 +61,13 @@ public interface GradleProperties {
      * The returned map is never null. An empty map is returned if nothing is found.
      */
     Map<String, String> getPropertiesWithPrefix(String prefix);
+
+    /**
+     * AVOID THIS METHOD UNLESS NECESSARY
+     * <p>
+     * It is equivalent to {@link #find(String)}, except that it does not enforce the type of the returned value.
+     */
+    // TODO: Remove non-String project properties support in Gradle 10 - https://github.com/gradle/gradle/issues/34454
+    @Nullable
+    Object findUnsafe(String propertyName);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/properties/GradleProperties.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/properties/GradleProperties.java
@@ -32,4 +32,6 @@ public interface GradleProperties {
     String find(String propertyName);
 
     Map<String, String> getProperties();
+
+    Map<String, String> getPropertiesWithPrefix(String prefix);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesController.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesController.java
@@ -120,6 +120,11 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
             return gradleProperties().getPropertiesWithPrefix(prefix);
         }
 
+        @Override
+        public @Nullable Object findUnsafe(String propertyName) {
+            return gradleProperties().findUnsafe(propertyName);
+        }
+
         private GradleProperties gradleProperties() {
             return checkLoaded().gradleProperties;
         }
@@ -258,6 +263,11 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
         @Override
         public Map<String, String> getPropertiesWithPrefix(String prefix) {
             return gradleProperties().getPropertiesWithPrefix(prefix);
+        }
+
+        @Override
+        public @Nullable Object findUnsafe(String propertyName) {
+            return gradleProperties().findUnsafe(propertyName);
         }
 
         private GradleProperties gradleProperties() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesController.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesController.java
@@ -21,8 +21,8 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.properties.GradleProperties;
-import org.gradle.initialization.properties.GradlePropertiesLoader;
 import org.gradle.initialization.properties.DefaultGradleProperties;
+import org.gradle.initialization.properties.GradlePropertiesLoader;
 import org.gradle.initialization.properties.SystemPropertiesInstaller;
 import org.jspecify.annotations.Nullable;
 
@@ -113,6 +113,11 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
         @Override
         public Map<String, String> getProperties() {
             return gradleProperties().getProperties();
+        }
+
+        @Override
+        public Map<String, String> getPropertiesWithPrefix(String prefix) {
+            return gradleProperties().getPropertiesWithPrefix(prefix);
         }
 
         private GradleProperties gradleProperties() {
@@ -248,6 +253,11 @@ public class DefaultGradlePropertiesController implements GradlePropertiesContro
         @Override
         public Map<String, String> getProperties() {
             return gradleProperties().getProperties();
+        }
+
+        @Override
+        public Map<String, String> getPropertiesWithPrefix(String prefix) {
+            return gradleProperties().getPropertiesWithPrefix(prefix);
         }
 
         private GradleProperties gradleProperties() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/ProjectPropertySettingBuildLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ProjectPropertySettingBuildLoader.java
@@ -68,9 +68,7 @@ public class ProjectPropertySettingBuildLoader implements BuildLoader {
      *
      * @implNote The properties are looked up by known names to avoid eager access of all Gradle-properties.
      */
-    // Suppressing deprecations, because IntelliJ sees the `find(): String` type and suggests to "simplify" the code
-    // However, the simplification would not support the `GradleBuild` task edge case described in the method.
-    @SuppressWarnings({"deprecation", "DataFlowIssue", "CastCanBeRemovedNarrowingVariableType"})
+    @SuppressWarnings({"deprecation"})
     private static Set<String> assignSelectedPropertiesDirectly(
         ProjectInternal project,
         GradleProperties projectGradleProperties
@@ -88,35 +86,35 @@ public class ProjectPropertySettingBuildLoader implements BuildLoader {
         // TODO: Remove non-String project properties support in Gradle 10 - https://github.com/gradle/gradle/issues/34454
 
         String versionName = "version";
-        Object versionValue = projectGradleProperties.find(versionName);
+        Object versionValue = projectGradleProperties.findUnsafe(versionName);
         if (versionValue != null) {
             project.setVersion(versionValue);
             consumedProperties.add(versionName);
         }
 
         String groupName = "group";
-        Object groupValue = projectGradleProperties.find(groupName);
+        Object groupValue = projectGradleProperties.findUnsafe(groupName);
         if (groupValue != null) {
             project.setGroup(groupValue);
             consumedProperties.add(groupName);
         }
 
         String statusName = "status";
-        Object statusValue = projectGradleProperties.find(statusName);
+        Object statusValue = projectGradleProperties.findUnsafe(statusName);
         if (statusValue != null) {
             project.setStatus(statusValue);
             consumedProperties.add(statusName);
         }
 
         String buildDirName = "buildDir";
-        Object buildDirValue = projectGradleProperties.find(buildDirName);
+        Object buildDirValue = projectGradleProperties.findUnsafe(buildDirName);
         if (buildDirValue != null) {
             project.setBuildDir(buildDirValue);
             consumedProperties.add(buildDirName);
         }
 
         String descriptionName = "description";
-        Object descriptionValue = projectGradleProperties.find(descriptionName);
+        Object descriptionValue = projectGradleProperties.findUnsafe(descriptionName);
         // This intentionally differs from others for backward-compatibility.
         // Other setters accept `Object` as an argument and therefore consume a property of any type.
         // If it so happens that the description value is not a String, it would not match the

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
@@ -33,8 +33,6 @@ import org.gradle.internal.service.scopes.SettingsScopeServices;
 
 import java.io.File;
 
-import static org.gradle.internal.Cast.uncheckedNonnullCast;
-
 public class SettingsFactory {
     private final Instantiator instantiator;
     private final ServiceRegistry buildScopeServices;
@@ -68,7 +66,7 @@ public class SettingsFactory {
             startParameter
         );
         ((ExtraPropertiesExtensionInternal) settings.getExtensions().getExtraProperties())
-            .setGradleProperties(uncheckedNonnullCast(gradleProperties.getProperties()));
+            .setGradleProperties(gradleProperties);
         return new SettingsState(settings, serviceRegistryFactory.services);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/properties/DefaultGradleProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/properties/DefaultGradleProperties.java
@@ -36,6 +36,11 @@ public class DefaultGradleProperties implements GradleProperties {
     }
 
     @Override
+    public @Nullable Object findUnsafe(String propertyName) {
+        return properties.get(propertyName);
+    }
+
+    @Override
     public Map<String, String> getProperties() {
         return properties;
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/properties/DefaultGradleProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/properties/DefaultGradleProperties.java
@@ -39,4 +39,11 @@ public class DefaultGradleProperties implements GradleProperties {
     public Map<String, String> getProperties() {
         return properties;
     }
+
+    @Override
+    public Map<String, String> getPropertiesWithPrefix(String prefix) {
+        return properties.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(prefix))
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/properties/FilteringGradleProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/properties/FilteringGradleProperties.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization.properties;
+
+import com.google.common.collect.ImmutableMap;
+import org.gradle.api.internal.properties.GradleProperties;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+public class FilteringGradleProperties implements GradleProperties {
+
+    private final GradleProperties delegate;
+    private final Predicate<String> propertyNameFilter;
+
+    public FilteringGradleProperties(GradleProperties delegate, Predicate<String> propertyNameFilter) {
+        this.delegate = delegate;
+        this.propertyNameFilter = propertyNameFilter;
+    }
+
+    @Override
+    public @Nullable String find(String propertyName) {
+        if (!propertyNameFilter.test(propertyName)) {
+            return null;
+        }
+        return delegate.find(propertyName);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return collectProperties(propertyNameFilter);
+    }
+
+    @Override
+    public Map<String, String> getPropertiesWithPrefix(String prefix) {
+        return collectProperties(it -> it.startsWith(prefix) && propertyNameFilter.test(it));
+    }
+
+    private ImmutableMap<String, String> collectProperties(Predicate<String> keyFilter) {
+        return delegate.getProperties().entrySet().stream()
+            .filter(it -> keyFilter.test(it.getKey()))
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/properties/FilteringGradleProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/properties/FilteringGradleProperties.java
@@ -23,6 +23,8 @@ import org.jspecify.annotations.Nullable;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import static org.gradle.internal.Cast.uncheckedCast;
+
 public class FilteringGradleProperties implements GradleProperties {
 
     private final GradleProperties delegate;
@@ -34,11 +36,16 @@ public class FilteringGradleProperties implements GradleProperties {
     }
 
     @Override
-    public @Nullable String find(String propertyName) {
+    public @Nullable Object findUnsafe(String propertyName) {
         if (!propertyNameFilter.test(propertyName)) {
             return null;
         }
-        return delegate.find(propertyName);
+        return delegate.findUnsafe(propertyName);
+    }
+
+    @Override
+    public @Nullable String find(String propertyName) {
+        return uncheckedCast(findUnsafe(propertyName));
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSystemPropertiesInstallerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSystemPropertiesInstallerTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.initialization
 import org.gradle.api.Project
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.properties.GradleProperties
+import org.gradle.initialization.properties.DefaultGradleProperties
 import org.gradle.initialization.properties.DefaultSystemPropertiesInstaller
 import org.gradle.initialization.properties.SystemPropertiesInstaller
 import org.gradle.util.SetSystemProperties
@@ -29,12 +30,10 @@ import static java.util.Collections.emptyMap
 
 class DefaultSystemPropertiesInstallerTest extends Specification {
 
-    private GradleProperties loadedGradleProperties = Mock(GradleProperties) {
-        getProperties() >> [
-            (Project.SYSTEM_PROP_PREFIX + ".userSystemProp"): "userSystemValue",
-            (Project.SYSTEM_PROP_PREFIX + ".userSystemProp2"): "userSystemValue2",
-        ]
-    }
+    private GradleProperties loadedGradleProperties = new DefaultGradleProperties([
+        (Project.SYSTEM_PROP_PREFIX + ".userSystemProp"): "userSystemValue",
+        (Project.SYSTEM_PROP_PREFIX + ".userSystemProp2"): "userSystemValue2",
+    ])
     private EnvironmentChangeTracker environmentChangeTracker = Mock(EnvironmentChangeTracker)
     private StartParameterInternal startParameter = Mock(StartParameterInternal) {
         systemPropertiesArgs >> { startParameterSystemProperties }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectPropertySettingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectPropertySettingBuildLoaderTest.groovy
@@ -100,11 +100,11 @@ class ProjectPropertySettingBuildLoaderTest extends Specification {
         loader.load(settings, gradle)
 
         then:
-        1 * rootGradleProperties.find("version") >> null
-        1 * rootGradleProperties.find("group") >> null
-        1 * rootGradleProperties.find("status") >> null
-        1 * rootGradleProperties.find("buildDir") >> null
-        1 * rootGradleProperties.find("description") >> null
+        1 * rootGradleProperties.findUnsafe("version") >> null
+        1 * rootGradleProperties.findUnsafe("group") >> null
+        1 * rootGradleProperties.findUnsafe("status") >> null
+        1 * rootGradleProperties.findUnsafe("buildDir") >> null
+        1 * rootGradleProperties.findUnsafe("description") >> null
         0 * rootGradleProperties._
 
         0 * rootProject.setDescription(_)
@@ -114,11 +114,11 @@ class ProjectPropertySettingBuildLoaderTest extends Specification {
         0 * rootProject.setBuildDir(_)
 
         then:
-        1 * childGradleProperties.find("version") >> null
-        1 * childGradleProperties.find("group") >> null
-        1 * childGradleProperties.find("status") >> null
-        1 * childGradleProperties.find("buildDir") >> null
-        1 * childGradleProperties.find("description") >> null
+        1 * childGradleProperties.findUnsafe("version") >> null
+        1 * childGradleProperties.findUnsafe("group") >> null
+        1 * childGradleProperties.findUnsafe("status") >> null
+        1 * childGradleProperties.findUnsafe("buildDir") >> null
+        1 * childGradleProperties.findUnsafe("description") >> null
         0 * childGradleProperties._
 
         0 * childProject.setDescription(_)

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/properties/FilteringGradlePropertiesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/properties/FilteringGradlePropertiesTest.groovy
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization.properties
+
+import org.gradle.api.internal.properties.GradleProperties
+import spock.lang.Specification
+
+import java.util.function.Predicate
+
+class FilteringGradlePropertiesTest extends Specification {
+
+    def delegate = Mock(GradleProperties)
+
+    def "find returns null when property name is filtered out"() {
+        given:
+        def predicate = { String name -> name.startsWith("allowed") } as Predicate<String>
+        def filteringProperties = new FilteringGradleProperties(delegate, predicate)
+
+        when:
+        def result = filteringProperties.find("blocked.property")
+
+        then:
+        result == null
+        0 * delegate.find(_)
+    }
+
+    def "find delegates to underlying implementation when property name passes filter"() {
+        given:
+        def predicate = { String name -> name.startsWith("allowed") } as Predicate<String>
+        def filteringProperties = new FilteringGradleProperties(delegate, predicate)
+        delegate.find("allowed.property") >> "value"
+
+        when:
+        def result = filteringProperties.find("allowed.property")
+
+        then:
+        result == "value"
+    }
+
+    def "find returns null when property name passes filter but delegate returns null"() {
+        given:
+        def predicate = { String name -> name.startsWith("allowed") } as Predicate<String>
+        def filteringProperties = new FilteringGradleProperties(delegate, predicate)
+        delegate.find("allowed.property") >> null
+
+        when:
+        def result = filteringProperties.find("allowed.property")
+
+        then:
+        result == null
+    }
+
+    def "getProperties filters out properties that don't match predicate"() {
+        given:
+        def predicate = { String name -> name.startsWith("keep") } as Predicate<String>
+        def filteringProperties = new FilteringGradleProperties(delegate, predicate)
+        delegate.getProperties() >> [
+            "keep.prop1": "value1",
+            "keep.prop2": "value2",
+            "remove.prop1": "value3",
+            "remove.prop2": "value4"
+        ]
+
+        when:
+        def result = filteringProperties.getProperties()
+
+        then:
+        result == [
+            "keep.prop1": "value1",
+            "keep.prop2": "value2"
+        ]
+    }
+
+    def "getProperties returns empty map when no properties match filter"() {
+        given:
+        def predicate = { String name -> name.startsWith("nonexistent") } as Predicate<String>
+        def filteringProperties = new FilteringGradleProperties(delegate, predicate)
+        delegate.getProperties() >> [
+            "prop1": "value1",
+            "prop2": "value2"
+        ]
+
+        when:
+        def result = filteringProperties.getProperties()
+
+        then:
+        result.isEmpty()
+    }
+
+    def "getProperties returns all properties when filter accepts everything"() {
+        given:
+        def predicate = { String name -> true } as Predicate<String>
+        def filteringProperties = new FilteringGradleProperties(delegate, predicate)
+        def allProps = [
+            "prop1": "value1",
+            "prop2": "value2",
+            "prop3": "value3"
+        ]
+        delegate.getProperties() >> allProps
+
+        when:
+        def result = filteringProperties.getProperties()
+
+        then:
+        result == allProps
+    }
+
+    def "getPropertiesWithPrefix applies both prefix and filter constraints"() {
+        given:
+        def predicate = { String name -> !name.contains("exclude") } as Predicate<String>
+        def filteringProperties = new FilteringGradleProperties(delegate, predicate)
+        delegate.getProperties() >> [
+            "org.gradle.prop1": "value1",
+            "org.gradle.exclude.prop2": "value2",
+            "org.gradle.prop3": "value3",
+            "other.gradle.prop4": "value4",
+            "org.exclude.prop5": "value5"
+        ]
+
+        when:
+        def result = filteringProperties.getPropertiesWithPrefix("org.gradle")
+
+        then:
+        result == [
+            "org.gradle.prop1": "value1",
+            "org.gradle.prop3": "value3"
+        ]
+    }
+
+    def "getPropertiesWithPrefix returns empty map when no properties match both prefix and filter"() {
+        given:
+        def predicate = { String name -> name.startsWith("allowed") } as Predicate<String>
+        def filteringProperties = new FilteringGradleProperties(delegate, predicate)
+        delegate.getProperties() >> [
+            "org.gradle.prop1": "value1",
+            "org.gradle.prop2": "value2"
+        ]
+
+        when:
+        def result = filteringProperties.getPropertiesWithPrefix("org.gradle")
+
+        then:
+        result.isEmpty()
+    }
+
+    def "getPropertiesWithPrefix works with empty prefix"() {
+        given:
+        def predicate = { String name -> name.startsWith("keep") } as Predicate<String>
+        def filteringProperties = new FilteringGradleProperties(delegate, predicate)
+        delegate.getProperties() >> [
+            "keep.prop1": "value1",
+            "remove.prop2": "value2",
+            "keep.prop3": "value3"
+        ]
+
+        when:
+        def result = filteringProperties.getPropertiesWithPrefix("")
+
+        then:
+        result == [
+            "keep.prop1": "value1",
+            "keep.prop3": "value3"
+        ]
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/properties/FilteringGradlePropertiesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/properties/FilteringGradlePropertiesTest.groovy
@@ -42,7 +42,8 @@ class FilteringGradlePropertiesTest extends Specification {
         given:
         def predicate = { String name -> name.startsWith("allowed") } as Predicate<String>
         def filteringProperties = new FilteringGradleProperties(delegate, predicate)
-        delegate.find("allowed.property") >> "value"
+        1 * delegate.findUnsafe("allowed.property") >> "value"
+        0 * delegate.find(_)
 
         when:
         def result = filteringProperties.find("allowed.property")
@@ -55,7 +56,8 @@ class FilteringGradlePropertiesTest extends Specification {
         given:
         def predicate = { String name -> name.startsWith("allowed") } as Predicate<String>
         def filteringProperties = new FilteringGradleProperties(delegate, predicate)
-        delegate.find("allowed.property") >> null
+        1 * delegate.findUnsafe("allowed.property") >> null
+        0 * delegate.find(_)
 
         when:
         def result = filteringProperties.find("allowed.property")


### PR DESCRIPTION
Part of https://github.com/gradle/gradle/issues/34019, follow-up for https://github.com/gradle/gradle/pull/34507

This does not fully solve the original issue, but brings us closer still.

In summary, almost all places where Gradle properties were eagerly turned into a map of key-values are replaced with keeping the reference to the original `GradleProperties` instance, and the look-ups from it are deferred until required.

In some places, the properties were eagerly materialized to find only some of them that were prefixed. There is now `GradleProperties.getPropertiesWithPrefix()` that allows to find only those and avoid the look-up of others.

---

This:
- https://github.com/gradle/gradle/issues/34454

bites us still as we transition to the fine-grained look-up, because for methods that return non-generic type the JVM actually validates the returned value and throws a class-cast exception. That's why an `GradleProperties.findUnsafe()` method is introduced as a temporary measure, until the support for non-String properties is fully removed in Gradle 10.