### PR TITLE
Require isolated daemons for KotlinDslPluginCrossVersionSmokeTest test cases

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -76,6 +76,8 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
         withBuildScript("""plugins { id("some") }""")
 
         expectConfigurationCacheRequestedDeprecation()
+        // See https://github.com/gradle/gradle-private/issues/4767
+        executer.requireIsolatedDaemons()
 
         // Suppress CC problem caused by the outdated KGP version. Can be removed when KGP 2.0+ is used.
         build("help", "-Dorg.gradle.configuration-cache.unsafe.ignore.unsupported-build-events-listeners=true").apply {
@@ -125,6 +127,8 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
         withBuildScript("""plugins { id("some") }""")
 
         expectConfigurationCacheRequestedDeprecation()
+        // See https://github.com/gradle/gradle-private/issues/4767
+        executer.requireIsolatedDaemons()
         executer.expectExternalDeprecatedMessage("w: Language version 1.4 is deprecated and its support will be removed in a future version of Kotlin")
 
         // Suppress CC problem caused by the outdated KGP version. Can be removed when KGP 2.0+ is used.


### PR DESCRIPTION
As discussed in https://github.com/gradle/gradle-private/issues/4767#issuecomment-3182348221, these test cases need isolated daemons to avoid interfering each other.