### PR TITLE
Add Waiting for Debugger message to console if `-Dorg.gradle.debug=true` is enabled

### DIFF
--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonOutputConsumer.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonOutputConsumer.java
@@ -53,8 +53,11 @@ public class DaemonOutputConsumer implements StreamsHandler {
             PrintWriter printer = new PrintWriter(output);
             while (scanner.hasNext()) {
                 String line = scanner.nextLine();
-                LOGGER.debug("daemon out: {}", line);
+                LOGGER.debug("Daemon output: {}", line);
                 printer.println(line);
+                if (startupCommunication.containsDebugMessage(line)) {
+                    LOGGER.lifecycle(line);
+                }
                 if (startupCommunication.containsGreeting(line)) {
                     break;
                 }

--- a/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonStartupCommunication.java
+++ b/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonStartupCommunication.java
@@ -97,7 +97,18 @@ public class DaemonStartupCommunication {
         return message.contains(daemonGreeting());
     }
 
+    public boolean containsDebugMessage(String message) {
+        if (message == null) {
+            return false;
+        }
+        return message.contains(debugMessage());
+    }
+
     private static String daemonGreeting() {
         return DaemonMessages.ABOUT_TO_CLOSE_STREAMS;
+    }
+
+    private static String debugMessage() {
+        return DaemonMessages.WAITING_FOR_DEBUGGER;
     }
 }

--- a/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/logging/DaemonMessages.java
+++ b/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/logging/DaemonMessages.java
@@ -34,4 +34,5 @@ public abstract class DaemonMessages {
     public static final String REMOVING_DAEMON_ADDRESS_ON_FAILURE = "Removing daemon from the registry due to communication failure. Daemon information: ";
     public static final String UNABLE_TO_STOP_DAEMON = "Unable to stop one of the daemons. The daemon may have crashed.";
     public static final String WAITING_ON_CANCELED = "Waiting for daemons with canceled builds to become available";
+    public static final String WAITING_FOR_DEBUGGER = "Listening for transport dt_socket at address";
 }

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineIntegrationSpec.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineIntegrationSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.launcher
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.jvm.JDWPUtil
+import org.gradle.launcher.daemon.logging.DaemonMessages
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.Flaky
 import org.gradle.test.precondition.Requires
@@ -64,6 +65,7 @@ class CommandLineIntegrationSpec extends AbstractIntegrationSpec {
         value << ["-1", "0", "foo", " 1"]
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/21695")
     @Requires(IntegTestPreconditions.NotEmbeddedExecutor)
     def "can debug with org.gradle.debug=true"() {
         given:
@@ -78,7 +80,10 @@ class CommandLineIntegrationSpec extends AbstractIntegrationSpec {
             // Connect, resume threads, and disconnect from VM
             jdwpClient.connect().dispose()
         }
-        gradle.waitForFinish()
+        def output = gradle.waitForFinish().getOutput();
+
+        expect:
+        output.contains(DaemonMessages.WAITING_FOR_DEBUGGER)
     }
 
     @Issue('https://github.com/gradle/gradle/issues/18084')


### PR DESCRIPTION
Fixes #21695 

User submitted an issue asking for a message to inform the user on the console that it is waiting for a debugger to attach and to display the port number.  

This change adds a Logger message to print `Listening for transport dt_socket at address: <port number>` to the console if `-Dorg.gradle.debug` is set to true. 

- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
