### PR TITLE
Don't OOM when many unrelated transforms are registered with no solution

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -32,6 +32,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
@@ -177,11 +178,13 @@ public class ConsumerProvidedVariantFinder {
                 // Construct new states for processing at the next depth in case we can't find any solutions at this depth.
                 for (int i = 0; i < candidates.size(); i++) {
                     TransformRegistration candidate = candidates.get(i);
-                    nextDepth.add(new ChainState(
-                        new ChainNode(state.chain, candidate),
-                        attributesFactory.concat(state.requested, candidate.getFrom()),
-                        state.transforms.withoutIndexFrom(i, candidates)
-                    ));
+                    if (!Collections.disjoint(state.requested.keySet(), candidate.getTo().keySet())) {
+                        nextDepth.add(new ChainState(
+                            new ChainNode(state.chain, candidate),
+                            attributesFactory.concat(state.requested, candidate.getFrom()),
+                            state.transforms.withoutIndexFrom(i, candidates)
+                        ));
+                    }
                 }
             }
 


### PR DESCRIPTION
The artifact transform traversal algorithm short-circuits when it finds the shortest solution. However, if there is no solution, it will traverse the entire transform graph attempting to find a solution. This can lead to a massive exponential growth in time and memory.

We prune transforms from the search that are not releavent, and will not help produce a solution. This avoids the observed OOM.

Fixes https://github.com/gradle/gradle/issues/33298

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
