### PR TITLE
Throw UnknownProjectException when failing to create project dependency

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesIntegrationTest.groovy
@@ -100,6 +100,27 @@ class ProjectDependenciesIntegrationTest extends AbstractDependencyResolutionTes
         failureHasCause("Required keys [path] are missing from map")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/34692")
+    def "throws UnknownProjectException when creating project dependency from map with unknown project"() {
+        buildFile("""
+            configurations.dependencyScope("deps")
+            dependencies {
+                try {
+                    deps(project(path: "unknown"))
+                } catch (Exception e) {
+                    assert e instanceof UnknownProjectException
+                    throw e
+                }
+            }
+        """)
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("Project with path ':unknown' could not be found.")
+    }
+
     def "can add constraint on root project"() {
         given:
         mavenRepo.module("org", "foo").publish()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.UnknownProjectException;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
@@ -59,7 +60,10 @@ public class DefaultProjectDependencyFactory {
     }
 
     public ProjectDependency create(Path projectIdentityPath) {
-        ProjectState projectState = projectStateRegistry.stateFor(projectIdentityPath);
+        ProjectState projectState = projectStateRegistry.findProjectState(projectIdentityPath);
+        if (projectState == null) {
+            throw new UnknownProjectException(String.format("Project with path '%s' could not be found.", projectIdentityPath.getPath()));
+        }
         return create(projectState);
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
@@ -41,7 +41,7 @@ class ProjectDependencyFactoryTest extends Specification {
 
     def capabilityNotationParser = new CapabilityNotationParserFactory(false).create()
     def projectStateRegistry = Mock(ProjectStateRegistry) {
-        stateFor(Path.path(":foo:bar")) >> projectState
+        findProjectState(Path.path(":foo:bar")) >> projectState
     }
     def depFactory = new DefaultProjectDependencyFactory(
         TestUtil.instantiatorFactory().decorateLenient(),

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -158,6 +158,13 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     }
 
     @Override
+    public @Nullable ProjectState findProjectState(Path identityPath) {
+        synchronized (lock) {
+            return projectsByPath.get(identityPath);
+        }
+    }
+
+    @Override
     public BuildProjectRegistry projectsFor(BuildIdentifier buildIdentifier) throws IllegalArgumentException {
         synchronized (lock) {
             BuildProjectRegistry registry = projectsByBuild.get(buildIdentifier);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -57,6 +57,11 @@ public interface ProjectStateRegistry {
     ProjectState stateFor(Path identityPath) throws IllegalArgumentException;
 
     /**
+     * Locates the state object that owns the project with the given identity path, or null if this project is not present.
+     */
+    @Nullable ProjectState findProjectState(Path identityPath);
+
+    /**
      * Locates the state objects for all projects of the given build.
      */
     BuildProjectRegistry projectsFor(BuildIdentifier buildIdentifier) throws IllegalArgumentException;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
@@ -80,7 +80,7 @@ class DefaultProjectDependencyConstraintTest extends Specification {
         projectState.getMutableModel() >> project
 
         def projectStateRegistry = Mock(ProjectStateRegistry) {
-            stateFor(Path.ROOT) >> projectState
+            findProjectState(Path.ROOT) >> projectState
         }
 
         def dependencyFactory = new DefaultProjectDependencyFactory(


### PR DESCRIPTION
This fixes a regression in 9.1


Fixes https://github.com/gradle/gradle/issues/34692 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
