### PR TITLE
docs(build-cache): Clarify that HttpBuildCacheCredentials uses HTTP Basic Auth

### DIFF
--- a/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCacheCredentials.java
+++ b/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCacheCredentials.java
@@ -21,9 +21,13 @@ import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyPro
 import org.jspecify.annotations.Nullable;
 
 /**
- * Password credentials for a HTTP build cache backend.
+ * Credentials for authenticating with an HTTP build cache.
  *
- * @since 3.5
+ * <p>When configured on {@link HttpBuildCache}, these credentials are sent using
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7617">HTTP Basic authentication</a>
+ * (i.e. via the {@code Authorization: Basic} header).</p>
+ *
+ * @see HttpBuildCache
  */
 public class HttpBuildCacheCredentials implements PasswordCredentials {
     private String username;


### PR DESCRIPTION
This updates the Javadoc of `HttpBuildCacheCredentials` to explicitly state that
credentials are sent via HTTP Basic authentication (i.e. `Authorization: Basic` header)
when used with `HttpBuildCache`, aligning with the existing `HttpBuildCache` Javadoc.

- Adds RFC 7617 link for clarity
- Adds @see reference to HttpBuildCache
- No API or behavioral changes

Fixes gradle/gradle#21833