### PR TITLE
Remove mutable references to other projects in DefaultProject

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -39,7 +39,6 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.CrossProjectModelAccess
 import org.gradle.api.internal.project.DefaultCrossProjectModelAccess
 import org.gradle.api.internal.project.MutableStateAccessAwareProject
-import org.gradle.api.internal.project.ProjectIdentifier
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectOrderingUtil
@@ -436,10 +435,6 @@ class ProblemReportingCrossProjectModelAccess(
         }
 
         override fun getConfigurationTargetIdentifier(): ConfigurationTargetIdentifier {
-            shouldNotBeUsed()
-        }
-
-        override fun getParentIdentifier(): ProjectIdentifier {
             shouldNotBeUsed()
         }
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -27,6 +27,7 @@ import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.api.internal.initialization.StandaloneDomainObjectContext
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectOrderingUtil
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
@@ -352,8 +353,15 @@ fun textResourceScriptSource(description: String, scriptFile: File, resourceLoad
 
 
 private
-fun sourceLookupScriptHandlersFor(project: Project) =
-    project.hierarchy.map { it.buildscript }.toList()
+fun sourceLookupScriptHandlersFor(project: ProjectInternal) =
+     buildList {
+         var current: ProjectState? = project.owner
+         while (current != null) {
+             add(current.mutableModelEvenAfterFailure.buildscript)
+             current = current.parent
+         }
+     }
+
 
 
 private
@@ -471,18 +479,6 @@ inline fun KotlinScriptClassPathProvider.safeCompilationClassPathOf(
 internal
 val Project.scriptImplicitImports
     get() = serviceOf<ImplicitImports>().list
-
-
-private
-val Project.hierarchy: Sequence<Project>
-    get() = sequence {
-        var project = this@hierarchy
-        yield(project)
-        while (project != project.rootProject) {
-            project = project.parent!!
-            yield(project)
-        }
-    }
 
 
 internal

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
@@ -91,7 +91,7 @@ abstract class AbstractKotlinDslScriptsModelBuilder : ToolingModelBuilder {
 
     private
     fun requireRootProject(project: Project) =
-        require(project == project.rootProject) {
+        require(project.parent == null) {
             "$MODEL_NAME can only be requested on the root project, got $project"
         }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.api.internal.project;
 
 import groovy.lang.Closure;
@@ -48,6 +47,7 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.SyncSpec;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DynamicObjectAware;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.ProcessOperations;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
@@ -91,7 +91,6 @@ import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
-import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.internal.buildoption.FeatureFlags;
 import org.gradle.internal.buildoption.InternalOption;
 import org.gradle.internal.buildoption.InternalOptions;
@@ -136,7 +135,6 @@ import org.gradle.util.internal.ClosureBackedAction;
 import org.gradle.util.internal.ConfigureUtil;
 import org.jspecify.annotations.Nullable;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
@@ -150,7 +148,9 @@ import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.inject.Inject;
 
+import org.gradle.internal.build.BuildState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Collections.singletonMap;
 import static org.gradle.util.internal.ConfigureUtil.configureUsing;
@@ -182,20 +182,9 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     private final ClassLoaderScope baseClassLoaderScope;
     private final ServiceRegistry services;
 
-    private final ProjectInternal rootProject;
-
-    private final GradleInternal gradle;
-
     private final ScriptSource buildScriptSource;
 
-    private final File projectDir;
-
     private final File buildFile;
-
-    @Nullable
-    private final ProjectInternal parent;
-
-    private final String name;
 
     @Nullable
     private Object group;
@@ -233,12 +222,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     private Object beforeProjectActionState;
 
     public DefaultProject(
-        String name,
-        @Nullable ProjectInternal parent,
-        File projectDir,
         File buildFile,
         ScriptSource buildScriptSource,
-        GradleInternal gradle,
         ProjectState owner,
         ServiceRegistryFactory serviceRegistryFactory,
         ClassLoaderScope selfClassLoaderScope,
@@ -247,15 +232,9 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         this.owner = owner;
         this.classLoaderScope = selfClassLoaderScope;
         this.baseClassLoaderScope = baseClassLoaderScope;
-        // TODO:isolated mutable model of the current project should NOT keep a direct link to the mutable model of root and parent projects
-        this.rootProject = parent != null ? owner.getOwner().getRootProject().getMutableModel() : this;
-        this.projectDir = projectDir;
         this.buildFile = buildFile;
-        this.parent = parent;
-        this.name = name;
         this.state = new ProjectStateInternal();
         this.buildScriptSource = buildScriptSource;
-        this.gradle = gradle;
 
         services = serviceRegistryFactory.createFor(this);
         taskContainer = services.get(TaskContainerInternal.class);
@@ -277,7 +256,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
         ProjectFeatureSupportInternal.attachLegacyDefinitionContext(this, services.get(ProjectFeatureApplicator.class), services.get(ProjectFeatureDeclarations.class), getObjects());
 
-        evaluationListener.add(gradle.getProjectEvaluationBroadcaster());
+        evaluationListener.add(getBuildState().getMutableModel().getProjectEvaluationBroadcaster());
 
         ruleBasedPluginListenerBroadcast.add((RuleBasedPluginListener) project -> populateModelRegistry(services.get(ModelRegistry.class)));
     }
@@ -351,6 +330,14 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         }
     }
 
+    private ProjectState getRootProjectState() {
+        return getBuildState().getProjects().getRootProject();
+    }
+
+    private BuildState getBuildState() {
+        return owner.getOwner();
+    }
+
     private ListenerBroadcast<ProjectEvaluationListener> newProjectEvaluationListenerBroadcast() {
         return new ListenerBroadcast<>(ProjectEvaluationListener.class);
     }
@@ -394,12 +381,12 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public ProjectInternal getRootProject(ProjectIdentity referrer) {
-        return getCrossProjectModelAccess().access(referrer, rootProject);
+        return getCrossProjectModelAccess().accessFromState(referrer, getRootProjectState());
     }
 
     @Override
     public GradleInternal getGradle() {
-        return getCrossProjectModelAccess().gradleInstanceForProject(getProjectIdentity(), gradle);
+        return getCrossProjectModelAccess().gradleInstanceForProject(getProjectIdentity(), getBuildState().getMutableModel());
     }
 
     @Inject
@@ -430,7 +417,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public File getRootDir() {
-        return owner.getOwner().getRootProject().getProjectDir();
+        return getRootProjectState().getProjectDir();
     }
 
     @Override
@@ -442,16 +429,11 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @Nullable
     @Override
     public ProjectInternal getParent(ProjectIdentity referrer) {
+        ProjectState parent = owner.getParent();
         if (parent == null) {
             return null;
         }
-        return getCrossProjectModelAccess().access(referrer, parent);
-    }
-
-    @Nullable
-    @Override
-    public ProjectIdentifier getParentIdentifier() {
-        return parent;
+        return getCrossProjectModelAccess().accessFromState(referrer, parent);
     }
 
     @Override
@@ -466,7 +448,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public String getName() {
-        return name;
+        return owner.getName();
     }
 
     @Override
@@ -500,9 +482,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
             return "";
         }
 
-        String rootProjectName = owner.getOwner().getRootProject().getName();
         return Stream.concat(
-            Stream.of(rootProjectName),
+            Stream.of(getRootProjectState().getName()),
             parent.getProjectIdentity().getProjectPath().segments().stream()
         ).collect(Collectors.joining("."));
     }
@@ -679,7 +660,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public Path getBuildPath() {
-        return gradle.getIdentityPath();
+        return getBuildState().getIdentityPath();
     }
 
     @Override
@@ -859,7 +840,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public File getProjectDir() {
-        return projectDir;
+        return owner.getProjectDir();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/IProjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/IProjectFactory.java
@@ -15,13 +15,12 @@
  */
 package org.gradle.api.internal.project;
 
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.project.ImmutableProjectDescriptor;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Creates a {@link ProjectInternal} implementation.
@@ -29,10 +28,9 @@ import org.jspecify.annotations.Nullable;
 @ServiceScope(Scope.Build.class)
 public interface IProjectFactory {
     ProjectInternal createProject(
-        GradleInternal gradle,
+        BuildState build,
         ImmutableProjectDescriptor projectDescriptor,
         ProjectState owner,
-        @Nullable ProjectInternal parent,
         ServiceRegistryFactory serviceRegistryFactory,
         ClassLoaderScope selfClassLoaderScope,
         ClassLoaderScope baseClassLoaderScope

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/MutableStateAccessAwareProject.java
@@ -709,12 +709,6 @@ public abstract class MutableStateAccessAwareProject implements ProjectInternal,
         return delegate.ant(configureAction);
     }
 
-    @Nullable
-    @Override
-    public ProjectIdentifier getParentIdentifier() {
-        return delegate.getParentIdentifier();
-    }
-
     @Override
     public String getBuildTreePath() {
         return delegate.getBuildTreePath();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectFactory.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.api.internal.project;
 
 import org.gradle.api.internal.GradleInternal;
@@ -22,6 +21,7 @@ import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.groovy.scripts.TextResourceScriptSource;
 import org.gradle.initialization.DefaultProjectDescriptor;
 import org.gradle.initialization.DependenciesAccessors;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.management.DependencyResolutionManagementInternal;
 import org.gradle.internal.project.ImmutableProjectDescriptor;
 import org.gradle.internal.reflect.Instantiator;
@@ -30,7 +30,6 @@ import org.gradle.internal.resource.TextResource;
 import org.gradle.internal.scripts.ProjectScopedScriptResolution;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.util.internal.NameValidator;
-import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 
@@ -47,10 +46,9 @@ public class ProjectFactory implements IProjectFactory {
 
     @Override
     public ProjectInternal createProject(
-        GradleInternal gradle,
+        BuildState build,
         ImmutableProjectDescriptor projectDescriptor,
         ProjectState owner,
-        @Nullable ProjectInternal parent,
         ServiceRegistryFactory serviceRegistryFactory,
         ClassLoaderScope selfClassLoaderScope,
         ClassLoaderScope baseClassLoaderScope
@@ -60,17 +58,14 @@ public class ProjectFactory implements IProjectFactory {
         TextResource resource = textFileResourceLoader.loadFile("build file", buildFile);
         ScriptSource source = new TextResourceScriptSource(resource);
         DefaultProject project = instantiator.newInstance(DefaultProject.class,
-            projectDescriptor.getIdentity().getProjectName(),
-            parent,
-            projectDescriptor.getProjectDir(),
             buildFile,
             source,
-            gradle,
             owner,
             serviceRegistryFactory,
             selfClassLoaderScope,
             baseClassLoaderScope
         );
+        GradleInternal gradle = build.getMutableModel();
         gradle.getServices().get(DependencyResolutionManagementInternal.class).configureProject(project);
         project.beforeEvaluate(p -> {
             NameValidator.validate(project.getName(), "project name", DefaultProjectDescriptor.INVALID_NAME_IN_INCLUDE_HINT);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectIdentifier.java
@@ -15,20 +15,17 @@
  */
 package org.gradle.api.internal.project;
 
-import org.jspecify.annotations.Nullable;
-
 import java.io.File;
 
-// TODO need a better name for this
+/**
+ * A legacy identifier for a project, used in some legacy software model implementations.
+ * <p>
+ * Avoid this type if possible. Prefer {@link ProjectIdentity}.
+ */
 public interface ProjectIdentifier {
-    String getName();
 
     String getPath();
 
-    @Nullable
-    ProjectIdentifier getParentIdentifier();
-
     File getProjectDir();
 
-    File getBuildFile();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectIdentifier.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.internal.project;
 
+import org.gradle.internal.scan.UsedByScanPlugin;
+
 import java.io.File;
 
 /**
@@ -22,6 +24,7 @@ import java.io.File;
  * <p>
  * Avoid this type if possible. Prefer {@link ProjectIdentity}.
  */
+@UsedByScanPlugin("ImportJUnitXmlReports")
 public interface ProjectIdentifier {
 
     String getPath();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
@@ -73,14 +73,12 @@ public class ProjectLifecycleController implements Closeable {
         IProjectFactory projectFactory
     ) {
         controller.transition(State.NotCreated, State.Created, () -> {
-            ProjectState parent = owner.getParent();
-            ProjectInternal parentModel = parent == null ? null : parent.getMutableModel();
             ServiceRegistryFactory serviceRegistryFactory = domainObject -> {
                 LoggingManagerFactory loggingManagerFactory = buildServices.get(LoggingManagerFactory.class);
                 projectScopeServices = ProjectScopeServices.create(buildServices, (ProjectInternal) domainObject, loggingManagerFactory);
                 return projectScopeServices;
             };
-            project = projectFactory.createProject(build.getMutableModel(), descriptor, owner, parentModel, serviceRegistryFactory, selfClassLoaderScope, baseClassLoaderScope);
+            project = projectFactory.createProject(build, descriptor, owner, serviceRegistryFactory, selfClassLoaderScope, baseClassLoaderScope);
         });
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -40,7 +40,11 @@ import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.util.internal.PatternSets
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator
+import org.gradle.features.internal.binding.ProjectFeatureApplicator
+import org.gradle.features.internal.binding.ProjectFeatureDeclarations
+import org.gradle.features.internal.binding.ProjectFeaturesDynamicObject
 import org.gradle.internal.Describables
+import org.gradle.internal.build.BuildState
 import org.gradle.internal.buildoption.DefaultInternalOptions
 import org.gradle.internal.buildoption.FeatureFlags
 import org.gradle.internal.buildoption.InternalOptions
@@ -54,12 +58,10 @@ import org.gradle.internal.scripts.ProjectScopedScriptResolution
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.Provides
 import org.gradle.internal.service.ServiceRegistrationProvider
+import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.ServiceRegistryFactory
 import org.gradle.invocation.GradleLifecycleActionExecutor
 import org.gradle.model.internal.registry.ModelRegistry
-import org.gradle.features.internal.binding.ProjectFeatureApplicator
-import org.gradle.features.internal.binding.ProjectFeaturesDynamicObject
-import org.gradle.features.internal.binding.ProjectFeatureDeclarations
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Path
 import org.gradle.util.TestUtil
@@ -71,12 +73,13 @@ import javax.annotation.Nullable
 
 @UsesNativeServices
 class DefaultProjectSpec extends Specification {
+
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "can create file collection configured with an Action"() {
         given:
-        def project = project('root', null, Stub(GradleInternal))
+        def project = project('root', null, build(Path.ROOT))
         def action = { files -> files.builtBy('something') } as Action<ConfigurableFileCollection>
 
         when:
@@ -88,7 +91,7 @@ class DefaultProjectSpec extends Specification {
 
     def "can create file tree configured with an Action"() {
         given:
-        def project = project('root', null, Stub(GradleInternal))
+        def project = project('root', null, build(Path.ROOT))
         def action = { fileTree -> fileTree.builtBy('something') } as Action<ConfigurableFileTree>
 
         when:
@@ -100,7 +103,7 @@ class DefaultProjectSpec extends Specification {
 
     def "can configure ant tasks with an Action"() {
         given:
-        def project = project('root', null, Stub(GradleInternal))
+        def project = project('root', null, build(Path.ROOT))
 
         when:
         project.ant({ AntBuilder ant -> ant.importBuild('someAntBuild') } as Action<AntBuilder>)
@@ -111,7 +114,7 @@ class DefaultProjectSpec extends Specification {
 
     def "can configure artifacts with an Action"() {
         given:
-        def project = project('root', null, Stub(GradleInternal))
+        def project = project('root', null, build(Path.ROOT))
 
         when:
         project.artifacts({ artifacts -> artifacts.add('foo', 'bar') } as Action<ArtifactHandler>)
@@ -122,8 +125,7 @@ class DefaultProjectSpec extends Specification {
 
     def "can view as an IsolatedProject"() {
         given:
-        def rootBuild = Stub(GradleInternal)
-        rootBuild.identityPath >> Path.ROOT
+        def rootBuild = build(Path.ROOT)
         def project = project('root', null, rootBuild)
 
         when:
@@ -138,20 +140,12 @@ class DefaultProjectSpec extends Specification {
     }
 
     def "has useful toString and displayName and paths"() {
-        def rootBuild = Stub(GradleInternal)
-        rootBuild.isRootBuild() >> true
-        rootBuild.parent >> null
-        rootBuild.identityPath >> Path.ROOT
-
-        def nestedBuild = Stub(GradleInternal)
-        rootBuild.isRootBuild() >> false
-        nestedBuild.parent >> rootBuild
-        nestedBuild.identityPath >> Path.path(":nested")
-
+        def rootBuild = build(Path.ROOT)
         def rootProject = project("root", null, rootBuild)
         def child1 = project("child1", rootProject, rootBuild)
         def child2 = project("child2", child1, rootBuild)
 
+        def nestedBuild = build(Path.path(":nested"), rootBuild)
         def nestedRootProject = project("root", null, nestedBuild)
         def nestedChild1 = project("child1", nestedRootProject, nestedBuild)
         def nestedChild2 = project("child2", nestedChild1, nestedBuild)
@@ -201,20 +195,12 @@ class DefaultProjectSpec extends Specification {
     }
 
     def "isolated project view preserves the path and build tree path"() {
-        def rootBuild = Stub(GradleInternal)
-        rootBuild.isRootBuild() >> true
-        rootBuild.parent >> null
-        rootBuild.identityPath >> Path.ROOT
-
-        def nestedBuild = Stub(GradleInternal)
-        rootBuild.isRootBuild() >> false
-        nestedBuild.parent >> rootBuild
-        nestedBuild.identityPath >> Path.path(":nested")
-
+        def rootBuild = build(Path.ROOT)
         def rootProject = project("root", null, rootBuild)
         def child1 = project("child1", rootProject, rootBuild)
         def child2 = project("child2", child1, rootBuild)
 
+        def nestedBuild = build(Path.path(":nested"), rootBuild)
         def nestedRootProject = project("root", null, nestedBuild)
         def nestedChild1 = project("child1", nestedRootProject, nestedBuild)
         def nestedChild2 = project("child2", nestedChild1, nestedBuild)
@@ -239,7 +225,26 @@ class DefaultProjectSpec extends Specification {
         nestedChild2.isolated.buildTreePath == ":nested:child1:child2"
     }
 
-    ProjectInternal project(String name, @Nullable ProjectInternal parent, GradleInternal build) {
+    BuildState build(Path path, BuildState parent = null) {
+        ServiceRegistry services = Mock(ServiceRegistry) {
+            get(DependencyResolutionManagementInternal) >> Mock(DependencyResolutionManagementInternal)
+        }
+        GradleInternal build = Mock(GradleInternal) {
+            isRootBuild() >> (path == Path.ROOT)
+            getParent() >> parent?.mutableModel
+            getIdentityPath() >> path
+            getServices() >> services
+        }
+        BuildState state = Mock(BuildState) {
+            getMutableModel() >> build
+            getParent() >> parent
+            getIdentityPath() >> path
+        }
+        build.getOwner() >> state
+        state
+    }
+
+    ProjectInternal project(String name, @Nullable ProjectInternal parent, BuildState buildState) {
         def fileOperations = Stub(FileOperations) {
             fileTree(_) >> TestFiles.fileOperations(tmpDir.testDirectory, new DefaultTemporaryFileProvider(() -> new File(tmpDir.testDirectory, "cache"))).fileTree('tree')
         }
@@ -301,6 +306,7 @@ class DefaultProjectSpec extends Specification {
             createFor(_) >> serviceRegistry
         }
 
+        def build = buildState.mutableModel
         build.services >> serviceRegistry
 
         def projectPath = parent == null ? Path.ROOT : parent.projectPath.child(name)
@@ -319,6 +325,12 @@ class DefaultProjectSpec extends Specification {
             identity = ProjectIdentity.forSubproject(buildPath, projectPath)
         }
 
+        def descriptor = Mock(ImmutableProjectDescriptor) {
+            getIdentity() >> identity
+            getProjectDir() >> new File("project")
+            getBuildFile() >> new File("build file")
+        }
+
         def container = Mock(ProjectState)
         _ * container.name >> name
         _ * container.projectPath >> identity.projectPath
@@ -328,12 +340,7 @@ class DefaultProjectSpec extends Specification {
         _ * container.identity >> identity
         _ * container.isolated >> { new DefaultIsolatedProject(container) }
         _ * container.rootProject >> { parent == null }
-
-        def descriptor = Mock(ImmutableProjectDescriptor) {
-            getIdentity() >> identity
-            getProjectDir() >> new File("project")
-            getBuildFile() >> new File("build file")
-        }
+        _ * container.projectDir >> descriptor.projectDir
 
         def scriptResolution = Stub(ProjectScopedScriptResolution) {
             resolveScriptsForProject(_, _) >> { project, action -> action.get() }
@@ -341,8 +348,9 @@ class DefaultProjectSpec extends Specification {
 
         def instantiator = TestUtil.instantiatorFactory().decorateLenient(serviceRegistry)
         def factory = new ProjectFactory(instantiator, new DefaultTextFileResourceLoader(null), scriptResolution)
-        def project = factory.createProject(build, descriptor, container, parent, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope))
+        def project = factory.createProject(buildState, descriptor, container, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope))
         _ * container.mutableModel >> project
         return project
     }
+
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectStateRegistryTest.groovy
@@ -112,14 +112,14 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         def rootProject = project(":")
         def rootState = registry.stateFor(projectId(":"))
 
-        1 * projectFactory.createProject(_, _, rootState, _, _, _, _) >> rootProject
+        1 * projectFactory.createProject(_, _, rootState, _, _, _) >> rootProject
 
         rootState.createMutableModel(Stub(ClassLoaderScope), Stub(ClassLoaderScope))
 
         def project = project("p1")
         def state = registry.stateFor(projectId("p1"))
 
-        1 * projectFactory.createProject(_, _, state, _, _, _, _) >> project
+        1 * projectFactory.createProject(_, _, state, _, _, _) >> project
 
         state.createMutableModel(Stub(ClassLoaderScope), Stub(ClassLoaderScope))
 
@@ -898,13 +898,13 @@ class DefaultProjectStateRegistryTest extends ConcurrentSpec {
         def rootProject = project(':')
         def rootState = registry.stateFor(projectId(buildPath, ':'))
 
-        1 * projectFactory.createProject(_, _, rootState, _, _, _, _) >> rootProject
+        1 * projectFactory.createProject(_, _, rootState, _, _, _) >> rootProject
 
         rootState.createMutableModel(Stub(ClassLoaderScope), Stub(ClassLoaderScope))
     }
 
     void createProject(ProjectState state, ProjectInternal project) {
-        1 * projectFactory.createProject(_, _, state, _, _, _, _) >> project
+        1 * projectFactory.createProject(_, _, state, _, _, _) >> project
 
         state.createMutableModel(Stub(ClassLoaderScope), Stub(ClassLoaderScope))
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -133,7 +133,13 @@ class DefaultProjectTest extends Specification {
 
     DefaultProject project, child1, child2, childchild
     ProjectState projectState, child1State, child2State, chilchildState
-    BuildState buildState
+    BuildState buildState = Mock(BuildState) {
+        getMutableModel() >> Mock(GradleInternal) {
+            getProjectEvaluationBroadcaster() >> Stub(ProjectEvaluationListener)
+        }
+        getProjects() >> Mock(BuildProjectRegistry)
+        getIdentityPath() >> Path.ROOT
+    }
 
     ProjectEvaluator projectEvaluator = Mock(ProjectEvaluator)
 
@@ -158,7 +164,6 @@ class DefaultProjectTest extends Specification {
     DependencyFactory dependencyFactoryMock = Stub(DependencyFactory)
     ComponentMetadataHandler moduleHandlerMock = Stub(ComponentMetadataHandler)
     ScriptHandlerInternal scriptHandlerMock = Mock(ScriptHandlerInternal)
-    GradleInternal build = Stub(GradleInternal)
     ConfigurationTargetIdentifier configurationTargetIdentifier = Stub(ConfigurationTargetIdentifier)
     FileOperations fileOperationsMock = Stub(FileOperations)
     ProviderFactory propertyStateFactoryMock = Stub(ProviderFactory)
@@ -267,14 +272,6 @@ class DefaultProjectTest extends Specification {
         serviceRegistryMock.get(ModelSchemaStore) >> modelSchemaStore
         serviceRegistryMock.get((Type) ProjectLayout) >> new DefaultProjectLayout(rootDir, rootDir, fileResolver, Stub(TaskDependencyFactory), Stub(PatternSetFactory), Stub(PropertyHost), Stub(FileCollectionFactory), TestFiles.filePropertyFactory(), TestFiles.fileFactory())
 
-        build.getProjectEvaluationBroadcaster() >> Stub(ProjectEvaluationListener)
-        build.getParent() >> null
-        build.isRootBuild() >> true
-        build.getIdentityPath() >> Path.ROOT
-
-        buildState = Stub(BuildState)
-        buildState.getIdentityPath() >> Path.ROOT
-
         serviceRegistryMock.get((Type) ObjectFactory) >> Stub(ObjectFactory)
         serviceRegistryMock.get((Type) DependencyLockingHandler) >> Stub(DependencyLockingHandler)
         serviceRegistryMock.get((Type) DynamicCallContextTracker) >> Stub(DynamicCallContextTracker)
@@ -284,7 +281,6 @@ class DefaultProjectTest extends Specification {
         projectState = Mock(ProjectState)
         projectState.name >> 'root'
         projectState.displayName >> Describables.of("displayname")
-        projectState.owner >> buildState
         projectState.fromMutableState(_) >> { Function f -> f.apply(project) }
         project = defaultProject('root', projectState, null, rootDir, rootProjectClassLoaderScope)
         projectState.mutableModel >> project
@@ -293,7 +289,6 @@ class DefaultProjectTest extends Specification {
 
         def child1ClassLoaderScope = rootProjectClassLoaderScope.createChild("project-child1", null)
         child1State = Mock(ProjectState)
-        child1State.owner >> buildState
         child1State.displayName >> Describables.of("project ':child1'")
         child1State.fromMutableState(_) >> { Function f -> f.apply(child1) }
         child1State.parent >> projectState
@@ -302,7 +297,6 @@ class DefaultProjectTest extends Specification {
         child1State.name >> "child1"
 
         chilchildState = Mock(ProjectState)
-        chilchildState.owner >> buildState
         chilchildState.displayName >> Describables.of("project ':child1:childchild'")
         chilchildState.fromMutableState(_) >> { Function f -> f.apply(childchild) }
         chilchildState.parent >> child1State
@@ -310,7 +304,6 @@ class DefaultProjectTest extends Specification {
         chilchildState.mutableModel >> childchild
 
         child2State = Mock(ProjectState)
-        child2State.owner >> buildState
         child2State.displayName >> Describables.of("project ':child2'")
         child2State.fromMutableState(_) >> { Function f -> f.apply(child2) }
         child2State.parent >> projectState
@@ -328,6 +321,7 @@ class DefaultProjectTest extends Specification {
             projectRegistry.findProject(it.identity.projectPath) >> it
             projectRegistry.getProject(it.identity.projectPath) >> it
         }
+        buildState.projects.rootProject >> projectState
     }
 
     private DefaultProject defaultProject(
@@ -351,21 +345,22 @@ class DefaultProjectTest extends Specification {
         _ * owner.identityPath >> identity.buildTreePath
         _ * owner.projectPath >> identity.projectPath
         _ * owner.depth >> owner.projectPath.segmentCount()
+        _ * owner.owner >> buildState
+        _ * owner.parent >> parent?.owner
+        _ * owner.projectDir >> rootDir
+        _ * owner.name >> name
 
         def project = TestUtil.instantiatorFactory().decorateLenient().newInstance(
             DefaultProject,
-            name,
-            parent,
-            rootDir,
             new File(rootDir, 'build.gradle'),
             script,
-            build,
             owner,
             projectServiceRegistryFactoryMock,
             scope,
             baseClassLoaderScope
         )
         _ * owner.applyToMutableState(_) >> { Consumer action -> action.accept(project) }
+        _ * owner.getMutableModel() >> project
         return project
     }
 
@@ -399,7 +394,7 @@ class DefaultProjectTest extends Specification {
         assert project.buildFile == new File(projectDir, TEST_BUILD_FILE_NAME)
         assert project.projectEvaluator.is(projectEvaluator)
         assert project.antBuilderFactory.is(antBuilderFactoryMock)
-        assert project.gradle.is(build)
+        assert project.gradle.is(buildState.mutableModel)
         assert project.ant != null
         assert project.extensions != null
         assert project.defaultTasks == []
@@ -878,35 +873,37 @@ def scriptMethod(Closure closure) {
     }
 
     def subprojects() {
+        String propValue = 'someValue'
+        project.subprojects {
+            ext.testSubProp = propValue
+        }
+
         expect:
-        checkConfigureProject('subprojects', listWithAllChildProjects)
+        listWithAllChildProjects.each {
+            assert it.testSubProp == propValue
+        }
     }
 
     def allprojects() {
+        String propValue = 'someValue'
+        project.allprojects {
+            ext.testSubProp = propValue
+        }
+
         expect:
-        checkConfigureProject('allprojects', listWithAllProjects)
+        listWithAllProjects.each {
+            assert it.testSubProp == propValue
+        }
     }
 
     def configureProjects() {
-        expect:
-        checkConfigureProject('configure', [project, child1] as Set)
-    }
-
-    private void checkConfigureProject(String configureMethod, Set projectsToCheck) {
         String propValue = 'someValue'
-        if (configureMethod == 'configure') {
-            project."$configureMethod" projectsToCheck as List,
-                {
-                    ext.testSubProp = propValue
-                }
-        } else {
-            project."$configureMethod"(
-                {
-                    ext.testSubProp = propValue
-                })
+        project.configure([project, child1]) {
+            ext.testSubProp = propValue
         }
 
-        projectsToCheck.each {
+        expect:
+        [project, child1].each {
             assert it.testSubProp == propValue
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/ProjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/ProjectFactoryTest.groovy
@@ -41,73 +41,60 @@ class ProjectFactoryTest extends Specification {
     def buildFile = tmpDir.file("build.gradle")
     def projectDir = tmpDir.file("project")
     def projectIdentity = ProjectIdentity.forRootProject(buildId, "name")
-    def projectDescriptor = Stub(ImmutableProjectDescriptor)
-    def gradle = Stub(GradleInternal)
+    def projectDescriptor = Stub(ImmutableProjectDescriptor) {
+        getIdentity() >> projectIdentity
+        getProjectDir() >> projectDir
+        getBuildFile() >> buildFile
+    }
     def serviceRegistryFactory = Stub(ServiceRegistryFactory)
     def project = Stub(DefaultProject)
-    def owner = Stub(BuildState)
-    def projectState = Stub(ProjectState)
+    def projectState = Stub(ProjectState) {
+        getIdentity() >> projectIdentity
+    }
     def scriptResolution = Stub(ProjectScopedScriptResolution) {
         resolveScriptsForProject(_, _) >> { project, action -> action.get() }
     }
     def factory = new ProjectFactory(instantiator, new DefaultTextFileResourceLoader(), scriptResolution)
     def rootProjectScope = Mock(ClassLoaderScope)
     def baseScope = Mock(ClassLoaderScope)
-    def serviceRegistry = Mock(ServiceRegistry)
     def dependencyResolutionManagement = Mock(DependencyResolutionManagementInternal)
+    def serviceRegistry = Mock(ServiceRegistry) {
+        get(DependencyResolutionManagementInternal) >> dependencyResolutionManagement
+    }
+    def gradle = Stub(GradleInternal) {
+        getServices() >> serviceRegistry
+    }
+    def buildState = Stub(BuildState) {
+        getMutableModel() >> gradle
+    }
 
     def setup() {
-        owner.identityPath >> buildId
-
-        projectDescriptor.identity >> projectIdentity
-        projectDescriptor.projectDir >> projectDir
-        projectDescriptor.buildFile >> buildFile
-
-        projectState.identity >> projectIdentity
-
         projectDir.createDir()
     }
 
     def "creates a project with build script"() {
         given:
         buildFile.createFile()
-        gradle.services >> serviceRegistry
-        serviceRegistry.get(DependencyResolutionManagementInternal) >> dependencyResolutionManagement
 
         when:
-        def result = factory.createProject(gradle, projectDescriptor, projectState, null, serviceRegistryFactory, rootProjectScope, baseScope)
+        def result = factory.createProject(buildState, projectDescriptor, projectState, serviceRegistryFactory, rootProjectScope, baseScope)
 
         then:
         result == project
-        1 * instantiator.newInstance(DefaultProject, "name", null, projectDir, buildFile, { it instanceof TextResourceScriptSource }, gradle, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
+        1 * instantiator.newInstance(DefaultProject, buildFile, { it instanceof TextResourceScriptSource }, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
         1 * dependencyResolutionManagement.configureProject(project)
     }
 
     def "creates a project with missing build script"() {
         given:
-        gradle.services >> serviceRegistry
-        serviceRegistry.get(DependencyResolutionManagementInternal) >> dependencyResolutionManagement
+        assert !buildFile.exists()
+
         when:
-        def result = factory.createProject(gradle, projectDescriptor, projectState, null, serviceRegistryFactory, rootProjectScope, baseScope)
+        def result = factory.createProject(buildState, projectDescriptor, projectState, serviceRegistryFactory, rootProjectScope, baseScope)
 
         then:
         result == project
-        1 * instantiator.newInstance(DefaultProject, "name", null, projectDir, buildFile, { it.resource instanceof EmptyFileTextResource }, gradle, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
-        1 * dependencyResolutionManagement.configureProject(project)
+        1 * instantiator.newInstance(DefaultProject, buildFile, { it.resource instanceof EmptyFileTextResource }, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
     }
 
-    def "creates a child project"() {
-        def parent = Mock(ProjectInternal)
-
-        given:
-        gradle.services >> serviceRegistry
-        serviceRegistry.get(DependencyResolutionManagementInternal) >> dependencyResolutionManagement
-        when:
-        def result = factory.createProject(gradle, projectDescriptor, projectState, parent, serviceRegistryFactory, rootProjectScope, baseScope)
-
-        then:
-        result == project
-        1 * instantiator.newInstance(DefaultProject, "name", parent, projectDir, buildFile, _, gradle, projectState, serviceRegistryFactory, rootProjectScope, baseScope) >> project
-        1 * dependencyResolutionManagement.configureProject(project)
-    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.ClassLoaderScope
-import org.gradle.api.internal.project.IProjectFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.problems.ProblemReporter
@@ -39,7 +38,6 @@ import spock.lang.Specification
 class InstantiatingBuildLoaderTest extends Specification {
 
     InstantiatingBuildLoader buildLoader
-    IProjectFactory projectFactory
     File testDir
     File rootProjectDir
     File childProjectDir
@@ -64,7 +62,6 @@ class InstantiatingBuildLoaderTest extends Specification {
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def setup() {
-        projectFactory = Mock(IProjectFactory)
         buildLoader = new InstantiatingBuildLoader()
         testDir = tmpDir.testDirectory
         (rootProjectDir = new File(testDir, 'root')).mkdirs()


### PR DESCRIPTION
DefaultProject previously held mutable references to the root project, its parent project, and its owning Gradle instance. Now, we access parents, roots, and builds through the 'owner' ProjectState field, which facilitates safer access to this mutable state.

See https://github.com/gradle/gradle/issues/34469

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
