### PR TITLE
Improve package info arch test to filter comments

### DIFF
--- a/testing/architecture-test/src/test/java/org/gradle/architecture/test/PackageInfoTest.java
+++ b/testing/architecture-test/src/test/java/org/gradle/architecture/test/PackageInfoTest.java
@@ -24,13 +24,13 @@ import org.junit.jupiter.api.function.Executable;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -78,9 +78,9 @@ public class PackageInfoTest {
     }
 
     private static void assertPackageInfoFilesAreIdentical(String packageName, List<Path> infoFiles) {
-        String referenceContent = readAsString(infoFiles.get(0));
+        List<String> referenceContent = readPackageInfo(infoFiles.get(0));
         boolean hasInconsistencies = infoFiles.subList(1, infoFiles.size()).stream()
-            .anyMatch(file -> !referenceContent.equals(readAsString(file)));
+            .anyMatch(file -> !referenceContent.equals(readPackageInfo(file)));
         if (hasInconsistencies) {
             fail("Inconsistent package-info files for package " + packageName + ": " +
                 infoFiles.stream()
@@ -90,10 +90,14 @@ public class PackageInfoTest {
         }
     }
 
-    private static String readAsString(Path path) {
-        try {
-            byte[] bytes = Files.readAllBytes(path);
-            return new String(bytes, StandardCharsets.UTF_8);
+    private static List<String> readPackageInfo(Path path) {
+        try (Stream<String> fileStream = Files.lines(path)) {
+            return fileStream
+                // Should use Class-File API (part of Java 24) to parse package-info.java and
+                // to drop irrelevant comments/handle (non) qualified imports
+                .filter(line -> !(line.startsWith("/*") || line.startsWith(" *") || line.startsWith(" */")))
+                .filter(s -> !s.isEmpty())
+                .toList();
         } catch (IOException e) {
             throw new RuntimeException("Failed reading contents of " + path, e);
         }


### PR DESCRIPTION
Follow-up of #34826

### Context
The old implementation requires the exact same package-info.java file, including 1:1 comments like copyright (year) or comments explaining the package/annotations.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
