### PR TITLE
Deprecate Configuration.resolve

### DIFF
--- a/platforms/core-configuration/flow-services/src/integTest/groovy/org/gradle/internal/flow/services/FlowScopeIntegrationTest.groovy
+++ b/platforms/core-configuration/flow-services/src/integTest/groovy/org/gradle/internal/flow/services/FlowScopeIntegrationTest.groovy
@@ -369,7 +369,7 @@ class FlowScopeIntegrationTest extends AbstractIntegrationSpec {
                 void apply(Project target) {
                     def classpath = target.configurations["compileClasspath"]
 
-                    def p = target.provider { classpath.resolve().join(", ") }
+                    def p = target.provider { classpath.getFiles().join(", ") }
 
                     flowScope.always(FlowActionInjection) {
                         parameters {

--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_tasks.adoc
@@ -304,7 +304,7 @@ However, calling some available methods from this interface—such as `.size()`,
 The same is possible using Kotlin stdlib collection extension methods or Groovy GDK collection extensions.
 Converting a `Configuration` to a `Set<File>` also discards any implicit task dependencies it carries.
 
-You should avoid using these methods when configuring your build. 
+You should avoid using these methods when configuring your build.
 Instead, use the methods defined directly on the Gradle interfaces - this is a necessary _first step_ towards preventing eager resolutions.
 Be sure to use <<lazy_configuration.adoc#working_with_files_in_lazy_properties,lazy types and APIs>> that defer resolution to wire task dependencies and inputs correctly.
 Some methods that cause resolution are not obvious.
@@ -357,7 +357,7 @@ Resolving configurations before the task execution phase can lead to incorrect r
 
 === Explanation
 
-Resolving a configuration - either directly via calling its link:{javadocPath}/org/gradle/api/artifacts/Configuration.html#resolve()[`resolve()`] method or indirectly via accessing its set of artifacts - returns a set of files that does not preserve references to the tasks that produced those files.
+Resolving a configuration - either directly via calling its link:{javadocPath}/org/gradle/api/artifacts/Configuration.html#resolve()[`resolve()`] method, its link:{javadocPath}/org/gradle/api/file/FileCollection.html#getFiles()[`getFiles()`] method, or indirectly via accessing its set of artifacts - returns a set of files that does not preserve references to the tasks that produced those files.
 
 Configurations _are_ file collections and can be added to `@InputFiles` properties on other tasks.
 It is important to do this correctly to avoid breaking automatic task dependency wiring between a consumer task and any tasks that are implicitly required to produce the artifacts being consumed.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -119,6 +119,34 @@ The following bundled plugins apply the Java plugin automatically:
 - `scala`
 - `war`
 
+[[deprecated_configuration_resolve]]
+==== Deprecated `Configuration.resolve()`
+
+The link:{javadocPath}/org/gradle/api/artifacts/Configuration.html#resolve()[`Configuration.resolve()`] method has been deprecated and will be removed in Gradle 10.0.0.
+The link:{javadocPath}/org/gradle/api/file/FileCollection.html#getFiles()[`Configuration.getFiles()`] method has identical behavior and is a direct replacement for `resolve()`.
+
+Both the `resolve()` and `getFiles()` methods return a `Set<File>`.
+In general, it is better to use a `FileCollection` instead of a `Set<File>` when consuming the outputs of a resolved configuration, as using a `FileCollection` will <<best_practices_tasks.adoc#dont_resolve_configurations_before_task_execution,preserve the dependencies on tasks that produce resolved artifacts>>.
+
+.build.gradle.kts
+[source,kotlin]
+----
+// Given some task that accepts files as input
+abstract class ResolveFiles : DefaultTask() {
+    @get:InputFiles
+    abstract val files: ConfigurableFileCollection
+}
+
+tasks.register<ResolveFiles>("resolveFiles") {
+    // Instead of wiring resolved files using a `Set<File>`
+    files.from(configurations.runtimeClasspath.map { it.files })
+    files.from(configurations.runtimeClasspath.map { it.resolve() })
+
+    // Wire the resolved files using a `FileCollection` to preserve task dependencies
+    files.from(configurations.runtimeClasspath.map { it.incoming.files })
+}
+----
+
 [[changes_9.1.0]]
 == Upgrading from 9.0.0 and earlier
 

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidResolvingConfigurationsManually-avoid/groovy/app/build.gradle
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidResolvingConfigurationsManually-avoid/groovy/app/build.gradle
@@ -30,6 +30,6 @@ abstract class BadClasspathPrinter extends DefaultTask {
 }
 
 tasks.register("badClasspathPrinter", BadClasspathPrinter) {
-    classpath = configurations.named("runtimeClasspath").get().resolve() // <4>
+    classpath = configurations.named("runtimeClasspath").get().files // <4>
 }
 // end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidResolvingConfigurationsManually-avoid/kotlin/app/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidResolvingConfigurationsManually-avoid/kotlin/app/build.gradle.kts
@@ -28,6 +28,6 @@ abstract class BadClasspathPrinter : DefaultTask() {
 }
 
 tasks.register("badClasspathPrinter", BadClasspathPrinter::class) {
-    classpath = configurations.named("runtimeClasspath").get().resolve() // <4>
+    classpath = configurations.named("runtimeClasspath").get().files // <4>
 }
 // end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/artifactTransforms-simple/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/artifactTransforms-simple/groovy/build.gradle
@@ -50,8 +50,9 @@ dependencies {
 
 tasks.register("resolve") {
     def files = configurations.runtimeClasspath.incoming.files
-    def fileNames = files.collect { it.name }
+    inputs.files(files)
     doLast {
+        def fileNames = files.collect { it.name }
         assert fileNames.contains("guava-33.2.1-jre-transformed.jar")
     }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/artifactTransforms-simple/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/artifactTransforms-simple/kotlin/build.gradle.kts
@@ -45,8 +45,9 @@ dependencies {
 
 tasks.register("resolve") {
     val files = configurations.runtimeClasspath.get().incoming.files
-    val fileNames = files.map { it.name }
+    inputs.files(files)
     doLast {
+        val fileNames = files.map { it.name }
         check(fileNames.contains("guava-33.2.1-jre-transformed.jar"))
     }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/dependencyLocking-lockingAllConfigurations/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/dependencyLocking-lockingAllConfigurations/groovy/build.gradle
@@ -18,7 +18,7 @@ tasks.register('resolveAndLockAll') {
         configurations.findAll {
             // Add any custom filtering on the configurations to be resolved
             it.canBeResolved
-        }.each { it.resolve() }
+        }.each { it.files }
     }
 }
 // end::resolve-all[]

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/dependencyLocking-lockingAllConfigurations/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/dependencyLocking-lockingAllConfigurations/kotlin/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.register("resolveAndLockAll") {
         configurations.filter {
             // Add any custom filtering on the configurations to be resolved
             it.isCanBeResolved
-        }.forEach { it.resolve() }
+        }.forEach { it.files }
     }
 }
 // end::resolve-all[]

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsPerformanceIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsPerformanceIntegrationTest.groovy
@@ -69,7 +69,7 @@ class GradleImplDepsPerformanceIntegrationTest extends BaseGradleImplDepsIntegra
             task resolveDependencies {
                 doLast {
                     def timeStart = new Date()
-                    configurations.deps.resolve()
+                    configurations.deps.getFiles()
                     def timeStop = new Date()
                     def duration = groovy.time.TimeCategory.minus(timeStop, timeStart)
                     assert duration.toMilliseconds() < $maxMillis

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsShadingIssuesIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsShadingIssuesIntegrationTest.groovy
@@ -42,7 +42,7 @@ class GradleImplDepsShadingIssuesIntegrationTest extends BaseGradleImplDepsInteg
                     project.dependencies {
                         bug 'junit:junit:4.13'
                     }
-                    conf.resolve()
+                    conf.getFiles()
                 }
             }
         """

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r900/GradleProjectModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r900/GradleProjectModelCrossVersionSpec.groovy
@@ -33,7 +33,7 @@ class GradleProjectModelCrossVersionSpec extends ToolingApiSpecification {
         projectDir.file('a/build.gradle').text = """
             def something = configurations.create('something')
             tasks.register('aTask') {
-               something.resolve()
+               something.getFiles()
             }
             """
 
@@ -58,7 +58,7 @@ class GradleProjectModelCrossVersionSpec extends ToolingApiSpecification {
             '''
         projectDir.file('a/build.gradle').text = """
             def something = configurations.create('something')
-            something.resolve()
+            something.getFiles()
             """
 
         when:

--- a/platforms/jvm/language-jvm/src/integTest/groovy/org/gradle/integtests/resolve/consistency/JavaProjectResolutionConsistencyIntegrationTest.groovy
+++ b/platforms/jvm/language-jvm/src/integTest/groovy/org/gradle/integtests/resolve/consistency/JavaProjectResolutionConsistencyIntegrationTest.groovy
@@ -247,7 +247,7 @@ class JavaProjectResolutionConsistencyIntegrationTest extends AbstractHttpDepend
                 doFirst {
                     // in order to trigger the bug, we need to resolve the configuration
                     // which extends from a resolvable configuration first
-                    configurations.myCompileClasspath.resolve()
+                    configurations.myCompileClasspath.getFiles()
                 }
             }
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BeforeResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BeforeResolveIntegrationTest.groovy
@@ -293,7 +293,7 @@ task resolveDependencies {
                 bar {
                     incoming.beforeResolve {
                         println "resolving foo..."
-                        foo.resolve()
+                        foo.getFiles()
                         // bar should still be in an unresolved state, so we should be able to modify the
                         // things like dependency constraints here
                         bar.validateMutation(${MutationValidator.MutationType.class.name}.DEPENDENCIES)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -657,7 +657,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
             assert configurations.conf.state == Configuration.State.UNRESOLVED
             assert project(":api").configurations.conf.state == Configuration.State.UNRESOLVED
 
-            configurations.conf.resolve()
+            configurations.conf.getFiles()
 
             assert configurations.conf.state == Configuration.State.RESOLVED
             assert project(":api").configurations.conf.state == Configuration.State.UNRESOLVED

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactOrderingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactOrderingIntegrationTest.groovy
@@ -94,6 +94,9 @@ class ResolvedArtifactOrderingIntegrationTest extends AbstractHttpDependencyReso
             }
         """
 
+        if (!GradleContextualExecuter.configCache) {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
+        }
         assert succeeds("check${name}")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
@@ -120,6 +120,10 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
         """
 
         when:
+        if (expression == "resolve()") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
+        }
+
         fails(":resolve")
 
         then:
@@ -141,8 +145,7 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
             "incoming.artifactView { }.artifacts.failures",
             "incoming.artifactView { }.artifacts.artifactFiles.files",
             "resolve()",
-            "resolvedConfiguration.files",
-            "resolvedConfiguration.resolvedArtifacts"
+            "resolvedConfiguration"
         ]
     }
 
@@ -182,12 +185,8 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
         """
 
         when:
-        if (expression == "files { true }") {
-            executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
-        } else if (expression == "fileCollection { true }.files") {
-            executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
-        } else if (expression == "resolvedConfiguration.files") {
-            executer.expectDocumentedDeprecationWarning("The ResolvedConfiguration.getFiles() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration#getFiles instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_legacy_configuration_get_files")
+        if (expression == "resolve()") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
         }
 
         def shouldSucceed = ccMessage instanceof Wildcard || !GradleContextualExecuter.isConfigCache()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
@@ -382,11 +382,11 @@ confCopy.withDependencies { incoming ->
 
 task check {
     doLast {
-        conf.resolve()
+        conf.getFiles()
         assert calls == ["sharedWithDependencies", "confWithDependencies", "sharedBeforeResolve", "confBeforeResolve"]
         calls.clear()
 
-        confCopy.resolve()
+        confCopy.getFiles()
         assert calls == ["sharedWithDependencies", "copyWithDependencies", "sharedBeforeResolve", "copyBeforeResolve"]
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/InvalidConfigurationUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/InvalidConfigurationUsageIntegrationTest.groovy
@@ -53,6 +53,9 @@ class InvalidConfigurationUsageIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
+        if (methodName == "resolve()") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
+        }
         fails('help')
 
         then:
@@ -124,7 +127,6 @@ class InvalidConfigurationUsageIntegrationTest extends AbstractIntegrationSpec {
         where:
         methodName                                      | role                                                                                                          | methodCall
         'getResolvedConfiguration()'                    | 'migratingLocked("custom", ConfigurationRolesForMigration.RESOLVABLE_DEPENDENCY_SCOPE_TO_DEPENDENCY_SCOPE)'   | 'getResolvedConfiguration()'
-        'resolve()'                                     | 'migratingLocked("custom", ConfigurationRolesForMigration.RESOLVABLE_DEPENDENCY_SCOPE_TO_DEPENDENCY_SCOPE)'   | 'resolve()'
     }
 
     def "calling an invalid internal API method #methodName for role #role fails"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
@@ -119,7 +119,10 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
         """
 
         when:
-        run 'show'
+        if (expression == "configurations.compile.resolve()") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
+        }
+        succeeds("show")
 
         then:
         outputContains("files: [test-lib.jar, a.jar, a-lib.jar, test-1.0.jar, b.jar, b-lib.jar, test2-1.0.jar")
@@ -200,8 +203,13 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
             ${freeAndPaidFlavoredJars('b')}
         """
 
-        expect:
+        when:
+        if (expression == "configurations.compile.resolve()") {
+            2.times { executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve") }
+        }
         succeeds("show")
+
+        then:
         output.contains("files: [a-free.jar, b-paid.jar]")
         if (FILE_COLLECTION_EXPRESSION_LIST.contains(expression)) {
             result.assertTasksScheduled(':a:freeJar', ':b:paidJar', ':show')
@@ -270,8 +278,13 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
             ${freeAndPaidFlavoredJars('b')}
         """
 
-        expect:
+        when:
+        if (expression == "configurations.compile.resolve()") {
+            2.times { executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve") }
+        }
         succeeds("show")
+
+        then:
         output.contains("files: [a-free.jar, b-paid.jar]")
         if (FILE_COLLECTION_EXPRESSION_LIST.contains(expression)) {
             result.assertTasksScheduled(':a:freeJar', ':b:paidJar', ':show')
@@ -326,8 +339,13 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
             ${freeAndPaidFlavoredJars('b')}
         """
 
-        expect:
+        when:
+        if (expression == "configurations.compile.resolve()") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
+        }
         fails("show")
+
+        then:
         failure.assertHasCause("""The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project :a:
   - Configuration ':a:compile' variant free declares attribute 'usage' with value 'compile':
       - Unmatched attributes:
@@ -396,8 +414,13 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
             ${freeAndPaidFlavoredJars('b')}
         """
 
-        expect:
+        when:
+        if (expression == "configurations.compile.resolve()") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
+        }
         fails("show")
+
+        then:
         failure.assertHasCause("""No variants of project :a match the consumer attributes:
   - Configuration ':a:compile' variant free declares attribute 'usage' with value 'compile':
       - Incompatible because this component declares attribute 'artifactType' with value 'jar', attribute 'flavor' with value 'free' and the consumer needed attribute 'artifactType' with value 'dll', attribute 'flavor' with value 'preview'
@@ -451,7 +474,10 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
         m.pom.expectGetBroken()
 
         when:
-        fails 'show'
+        if (expression == "configurations.compile.resolve()") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
+        }
+        fails("show")
 
         then:
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
@@ -494,7 +520,10 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
         m2.artifact.expectGet()
 
         when:
-        fails 'show'
+        if (expression == "configurations.compile.resolve()") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
+        }
+        fails("show")
 
         then:
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
@@ -521,8 +550,11 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
             }
         """
 
-        when:\
-        fails 'show'
+        when:
+        if (expression == "configurations.compile.resolve()") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
+        }
+        fails("show")
 
         then:
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
@@ -576,7 +608,10 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
         m2.artifact.expectGetBroken()
 
         when:
-        fails 'show'
+        if (expression == "configurations.compile.resolve()") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.resolve method has been deprecated. This is scheduled to be removed in Gradle 10. Please use the getIncoming().getFiles() method instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_configuration_resolve")
+        }
+        fails("show")
 
         then:
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/UnsupportedConfigurationMutationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/UnsupportedConfigurationMutationTest.groovy
@@ -28,7 +28,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow adding dependencies to a configuration that has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             dependencies { a files("some.jar") }
         """
 
@@ -42,7 +42,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow adding artifacts to a configuration that has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             artifacts { a file("some.jar") }
         """
 
@@ -56,7 +56,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow changing excludes on a configuration that has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             configurations.a.exclude group: 'someGroup'
         """
 
@@ -70,7 +70,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow changing conflict resolution on a configuration that has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             configurations.a.resolutionStrategy.failOnVersionConflict()
         """
 
@@ -84,7 +84,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow changing forced versions on a configuration that has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             configurations.a.resolutionStrategy.force "org.utils:api:1.3"
         """
 
@@ -98,7 +98,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow changing cache policy on a configuration that has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             configurations.a.resolutionStrategy.cacheChangingModulesFor 0, "seconds"
         """
 
@@ -112,7 +112,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow changing resolution rules on a configuration that has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             configurations.a.resolutionStrategy.eachDependency {}
         """
 
@@ -126,7 +126,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow changing substitution rules on a configuration that has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             configurations.a.resolutionStrategy.dependencySubstitution.all {}
         """
 
@@ -140,7 +140,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
     def "does not allow changing component selection rules on a configuration that has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             configurations.a.resolutionStrategy.componentSelection.all {}
         """
 
@@ -319,7 +319,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
                 b.extendsFrom a
                 c.extendsFrom b
             }
-            configurations.c.resolve()
+            configurations.c.getFiles()
             dependencies { a files("some.jar") }
         """
 
@@ -338,7 +338,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
                 b.extendsFrom a
                 c.extendsFrom b
             }
-            configurations.c.resolve()
+            configurations.c.getFiles()
             artifacts { a file("some.jar") }
         """
 
@@ -357,7 +357,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
                 b.extendsFrom a
                 c.extendsFrom b
             }
-            configurations.c.resolve()
+            configurations.c.getFiles()
             configurations.a.exclude group: 'someGroup'
         """
 
@@ -375,7 +375,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
                 b.extendsFrom a
                 c.extendsFrom b
             }
-            configurations.c.resolve()
+            configurations.c.getFiles()
             configurations.a.resolutionStrategy.failOnVersionConflict()
             configurations.a.resolutionStrategy.force "org.utils:api:1.3"
             configurations.a.resolutionStrategy.forcedModules = [ "org.utils:api:1.4" ]
@@ -395,9 +395,9 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
                 a
                 b.extendsFrom a
             }
-            configurations.b.resolve()
+            configurations.b.getFiles()
             configurations.a.exclude group: 'someGroup'
-            configurations.a.resolve()
+            configurations.a.getFiles()
             configurations.a.exclude group: 'otherGroup'
         """
 
@@ -414,7 +414,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
             configurations {
                 a
                 b.extendsFrom a
-                b.resolve()
+                b.getFiles()
                 a.description = 'some conf'
             }
         """
@@ -429,7 +429,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
             configurations {
                 a
                 b
-                b.resolve()
+                b.getFiles()
             }
             dependencies { a "a:b:c" }
         """
@@ -445,7 +445,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
                 b
             }
             dependencies { b files("some.jar") }
-            configurations.b.resolve()
+            configurations.b.getFiles()
             dependencies { a "a:b:c" }
         """
 
@@ -470,7 +470,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
             dependencies {
                 compile project(":api")
             }
-            configurations.compile.resolve()
+            configurations.compile.getFiles()
         """
 
         file("api/build.gradle") << """
@@ -517,8 +517,8 @@ repositories {
 
 task resolveChildFirst {
     doLast {
-        configurations.childConfig.resolve()
-        configurations.parentConfig.resolve()
+        configurations.childConfig.getFiles()
+        configurations.parentConfig.getFiles()
     }
 }
         """
@@ -533,7 +533,7 @@ task resolveChildFirst {
     def "does not allow adding attributes to a configuration that has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             configurations.a.attributes { attribute(Attribute.of('foo', String), 'bar') }
         """
 
@@ -547,7 +547,7 @@ task resolveChildFirst {
     def "cannot change the configuration role (#code) after it has been resolved"() {
         buildFile << """
             configurations { a }
-            configurations.a.resolve()
+            configurations.a.getFiles()
             ${code}
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDescriptorValidationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDescriptorValidationIntegrationTest.groovy
@@ -36,7 +36,7 @@ class IvyDescriptorValidationIntegrationTest extends AbstractDependencyResolutio
   }
   task resolve {
       doLast {
-          configurations.compile.resolve()
+          configurations.compile.getFiles()
       }
   }
   """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
@@ -1138,7 +1138,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
                 implementation('org:monitor:1.0')
             }
             tasks.register('resolveCompileClasspath') {
-                configurations.compileClasspath.resolve()
+                configurations.compileClasspath.getFiles()
             }
         """
         mavenLocal(repoDir).module('org', 'monitor', '1.0').publish()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -475,7 +475,14 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     }
 
     @Override
+    @Deprecated
     public Set<File> resolve() {
+        DeprecationLogger.deprecateMethod(Configuration.class, "resolve")
+            .replaceWith("getIncoming().getFiles()")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecated_configuration_resolve")
+            .nagUser();
+
         warnOrFailOnInvalidUsage("resolve()", ProperMethodUsage.RESOLVABLE);
         return getFiles();
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -305,9 +305,11 @@ class DefaultConfigurationSpec extends Specification {
         resolver.resolveGraph(configuration) >> graphResolved(fileSet)
 
         when:
+        def files = configuration.getFiles()
         def resolved = configuration.resolve()
 
         then:
+        files == fileSet
         resolved == fileSet
         configuration.state == RESOLVED
     }
@@ -329,7 +331,7 @@ class DefaultConfigurationSpec extends Specification {
         configuration.getState() == RESOLVED_WITH_FAILURES
 
         when:
-        configuration.resolve()
+        configuration.files
 
         then:
         def t = thrown(ResolveException)

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -337,7 +337,7 @@ project :$expectedProject
             dependencies {
             }
 
-            configurations.compileClasspath.resolve()
+            configurations.compileClasspath.getFiles()
 
             task insight(type: DependencyInsightReportTask) {
                 showingAllVariants = true

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -204,7 +204,10 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * called on a configuration that does not permit this usage, or has allowed this usage but marked it as deprecated.
      *
      * @return The files of this configuration.
+     *
+     * @deprecated This method will be removed in Gradle 10. Use {@link ResolvableDependencies#getFiles()} instead.
      */
+    @Deprecated
     Set<File> resolve();
 
     /**

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/CacheProjectIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/CacheProjectIntegrationTest.groovy
@@ -187,7 +187,7 @@ task 'hello$i' {
     File file = file('$TEST_FILE')
     outputs.file file
     def compileFiles = provider {
-        configurations.compile.resolve()
+        configurations.compile.getFiles()
     }
     doLast {
         compileFiles.get()
@@ -215,7 +215,7 @@ task newTask {
     File file = file('$TEST_FILE')
     outputs.file file
     def otherFiles = provider {
-        configurations.other.resolve()
+        configurations.other.getFiles()
     }
     doLast {
         otherFiles.get()

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/configuration/ExecuteDomainObjectCollectionCallbackBuildOperationTypeIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/configuration/ExecuteDomainObjectCollectionCallbackBuildOperationTypeIntegrationTest.groovy
@@ -374,7 +374,7 @@ class ExecuteDomainObjectCollectionCallbackBuildOperationTypeIntegrationTest ext
                 mavenCentral()
             }
 
-            configurations.foo.resolve()
+            configurations.foo.getFiles()
 
         """
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveFailureTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveFailureTestFixture.groovy
@@ -43,7 +43,7 @@ class ResolveFailureTestFixture {
                         }
                     } else {
                         doLast {
-                            configurations.${config}.resolve()
+                            configurations.${config}.getFiles()
                         }
                     }
                 }


### PR DESCRIPTION
This method is identical in behavior and signature to the getFiles method. We deprecate this method in favor of the direct replacement getFiles.

In the upgrade guide, we further recommend using FileCollection instead of Set<File>


Fixes https://github.com/gradle/gradle/issues/34279

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
