### PR TITLE
Revert "Fix class loading mechanism in TAPI current execution (#34640)"

### DIFF
--- a/platforms/ide/tooling-api/build.gradle.kts
+++ b/platforms/ide/tooling-api/build.gradle.kts
@@ -1,5 +1,3 @@
-import gradlebuild.shade.tasks.ShadedJar
-
 plugins {
     id("gradlebuild.distribution.api-java")
     id("gradlebuild.publish-public-libraries")
@@ -37,13 +35,6 @@ shadedJar {
     keepPackages = listOf("org.gradle.tooling")
     unshadedPackages = listOf("org.gradle", "org.slf4j", "sun.misc")
     ignoredPackages = setOf("org.gradle.tooling.provider.model")
-}
-
-configurations.consumable("shadedTapi") {
-    outgoing.artifact(tasks.named<ShadedJar>("toolingApiShadedJar"))
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named<Category>("Shaded"))
-    }
 }
 
 errorprone {

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/CrossVersionTestEngine.java
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/CrossVersionTestEngine.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.gradle.integtests.fixtures.compatibility.AbstractContextualMultiVersionTestInterceptor.VERSIONS_SYSPROP_NAME;
-import static org.gradle.integtests.tooling.fixture.CrossVersionTestEngine.loadAndInitializeClass;
 
 
 public class CrossVersionTestEngine extends HierarchicalTestEngine<SpockExecutionContext> {
@@ -99,14 +98,6 @@ public class CrossVersionTestEngine extends HierarchicalTestEngine<SpockExecutio
             }
         }
         return rootDescriptor;
-    }
-
-    public static Class<?> loadAndInitializeClass(String className, ClassLoader classLoader) {
-        try {
-            return Class.forName(className, true, classLoader);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
     }
 }
 
@@ -153,7 +144,6 @@ class TestVariant {
 class DelegatingDiscoveryRequest implements EngineDiscoveryRequest {
     private final EngineDiscoveryRequest delegate;
     private final List<ClassSelector> selectors = new ArrayList<ClassSelector>();
-    protected ToolingApiDistribution toolingApi;
 
     DelegatingDiscoveryRequest(EngineDiscoveryRequest delegate) {
         this.delegate = delegate;
@@ -161,17 +151,6 @@ class DelegatingDiscoveryRequest implements EngineDiscoveryRequest {
 
     void addSelector(ClassSelector selector) {
         selectors.add(selector);
-    }
-
-    protected ClassLoader toolingApiClassLoaderForTest(Class<?> testClass, String toolingApiVersion) {
-        return ToolingApiClassLoaderProvider.getToolingApiClassLoader(getToolingApi(toolingApiVersion), testClass);
-    }
-
-    protected ToolingApiDistribution getToolingApi(final String version) {
-        if (toolingApi == null) {
-            toolingApi = new ToolingApiDistributionResolver().resolve(version);
-        }
-        return toolingApi;
     }
 
     @Override
@@ -215,6 +194,7 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
 
     private final String toolingApiVersionToLoad;
     private final String variant;
+    private ToolingApiDistribution toolingApi;
 
     ToolingApiClassloaderDiscoveryRequest(EngineDiscoveryRequest delegate, String variant) {
         super(delegate);
@@ -233,8 +213,12 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
 
         for (ClassSelector selector : delegate.getSelectorsByType(ClassSelector.class)) {
             if (ToolingApiSpecification.class.isAssignableFrom(selector.getJavaClass())) {
-                ClassLoader classLoader = toolingApiClassLoaderForTest(selector.getJavaClass(), toolingApiVersionToLoad);
-                addSelector(DiscoverySelectors.selectClass(loadAndInitializeClass(selector.getClassName(), classLoader)));
+                ClassLoader classLoader = toolingApiClassLoaderForTest(selector.getJavaClass());
+                try {
+                    addSelector(DiscoverySelectors.selectClass(classLoader.loadClass(selector.getClassName())));
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
             }
         }
     }
@@ -275,7 +259,7 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
             try {
                 Class<?> testClass = Class.forName(classToLoad);
                 if (ToolingApiSpecification.class.isAssignableFrom(testClass)) {
-                    return loadAndInitializeClass(classToLoad, toolingApiClassLoaderForTest(testClass, toolingApiVersionToLoad));
+                    return toolingApiClassLoaderForTest(testClass).loadClass(classToLoad);
                 }
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
@@ -288,6 +272,17 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
     private boolean isVariantSelected(UniqueId.Segment candidate) {
         return TestVariant.SEGMENT_TYPE.equals(candidate.getType())
             && variant.equals(candidate.getValue());
+    }
+
+    private ClassLoader toolingApiClassLoaderForTest(Class<?> testClass) {
+        return ToolingApiClassLoaderProvider.getToolingApiClassLoader(getToolingApi(toolingApiVersionToLoad), testClass);
+    }
+
+    private ToolingApiDistribution getToolingApi(final String versionToTestAgainst) {
+        if (toolingApi == null) {
+            toolingApi = new ToolingApiDistributionResolver().resolve(versionToTestAgainst);
+        }
+        return toolingApi;
     }
 
     private String getToolingApiVersionToLoad() {
@@ -304,6 +299,7 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
 }
 
 class ToolingApiCurrentDiscoveryRequest extends DelegatingDiscoveryRequest {
+
     ToolingApiCurrentDiscoveryRequest(EngineDiscoveryRequest delegate) {
         super(delegate);
         String candidateTapiVersion = System.getProperty(VERSIONS_SYSPROP_NAME);
@@ -312,8 +308,7 @@ class ToolingApiCurrentDiscoveryRequest extends DelegatingDiscoveryRequest {
         }
         for (ClassSelector selector : delegate.getSelectorsByType(ClassSelector.class)) {
             if (ToolingApiSpecification.class.isAssignableFrom(selector.getJavaClass())) {
-                ClassLoader classLoader = toolingApiClassLoaderForTest(selector.getJavaClass(), GradleVersion.current().getBaseVersion().getVersion());
-                addSelector(DiscoverySelectors.selectClass(loadAndInitializeClass(selector.getClassName(), classLoader)));
+                addSelector(DiscoverySelectors.selectClass(selector.getJavaClass()));
             }
         }
     }


### PR DESCRIPTION
This reverts https://github.com/gradle/gradle/pull/34640 while we are working on https://github.com/gradle/gradle-private/issues/4814