### PR TITLE
Let CC release per-project fingerprint context as soon as possible

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareProjectEvaluator.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareProjectEvaluator.kt
@@ -28,7 +28,7 @@ class ConfigurationCacheAwareProjectEvaluator(
     private val controller: ConfigurationCacheFingerprintController
 ) : ProjectEvaluator {
     override fun evaluate(project: ProjectInternal, state: ProjectStateInternal) {
-        controller.runCollectingFingerprintForProject(project.projectIdentity) {
+        controller.runCollectingFingerprintForProject(project.projectIdentity, keepAlive = false) {
             delegate.evaluate(project, state)
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -539,7 +539,7 @@ class ConfigurationCacheFingerprintWriter(
         return simplifyingVisitor.simplify()
     }
 
-    fun <T> runCollectingFingerprintForProject(project: ProjectIdentity, action: () -> T): T {
+    fun <T> runCollectingFingerprintForProject(project: ProjectIdentity, keepAlive: Boolean, action: () -> T): T {
         val previous = projectForThread.get()
         val projectSink = sinksForProject.computeIfAbsent(project.buildTreePath) {
             ProjectScopedSink(host, project, projectScopedWriter)
@@ -548,6 +548,9 @@ class ConfigurationCacheFingerprintWriter(
         try {
             return action()
         } finally {
+            if (!keepAlive) {
+                sinksForProject.remove(project.buildTreePath)
+            }
             projectForThread.set(previous)
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/models/IntermediateModelController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/models/IntermediateModelController.kt
@@ -66,7 +66,7 @@ class IntermediateModelController(
         return loadOrCreateValue(key) {
             try {
                 val model = if (project != null) {
-                    cacheFingerprintController.runCollectingFingerprintForProject(project, creator)
+                    cacheFingerprintController.runCollectingFingerprintForProject(project, true, creator)
                 } else {
                     creator()
                 }


### PR DESCRIPTION
Except when building models since project model requests can arrive at any point.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
