### PR TITLE
Use weak references in DefaultCrossBuildInMemoryCache to prevent Worker API leak

### DIFF
--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -540,7 +540,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         then:
         def operation = buildOperations.only(ExecuteWorkItemBuildOperationType)
         operation.displayName == "org.gradle.test.TestWorkAction"
-        with (operation.details) {
+        with(operation.details) {
             className == "org.gradle.test.TestWorkAction"
             displayName == "org.gradle.test.TestWorkAction"
         }
@@ -1073,5 +1073,136 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         builder.buildJar(workActionJar)
 
         fixture.addImportToBuildScript("org.gradle.test.TestWorkAction")
+    }
+
+    def "classLoaderIsolation doesn't cause java.lang.OutOfMemoryError: Metaspace"() {
+        fixture.withWorkActionClassInBuildScript()
+
+        // By default, AbstractGradleExecutor sets a hard-limit on metaspace using MaxMetaspaceSize.
+        // Remove it, because since JEP-387 in Java 16+ metaspace is more flexibly reclaimed and doesn't need a strict limit.
+        // The strict limit just causes OOM whenever the limit is reached.
+        // Without the limit, Java will GC when Xmx is reached.
+        executer.useOnlyRequestedJvmOpts()
+            .withBuildJvmOpts(
+                "-ea",
+                "-Xms256m",
+                "-Xmx512m",
+                "-XX:+HeapDumpOnOutOfMemoryError",
+                "-XX:HeapDumpPath=" + buildContext.getGradleUserHomeDir(),
+            )
+
+        file("buildSrc/build.gradle.kts").parentFile.mkdirs()
+        file("buildSrc/build.gradle.kts").createFile()
+        file("buildSrc/build.gradle.kts").write(
+            """
+            plugins {
+              `kotlin-dsl`
+            }
+            repositories {
+              mavenCentral()
+            }
+            """.stripIndent())
+
+        file("buildSrc/src/main/kotlin/demo.kt").parentFile.mkdirs()
+        file("buildSrc/src/main/kotlin/demo.kt").createFile()
+        file("buildSrc/src/main/kotlin/demo.kt").write(
+            """
+            import java.util.jar.JarFile
+            import javax.inject.Inject
+            import org.gradle.api.*
+            import org.gradle.api.file.*
+            import org.gradle.api.tasks.*
+            import org.gradle.workers.*
+
+            abstract class FooTask : DefaultTask() {
+              @Inject
+              abstract fun getWorkerExecutor(): WorkerExecutor
+
+              @get:InputFiles
+              abstract val compilerClasspath: ConfigurableFileCollection
+
+              @TaskAction
+              fun taskAction() {
+                val workQueue = getWorkerExecutor().classLoaderIsolation {
+                  classpath.from(compilerClasspath)
+                }
+
+                workQueue.submit(FooWork::class.java) {
+                  classpath.from(compilerClasspath)
+                }
+              }
+            }
+
+            interface FooWorkParams : WorkParameters {
+              val classpath: ConfigurableFileCollection
+            }
+
+            abstract class FooWork : WorkAction<FooWorkParams> {
+              override fun execute() {
+                val classLoader = javaClass.classLoader
+                var count = 0
+                parameters.classpath.files.forEach { file ->
+                  JarFile(file).use { jar ->
+                    jar.entries().iterator().forEachRemaining { entry ->
+                      val name = entry.name
+                      if (!entry.isDirectory && name.endsWith(".class") && !name.endsWith("module-info.class")) {
+                        val className = name.removeSuffix(".class").replace("/", ".")
+                        try {
+                          classLoader.loadClass(className)
+                        } catch (e: Throwable) {
+                          e.printStackTrace()
+                          throw e
+                        }
+                        count++
+                      }
+                    }
+                  }
+                }
+
+                println("loaded \$count classes")
+              }
+            }
+            """.stripIndent())
+
+
+        buildFile.delete()
+        file("build.gradle.kts").write(
+            """
+            val dependencyScope = configurations.dependencyScope("fooScope").get()
+            dependencyScope.dependencies.add(dependencies.create("com.apollographql.apollo:apollo-compiler:4.1.0"))
+            val resolvable = configurations.resolvable("fooResolvable").get()
+            resolvable.extendsFrom(dependencyScope)
+
+            val allFoo by tasks.registering
+
+            repeat(100) { i ->
+                val foo = tasks.register("foo\$i", FooTask::class) {
+                  compilerClasspath.from(resolvable)
+                }
+                allFoo.configure {
+                  dependsOn(foo)
+                }
+            }
+            """.stripIndent())
+
+        settingsKotlinFile.write(
+            """
+            pluginManagement {
+              repositories {
+                mavenCentral()
+                gradlePluginPortal()
+              }
+            }
+
+            dependencyResolutionManagement {
+              @Suppress("UnstableApiUsage")
+              repositories {
+                mavenCentral()
+              }
+            }
+            """.stripIndent())
+
+        expect:
+        succeeds "allFoo"
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -201,13 +201,16 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
 
     private static class DefaultCrossBuildInMemoryCache<K, V> extends AbstractCrossBuildInMemoryCache<K, V> {
 
-        private final Set<V> valuesForPreviousSession;
+        /**
+         * This is used only to retain weak references to the values.
+         * Use weak references, in case Java needs to GC the values.
+         */
+        private final Set<V> valuesForPreviousSession = newSetFromMap(new WeakHashMap<>());
         private final Map<K, WeakReference<V>> allValues;
 
         public DefaultCrossBuildInMemoryCache(
             KeyRetentionPolicy retentionPolicy
         ) {
-            this.valuesForPreviousSession = newSetFromMap(new WeakHashMap<>());
             this.allValues = mapFor(retentionPolicy);
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactoryTest.groovy
@@ -27,7 +27,7 @@ class DefaultCrossBuildInMemoryCacheFactoryTest extends AbstractCrossBuildInMemo
         return factory.newCache()
     }
 
-    def "retains strong references to values from the previous session"() {
+    def "retains references to values from the previous session"() {
         def function = Mock(Function)
 
         when:
@@ -42,7 +42,6 @@ class DefaultCrossBuildInMemoryCacheFactoryTest extends AbstractCrossBuildInMemo
 
         when:
         listenerManager.getBroadcaster(BuildSessionLifecycleListener).beforeComplete()
-        System.gc()
         cache.get("a", function)
         cache.get("b", function)
 


### PR DESCRIPTION
Fix #18313


DefaultCrossBuildInMemoryCache is used to cache types like `java.lang.reflect.Constructor`. Such types reference the key used in the cache: `java.lang.Class`, which prevents the weak key being removed when SoftReference is used. Instead, using WeakReference permits entries in DefaultCrossBuildInMemoryCache to be collected.

With this change the metaspace can be reclaimed. When I run `gradle allFoo` (using the project defined in this PR's integration test) multiple times I see metaspace is reclaimed, and **_no java.lang.OutOfMemoryError: Metaspace_**!!!

<img width="1092" height="1003" alt="image" src="https://github.com/user-attachments/assets/2ccf7c90-89e2-4f76-b1a9-0f36b156e4fa" />


Without this change the Gradle daemon will inevitability OOM due to metaspace exhaustion. This makes classloader isolation impractical to use.


### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
