### PR TITLE
Only test last version per major in quickFeedbackCrossVersionTests

### DIFF
--- a/build-logic-commons/module-identity/src/main/kotlin/gradlebuild/identity/extension/ReleasedVersionsDetails.kt
+++ b/build-logic-commons/module-identity/src/main/kotlin/gradlebuild/identity/extension/ReleasedVersionsDetails.kt
@@ -64,7 +64,7 @@ class ReleasedVersionsDetails(currentBaseVersion: GradleVersion, releasedVersion
         // Limit to first and last release of each major version
         mainTestedVersions = testedVersions.map { VersionNumber.parse(it.gradleVersion().version) }
             .groupBy { it.major }
-            .map { (_, v) -> listOf(v.minOrNull()!!.format(), v.maxOrNull()!!.format()) }.flatten()
+            .map { (_, v) -> listOf(v.maxOrNull()!!.format()) }.flatten()
     }
 
     private


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/4817

There is `mainTestedVersions` and `allTestedVersions` in `ReleasedVersionsDetails`, with the intentions:

- `mainTestedVersions` only includes the first and last version per major, like `[8.14.3, 8.0, 7.6.6, 7.0, ...]`, for quickFeedbackCrossVersionTests
- `allTestedVersions` includes all versions, but only the last patch version for each minor, like `[8.14.3, 8.13, 8.12.1, 8.10.2, ..., ]`, for allVersionsCrossVersionTests.

However, there is a bug: `mainTestedVersions` includes first version per major, but `allTestedVersions` includes "last patch version for first minor", i.e. `mainTestedVersions` has `8.0` but `allTestedVersions` has `8.0.2`. `quickFeedbackCrossVersionTests` runs the intersection of these two sets, i.e. we test 2 versions in 9.x, but only 1 version for 8.x, 7.x, etc.

- 9.1.0-20250909012757+0000: last version of 9.x
- 9.0.0: it's the only version in 9.0.x.
- 8.14.3
- 7.6.6
- ...

This PR fixes it by only test the latest version per major.