### PR TITLE
Add check to execute daemon expiration check when daemon registry has not changed

### DIFF
--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/Daemon.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/Daemon.java
@@ -269,10 +269,12 @@ public class Daemon implements Stoppable {
         @Override
         public void run() {
             try {
+                LOGGER.debug("Starting periodic daemon health check.");
                 final DaemonExpirationResult result = expirationStrategy.checkExpiration();
                 if (result.getStatus() != DO_NOT_EXPIRE) {
                     listenerBroadcast.onExpirationEvent(result);
                 }
+                LOGGER.debug("Finished periodic daemon health check.");
             } catch (Throwable t) {
                 // this class is used as task in a scheduled executor service, so it must not throw any throwable,
                 // otherwise the further invocations of this task get automatically and silently cancelled


### PR DESCRIPTION
Fixes #34489 

### Context
User submitted an issue that, when looking at certain debug or daemon logging, certain lines are confusingly attributed to a Gradle build hanging when the daemon is simply performing routine tasks. 
This change: 
- Checks if the daemon registry has changed. If it has changed, it will execute a daemon expiration check. If it has not changed, no expiration check will be performed
- Added debug logging messages to the start and end of the check to make more clear to the user that a periodic check is happening and not the result of a build hanging. 

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
