### PR TITLE
Introduce a third IP mode, 'warn'

### DIFF
--- a/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/problems/IgnoringProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache-base/src/main/kotlin/org/gradle/internal/cc/base/problems/IgnoringProblemsListener.kt
@@ -29,7 +29,7 @@ import org.gradle.internal.service.scopes.ServiceScope
  */
 @ServiceScope(Scope.BuildTree::class)
 object IgnoringProblemsListener : ProblemsListener {
-    override fun onProblem(problem: PropertyProblem) = Unit
+    override fun onProblem(problem: PropertyProblem, interrupting: Boolean) = Unit
 
     override fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) = Unit
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/AbstractIsolatedProjectsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/AbstractIsolatedProjectsIntegrationTest.groovy
@@ -21,15 +21,28 @@ import org.gradle.internal.cc.impl.fixtures.AbstractConfigurationCacheOptInFeatu
 import static org.gradle.initialization.StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME
 
 abstract class AbstractIsolatedProjectsIntegrationTest extends AbstractConfigurationCacheOptInFeatureIntegrationTest {
-    public static final String ENABLE_CLI = "-D${PROPERTY_NAME}=true"
+    public static final String WARN_CLI = "-D${PROPERTY_NAME}=warn"
+    public static final String ENABLE_CLI = "-D${PROPERTY_NAME}=enabled"
     final def fixture = new IsolatedProjectsFixture(this)
+
+    void withIsolatedProjectsWarnOnly(String... moreExecuterArgs) {
+        executer.withArgument(WARN_CLI, *moreExecuterArgs)
+    }
 
     void withIsolatedProjects(String... moreExecuterArgs) {
         executer.withArgument(ENABLE_CLI, *moreExecuterArgs)
     }
 
+    void isolatedProjectsWarnOnlyRun(String... tasks) {
+        run(WARN_CLI, *tasks)
+    }
+
     void isolatedProjectsRun(String... tasks) {
         run(ENABLE_CLI, *tasks)
+    }
+
+    void isolatedProjectsWarnOnlyFails(String... tasks) {
+        fails(WARN_CLI, *tasks)
     }
 
     void isolatedProjectsFails(String... tasks) {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -34,7 +34,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsWarnOnlyFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -63,7 +63,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsWarnOnlyFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -93,7 +93,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsWarnOnlyFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -121,7 +121,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsWarnOnlyFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -141,7 +141,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsWarnOnlyFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -166,7 +166,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsWarnOnlyFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -193,7 +193,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsWarnOnlyFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -225,7 +225,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsWarnOnlyFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -256,7 +256,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("assemble")
+        isolatedProjectsWarnOnlyFails("assemble")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -283,7 +283,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":a:help", ":b:help")
+        isolatedProjectsWarnOnlyFails(":a:help", ":b:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -313,7 +313,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":include:help")
+        isolatedProjectsWarnOnlyFails(":include:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -342,7 +342,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":a:help", ":b:help")
+        isolatedProjectsWarnOnlyFails(":a:help", ":b:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -370,7 +370,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
 
         when:
         // TODO:isolated expected behavior for incremental configuration
-//        isolatedProjectsFails(":a:help", ":b:help")
+//        isolatedProjectsWarnOnlyFails(":a:help", ":b:help")
         isolatedProjectsRun(":a:help", ":b:help")
 
         then:
@@ -434,7 +434,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":help", ":a:help")
+        isolatedProjectsWarnOnlyFails(":help", ":a:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -476,7 +476,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         if (shouldSucceed) {
             isolatedProjectsRun(*tasksToRun)
         } else {
-            isolatedProjectsFails(*tasksToRun)
+            isolatedProjectsWarnOnlyFails(*tasksToRun)
         }
 
         then:
@@ -518,7 +518,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":a:help")
+        isolatedProjectsWarnOnlyFails(":a:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -555,7 +555,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":sub:sub-a:help", ":sub:sub-b:help")
+        isolatedProjectsWarnOnlyFails(":sub:sub-a:help", ":sub:sub-b:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -587,7 +587,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":a:help")
+        isolatedProjectsWarnOnlyFails(":a:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -622,7 +622,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails("help")
+        isolatedProjectsWarnOnlyFails("help")
 
         then:
         outputContains("My property: hello")
@@ -693,7 +693,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
 
         when:
         // TODO:isolated should succeed without problems
-        isolatedProjectsFails("something")
+        isolatedProjectsWarnOnlyFails("something")
 
         then:
         outputContains("project name = root")
@@ -755,7 +755,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":help")
+        isolatedProjectsWarnOnlyFails(":help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -796,7 +796,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails(":a:b:help")
+        isolatedProjectsWarnOnlyFails(":a:b:help")
 
         then:
         fixture.assertStateStoredAndDiscarded {
@@ -844,7 +844,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails 'help', WARN_PROBLEMS_CLI_OPT
+        isolatedProjectsWarnOnlyFails 'help', WARN_PROBLEMS_CLI_OPT
 
         then:
         failure.assertHasErrorOutput("Could not find method foo() for arguments [] on project ':a:sub' of type org.gradle.api.Project")
@@ -878,7 +878,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails 'help', WARN_PROBLEMS_CLI_OPT
+        isolatedProjectsWarnOnlyFails 'help', WARN_PROBLEMS_CLI_OPT
 
         then:
         failure.assertHasErrorOutput("Could not get unknown property 'myExtension' for project ':a:sub' of type org.gradle.api.Project")
@@ -918,7 +918,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         """
 
         when:
-        isolatedProjectsFails 'help'
+        isolatedProjectsWarnOnlyFails 'help'
 
         then:
         fixture.assertStateStoredAndDiscarded {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/buildtree/BuildModelParametersProvider.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/buildtree/BuildModelParametersProvider.kt
@@ -118,7 +118,7 @@ object BuildModelParametersProvider {
                 requiresToolingModels = true,
                 parallelProjectExecution = parallelProjectExecution,
                 configureOnDemand = configureOnDemand,
-                configurationCache = isolatedProjectsEnabled,
+                configurationCache = useIsolatedProjectFlags,
                 configurationCacheParallelStore = parallelConfigurationCacheStore,
                 configurationCacheParallelLoad = parallelConfigurationCacheLoad,
                 isolatedProjects = isolatedProjectsEnabled,
@@ -131,7 +131,7 @@ object BuildModelParametersProvider {
                 resilientModelBuilding = resilientModelBuilding
             )
         } else {
-            val configurationCache = isolatedProjectsEnabled || startParameter.configurationCache.get()
+            val configurationCache = useIsolatedProjectFlags || startParameter.configurationCache.get()
 
             fun disabledConfigurationCacheBuildModelParameters(buildOptionReason: String): BuildModelParameters {
                 logger.log(configurationCacheLogLevel, "{} as configuration cache cannot be reused due to --{}", requirements.actionDisplayName.capitalizedDisplayName, buildOptionReason)
@@ -143,7 +143,7 @@ object BuildModelParametersProvider {
                     configurationCacheParallelStore = false,
                     configurationCacheParallelLoad = false,
                     isolatedProjects = false,
-                    isolatedProjectsProblemDetection = useIsolatedProjectFlags,
+                    isolatedProjectsProblemDetection = false,
                     parallelProjectConfiguration = parallelProjectConfiguration,
                     intermediateModelCache = false,
                     parallelToolingApiActions = parallelToolingActions,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/buildtree/DefaultBuildModelParameters.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/buildtree/DefaultBuildModelParameters.kt
@@ -27,6 +27,7 @@ data class DefaultBuildModelParameters(
     private val configurationCacheParallelStore: Boolean,
     private val configurationCacheParallelLoad: Boolean,
     private val isolatedProjects: Boolean,
+    private val isolatedProjectsProblemDetection: Boolean,
     private val parallelProjectConfiguration: Boolean,
     private val intermediateModelCache: Boolean,
     private val parallelToolingApiActions: Boolean,
@@ -49,6 +50,8 @@ data class DefaultBuildModelParameters(
 
     override fun isIsolatedProjects(): Boolean = isolatedProjects
 
+    override fun isIsolatedProjectsProblemDetection(): Boolean = isolatedProjectsProblemDetection
+
     override fun isParallelProjectConfiguration(): Boolean = parallelProjectConfiguration
 
     override fun isIntermediateModelCache(): Boolean = intermediateModelCache
@@ -69,6 +72,7 @@ data class DefaultBuildModelParameters(
         "configurationCacheParallelStore" to configurationCacheParallelStore,
         "configurationCacheParallelLoad" to configurationCacheParallelLoad,
         "isolatedProjects" to isolatedProjects,
+        "isolatedProjectsProblemDetection" to isolatedProjectsProblemDetection,
         "parallelProjectConfiguration" to parallelProjectConfiguration,
         "intermediateModelCache" to intermediateModelCache,
         "parallelToolingApiActions" to parallelToolingApiActions,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheKey.kt
@@ -69,6 +69,7 @@ class ConfigurationCacheKey(
 
         putBoolean(startParameter.isOffline)
         putBoolean(startParameter.isIsolatedProjects)
+        putBoolean(startParameter.isIsolatedProjectsProblemDetection)
         putBuildScan()
         putBoolean(encryptionConfiguration.isEncrypting)
         putHash(encryptionConfiguration.encryptionKeyHashCode)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingParentDynamicObject.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingParentDynamicObject.kt
@@ -20,7 +20,6 @@ import groovy.lang.MissingMethodException
 import groovy.lang.MissingPropertyException
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.configuration.problems.ProblemFactory
-import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyKind
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.metaobject.DynamicInvokeResult
@@ -33,7 +32,7 @@ class CrossProjectModelAccessTrackingParentDynamicObject(
     private val ownerProject: ProjectInternal,
     private val delegate: DynamicObject,
     private val referrerProject: ProjectInternal,
-    private val problems: ProblemsListener,
+    private val ipProblems: IsolatedProjectsProblems,
     private val coupledProjectsListener: CoupledProjectsListener,
     private val problemFactory: ProblemFactory,
     private val dynamicCallProblemReporting: DynamicCallProblemReporting
@@ -140,7 +139,7 @@ class CrossProjectModelAccessTrackingParentDynamicObject(
                 }
                 .exception()
                 .build()
-            problems.onProblem(problem)
+            ipProblems.onProblem(problem)
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildModelControllerServices.kt
@@ -79,7 +79,7 @@ class DefaultBuildModelControllerServices(
             } else {
                 registration.addProvider(VintageBuildControllerProvider())
             }
-            if (buildModelParameters.isIsolatedProjects) {
+            if (buildModelParameters.isIsolatedProjectsProblemDetection) {
                 registration.addProvider(ConfigurationCacheIsolatedProjectsProvider())
             } else {
                 registration.addProvider(VintageIsolatedProjectsProvider())
@@ -159,6 +159,7 @@ class DefaultBuildModelControllerServices(
         fun createCrossProjectModelAccess(
             projectRegistry: ProjectRegistry,
             problemsListener: ProblemsListener,
+            isolatedProjectsProblems: IsolatedProjectsProblems,
             problemFactory: ProblemFactory,
             listenerManager: ListenerManager,
             dynamicCallProblemReporting: DynamicCallProblemReporting,
@@ -169,6 +170,7 @@ class DefaultBuildModelControllerServices(
             return ProblemReportingCrossProjectModelAccess(
                 delegate,
                 problemsListener,
+                isolatedProjectsProblems,
                 listenerManager.getBroadcaster(CoupledProjectsListener::class.java),
                 problemFactory,
                 dynamicCallProblemReporting,
@@ -186,12 +188,8 @@ class DefaultBuildModelControllerServices(
 
         @Provides
         fun createDynamicLookupRoutine(
-            dynamicCallContextTracker: DynamicCallContextTracker,
-            buildModelParameters: BuildModelParameters
-        ): DynamicLookupRoutine = when {
-            buildModelParameters.isIsolatedProjects -> TrackingDynamicLookupRoutine(dynamicCallContextTracker)
-            else -> DefaultDynamicLookupRoutine()
-        }
+            dynamicCallContextTracker: DynamicCallContextTracker
+        ): DynamicLookupRoutine = TrackingDynamicLookupRoutine(dynamicCallContextTracker)
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -82,7 +82,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val startParameter = requirements.startParameter
 
         // Isolated projects also implies configuration cache
-        if (startParameter.isolatedProjects == IsolatedProjectsOption.Mode.ENABLED && !startParameter.configurationCache.get()) {
+        if (startParameter.isolatedProjects != IsolatedProjectsOption.Mode.DISABLED && !startParameter.configurationCache.get()) {
             if (startParameter.configurationCache.isExplicit) {
                 throw GradleException("The configuration cache cannot be disabled when isolated projects is enabled.")
             }
@@ -92,7 +92,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val modelParameters = BuildModelParametersProvider.parameters(requirements, startParameter, configurationCacheLogLevel)
         logger.info("Operational build model parameters: {}", modelParameters.toDisplayMap())
 
-        if (modelParameters.isIsolatedProjects) {
+        if (modelParameters.isIsolatedProjectsProblemDetection) {
             IncubationLogger.incubatingFeatureUsed("Isolated projects")
         } else {
             if (modelParameters.isConfigurationCacheParallelStore) {
@@ -167,6 +167,9 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
                 ConfigurationCacheInputFileChecker.Host::class.java,
                 DefaultConfigurationCacheInputFileCheckerHost::class.java
             )
+            if (modelParameters.isIsolatedProjectsProblemDetection) {
+                registration.add(IsolatedProjectsProblems::class.java)
+            }
             if (modelParameters.isIsolatedProjects) {
                 registration.add(
                     ClassLoaderScopesFingerprintController::class.java,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildTreeModelControllerServices.kt
@@ -26,10 +26,10 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
 import org.gradle.execution.selection.BuildTaskSelector
 import org.gradle.initialization.Environment
+import org.gradle.initialization.StartParameterBuildOptions.IsolatedProjectsOption
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.buildtree.BuildActionModelRequirements
 import org.gradle.internal.buildtree.BuildModelParameters
-import org.gradle.internal.cc.buildtree.BuildModelParametersProvider
 import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory
 import org.gradle.internal.buildtree.BuildTreeModelControllerServices
 import org.gradle.internal.buildtree.BuildTreeModelSideEffectExecutor
@@ -38,6 +38,7 @@ import org.gradle.internal.buildtree.DefaultBuildTreeModelSideEffectExecutor
 import org.gradle.internal.buildtree.DefaultBuildTreeWorkGraphPreparer
 import org.gradle.internal.buildtree.RunTasksRequirements
 import org.gradle.internal.cc.base.problems.IgnoringProblemsListener
+import org.gradle.internal.cc.buildtree.BuildModelParametersProvider
 import org.gradle.internal.cc.impl.barrier.BarrierAwareBuildTreeLifecycleControllerFactory
 import org.gradle.internal.cc.impl.barrier.VintageConfigurationTimeActionRunner
 import org.gradle.internal.cc.impl.fingerprint.ClassLoaderScopesFingerprintController
@@ -81,7 +82,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val startParameter = requirements.startParameter
 
         // Isolated projects also implies configuration cache
-        if (startParameter.isolatedProjects.get() && !startParameter.configurationCache.get()) {
+        if (startParameter.isolatedProjects == IsolatedProjectsOption.Mode.ENABLED && !startParameter.configurationCache.get()) {
             if (startParameter.configurationCache.isExplicit) {
                 throw GradleException("The configuration cache cannot be disabled when isolated projects is enabled.")
             }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/IsolatedProjectsProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/IsolatedProjectsProblems.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl
+
+import org.gradle.internal.buildtree.BuildModelParameters
+import org.gradle.internal.configuration.problems.ProblemsListener
+import org.gradle.internal.configuration.problems.PropertyProblem
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
+import javax.inject.Inject
+
+/**
+ * Helper for reporting IP problems. Respects the current IP mode ([org.gradle.initialization.StartParameterBuildOptions.IsolatedProjectsOption.Mode]).
+ */
+@ServiceScope(Scope.BuildTree::class)
+class IsolatedProjectsProblems
+@Inject constructor(
+    private val modelParameters: BuildModelParameters,
+    private val problems: ProblemsListener,
+) {
+    /**
+     * Report a problem, respecting the current IP mode.
+     *
+     * - In "disabled" mode, this should not be called as the service is not available. An error will be thrown if it is called.
+     * - In "warn" mode, the problem is reported as a warning (non-interrupting).
+     * - In "enabled" mode, the problem is reported as an error (interrupting).
+     */
+    fun onProblem(problem: PropertyProblem) {
+        if (!modelParameters.isIsolatedProjectsProblemDetection) {
+            throw AssertionError("IsolatedProjectsProblems service should not be used when isolated projects problem detection is disabled.")
+        }
+        problems.onProblem(problem, interrupting = modelParameters.isIsolatedProjects)
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -81,6 +81,7 @@ internal
 class ProblemReportingCrossProjectModelAccess(
     private val delegate: CrossProjectModelAccess,
     private val problems: ProblemsListener,
+    private val ipProblems: IsolatedProjectsProblems,
     private val coupledProjectsListener: CoupledProjectsListener,
     private val problemFactory: ProblemFactory,
     private val dynamicCallProblemReporting: DynamicCallProblemReporting,
@@ -130,7 +131,7 @@ class ProblemReportingCrossProjectModelAccess(
     override fun parentProjectDynamicInheritedScope(referrerProject: ProjectInternal): DynamicObject? {
         val parent = referrerProject.parent ?: return null
         return CrossProjectModelAccessTrackingParentDynamicObject(
-            parent, parent.inheritedScope, referrerProject, problems, coupledProjectsListener, problemFactory, dynamicCallProblemReporting
+            parent, parent.inheritedScope, referrerProject, ipProblems, coupledProjectsListener, problemFactory, dynamicCallProblemReporting
         )
     }
 
@@ -140,7 +141,7 @@ class ProblemReportingCrossProjectModelAccess(
         access: CrossProjectModelAccessInstance,
         instantiator: Instantiator
     ): ProjectInternal = MutableStateAccessAwareProject.wrap(this, referrer) {
-        instantiator.newInstance(ProblemReportingProject::class.java, this, referrer, access, problems, coupledProjectsListener, problemFactory, buildModelParameters, dynamicCallProblemReporting)
+        instantiator.newInstance(ProblemReportingProject::class.java, this, referrer, access, ipProblems, coupledProjectsListener, problemFactory, buildModelParameters, dynamicCallProblemReporting)
     }
 
     @Suppress("LargeClass")
@@ -148,7 +149,7 @@ class ProblemReportingCrossProjectModelAccess(
         delegate: ProjectInternal,
         referrer: ProjectInternal,
         private val access: CrossProjectModelAccessInstance,
-        private val problems: ProblemsListener,
+        private val ipProblems: IsolatedProjectsProblems,
         private val coupledProjectsListener: CoupledProjectsListener,
         private val problemFactory: ProblemFactory,
         private val buildModelParameters: BuildModelParameters,
@@ -560,7 +561,7 @@ class ProblemReportingCrossProjectModelAccess(
                 .exception()
                 .build()
 
-            problems.onProblem(problem)
+            ipProblems.onProblem(problem)
         }
 
         private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -187,6 +187,9 @@ class ConfigurationCacheStartParameter internal constructor(
     val isIsolatedProjects: Boolean
         get() = modelParameters.isIsolatedProjects
 
+    val isIsolatedProjectsProblemDetection: Boolean
+        get() = modelParameters.isIsolatedProjectsProblemDetection
+
     val entriesPerKey: Int
         get() = startParameter.configurationCacheEntriesPerKey
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -249,8 +249,8 @@ class ConfigurationCacheProblems(
         summarizer.onIncompatibleFeature()
     }
 
-    override fun onProblem(problem: PropertyProblem) {
-        onProblem(problem, ProblemSeverity.Deferred)
+    override fun onProblem(problem: PropertyProblem, interrupting: Boolean) {
+        onProblem(problem, if (interrupting) ProblemSeverity.Interrupting else ProblemSeverity.Deferred)
     }
 
     private
@@ -519,7 +519,8 @@ class ConfigurationCacheProblems(
         val problemSeverity: ProblemSeverity
     ) : AbstractProblemsListener() {
 
-        override fun onProblem(problem: PropertyProblem) {
+        override fun onProblem(problem: PropertyProblem, interrupting: Boolean) {
+            // ignore interrupting flag, always use the configured severity
             onProblem(problem, problemSeverity)
         }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/promo/ConfigurationCachePromoHandler.kt
@@ -121,7 +121,7 @@ internal class ConfigurationCachePromoHandler(
         Logging.getLogger(ConfigurationCachePromoHandler::class.java).lifecycle("Consider enabling configuration cache to speed up this build: $docUrl")
     }
 
-    override fun onProblem(problem: PropertyProblem) {
+    override fun onProblem(problem: PropertyProblem, interrupting: Boolean) {
         problems.addIfNeeded(true)
     }
 

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -64,7 +64,7 @@ abstract class AbstractUserTypeCodecTest {
                 bean,
                 codec,
                 object : AbstractProblemsListener() {
-                    override fun onProblem(problem: PropertyProblem) {
+                    override fun onProblem(problem: PropertyProblem, interrupting: Boolean) {
                         problems += problem
                     }
 
@@ -163,7 +163,7 @@ abstract class AbstractUserTypeCodecTest {
         )
 
     private fun loggingProblemsListener() = object : AbstractProblemsListener() {
-        override fun onProblem(problem: PropertyProblem) {
+        override fun onProblem(problem: PropertyProblem, interrupting: Boolean) {
             println(problem)
         }
 

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemsListener.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/ProblemsListener.kt
@@ -21,7 +21,7 @@ import org.gradle.api.Task
 
 interface ProblemsListener {
 
-    fun onProblem(problem: PropertyProblem)
+    fun onProblem(problem: PropertyProblem, interrupting: Boolean = false)
 
     fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder)
 

--- a/platforms/core-configuration/graph-isolation/src/main/kotlin/org/gradle/internal/isolate/graph/IsolatedActionSerializer.kt
+++ b/platforms/core-configuration/graph-isolation/src/main/kotlin/org/gradle/internal/isolate/graph/IsolatedActionSerializer.kt
@@ -182,7 +182,7 @@ class EnvironmentDecoder(
  */
 private
 object ThrowingProblemsListener : AbstractProblemsListener() {
-    override fun onProblem(problem: PropertyProblem) {
+    override fun onProblem(problem: PropertyProblem, interrupting: Boolean) {
         // TODO: consider throwing more specific exception
         throw ConfigurationCacheError("Failed to isolate 'GradleLifecycle' action: ${problem.message}")
     }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
@@ -44,6 +44,8 @@ public interface BuildModelParameters {
 
     boolean isIsolatedProjects();
 
+    boolean isIsolatedProjectsProblemDetection();
+
     /**
      * Whether projects should be configured in parallel.
      * <p>

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -26,6 +26,7 @@ import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption;
+import org.gradle.initialization.StartParameterBuildOptions.IsolatedProjectsOption;
 import org.gradle.internal.DefaultTaskExecutionRequest;
 import org.gradle.internal.RunDefaultTasksExecutionRequest;
 import org.gradle.internal.build.event.BuildEventSubscriptions;
@@ -137,7 +138,7 @@ public class BuildActionSerializer {
             encoder.writeString(startParameter.getWatchFileSystemMode().name());
             encoder.writeBoolean(startParameter.isVfsVerboseLogging());
             valueSerializer.write(encoder, startParameter.getConfigurationCache());
-            valueSerializer.write(encoder, startParameter.getIsolatedProjects());
+            encoder.writeString(startParameter.getIsolatedProjects().name());
             encoder.writeString(startParameter.getConfigurationCacheProblems().name());
             encoder.writeBoolean(startParameter.isConfigurationCacheIgnoreInputsDuringStore());
             encoder.writeBoolean(startParameter.isConfigurationCacheIgnoreUnsupportedBuildEventsListeners());
@@ -232,7 +233,7 @@ public class BuildActionSerializer {
             startParameter.setWatchFileSystemMode(WatchMode.valueOf(decoder.readString()));
             startParameter.setVfsVerboseLogging(decoder.readBoolean());
             startParameter.setConfigurationCache(valueSerializer.read(decoder));
-            startParameter.setIsolatedProjects(valueSerializer.read(decoder));
+            startParameter.setIsolatedProjects(IsolatedProjectsOption.Mode.valueOf(decoder.readString()));
             startParameter.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.valueOf(decoder.readString()));
             startParameter.setConfigurationCacheIgnoreInputsDuringStore(decoder.readBoolean());
             startParameter.setConfigurationCacheIgnoreUnsupportedBuildEventsListeners(decoder.readBoolean());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal;
 import org.gradle.StartParameter;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption;
+import org.gradle.initialization.StartParameterBuildOptions.IsolatedProjectsOption;
 import org.gradle.initialization.layout.BuildLayoutConfiguration;
 import org.gradle.internal.buildoption.Option;
 import org.gradle.internal.buildtree.BuildModelParameters;
@@ -34,7 +35,7 @@ public class StartParameterInternal extends StartParameter {
     private boolean vfsVerboseLogging;
 
     private Option.Value<Boolean> configurationCache = Option.Value.defaultValue(false);
-    private Option.Value<Boolean> isolatedProjects = Option.Value.defaultValue(false);
+    private IsolatedProjectsOption.Mode isolatedProjects = IsolatedProjectsOption.Mode.DISABLED;
     private ConfigurationCacheProblemsOption.Value configurationCacheProblems = ConfigurationCacheProblemsOption.Value.FAIL;
     private boolean configurationCacheDebug;
     private boolean configurationCacheIgnoreInputsDuringStore = false;
@@ -153,7 +154,7 @@ public class StartParameterInternal extends StartParameter {
         this.configurationCache = configurationCache;
     }
 
-    public Option.Value<Boolean> getIsolatedProjects() {
+    public IsolatedProjectsOption.Mode getIsolatedProjects() {
         return isolatedProjects;
     }
 
@@ -164,7 +165,7 @@ public class StartParameterInternal extends StartParameter {
         return configurationCache.get();
     }
 
-    public void setIsolatedProjects(Option.Value<Boolean> isolatedProjects) {
+    public void setIsolatedProjects(IsolatedProjectsOption.Mode isolatedProjects) {
         this.isolatedProjects = isolatedProjects;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/configuration/DefaultBuildFeatures.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/configuration/DefaultBuildFeatures.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
+import org.gradle.initialization.StartParameterBuildOptions.IsolatedProjectsOption;
 import org.gradle.internal.buildoption.Option;
 import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.lazy.Lazy;
@@ -56,7 +57,7 @@ public class DefaultBuildFeatures implements BuildFeatures {
     }
 
     private static BuildFeature createIsolatedProjects(StartParameterInternal startParameter, BuildModelParameters buildModelParameters) {
-        Provider<Boolean> isRequested = getRequestedProvider(startParameter.getIsolatedProjects());
+        Provider<Boolean> isRequested = Providers.of(startParameter.getIsolatedProjects() == IsolatedProjectsOption.Mode.ENABLED);
         Provider<Boolean> isActive = Providers.of(buildModelParameters.isIsolatedProjects());
         return new DefaultBuildFeature(isRequested, isActive);
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -483,16 +483,36 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         }
     }
 
-    public static class IsolatedProjectsOption extends BooleanBuildOption<StartParameterInternal> {
+    public static class IsolatedProjectsOption extends EnumBuildOption<IsolatedProjectsOption.Mode, StartParameterInternal> {
         public static final String PROPERTY_NAME = "org.gradle.unsafe.isolated-projects";
 
+        public enum Mode {
+            /**
+             * Isolated projects are disabled. This is the default.
+             */
+            DISABLED,
+            /**
+             * Isolated projects are disabled, but a warning is logged if APIs that are known to be incompatible with isolated projects are used.
+             */
+            WARN,
+            /**
+             * Isolated projects are enabled. Warnings from "warn" mode may become errors or have different behavior.
+             */
+            ENABLED,
+        }
+
         public IsolatedProjectsOption() {
-            super(PROPERTY_NAME);
+            super(
+                PROPERTY_NAME,
+                Mode.class,
+                Mode.values(),
+                PROPERTY_NAME
+            );
         }
 
         @Override
-        public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
-            settings.setIsolatedProjects(Option.Value.value(value));
+        public void applyTo(Mode value, StartParameterInternal settings, Origin origin) {
+            settings.setIsolatedProjects(value);
         }
     }
 


### PR DESCRIPTION
Part of https://github.com/gradle/gradle/issues/34799

It is now required to pass one of the following values to `org.gradle.unsafe.isolated-projects`:
- disabled (equivalent to old 'false' value)
- warn (uses IP-mode flags, but without any parallelism)
- enabled (equivalent to old 'true' value)

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
