### PR TITLE
change gradleApi() to accept a version argument

### DIFF
--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/GradlePluginDevelopmentExtension.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/GradlePluginDevelopmentExtension.java
@@ -164,4 +164,6 @@ public abstract class GradlePluginDevelopmentExtension {
     public void setAutomatedPublishing(boolean automatedPublishing) {
         this.automatedPublishing = automatedPublishing;
     }
+
+    public abstract Property<String> getGradleApiVersion();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -237,6 +237,11 @@ public abstract class DefaultDependencyHandler implements DependencyHandlerInter
     }
 
     @Override
+    public Dependency gradleApi(String gradleVersion) {
+        return dependencyFactory.create("org.gradle.experimental","gradle-public-api",gradleVersion);
+    }
+
+    @Override
     public Dependency gradleTestKit() {
         return dependencyFactory.createDependency(DependencyFactoryInternal.ClassPathNotation.GRADLE_TEST_KIT);
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -338,6 +338,13 @@ public interface DependencyHandler extends ExtensionAware {
     Dependency gradleApi();
 
     /**
+     * Creates a dependency on the API of the specified version of Gradle.
+     *
+     * @return The dependency.
+     */
+    Dependency gradleApi(String gradleVersion);
+
+    /**
      * Creates a dependency on the <a href="https://docs.gradle.org/current/userguide/test_kit.html" target="_top">Gradle test-kit</a> API.
      *
      * @return The dependency.


### PR DESCRIPTION
use the parameterized version of gradleApi() in the java gradle plugin plugin and align the version with the attribute

fixes #1835 and #33119

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
