### PR TITLE
Add Best Practice: Using unique output files and directories

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_index.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_index.adoc
@@ -56,6 +56,7 @@ Use this as a quick reference to track newly added recommendations, check adopti
 | <<best_practices_tasks.adoc#avoid_provider_get_outside_task_action,Do not call `get()` on a Provider outside a Task action>> | Task | 9.1.0
 | <<best_practices_tasks.adoc#dont_resolve_configurations_before_task_execution,Don't resolve Configurations before Task Execution>> | Task | 9.1.0
 | <<best_practices_tasks.adoc#avoid_eager_file_collection_apis,Avoid using eager APIs on File Collections>> | Task | 9.1.0
+| <<best_practices_tasks.adoc#use_unique_output_files_and_directories,Use unique output files and directories>> | Task | 9.3.0
 
 | <<best_practices_performance.adoc#use_utf8_encoding,Enable UTF‑8>> | Performance | 9.0.0
 | <<best_practices_performance.adoc#use_build_cache,Use the Build Cache>> | Performance | 9.1.0

--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_tasks.adoc
@@ -304,7 +304,7 @@ However, calling some available methods from this interface—such as `.size()`,
 The same is possible using Kotlin stdlib collection extension methods or Groovy GDK collection extensions.
 Converting a `Configuration` to a `Set<File>` also discards any implicit task dependencies it carries.
 
-You should avoid using these methods when configuring your build. 
+You should avoid using these methods when configuring your build.
 Instead, use the methods defined directly on the Gradle interfaces - this is a necessary _first step_ towards preventing eager resolutions.
 Be sure to use <<lazy_configuration.adoc#working_with_files_in_lazy_properties,lazy types and APIs>> that defer resolution to wire task dependencies and inputs correctly.
 Some methods that cause resolution are not obvious.
@@ -400,7 +400,7 @@ include::sample[dir="snippets/bestPractices/avoidResolvingConfigurationsManually
 include::sample[dir="snippets/bestPractices/avoidResolvingConfigurationsManually-do/groovy/app",files="build.gradle[tags=do-this]"]
 ====
 
-<1> *Add project dependency*: This is the same.
+<1> *Write to a file in the output directory*: This is the same.
 <2> *Declare input files property as ConfigurableFileCollection*: This lazy collection type will track task dependencies.
 <3> *Dependency artifacts are resolved to calculate digest*: The classpath will be resolved at execution time to calculate the digest.
 <4> *Configuration is passed to input property directly*: Using `from` causes the configuration to be lazily wired to the input proeprty.
@@ -409,3 +409,62 @@ The output reveals that the `lib` project is now built when the `:app:goodClassp
 
 === Tags
 `<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:inputs-and-outputs,#inputs-and-outputs>>`, `<<tags_reference.adoc#tag:configurations,#configurations>>`
+
+[[use_unique_output_files_and_directories]]
+== Use unique output files and directories
+
+Using overlapping output files and directories will result in rerun tasks and wasted work.
+
+=== Explanation
+
+Gradle keeps track of all of output files and directories declared by tasks. It uses that information to determine if a given task needs to be rerun. For example, if the contents of the output directory are modified since the last time a given task with that output directory ran, Gradle will know that this task needs to be rerun.
+
+Using unique output files and directories for tasks within a single project and the build as a whole ensures that Gradle does not have to do unnecessary work.
+
+=== Example
+
+==== Don't Do This
+
+====
+include::sample[dir="snippets/bestPractices/uniqueOutputs-avoid/kotlin",files="build.gradle.kts[tags=avoid-this]"]
+include::sample[dir="snippets/bestPractices/uniqueOutputs-avoid/groovy",files="build.gradle[tags=avoid-this]"]
+====
+
+<1> *Write to a file in the output directory*: This task produces a single file in the `outputDirectory` based on the `flavor` input.
+<2> *Read a specific file in the input directory*: This task only needs to read a single `a.txt` file in the input directory.
+<3> *Set output directory*: Sets `outputDirectory` to a subdirectory in `buildDirectory`
+<4> *Set output directory*: Same as above, using the same `shared` directory.
+<5> *Wire taskA to consumer*: Makes sure that `taskA` and produces the output directory before it is used by `consumer`.
+
+Running `consumer` task, then `taskB`, the `consumer` task will be invalidated.
+The next time `consumer` is run it will *not* be `UP-TO-DATE` and will have to run again despite not using the output from `taskB`.
+
+==== Do This Instead
+
+To avoid issues, avoid using shared task output directories and files. Instead, narrow down to only consuming the inputs that the task actually needs.
+
+++++
+<div style="text-align: right;">
+  <a class="download-project-link"
+     data-base-path="https://github.com/gradle/gradle/tree/master/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/"
+     href="https://download-directory.github.io/?url=https://github.com/gradle/gradle/tree/master/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/kotlin">
+    <img src="https://img.shields.io/badge/Download%20Project-GitHub-blue?logo=github&style=flat" alt="Download"/>
+  </a>
+</div>
+++++
+
+====
+include::sample[dir="snippets/bestPractices/uniqueOutputs-do/kotlin",files="build.gradle.kts[tags=do-this]"]
+include::sample[dir="snippets/bestPractices/uniqueOutputs-do/groovy",files="build.gradle[tags=do-this]"]
+====
+
+<1> *Write to a specific output file*: This task produces a single file to a directly specified `outputFile` without registering an entire output directory
+<2> *Read a specific file*: Unlike the previous example the input is a single directly specified `inputFile` file.
+<3> *Set output file*: Sets `outputFile` to a file that is inside a `shared` subdirectory of `buildDirectory`
+<4> *Set output file*: Same as above, using the same `shared` directory.
+<5> *Wire taskA to consumer*: Makes sure that `taskA` produces the output file before it is used by `consumer`.
+
+Running `consumer` task, then `taskB`, the `consumer` task will stay up to date as Gradle knows that it is not using the output from `taskB`.
+
+=== Tags
+`<<tags_reference.adoc#tag:tasks,#tasks>>`, `<<tags_reference.adoc#tag:inputs-and-outputs,#inputs-and-outputs>>`

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/groovy/build.gradle
@@ -1,0 +1,38 @@
+// tag::avoid-this[]
+abstract class GreetingTask extends DefaultTask {
+    @Input
+    abstract Property<String> getType()
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDirectory()
+
+    @TaskAction
+    void run() {
+        outputDirectory.get().file("${type.get()}.txt").asFile << "Hello" // <1>
+    }
+}
+
+abstract class ConsumerTask extends DefaultTask {
+    @InputDirectory
+    abstract DirectoryProperty getInputDirectory()
+    @OutputFile
+    abstract RegularFileProperty getOutputFile()
+
+    @TaskAction
+    void run() {
+        outputFile.get().asFile.write(inputDirectory.get().file("a.txt").asFile.text) // <2>
+    }
+}
+
+def taskA = tasks.register("taskA", GreetingTask) {
+    type = "a"
+    outputDirectory = layout.buildDirectory.dir("shared") // <3>
+}
+tasks.register("taskB", GreetingTask) {
+    type = "b"
+    outputDirectory = layout.buildDirectory.dir("shared") // <4>
+}
+tasks.register("consumer", ConsumerTask) {
+    inputDirectory = taskA.flatMap { it.outputDirectory }  // <5>
+    outputFile = layout.buildDirectory.file("consumerOutput.txt")
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "unique-outputs-avoid"

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/kotlin/build.gradle.kts
@@ -1,0 +1,38 @@
+// tag::avoid-this[]
+abstract class GreetingTask : DefaultTask() {
+    @get:Input
+    abstract val type: Property<String>
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun run() {
+        outputDirectory.get().file("${type.get()}.txt").asFile.writeText("Hello") // <1>
+    }
+}
+
+abstract class ConsumerTask : DefaultTask() {
+    @get:InputDirectory
+    abstract val inputDirectory: DirectoryProperty
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        outputFile.get().asFile.writeText(inputDirectory.get().file("a.txt").asFile.readText()) // <2>
+    }
+}
+
+val taskA = tasks.register<GreetingTask>("taskA") {
+    type = "a"
+    outputDirectory = layout.buildDirectory.dir("shared") // <3>
+}
+tasks.register<GreetingTask>("taskB") {
+    type = "b"
+    outputDirectory = layout.buildDirectory.dir("shared") // <4>
+}
+tasks.register<ConsumerTask>("consumer") {
+    inputDirectory = taskA.flatMap { it.outputDirectory } // <5>
+    outputFile = layout.buildDirectory.file("consumerOutput.txt")
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "unique-outputs-avoid"

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/tests/uniqueOutputs.1.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/tests/uniqueOutputs.1.out
@@ -1,0 +1,5 @@
+> Task :taskA
+> Task :consumer
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/tests/uniqueOutputs.2.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/tests/uniqueOutputs.2.out
@@ -1,0 +1,4 @@
+> Task :taskB
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/tests/uniqueOutputs.3.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/tests/uniqueOutputs.3.out
@@ -1,0 +1,5 @@
+> Task :taskA UP-TO-DATE
+> Task :consumer
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 1 executed, 1 up-to-date

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/tests/uniqueOutputs.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-avoid/tests/uniqueOutputs.sample.conf
@@ -1,0 +1,15 @@
+commands: [{
+    executable: gradle
+    args: consumer
+    expected-output-file: uniqueOutputs.1.out
+},
+{
+    executable: gradle
+    args: taskB
+    expected-output-file: uniqueOutputs.2.out
+},
+{
+    executable: gradle
+    args: consumer
+    expected-output-file: uniqueOutputs.3.out
+}]

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/groovy/build.gradle
@@ -1,0 +1,34 @@
+// tag::do-this[]
+abstract class GreetingTask extends DefaultTask {
+    @OutputFile
+    abstract RegularFileProperty getOutputFile()
+
+    @TaskAction
+    void run() {
+        outputFile.get().asFile << "Hello" // <1>
+    }
+}
+
+abstract class ConsumerTask extends DefaultTask {
+    @InputFile
+    abstract RegularFileProperty getInputFile()
+    @OutputFile
+    abstract RegularFileProperty getOutputFile()
+
+    @TaskAction
+    void run() {
+        outputFile.get().asFile.write(inputFile.get().asFile.text) // <2>
+    }
+}
+
+def taskA = tasks.register("taskA", GreetingTask) {
+    outputFile = layout.buildDirectory.file("shared/a.txt") // <3>
+}
+tasks.register("taskB", GreetingTask) {
+    outputFile = layout.buildDirectory.file("shared/b.txt") // <4>
+}
+tasks.register("consumer", ConsumerTask) {
+    inputFile = taskA.flatMap { it.outputFile }  // <5>
+    outputFile = layout.buildDirectory.file("consumerOutput.txt")
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "unique-outputs-do"

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/kotlin/build.gradle.kts
@@ -1,0 +1,34 @@
+// tag::do-this[]
+abstract class GreetingTask : DefaultTask() {
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        outputFile.get().asFile.writeText("Hello") // <1>
+    }
+}
+
+abstract class ConsumerTask : DefaultTask() {
+    @get:InputFile
+    abstract val inputFile: RegularFileProperty
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        outputFile.get().asFile.writeText(inputFile.get().asFile.readText()) // <2>
+    }
+}
+
+val taskA = tasks.register<GreetingTask>("taskA") {
+    outputFile = layout.buildDirectory.file("shared/a.txt") // <3>
+}
+tasks.register<GreetingTask>("taskB") {
+    outputFile = layout.buildDirectory.file("shared/b.txt") // <4>
+}
+tasks.register<ConsumerTask>("consumer") {
+    inputFile = taskA.flatMap { it.outputFile } // <5>
+    outputFile = layout.buildDirectory.file("consumerOutput.txt")
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "unique-outputs-do"

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/tests/uniqueOutputs.1.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/tests/uniqueOutputs.1.out
@@ -1,0 +1,5 @@
+> Task :taskA
+> Task :consumer
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/tests/uniqueOutputs.2.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/tests/uniqueOutputs.2.out
@@ -1,0 +1,4 @@
+> Task :taskB
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/tests/uniqueOutputs.3.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/tests/uniqueOutputs.3.out
@@ -1,0 +1,5 @@
+> Task :taskA UP-TO-DATE
+> Task :consumer UP-TO-DATE
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 up-to-date

--- a/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/tests/uniqueOutputs.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/uniqueOutputs-do/tests/uniqueOutputs.sample.conf
@@ -1,0 +1,15 @@
+commands: [{
+    executable: gradle
+    args: consumer
+    expected-output-file: uniqueOutputs.1.out
+},
+{
+    executable: gradle
+    args: taskB
+    expected-output-file: uniqueOutputs.2.out
+},
+{
+    executable: gradle
+    args: consumer
+    expected-output-file: uniqueOutputs.3.out
+}]


### PR DESCRIPTION
Docs tested with: `./gradlew serveDocs -PquickDocs`

Tests ran with  `./gradlew :docs:docsTest --tests "*snippet-best-practices-unique-outputs*" -PbuildTimestamp=20250822135335UTC`

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
