### PR TITLE
Use invokeExact when calling constructors for instantiated types

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -72,7 +72,6 @@ import javax.inject.Inject;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
@@ -518,7 +517,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             }
 
             @Override
-            public Object newInstance(ServiceLookup services, InstanceGenerator nested) throws InvocationTargetException, IllegalAccessException, InstantiationException {
+            public Object newInstance(ServiceLookup services, InstanceGenerator nested) throws Throwable {
                 return strategy.newInstance(services, nested, null, NO_PARAMS);
             }
         }
@@ -533,7 +532,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             }
 
             @Override
-            public Object newInstance(ServiceLookup services, InstanceGenerator nested, @Nullable Describable displayName, Object[] params) throws InvocationTargetException, IllegalAccessException, InstantiationException {
+            public Object newInstance(ServiceLookup services, InstanceGenerator nested, @Nullable Describable displayName, Object[] params) throws Throwable {
                 return strategy.newInstance(services, nested, displayName, params);
             }
 
@@ -1490,7 +1489,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
     }
 
     protected interface InstantiationStrategy {
-        Object newInstance(ServiceLookup services, InstanceGenerator nested, @Nullable Describable displayName, Object[] params) throws InvocationTargetException, IllegalAccessException, InstantiationException;
+        Object newInstance(ServiceLookup services, InstanceGenerator nested, @Nullable Describable displayName, Object[] params) throws Throwable;
     }
 
     protected interface ClassGenerationVisitor {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/ClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/ClassGenerator.java
@@ -22,7 +22,6 @@ import org.gradle.internal.service.ServiceLookup;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.util.List;
 
@@ -55,14 +54,14 @@ interface ClassGenerator {
         /**
          * Creates a new instance, using the given services and parameters. Uses the given instantiator to create nested objects, if required.
          */
-        T newInstance(ServiceLookup services, InstanceGenerator nested) throws InvocationTargetException, IllegalAccessException, InstantiationException;
+        T newInstance(ServiceLookup services, InstanceGenerator nested) throws Throwable;
     }
 
     interface GeneratedConstructor<T> {
         /**
          * Creates a new instance, using the given services and parameters. Uses the given instantiator to create nested objects, if required.
          */
-        T newInstance(ServiceLookup services, InstanceGenerator nested, @Nullable Describable displayName, Object[] params) throws InvocationTargetException, IllegalAccessException, InstantiationException;
+        T newInstance(ServiceLookup services, InstanceGenerator nested, @Nullable Describable displayName, Object[] params) throws Throwable;
 
         /**
          * Does this constructor use the given service type?

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
@@ -27,7 +27,6 @@ import org.gradle.internal.instantiation.generator.ClassGenerator.SerializationC
 import org.gradle.internal.service.ServiceLookup;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Set;
 
 class DefaultInstantiationScheme implements InstantiationScheme {
@@ -112,9 +111,7 @@ class DefaultInstantiationScheme implements InstantiationScheme {
             try {
                 SerializationConstructor<?> constructor = serializationConstructorFor(implType, baseClass);
                 return implType.cast(constructor.newInstance(services, nestedGenerator));
-            } catch (InvocationTargetException e) {
-                throw new ObjectInstantiationException(implType, e.getCause());
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 throw new ObjectInstantiationException(implType, e);
             }
         }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -48,6 +48,7 @@ import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.tasks.Nested;
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.extensibility.ConventionAwareHelper;
 import org.gradle.internal.extensibility.DefaultExtensionContainer;
 import org.gradle.internal.extensibility.ExtensibleDynamicObject;
@@ -77,7 +78,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -146,7 +146,11 @@ public class AsmBackedClassGeneratorTest {
                     }
                 }
                 if (i == args.length) {
-                    return (T) constructor.newInstance(services, null, null, args);
+                    try {
+                        return (T) constructor.newInstance(services, null, null, args);
+                    } catch (Throwable e) {
+                        throw UncheckedException.throwAsUncheckedException(e);
+                    }
                 }
             }
         }
@@ -459,8 +463,8 @@ public class AsmBackedClassGeneratorTest {
         try {
             newInstance(UnconstructibleBean.class);
             fail();
-        } catch (InvocationTargetException e) {
-            assertThat(e.getCause(), sameInstance(UnconstructibleBean.failure));
+        } catch (UnsupportedOperationException e) {
+            assertThat(e, sameInstance(UnconstructibleBean.failure));
         }
     }
 


### PR DESCRIPTION
This might be faster than what we had

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
