### PR TITLE
Skip dynamic version resolution when incompatible

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -495,6 +495,8 @@ task resolve {
         mavenHttpRepo.module('org', 'foo', '1.1').publish()
         mavenHttpRepo.module('org', 'foo', '2.0').publish()
         def bar10 = mavenHttpRepo.module('org', 'bar', '1.0').dependsOn('org', 'foo', '[1.0,2.0)').publish()
+        def bar11 = mavenHttpRepo.module('org', 'bar', '1.1').dependsOn('org', 'foo', '[1.0,2.0)').publish()
+        def bar15 = mavenHttpRepo.module('org', 'bar', '1.5').dependsOn('org', 'foo', '[1.0,2.0)').publish()
         def bar21 = mavenHttpRepo.module('org', 'bar', '2.1').dependsOn('org', 'foo', '[1.0,2.0)').publish()
 
         lockfileFixture.createLockfile('lockedConf', ['org:bar:2.1', 'org:foo:1.0'], false)
@@ -527,7 +529,6 @@ dependencies {
 """
         when:
         foo10.pom.expectGet()
-        bar21.rootMetaData.expectGet()
         bar21.pom.expectGet()
 
         then:

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractVersionSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/AbstractVersionSelector.java
@@ -58,4 +58,10 @@ abstract class AbstractVersionSelector implements VersionSelector {
     public int hashCode() {
         return selector.hashCode();
     }
+
+    @Override
+    public boolean noCompatibleVersionsWith(VersionSelector rejectionSelector) {
+        // By default, we do not know
+        return false;
+    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/InverseVersionSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/InverseVersionSelector.java
@@ -68,4 +68,9 @@ public class InverseVersionSelector implements VersionSelector {
     public boolean canShortCircuitWhenVersionAlreadyPreselected() {
         return false;
     }
+
+    @Override
+    public boolean noCompatibleVersionsWith(VersionSelector rejectionSelector) {
+        return false;
+    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/UnionVersionSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/UnionVersionSelector.java
@@ -111,6 +111,11 @@ public class UnionVersionSelector implements CompositeVersionSelector {
     }
 
     @Override
+    public boolean noCompatibleVersionsWith(VersionSelector rejectionSelector) {
+        return false;
+    }
+
+    @Override
     public String getSelector() {
         throw new UnsupportedOperationException("Union selectors should only be used internally and don't provide a public string representation");
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
@@ -173,6 +173,17 @@ public class VersionRangeSelector extends AbstractVersionVersionSelector {
         return upperBound == null || isLower(candidate, upperBoundVersion, upperInclusive);
     }
 
+    @Override
+    public boolean noCompatibleVersionsWith(VersionSelector rejectionSelector) {
+        if (rejectionSelector instanceof InverseVersionSelector) {
+            VersionSelector inverseSelector = ((InverseVersionSelector) rejectionSelector).getInverseSelector();
+            if (inverseSelector instanceof ExactVersionSelector) {
+                return !accept(inverseSelector.getSelector());
+            }
+        }
+        return false;
+    }
+
     /**
      * Tells if version1 is lower than version2.
      */

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionSelector.java
@@ -81,4 +81,13 @@ public interface VersionSelector {
      * @return a stringy representation of this selector
      */
     String getSelector();
+
+    /**
+     * Checks if this version selector cannot have versions compatible with the given rejection selector.
+     * {@code false} might mean that version compatibility is not known, or that it is known to be compatible.
+     *
+     * @param rejectionSelector the version selector that is used to reject candidates
+     * @return true if this version selector cannot have compatible versions with the rejection selector, false otherwise
+     */
+    boolean noCompatibleVersionsWith(VersionSelector rejectionSelector);
 }


### PR DESCRIPTION
With this change, Gradle no longer even resolves the versions if it knows already that none can match.

Fixes #33593