### PR TITLE
Define proper nullability for Factory's generic argument

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractIsolatedMap.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractIsolatedMap.java
@@ -38,6 +38,10 @@ abstract public class AbstractIsolatedMap<T extends Map<Object, Object>> extends
         return new MapValueSnapshot(builder.build());
     }
 
+    // Suppresses IDEA nullability warning.
+    @Override
+    public abstract T create();
+
     @Override
     public T isolate() {
         T map = create();

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedProperties.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedProperties.java
@@ -18,7 +18,6 @@ package org.gradle.internal.snapshot.impl;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.internal.isolation.Isolatable;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Properties;
 
@@ -27,7 +26,6 @@ public class IsolatedProperties extends AbstractIsolatedMap<Properties> {
         super(entries);
     }
 
-    @Nullable
     @Override
     public Properties create() {
         return new Properties();

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
@@ -27,7 +27,6 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 import org.gradle.workers.WorkerExecutor;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 
@@ -60,7 +59,6 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
                     DefaultWorkResult result;
                     try {
                         result = ClassLoaderUtils.executeInClassloader(contextClassLoader, new Factory<DefaultWorkResult>() {
-                            @Nullable
                             @Override
                             public DefaultWorkResult create() {
                                 return workerServer.execute(specFactory.newSimpleSpec(workSpec));

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerExecutionQueueFactory.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/WorkerExecutionQueueFactory.java
@@ -31,19 +31,19 @@ import javax.annotation.concurrent.ThreadSafe;
 public class WorkerExecutionQueueFactory implements Factory<ConditionalExecutionQueue<DefaultWorkResult>>, Stoppable {
     public static final String QUEUE_DISPLAY_NAME = "WorkerExecutor Queue";
     private final ConditionalExecutionQueueFactory conditionalExecutionQueueFactory;
-    private ConditionalExecutionQueue<DefaultWorkResult> queue;
+    private @Nullable ConditionalExecutionQueue<DefaultWorkResult> queue;
 
     public WorkerExecutionQueueFactory(ConditionalExecutionQueueFactory conditionalExecutionQueueFactory) {
         this.conditionalExecutionQueueFactory = conditionalExecutionQueueFactory;
     }
 
-    @Nullable
     @Override
     public synchronized ConditionalExecutionQueue<DefaultWorkResult> create() {
-        if (queue == null) {
-            queue = conditionalExecutionQueueFactory.create(QUEUE_DISPLAY_NAME, DefaultWorkResult.class);
+        ConditionalExecutionQueue<DefaultWorkResult> result = this.queue;
+        if (result == null) {
+            this.queue = result = conditionalExecutionQueueFactory.create(QUEUE_DISPLAY_NAME, DefaultWorkResult.class);
         }
-        return queue;
+        return result;
     }
 
     @Override

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/Factories.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/Factories.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.internal;
 
+import org.jspecify.annotations.Nullable;
+
 import java.lang.ref.SoftReference;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -24,10 +26,10 @@ public final class Factories {
         /* no-op */
     }
 
-    public static <T> Factory<T> toFactory(final Runnable runnable) {
-        return new Factory<T>() {
+    public static <T> Factory<@Nullable T> toFactory(final Runnable runnable) {
+        return new Factory<@Nullable T>() {
             @Override
-            public T create() {
+            public @Nullable T create() {
                 runnable.run();
                 return null;
             }
@@ -47,7 +49,7 @@ public final class Factories {
         return new CachingSoftReferenceFactory<T>(factory);
     }
 
-    private static class CachingSoftReferenceFactory<T> implements Factory<T> {
+    private static class CachingSoftReferenceFactory<T extends @Nullable Object> implements Factory<T> {
         private final Factory<T> factory;
         private final AtomicReference<SoftReference<T>> cachedReference = new AtomicReference<SoftReference<T>>();
 

--- a/platforms/core-runtime/file-temp/src/main/java/org/gradle/api/internal/file/temp/DefaultTemporaryFileProvider.java
+++ b/platforms/core-runtime/file-temp/src/main/java/org/gradle/api/internal/file/temp/DefaultTemporaryFileProvider.java
@@ -53,7 +53,6 @@ public class DefaultTemporaryFileProvider implements TemporaryFileProvider {
     @Override
     public Factory<File> temporaryDirectoryFactory(final String... path) {
         return new Factory<File>() {
-            @Nullable
             @Override
             public File create() {
                 return newTemporaryDirectory(path);

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
@@ -232,8 +232,7 @@ public class DeprecationLogger {
         }
     }
 
-    @Nullable
-    public static <T> T whileDisabled(Factory<T> factory) {
+    public static <T extends @Nullable Object> T whileDisabled(Factory<T> factory) {
         disable();
         try {
             return factory.create();
@@ -297,7 +296,6 @@ public class DeprecationLogger {
      */
     private static <T, E extends Exception> Factory<T> toUncheckedThrowingFactory(final ThrowingFactory<T, E> throwingFactory) {
         return new Factory<T>() {
-            @Nullable
             @Override
             public T create() {
                 @SuppressWarnings("unchecked")

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/Factory.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/Factory.java
@@ -22,11 +22,10 @@ import org.jspecify.annotations.Nullable;
  *
  * @param <T> The type of object created.
  */
-public interface Factory<T> {
+public interface Factory<T extends @Nullable Object> {
     /**
      * Creates a new instance of type T.
      * @return The instance.
      */
-    @Nullable
     T create();
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/TimeTrackingProcessor.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/TimeTrackingProcessor.java
@@ -21,6 +21,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Ticker;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessorResult;
 import org.gradle.internal.Factory;
+import org.jspecify.annotations.Nullable;
 
 import javax.annotation.processing.Completion;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -82,9 +83,9 @@ public class TimeTrackingProcessor extends DelegatingProcessor {
 
     @Override
     public void init(final ProcessingEnvironment processingEnv) {
-        track(new Factory<Void>() {
+        track(new Factory<@Nullable Void>() {
             @Override
-            public Void create() {
+            public @Nullable Void create() {
                 TimeTrackingProcessor.super.init(processingEnv);
                 return null;
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ComponentIdentifierParserFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/ComponentIdentifierParserFactory.java
@@ -26,13 +26,11 @@ import org.gradle.internal.typeconversion.MapNotationConverter;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 import org.gradle.internal.typeconversion.TypedNotationConverter;
-import org.jspecify.annotations.Nullable;
 
 import static org.gradle.api.internal.notations.ModuleNotationValidation.validate;
 
 public class ComponentIdentifierParserFactory implements Factory<NotationParser<Object, ComponentIdentifier>> {
 
-    @Nullable
     @Override
     public NotationParser<Object, ComponentIdentifier> create() {
         return NotationParserBuilder.toType(ComponentIdentifier.class)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -25,7 +25,6 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.VariantIdentifier;
-import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -164,7 +163,6 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
 
     private Factory<List<ModuleDependencyMetadata>> lazyConfigDependencies() {
         return new Factory<List<ModuleDependencyMetadata>>() {
-            @Nullable
             @Override
             public List<ModuleDependencyMetadata> create() {
                 return DefaultConfigurationMetadata.super.getConfigDependencies();


### PR DESCRIPTION
This helps to avoid null checks in places where the producer returns non-null value.

This commit also fixes some of the places that use Factory with improper nullability.

Part of #34769.
