### PR TITLE
feat: Add FreeBSD support for native toolchains

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
@@ -108,6 +108,10 @@ public abstract class OperatingSystem {
         return false;
     }
 
+    public boolean isFreeBSD() {
+        return false;
+    }
+
     public abstract String getNativePrefix();
 
     public abstract String getScriptName(String scriptPath);
@@ -410,6 +414,15 @@ public abstract class OperatingSystem {
     }
 
     static class FreeBSD extends Unix {
+        @Override
+        public boolean isFreeBSD() {
+            return true;
+        }
+
+        @Override
+        public String getFamilyName() {
+            return "freebsd";
+        }
     }
 
     static class Solaris extends Unix {

--- a/platforms/documentation/docs/src/docs/userguide/platforms/native/native_software.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/platforms/native/native_software.adoc
@@ -848,10 +848,10 @@ The core Gradle tool chains are able to target the following architectures out o
 | Architectures
 
 | GCC
-| x86, x86_64, arm64 (macOS & linux Only)
+| x86, x86_64, arm64 (macOS & linux & freeBSD Only)
 
 | Clang
-| x86, x86_64, arm64 (macOS & linux only)
+| x86, x86_64, arm64 (macOS & linux & freeBSD Only)
 
 | Visual C++
 | x86, x86_64, ia-64

--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
@@ -335,7 +335,8 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
         public boolean supportsPlatform(NativePlatformInternal targetPlatform) {
             return targetPlatform.getOperatingSystem().isCurrent()
                     && (targetPlatform.getOperatingSystem().isMacOsX()
-                        || (targetPlatform.getOperatingSystem().isLinux() && DefaultNativePlatform.getCurrentArchitecture().isArm64()))
+                        || (targetPlatform.getOperatingSystem().isLinux() && DefaultNativePlatform.getCurrentArchitecture().isArm64())
+                        || (targetPlatform.getOperatingSystem().isFreeBSD() && DefaultNativePlatform.getCurrentArchitecture().isArm64()))
                 && targetPlatform.getArchitecture().isArm();
         }
 

--- a/platforms/native/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
+++ b/platforms/native/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
@@ -419,6 +419,29 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         })
     }
 
+    def "is available on FreeBSD for supported architectures"() {
+        given:
+        def freeBsd = Mock(DefaultOperatingSystem) {
+            isFreeBSD() >> true
+            isCurrent() >> true
+        }
+        platform.operatingSystem >> freeBsd
+        platform.architecture >> Architectures.forInput(arch)
+
+        and:
+        toolSearchPath.locate(_, _) >> tool
+        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+
+        when:
+        def result = toolChain.select(platform)
+
+        then:
+        result.available
+
+        where:
+        arch << ["x86_64", "arm64"]
+    }
+
     def getMessage(ToolSearchResult result) {
         def formatter = new TreeFormatter()
         result.explain(formatter)


### PR DESCRIPTION
Summary of changes
- Introduce `isFreeBSD()` and `FreeBSD` OS type.
- Update `AbstractGccCompatibleToolChain` to support FreeBSD for `amd64` and `arm64` targets.
- Enhance test suite with FreeBSD-specific tests, ensuring environment independence.

Fixes #32895 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
