### PR TITLE
Do not sort child projects

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ProjectReportTask.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ProjectReportTask.java
@@ -15,11 +15,13 @@
  */
 package org.gradle.api.tasks.diagnostics;
 
+import com.google.common.collect.Streams;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectOrderingUtil;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.tasks.diagnostics.internal.ProjectDetails;
 import org.gradle.api.tasks.diagnostics.internal.TextReportRenderer;
 import org.gradle.initialization.BuildClientMetaData;
@@ -138,7 +140,8 @@ public abstract class ProjectReportTask extends AbstractProjectBasedReportTask<P
     }
 
     private List<ProjectReportModel> calculateChildrenProjectsFor(Project project) {
-        return ((ProjectInternal) project).getOwner().getChildProjects().stream()
+        ProjectState owner = ((ProjectInternal) project).getOwner();
+        return Streams.stream(owner.getChildProjects())
             .sorted(ProjectOrderingUtil::compare)
             .map(state -> calculateReportModelFor(state.getMutableModel()))
             .collect(Collectors.toList());

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilder.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilder.java
@@ -16,6 +16,7 @@
 
 package org.gradle.plugins.ide.internal.tooling;
 
+import com.google.common.collect.Streams;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -58,7 +59,7 @@ public class GradleProjectBuilder implements GradleProjectBuilderInternal {
      * When {@code realizeTasks} is false, the project's task graph will not be realized, and the task list in the model will be empty
      */
     private static DefaultGradleProject buildHierarchy(ProjectState project, boolean realizeTasks) {
-        List<DefaultGradleProject> children = project.getChildProjects().stream()
+        List<DefaultGradleProject> children = Streams.stream(project.getChildProjects())
             .map(it -> buildHierarchy(it, realizeTasks))
             .collect(toList());
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.project;
 
+import com.google.common.collect.Streams;
 import org.gradle.api.Project;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.tasks.TaskDependencyUsageTracker;
@@ -47,7 +48,7 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
 
     @Override
     public Map<String, Project> getChildProjects(ProjectInternal referrer, ProjectInternal target) {
-        return target.getOwner().getChildProjects().stream().collect(
+        return Streams.stream(target.getOwner().getChildProjects()).collect(
             Collectors.toMap(
                 ProjectState::getName,
                 projectState -> access(referrer, projectState.getMutableModel())

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -332,16 +332,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         }
 
         @Override
-        public Set<ProjectState> getChildProjects() {
-            Set<ProjectState> children = new TreeSet<>(Comparator.comparing(ProjectState::getIdentityPath));
-            for (ProjectDescriptorInternal child : descriptor.children()) {
-                children.add(getStateForChild(child));
-            }
-            return children;
-        }
-
-        @Override
-        public Iterable<ProjectState> getUnorderedChildProjects() {
+        public Iterable<ProjectState> getChildProjects() {
             return Iterables.transform(descriptor.children(), this::getStateForChild);
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -28,7 +28,6 @@ import org.jspecify.annotations.Nullable;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.File;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -58,14 +57,9 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
     ProjectState getBuildParent();
 
     /**
-     * Returns the direct children of this project, in public iteration order.
-     */
-    Set<ProjectState> getChildProjects();
-
-    /**
      * Returns the direct children of this project in no particular order.
      */
-    Iterable<ProjectState> getUnorderedChildProjects();
+    Iterable<ProjectState> getChildProjects();
 
     /**
      * Checks whether this project has child projects.

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.execution;
 
+import com.google.common.collect.Iterables;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -118,7 +119,7 @@ public abstract class DefaultTaskSelector implements TaskSelector {
 
     @NonNull
     private static String getSearchContext(ProjectState targetProject, boolean includeSubprojects) {
-        if (includeSubprojects && !targetProject.getChildProjects().isEmpty()) {
+        if (includeSubprojects && !Iterables.isEmpty(targetProject.getChildProjects())) {
             return targetProject.getDisplayName() + " and its subprojects";
         }
         return targetProject.getDisplayName().getDisplayName();

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskPathProjectEvaluator.java
@@ -140,7 +140,7 @@ public class TaskPathProjectEvaluator implements ProjectConfigurer {
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
-                for (final ProjectState child : next.getUnorderedChildProjects()) {
+                for (final ProjectState child : next.getChildProjects()) {
                     queue.add(traverseProject(child, readyQueue));
                     if (child.hasChildren()) {
                         // Only wait for projects that have children to be configured


### PR DESCRIPTION
In many cases, the consumers of the child projects do not care about the order of the child projects. For the consumer which do care about the order, they should perform the sorting themselves.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
