### PR TITLE
Feat(antlr): Organize Antlr tasks into a dedicated group

### DIFF
--- a/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -44,6 +44,7 @@ import static org.gradle.api.plugins.antlr.internal.AntlrSpec.PACKAGE_ARG;
  */
 public abstract class AntlrPlugin implements Plugin<Project> {
     public static final String ANTLR_CONFIGURATION_NAME = "antlr";
+    public static final String ANTLR_TASK_GROUP = "Antlr";
     private final ObjectFactory objectFactory;
 
     @Inject
@@ -90,6 +91,7 @@ public abstract class AntlrPlugin implements Plugin<Project> {
                     // 4) Register a source-generating task, and
                     TaskProvider<AntlrTask> antlrTask = project.getTasks().register(taskName, AntlrTask.class, task -> {
                         task.setDescription("Processes the " + sourceSet.getName() + " Antlr grammars.");
+                        task.setGroup(ANTLR_TASK_GROUP);
                         // 4.1) set up convention mapping for default sources (allows user to not have to specify)
                         task.setSource(antlrSourceSet);
                         task.setOutputDirectory(outputDirectory);

--- a/platforms/software/antlr/src/test/groovy/org/gradle/api/plugins/antlr/AntlrPluginTest.groovy
+++ b/platforms/software/antlr/src/test/groovy/org/gradle/api/plugins/antlr/AntlrPluginTest.groovy
@@ -110,4 +110,13 @@ class AntlrPluginTest extends AbstractProjectBuilderSpec {
         def sourcesJar = project.tasks.sourcesJar
         sourcesJar.taskDependencies.getDependencies(null).contains(generateGrammarSource)
     }
+
+    @Issue('https://github.com/gradle/gradle/issues/33373')
+    def "Antlr tasks are assigned to the correct group"() {
+        when:
+        project.pluginManager.apply(AntlrPlugin)
+
+        then:
+        project.tasks.withType(AntlrTask).all { it.group == AntlrPlugin.ANTLR_TASK_GROUP }
+    }
 }


### PR DESCRIPTION
Summary of changes

- Updated AntlrPlugin so that all AntlrTask instances (generateGrammarSource, generateTestGrammarSource, etc.) have their group property set to "Antlr".
- Added a test that uses project.tasks.withType(AntlrTask) to verify that all Antlr tasks are correctly grouped.

Closes #33373

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
