### PR TITLE
Allow arbitrary property types when isolating them 

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyFactory.java
@@ -41,6 +41,12 @@ public class DefaultPropertyFactory implements PropertyFactory {
     }
 
     @Override
+    @Deprecated
+    public <T> DefaultProperty<T> propertyOfAnyType(Class<T> type) {
+        return new DefaultProperty<>(propertyHost, maybeAsWrapperType(type));
+    }
+
+    @Override
     public <T> DefaultProperty<T> property(Class<T> type) {
         if (List.class.isAssignableFrom(type)) {
             // This is a terrible hack. We made a mistake in making this type a List<Thing> vs using a ListProperty<Thing>

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -68,20 +68,24 @@ public class ManagedFactories {
 
             ProviderInternal<S> provider = Cast.uncheckedNonnullCast(state);
             Class<S> providerType = provider.getType();
+            // We should properly serialize the type for the source property instead
+            // of trying to infer it from the backing provider.
             if (providerType == null) {
                 // TODO: This violates the assumption that all Property instances have a type.
-                // We should properly serialize the type for the source property instead
-                // of trying to infer it from the backing provider.
                 @SuppressWarnings("deprecation")
                 DefaultProperty<?> noTypeProperty = propertyFactory.propertyWithNoType();
+                // TODO(mlopatkin) we don't set the value here, is it bad?
                 return type.cast(noTypeProperty);
             } else {
                 return type.cast(propertyOf(providerType, provider));
             }
         }
 
+        @SuppressWarnings("deprecation")
         <V> Property<V> propertyOf(Class<V> type, Provider<V> value) {
-            return propertyFactory.property(type).value(value);
+            // As we're inferring the type from the value, it may not exactly match the type of property and may actually be forbidden.
+            // Imagine Property<Object> holding a List - the users will be asked to use ListProperty.
+            return propertyFactory.propertyOfAnyType(type).value(value);
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -72,10 +72,7 @@ public class ManagedFactories {
             // of trying to infer it from the backing provider.
             if (providerType == null) {
                 // TODO: This violates the assumption that all Property instances have a type.
-                @SuppressWarnings("deprecation")
-                DefaultProperty<?> noTypeProperty = propertyFactory.propertyWithNoType();
-                // TODO(mlopatkin) we don't set the value here, is it bad?
-                return type.cast(noTypeProperty);
+                return type.cast(propertyWithNoType(provider));
             } else {
                 return type.cast(propertyOf(providerType, provider));
             }
@@ -86,6 +83,11 @@ public class ManagedFactories {
             // As we're inferring the type from the value, it may not exactly match the type of property and may actually be forbidden.
             // Imagine Property<Object> holding a List - if we didn't use `propertyOfAnyType` we would throw an exception asking the user to use ListProperty.
             return propertyFactory.propertyOfAnyType(type).value(value);
+        }
+
+        @SuppressWarnings("deprecation")
+        <V> Property<V> propertyWithNoType(ProviderInternal<V> provider) {
+            return Cast.<Property<V>>uncheckedCast(propertyFactory.propertyWithNoType()).value(provider);
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -84,7 +84,7 @@ public class ManagedFactories {
         @SuppressWarnings("deprecation")
         <V> Property<V> propertyOf(Class<V> type, Provider<V> value) {
             // As we're inferring the type from the value, it may not exactly match the type of property and may actually be forbidden.
-            // Imagine Property<Object> holding a List - the users will be asked to use ListProperty.
+            // Imagine Property<Object> holding a List - if we didn't use `propertyOfAnyType` we would throw an exception asking the user to use ListProperty.
             return propertyFactory.propertyOfAnyType(type).value(value);
         }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/PropertyFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/PropertyFactory.java
@@ -28,6 +28,17 @@ public interface PropertyFactory {
     @Deprecated
     DefaultProperty<?> propertyWithNoType();
 
+    /**
+     * Creates a property with an arbitrary value type without applying the usual checks (like no {@code Property<Directory>}, etc.)
+     *
+     * @param type the type of the property value
+     * @param <T> the type of the property value
+     * @return the property
+     * @deprecated Consider passing around the type information and using {@link #property(Class)} instead.
+     */
+    @Deprecated
+    <T> DefaultProperty<T> propertyOfAnyType(Class<T> type);
+
     <T> DefaultProperty<T> property(Class<T> type);
 
     <T> DefaultListProperty<T> listProperty(Class<T> elementType);

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.workers.internal
 
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -314,9 +313,8 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/34667")
-    @ToBeImplemented
-    def "can provide object property with #valueType value with isolation mode #isolationMode"() {
-        buildFile << """
+    def "can provide object property with #valueType value with isolation mode #isolationMode"(def isolationMode, String valueType, String value, String expectedOutput) {
+        buildFile """
             ${parameterWorkAction('Property<Object>', 'println parameters.testParam.get()')}
 
             task runWork(type: ParameterTask) {
@@ -329,28 +327,27 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        // succeeds("runWork")
-        fails("runWork")
+        succeeds("runWork")
 
         then:
-        failureHasCause(~/Creating a property of type 'Property<.+>' is unsupported. Use '.+' instead./)
+        outputContains(expectedOutput)
 
         where:
-        [isolationMode, valueType, value] << [ISOLATION_MODES, [
-            ["List", "['a'] as List<String>"],
-            ["Set", "['a'] as Set<String>"],
-            ["Map", "[a: 'b'] as Map<String, String>"],
-            ["Directory", "layout.projectDirectory.dir('foo')"],
-            ["RegularFile", "layout.projectDirectory.file('foo')"],
+        [isolationMode, valueType, value, expectedOutput] << [ISOLATION_MODES, [
+            ["String", "'some string'", "some string"],
+            ["List", "['a'] as List<String>", "[a]"],
+            ["Set", "['a'] as Set<String>", "[a]"],
+            ["Map", "[a: 'b'] as Map<String, String>", "[a:b]"],
+            ["Directory", "layout.projectDirectory.dir('foo')", "/foo"],
+            ["RegularFile", "layout.projectDirectory.file('foo')", "/foo"],
         ]].combinations { mode, valueData ->
             [mode] + valueData
         }
     }
 
     @Issue("https://github.com/gradle/gradle/issues/34667")
-    @ToBeImplemented
-    def "can provide managed object property with #valueType value with isolation mode #isolationMode"() {
-        buildFile << """
+    def "can provide managed object property with #valueType value with isolation mode #isolationMode"(def isolationMode, String valueType, String value, String expectedOutput) {
+        buildFile """
             interface MyManagedObject {
                 Property<Object> getValue()
             }
@@ -367,19 +364,19 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        // succeeds("runWork")
-        fails("runWork")
+        succeeds("runWork")
 
         then:
-        failureHasCause(~/Creating a property of type 'Property<.+>' is unsupported. Use '.+' instead./)
+        outputContains(expectedOutput)
 
         where:
-        [isolationMode, valueType, value] << [ISOLATION_MODES, [
-            ["List", "['a'] as List<String>"],
-            ["Set", "['a'] as Set<String>"],
-            ["Map", "[a: 'b'] as Map<String, String>"],
-            ["Directory", "layout.projectDirectory.dir('foo')"],
-            ["RegularFile", "layout.projectDirectory.file('foo')"],
+        [isolationMode, valueType, value, expectedOutput] << [ISOLATION_MODES, [
+            ["String", "'some string'", "some string"],
+            ["List", "['a'] as List<String>", "[a]"],
+            ["Set", "['a'] as Set<String>", "[a]"],
+            ["Map", "[a: 'b'] as Map<String, String>", "[a:b]"],
+            ["Directory", "layout.projectDirectory.dir('foo')", "/foo"],
+            ["RegularFile", "layout.projectDirectory.file('foo')", "/foo"],
         ]].combinations { mode, valueData ->
             [mode] + valueData
         }

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -338,8 +338,8 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             ["List", "['a'] as List<String>", "[a]"],
             ["Set", "['a'] as Set<String>", "[a]"],
             ["Map", "[a: 'b'] as Map<String, String>", "[a:b]"],
-            ["Directory", "layout.projectDirectory.dir('foo')", "/foo"],
-            ["RegularFile", "layout.projectDirectory.file('foo')", "/foo"],
+            ["Directory", "layout.projectDirectory.dir('foo')", File.separator + "foo"],
+            ["RegularFile", "layout.projectDirectory.file('foo')", File.separator + "foo"],
         ]].combinations { mode, valueData ->
             [mode] + valueData
         }
@@ -375,8 +375,8 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             ["List", "['a'] as List<String>", "[a]"],
             ["Set", "['a'] as Set<String>", "[a]"],
             ["Map", "[a: 'b'] as Map<String, String>", "[a:b]"],
-            ["Directory", "layout.projectDirectory.dir('foo')", "/foo"],
-            ["RegularFile", "layout.projectDirectory.file('foo')", "/foo"],
+            ["Directory", "layout.projectDirectory.dir('foo')", File.separator + "foo"],
+            ["RegularFile", "layout.projectDirectory.file('foo')", File.separator + "foo"],
         ]].combinations { mode, valueData ->
             [mode] + valueData
         }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
@@ -143,8 +143,8 @@ abstract class Resolve extends Copy {
         "List"        | "['a'] as List<String>"               | "[a]"
         "Set"         | "['a'] as Set<String>"                | "[a]"
         "Map"         | "[a: 'b'] as Map<String, String>"     | "[a:b]"
-        "Directory"   | "layout.projectDirectory.dir('foo')"  | "/foo"
-        "RegularFile" | "layout.projectDirectory.file('foo')" | "/foo"
+        "Directory"   | "layout.projectDirectory.dir('foo')"  | File.separator + "foo"
+        "RegularFile" | "layout.projectDirectory.file('foo')" | File.separator + "foo"
     }
 
     @Issue("https://github.com/gradle/gradle/issues/34667")
@@ -212,8 +212,8 @@ abstract class Resolve extends Copy {
         "List"        | "['a'] as List<String>"               | "[a]"
         "Set"         | "['a'] as Set<String>"                | "[a]"
         "Map"         | "[a: 'b'] as Map<String, String>"     | "[a:b]"
-        "Directory"   | "layout.projectDirectory.dir('foo')"  | "/foo"
-        "RegularFile" | "layout.projectDirectory.file('foo')" | "/foo"
+        "Directory"   | "layout.projectDirectory.dir('foo')"  | File.separator + "foo"
+        "RegularFile" | "layout.projectDirectory.file('foo')" | File.separator + "foo"
     }
 
     @Requires(IntegTestPreconditions.NotParallelExecutor)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
 /**
@@ -84,7 +83,6 @@ abstract class Resolve extends Copy {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/34667")
-    @ToBeImplemented
     def "can isolate object property with #valueType value"() {
         given:
         mavenRepo.module("test", "test", "1.3").publish()
@@ -134,22 +132,22 @@ abstract class Resolve extends Copy {
         """
 
         when:
-        fails("resolve")
+        succeeds("resolve")
 
         then:
-        failureHasCause(~/Creating a property of type 'Property<.+>' is unsupported. Use '.+' instead./)
+        outputContains(expectedOutput)
 
         where:
-        valueType     | value
-        "List"        | "['a'] as List<String>"
-        "Set"         | "['a'] as Set<String>"
-        "Map"         | "[a: 'b'] as Map<String, String>"
-        "Directory"   | "layout.projectDirectory.dir('foo')"
-        "RegularFile" | "layout.projectDirectory.file('foo')"
+        valueType     | value                                 | expectedOutput
+        "String"      | "'some string'"                       | "some string"
+        "List"        | "['a'] as List<String>"               | "[a]"
+        "Set"         | "['a'] as Set<String>"                | "[a]"
+        "Map"         | "[a: 'b'] as Map<String, String>"     | "[a:b]"
+        "Directory"   | "layout.projectDirectory.dir('foo')"  | "/foo"
+        "RegularFile" | "layout.projectDirectory.file('foo')" | "/foo"
     }
 
     @Issue("https://github.com/gradle/gradle/issues/34667")
-    @ToBeImplemented
     def "can isolate managed object property with property holding #valueType value"() {
         given:
         mavenRepo.module("test", "test", "1.3").publish()
@@ -203,18 +201,19 @@ abstract class Resolve extends Copy {
         """
 
         when:
-        fails("resolve")
+        succeeds("resolve")
 
         then:
-        failureHasCause(~/Creating a property of type 'Property<.+>' is unsupported. Use '.+' instead./)
+        outputContains(expectedOutput)
 
         where:
-        valueType     | value
-        "List"        | "['a'] as List<String>"
-        "Set"         | "['a'] as Set<String>"
-        "Map"         | "[a: 'b'] as Map<String, String>"
-        "Directory"   | "layout.projectDirectory.dir('foo')"
-        "RegularFile" | "layout.projectDirectory.file('foo')"
+        valueType     | value                                 | expectedOutput
+        "String"      | "'some string'"                       | "some string"
+        "List"        | "['a'] as List<String>"               | "[a]"
+        "Set"         | "['a'] as Set<String>"                | "[a]"
+        "Map"         | "[a: 'b'] as Map<String, String>"     | "[a:b]"
+        "Directory"   | "layout.projectDirectory.dir('foo')"  | "/foo"
+        "RegularFile" | "layout.projectDirectory.file('foo')" | "/foo"
     }
 
     @Requires(IntegTestPreconditions.NotParallelExecutor)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
@@ -26,6 +26,8 @@ import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
+import org.gradle.util.internal.ToBeImplemented
+import spock.lang.Issue
 
 /**
  * Ensures that artifact transform parameters are isolated from one another and the surrounding project state.
@@ -79,6 +81,140 @@ abstract class Resolve extends Copy {
     }
 }
 """
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/34667")
+    @ToBeImplemented
+    def "can isolate object property with #valueType value"() {
+        given:
+        mavenRepo.module("test", "test", "1.3").publish()
+
+        buildFile """
+            abstract class PrintTransform implements TransformAction<Parameters> {
+                interface Parameters extends TransformParameters{
+                    @Internal
+                    Property<Object> getValue()
+                }
+
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    println("value = \${parameters.value.get()}")
+                    outputs.file(inputArtifact.get().asFile)
+                }
+            }
+
+            repositories {
+                maven { url = "${mavenRepo.uri}" }
+            }
+
+            configurations {
+                compile
+            }
+
+            dependencies {
+                compile 'test:test:1.3'
+            }
+
+            dependencies {
+                registerTransform(PrintTransform) {
+                    from.attribute(artifactType, 'jar')
+                    to.attribute(artifactType, 'transformedJar')
+                    parameters {
+                        value = $value
+                    }
+                }
+            }
+
+            tasks.register("resolve", Resolve) {
+                artifactTypeAttribute = 'transformedJar'
+                into layout.buildDirectory.dir('transformed')
+            }
+        """
+
+        when:
+        fails("resolve")
+
+        then:
+        failureHasCause(~/Creating a property of type 'Property<.+>' is unsupported. Use '.+' instead./)
+
+        where:
+        valueType     | value
+        "List"        | "['a'] as List<String>"
+        "Set"         | "['a'] as Set<String>"
+        "Map"         | "[a: 'b'] as Map<String, String>"
+        "Directory"   | "layout.projectDirectory.dir('foo')"
+        "RegularFile" | "layout.projectDirectory.file('foo')"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/34667")
+    @ToBeImplemented
+    def "can isolate managed object property with property holding #valueType value"() {
+        given:
+        mavenRepo.module("test", "test", "1.3").publish()
+
+        buildFile """
+            interface MyManagedObject {
+                Property<Object> getValue()
+            }
+
+            abstract class PrintTransform implements TransformAction<Parameters> {
+                interface Parameters extends TransformParameters{
+                    @Internal
+                    Property<MyManagedObject> getManagedObject()
+                }
+
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    println("value = \${parameters.managedObject.get().value.get()}")
+                    outputs.file(inputArtifact.get().asFile)
+                }
+            }
+
+            repositories {
+                maven { url = "${mavenRepo.uri}" }
+            }
+
+            configurations {
+                compile
+            }
+
+            dependencies {
+                compile 'test:test:1.3'
+            }
+
+            dependencies {
+                registerTransform(PrintTransform) {
+                    from.attribute(artifactType, 'jar')
+                    to.attribute(artifactType, 'transformedJar')
+                    parameters {
+                        managedObject = objects.newInstance(MyManagedObject).tap { value = $value }
+                    }
+                }
+            }
+
+            tasks.register("resolve", Resolve) {
+                artifactTypeAttribute = 'transformedJar'
+                into layout.buildDirectory.dir('transformed')
+            }
+        """
+
+        when:
+        fails("resolve")
+
+        then:
+        failureHasCause(~/Creating a property of type 'Property<.+>' is unsupported. Use '.+' instead./)
+
+        where:
+        valueType     | value
+        "List"        | "['a'] as List<String>"
+        "Set"         | "['a'] as Set<String>"
+        "Map"         | "[a: 'b'] as Map<String, String>"
+        "Directory"   | "layout.projectDirectory.dir('foo')"
+        "RegularFile" | "layout.projectDirectory.file('foo')"
     }
 
     @Requires(IntegTestPreconditions.NotParallelExecutor)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -1616,7 +1616,6 @@ Hello, subproject1
     }
 
     @Issue("https://github.com/gradle/gradle/issues/34667")
-    @ToBeImplemented
     def "can use Property with #valueType value as service parameter"() {
         buildFile """
             abstract class PrintService implements BuildService<PrintService.Params> {
@@ -1625,7 +1624,7 @@ Hello, subproject1
                 }
 
                 void printValue() {
-                    println(parameters.value)
+                    println(parameters.value.get())
                 }
             }
 
@@ -1642,23 +1641,22 @@ Hello, subproject1
         """
 
         when:
-        fails("print")
-        // succeeds("print")
+        succeeds("print")
 
         then:
-        failureHasCause(~/Creating a property of type 'Property<.+>' is unsupported. Use '.+' instead./)
+        outputContains(expectedOutput)
 
         where:
-        valueType     | value
-        "List"        | "['a'] as List<String>"
-        "Set"         | "['a'] as Set<String>"
-        "Map"         | "[a: 'b'] as Map<String, String>"
-        "Directory"   | "layout.projectDirectory.dir('foo')"
-        "RegularFile" | "layout.projectDirectory.file('foo')"
+        valueType     | value                                 | expectedOutput
+        "String"      | "'some string'"                       | "some string"
+        "List"        | "['a'] as List<String>"               | "[a]"
+        "Set"         | "['a'] as Set<String>"                | "[a]"
+        "Map"         | "[a: 'b'] as Map<String, String>"     | "[a:b]"
+        "Directory"   | "layout.projectDirectory.dir('foo')"  | "/foo"
+        "RegularFile" | "layout.projectDirectory.file('foo')" | "/foo"
     }
 
     @Issue("https://github.com/gradle/gradle/issues/34667")
-    @ToBeImplemented
     def "can use Property with #valueType value in a managed object as service parameter"() {
         buildFile """
             interface MyManagedObject {
@@ -1671,7 +1669,7 @@ Hello, subproject1
                 }
 
                 void printValue() {
-                    println(parameters.managedObject.value.get())
+                    println(parameters.managedObject.get().value.get())
                 }
             }
 
@@ -1688,19 +1686,19 @@ Hello, subproject1
         """
 
         when:
-        fails("print")
-        // succeeds("print")
+        succeeds("print")
 
         then:
-        failureHasCause(~/Creating a property of type 'Property<.+>' is unsupported. Use '.+' instead./)
+        outputContains(expectedOutput)
 
         where:
-        valueType     | value
-        "List"        | "['a'] as List<String>"
-        "Set"         | "['a'] as Set<String>"
-        "Map"         | "[a: 'b'] as Map<String, String>"
-        "Directory"   | "layout.projectDirectory.dir('foo')"
-        "RegularFile" | "layout.projectDirectory.file('foo')"
+        valueType     | value                                 | expectedOutput
+        "String"      | "'some string'"                       | "some string"
+        "List"        | "['a'] as List<String>"               | "[a]"
+        "Set"         | "['a'] as Set<String>"                | "[a]"
+        "Map"         | "[a: 'b'] as Map<String, String>"     | "[a:b]"
+        "Directory"   | "layout.projectDirectory.dir('foo')"  | "/foo"
+        "RegularFile" | "layout.projectDirectory.file('foo')" | "/foo"
     }
 
     def "should not resolve providers when computing shared resources"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -825,8 +825,7 @@ service: closed with value 10001
         outputContains("service: closed with value 11")
     }
 
-    @Requires(IntegTestPreconditions.NotConfigCached)
-    // already covers CC behavior
+    @Requires(value = IntegTestPreconditions.NotConfigCached, reason = "already covers CC behavior")
     def "service used at configuration is discarded before execution time when used with configuration cache"() {
         serviceImplementation()
         buildFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -1652,8 +1652,8 @@ Hello, subproject1
         "List"        | "['a'] as List<String>"               | "[a]"
         "Set"         | "['a'] as Set<String>"                | "[a]"
         "Map"         | "[a: 'b'] as Map<String, String>"     | "[a:b]"
-        "Directory"   | "layout.projectDirectory.dir('foo')"  | "/foo"
-        "RegularFile" | "layout.projectDirectory.file('foo')" | "/foo"
+        "Directory"   | "layout.projectDirectory.dir('foo')"  | File.separator + "foo"
+        "RegularFile" | "layout.projectDirectory.file('foo')" | File.separator + "foo"
     }
 
     @Issue("https://github.com/gradle/gradle/issues/34667")
@@ -1697,8 +1697,8 @@ Hello, subproject1
         "List"        | "['a'] as List<String>"               | "[a]"
         "Set"         | "['a'] as Set<String>"                | "[a]"
         "Map"         | "[a: 'b'] as Map<String, String>"     | "[a:b]"
-        "Directory"   | "layout.projectDirectory.dir('foo')"  | "/foo"
-        "RegularFile" | "layout.projectDirectory.file('foo')" | "/foo"
+        "Directory"   | "layout.projectDirectory.dir('foo')"  | File.separator + "foo"
+        "RegularFile" | "layout.projectDirectory.file('foo')" | File.separator + "foo"
     }
 
     def "should not resolve providers when computing shared resources"() {


### PR DESCRIPTION
Fixes #34667

The `fromState` runs "on the other side" of the isolation, but uses the type of the value rather than the defined type of the Property. When the property holds some type, for which a more specialized property type exists, the check in creating a new property instance causes failure.

Given that the isolation happens on a valid property, we should not complain about it when restoring the state.

A proper fix would be to save and restore the type of the property, but we need to study its performance implications first.

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
