### PR TITLE
Use $Inject_ for generated classes using injectOnly instantiator

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -227,7 +227,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
     ) {
         // TODO - the suffix should be a deterministic function of the known and enabled annotations
         // For now, just assign using a counter
-        String suffix = ClassGeneratorSuffixRegistry.assign("$Inject");
+        String suffix = ClassGeneratorSuffixRegistry.assign("$Inject_");
         return new AsmBackedClassGenerator(false, suffix, allKnownAnnotations, enabledInjectAnnotations, roleHandler, cacheFactory.newClassMap(), factoryId);
     }
 

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorInjectUndecoratedTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorInjectUndecoratedTest.groovy
@@ -55,6 +55,7 @@ class AsmBackedClassGeneratorInjectUndecoratedTest extends AbstractClassGenerato
         bean.a == "a"
 
         bean instanceof GeneratedSubclass
+        bean.class.simpleName.startsWith("AsmBackedClassGeneratorTest\$AbstractBean\$Inject_")
         bean.publicType() == AbstractBean
 
         bean instanceof ModelObject

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ContainerElementServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ContainerElementServiceInjectionIntegrationTest.groovy
@@ -25,6 +25,27 @@ import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.process.ExecOperations
 
 class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
+    def "instantiated Named does not interfere with instantiating other objects"() {
+        when:
+        buildFile """
+            def c = project.container(Named)
+            c.create("foo")
+        """
+        then:
+        succeeds()
+        when:
+        buildFile """
+            abstract class Element implements Named {
+                @Inject
+                Element() { }
+            }
+            def cc = project.objects.domainObjectContainer(Element)
+            cc.create("foo")
+        """
+        then:
+        succeeds()
+    }
+
     // Document current behaviour
     def "container element can receive services through constructor and is not annotated with @Inject"() {
         buildFile  """


### PR DESCRIPTION
There's a subtle way to create a class named Inject that interferes with the Inject annotation

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
