### PR TITLE
Start JUnit 4 test runs more properly

### DIFF
--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassExecutor.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassExecutor.java
@@ -27,6 +27,7 @@ import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.time.Clock;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 import org.junit.runner.RunWith;
 import org.junit.runner.Runner;
@@ -115,11 +116,14 @@ public class JUnitTestClassExecutor implements Action<String> {
 
         if (spec.isDryRun()) {
             runner = new JUnitTestDryRunner(runner);
+            RunNotifier notifier = new RunNotifier();
+            notifier.addListener(listener);
+            runner.run(notifier);
+        } else {
+            JUnitCore junit = new JUnitCore();
+            junit.addListener(listener);
+            junit.run(request);
         }
-
-        RunNotifier notifier = new RunNotifier();
-        notifier.addListener(listener);
-        runner.run(notifier);
     }
 
     // https://github.com/gradle/gradle/issues/2319

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
@@ -229,4 +229,8 @@ public class JUnitTestEventAdapter extends RunListener {
         return new TestStartEvent(clock.getCurrentTime());
     }
 
+    @Override
+    public void testRunStarted(Description description) throws Exception {
+        super.testRunStarted(description);
+    }
 }


### PR DESCRIPTION
Per the JUnit documentation, this is a more proper way to start a test run.

This also allows non-dry runs to properly report testRunStarted() events.  Those events contain hierarchical descriptions of JUnit 4 test suites including their test classes and their test methods.  These descriptions can probably help us make our test reports more accurate when running these suites.

