### PR TITLE
Preserve the order of extra JavaDoc options

### DIFF
--- a/platforms/jvm/javadoc/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFile.java
+++ b/platforms/jvm/javadoc/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFile.java
@@ -151,6 +151,12 @@ public class JavadocOptionFile {
     public Map<String, String> stringifyExtraOptionsToMap(Set<String> optionsToExclude) {
         return options.entrySet().stream()
                 .filter(entry -> !optionsToExclude.contains(entry.getKey()))
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> String.valueOf(entry.getValue().getValue())));
+                .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> String.valueOf(entry.getValue().getValue()),
+                    (a, b) -> {
+                        throw new AssertionError();
+                    },
+                    LinkedHashMap::new));
     }
 }

--- a/platforms/jvm/javadoc/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFileWriter.java
+++ b/platforms/jvm/javadoc/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFileWriter.java
@@ -23,8 +23,8 @@ import org.gradle.external.javadoc.JavadocOptionFileOption;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.TreeMap;
 
 public class JavadocOptionFileWriter {
     private final JavadocOptionFile optionFile;
@@ -40,7 +40,7 @@ public class JavadocOptionFileWriter {
         IoActions.writeTextFile(outputFile, new ErroringAction<BufferedWriter>() {
             @Override
             protected void doExecute(BufferedWriter writer) throws Exception {
-                final Map<String, JavadocOptionFileOption<?>> options = new TreeMap<String, JavadocOptionFileOption<?>>(optionFile.getOptions());
+                final Map<String, JavadocOptionFileOption<?>> options = new LinkedHashMap<>(optionFile.getOptions());
                 JavadocOptionFileWriterContext writerContext = new JavadocOptionFileWriterContext(writer);
 
                 JavadocOptionFileOption<?> localeOption = options.remove("locale");

--- a/platforms/jvm/javadoc/src/test/groovy/org/gradle/external/javadoc/StandardJavadocDocletOptionsTest.java
+++ b/platforms/jvm/javadoc/src/test/groovy/org/gradle/external/javadoc/StandardJavadocDocletOptionsTest.java
@@ -464,13 +464,13 @@ public class StandardJavadocDocletOptionsTest {
         TestFile optionsFile = temporaryFolder.file("javadoc.options");
         options.write(optionsFile);
 
+        assertEquals("addMultilineStringsOption:[a, b, c], addStringsOption:[a, b, c], addMultilineMultiValueOption:[[a], [b, c]]", options.getExtraOptions());
+
         optionsFile.assertContents(containsNormalizedString("-addMultilineStringsOption 'a'\n" +
             "-addMultilineStringsOption 'b'\n" +
-            "-addMultilineStringsOption 'c'"));
-
-        optionsFile.assertContents(containsNormalizedString("-addStringsOption 'a b c'"));
-
-        optionsFile.assertContents(containsNormalizedString("-addMultilineMultiValueOption \n" +
+            "-addMultilineStringsOption 'c'\n" +
+            "-addStringsOption 'a b c'\n" +
+            "-addMultilineMultiValueOption \n" +
             "'a' \n" +
             "-addMultilineMultiValueOption \n" +
             "'b' 'c' "));


### PR DESCRIPTION
### Context
Currently the JavaDoc options are sorted by option name.
But this is bad for options where the order matters.
For example if some plugin sets `-Xdoclint:none` on all JavaDoc tasks and a consumer build sets `-Xdoclint:all,-missing`.
The latter one will be sorted above the former one and thus be ignored even if it is set after the former.
Currently, you will have to manually unset the option that was set by the plugin so that your own option wins.

With this change merged, the order of options will be preserved, as a `LinkedHashMap` is used instead of a `TreeMap`.

This also seems to align better with the `JavadocOptionFile` implementation which used `LinkedHashMap`s already,
except when extracting the `stringifyExtraOptionsToMap` where the order was lost again.
The `JavadocOptionFileWriter` did then also loose the ordering that was maintained by `JavadocOptionFile`
by using a `TreeSet`, which is changed now with this PR that makes sure the order is preserved.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- n/a Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
