### PR TITLE
Add more documentation to Project.getPath()

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -571,7 +571,8 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
     Task task(String name, Action<? super Task> configureAction);
 
     /**
-     * <p>Returns the path of this project.  The path is the fully qualified name of the project.</p>
+     * <p>Returns the path of this project, starting with ':'. See {@link org.gradle.api.initialization.Settings#include(String...)}
+     * for more information about project paths.</p>
      *
      * @return The path. Never returns null.
      */


### PR DESCRIPTION
Minor edit to make it explicit that project paths contain `:` and redirect to `Settings.include` which contains more details about what path are.