### PR TITLE
Fix typo in version_catalogs.adoc

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/version_catalogs.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dep-man/centralizing-dependencies/version_catalogs.adoc
@@ -268,7 +268,7 @@ include::sample[dir="snippets/dependencyManagement/catalogs-versionCatalogPlugin
 include::sample[dir="snippets/dependencyManagement/catalogs-versionCatalogPlugin/groovy",files="build.gradle[tags=catalog_spec]"]
 ====
 
-The plugin must be created programmatically, see <<sec:programmatic-catalog-versions,Programming catalogs>> for details.
+The catalog must be created programmatically, see <<sec:programmatic-catalog-versions,Programming catalogs>> for details.
 
 Such a catalog can then be published by applying either the `maven-publish` or `ivy-publish` plugin and configuring the publication to use the `versionCatalog` component:
 


### PR DESCRIPTION
### Context
This PR fixes a typo in the `version_catalogs.adoc` as it seems that the word should be "catalog", not "plugin".

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
