### PR TITLE
Remove BuildLayoutConfiguration dependency on StartParameter

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslServices.kt
@@ -18,15 +18,14 @@ package org.gradle.internal.declarativedsl.provider
 
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.model.ObjectFactory
-import org.gradle.initialization.layout.BuildLayoutConfiguration
 import org.gradle.initialization.layout.BuildLayoutFactory
+import org.gradle.internal.declarativedsl.evaluationSchema.InterpretationSchemaBuilder
 import org.gradle.internal.declarativedsl.interpreter.DeclarativeKotlinScriptEvaluator
 import org.gradle.internal.declarativedsl.interpreter.GradleProcessInterpretationSchemaBuilder
 import org.gradle.internal.declarativedsl.interpreter.MemoizedInterpretationSchemaBuilder
 import org.gradle.internal.declarativedsl.interpreter.StoringInterpretationSchemaBuilder
 import org.gradle.internal.declarativedsl.interpreter.defaultDeclarativeScriptEvaluator
 import org.gradle.internal.declarativedsl.interpreter.defaults.DeclarativeModelDefaultsHandler
-import org.gradle.internal.declarativedsl.evaluationSchema.InterpretationSchemaBuilder
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.Provides
 import org.gradle.internal.service.ServiceRegistration
@@ -81,5 +80,5 @@ object BuildServices : ServiceRegistrationProvider {
 
     private
     fun BuildLayoutFactory.settingsDir(gradle: GradleInternal): File =
-        getLayoutFor(BuildLayoutConfiguration(gradle.startParameter)).settingsDir
+        getLayoutFor(gradle.startParameter.toBuildLayoutConfiguration()).settingsDir
 }

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
@@ -57,9 +57,9 @@ class ToolingApiClasspathIntegrationTest extends AbstractIntegrationSpec {
                     // If this suddenly fails without an obvious reason, you likely have added some code
                     // that references types that were previously eliminated from gradle-tooling-api.jar.
                     def jarSize = files.find { it.name ==~ /gradle-tooling-api.*\\.jar/ }.size()
-                    assert jarSize < 3_600_000
+                    assert jarSize < 3_300_000
                     // If this suddenly fails you should adjust both values so the size reduction doesn't accidentally regress again.
-                    assert jarSize > 3_450_000
+                    assert jarSize > 3_200_000
                 }
             }
         """

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal;
 import org.gradle.StartParameter;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption;
+import org.gradle.initialization.layout.BuildLayoutConfiguration;
 import org.gradle.internal.buildoption.Option;
 import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.deprecation.StartParameterDeprecations;
@@ -290,5 +291,9 @@ public class StartParameterInternal extends StartParameter {
 
     public void setDaemonJvmCriteriaConfigured(boolean daemonJvmCriteriaConfigured) {
         this.daemonJvmCriteriaConfigured = daemonJvmCriteriaConfigured;
+    }
+
+    public BuildLayoutConfiguration toBuildLayoutConfiguration() {
+        return new BuildLayoutConfiguration(getCurrentDir(), isSearchUpwards(), isUseEmptySettings());
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -31,7 +31,6 @@ import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.initialization.buildsrc.BuildSrcDetector;
 import org.gradle.initialization.layout.BuildLayout;
-import org.gradle.initialization.layout.BuildLayoutConfiguration;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.deprecation.Documentation;
 import org.gradle.util.Path;
@@ -77,8 +76,8 @@ public class DefaultSettingsLoader implements SettingsLoader {
 
     @Override
     public SettingsState findAndLoadSettings(GradleInternal gradle) {
-        StartParameter startParameter = gradle.getStartParameter();
-        SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
+        StartParameterInternal startParameter = gradle.getStartParameter();
+        SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(startParameter.toBuildLayoutConfiguration());
 
         SettingsState state;
         ProjectSpec spec;
@@ -147,7 +146,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
         StartParameterInternal noSearchParameter = (StartParameterInternal) startParameter.newInstance();
         noSearchParameter.useEmptySettings();
         noSearchParameter.doNotSearchUpwards();
-        BuildLayout layout = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(noSearchParameter));
+        BuildLayout layout = buildLayoutFactory.getLayoutFor(noSearchParameter.toBuildLayoutConfiguration());
         SettingsState state = findSettingsAndLoadIfAppropriate(gradle, noSearchParameter, layout, classLoaderScope);
         return state;
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradlePropertiesHandlingSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradlePropertiesHandlingSettingsLoader.java
@@ -19,7 +19,6 @@ package org.gradle.initialization;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.properties.GradlePropertiesController;
-import org.gradle.initialization.layout.BuildLayoutConfiguration;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 
 public class GradlePropertiesHandlingSettingsLoader implements SettingsLoader {
@@ -35,7 +34,7 @@ public class GradlePropertiesHandlingSettingsLoader implements SettingsLoader {
 
     @Override
     public SettingsState findAndLoadSettings(GradleInternal gradle) {
-        SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(gradle.getStartParameter()));
+        SettingsLocation settingsLocation = buildLayoutFactory.getLayoutFor(gradle.getStartParameter().toBuildLayoutConfiguration());
         BuildIdentifier buildId = gradle.getOwner().getBuildIdentifier();
         gradlePropertiesController.loadGradleProperties(buildId, settingsLocation.getSettingsDir(), true);
         return delegate.findAndLoadSettings(gradle);

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.initialization.layout;
 
-import org.gradle.StartParameter;
-import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.initialization.BuildLayoutParameters;
 
 import java.io.File;
@@ -29,10 +27,10 @@ public class BuildLayoutConfiguration {
     private final boolean searchUpwards;
     private final boolean useEmptySettings;
 
-    public BuildLayoutConfiguration(StartParameter startParameter) {
-        currentDir = startParameter.getCurrentDir();
-        searchUpwards = ((StartParameterInternal)startParameter).isSearchUpwards();
-        useEmptySettings = ((StartParameterInternal)startParameter).isUseEmptySettings();
+    public BuildLayoutConfiguration(File currentDir, boolean searchUpwards, boolean useEmptySettings) {
+        this.currentDir = currentDir;
+        this.searchUpwards = searchUpwards;
+        this.useEmptySettings = useEmptySettings;
     }
 
     public BuildLayoutConfiguration(BuildLayoutParameters parameters) {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildLayoutValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildLayoutValidator.java
@@ -22,7 +22,6 @@ import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.initialization.layout.BuildLayout;
-import org.gradle.initialization.layout.BuildLayoutConfiguration;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.exceptions.FailureResolutionAware;
 import org.gradle.internal.service.scopes.Scope;
@@ -54,7 +53,7 @@ public class BuildLayoutValidator {
     }
 
     public void validate(StartParameterInternal startParameter) {
-        BuildLayout buildLayout = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
+        BuildLayout buildLayout = buildLayoutFactory.getLayoutFor(startParameter.toBuildLayoutConfiguration());
         if (!buildLayout.isBuildDefinitionMissing()) {
             // All good
             return;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -149,7 +149,6 @@ import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.initialization.buildsrc.BuildSrcBuildListenerFactory;
 import org.gradle.initialization.buildsrc.BuildSrcProjectConfigurationAction;
 import org.gradle.initialization.layout.BuildLayout;
-import org.gradle.initialization.layout.BuildLayoutConfiguration;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.initialization.layout.ResolvedBuildLayout;
 import org.gradle.internal.actor.ActorFactory;
@@ -316,7 +315,7 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected BuildLayout createBuildLocations(BuildLayoutFactory buildLayoutFactory, BuildDefinition buildDefinition) {
-        return buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(buildDefinition.getStartParameter()));
+        return buildLayoutFactory.getLayoutFor(buildDefinition.getStartParameter().toBuildLayoutConfiguration());
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreBuildSessionServices.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.service.scopes;
 
 import org.gradle.StartParameter;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.BuildSessionScopeFileTimeStampInspector;
 import org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache;
@@ -40,7 +41,6 @@ import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildRequestMetaData;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.initialization.layout.BuildLayout;
-import org.gradle.initialization.layout.BuildLayoutConfiguration;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.initialization.layout.BuildTreeLocations;
 import org.gradle.initialization.layout.ProjectCacheDir;
@@ -104,7 +104,7 @@ public class CoreBuildSessionServices implements ServiceRegistrationProvider {
 
     @Provides
     BuildTreeLocations createBuildTreeLocations(BuildLayoutFactory buildLayoutFactory, StartParameter startParameter) {
-        BuildLayout rootBuildLayout = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
+        BuildLayout rootBuildLayout = buildLayoutFactory.getLayoutFor(((StartParameterInternal) startParameter).toBuildLayoutConfiguration());
         return new BuildTreeLocations(rootBuildLayout);
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -162,7 +162,7 @@ class BuildLayoutFactoryTest extends Specification {
         currentDir.createFile(settingsFilename)
         def startParameter = new StartParameterInternal()
         startParameter.currentDir = currentDir
-        def config = new BuildLayoutConfiguration(startParameter)
+        def config = startParameter.toBuildLayoutConfiguration()
 
         expect:
         def layout = locator.getLayoutFor(config)


### PR DESCRIPTION
Initially part of
- https://github.com/gradle/gradle/pull/34373

But that got reverted (#34566) due to https://github.com/gradle/gradle-private/issues/4771

---

For platformization purposes, this PR removes the direct dependency of the `BuildLayoutConfiguration` on the `StartParameter` class. It was previously used only in the constructor to extract relevant bits for the layout configuration.

Removing this dependency has a significant effect on the shaded TAPI jar: it's size is reduced from ~3.5Kb to ~3.2Kb. This is because we do tree-shaking when constructing the TAPI jar, and `StartParameter` has brought a lot of dependencies with itself.

The previous attempt to merge this change resulted in the need to revert, because our cross version tests accidentally relied on the classes from the shaded TAPI jar to be present for testing (when testing `current` -> `current`). This resulted in the CI not catching the failure. This was fixed in https://github.com/gradle/gradle/pull/34640