### PR TITLE
Avoid memory leak in `DefaultConfigurationCacheDegradationController`

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
@@ -105,7 +105,7 @@ internal class DefaultConfigurationCacheDegradationController(
         val degradedTaskCount: Int
             get() = taskDegradationReasons.size
 
-        fun degradationReasonForTask(task: Task): List<String>? = taskDegradationReasons[task.identity]
+        fun degradationReasonForTask(taskIdentity: TaskIdentity<*>): List<String>? = taskDegradationReasons[taskIdentity]
 
         fun onDegradedTask(consumer: (TaskIdentity<*>, List<String>) -> Unit) {
             taskDegradationReasons.forEach(consumer)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCacheDegradationController.kt
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl
 import com.google.common.collect.ImmutableMap
 import org.gradle.api.Task
 import org.gradle.api.internal.ConfigurationCacheDegradationController
+import org.gradle.api.internal.project.HoldsProjectState
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Provider
@@ -33,7 +34,7 @@ internal class DefaultConfigurationCacheDegradationController(
     private val configurationTimeBarrier: ConfigurationTimeBarrier,
     private val vcsMappingsStore: VcsMappingsStore,
     private val buildModelParameters: BuildModelParameters
-) : ConfigurationCacheDegradationController {
+) : ConfigurationCacheDegradationController, HoldsProjectState {
 
     private val logger = Logging.getLogger(DefaultConfigurationCacheDegradationController::class.java)
     private val tasksDegradationRequests = ConcurrentHashMap<Task, List<Provider<String>>>()
@@ -48,6 +49,10 @@ internal class DefaultConfigurationCacheDegradationController(
         tasksDegradationRequests.compute(task) { _, reasons ->
             reasons?.plus(reason) ?: listOf(reason)
         }
+    }
+
+    override fun discardAll() {
+        tasksDegradationRequests.clear()
     }
 
     private fun collectDegradationReasons(): DegradationDecision =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -196,10 +196,10 @@ class ConfigurationCacheProblems(
     }
 
     override fun forTask(task: Task): ProblemsListener {
-        val degradationReasons = degradationDecision.degradationReasonForTask(task)
+        val degradationReasons = degradationDecision.degradationReasonForTask(task.identity)
         return if (!degradationReasons.isNullOrEmpty()) {
             onIncompatibleTask(
-                locationForTask((task as TaskInternal).taskIdentity),
+                locationForTask(task.identity),
                 degradationReasons.joinToString()
             )
             ErrorsAreProblemsProblemsListener(ProblemSeverity.SuppressedSilently)
@@ -207,6 +207,10 @@ class ConfigurationCacheProblems(
     }
 
     fun shouldDegradeGracefully(): Boolean = degradationDecision.shouldDegrade
+
+    private
+    val Task.identity: TaskIdentity<*>
+        get() = (this as TaskInternal).taskIdentity
 
     private
     fun onIncompatibleTask(trace: PropertyTrace, reason: String) {


### PR DESCRIPTION
Having a strong references to `Task` in the `DCCDC`s state doesn't allow `Project` instances to be collected

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
