### PR TITLE
`requireIsolatedUserHome` for flaky KotlinBuildScriptModelCrossVersionSpec

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r83/KotlinBuildScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r83/KotlinBuildScriptModelCrossVersionSpec.groovy
@@ -28,6 +28,9 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
     @Issue("https://github.com/gradle/gradle/issues/25555")
     def "single project with parallel build should not emit configuration resolution deprecation warning"() {
         given:
+        // This test is flaky because of locking timeout on shared caches.
+        // See https://github.com/gradle/gradle/pull/34665
+        requireIsolatedUserHome()
         propertiesFile << gradleProperties
 
         expect:


### PR DESCRIPTION
[This test is flaky](https://ge.gradle.org/scans/tests?search.relativeStartTime=P7D&search.timeZoneId=Europe%2FBerlin&tests.container=org.gradle.kotlin.dsl.tooling.builders.r83.KotlinBuildScriptModelCrossVersionSpec&tests.expandedTests=WzAsMSwyLDRd&tests.sortField=FLAKY&tests.test=single%20project%20with%20parallel%20build%20should%20not%20emit%20configuration%20resolution%20deprecation%20warning%20TAPI%209.1.0-20250805104018%2B0000%20-%3E%20Gradle%20current) because of locking timeout on shared caches. This PR makes it use isolated user home.