### PR TITLE
Add a task to find next projects to adopt NullAway

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/nullaway/NullawayAttributes.kt
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/nullaway/NullawayAttributes.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.nullaway
+
+import org.gradle.api.NamedDomainObjectProvider
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.AttributeCompatibilityRule
+import org.gradle.api.attributes.CompatibilityCheckDetails
+import org.gradle.api.provider.Provider
+
+enum class NullawayState {
+    ENABLED, DISABLED
+}
+
+object NullawayAttributes {
+    val nullawayAttribute = Attribute.of("org.gradle.gradlebuild.nullaway", NullawayState::class.java)
+
+    fun addToConfiguration(configuration: NamedDomainObjectProvider<Configuration>, value: Provider<NullawayState>) {
+        configuration.configure {
+            attributes {
+                attributeProvider(nullawayAttribute, value)
+            }
+        }
+    }
+}
+
+class NullawayCompatibilityRule : AttributeCompatibilityRule<NullawayState> {
+    override fun execute(details: CompatibilityCheckDetails<NullawayState>) {
+        with(details) {
+            when {
+                // Nullaway-enabled targets must not depend on nullaway-disabled ones.
+                // They can depend on nullaway-undefined, which any external dependency is going to be.
+                producerValue == NullawayState.DISABLED && consumerValue == NullawayState.ENABLED -> incompatible()
+                else -> compatible()
+            }
+        }
+    }
+}

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/nullaway/NullawayStatusService.kt
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/nullaway/NullawayStatusService.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.nullaway
+
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import java.io.Closeable
+import java.util.concurrent.ConcurrentHashMap
+
+internal abstract class NullawayStatusService : BuildService<BuildServiceParameters.None>, Closeable {
+    private val projectsWithNullAwayEnabled = ConcurrentHashMap.newKeySet<String>()
+    private val projectsWithUncheckedDeps = ConcurrentHashMap.newKeySet<String>()
+    private val projectsToEnableNullaway = ConcurrentHashMap.newKeySet<String>()
+
+    private fun ensureProjectNotSeen(projectPath: String) {
+        require(projectPath !in projectsWithNullAwayEnabled)
+        require(projectPath !in projectsWithUncheckedDeps)
+        require(projectPath !in projectsToEnableNullaway)
+    }
+
+    fun addProjectWithNullawayEnabled(projectPath: String) {
+        ensureProjectNotSeen(projectPath)
+
+        projectsWithNullAwayEnabled.add(projectPath)
+    }
+
+    fun addProjectWithUncheckedDeps(projectPath: String) {
+        ensureProjectNotSeen(projectPath)
+
+        projectsWithUncheckedDeps.add(projectPath)
+    }
+
+    fun addProjectToEnableNullawayIn(projectPath: String) {
+        ensureProjectNotSeen(projectPath)
+
+        projectsToEnableNullaway.add(projectPath)
+    }
+
+    private val seenProjectsCount: Int
+        get() = projectsWithNullAwayEnabled.size + projectsWithUncheckedDeps.size + projectsToEnableNullaway.size
+
+    override fun close() {
+        require(seenProjectsCount > 0) {
+            "NullawayStatusService was created but no status tasks have run"
+        }
+
+        printResult {
+            println("Collected status of ${seenProjectsCount} ${projectS(seenProjectsCount)}.")
+
+            val enabledCount = projectsWithNullAwayEnabled.size
+            val toEnableCount = projectsToEnableNullaway.size
+            val uncheckedCount = projectsWithUncheckedDeps.size
+
+            if (enabledCount == seenProjectsCount) {
+                println("All have NullAway enabled.")
+            } else {
+                println("NullAway enabled in ${enabledCount} ${projectS(enabledCount)}.")
+
+                if (projectsToEnableNullaway.isNotEmpty()) {
+                    println("${toEnableCount} ${projectS(toEnableCount)} with checked dependencies are ready to be worked on:")
+                    projectsToEnableNullaway.sorted().forEach {
+                        println("  * $it")
+                    }
+                } else if (projectsWithUncheckedDeps.isNotEmpty()) {
+                    println("Unchecked dependencies of $uncheckedCount ${projectS(uncheckedCount)} need NullAway enabled first (run `./gradlew nullawayStatus` to see those).")
+                } else {
+                    // This should not happen.
+                    error("Invalid projects count: $seenProjectsCount != $enabledCount + $toEnableCount + $uncheckedCount")
+                }
+            }
+        }
+    }
+
+    private fun projectS(num: Int) = if (num == 1) "project" else "projects"
+
+    private inline fun printResult(block: NullawayStatusService.() -> Unit) {
+        val delimiter = "=".repeat(72)
+        println(delimiter)
+        block()
+        println(delimiter)
+    }
+
+    companion object {
+        val SERVICE_NAME = NullawayStatusService::class.qualifiedName!!
+    }
+}

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/nullaway/NullawayStatusTask.kt
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild/nullaway/NullawayStatusTask.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.nullaway
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.ArtifactCollection
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+
+@Suppress("UnstableApiUsage")
+internal abstract class NullawayStatusTask : DefaultTask() {
+    @get:ServiceReference
+    abstract val statusService: Property<NullawayStatusService>
+
+    @get:Input
+    val projectPath = project.buildTreePath
+
+    @get:Input
+    abstract val nullawayEnabled: Property<Boolean>
+
+    // TODO(https://github.com/gradle/gradle/issues/27582): We cannot use a SetProperty<ResolvedArtifactResult> because some projects
+    //  have no task dependencies and thus are non-CC serializable.
+    @get:Input
+    abstract val nullawayAwareDeps: Property<ArtifactCollection>
+
+    init {
+        project.gradle.sharedServices.registerIfAbsent(NullawayStatusService.SERVICE_NAME, NullawayStatusService::class)
+        group = LifecycleBasePlugin.BUILD_GROUP
+        description = "Checks status of NullAway support in this project. Call unqualified to get summary for all projects."
+    }
+
+    @TaskAction
+    fun action() {
+        val nullawayIncompatibleDeps = nullawayAwareDeps.get().filter { it.hasNullAwayDisabled }
+        val service = statusService.get()
+        when {
+            nullawayEnabled.get() -> service.addProjectWithNullawayEnabled(projectPath)
+            nullawayIncompatibleDeps.isEmpty() -> service.addProjectToEnableNullawayIn(projectPath)
+            else -> service.addProjectWithUncheckedDeps(projectPath)
+        }
+    }
+
+    private val ResolvedArtifactResult.hasNullAwayDisabled
+        get() = variant.attributes.getAttribute(NullawayAttributes.nullawayAttribute) == NullawayState.DISABLED
+}


### PR DESCRIPTION
Run `./gradlew nullawayStatus` to get the list of projects having all their dependencies nullaway-checked.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
