### PR TITLE
Sanity check for shaded TAPI jar

### DIFF
--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
@@ -23,11 +23,13 @@ import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.internal.file.locking.ExclusiveFileAccessManager
 import org.gradle.test.fixtures.file.TestFile
+import org.junit.Assert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.zip.ZipFile
 
 /**
  * Downloads Tooling API clients of a given version, for use in cross version testing.
@@ -64,7 +66,16 @@ class ToolingApiDistributionResolver {
         distributions[toolingApiVersion]
     }
 
+    private void checkTapiJar(File tapiJar) {
+        Assert.assertTrue("${tapiJar.absolutePath} doesn't exist!", tapiJar.exists())
+        Assert.assertTrue("${tapiJar.absolutePath} is not readable!", Files.isReadable(tapiJar.toPath()))
+        try (ZipFile zipFile = new ZipFile(tapiJar)) {
+            Assert.assertTrue("${tapiJar.absolutePath} has no entries!", zipFile.stream().findFirst().isPresent())
+        }
+    }
+
     private ExternalToolingApiDistribution resolveExternalToolingApiDistribution(String tapiVersion, File tapiJar) {
+        checkTapiJar(tapiJar)
         File slf4jApi = locateLocalSlf4j()
         return new ExternalToolingApiDistribution(tapiVersion, [slf4jApi, tapiJar])
     }


### PR DESCRIPTION
We've been bothered by https://github.com/gradle/gradle-private/issues/4814, and made an attempt to fix it in https://github.com/gradle/gradle/pull/34824. 

Unfortunately, the fix was not successful, but it helps us understand the problem better: `org.gradle.util.GradleVersion` class should be loaded from the shaded TAPI jar, when the jar is missing or not readable (because it's only happening on Windows now, it's very likely to be a windows file contention issue), the `ClassNotFoundException` will be raised instead of the real file reading issue.

This PR does a pre-check before loading classes from the shaded jar, which could help us understand what's going on with the shaded jar.