### PR TITLE
Raise tested Groovy version for gradle3235

### DIFF
--- a/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/groovy/compile/AbstractGroovyCompilerIntegrationSpec.groovy
+++ b/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/groovy/compile/AbstractGroovyCompilerIntegrationSpec.groovy
@@ -83,9 +83,8 @@ abstract class AbstractGroovyCompilerIntegrationSpec extends AbstractBasicGroovy
     // Groovy code.
     @Issue("GRADLE-3235")
     def gradle3235() {
-        if (versionLowerThan('2.0.5')) {
-            return
-        }
+        // This test requires https://issues.apache.org/jira/browse/GROOVY-8480 which is in Groovy 2.5.0+
+        Assume.assumeFalse(versionLowerThan('2.5.0'))
 
         def useJavaxServlet = versionLowerThan("5.0.0")
         given:


### PR DESCRIPTION
It uses https://issues.apache.org/jira/browse/GROOVY-8480 which needs 2.5.0+

Re-tested with `:language-groovy:eIT --tests "*gradle3235*" -PtestVersions=all` so I hope it's not failing anywhere anymore!

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
