### PR TITLE
Formally deincubate Kotlin*ScriptTemplate to fix Unstable API warnings in the IDE

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinGradleScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinGradleScriptTemplate.kt
@@ -39,9 +39,10 @@ class KotlinGradleScriptTemplateCompilationConfiguration : KotlinDslStandaloneSc
 /**
  * Base class for Gradle Kotlin DSL standalone [Gradle] scripts IDE support, aka. init scripts.
  *
+ * This class has the [Incubating]-level compatibility guarantees but is not annotated as such to avoid Unstable API warnings in the IDE on indirect usages.
+ *
  * @since 8.1
  */
-@Incubating
 @KotlinScript(
     compilationConfiguration = KotlinGradleScriptTemplateCompilationConfiguration::class
 )

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinGradleScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinGradleScriptTemplate.kt
@@ -39,7 +39,10 @@ class KotlinGradleScriptTemplateCompilationConfiguration : KotlinDslStandaloneSc
 /**
  * Base class for Gradle Kotlin DSL standalone [Gradle] scripts IDE support, aka. init scripts.
  *
- * This class has the [Incubating]-level compatibility guarantees but is not annotated as such to avoid Unstable API warnings in the IDE on indirect usages.
+ * This class has the [Incubating]-level compatibility guarantees but is not annotated as such to avoid Unstable API warnings caused by the IDE
+ * using this class as the Kotlin DSL script template. When the IDE chooses to use this script template, there is no direct usage of an incubating
+ * API by the build author, but usages of the members are still reported as unstable API usages.
+ * See: [issue 34820](https://github.com/gradle/gradle/issues/34820).
  *
  * @since 8.1
  */

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinProjectScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinProjectScriptTemplate.kt
@@ -41,9 +41,10 @@ class KotlinProjectScriptTemplateCompilationConfiguration : KotlinDslStandaloneS
 /**
  * Base class for Gradle Kotlin DSL standalone [Project] scripts IDE support, aka. build scripts.
  *
+ * This class has the [Incubating]-level compatibility guarantees but is not annotated as such to avoid Unstable API warnings in the IDE on indirect usages (e.g., the [plugins] calls).
+ *
  * @since 8.1
  */
-@Incubating
 @KotlinScript(
     compilationConfiguration = KotlinProjectScriptTemplateCompilationConfiguration::class
 )

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinProjectScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinProjectScriptTemplate.kt
@@ -41,7 +41,10 @@ class KotlinProjectScriptTemplateCompilationConfiguration : KotlinDslStandaloneS
 /**
  * Base class for Gradle Kotlin DSL standalone [Project] scripts IDE support, aka. build scripts.
  *
- * This class has the [Incubating]-level compatibility guarantees but is not annotated as such to avoid Unstable API warnings in the IDE on indirect usages (e.g., the [plugins] calls).
+ * This class has the [Incubating]-level compatibility guarantees but is not annotated as such to avoid Unstable API warnings caused by the IDE
+ * using this class as the Kotlin DSL script template. When the IDE chooses to use this script template, there is no direct usage of an incubating
+ * API by the build author, but usages of the members, such as [plugins], are still reported as unstable API usages.
+ * See: [issue 34820](https://github.com/gradle/gradle/issues/34820).
  *
  * @since 8.1
  */

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt
@@ -40,9 +40,10 @@ class KotlinSettingsScriptTemplateCompilationConfiguration : KotlinDslStandalone
 /**
  * Base class for Gradle Kotlin DSL standalone [Settings] scripts IDE support.
  *
+ * This class has the [Incubating]-level compatibility guarantees but is not annotated as such to avoid Unstable API warnings in the IDE on indirect usages (e.g., the [plugins] calls).
+ *
  * @since 8.1
  */
-@Incubating
 @KotlinScript(
     compilationConfiguration = KotlinSettingsScriptTemplateCompilationConfiguration::class
 )

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScriptTemplate.kt
@@ -40,7 +40,10 @@ class KotlinSettingsScriptTemplateCompilationConfiguration : KotlinDslStandalone
 /**
  * Base class for Gradle Kotlin DSL standalone [Settings] scripts IDE support.
  *
- * This class has the [Incubating]-level compatibility guarantees but is not annotated as such to avoid Unstable API warnings in the IDE on indirect usages (e.g., the [plugins] calls).
+ * This class has the [Incubating]-level compatibility guarantees but is not annotated as such to avoid Unstable API warnings caused by the IDE
+ * using this class as the Kotlin DSL script template. When the IDE chooses to use this script template, there is no direct usage of an incubating
+ * API by the build author, but usages of the members, such as [plugins], are still reported as unstable API usages.
+ * See: [issue 34820](https://github.com/gradle/gradle/issues/34820).
  *
  * @since 8.1
  */


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/34820

Tested manually in IntelliJ IDEA 2025.2.1 – using a local Gradle installation with the fix in the IDE fixes the Unstable API warnings.