### PR TITLE
Add since-Gradle and incubating labels macros for userguide

### DIFF
--- a/platforms/documentation/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/GradleDocsAsciidoctorExtensionRegistry.java
+++ b/platforms/documentation/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/GradleDocsAsciidoctorExtensionRegistry.java
@@ -31,6 +31,9 @@ public class GradleDocsAsciidoctorExtensionRegistry implements ExtensionRegistry
         registry.includeProcessor(GuidesContributeIncludeProcessor.class);
         registry.includeProcessor(SampleIncludeProcessor.class);
 
+        registry.inlineMacro(SinceGradleLabelProcessor.class);
+        registry.inlineMacro(IncubatingLabelProcessor.class);
+
         registry.treeprocessor(ExampleSelfLinkProcessor.class);
 
         registry.postprocessor(ClipboardPostprocessor.class);

--- a/platforms/documentation/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/IncubatingLabelProcessor.java
+++ b/platforms/documentation/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/IncubatingLabelProcessor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.docs.asciidoctor;
+
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.extension.Format;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.Name;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.asciidoctor.extension.FormatType.SHORT;
+
+/**
+ * Processes {@code incubating-label} inline macros to add incubation badges.
+ * <p>
+ * Usage: {@code incubating-label:[]}
+ * <p>
+ * This creates a small badge indicating that something is incubating.
+ */
+@Name("incubating-label")
+@Format(SHORT)
+public class IncubatingLabelProcessor extends InlineMacroProcessor {
+
+    @Override
+    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+        String html = "<span class=\"incubating-label\">Incubating</span>";
+        return createPhraseNode(parent, "quoted", html, attributes, new HashMap<>());
+    }
+}

--- a/platforms/documentation/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/SinceGradleLabelProcessor.java
+++ b/platforms/documentation/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/SinceGradleLabelProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.docs.asciidoctor;
+
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.Name;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Processes since-gradle-label inline macros to add version information badges.
+ * <p>
+ * Usage: {@code since-gradle-label:9.1.0[]}
+ * <p>
+ * This creates a small badge indicating since which Gradle version a feature is available.
+ */
+@Name("since-gradle-label")
+public class SinceGradleLabelProcessor extends InlineMacroProcessor {
+
+    @Override
+    public PhraseNode process(ContentNode parent, String target, Map<String, Object> attributes) {
+        String version = target;
+        if (version == null || version.trim().isEmpty()) {
+            return null;
+        }
+
+        String html = "<span class=\"since-gradle-label\">Since " + version + "</span>";
+
+        return createPhraseNode(parent, "quoted", html, attributes, new HashMap<>());
+    }
+}

--- a/platforms/documentation/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/IncubatingLabelProcessorTest.groovy
+++ b/platforms/documentation/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/IncubatingLabelProcessorTest.groovy
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.docs.asciidoctor
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.Options
+import org.asciidoctor.extension.JavaExtensionRegistry
+import spock.lang.Specification
+
+class IncubatingLabelProcessorTest extends Specification {
+
+    Asciidoctor asciidoctor
+
+    def setup() {
+        asciidoctor = Asciidoctor.Factory.create()
+        JavaExtensionRegistry extensionRegistry = asciidoctor.javaExtensionRegistry()
+        extensionRegistry.inlineMacro(IncubatingLabelProcessor.class)
+    }
+
+    private String convertContent(String content) {
+        return asciidoctor.convert(content, Options.builder().build())
+    }
+
+    def "renders incubating-label"() {
+        given:
+        String asciidocContent = """
+This feature is incubating-label:[]
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        content.contains('<span class="incubating-label">Incubating</span>')
+    }
+
+    def "renders incubating-label with surrounding text"() {
+        given:
+        String asciidocContent = """
+This feature is incubating-label:[] and may change in future versions.
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        content.contains('<span class="incubating-label">Incubating</span>')
+        content.contains('This feature is')
+        content.contains('and may change in future versions.')
+    }
+
+    def "renders multiple incubating-labels"() {
+        given:
+        String asciidocContent = """
+Feature A is incubating-label:[]
+Feature B is also incubating-label:[]
+Feature C is stable
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        content.count('<span class="incubating-label">Incubating</span>') == 2
+        content.contains('Feature A is')
+        content.contains('Feature B is also')
+        content.contains('Feature C is stable')
+    }
+
+    def "renders incubating-label inside definition list term"() {
+        given:
+        String asciidocContent = """
+`publish` incubating-label:[]::
+This task publishes the artifact to the repository.
+
+`build`::
+This task builds the project.
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        content.contains('<span class="incubating-label">Incubating</span>')
+        content.contains('<code>publish</code>')
+        content.contains('This task publishes the artifact to the repository.')
+    }
+
+    def "does not render incubating-label in code blocks"() {
+        given:
+        String asciidocContent = """
+[source,gradle]
+----
+// This feature is incubating-label:[]
+configurations {
+    customConfig
+}
+----
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        !content.contains('<span class="incubating-label">Incubating</span>')
+        content.contains('incubating-label:[]')
+    }
+
+    def "renders incubating-label in table cells"() {
+        given:
+        String asciidocContent = """
+|===
+|Feature |Status
+
+|Feature A
+|incubating-label:[]
+
+|Feature B
+|Stable
+|===
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        content.contains('<span class="incubating-label">Incubating</span>')
+        content.contains('Feature A')
+        content.contains('Feature B')
+        content.contains('Stable')
+    }
+}

--- a/platforms/documentation/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/SinceGradleLabelProcessorTest.groovy
+++ b/platforms/documentation/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/SinceGradleLabelProcessorTest.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.docs.asciidoctor
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.Options
+import spock.lang.Specification
+
+class SinceGradleLabelProcessorTest extends Specification {
+
+    Asciidoctor asciidoctor
+
+    def setup() {
+        asciidoctor = Asciidoctor.Factory.create()
+    }
+
+    private String convertContent(String content) {
+        return asciidoctor.convert(content, Options.builder().build())
+    }
+
+    def "renders since-gradle-label with version"() {
+        given:
+        String asciidocContent = """
+This feature is available since-gradle-label:9.1.0[]
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        content.contains('<span class="since-gradle-label">Since 9.1.0</span>')
+    }
+
+    def "handles empty version by not rendering span"() {
+        given:
+        String asciidocContent = """
+This feature is available since-gradle-label:[]
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        !content.contains('<span class="since-gradle-label">')
+        content.contains('This feature is available')
+    }
+
+    def "handles null version by not rendering span"() {
+        given:
+        String asciidocContent = """
+This feature is available since-gradle-label:[]
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        !content.contains('<span class="since-gradle-label">')
+    }
+
+    def "renders since-gradle-label with different version formats"() {
+        given:
+        String asciidocContent = """
+Feature A is available since-gradle-label:8.5[]
+Feature B is available since-gradle-label:9.0.0[]
+Feature C is available since-gradle-label:10.1.2-rc-1[]
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        content.contains('<span class="since-gradle-label">Since 8.5</span>')
+        content.contains('<span class="since-gradle-label">Since 9.0.0</span>')
+        content.contains('<span class="since-gradle-label">Since 10.1.2-rc-1</span>')
+    }
+
+    def "renders since-gradle-label inside definition list term"() {
+        given:
+        String asciidocContent = """
+`publish` since-gradle-label:9.1.0[]::
+This task publishes the artifact to the repository.
+
+`build`::
+This task builds the project.
+"""
+
+        when:
+        String content = convertContent(asciidocContent)
+
+        then:
+        content.contains('<span class="since-gradle-label">Since 9.1.0</span>')
+        content.contains('<code>publish</code>')
+        content.contains('This task publishes the artifact to the repository.')
+    }
+}

--- a/platforms/documentation/docs/src/docs/css/manual.css
+++ b/platforms/documentation/docs/src/docs/css/manual.css
@@ -4605,3 +4605,32 @@ input:checked+.slider:before {
 .slider:before {
 	border-radius: 50%;
 }
+
+/* Feature Status Labels */
+
+.incubating-label,
+.since-gradle-label {
+    display: inline-block;
+
+    /* better center vertically on the line */
+    position: relative;
+    top: -1px;
+
+    padding: 0 6px;
+    margin-left: 4px;
+    border-radius: 4px;
+    white-space: nowrap;
+    color: var(--code-text-color);
+    font-weight: normal;
+    font-size: 80%;
+    font-style: italic;
+}
+
+.since-gradle-label {
+    background-color: var(--code-color);
+}
+
+.incubating-label {
+    /* use the warning color with 20% opacity */
+    background-color: rgb(from var(--warning-color) r g b / 0.2);
+}

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
@@ -593,7 +593,7 @@ Set to `warn` to report problems without failing the build.
 +
 Set to `fail` to report problems and fail the build if there are any problems.
 
-`--configure-on-demand`, `--no-configure-on-demand`::
+`--configure-on-demand`, `--no-configure-on-demand` incubating-label:[]::
 Toggles configure-on-demand. Only relevant projects are configured in this build run. _Default is off_.
 
 `--max-workers`::
@@ -685,11 +685,13 @@ Set to `verbose` to enable color and other rich output like `rich` with output t
 [[sec:command_line_problems]]
 === Reporting problems
 
-`--no-problems-report`::
-Disable the generation of `build/reports/problems-report.html`, by default this report is generated with problems provided to the <<reporting_problems.adoc#sec:reporting_problems,Problems API>>.
+`--problems-report` (enabled by default) incubating-label:[]::
+Enable the generation of `build/reports/problems-report.html`.
+This is the default behaviour.
+The report is generated with problems provided to the <<reporting_problems.adoc#sec:reporting_problems,Problems API>>.
 
-`--problems-report`::
-Enable the generation of `build/reports/problems-report.html`. This is the default behaviour. The report is generated with problems provided to the <<reporting_problems.adoc#sec:reporting_problems,Problems API>>.
+`--no-problems-report` incubating-label:[]::
+Disable the generation of `build/reports/problems-report.html`, by default this report is generated with problems provided to the <<reporting_problems.adoc#sec:reporting_problems,Problems API>>.
 
 [[sec:command_line_warnings]]
 === Showing or hiding warnings
@@ -750,10 +752,7 @@ Refresh the <<dependency_caching.adoc#sec:controlling-dependency-caching-command
 `-m`, `--dry-run`::
 Run Gradle with all task actions disabled. Use this to show which task would have executed.
 
-`--task-graph`::
-_Incubating._
-_Since Gradle 9.1.0_
-+
+`--task-graph` since-gradle-label:9.1.0[] incubating-label:[]::
 Run Gradle with all task actions disabled and print the task dependency graph.
 
 `-t`, `--continuous`::


### PR DESCRIPTION
Introduces inline macros for Asciidoc that allow marking flags or features as incubating and also specify since which Gradle verison they are available.

For instance, they can be used in the definition list, in the term clause:
```
`--task-graph` since-gradle-label:9.1.0[] incubating-label:[]::
Run Gradle with all task actions disabled and print the task dependency graph.
```

These render as
<img width="1026" height="149" alt="image" src="https://github.com/user-attachments/assets/3360f815-ea50-44d5-bc0f-2631ea09c9d0" />

---

This is nothing specific to the definition list, the inline macros can be used almost anywhere.