### PR TITLE
Increase Xmx=1g for smoke-ide-test project

### DIFF
--- a/testing/smoke-ide-test/build.gradle.kts
+++ b/testing/smoke-ide-test/build.gradle.kts
@@ -92,3 +92,5 @@ dependencies {
     }
     smokeIdeTestImplementation(testFixtures(projects.core))
 }
+
+integTest.testJvmXmx = "1g"


### PR DESCRIPTION
We've seen such errors in IDE smoke tests:

```
Condition failed with Exception:
  
  fixture.assertHtmlReportHasProblems { // In gradle/gradle total problems count depends on amount of subprojects. // We want to avoid useless test failures ignoreTotalProblemsCount = true withLocatedProblem("Plugin class 'JetGradlePlugin'", "Project ':' cannot access 'Project.extensions' functionality on subprojects via 'allprojects'") }
  Condition failed with Exception:
  fixture.assertHtmlReportHasProblems { // In gradle/gradle total problems count depends on amount of subprojects. // We want to avoid useless test failures ignoreTotalProblemsCount = true withLocatedProblem("Plugin class 'JetGradlePlugin'", "Project ':' cannot access 'Project.extensions' functionality on subprojects via 'allprojects'") }
    at org.gradle.ide.sync.IsolatedProjectsGradleceptionSyncTest.can sync gradle/gradle build with known problems(IsolatedProjectsGradleceptionSyncTest.groovy:35)
  Caused by: java.lang.OutOfMemoryError: Java heap space
    at java.base/java.util.Arrays.copyOf(Arrays.java:3537)
    at java.base/java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:228)
    at java.base/java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:740)
    at java.base/java.lang.StringBuilder.append(StringBuilder.java:233)
    at java.base/java.io.BufferedReader.readLine(BufferedReader.java:376)
    at java.base/java.io.BufferedReader.readLine(BufferedReader.java:396)
    at java.base/java.io.BufferedReader$1.hasNext(BufferedReader.java:571)
    at java.base/java.util.Spliterators$IteratorSpliterator.tryAdvance(Spliterators.java:1855)
    at java.base/java.util.Spliterators$1Adapter.hasNext(Spliterators.java:681)
    at org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheProblemsFixture.linesBetween_closure6(ConfigurationCacheProblemsFixture.groovy:496)
```

Heap dump shows that there are a huge 200M JSON string:

<img width="900" height="316" alt="image" src="https://github.com/user-attachments/assets/bd1db80b-f752-42e5-b81f-f0e0072b738d" />

Let's increase the Xmx to 1G to see if it gets better.