### PR TITLE
Ear Plugin: application descriptors for Jakarta EE 12+

### DIFF
--- a/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
+++ b/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
@@ -372,7 +372,9 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
     private DomNode toXmlNode() {
         DomNode root = new DomNode(nodeNameFor("application"));
         Map<String, String> rootAttributes = Cast.uncheckedCast(root.attributes());
-        rootAttributes.put("version", version);
+        if (version != null) {
+            rootAttributes.put("version", version);
+        }
         if (!"1.3".equals(version)) {
             rootAttributes.put("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
         }

--- a/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
+++ b/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
@@ -46,11 +46,15 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
 
     private static final String ACCESS_EXTERNAL_DTD = "http://javax.xml.XMLConstants/property/accessExternalDTD";
     private static final String ALLOW_ANY_EXTERNAL_DTD = "all";
+
+    // Pattern to match plausible Jakarta EE Versions "9", "10", "11" ... "99"
+    private static final Pattern JAKARTA_VERSION_PATTERN = Pattern.compile("9|[1-9][0-9]");
 
     private final XmlTransformer transformer = new XmlTransformer();
     private final PathToFileResolver fileResolver;
@@ -381,7 +385,7 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
             rootAttributes.put("xsi:schemaLocation", "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_" + version + ".xsd");
         } else if ("7".equals(version) || "8".equals(version)) {
             rootAttributes.put("xsi:schemaLocation", "http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_" + version + ".xsd");
-        } else if ("9".equals(version) || "10".equals(version) || "11".equals(version)) {
+        } else if (version != null && JAKARTA_VERSION_PATTERN.matcher(version).matches()) {
             rootAttributes.put("xsi:schemaLocation", "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_" + version + ".xsd");
         }
         if (applicationName != null) {
@@ -437,7 +441,7 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
             return new QName("http://java.sun.com/xml/ns/javaee", name);
         } else if ("7".equals(version) || "8".equals(version)) {
             return new QName("http://xmlns.jcp.org/xml/ns/javaee", name);
-        } else if ("9".equals(version) || "10".equals(version) || "11".equals(version)) {
+        } else if (version != null && JAKARTA_VERSION_PATTERN.matcher(version).matches()) {
             return new QName("https://jakarta.ee/xml/ns/jakartaee", name);
         } else {
             return new QName(name);

--- a/platforms/jvm/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
+++ b/platforms/jvm/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
@@ -124,7 +124,9 @@ class DefaultDeploymentDescriptorTest extends Specification {
                 return attributesPermutations('<?xml version="1.0"?>\n<application ##ATTRIBUTES##/>\n', attributes).collect { String descriptor ->
                     toPlatformLineSeparators(descriptor)
                 }
-            default:
+            case '9':
+            case '10':
+            case '11':
                 def attributes = [
                     'xmlns="https://jakarta.ee/xml/ns/jakartaee"',
                     "xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_${version}.xsd\"",
@@ -132,6 +134,17 @@ class DefaultDeploymentDescriptorTest extends Specification {
                     "version=\"${version}\""
                 ]
                 return attributesPermutations('<?xml version="1.0"?>\n<application ##ATTRIBUTES##/>\n', attributes).collect { String descriptor ->
+                    toPlatformLineSeparators(descriptor)
+                }
+            default:
+                def attributes = [
+                    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+                    "version=\"${version}\""
+                ]
+                // variant asNode results in an extra attribute: xmlns="" while asElement does not
+                def permutations = attributesPermutations('<?xml version="1.0"?>\n<application ##ATTRIBUTES##/>\n', attributes)
+                permutations.addAll(attributesPermutations('<?xml version="1.0"?>\n<application ##ATTRIBUTES##/>\n', attributes + 'xmlns=""'))
+                return permutations.collect { String descriptor ->
                     toPlatformLineSeparators(descriptor)
                 }
         }
@@ -220,6 +233,8 @@ class DefaultDeploymentDescriptorTest extends Specification {
         '10'    | 'asElement'        | { it.asElement() }
         '11'    | 'asNode'           | { it.asNode() }
         '11'    | 'asElement'        | { it.asElement() }
+        'ABC'   | 'asNode'           | { it.asNode() }
+        'ABC'   | 'asElement'        | { it.asElement() }
         acceptableDescriptors = defaultDescriptorForVersion(version)
     }
 

--- a/platforms/jvm/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
+++ b/platforms/jvm/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
@@ -73,6 +73,8 @@ class DefaultDeploymentDescriptorTest extends Specification {
         '9'     | _
         '10'    | _
         '11'    | _
+        null    | _
+        'ABC'   | _
         acceptableDescriptors = defaultDescriptorForVersion(version)
     }
 
@@ -137,10 +139,10 @@ class DefaultDeploymentDescriptorTest extends Specification {
                     toPlatformLineSeparators(descriptor)
                 }
             default:
-                def attributes = [
-                    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
-                    "version=\"${version}\""
-                ]
+                def attributes = ['xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"']
+                if (version != null) {
+                    attributes.add("version=\"${version}\"")
+                }
                 // variant asNode results in an extra attribute: xmlns="" while asElement does not
                 def permutations = attributesPermutations('<?xml version="1.0"?>\n<application ##ATTRIBUTES##/>\n', attributes)
                 permutations.addAll(attributesPermutations('<?xml version="1.0"?>\n<application ##ATTRIBUTES##/>\n', attributes + 'xmlns=""'))
@@ -233,6 +235,8 @@ class DefaultDeploymentDescriptorTest extends Specification {
         '10'    | 'asElement'        | { it.asElement() }
         '11'    | 'asNode'           | { it.asNode() }
         '11'    | 'asElement'        | { it.asElement() }
+        null    | 'asNode'           | { it.asNode() }
+        null    | 'asElement'        | { it.asElement() }
         'ABC'   | 'asNode'           | { it.asNode() }
         'ABC'   | 'asElement'        | { it.asElement() }
         acceptableDescriptors = defaultDescriptorForVersion(version)


### PR DESCRIPTION
It's better to assume the schema for ear application descriptor files doesn't change in upcoming versions than generating a application xml file that most probably isn't correct.
If a compatibility issue raises in a future Jakarta EE Release, the generation for the descriptor could then be fixed in an upcoming Gradle release and could be worked around by using a custom xml descriptor until then.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->
This is a followup to #34342 / #34343

### Context
See comments at https://github.com/gradle/gradle/issues/34342#issuecomment-3103329757
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
