### PR TITLE
Add internal property to suppress adding local Gradle Test Kit

### DIFF
--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -119,6 +119,13 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
     static final InternalFlag EXPERIMENTAL_SUPPRESS_GRADLE_API_PROPERTY = new InternalFlag("org.gradle.unsafe.suppress-gradle-api");
 
     /**
+     * Suppress adding the {@code DependencyHandler#gradleTestKit()} dependency to all test's {@code implementation} configuration.
+     *
+     * Experimental property used to test using an external Gradle Test Kit dependency.
+     */
+    static final InternalFlag EXPERIMENTAL_SUPPRESS_GRADLE_TEST_KIT_PROPERTY = new InternalFlag("org.gradle.unsafe.suppress-gradle-test-kit");
+
+    /**
      * The task group used for tasks created by the Java Gradle plugin development plugin.
      *
      * @since 4.0
@@ -455,9 +462,14 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
                 test.getJvmArgumentProviders().add(new AddOpensCommandLineArgumentProvider(test));
             });
 
+            // TODO See #applyDependencies(Project)
+            InternalOptions internalOptions = ((ProjectInternal) project).getServices().get(InternalOptions.class);
+            boolean addGradleTestKit = internalOptions.getOption(EXPERIMENTAL_SUPPRESS_GRADLE_TEST_KIT_PROPERTY).get();
             for (SourceSet testSourceSet : testSourceSets) {
-                String implementationConfigurationName = testSourceSet.getImplementationConfigurationName();
-                dependencies.add(implementationConfigurationName, dependencies.gradleTestKit());
+                if (addGradleTestKit) {
+                    String implementationConfigurationName = testSourceSet.getImplementationConfigurationName();
+                    dependencies.add(implementationConfigurationName, dependencies.gradleTestKit());
+                }
                 String runtimeOnlyConfigurationName = testSourceSet.getRuntimeOnlyConfigurationName();
                 dependencies.add(runtimeOnlyConfigurationName, project.getLayout().files(pluginClasspathTask));
             }


### PR DESCRIPTION
This PR adds an internal flag, `org.gradle.unsafe.suppress-gradle-test-kit`, to suppress adding the local Gradle Test Kit to all test source sets' implementation configurations.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Currently, to test the usage of external Gradle public API, an internal flag is used to suppress adding `DependencyHandler#gradleApi` to the `api` configuration (`org.gradle.unsafe.suppress-gradle-api`). While this allows compiling a Gradle plugin with a specific version of the Gradle API, it does not prevent automatically adding the test kit to test suits' dependencies. This can cause a clash when attempting to migrate the buildscript of an older Gradle plugin to a newer version of Gradle (i.e. 9.0.0) in order to be able to build the project in the most recent versions of popular IDEs, such as IntelliJ IDEA. This is because the testing code may be expecting to compile for the specific version of Gradle the plugin was built for, but instead must attempt to compile against the locally provided version.

I am all for Gradle's work on slowly releasing a stable public API jar that can be used instead of the local Gradle API. However, there are plenty of redistributions of the API and Test Kit, such as the ones by [remal](https://github.com/remal-gradle-plugins/gradle-api) and [Nokee](https://github.com/gradle-plugins/gradle-api), that can be used now to compile against a specific version of Gradle.

The addition of this flag also gives Gradle the ability to test their own external publications of the test kit without needing to manually remove it from each test's implementation dependencies, which is what I am sure the internal flag for suppressing the Gradle API exists to do in the first place.

**An important caveat** to this is that since Gradle does not currently publish the latest version of the test kit to their repository, I don't know what test to write for this at the moment. Open to comments and suggestions on this. An idea I have would be to add the local test kit dependency to the test dependencies `runtimeOnly` configuration, while adding an external test kit to the `compileOnly` configuration, but I'm not sure how I would accomplish this.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
