### PR TITLE
Avoid GradleExecuter dependency in TAPI cross version tests

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/BuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/BuildActionCrossVersionSpec.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.integtests.tooling.r22
 
-import org.gradle.integtests.fixtures.executer.GradleBackedArtifactBuilder
-import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.BuildAction
 import org.gradle.tooling.BuildController
@@ -30,23 +28,18 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
         // Make sure we reuse the same daemon
         toolingApi.requireIsolatedDaemons()
 
-        def workDir = temporaryFolder.file("work")
-        def implJar = workDir.file("action-impl.jar")
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(dist, temporaryFolder).withWarningMode(null), workDir)
-
         given:
-        builder.sourceFile('ActionImpl.java') << """
-public class ActionImpl implements ${BuildAction.name}<java.io.File> {
-    public java.io.File execute(${BuildController.name} controller) {
-        try {
-            return new java.io.File(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
-        } catch (java.net.URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
-}
-"""
-        builder.buildJar(implJar)
+        File implJar = buildActionJar("""
+            public class ActionImpl implements ${BuildAction.name}<java.io.File> {
+                public java.io.File execute(${BuildController.name} controller) {
+                    try {
+                        return new java.io.File(getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+                    } catch (java.net.URISyntaxException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        """)
 
         def cl1 = new URLClassLoader([implJar.toURI().toURL()] as URL[], getClass().classLoader)
         def action1 = cl1.loadClass("ActionImpl").getConstructor().newInstance()
@@ -63,14 +56,14 @@ public class ActionImpl implements ${BuildAction.name}<java.io.File> {
         actualJar1.name == implJar.name
 
         when:
-        builder.sourceFile('ActionImpl.java').text = """
-public class ActionImpl implements ${BuildAction.name}<String> {
-    public String execute(${BuildController.name} controller) {
-        return getClass().getProtectionDomain().getCodeSource().getLocation().toString();
-    }
-}
-"""
-        builder.buildJar(implJar)
+        implJar = buildActionJar("""
+            public class ActionImpl implements ${BuildAction.name}<String> {
+                public String execute(${BuildController.name} controller) {
+                    return getClass().getProtectionDomain().getCodeSource().getLocation().toString();
+                }
+            }
+        """)
+
         def cl2 = new URLClassLoader([implJar.toURI().toURL()] as URL[], getClass().classLoader)
         def action2 = cl2.loadClass("ActionImpl").getConstructor().newInstance()
 
@@ -89,5 +82,28 @@ public class ActionImpl implements ${BuildAction.name}<String> {
         cleanup:
         cl1?.close()
         cl2?.close()
+    }
+
+    private File buildActionJar(String actionContent) {
+        file("other/settings.gradle").text = """
+            rootProject.name = 'other'
+        """
+        file("other/build.gradle").text = """
+            plugins {
+                id("java-library")
+            }
+            dependencies {
+                implementation(gradleApi())
+            }
+        """
+        file('other/src/main/java/ActionImpl.java').text = actionContent
+
+        connector(file("other"))
+            .connect()
+            .newBuild()
+            .forTasks("jar")
+            .run()
+
+        return file("other/build/libs/other.jar")
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/IncompatibilityCrossVersionSpec.groovy
@@ -16,30 +16,31 @@
 
 package org.gradle.integtests.tooling.r33
 
-import org.gradle.integtests.fixtures.executer.GradleBackedArtifactBuilder
-import org.gradle.integtests.fixtures.executer.GradleDistribution
-import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import org.gradle.test.precondition.Requires
-import org.gradle.test.preconditions.UnitTestPreconditions
-import spock.lang.Ignore
+import org.gradle.tooling.internal.consumer.DefaultGradleConnector
 
-@Requires(
-    value = UnitTestPreconditions.Jdk8OrEarlier,
-    reason = "tests against old Gradle version that can only work with Java versions up to 8"
-)
 @ToolingApiVersion("current")
+@TargetGradleVersion("current")
 class IncompatibilityCrossVersionSpec extends ToolingApiSpecification {
+
     def buildPluginWith(String gradleVersion) {
-        buildPluginWith(buildContext.distribution(gradleVersion))
-    }
-    def buildPluginWith(GradleDistribution gradleDist) {
-        println "Building plugin with $gradleDist"
-        def pluginDir = file("plugin")
-        def pluginJar = pluginDir.file("plugin.jar")
-        def builder = new GradleBackedArtifactBuilder(new NoDaemonGradleExecuter(gradleDist, temporaryFolder).withWarningMode(null), pluginDir)
-        builder.sourceFile("com/example/MyTask.java") << """
+        def gradleDist = buildContext.distribution(gradleVersion)
+
+        file("other/settings.gradle") << """
+            rootProject.name = 'other'
+        """
+        file("other/build.gradle") << """
+            plugins {
+                id("java")
+            }
+            dependencies {
+                compile(gradleApi())
+            }
+        """
+        file('other/src/main/java/com/example/MyTask.java') << """
             package com.example;
 
             import org.gradle.api.*;
@@ -55,7 +56,21 @@ class IncompatibilityCrossVersionSpec extends ToolingApiSpecification {
                 }
             }
         """
-        builder.buildJar(pluginJar)
+
+        rawConnector(file("other"))
+            .useInstallation(gradleDist.gradleHomeDir)
+            .connect()
+            .newBuild()
+            .setJavaHome(AvailableJavaHomes.getAvailableJdk { md -> gradleDist.daemonWorksWith(md.javaMajorVersion)}.getJavaHome())
+            .forTasks("jar")
+            .addArguments("--stacktrace")
+            .run()
+
+        return file("other/build/libs/other.jar")
+    }
+
+    def "can use plugin built with minimum supported Gradle version"() {
+        File pluginJar = buildPluginWith(DefaultGradleConnector.MINIMUM_SUPPORTED_GRADLE_VERSION.version)
 
         buildFile << """
             buildscript {
@@ -66,35 +81,14 @@ class IncompatibilityCrossVersionSpec extends ToolingApiSpecification {
 
             task myTask(type: com.example.MyTask)
         """
-    }
 
-    def "can use plugin built with Gradle 3.0 with"() {
         expect:
-        buildPluginWith("3.0")
-        assertWorks()
-    }
-
-    // Gradle 3.2 and 3.2.1 leaked internal types that fail when used with
-    // newer versions of Gradle.
-    @Ignore
-    def "can use plugin built with Gradle 3.2.1 with"() {
-        expect:
-        buildPluginWith("3.2.1")
-        assertWorks()
-    }
-
-    private void assertWorks() {
-        // So we don't try to use a classpath distribution
-        toolingApi.requireDaemons()
-
-        withConnector {
-            // TestKit builds that use debug will set this to true
-            it.embedded(true)
-        }
-
-        // Run the build
-        withConnection { c ->
-            c.newBuild().forTasks("myTask").run()
+        succeeds { c ->
+            c.newBuild()
+                .forTasks("myTask")
+                .run()
+            true
         }
     }
+
 }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/TestResultHandler.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/TestResultHandler.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.tooling.fixture
 
 import org.gradle.internal.UncheckedException
-import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.tooling.GradleConnectionException
 import org.gradle.tooling.ResultHandler
 import org.gradle.tooling.internal.consumer.BlockingResultHandler
@@ -25,7 +24,7 @@ import org.gradle.tooling.internal.consumer.BlockingResultHandler
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-class TestResultHandler implements ResultHandler<Object>, BlockingHttpServer.FailureTracker {
+class TestResultHandler implements ResultHandler<Object> {
     final latch = new CountDownLatch(1)
     GradleConnectionException failure
 
@@ -38,11 +37,11 @@ class TestResultHandler implements ResultHandler<Object>, BlockingHttpServer.Fai
         latch.countDown()
     }
 
-    def finished() {
+    void finished() {
         finished(20)
     }
 
-    def finished(int seconds) {
+    void finished(int seconds) {
         if (!latch.await(seconds, TimeUnit.SECONDS)) {
             throw new AssertionError("Timeout waiting for operation to complete.")
         }


### PR DESCRIPTION
The cross version tests must compile to Java 8, however we want to allow the integ testing infrastructure to compile to Java 17.

We avoid depending on GradleExecuter in the TAPI cross version tests by converting as many usages as possible to the TAPI. For any other test that explicitly requires the cmdline, we convert that test into an integration test.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
