### PR TITLE
Add repository check to maintenance workflows to prevent fork execution

### DIFF
--- a/.github/workflows/update-perf-test-buckets.yml
+++ b/.github/workflows/update-perf-test-buckets.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   update-perf-test-buckets:
     runs-on: ubuntu-latest
+
+    if: github.repository == 'gradle/gradle'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/upgrade-to-latest-wrapper.yml
+++ b/.github/workflows/upgrade-to-latest-wrapper.yml
@@ -12,6 +12,8 @@ jobs:
   upgrade-latest-wrapper:
     runs-on: ubuntu-latest
 
+    if: github.repository == 'gradle/gradle'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
- fixes #34627 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

This PR prevents maintenance workflows from running on forked repositories, eliminating spam notifications for contributors.
Problem: Two scheduled maintenance workflows are currently running on all forks and causing daily/weekly failure notifications:

"Upgrade to latest wrapper" (daily) - fails because devprod/upgrade-to-latest-wrapper branch doesn't exist on forks
"Auto update performance test durations JSON" (weekly) - fails with AWS permission errors

Impact: All users who have forked the repository receive unnecessary failure notifications, creating friction for contributors and wasting CI resources.

Solution: Added if: github.repository == 'gradle/gradle' condition to both workflows to restrict execution to the main repository only. This follows the common pattern used in open-source projects to prevent maintenance workflows from running on forks.


### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
