### PR TITLE
Include callout in selection from snippet so it can be seen in docs

### DIFF
--- a/platforms/documentation/docs/src/snippets/plugins/simple/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/plugins/simple/groovy/build.gradle
@@ -44,8 +44,9 @@ class SamplePlugin implements Plugin<Project> { // <1>
         }
     }
 }
-// end::plugin[]
+
 apply plugin: SamplePlugin // <3>
+// end::plugin[]
 
 // tag::plugin-1[]
 class SamplePlugin1 implements Plugin<Project> { // <1>

--- a/platforms/documentation/docs/src/snippets/plugins/simple/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/plugins/simple/kotlin/build.gradle.kts
@@ -41,8 +41,9 @@ abstract class SamplePlugin : Plugin<Project> { // <1>
         }
     }
 }
-// end::plugin[]
+
 apply<SamplePlugin>() // <3>
+// end::plugin[]
 
 // tag::plugin-1[]
 abstract class SamplePlugin1 : Plugin<Project> { // <1>


### PR DESCRIPTION
Gets rid of this warning in the build by making the callout target visible within the selected tags of the example.

```
> Task :docs:userguideMultiPage
writing_plugins.adoc: line 33: no callout found for <3>
```