### PR TITLE
Demonstrate missing task dependencies when using intermediate project component cache (ProjectMetadataController)

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -209,7 +209,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
                     configureOnDemand = configureOnDemand,
                     configurationCache = configurationCache,
                     isolatedProjects = isolatedProjects,
-                    intermediateModelCache = false,
+                    intermediateModelCache = isolatedProjects,
                     parallelToolingApiActions = parallelToolingActions,
                     invalidateCoupledProjects = invalidateCoupledProjects,
                     modelAsProjectDependency = modelAsProjectDependency,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -333,7 +333,7 @@ class DefaultConfigurationCache internal constructor(
         // because it carries information required by dependency resolution
         // to ensure project artifacts are actually created the first time around.
         // When the value is loaded from the store, the dependency information is lost.
-        return projectMetadata.loadOrCreateOriginalValue(identityPath, creator)
+        return projectMetadata.loadOrCreateValue(identityPath, creator)
     }
 
     override fun finalizeCacheEntry() {

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKeyTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKeyTest.kt
@@ -147,7 +147,7 @@ class ConfigurationCacheKeyTest {
                     configureOnDemand = false,
                     configurationCache = true,
                     isolatedProjects = startParameter.isolatedProjects.get(),
-                    intermediateModelCache = false,
+                    intermediateModelCache = startParameter.isolatedProjects.get(),
                     parallelToolingApiActions = false,
                     invalidateCoupledProjects = false,
                     modelAsProjectDependency = false,

--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/PublishArtifactLocalArtifactMetadataCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/PublishArtifactLocalArtifactMetadataCodec.kt
@@ -23,7 +23,6 @@ import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
 
-
 /**
  * This class exists because PublishArtifactLocalArtifactMetadata is used as its own id, and so when serialized as an id causes
  * a lot of unnecessary and unserializable state to be dragged in.
@@ -37,6 +36,9 @@ object PublishArtifactLocalArtifactMetadataCodec : Codec<PublishArtifactLocalArt
     override suspend fun WriteContext.encode(value: PublishArtifactLocalArtifactMetadata) {
         write(value.componentIdentifier)
         value.publishArtifact.run {
+            // TODO: We need to also serialize the TaskDependencyContainer of the publish artifact.
+            // Otherwise, the artifacts that we load in the ProjectMetdataController are not able
+            // to be used by dependency resolution to build task dependency graphs.
             write(ImmutablePublishArtifact(name, extension, type, classifier, file))
         }
     }


### PR DESCRIPTION
This commit ensures we use the ProjectMetadataController when IP is enabled. We also ensure that we use proper load-after-store semantics when loading cached project components, instead of the previous behavior of returning the live pre-serialized object on the first call to the cache.

Enabling this behavior demonstrates an existing issue with cached local project components. The artifacts of variants are serialized without their task dependencies. This means when we load a component from the cache, dependency resolution fails to also see task dependencies of those artifacts. When building task graphs from dependency resolution results, the proper task dependencies are not included as part of the work graph.

If we want to be able to use cached project instances to build work graphs, we need to serialize this data. In particular, the data to serialize would be the task dependencies of the a PublishArtifactLocalArtifactMetadata. A TODO has been added to PublishArtifactLocalArtifactMetadataCodec to capture this.

Another option is to only use cached project components in cases where we do not need to build a new task graph, while still using the live pre-serialized instances for building graphs for task dependencies. Though, the situations where this approach is applicable are questionable. If for example I modify the buildscript of a project that produces tasks in the current task graph, we cannot be sure that the existing graph is still valid. For this reason, I believe serializing the task dependencies is necessary for incremental project configuration.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
