### PR TITLE
Fix ClassNotFoundException in cross version tests

### DIFF
--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClassLoaderProvider.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClassLoaderProvider.groovy
@@ -106,6 +106,6 @@ class ToolingApiClassLoaderProvider {
 
         def parentClassLoader = new MultiParentClassLoader(toolingApi.classLoader, sharedClassLoader)
 
-        return new VisitableURLClassLoader("test", parentClassLoader, testClassPath.collect { it.toURI().toURL() })
+        return new VisitableURLClassLoader("tapi-test", parentClassLoader, testClassPath.collect { it.toURI().toURL() })
     }
 }


### PR DESCRIPTION
This is an attempt to fix https://github.com/gradle/gradle-private/issues/4814

Looking at the exception, the problem is that when Spock try to build a spec from class X, it calls `Class.getDeclaredMethods()` on class X and all its super classes. The problem is that when class X is loaded, its super class and classes in method signatures may not be resolved yet. In this case, the classes might be loaded by context classloader instead of the classloader we intend to use.

This PR uses `Class.forName(className, true, classLoader)` to load test classes, so that all super classes and classes in method signature could be loaded eagerly with intended classloader (or at least raise exception earlier).