### PR TITLE
Fix issue with daemon toolchains properties integration test

### DIFF
--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainPropertiesIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainPropertiesIntegrationTest.groovy
@@ -117,13 +117,13 @@ class DaemonToolchainPropertiesIntegrationTest extends AbstractIntegrationSpec i
         captureJavaHome()
 
         expect:
-        executer.withArgument("-Dorg.gradle.java.installations.paths=" + otherJvm.javaHome.absolutePath)
-        executer.withArgument("-Porg.gradle.java.installations.paths=" + Jvm.current().javaHome.absolutePath)
+        executer.withArgument("-Dorg.gradle.java.installations.paths=" + Jvm.current().javaHome.absolutePath)
+        executer.withArgument("-Porg.gradle.java.installations.paths=" + otherJvm.javaHome.absolutePath)
         fails("help")
 
         and:
-        failure.assertHasDescription("The Gradle property 'org.gradle.java.installations.paths' (set to '${otherJvm.javaHome.absolutePath}')" +
-                " has a different value than the project property 'org.gradle.java.installations.paths' (set to '${Jvm.current().javaHome.absolutePath}')." +
+        failure.assertHasDescription("The Gradle property 'org.gradle.java.installations.paths' (set to '${Jvm.current().javaHome.absolutePath}')" +
+                " has a different value than the project property 'org.gradle.java.installations.paths' (set to '${otherJvm.javaHome.absolutePath}')." +
                 " Please set them to the same value or only set the Gradle property.")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -91,6 +91,7 @@ public class StartParameterInternal extends StartParameter {
         p.searchUpwards = searchUpwards;
         p.useEmptySettings = useEmptySettings;
         p.enableProblemReportGeneration = enableProblemReportGeneration;
+        p.daemonJvmCriteriaConfigured = daemonJvmCriteriaConfigured;
         return p;
     }
 


### PR DESCRIPTION
This test checks that we get an error when the property is set to different values using `-D` and `-P`.  Since this check happens on the daemon side, we need to be able to start the daemon to emit the error.  So, one of these values needs to be accepted in order to start the daemon and then emit the error.  It turns out, the `-P` option is effective because of how `StringBuildOption` works.  However, the daemon jvm criteria expects the JDK specified with `-D` so we can't start the daemon.  To fix this, we just swap these values so that the effective paths match the daemon jvm criteria.

This also fixes another issue I noticed around creating start parameters from existing start parameters.  I'm not sure I fully understand why the `prepareNewBuild()` method exists.  This method is protected and I don't think it's used anywhere except with a completely fresh start parameter object (i.e. `newBuild()` or `newInstance()`), so this might not have any meaningful effect, but copying `daemonJvmCriteriaConfigured` here is more "correct".

Fixes https://github.com/gradle/gradle-private/issues/4804

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
