### PR TITLE
Push display name down to roots in generic test report

### DIFF
--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericPageRenderer.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericPageRenderer.java
@@ -86,17 +86,20 @@ final class GenericPageRenderer extends TabbedPageRenderer<TestTreeModel> {
 
     @Override
     protected String getTitle() {
-        // This should maybe be the display name, but we'd need to handle different display names for the same path.
-        String name = getModel().getPath().getName();
-        if (name == null) {
+        // Show "All Results" in the root, otherwise show nothing, the display name will be provided in each root.
+        if (getModel().getPath().getName() == null) {
             return "All Results";
         }
-        return name;
+        return "";
     }
 
     @Override
     protected String getPageTitle() {
-        return "Test results - " + getTitle();
+        String title = getModel().getPath().getName();
+        if (title == null) {
+            title = "All Results";
+        }
+        return "Test results - " + title;
     }
 
     @Override
@@ -126,7 +129,13 @@ final class GenericPageRenderer extends TabbedPageRenderer<TestTreeModel> {
                 tabsRenderer.add("metadata", new PerRootTabRenderer.ForMetadata(rootIndex, metadataRendererRegistry));
             }
 
-            rootTabsRenderer.add(rootDisplayNames.get(rootIndex), tabsRenderer);
+            rootTabsRenderer.add(rootDisplayNames.get(rootIndex), new ReportRenderer<TestTreeModel, SimpleHtmlWriter>() {
+                @Override
+                public void render(TestTreeModel model, SimpleHtmlWriter output) throws IOException {
+                    output.startElement("h1").characters(info.getResult().getDisplayName()).endElement();
+                    tabsRenderer.render(model, output);
+                }
+            });
         });
         return rootTabsRenderer;
     }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericPageRenderer.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericPageRenderer.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.function.Function;
 
 final class GenericPageRenderer extends TabbedPageRenderer<TestTreeModel> {
     private static final URL STYLE_URL = Resources.getResource(GenericPageRenderer.class, "style.css");
@@ -87,19 +88,20 @@ final class GenericPageRenderer extends TabbedPageRenderer<TestTreeModel> {
     @Override
     protected String getTitle() {
         // Show "All Results" in the root, otherwise show nothing, the display name will be provided in each root.
-        if (getModel().getPath().getName() == null) {
-            return "All Results";
-        }
-        return "";
+        return buildTitle("All Results", name -> "");
     }
 
     @Override
     protected String getPageTitle() {
-        String title = getModel().getPath().getName();
-        if (title == null) {
-            title = "All Results";
+        return buildTitle("Test results - All Results", name -> "Test results - " + name);
+    }
+
+    private String buildTitle(String rootTitle, Function<String, String> buildTitleFromName) {
+        String name = getModel().getPath().getName();
+        if (name == null) {
+            return rootTitle;
         }
-        return "Test results - " + title;
+        return buildTitleFromName.apply(name);
     }
 
     @Override


### PR DESCRIPTION
Part of #32317. However, this isn't something that can be done in the current API, because we don't expose group display names. Therefore, this PR has no tests.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
