### PR TITLE
Update upgrade guide entry for allJvmArgs

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -188,13 +188,62 @@ There is no direct replacement for this method.
 [[set-all-jvm-args]]
 ==== Deprecation of `JavaForkOptions.setAllJvmArgs()`
 
-The link:{javadocPath}/org/gradle/process/JavaForkOptions.html#setAllJvmArgs(java.util.List)[`setAllJvmArgs()` method] on `JavaForkOptions` has been deprecated and will be removed in Gradle 10.0.0.
+The link:{javadocPath}/org/gradle/process/JavaForkOptions.html#setAllJvmArgs(java.util.List)[`setAllJvmArgs()` method] on `JavaForkOptions` and, by inheritance, on `JavaExecSpec` has been deprecated and will be removed in Gradle 10.0.0.
 
-Instead, use one of the following:
+Instead, to overwrite existing JVM arguments, use:
 
 * `JavaForkOptions.jvmArgs()`
 * `JavaForkOptions.setJvmArgs()`
-* Provide a <<incremental_build.adoc#sec:task_input_nested_inputs,`CommandLineArgumentProvider`>> to add arguments via `JavaForkOptions.getJvmArgumentProviders()`.
+* Provide a <<incremental_build.adoc#sec:task_input_nested_inputs,`CommandLineArgumentProvider`>> to add arguments via `JavaForkOptions.getJvmArgumentProviders()`
+
+Note that link:{javadocPath}/org/gradle/process/JavaForkOptions.html#setAllJvmArgs(java.util.List)[`setAllJvmArgs()` method] on `JavaForkOptions` cleared all fork options before setting `jvmArgs`.
+The properties cleared included:
+
+* System properties configured via `JavaForkOptions.systemProperties`
+* JVM argument providers configured via `JavaForkOptions.jvmArgumentProviders`
+* Argument providers configured via `JavaExecSpec.argumentProviders`
+* Memory settings configured via `JavaForkOptions.minHeapSize` and `JavaForkOptions.maxHeapSize`
+* All other JVM arguments configured via `JavaForkOptions.jvmArgs`
+* The assertion and debug flags configured via `JavaForkOptions.enableAssertions` and `JavaForkOptions.debug`
+
+If the arguments you provide to `setJvmArgs()` or `jvmArgs()` depend on any of the above properties being cleared, you will need to manually clear them.
+
+Consider the following snippets for examples of how to implement this change:
+
+====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source, kotlin]
+----
+plugins {
+    id("java")
+}
+
+tasks.register<JavaExec>("myRunTask") {
+    jvmArgumentProviders.clear() // Clear existing JVM argument providers
+    maxHeapSize = null // Clear max heap size
+    jvmArgs = listOf("-Dfoo", "-Dbar") // Set new JVM arguments
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source, groovy]
+----
+plugins {
+    id("java")
+}
+
+tasks.named('myRunTask', JavaExec) {
+    jvmArgumentProviders.clear() // Clear existing JVM argument providers
+    maxHeapSize = null // Clear max heap size
+    jvmArgs = ["-Dfoo", "-Dbar"] // Set new JVM arguments
+}
+----
+=====
+====
 
 [[archives-configuration]]
 ==== Deprecation of `archives` configuration


### PR DESCRIPTION
This clarifies what was cleared with the deprecated method and what users need to do if their changes relied on this behavior.