### PR TITLE
Update Release Notes: add new contributor from RC2

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -23,6 +23,7 @@ Additionally, this release provides [build authoring improvements](#build-author
 We would like to thank the following community members for their contributions to this release of Gradle:
 [Eng Zer Jun](https://github.com/Juneezee),
 [EunHyunsu](https://github.com/ehs208),
+[Gaëtan Muller](https://github.com/MGaetan89),
 [HeeChul Yang](https://github.com/yangchef1),
 [Jendrik Johannes](https://github.com/jjohannes),
 [Johnny Lim](https://github.com/izeye),


### PR DESCRIPTION
### Details
This is a Documentation and Documentation Infrastructure change ONLY.

### Context
Update release notes for RC2