### PR TITLE
Fix issue with windows path separators in properties files

### DIFF
--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainPropertiesIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainPropertiesIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.internal.buildconfiguration.fixture.DaemonJvmPropertiesFixture
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
+import org.gradle.util.internal.TextUtil
 
 @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "explicitly requests a daemon")
 class DaemonToolchainPropertiesIntegrationTest extends AbstractIntegrationSpec implements DaemonJvmPropertiesFixture, JavaToolchainFixture, ToolchainPropertiesDeprecationsFixture {
@@ -76,7 +77,7 @@ class DaemonToolchainPropertiesIntegrationTest extends AbstractIntegrationSpec i
         captureJavaHome()
 
         expect:
-        file("gradle.properties") << "org.gradle.java.installations.paths=" + otherJvm.javaHome.absolutePath
+        file("gradle.properties") << "org.gradle.java.installations.paths=" + TextUtil.normaliseFileSeparators(otherJvm.javaHome.absolutePath)
         succeeds("help")
         assertDaemonUsedJvm(otherJvm)
     }
@@ -90,7 +91,7 @@ class DaemonToolchainPropertiesIntegrationTest extends AbstractIntegrationSpec i
 
         expect:
         executer.requireOwnGradleUserHomeDir("so we can set properties in GUH/gradle.properties")
-        file("user-home/gradle.properties") << "org.gradle.java.installations.paths=" + otherJvm.javaHome.absolutePath
+        file("user-home/gradle.properties") << "org.gradle.java.installations.paths=" + TextUtil.normaliseFileSeparators(otherJvm.javaHome.absolutePath)
         succeeds("help")
         assertDaemonUsedJvm(otherJvm)
     }


### PR DESCRIPTION
Fixes this issue: https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_NoDaemon_13_bucket27/102022772

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
