### PR TITLE
Mark task-graph printing as incubating

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/TaskGraphIntegrationTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/TaskGraphIntegrationTest.groovy
@@ -41,6 +41,9 @@ Tasks graph for: root
 (*) - details omitted (listed previously)
 """)
         outputDoesNotContain("I'm a task called")
+
+        and:
+        outputContains("Task graph printing is an incubating feature.")
     }
 
     def "shows simple graph of tasks with multiple roots"() {
@@ -256,7 +259,7 @@ Tasks graph for: root
             }
         """
         executer
-                .inDirectory(file("buildSrc"))
+            .inDirectory(file("buildSrc"))
 
         succeeds("jar", "--task-graph")
 
@@ -290,7 +293,7 @@ Tasks graph for: jar
                 group = 'org.test'
                 version = '1.0'
             """
-            javaFile 'src/main/java/Lib.java',  """
+            javaFile 'src/main/java/Lib.java', """
                 public class Lib { public static void main() {
                     System.out.println("Before!");
                 } }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingIncubatingFeatureHandler.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingIncubatingFeatureHandler.java
@@ -22,15 +22,17 @@ import org.slf4j.LoggerFactory;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.gradle.util.internal.IncubationLogger.INCUBATION_MESSAGE;
+
 public class LoggingIncubatingFeatureHandler implements FeatureHandler<IncubatingFeatureUsage> {
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingIncubatingFeatureHandler.class);
 
-    private final Set<String> features = new HashSet<String>();
+    private final Set<String> features = new HashSet<>();
 
     @Override
     public void featureUsed(IncubatingFeatureUsage usage) {
         if (features.add(usage.getSummary())) {
-            LOGGER.warn(String.format("%s is an incubating feature.", usage.getSummary()));
+            LOGGER.warn(String.format(INCUBATION_MESSAGE, usage.getSummary()));
         }
     }
 

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/util/internal/IncubationLogger.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/util/internal/IncubationLogger.java
@@ -31,6 +31,9 @@ public class IncubationLogger {
         INCUBATING_FEATURE_HANDLER.reset();
     }
 
+    /**
+     * Prints {@value #INCUBATION_MESSAGE} as a warning.
+     */
     public static synchronized void incubatingFeatureUsed(String incubatingFeature) {
         INCUBATING_FEATURE_HANDLER.featureUsed(new IncubatingFeatureUsage(incubatingFeature, IncubationLogger.class));
     }

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/features/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/features/command_line_interface.adoc
@@ -751,6 +751,9 @@ Refresh the <<dependency_caching.adoc#sec:controlling-dependency-caching-command
 Run Gradle with all task actions disabled. Use this to show which task would have executed.
 
 `--task-graph`::
+_Incubating._
+_Since Gradle 9.1.0_
++
 Run Gradle with all task actions disabled and print the task dependency graph.
 
 `-t`, `--continuous`::

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/GradleHelpIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/GradleHelpIntegrationTest.groovy
@@ -84,7 +84,7 @@ USAGE: gradle [option...] [task...]
 --status                           Shows status of running and recently stopped Gradle daemon(s).
 --stop                             Stops the Gradle daemon if it is running.
 -t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
---task-graph                       Print task graph instead of executing tasks.
+--task-graph                       (Experimental) Print task graph instead of executing tasks.
 -U, --refresh-dependencies         Refresh the state of dependencies.
 --update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
 -V, --show-version                 Print version info and continue.

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -711,7 +711,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         public static final String LONG_OPTION = "task-graph";
 
         public TaskGraphOption() {
-            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "Print task graph instead of executing tasks."));
+            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "(Experimental) Print task graph instead of executing tasks."));
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/TaskGraphBuildExecutionAction.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/TaskGraphBuildExecutionAction.java
@@ -31,6 +31,7 @@ import org.gradle.internal.graph.DirectedGraphRenderer;
 import org.gradle.internal.graph.GraphNodeRenderer;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.util.internal.IncubationLogger;
 
 import java.util.Collection;
 import java.util.List;
@@ -63,6 +64,7 @@ public class TaskGraphBuildExecutionAction implements BuildWorkExecutor {
 
         // The task sub-graph from an included build will be traversed and printed from the root build as well
         if (gradle.isRootBuild()) {
+            IncubationLogger.incubatingFeatureUsed("Task graph printing");
             renderTaskGraph(gradle, plan);
         }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/execution/TaskGraphBuildExecutionAction.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/execution/TaskGraphBuildExecutionAction.java
@@ -18,6 +18,7 @@ package org.gradle.internal.execution;
 import com.google.common.collect.Streams;
 import org.gradle.TaskExecutionRequest;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier;
 import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.execution.plan.FinalizedExecutionPlan;
@@ -62,22 +63,28 @@ public class TaskGraphBuildExecutionAction implements BuildWorkExecutor {
 
         // The task sub-graph from an included build will be traversed and printed from the root build as well
         if (gradle.isRootBuild()) {
-            StyledTextOutput output = textOutputFactory.create(TaskGraphBuildExecutionAction.class);
-
-            plan.getContents().getScheduledNodes().visitNodes((nodes, entryNodes) -> {
-                String invocation = gradle
-                    .getStartParameter()
-                    .getTaskRequests()
-                    .stream()
-                    .map(TaskExecutionRequest::getArgs)
-                    .flatMap(List::stream)
-                    .collect(Collectors.joining(" "));
-
-                DirectedGraphRenderer<TaskInfo> renderer = new DirectedGraphRenderer<>(new NodeRenderer(), new NodesGraph());
-                renderer.renderTo(new RootNode(entryNodes, invocation), output);
-            });
+            renderTaskGraph(gradle, plan);
         }
+
         return ExecutionResult.succeeded();
+    }
+
+    private void renderTaskGraph(GradleInternal gradle, FinalizedExecutionPlan plan) {
+        plan.getContents().getScheduledNodes().visitNodes((nodes, entryNodes) -> {
+            String invocation = renderRequestedTasks(gradle.getStartParameter());
+            StyledTextOutput output = textOutputFactory.create(TaskGraphBuildExecutionAction.class);
+            DirectedGraphRenderer<TaskInfo> renderer = new DirectedGraphRenderer<>(new NodeRenderer(), new NodesGraph());
+            renderer.renderTo(new RootNode(entryNodes, invocation), output);
+        });
+    }
+
+    private static String renderRequestedTasks(StartParameterInternal startParameter) {
+        return startParameter
+            .getTaskRequests()
+            .stream()
+            .map(TaskExecutionRequest::getArgs)
+            .flatMap(List::stream)
+            .collect(Collectors.joining(" "));
     }
 
     private static class NodeRenderer implements GraphNodeRenderer<TaskInfo> {


### PR DESCRIPTION
Clearly marked recently added `--task-graph` feature as incubating:

- In the console output (when used)
- In the command-line options
- In the user guide

---

In the command-line options it's marked as `(Experimental)` mostly to align with already existing options there. We should do a follow-up and clean up those to say `(Incubating)`, since Gradle formally [does not have an "experimental"](https://docs.gradle.org/current/userguide/feature_lifecycle.html) feature state.