### PR TITLE
Revert "Release dependency management caches when releasing project state"

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantArtifactSetCache.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantArtifactSetCache.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.simple.DefaultExcludeFactory;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.VariantGraphResolveState;
@@ -36,16 +35,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * This cache contains ArtifactSets for the entire build tree.
  */
 @ServiceScope(Scope.BuildTree.class)
-public class VariantArtifactSetCache implements HoldsProjectState {
+public class VariantArtifactSetCache {
 
     private static final ExcludeSpec EXCLUDE_NOTHING = new DefaultExcludeFactory().nothing();
 
     private final Map<Long, ArtifactSet> cache = new ConcurrentHashMap<>();
-
-    @Override
-    public void discardAll() {
-        cache.clear();
-    }
 
     /**
      * Caches the implicit artifact set for the given node of the given component.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ThisBuildTreeOnlyComponentResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ThisBuildTreeOnlyComponentResultSerializer.java
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphVariant;
-import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.serialize.Decoder;
@@ -45,7 +44,7 @@ import java.util.List;
  * to adhoc components would prevent them from being garbage collected.
  */
 @ServiceScope(Scope.BuildTree.class)
-public class ThisBuildTreeOnlyComponentResultSerializer implements ComponentResultSerializer, HoldsProjectState {
+public class ThisBuildTreeOnlyComponentResultSerializer implements ComponentResultSerializer {
 
     private final Long2ObjectMap<ComponentGraphResolveState> components = Long2ObjectMaps.synchronize(new Long2ObjectOpenHashMap<>());
     private final Long2ObjectMap<VariantGraphResolveState> variants = Long2ObjectMaps.synchronize(new Long2ObjectOpenHashMap<>());
@@ -56,12 +55,6 @@ public class ThisBuildTreeOnlyComponentResultSerializer implements ComponentResu
         ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory
     ) {
         this.reasonSerializer = new ComponentSelectionReasonSerializer(componentSelectionDescriptorFactory);
-    }
-
-    @Override
-    public void discardAll() {
-        components.clear();
-        variants.clear();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ResolvedVariantCache.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ResolvedVariantCache.java
@@ -18,7 +18,6 @@ package org.gradle.internal.resolve.resolver;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.attributes.immutable.artifact.ImmutableArtifactTypeRegistry;
-import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -34,14 +33,9 @@ import java.util.function.Function;
  * This cache contains ResolvedVariants for the entire build tree.
  */
 @ServiceScope(Scope.BuildTree.class)
-public class ResolvedVariantCache implements HoldsProjectState {
+public class ResolvedVariantCache  {
 
     private final Map<CacheKey, ResolvedVariant> cache = new ConcurrentHashMap<>();
-
-    @Override
-    public void discardAll() {
-        cache.clear();
-    }
 
     /**
      * Get the resolved variant associated with the key, if present.


### PR DESCRIPTION
Reverts gradle/gradle#34775.

Releasing `ThisBuildTreeOnlyComponentResultSerializer` state is not safe due to Develocity asynchronous processing. 