### PR TITLE
Use Locale.English to avoid "Sept"

### DIFF
--- a/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/fixtures/S3Server.groovy
+++ b/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/fixtures/S3Server.groovy
@@ -37,7 +37,7 @@ import java.time.format.DateTimeFormatter
 class S3Server extends HttpServer implements RepositoryServer {
 
     public static final String BUCKET_NAME = "tests3bucket"
-    protected static final DateTimeFormatter RCF_822_DATE_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z").withZone(ZoneId.of("GMT"))
+    protected static final DateTimeFormatter RCF_822_DATE_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z").withZone(ZoneId.of("GMT")).withLocale(Locale.ENGLISH)
 
     public static final String ETAG = 'd41d8cd98f00b204e9800998ecf8427e'
     public static final String X_AMZ_REQUEST_ID = '0A398F9A1BAD4027'


### PR DESCRIPTION
Some S3 resolver tests are failing since September because mac agents have default locale `Locale.IE`, which formats September as "Sept":

```
jshell> java.util.Locale.getDefault();
$1 ==> en_IE

jshell> java.time.ZonedDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z").withZone(java.time.ZoneId.of("GMT")))
$2 ==> "Thu, 04 Sept 2025 03:10:23 GMT"
```

```
Unable to parse last modified date: Thu, 04 Sept 2025 01:21:01 GMT
java.lang.IllegalArgumentException: Invalid format: "Thu, 04 Sept 2025 01:21:01 GMT" is malformed at "t 2025 01:21:01 GMT"
  at org.joda.time.format.DateTimeParserBucket.doParseMillis(DateTimeParserBucket.java:186)
```

This PR uses `Locale.ENGLISH` to make it "Sep":

```
jshell> java.time.ZonedDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z").withZone(java.time.ZoneId.of("GMT")).withLocale(java.util.Locale.ENGLISH))
$3 ==> "Thu, 04 Sep 2025 03:11:56 GMT"
```

