### PR TITLE
Revert "Fix class loading mechanism in TAPI current execution (#34640)"

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.cross-version-tests.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.cross-version-tests.gradle.kts
@@ -36,47 +36,17 @@ addDependenciesAndConfigurations(TestType.CROSSVERSION.prefix)
 createQuickFeedbackTasks()
 createAggregateTasks(sourceSet)
 configureIde(TestType.CROSSVERSION)
+configureTestFixturesForCrossVersionTests()
 
-val tapiProjectDependency = configurations.dependencyScope("tapiProjectDependency")
-val tapiShadedResolvable = configurations.resolvable("tapiShadedResolvable") {
-    extendsFrom(tapiProjectDependency.get())
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named<Category>("Shaded"))
-    }
-}
-
-configureDependenciesForCrossVersionTests()
-
-fun configureDependenciesForCrossVersionTests() {
+fun configureTestFixturesForCrossVersionTests() {
     // do not attempt to find projects when the plugin is applied just to generate accessors
     if (project.name != "gradle-kotlin-dsl-accessors" && project.name != "test" /* remove once wrapper is updated */) {
         dependencies {
             "crossVersionTestImplementation"(testFixtures(project(":tooling-api")))
-            add(tapiProjectDependency.name, project(":tooling-api"))
         }
     }
 }
-
 val releasedVersions = gradleModule.identity.releasedVersions.orNull
-
-class TAPIShadedJarCommandLineArgumentProvider(
-    @InputFiles
-    @PathSensitive(PathSensitivity.NONE)
-    val shadedJar: FileCollection
-) : CommandLineArgumentProvider {
-    override fun asArguments(): Iterable<String?>? {
-        val jar = shadedJar.files.filter { it.name.contains("gradle-tooling-api-shaded") }
-        return if (jar.isNotEmpty()) {
-            listOf("-DtoolingApi.shadedJar=${jar.first().absolutePath}")
-        } else {
-            emptyList()
-        }
-    }
-}
-
-fun Test.addTapiShadedJarDependency() {
-    jvmArgumentProviders.add(TAPIShadedJarCommandLineArgumentProvider(tapiShadedResolvable.get()))
-}
 
 fun createQuickFeedbackTasks() {
     val testType = TestType.CROSSVERSION
@@ -85,7 +55,6 @@ fun createQuickFeedbackTasks() {
     testType.executers.forEach { executer ->
         val taskName = "$executer${prefix.capitalize()}Test"
         val testTask = createTestTask(taskName, executer, sourceSet, testType) {
-            addTapiShadedJarDependency()
             this.setSystemPropertiesOfTestJVM("latest")
             this.systemProperties["org.gradle.integtest.crossVersion"] = "true"
             this.systemProperties["org.gradle.integtest.crossVersion.lowestTestedVersion"] = releasedVersions?.lowestTestedVersion?.version
@@ -115,7 +84,6 @@ fun createAggregateTasks(sourceSet: SourceSet) {
     val releasedVersions = gradleModule.identity.releasedVersions.orNull
     releasedVersions?.allTestedVersions?.forEach { targetVersion ->
         val crossVersionTest = createTestTask("gradle${targetVersion.version}CrossVersionTest", "forking", sourceSet, TestType.CROSSVERSION) {
-            addTapiShadedJarDependency()
             this.description = "Runs the cross-version tests against Gradle ${targetVersion.version}"
             this.systemProperties["org.gradle.integtest.versions"] = targetVersion.version
             this.systemProperties["org.gradle.integtest.crossVersion"] = "true"

--- a/platforms/ide/tooling-api/build.gradle.kts
+++ b/platforms/ide/tooling-api/build.gradle.kts
@@ -1,5 +1,3 @@
-import gradlebuild.shade.tasks.ShadedJar
-
 plugins {
     id("gradlebuild.distribution.api-java")
     id("gradlebuild.publish-public-libraries")
@@ -37,13 +35,6 @@ shadedJar {
     keepPackages = listOf("org.gradle.tooling")
     unshadedPackages = listOf("org.gradle", "org.slf4j", "sun.misc")
     ignoredPackages = setOf("org.gradle.tooling.provider.model")
-}
-
-configurations.consumable("shadedTapi") {
-    outgoing.artifact(tasks.named<ShadedJar>("toolingApiShadedJar"))
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named<Category>("Shaded"))
-    }
 }
 
 errorprone {

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolverTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolverTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.util.SetSystemProperties
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-import spock.util.environment.RestoreSystemProperties
 
 import java.nio.file.Files
 import java.nio.file.attribute.FileTime
@@ -41,17 +40,15 @@ class ToolingApiDistributionResolverTest extends Specification {
 
     ToolingApiDistributionResolver underTest = new ToolingApiDistributionResolver()
 
-    @RestoreSystemProperties
     def "uses distribution from classpath when resolving current version"() {
         given:
-        System.setProperty("toolingApi.shadedJar", "path/to/fake-unexisted-shaded.jar")
         def version = GradleVersion.current().baseVersion.version
 
         when:
         def result = underTest.resolve(version)
 
         then:
-        result instanceof ExternalToolingApiDistribution
+        result instanceof TestClasspathToolingApiDistribution
     }
 
     def "can resolve local distributions"() {

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/CrossVersionTestEngine.java
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/CrossVersionTestEngine.java
@@ -144,7 +144,6 @@ class TestVariant {
 class DelegatingDiscoveryRequest implements EngineDiscoveryRequest {
     private final EngineDiscoveryRequest delegate;
     private final List<ClassSelector> selectors = new ArrayList<ClassSelector>();
-    protected ToolingApiDistribution toolingApi;
 
     DelegatingDiscoveryRequest(EngineDiscoveryRequest delegate) {
         this.delegate = delegate;
@@ -152,17 +151,6 @@ class DelegatingDiscoveryRequest implements EngineDiscoveryRequest {
 
     void addSelector(ClassSelector selector) {
         selectors.add(selector);
-    }
-
-    protected ClassLoader toolingApiClassLoaderForTest(Class<?> testClass, String toolingApiVersion) {
-        return ToolingApiClassLoaderProvider.getToolingApiClassLoader(getToolingApi(toolingApiVersion), testClass);
-    }
-
-    protected ToolingApiDistribution getToolingApi(final String version) {
-        if (toolingApi == null) {
-            toolingApi = new ToolingApiDistributionResolver().resolve(version);
-        }
-        return toolingApi;
     }
 
     @Override
@@ -206,6 +194,7 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
 
     private final String toolingApiVersionToLoad;
     private final String variant;
+    private ToolingApiDistribution toolingApi;
 
     ToolingApiClassloaderDiscoveryRequest(EngineDiscoveryRequest delegate, String variant) {
         super(delegate);
@@ -224,7 +213,7 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
 
         for (ClassSelector selector : delegate.getSelectorsByType(ClassSelector.class)) {
             if (ToolingApiSpecification.class.isAssignableFrom(selector.getJavaClass())) {
-                ClassLoader classLoader = toolingApiClassLoaderForTest(selector.getJavaClass(), toolingApiVersionToLoad);
+                ClassLoader classLoader = toolingApiClassLoaderForTest(selector.getJavaClass());
                 try {
                     addSelector(DiscoverySelectors.selectClass(classLoader.loadClass(selector.getClassName())));
                 } catch (ClassNotFoundException e) {
@@ -270,7 +259,7 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
             try {
                 Class<?> testClass = Class.forName(classToLoad);
                 if (ToolingApiSpecification.class.isAssignableFrom(testClass)) {
-                    return toolingApiClassLoaderForTest(testClass, toolingApiVersionToLoad).loadClass(classToLoad);
+                    return toolingApiClassLoaderForTest(testClass).loadClass(classToLoad);
                 }
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
@@ -283,6 +272,17 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
     private boolean isVariantSelected(UniqueId.Segment candidate) {
         return TestVariant.SEGMENT_TYPE.equals(candidate.getType())
             && variant.equals(candidate.getValue());
+    }
+
+    private ClassLoader toolingApiClassLoaderForTest(Class<?> testClass) {
+        return ToolingApiClassLoaderProvider.getToolingApiClassLoader(getToolingApi(toolingApiVersionToLoad), testClass);
+    }
+
+    private ToolingApiDistribution getToolingApi(final String versionToTestAgainst) {
+        if (toolingApi == null) {
+            toolingApi = new ToolingApiDistributionResolver().resolve(versionToTestAgainst);
+        }
+        return toolingApi;
     }
 
     private String getToolingApiVersionToLoad() {
@@ -299,6 +299,7 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
 }
 
 class ToolingApiCurrentDiscoveryRequest extends DelegatingDiscoveryRequest {
+
     ToolingApiCurrentDiscoveryRequest(EngineDiscoveryRequest delegate) {
         super(delegate);
         String candidateTapiVersion = System.getProperty(VERSIONS_SYSPROP_NAME);
@@ -307,12 +308,7 @@ class ToolingApiCurrentDiscoveryRequest extends DelegatingDiscoveryRequest {
         }
         for (ClassSelector selector : delegate.getSelectorsByType(ClassSelector.class)) {
             if (ToolingApiSpecification.class.isAssignableFrom(selector.getJavaClass())) {
-                ClassLoader classLoader = toolingApiClassLoaderForTest(selector.getJavaClass(), GradleVersion.current().getBaseVersion().getVersion());
-                try {
-                    addSelector(DiscoverySelectors.selectClass(classLoader.loadClass(selector.getClassName())));
-                } catch (ClassNotFoundException e) {
-                    throw new RuntimeException(e);
-                }
+                addSelector(DiscoverySelectors.selectClass(selector.getJavaClass()));
             }
         }
     }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiDistributionResolver.groovy
@@ -54,19 +54,16 @@ class ToolingApiDistributionResolver {
     ToolingApiDistribution resolve(String toolingApiVersion) {
         if (!distributions[toolingApiVersion]) {
             if (useToolingApiFromTestClasspath(toolingApiVersion)) {
-                distributions[toolingApiVersion] = resolveExternalToolingApiDistribution(toolingApiVersion, new File(System.getProperty("toolingApi.shadedJar")))
+                distributions[toolingApiVersion] = new TestClasspathToolingApiDistribution()
             } else if (CommitDistribution.isCommitDistribution(toolingApiVersion)) {
                 throw new UnsupportedOperationException(String.format("Commit distributions are not supported in this context. Adjust %s code to support them", this.class.canonicalName))
             } else {
-                distributions[toolingApiVersion] = resolveExternalToolingApiDistribution(toolingApiVersion, locateToolingApi(toolingApiVersion))
+                File toolingApiJar = locateToolingApi(toolingApiVersion)
+                File slf4jApi = locateLocalSlf4j()
+                distributions[toolingApiVersion] = new ExternalToolingApiDistribution(toolingApiVersion, [slf4jApi, toolingApiJar])
             }
         }
         distributions[toolingApiVersion]
-    }
-
-    private ExternalToolingApiDistribution resolveExternalToolingApiDistribution(String tapiVersion, File tapiJar) {
-        File slf4jApi = locateLocalSlf4j()
-        return new ExternalToolingApiDistribution(tapiVersion, [slf4jApi, tapiJar])
     }
 
     private File locateToolingApi(String version) {


### PR DESCRIPTION
This reverts https://github.com/gradle/gradle/pull/34640 while we are working on https://github.com/gradle/gradle-private/issues/4814