### PR TITLE
Bundle additional services

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/ConfigurationServicesBundle.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/ConfigurationServicesBundle.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
@@ -51,4 +52,5 @@ public interface ConfigurationServicesBundle {
     CollectionCallbackActionDecorator getCollectionCallbackActionDecorator();
     InternalProblems getProblems();
     AttributeDesugaring getAttributeDesugaring();
+    ResolveExceptionMapper getExceptionMapper();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/ConfigurationServicesBundle.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/ConfigurationServicesBundle.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -49,4 +50,5 @@ public interface ConfigurationServicesBundle {
     FileCollectionFactory getFileCollectionFactory();
     CollectionCallbackActionDecorator getCollectionCallbackActionDecorator();
     InternalProblems getProblems();
+    AttributeDesugaring getAttributeDesugaring();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -95,6 +95,7 @@ import org.gradle.api.internal.artifacts.transform.TransformRegistrationFactory;
 import org.gradle.api.internal.artifacts.transform.TransformedVariantFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributeDescriberRegistry;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
@@ -592,7 +593,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                                       DomainObjectCollectionFactory domainObjectCollectionFactory,
                                                                       CalculatedValueContainerFactory calculatedValueContainerFactory,
                                                                       TaskDependencyFactory taskDependencyFactory,
-                                                                      InternalProblems problems) {
+                                                                      InternalProblems problems,
+                                                                      AttributeDesugaring attributeDesugaring) {
             return new DefaultConfigurationServicesBundle(
                 buildOperationRunner,
                 projectStateRegistry,
@@ -603,7 +605,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 attributesFactory,
                 domainObjectCollectionFactory,
                 collectionCallbackActionDecorator,
-                problems
+                problems,
+                attributeDesugaring
             );
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -594,7 +594,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                                       CalculatedValueContainerFactory calculatedValueContainerFactory,
                                                                       TaskDependencyFactory taskDependencyFactory,
                                                                       InternalProblems problems,
-                                                                      AttributeDesugaring attributeDesugaring) {
+                                                                      AttributeDesugaring attributeDesugaring,
+                                                                      ResolveExceptionMapper exceptionMapper) {
             return new DefaultConfigurationServicesBundle(
                 buildOperationRunner,
                 projectStateRegistry,
@@ -606,7 +607,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 domainObjectCollectionFactory,
                 collectionCallbackActionDecorator,
                 problems,
-                attributeDesugaring
+                attributeDesugaring,
+                exceptionMapper
             );
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -70,7 +70,6 @@ import org.gradle.api.internal.artifacts.resolver.ResolutionOutputsInternal;
 import org.gradle.api.internal.artifacts.result.DefaultResolutionResult;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.FreezableAttributeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.AbstractFileCollection;
@@ -226,7 +225,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
         NotationParser<Object, Capability> capabilityNotationParser,
         ResolveExceptionMapper exceptionMapper,
-        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory,
         ConfigurationRole roleAtCreation,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -157,8 +157,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     private @Nullable DefaultPublishArtifactSet allArtifacts;
     private final ConfigurationResolvableDependencies resolvableDependencies;
     private ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners;
-    private Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
-    private @Nullable ResolutionStrategyInternal resolutionStrategy;
     private final ResolveExceptionMapper exceptionMapper;
 
     private final Path identityPath;
@@ -207,7 +205,13 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     private @Nullable ConfigurationInternal consistentResolutionSource;
     private @Nullable String consistentResolutionReason;
+
+    /** This factory can't be extracted to the services bundle, as it would create a circular dependency between those two types. */
     private final DefaultConfigurationFactory defaultConfigurationFactory;
+
+    /** This factory has some unique usages during copy, so it can't be extracted to the services bundle. */
+    private Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
+    private @Nullable ResolutionStrategyInternal resolutionStrategy;
 
     private final ConfigurationServicesBundle configurationServices;
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -161,7 +161,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     private Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
     private @Nullable ResolutionStrategyInternal resolutionStrategy;
     private final ResolveExceptionMapper exceptionMapper;
-    private final AttributeDesugaring attributeDesugaring;
 
     private final Path identityPath;
     private final Path projectPath;
@@ -244,7 +243,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         this.dependencyResolutionListeners = dependencyResolutionListeners;
         this.domainObjectContext = domainObjectContext;
         this.exceptionMapper = exceptionMapper;
-        this.attributeDesugaring = attributeDesugaring;
 
         this.displayName = Describables.memoize(new ConfigurationDescription(identityPath));
         this.configurationAttributes = new FreezableAttributeContainer(configurationServices.getAttributesFactory().mutable(), this.displayName);
@@ -562,7 +560,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 taskDependencyFactory,
                 configurationServices.getCalculatedValueContainerFactory(),
                 configurationServices.getAttributesFactory(),
-                attributeDesugaring,
+                configurationServices.getAttributeDesugaring(),
                 configurationServices.getObjectFactory()
             );
         }
@@ -1678,7 +1676,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         @Override
         public ResolutionResult getResolutionResult() {
             configuration.assertIsResolvable();
-            return new DefaultResolutionResult(configuration.resolutionAccess, configuration.attributeDesugaring);
+            return new DefaultResolutionResult(configuration.resolutionAccess, configuration.configurationServices.getAttributeDesugaring());
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
@@ -25,7 +25,6 @@ import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -49,7 +48,6 @@ public class DefaultConfigurationFactory {
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
     private final NotationParser<Object, Capability> capabilityNotationParser;
     private final ResolveExceptionMapper exceptionContextualizer;
-    private final AttributeDesugaring attributeDesugaring;
     private final UserCodeApplicationContext userCodeApplicationContext;
 
     @Inject
@@ -59,7 +57,6 @@ public class DefaultConfigurationFactory {
         DomainObjectContext domainObjectContext,
         PublishArtifactNotationParserFactory artifactNotationParserFactory,
         ResolveExceptionMapper exceptionMapper,
-        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext
     ) {
         this.configurationServices = configurationServices;
@@ -68,7 +65,6 @@ public class DefaultConfigurationFactory {
         this.artifactNotationParser = artifactNotationParserFactory.create();
         this.capabilityNotationParser = new CapabilityNotationParserFactory(true).create();
         this.exceptionContextualizer = exceptionMapper;
-        this.attributeDesugaring = attributeDesugaring;
         this.userCodeApplicationContext = userCodeApplicationContext;
     }
 
@@ -96,7 +92,6 @@ public class DefaultConfigurationFactory {
             artifactNotationParser,
             capabilityNotationParser,
             exceptionContextualizer,
-            attributeDesugaring,
             userCodeApplicationContext,
             this,
             role
@@ -124,7 +119,6 @@ public class DefaultConfigurationFactory {
             artifactNotationParser,
             capabilityNotationParser,
             exceptionContextualizer,
-            attributeDesugaring,
             userCodeApplicationContext,
             this
         );
@@ -151,7 +145,6 @@ public class DefaultConfigurationFactory {
             artifactNotationParser,
             capabilityNotationParser,
             exceptionContextualizer,
-            attributeDesugaring,
             userCodeApplicationContext,
             this
         );
@@ -178,7 +171,6 @@ public class DefaultConfigurationFactory {
             artifactNotationParser,
             capabilityNotationParser,
             exceptionContextualizer,
-            attributeDesugaring,
             userCodeApplicationContext,
             this
         );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
@@ -22,7 +22,6 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
-import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory;
 import org.gradle.internal.Factory;
@@ -47,7 +46,6 @@ public class DefaultConfigurationFactory {
     private final DomainObjectContext domainObjectContext;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
     private final NotationParser<Object, Capability> capabilityNotationParser;
-    private final ResolveExceptionMapper exceptionContextualizer;
     private final UserCodeApplicationContext userCodeApplicationContext;
 
     @Inject
@@ -56,7 +54,6 @@ public class DefaultConfigurationFactory {
         ListenerManager listenerManager,
         DomainObjectContext domainObjectContext,
         PublishArtifactNotationParserFactory artifactNotationParserFactory,
-        ResolveExceptionMapper exceptionMapper,
         UserCodeApplicationContext userCodeApplicationContext
     ) {
         this.configurationServices = configurationServices;
@@ -64,7 +61,6 @@ public class DefaultConfigurationFactory {
         this.domainObjectContext = domainObjectContext;
         this.artifactNotationParser = artifactNotationParserFactory.create();
         this.capabilityNotationParser = new CapabilityNotationParserFactory(true).create();
-        this.exceptionContextualizer = exceptionMapper;
         this.userCodeApplicationContext = userCodeApplicationContext;
     }
 
@@ -91,7 +87,6 @@ public class DefaultConfigurationFactory {
             resolutionStrategyFactory,
             artifactNotationParser,
             capabilityNotationParser,
-            exceptionContextualizer,
             userCodeApplicationContext,
             this,
             role
@@ -118,7 +113,6 @@ public class DefaultConfigurationFactory {
             resolutionStrategyFactory,
             artifactNotationParser,
             capabilityNotationParser,
-            exceptionContextualizer,
             userCodeApplicationContext,
             this
         );
@@ -144,7 +138,6 @@ public class DefaultConfigurationFactory {
             resolutionStrategyFactory,
             artifactNotationParser,
             capabilityNotationParser,
-            exceptionContextualizer,
             userCodeApplicationContext,
             this
         );
@@ -170,7 +163,6 @@ public class DefaultConfigurationFactory {
             resolutionStrategyFactory,
             artifactNotationParser,
             capabilityNotationParser,
-            exceptionContextualizer,
             userCodeApplicationContext,
             this
         );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationServicesBundle.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationServicesBundle.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.ConfigurationServicesBundle;
+import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
@@ -49,6 +50,7 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
     private final CollectionCallbackActionDecorator collectionCallbackActionDecorator;
     private final InternalProblems problems;
     private final AttributeDesugaring attributeDesugaring;
+    private final ResolveExceptionMapper exceptionMapper;
 
     public DefaultConfigurationServicesBundle(BuildOperationRunner buildOperationRunner,
                                               ProjectStateRegistry projectStateRegistry,
@@ -60,7 +62,8 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
                                               DomainObjectCollectionFactory domainObjectCollectionFactory,
                                               CollectionCallbackActionDecorator collectionCallbackActionDecorator,
                                               InternalProblems problems,
-                                              AttributeDesugaring attributeDesugaring) {
+                                              AttributeDesugaring attributeDesugaring,
+                                              ResolveExceptionMapper exceptionMapper) {
         this.buildOperationRunner = buildOperationRunner;
         this.projectStateRegistry = projectStateRegistry;
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
@@ -72,6 +75,7 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
         this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
         this.problems = problems;
         this.attributeDesugaring = attributeDesugaring;
+        this.exceptionMapper = exceptionMapper;
     }
 
     @Override
@@ -127,5 +131,10 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
     @Override
     public AttributeDesugaring getAttributeDesugaring() {
         return attributeDesugaring;
+    }
+
+    @Override
+    public ResolveExceptionMapper getExceptionMapper() {
+        return exceptionMapper;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationServicesBundle.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationServicesBundle.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.ConfigurationServicesBundle;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -47,6 +48,7 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
     private final DomainObjectCollectionFactory domainObjectCollectionFactory;
     private final CollectionCallbackActionDecorator collectionCallbackActionDecorator;
     private final InternalProblems problems;
+    private final AttributeDesugaring attributeDesugaring;
 
     public DefaultConfigurationServicesBundle(BuildOperationRunner buildOperationRunner,
                                               ProjectStateRegistry projectStateRegistry,
@@ -57,7 +59,8 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
                                               AttributesFactory attributesFactory,
                                               DomainObjectCollectionFactory domainObjectCollectionFactory,
                                               CollectionCallbackActionDecorator collectionCallbackActionDecorator,
-                                              InternalProblems problems) {
+                                              InternalProblems problems,
+                                              AttributeDesugaring attributeDesugaring) {
         this.buildOperationRunner = buildOperationRunner;
         this.projectStateRegistry = projectStateRegistry;
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
@@ -68,6 +71,7 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
         this.domainObjectCollectionFactory = domainObjectCollectionFactory;
         this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
         this.problems = problems;
+        this.attributeDesugaring = attributeDesugaring;
     }
 
     @Override
@@ -118,5 +122,10 @@ public final class DefaultConfigurationServicesBundle implements ConfigurationSe
     @Override
     public InternalProblems getProblems() {
         return problems;
+    }
+
+    @Override
+    public AttributeDesugaring getAttributeDesugaring() {
+        return attributeDesugaring;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
@@ -23,7 +23,6 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
-import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -46,7 +45,6 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
         Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
         NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
         NotationParser<Object, Capability> capabilityNotationParser,
-        ResolveExceptionMapper exceptionMapper,
         UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory
     ) {
@@ -60,7 +58,6 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
             resolutionStrategyFactory,
             artifactNotationParser,
             capabilityNotationParser,
-            exceptionMapper,
             userCodeApplicationContext,
             defaultConfigurationFactory,
             ConfigurationRoles.CONSUMABLE,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -48,7 +47,6 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
         NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
         NotationParser<Object, Capability> capabilityNotationParser,
         ResolveExceptionMapper exceptionMapper,
-        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory
     ) {
@@ -63,7 +61,6 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
             artifactNotationParser,
             capabilityNotationParser,
             exceptionMapper,
-            attributeDesugaring,
             userCodeApplicationContext,
             defaultConfigurationFactory,
             ConfigurationRoles.CONSUMABLE,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -48,7 +47,6 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
         NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
         NotationParser<Object, Capability> capabilityNotationParser,
         ResolveExceptionMapper exceptionMapper,
-        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory
     ) {
@@ -63,7 +61,6 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
             artifactNotationParser,
             capabilityNotationParser,
             exceptionMapper,
-            attributeDesugaring,
             userCodeApplicationContext,
             defaultConfigurationFactory,
             ConfigurationRoles.DEPENDENCY_SCOPE,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
@@ -23,7 +23,6 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
-import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -46,7 +45,6 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
         Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
         NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
         NotationParser<Object, Capability> capabilityNotationParser,
-        ResolveExceptionMapper exceptionMapper,
         UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory
     ) {
@@ -60,7 +58,6 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
             resolutionStrategyFactory,
             artifactNotationParser,
             capabilityNotationParser,
-            exceptionMapper,
             userCodeApplicationContext,
             defaultConfigurationFactory,
             ConfigurationRoles.DEPENDENCY_SCOPE,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultLegacyConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultLegacyConfiguration.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -49,7 +48,6 @@ public class DefaultLegacyConfiguration extends DefaultConfiguration implements 
         NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
         NotationParser<Object, Capability> capabilityNotationParser,
         ResolveExceptionMapper exceptionMapper,
-        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory,
         ConfigurationRole roleAtCreation
@@ -65,7 +63,6 @@ public class DefaultLegacyConfiguration extends DefaultConfiguration implements 
             artifactNotationParser,
             capabilityNotationParser,
             exceptionMapper,
-            attributeDesugaring,
             userCodeApplicationContext,
             defaultConfigurationFactory,
             roleAtCreation,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultLegacyConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultLegacyConfiguration.java
@@ -23,7 +23,6 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
-import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -47,7 +46,6 @@ public class DefaultLegacyConfiguration extends DefaultConfiguration implements 
         Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
         NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
         NotationParser<Object, Capability> capabilityNotationParser,
-        ResolveExceptionMapper exceptionMapper,
         UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory,
         ConfigurationRole roleAtCreation
@@ -62,7 +60,6 @@ public class DefaultLegacyConfiguration extends DefaultConfiguration implements 
             resolutionStrategyFactory,
             artifactNotationParser,
             capabilityNotationParser,
-            exceptionMapper,
             userCodeApplicationContext,
             defaultConfigurationFactory,
             roleAtCreation,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -48,7 +47,6 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
         NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
         NotationParser<Object, Capability> capabilityNotationParser,
         ResolveExceptionMapper exceptionMapper,
-        AttributeDesugaring attributeDesugaring,
         UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory
     ) {
@@ -63,7 +61,6 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
             artifactNotationParser,
             capabilityNotationParser,
             exceptionMapper,
-            attributeDesugaring,
             userCodeApplicationContext,
             defaultConfigurationFactory,
             ConfigurationRoles.RESOLVABLE,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
@@ -23,7 +23,6 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.ConfigurationServicesBundle;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
-import org.gradle.api.internal.artifacts.ResolveExceptionMapper;
 import org.gradle.internal.Factory;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
@@ -46,7 +45,6 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
         Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
         NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
         NotationParser<Object, Capability> capabilityNotationParser,
-        ResolveExceptionMapper exceptionMapper,
         UserCodeApplicationContext userCodeApplicationContext,
         DefaultConfigurationFactory defaultConfigurationFactory
     ) {
@@ -60,7 +58,6 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
             resolutionStrategyFactory,
             artifactNotationParser,
             capabilityNotationParser,
-            exceptionMapper,
             userCodeApplicationContext,
             defaultConfigurationFactory,
             ConfigurationRoles.RESOLVABLE,

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -85,7 +85,6 @@ class DefaultConfigurationContainerSpec extends Specification {
         domainObjectContext,
         Stub(PublishArtifactNotationParserFactory),
         Stub(ResolveExceptionMapper),
-        new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
         userCodeApplicationContext
     )
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -75,7 +75,8 @@ class DefaultConfigurationContainerSpec extends Specification {
         attributesFactory,
         TestUtil.domainObjectCollectionFactory(),
         CollectionCallbackActionDecorator.NOOP,
-        TestUtil.problemsService()
+        TestUtil.problemsService(),
+        new AttributeDesugaring(AttributeTestUtil.attributesFactory())
     )
 
     private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.DependencyResolutionListener
 import org.gradle.api.artifacts.UnknownConfigurationException
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.ConfigurationServicesBundle
+import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper
@@ -76,7 +77,8 @@ class DefaultConfigurationContainerSpec extends Specification {
         TestUtil.domainObjectCollectionFactory(),
         CollectionCallbackActionDecorator.NOOP,
         TestUtil.problemsService(),
-        new AttributeDesugaring(AttributeTestUtil.attributesFactory())
+        new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
+        new ResolveExceptionMapper(domainObjectContext, new DocumentationRegistry())
     )
 
     private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(
@@ -84,7 +86,6 @@ class DefaultConfigurationContainerSpec extends Specification {
         listenerManager,
         domainObjectContext,
         Stub(PublishArtifactNotationParserFactory),
-        Stub(ResolveExceptionMapper),
         userCodeApplicationContext
     )
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -76,7 +76,8 @@ class DefaultConfigurationContainerTest extends Specification {
         attributesFactory,
         TestUtil.domainObjectCollectionFactory(),
         CollectionCallbackActionDecorator.NOOP,
-        TestUtil.problemsService()
+        TestUtil.problemsService(),
+        new AttributeDesugaring(attributesFactory),
     )
 
     private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.ResolvableConfiguration
 import org.gradle.api.artifacts.UnknownConfigurationException
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.ConfigurationServicesBundle
+import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.ResolveExceptionMapper
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
@@ -78,6 +79,7 @@ class DefaultConfigurationContainerTest extends Specification {
         CollectionCallbackActionDecorator.NOOP,
         TestUtil.problemsService(),
         new AttributeDesugaring(attributesFactory),
+        new ResolveExceptionMapper(StandaloneDomainObjectContext.ANONYMOUS, new DocumentationRegistry())
     )
 
     private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(
@@ -90,7 +92,6 @@ class DefaultConfigurationContainerTest extends Specification {
                 TestFiles.resolver(),
                 TestFiles.taskDependencyFactory(),
         ),
-        Stub(ResolveExceptionMapper),
         userCodeApplicationContext
     )
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -91,7 +91,6 @@ class DefaultConfigurationContainerTest extends Specification {
                 TestFiles.taskDependencyFactory(),
         ),
         Stub(ResolveExceptionMapper),
-        new AttributeDesugaring(AttributeTestUtil.attributesFactory()),
         userCodeApplicationContext
     )
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1650,7 +1650,8 @@ This method is only meant to be called on configurations which allow the (non-de
             attributesFactory,
             TestUtil.domainObjectCollectionFactory(),
             CollectionCallbackActionDecorator.NOOP,
-            TestUtil.problemsService()
+            TestUtil.problemsService(),
+            new AttributeDesugaring(attributesFactory),
         )
 
         new DefaultConfigurationFactory(

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1660,7 +1660,6 @@ This method is only meant to be called on configurations which allow the (non-de
             domainObjectContext,
             publishArtifactNotationParserFactory,
             new ResolveExceptionMapper(Mock(DomainObjectContext), Mock(DocumentationRegistry)),
-            new AttributeDesugaring(configurationServices.getAttributesFactory()),
             userCodeApplicationContext
         )
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1652,6 +1652,7 @@ This method is only meant to be called on configurations which allow the (non-de
             CollectionCallbackActionDecorator.NOOP,
             TestUtil.problemsService(),
             new AttributeDesugaring(attributesFactory),
+            new ResolveExceptionMapper(domainObjectContext, new DocumentationRegistry())
         )
 
         new DefaultConfigurationFactory(
@@ -1659,7 +1660,6 @@ This method is only meant to be called on configurations which allow the (non-de
             listenerManager,
             domainObjectContext,
             publishArtifactNotationParserFactory,
-            new ResolveExceptionMapper(Mock(DomainObjectContext), Mock(DocumentationRegistry)),
             userCodeApplicationContext
         )
     }


### PR DESCRIPTION
Bundle `AttributeDesugaring` and `ResolveExceptionMapper` into `ConfigurationServices`.

This further reduces the number of fields in each `Configuration` begun in https://github.com/gradle/gradle/pull/34497.  Also removes unnecessary `Problems` injection and slightly reduces size of code.