### PR TITLE
Deprecate Path.getPath() and add Path.asString()

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/AggregateMultiProjectTaskReportModelTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/AggregateMultiProjectTaskReportModelTest.groovy
@@ -81,7 +81,7 @@ class AggregateMultiProjectTaskReportModelTest extends AbstractTaskModelSpec {
         model.build()
 
         then:
-        model.getTasksForGroup('group')*.path*.path as Set == ['task', 'other'] as Set
+        model.getTasksForGroup('group')*.path*.asString() as Set == ['task', 'other'] as Set
     }
 
     def "shows tasks from specific group(s)"() {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -220,8 +220,8 @@ class FingerprintCheckResult(
     ) : ProjectInvalidationReasons {
 
         constructor(invalidation: CheckedFingerprint.InvalidProject) : this(
-            invalidation.buildPath.path,
-            invalidation.projectPath.path,
+            invalidation.buildPath.asString(),
+            invalidation.projectPath.asString(),
             listOf(FingerprintInvalidationReasonImpl(invalidation.reason.toString()))
         )
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheState.kt
@@ -250,7 +250,7 @@ class ConfigurationCacheState(
         return converted.computeIfAbsent(project.path) {
             // Root project name is serialized separately, could perhaps move it to this cached project state object
             val projectName = project.path.name ?: rootProjectName
-            BuildStructureOperationProject(projectName, project.path.path, project.path.path, project.projectDir.absolutePath, project.buildFile.absolutePath, childProjects)
+            BuildStructureOperationProject(projectName, project.path.asString(), project.path.asString(), project.projectDir.absolutePath, project.buildFile.absolutePath, childProjects)
         }
     }
 
@@ -429,7 +429,7 @@ class ConfigurationCacheState(
     private
     suspend fun WriteContext.writeBuildWithNoWork(buildState: BuildState) {
         withGradleIsolate(buildState.mutableModel, userTypesCodec) {
-            writeString(buildState.identityPath.path)
+            writeString(buildState.identityPath.asString())
             if (buildState.isProjectsCreated) {
                 writeBoolean(true)
                 writeString(buildState.projects.rootProject.name)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -81,7 +81,7 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
         return delegate.findTask(path).also { task ->
             if (task == null) {
                 // check whether the path refers to a different project
-                val parentPath = Path.path(path).parent?.path
+                val parentPath = Path.path(path).parent?.asString()
                 if (parentPath != referrerProject.path) {
                     // even though the task was not found, the current project is coupled with the other project:
                     // if the configuration of that project changes, the result of this call might be different

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheHost.kt
@@ -178,7 +178,7 @@ class DefaultConfigurationCacheHost internal constructor(
 
         private
         fun getProjectDescriptor(parentPath: Path?): DefaultProjectDescriptor? =
-            parentPath?.let { projectDescriptorRegistry.getProject(it.path) }
+            parentPath?.let { projectDescriptorRegistry.getProject(it.asString()) }
 
         private
         val projectDescriptorRegistry

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheIO.kt
@@ -130,7 +130,7 @@ class DefaultConfigurationCacheIO internal constructor(
                 addressSerializer.write(this, entry.value)
             }
             writeCollection(projectMetadata.entries) { entry ->
-                writeString(entry.key.path)
+                writeString(entry.key.asString())
                 addressSerializer.write(this, entry.value)
             }
             writeCollection(sideEffects) {
@@ -168,7 +168,7 @@ class DefaultConfigurationCacheIO internal constructor(
 
     private
     fun WriteContext.writeModelKey(key: ModelKey) {
-        writeNullableString(key.identityPath?.path)
+        writeNullableString(key.identityPath?.asString())
         writeString(key.modelName)
         writeNullableString(key.parameterHash?.toString())
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -1029,7 +1029,7 @@ class ConfigurationCacheFingerprintWriter(
         location: PropertyTrace
     ) = PropertyTrace.Project(
         path = when (propertyScope) {
-            is GradlePropertyScope.Project -> propertyScope.projectIdentity.buildTreePath.path
+            is GradlePropertyScope.Project -> propertyScope.projectIdentity.buildTreePath.asString()
             is GradlePropertyScope.Build -> propertyScope.buildIdentifier.buildPath
             else -> error("Unexpected property scope $propertyScope")
         },

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -143,7 +143,7 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
         }
 
     private
-    fun locationForTask(task: TaskInternal) = PropertyTrace.Task(GeneratedSubclasses.unpackType(task), task.identityPath.path)
+    fun locationForTask(task: TaskInternal) = PropertyTrace.Task(GeneratedSubclasses.unpackType(task), task.identityPath.asString())
 
     private
     fun problemsListenerFor(task: TaskInternal): ProblemsListener {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -495,7 +495,7 @@ class ConfigurationCacheProblems(
     val logger = Logging.getLogger(ConfigurationCacheProblems::class.java)
 
     private
-    fun locationForTask(task: Task) = PropertyTrace.Task(GeneratedSubclasses.unpackType(task), (task as TaskInternal).identityPath.path)
+    fun locationForTask(task: Task) = PropertyTrace.Task(GeneratedSubclasses.unpackType(task), (task as TaskInternal).identityPath.asString())
 
     private
     fun Int.counter(singular: String, plural: String = "${singular}s"): String {

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/TaskNodeCodec.kt
@@ -232,7 +232,7 @@ suspend fun <T> T.withTaskOf(
     action: suspend () -> Unit
 ) where T : IsolateContext, T : MutableIsolateContext {
     withIsolate(IsolateOwners.OwnerTask(task), codec) {
-        withPropertyTrace(PropertyTrace.Task(taskType, task.identityPath.path)) {
+        withPropertyTrace(PropertyTrace.Task(taskType, task.identityPath.asString())) {
             if (task.isCompatibleWithConfigurationCache) {
                 action()
             } else {

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/WorkNodeCodec.kt
@@ -205,7 +205,7 @@ class WorkNodeCodec(
         val groupedNodes = nodes.groupBy(NodeOwner::of)
         writeCollection(groupedNodes.keys) { nodeOwner ->
             val groupPath = nodeOwner.path()
-            writeString(groupPath.path)
+            writeString(groupPath.asString())
         }
 
         val batchedActionNodeSuccessors =
@@ -640,6 +640,6 @@ fun asBuildOperation(displayName: String, contextPath: Path, action: () -> Unit)
         override fun description(): BuildOperationDescriptor.Builder {
             return BuildOperationDescriptor
                 .displayName(displayName)
-                .progressDisplayName(contextPath.path)
+                .progressDisplayName(contextPath.asString())
         }
     }

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/SingleIncludePatternFileTreeSpec.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/SingleIncludePatternFileTreeSpec.groovy
@@ -295,8 +295,8 @@ class SingleIncludePatternFileTreeSpec extends Specification {
 
         then:
         1 * visitor.visitDir({ it.file == tempDir.file("dir2") }) >> { FileVisitDetails details -> details.stopVisiting() }
-        0 * visitor.visitDir({ it.path.startsWith("dir2") })
-        0 * visitor.visitFile({ it.path.startsWith("dir2") })
+        0 * visitor.visitDir({ it.asString().startsWith("dir2") })
+        0 * visitor.visitFile({ it.asString().startsWith("dir2") })
     }
 
     def "use exclude spec"() {

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -149,7 +149,7 @@ class DependencyHandlerExtensionsTest {
             dependency
         }
         val projectPath: Path = Path.path(":project")
-        whenever(dependency.path).thenReturn(projectPath.path)
+        whenever(dependency.path).thenReturn(projectPath.asString())
 
         dependencies {
 
@@ -157,7 +157,7 @@ class DependencyHandlerExtensionsTest {
                 events.add("configured")
                 assertThat(
                     path,
-                    sameInstance(projectPath.path)
+                    sameInstance(projectPath.asString())
                 )
             }
         }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/bean/DefaultPropertyWalkerTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/bean/DefaultPropertyWalkerTest.groovy
@@ -76,12 +76,12 @@ class DefaultPropertyWalkerTest extends AbstractProjectBuilderSpec {
         1 * visitor.visitInputProperty('bean.nestedInput', { it.call() == 'nested' }, false)
         1 * visitor.visitInputFileProperty('bean.inputDir', _, _, _, _, _, _, InputFilePropertyType.DIRECTORY)
 
-        1 * visitor.visitOutputFileProperty('outputFile', false, { it.call().path == 'output' }, OutputFilePropertyType.FILE)
-        1 * visitor.visitOutputFileProperty('bean.outputDir', false, { it.call().path == 'outputDir' }, OutputFilePropertyType.DIRECTORY)
+        1 * visitor.visitOutputFileProperty('outputFile', false, { it.call().asString() == 'output' }, OutputFilePropertyType.FILE)
+        1 * visitor.visitOutputFileProperty('bean.outputDir', false, { it.call().asString() == 'outputDir' }, OutputFilePropertyType.DIRECTORY)
 
-        1 * visitor.visitDestroyableProperty({ it.call().path == 'destroyed' })
+        1 * visitor.visitDestroyableProperty({ it.call().asString() == 'destroyed' })
 
-        1 * visitor.visitLocalStateProperty({ it.call().path == 'localState' })
+        1 * visitor.visitLocalStateProperty({ it.call().asString() == 'localState' })
 
         0 * _
     }

--- a/platforms/core-execution/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerTest.groovy
+++ b/platforms/core-execution/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerTest.groovy
@@ -76,7 +76,7 @@ class DefaultBuildCacheControllerTest extends Specification {
     BuildCacheController getController(boolean disableRemoteOnError = true) {
         new DefaultBuildCacheController(
             new BuildCacheServicesConfiguration(
-                Path.ROOT.path,
+                Path.ROOT.asString(),
                 local,
                 localPush,
                 remote,

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/resources/TaskExecutionLockRegistry.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/resources/TaskExecutionLockRegistry.java
@@ -38,7 +38,7 @@ public class TaskExecutionLockRegistry extends AbstractResourceLockRegistry<Path
         return getOrRegisterResourceLock(projectIdentityPath, new ResourceLockProducer<Path, TaskExecutionLock>() {
             @Override
             public TaskExecutionLock create(Path key, ResourceLockCoordinationService coordinationService, ResourceLockContainer owner) {
-                return new TaskExecutionLock("task execution for " + projectIdentityPath.getPath(), projectLockRegistry.getProjectLock(buildIdentityPath, projectIdentityPath1), coordinationService, owner);
+                return new TaskExecutionLock("task execution for " + projectIdentityPath.asString(), projectLockRegistry.getProjectLock(buildIdentityPath, projectIdentityPath1), coordinationService, owner);
             }
         });
     }
@@ -47,7 +47,7 @@ public class TaskExecutionLockRegistry extends AbstractResourceLockRegistry<Path
         return getOrRegisterResourceLock(buildIdentityPath, new ResourceLockProducer<Path, TaskExecutionLock>() {
             @Override
             public TaskExecutionLock create(Path projectPath, ResourceLockCoordinationService coordinationService, ResourceLockContainer owner) {
-                return new TaskExecutionLock("task execution for build " + buildIdentityPath.getPath(), projectLockRegistry.getProjectLock(buildIdentityPath, projectIdentityPath), coordinationService, owner);
+                return new TaskExecutionLock("task execution for build " + buildIdentityPath.asString(), projectLockRegistry.getProjectLock(buildIdentityPath, projectIdentityPath), coordinationService, owner);
             }
         });
     }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/Path.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/Path.java
@@ -84,7 +84,7 @@ public class Path implements Comparable<Path> {
 
     @Override
     public String toString() {
-        return getPath();
+       return asString();
     }
 
     /**
@@ -118,7 +118,12 @@ public class Path implements Comparable<Path> {
         return new Path(concat, absolute);
     }
 
+    @Deprecated
     public String getPath() {
+        return asString();
+    }
+
+    public String asString() {
         if (fullPath == null) {
             fullPath = createFullPath();
         }
@@ -243,7 +248,7 @@ public class Path implements Comparable<Path> {
      * Resolves the given name relative to this path. If an absolute path is provided, it is returned.
      */
     public String absolutePath(String path) {
-        return absolutePath(path(path)).getPath();
+        return absolutePath(path(path)).asString();
     }
 
     public Path absolutePath(Path path) {
@@ -262,7 +267,7 @@ public class Path implements Comparable<Path> {
      * Calculates a path relative to this path. If the given path is not a child of this path, it is returned unmodified.
      */
     public String relativePath(String path) {
-        return relativePath(path(path)).getPath();
+        return relativePath(path(path)).asString();
     }
 
     public Path relativePath(Path path) {
@@ -293,7 +298,7 @@ public class Path implements Comparable<Path> {
         } else if (n == segments.length && absolute) {
             return ROOT;
         } else if (n < 0 || n >= segments.length) {
-            throw new IllegalArgumentException("Cannot remove " + n + " segments from path " + getPath());
+            throw new IllegalArgumentException("Cannot remove " + n + " segments from path " + asString());
         }
 
         return new Path(Arrays.copyOfRange(segments, n, segments.length), absolute);
@@ -301,7 +306,7 @@ public class Path implements Comparable<Path> {
 
     public String segment(int index) {
         if (index < 0 || index >= segments.length) {
-            throw new IllegalArgumentException("Segment index " + index + " is invalid for path " + getPath());
+            throw new IllegalArgumentException("Segment index " + index + " is invalid for path " + asString());
         }
 
         return segments[index];

--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/util/PathTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/util/PathTest.groovy
@@ -27,14 +27,14 @@ import static org.gradle.util.Path.path
 class PathTest extends Specification {
     def "construction from string"() {
         expect:
-        path(':').getPath() == ':'
+        path(':').asString() == ':'
         path(':').is(Path.ROOT)
-        Path.ROOT.getPath() == ':'
-        path('a').getPath() == 'a'
-        path('a:b:c').getPath() == 'a:b:c'
-        path(':a').getPath() == ':a'
-        path(':a:b').getPath() == ':a:b'
-        path(':a:b:').getPath() == ':a:b'
+        Path.ROOT.asString() == ':'
+        path('a').asString() == 'a'
+        path('a:b:c').asString() == 'a:b:c'
+        path(':a').asString() == ':a'
+        path(':a:b').asString() == ':a:b'
+        path(':a:b:').asString() == ':a:b'
     }
 
     def "equals and hashCode"() {

--- a/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
+++ b/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
@@ -97,17 +97,17 @@ public class ProfileEventAdapter implements ProfileService, InternalBuildListene
     @Override
     public void beforeExecute(TaskIdentity<?> taskIdentity) {
         long now = clock.getCurrentTime();
-        String projectPath = taskIdentity.getProjectIdentity().getProjectPath().getPath();
+        String projectPath = taskIdentity.getProjectIdentity().getProjectPath().asString();
         ProjectProfile projectProfile = buildProfile.getProjectProfile(projectPath);
-        projectProfile.getTaskProfile(taskIdentity.getPath().getPath()).setStart(now);
+        projectProfile.getTaskProfile(taskIdentity.getPath().asString()).setStart(now);
     }
 
     @Override
     public void afterExecute(TaskIdentity<?> taskIdentity, TaskState state) {
         long now = clock.getCurrentTime();
-        String projectPath = taskIdentity.getProjectIdentity().getProjectPath().getPath();
+        String projectPath = taskIdentity.getProjectIdentity().getProjectPath().asString();
         ProjectProfile projectProfile = buildProfile.getProjectProfile(projectPath);
-        TaskExecution taskExecution = projectProfile.getTaskProfile(taskIdentity.getPath().getPath());
+        TaskExecution taskExecution = projectProfile.getTaskProfile(taskIdentity.getPath().asString());
         taskExecution.setFinish(now);
         taskExecution.completed(state);
     }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/exceptions/ExceptionMetadataHelper.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/exceptions/ExceptionMetadataHelper.java
@@ -44,7 +44,7 @@ public final class ExceptionMetadataHelper {
 
         if (t instanceof TaskExecutionException) {
             TaskExecutionException taskExecutionException = (TaskExecutionException) t;
-            String taskPath = ((TaskInternal) taskExecutionException.getTask()).getIdentityPath().getPath();
+            String taskPath = ((TaskInternal) taskExecutionException.getTask()).getIdentityPath().asString();
             metadata.put(METADATA_KEY_TASK_PATH, taskPath);
         }
 

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
@@ -109,11 +109,11 @@ public class GradleBuildBuilder implements BuildScopeModelBuilder {
     }
 
     private BasicGradleProject convert(BuildState owner, ProjectState project, Map<ProjectState, BasicGradleProject> convertedProjects) {
-        DefaultProjectIdentifier id = new DefaultProjectIdentifier(owner.getBuildRootDir(), project.getProjectPath().getPath());
+        DefaultProjectIdentifier id = new DefaultProjectIdentifier(owner.getBuildRootDir(), project.getProjectPath().asString());
         BasicGradleProject converted = new BasicGradleProject()
             .setName(project.getName())
             .setProjectIdentifier(id)
-            .setBuildTreePath(project.getIdentityPath().getPath())
+            .setBuildTreePath(project.getIdentityPath().asString())
             .setProjectDirectory(project.getProjectDir());
         if (project.getBuildParent() != null) {
             converted.setParent(convertedProjects.get(project.getBuildParent()));

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilder.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilder.java
@@ -62,7 +62,7 @@ public class GradleProjectBuilder implements GradleProjectBuilderInternal {
             .collect(toList());
 
         ProjectInternal projectInternal = (ProjectInternal) project;
-        String projectIdentityPath = projectInternal.getIdentityPath().getPath();
+        String projectIdentityPath = projectInternal.getIdentityPath().asString();
         DefaultGradleProject gradleProject = new DefaultGradleProject()
             .setProjectIdentifier(new DefaultProjectIdentifier(project.getRootDir(), project.getPath()))
             .setName(project.getName())

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/IsolatedGradleProjectInternalBuilder.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/IsolatedGradleProjectInternalBuilder.java
@@ -90,7 +90,7 @@ public class IsolatedGradleProjectInternalBuilder implements ParameterizedToolin
     }
 
     private static String getBuildTreePath(Task task) {
-        return ((TaskInternal) task).getIdentityPath().getPath();
+        return ((TaskInternal) task).getIdentityPath().asString();
     }
 
 }

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/IsolatedProjectsSafeGradleProjectBuilder.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/IsolatedProjectsSafeGradleProjectBuilder.java
@@ -111,7 +111,7 @@ public class IsolatedProjectsSafeGradleProjectBuilder implements GradleProjectBu
             .setDescription(isolatedModel.getDescription())
             .setBuildDirectory(isolatedModel.getBuildDirectory())
             .setProjectDirectory(isolatedModel.getProjectDirectory())
-            .setBuildTreePath(project.getIdentityPath().getPath());
+            .setBuildTreePath(project.getIdentityPath().asString());
 
         model.getBuildScript().setSourceFile(isolatedModel.getBuildScript().getSourceFile());
 

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelBuilderSupport.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelBuilderSupport.java
@@ -30,7 +30,7 @@ public abstract class ToolingModelBuilderSupport {
                 .setDescription(task.getDescription())
                 .setPublic(PublicTaskSpecification.INSTANCE.isSatisfiedBy(task))
                 .setProjectIdentifier(projectIdentifier)
-                .setBuildTreePath(((TaskInternal) task).getIdentityPath().getPath());
+                .setBuildTreePath(((TaskInternal) task).getIdentityPath().asString());
         return target;
     }
 }

--- a/platforms/ide/problems/src/main/java/org/gradle/problems/internal/services/ProblemsBuildTreeServices.java
+++ b/platforms/ide/problems/src/main/java/org/gradle/problems/internal/services/ProblemsBuildTreeServices.java
@@ -99,7 +99,7 @@ public class ProblemsBuildTreeServices implements ServiceRegistrationProvider {
                 } else {
                     return workExecutionTracker
                         .getCurrentTask(id)
-                        .map(task -> new TaskIdentity(task.getTaskIdentity().getPath().getPath()))
+                        .map(task -> new TaskIdentity(task.getTaskIdentity().getPath().asString()))
                         .orElse(null);
                 }
             }

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TaskForTestEventTracker.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TaskForTestEventTracker.java
@@ -49,7 +49,7 @@ class TaskForTestEventTracker implements BuildOperationTracker {
         Object details = buildOperation.getDetails();
         if (details instanceof ExecuteTaskBuildOperationDetails) {
             TaskInternal task = ((ExecuteTaskBuildOperationDetails) details).getTask();
-            String previous = runningTasks.put(buildOperation.getId(), task.getIdentityPath().getPath());
+            String previous = runningTasks.put(buildOperation.getId(), task.getIdentityPath().asString());
             if (previous != null) {
                 throw new IllegalStateException("Build operation " + buildOperation.getId() + " already started.");
             }

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TaskOperationMapper.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TaskOperationMapper.java
@@ -95,7 +95,7 @@ class TaskOperationMapper implements BuildOperationMapper<ExecuteTaskBuildOperat
         OperationIdentifier id = buildOperation.getId();
         String taskIdentityPath = buildOperation.getName();
         String displayName = buildOperation.getDisplayName();
-        String taskPath = details.getTask().getIdentityPath().getPath();
+        String taskPath = details.getTask().getIdentityPath().asString();
         Set<InternalOperationDescriptor> dependencies = operationDependenciesResolver.resolveDependencies(details.getTaskNode());
         InternalPluginIdentifier originPlugin = taskOriginTracker.getOriginPlugin(details.getTask().getTaskIdentity());
         DefaultTaskDescriptor descriptor = new DefaultTaskDescriptor(id, taskIdentityPath, taskPath, displayName, parent, dependencies, originPlugin);

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompileJavaBuildOperationReportingCompiler.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompileJavaBuildOperationReportingCompiler.java
@@ -48,7 +48,7 @@ public class CompileJavaBuildOperationReportingCompiler implements Compiler<Java
         return buildOperationRunner.call(new CallableBuildOperation<WorkResult>() {
             @Override
             public BuildOperationDescriptor.Builder description() {
-                String taskIdentityPath = task.getIdentityPath().getPath();
+                String taskIdentityPath = task.getIdentityPath().asString();
                 return BuildOperationDescriptor
                     .displayName("Compile Java for " + taskIdentityPath)
                     .details(new CompileJavaBuildOperationType.Details() {

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskSuccessResultPostProcessor.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskSuccessResultPostProcessor.java
@@ -61,7 +61,7 @@ public class JavaCompileTaskSuccessResultPostProcessor implements OperationResul
 
     @Override
     public AbstractTaskResult process(AbstractTaskResult taskResult, TaskInternal taskInternal) {
-        CompileJavaBuildOperationType.Result compileResult = results.remove(taskInternal.getIdentityPath().getPath());
+        CompileJavaBuildOperationType.Result compileResult = results.remove(taskInternal.getIdentityPath().asString());
         if (taskResult instanceof DefaultTaskSuccessResult) {
             if (compileResult != null) {
                 return new DefaultJavaCompileTaskSuccessResult((DefaultTaskSuccessResult) taskResult, toAnnotationProcessorResults(compileResult.getAnnotationProcessorDetails()));

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -671,7 +671,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 String projectPathString = null;
                 if (!domainObjectContext.isScript()) {
                     if (projectId != null) {
-                        projectPathString = projectId.getProjectPath().getPath();
+                        projectPathString = projectId.getProjectPath().asString();
                     }
                 }
                 return BuildOperationDescriptor.displayName(displayName)
@@ -680,7 +680,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                         getName(),
                         domainObjectContext.isScript(),
                         getDescription(),
-                        domainObjectContext.getBuildPath().getPath(),
+                        domainObjectContext.getBuildPath().asString(),
                         projectPathString,
                         visible,
                         isTransitive(),
@@ -1236,7 +1236,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     public ConfigurationIdentity getConfigurationIdentity() {
         String name = getName();
         ProjectIdentity projectId = domainObjectContext.getProjectIdentity();
-        String projectPath = projectId == null ? null : projectId.getProjectPath().getPath();
+        String projectPath = projectId == null ? null : projectId.getProjectPath().asString();
         String buildPath = domainObjectContext.getBuildPath().toString();
         return new DefaultConfigurationIdentity(buildPath, projectPath, name);
     }
@@ -1630,7 +1630,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public String getPath() {
-            return configuration.projectPath.getPath();
+            return configuration.projectPath.asString();
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -39,7 +39,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
 
     @Override
     public String getPath() {
-        return getTargetProjectIdentity().getProjectPath().getPath();
+        return getTargetProjectIdentity().getProjectPath().asString();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -219,7 +219,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
                 return Collections.emptyList();
             }
 
-            String taskPath = owningProject.getBuildTreePath().append(Path.path("dependencyInsight")).getPath();
+            String taskPath = owningProject.getBuildTreePath().append(Path.path("dependencyInsight")).asString();
 
             ModuleIdentifier moduleId = conflict.getModuleId();
             String dependencyNotation = moduleId.getGroup() + ":" + moduleId.getName();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
@@ -63,7 +63,7 @@ public class DefaultLocalComponentRegistry implements LocalComponentRegistry {
             // so we need to investigate why they are failing and then remove this condition.
             // Specifically, the following test breaks when we remove this check:
             // IsolatedProjectsToolingApiIdeaProjectIntegrationTest.ensures unique name for all Idea modules in composite
-            if (projectIdentifier.getBuild().getBuildPath().equals(currentBuildPath.getPath())) {
+            if (projectIdentifier.getBuild().getBuildPath().equals(currentBuildPath.asString())) {
                 projectComponentObservationListener.projectObserved(currentProjectPath, targetProjectPath);
             }
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/PathSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/PathSerializer.java
@@ -45,7 +45,7 @@ public class PathSerializer extends AbstractSerializer<Path> {
         encoder.writeBoolean(isRoot);
 
         if (!isRoot) {
-            encoder.writeString(value.getPath());
+            encoder.writeString(value.asString());
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
@@ -100,8 +100,8 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
 
     private PlannedTransformStepIdentity createIdentity() {
         ProjectIdentity projectId = transformStep.getOwningProject().getProjectIdentity();
-        String consumerBuildPath = projectId.getBuildPath().getPath();
-        String consumerProjectPath = projectId.getProjectPath().getPath();
+        String consumerBuildPath = projectId.getBuildPath().asString();
+        String consumerProjectPath = projectId.getProjectPath().asString();
         ComponentIdentifier componentId = ComponentToOperationConverter.convertComponentIdentifier(targetComponentVariant.getComponentId());
         Map<String, String> sourceAttributes = AttributesToMapConverter.convertToMap(this.sourceAttributes);
         Map<String, String> targetAttributes = AttributesToMapConverter.convertToMap(targetComponentVariant.getAttributes());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
@@ -74,7 +74,7 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
 
     @Override
     public String getBuildPath() {
-        return projectIdentity.getBuildPath().getPath();
+        return projectIdentity.getBuildPath().asString();
     }
 
     @Override
@@ -84,7 +84,7 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
 
     @Override
     public String getProjectPath() {
-        return projectIdentity.getProjectPath().getPath();
+        return projectIdentity.getProjectPath().asString();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/describer/ConfigurationDoesNotExistFailureDescriber.java
@@ -36,7 +36,7 @@ public abstract class ConfigurationDoesNotExistFailureDescriber extends Abstract
         if (isLocalComponent) {
             ProjectComponentIdentifierInternal id = (ProjectComponentIdentifierInternal) failure.getTargetComponent();
             Path outgoingVariantsPath = id.getIdentityPath().append(Path.path("outgoingVariants"));
-            resolutions.add("To determine which configurations are available in the target " + failure.getTargetComponent().getDisplayName() + ", run " + outgoingVariantsPath.getPath() + ".");
+            resolutions.add("To determine which configurations are available in the target " + failure.getTargetComponent().getDisplayName() + ", run " + outgoingVariantsPath.asString() + ".");
         }
 
         resolutions.addAll(buildResolutions(suggestReviewAlgorithm()));

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
@@ -60,7 +60,7 @@ class ProjectDependencyFactoryTest extends Specification {
         def projectDependency = factory.createFromMap(projectFinder, mapNotation);
 
         then:
-        projectDependency.path == projectState.identity.projectPath.path
+        projectDependency.path == projectState.identity.projectPath.asString()
         projectDependency.targetConfiguration == "compile"
         projectDependency.isTransitive() == expectedTransitive
     }
@@ -76,6 +76,6 @@ class ProjectDependencyFactoryTest extends Specification {
 
     def "can create project dependency from path"() {
         expect:
-        depFactory.create(Path.path(":foo:bar")).path == projectState.identity.projectPath.path
+        depFactory.create(Path.path(":foo:bar")).path == projectState.identity.projectPath.asString()
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/AcyclicIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/AcyclicIncludedBuildRegistry.java
@@ -61,7 +61,7 @@ public class AcyclicIncludedBuildRegistry extends DefaultIncludedBuildRegistry {
     }
 
     private static void reportCycle(DynamicGraphCycleDetector.Cycle<BuildState> cycle) {
-        String path = cycle.format(buildState -> buildState.getIdentityPath().getPath());
+        String path = cycle.format(buildState -> buildState.getIdentityPath().asString());
         throw new GradleException(String.format("A cycle has been detected in the definition of plugin builds: %s. This is not supported with Isolated Projects. Please update your build definition to remove one of the edges.", path));
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -135,7 +135,7 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
                     .details(new RunNestedBuildBuildOperationType.Details() {
                         @Override
                         public String getBuildPath() {
-                            return gradle.getIdentityPath().getPath();
+                            return gradle.getIdentityPath().asString();
                         }
                     });
             }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/project/ProjectIdentity.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/project/ProjectIdentity.java
@@ -123,7 +123,7 @@ public final class ProjectIdentity implements DisplayName {
         // TODO: This is inconsistent with DefaultProject.getDisplayName.
         // We should change this to match that of DefaultProject.
         String prefix = Path.ROOT.equals(buildTreePath) ? "root project" : "project";
-        this.displayName = Describables.memoize(Describables.of(prefix, buildTreePath.getPath()));
+        this.displayName = Describables.memoize(Describables.of(prefix, buildTreePath.asString()));
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -474,7 +474,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     @Internal
     @Override
     public String getPath() {
-        return identity.getPath().getPath();
+        return identity.getPath().asString();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifier.java
@@ -49,12 +49,12 @@ public class DefaultProjectComponentIdentifier implements ProjectComponentIdenti
 
     @Override
     public String getProjectPath() {
-        return projectIdentity.getProjectPath().getPath();
+        return projectIdentity.getProjectPath().asString();
     }
 
     @Override
     public String getBuildTreePath() {
-        return projectIdentity.getBuildTreePath().getPath();
+        return projectIdentity.getBuildTreePath().asString();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -621,7 +621,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public String getBuildTreePath() {
-        return getIdentityPath().getPath();
+        return getIdentityPath().asString();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectRegistry.java
@@ -81,7 +81,7 @@ public class DefaultProjectRegistry<T extends ProjectIdentifier> implements Proj
 
     @Override
     public T getRootProject() {
-        return getProject(Path.ROOT.getPath());
+        return getProject(Path.ROOT.asString());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -158,7 +158,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         synchronized (lock) {
             ProjectStateImpl projectState = projectsByPath.get(identityPath);
             if (projectState == null) {
-                throw new IllegalArgumentException(identityPath.getPath() + " not found.");
+                throw new IllegalArgumentException(identityPath.asString() + " not found.");
             }
             return projectState;
         }
@@ -284,7 +284,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
             if (identityPath.equals(Path.ROOT)) {
                 return Describables.withTypeAndName("root project", identity.getProjectName());
             } else {
-                return Describables.withTypeAndName("project", identityPath.getPath());
+                return Describables.withTypeAndName("project", identityPath.asString());
             }
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -54,7 +54,7 @@ public class TaskFactory implements ITaskFactory {
         if (!Task.class.isAssignableFrom(identity.getTaskType())) {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task '%s' of type '%s' as it does not implement the Task interface.",
-                identity.getBuildTreePath().getPath(),
+                identity.getBuildTreePath().asString(),
                 identity.getTaskType().getSimpleName()));
         }
 
@@ -68,16 +68,16 @@ public class TaskFactory implements ITaskFactory {
         } else if (identity.getTaskType() == org.gradle.api.internal.AbstractTask.class || identity.getTaskType() == TaskInternal.class) {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task '%s' of type '%s' as this type is not supported for task registration.",
-                identity.getBuildTreePath().getPath(),
+                identity.getBuildTreePath().asString(),
                 identity.getTaskType().getSimpleName()));
         } else {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task '%s' of type '%s' as directly extending AbstractTask is not supported.",
-                identity.getBuildTreePath().getPath(),
+                identity.getBuildTreePath().asString(),
                 identity.getTaskType().getSimpleName()));
         }
 
-        Describable displayName = Describables.withTypeAndName("task", identity.getBuildTreePath().getPath());
+        Describable displayName = Describables.withTypeAndName("task", identity.getBuildTreePath().asString());
 
         return org.gradle.api.internal.AbstractTask.injectIntoNewInstance(project, identity, new Callable<S>() {
             @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskIdentity.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskIdentity.java
@@ -147,7 +147,7 @@ public final class TaskIdentity<T extends Task> {
      */
     @Deprecated
     public String getTaskPath() {
-        return getPath().getPath();
+        return getPath().asString();
     }
 
     /**
@@ -155,7 +155,7 @@ public final class TaskIdentity<T extends Task> {
      */
     @Deprecated
     public String getProjectPath() {
-        return getProjectIdentity().getProjectPath().getPath();
+        return getProjectIdentity().getProjectPath().asString();
     }
 
     /**
@@ -165,14 +165,14 @@ public final class TaskIdentity<T extends Task> {
      */
     @Deprecated
     public String getIdentityPath() {
-        return getBuildTreePath().getPath();
+        return getBuildTreePath().asString();
     }
     /**
      * @deprecated Use {@link #getProjectIdentity()} instead.
      */
     @Deprecated
     public String getBuildPath() {
-        return getProjectIdentity().getBuildPath().getPath();
+        return getProjectIdentity().getBuildPath().asString();
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -730,12 +730,12 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     private static BuildOperationDescriptor.Builder realizeDescriptor(TaskIdentity<?> identity, boolean replacement, boolean eager) {
-        return BuildOperationDescriptor.displayName("Realize task " + identity.getBuildTreePath().getPath())
+        return BuildOperationDescriptor.displayName("Realize task " + identity.getBuildTreePath().asString())
             .details(new RealizeDetails(identity, replacement, eager));
     }
 
     private static BuildOperationDescriptor.Builder registerDescriptor(TaskIdentity<?> identity) {
-        return BuildOperationDescriptor.displayName("Register task " + identity.getBuildTreePath().getPath())
+        return BuildOperationDescriptor.displayName("Register task " + identity.getBuildTreePath().asString())
             .details(new RegisterDetails(identity));
     }
 
@@ -807,12 +807,12 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
         @Override
         public String getBuildPath() {
-            return identity.getProjectIdentity().getBuildPath().getPath();
+            return identity.getProjectIdentity().getBuildPath().asString();
         }
 
         @Override
         public String getTaskPath() {
-            return identity.getPath().getPath();
+            return identity.getPath().asString();
         }
 
         @Override
@@ -842,12 +842,12 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
         @Override
         public String getBuildPath() {
-            return identity.getProjectIdentity().getBuildPath().getPath();
+            return identity.getProjectIdentity().getBuildPath().asString();
         }
 
         @Override
         public String getTaskPath() {
-            return identity.getPath().getPath();
+            return identity.getPath().asString();
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationDetails.java
@@ -44,12 +44,12 @@ public class ExecuteTaskBuildOperationDetails implements ExecuteTaskBuildOperati
 
     @Override
     public String getBuildPath() {
-        return taskIdentity().getProjectIdentity().getBuildPath().getPath();
+        return taskIdentity().getProjectIdentity().getBuildPath().asString();
     }
 
     @Override
     public String getTaskPath() {
-        return taskIdentity().getPath().getPath();
+        return taskIdentity().getPath().asString();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ProblemsTaskPathTrackingTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ProblemsTaskPathTrackingTaskExecuter.java
@@ -37,7 +37,7 @@ public class ProblemsTaskPathTrackingTaskExecuter implements TaskExecuter {
     @Override
     public TaskExecuterResult execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
         try {
-            ProblemTaskIdentityTracker.setTaskIdentity(new TaskIdentity(task.getTaskIdentity().getPath().getPath()));
+            ProblemTaskIdentityTracker.setTaskIdentity(new TaskIdentity(task.getTaskIdentity().getPath().asString()));
             return taskExecuter.execute(task, state, context);
         } finally {
             ProblemTaskIdentityTracker.clear();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -238,7 +238,7 @@ public class TaskExecution implements MutableUnitOfWork {
             @Override
             public BuildOperationDescriptor.Builder description() {
                 return BuildOperationDescriptor
-                    .displayName(actionDisplayName + " for " + task.getIdentityPath().getPath())
+                    .displayName(actionDisplayName + " for " + task.getIdentityPath().asString())
                     .name(actionDisplayName)
                     .details(ExecuteTaskActionBuildOperationType.DETAILS_INSTANCE);
             }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/AbstractBuildCacheControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/AbstractBuildCacheControllerFactory.java
@@ -132,7 +132,7 @@ public abstract class AbstractBuildCacheControllerFactory<L extends BuildCacheSe
             @Override
             public BuildOperationDescriptor.Builder description() {
                 return BuildOperationDescriptor.displayName("Finalize build cache configuration")
-                    .details(new DetailsImpl(buildIdentityPath.getPath()));
+                    .details(new DetailsImpl(buildIdentityPath.asString()));
             }
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/DefaultBuildCacheControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/DefaultBuildCacheControllerFactory.java
@@ -95,7 +95,7 @@ public class DefaultBuildCacheControllerFactory extends AbstractBuildCacheContro
         boolean localPush = local != null && local.config.isPush();
         boolean remotePush = remote != null && remote.config.isPush();
         return new BuildCacheServicesConfiguration(
-            buildPath.getPath(),
+            buildPath.asString(),
             local != null ? local.service : null, localPush,
             remote != null ? remote.service : null, remotePush);
     }

--- a/subprojects/core/src/main/java/org/gradle/configuration/ConfigurationTargetIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/ConfigurationTargetIdentifier.java
@@ -81,12 +81,12 @@ public abstract class ConfigurationTargetIdentifier {
             @Nullable
             @Override
             public String getTargetPath() {
-                return project.getProjectPath().getPath();
+                return project.getProjectPath().asString();
             }
 
             @Override
             public String getBuildPath() {
-                return project.getGradle().getIdentityPath().getPath();
+                return project.getGradle().getIdentityPath().asString();
             }
         };
     }
@@ -106,7 +106,7 @@ public abstract class ConfigurationTargetIdentifier {
 
             @Override
             public String getBuildPath() {
-                return settings.getGradle().getIdentityPath().getPath();
+                return settings.getGradle().getIdentityPath().asString();
             }
         };
     }
@@ -126,7 +126,7 @@ public abstract class ConfigurationTargetIdentifier {
 
             @Override
             public String getBuildPath() {
-                return gradle.getIdentityPath().getPath();
+                return gradle.getIdentityPath().asString();
             }
         };
     }

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/LifecycleProjectEvaluator.java
@@ -161,12 +161,12 @@ public class LifecycleProjectEvaluator implements ProjectEvaluator {
 
         @Override
         public String getProjectPath() {
-            return projectPath.getPath();
+            return projectPath.asString();
         }
 
         @Override
         public String getBuildPath() {
-            return buildPath.getPath();
+            return buildPath.asString();
         }
 
         @Override
@@ -218,12 +218,12 @@ public class LifecycleProjectEvaluator implements ProjectEvaluator {
 
         @Override
         public String getProjectPath() {
-            return projectPath.getPath();
+            return projectPath.asString();
         }
 
         @Override
         public String getBuildPath() {
-            return buildPath.getPath();
+            return buildPath.asString();
         }
 
     }
@@ -282,12 +282,12 @@ public class LifecycleProjectEvaluator implements ProjectEvaluator {
 
         @Override
         public String getProjectPath() {
-            return projectPath.getPath();
+            return projectPath.asString();
         }
 
         @Override
         public String getBuildPath() {
-            return buildPath.getPath();
+            return buildPath.asString();
         }
 
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
@@ -77,7 +77,7 @@ public abstract class DefaultTaskSelector implements TaskSelector {
         TaskSelectionResult tasks = taskNameResolver.selectWithName(taskName, targetProject.getMutableModel(), includeSubprojects);
         if (tasks != null) {
             LOGGER.info("Task name matched '{}'", taskName);
-            return new TaskSelection(targetProject.getProjectPath().getPath(), taskName, tasks);
+            return new TaskSelection(targetProject.getProjectPath().asString(), taskName, tasks);
         }
 
         Map<String, TaskSelectionResult> tasksByName = taskNameResolver.selectAll(targetProject.getMutableModel(), includeSubprojects);
@@ -88,13 +88,13 @@ public abstract class DefaultTaskSelector implements TaskSelector {
             throw throwTaskSelectionException(context, targetProject, taskName, includeSubprojects, matcher);
         }
         LOGGER.info("Abbreviated task name '{}' matched '{}'", taskName, actualName);
-        return new TaskSelection(targetProject.getProjectPath().getPath(), taskName, tasksByName.get(actualName));
+        return new TaskSelection(targetProject.getProjectPath().asString(), taskName, tasksByName.get(actualName));
     }
 
     private RuntimeException throwTaskSelectionException(SelectionContext context, ProjectState targetProject, String taskName, boolean includeSubprojects, NameMatcher matcher) {
         String searchContext = getSearchContext(targetProject, includeSubprojects);
 
-        if (context.getOriginalPath().getPath().equals(taskName)) {
+        if (context.getOriginalPath().asString().equals(taskName)) {
             String message = matcher.formatErrorMessage("Task", searchContext);
             throw getProblemsService().getInternalReporter().throwing(new TaskSelectionException(message), matcher.problemId(), spec -> {
                 configureProblem(spec, context);
@@ -111,7 +111,7 @@ public abstract class DefaultTaskSelector implements TaskSelector {
     }
 
     private static ProblemSpec configureProblem(ProblemSpec spec, SelectionContext context) {
-        ((InternalProblemSpec) spec).additionalDataInternal(GeneralDataSpec.class, data -> data.put("requestedPath", Objects.requireNonNull(context.getOriginalPath().getPath())));
+        ((InternalProblemSpec) spec).additionalDataInternal(GeneralDataSpec.class, data -> data.put("requestedPath", Objects.requireNonNull(context.getOriginalPath().asString())));
         spec.severity(Severity.ERROR);
         return spec;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/DryRunBuildExecutionAction.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DryRunBuildExecutionAction.java
@@ -49,7 +49,7 @@ public class DryRunBuildExecutionAction implements BuildWorkExecutor {
         }
         for (Task task : plan.getContents().getTasks()) {
             textOutputFactory.create(DryRunBuildExecutionAction.class)
-                .append(((TaskInternal) task).getIdentityPath().getPath())
+                .append(((TaskInternal) task).getIdentityPath().asString())
                 .append(" ")
                 .style(StyledTextOutput.Style.ProgressStatus)
                 .append("SKIPPED")

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ResolveMutationsNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ResolveMutationsNode.java
@@ -103,7 +103,7 @@ public class ResolveMutationsNode extends Node implements SelfExecutingNode {
             @Override
             public BuildOperationDescriptor.Builder description() {
                 TaskIdentity<?> taskIdentity = node.getTask().getTaskIdentity();
-                return BuildOperationDescriptor.displayName("Resolve mutations for task " + taskIdentity.getBuildTreePath().getPath())
+                return BuildOperationDescriptor.displayName("Resolve mutations for task " + taskIdentity.getBuildTreePath().asString())
                     .details(new ResolveTaskMutationsDetails(taskIdentity));
             }
         });
@@ -118,12 +118,12 @@ public class ResolveMutationsNode extends Node implements SelfExecutingNode {
 
         @Override
         public String getBuildPath() {
-            return taskIdentity.getProjectIdentity().getBuildPath().getPath();
+            return taskIdentity.getProjectIdentity().getBuildPath().asString();
         }
 
         @Override
         public String getTaskPath() {
-            return taskIdentity.getPath().getPath();
+            return taskIdentity.getPath().asString();
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
@@ -65,12 +65,12 @@ public class ToPlannedTaskConverter implements ToPlannedNodeConverter {
 
         @Override
         public String getBuildPath() {
-            return delegate.getProjectIdentity().getBuildPath().getPath();
+            return delegate.getProjectIdentity().getBuildPath().asString();
         }
 
         @Override
         public String getTaskPath() {
-            return delegate.getPath().getPath();
+            return delegate.getPath().asString();
         }
 
         @Override
@@ -97,7 +97,7 @@ public class ToPlannedTaskConverter implements ToPlannedNodeConverter {
 
         @Override
         public String toString() {
-            return "Task " + delegate.getBuildTreePath().getPath();
+            return "Task " + delegate.getBuildTreePath().asString();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
@@ -177,7 +177,7 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
 
         String message = String.format("Cannot locate %s that match '%s' as %s", context.getType(), context.getOriginalPath(), nameMatcher.formatErrorMessage("project", project.getDisplayName()));
         throw problemsService.getInternalReporter().throwing(new ProjectSelectionException(message), nameMatcher.problemId(), spec -> {
-            configureProblem(spec, message, context.getOriginalPath().getPath());
+            configureProblem(spec, message, context.getOriginalPath().asString());
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -422,7 +422,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
 
         @Override
         public String getBuildPath() {
-            return buildPath.getPath();
+            return buildPath.asString();
         }
 
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
@@ -113,7 +113,7 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
                 .details(new Details() {
                     @Override
                     public String getBuildPath() {
-                        return gradle.getIdentityPath().getPath();
+                        return gradle.getIdentityPath().asString();
                     }
                 });
         }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -138,7 +138,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
 
     @Override
     public String getBuildPath() {
-        return getIdentityPath().getPath();
+        return getIdentityPath().asString();
     }
 
     @Override
@@ -151,7 +151,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
         if (isRootBuild()) {
             return description;
         } else {
-            return description + " (" + getIdentityPath().getPath() + ")";
+            return description + " (" + getIdentityPath().asString() + ")";
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistry.java
@@ -347,14 +347,14 @@ public class DefaultToolingModelBuilderRegistry implements ToolingModelBuilderRe
                         progressDisplayName("Building model '" + modelName + "'").details(new QueryToolingModelBuildOperationType.Details() {
                             @Override
                             public String getBuildPath() {
-                                return targetBuild.getIdentityPath().getPath();
+                                return targetBuild.getIdentityPath().asString();
                             }
 
                             @Nullable
                             @Override
                             public String getProjectPath() {
                                 if (targetProject != null) {
-                                    return targetProject.getProjectPath().getPath();
+                                    return targetProject.getProjectPath().asString();
                                 } else {
                                     return null;
                                 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -54,7 +54,7 @@ class DefaultProjectDependencyTest extends Specification {
 
     def "exposes local project path"() {
         expect:
-        projectDependency.path == projectState.identity.projectPath.path
+        projectDependency.path == projectState.identity.projectPath.asString()
     }
 
     void "provides dependency information"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -298,7 +298,7 @@ class DefaultProjectSpec extends Specification {
 
         def projectPath = parent == null ? Path.ROOT : parent.projectPath.child(name)
         def buildPath
-        if (build.identityPath.getPath().isEmpty()) {
+        if (build.identityPath.asString().isEmpty()) {
             // No identity path was configured
             buildPath = Path.ROOT
         } else {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -498,7 +498,7 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
         }
 
         private String path(Task task) {
-            return ((TaskInternal) task).getIdentityPath().getPath();
+            return ((TaskInternal) task).getIdentityPath().asString();
         }
     }
 


### PR DESCRIPTION
Fixes #34534 

### Context
Path.java has a getPath() function, which converts the Path to a String. However, the name is confusing since you are already operating on a Path and end up with `Path.getPath().getPath()` in order to get a Path object and convert it to a String. 

Deprecating `getPath()` in favor of `asString()`. 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
