### PR TITLE
Auto update test buckets

### DIFF
--- a/.github/workflows/update-test-buckets.yml
+++ b/.github/workflows/update-test-buckets.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cd /tmp/gradle-ci-health
           ./gradlew :run --args "/tmp/test-class-data.json ${GITHUB_WORKSPACE}"
-      - name: Run mvn command
+      - name: Update test bucket split
         run: |
           cd ${GITHUB_WORKSPACE}/.teamcity
           ./mvnw compile exec:java@update-test-buckets -DinputTestClassDataJson=/tmp/test-class-data.json


### PR DESCRIPTION
Closes https://github.com/gradle/ci-health/issues/229

Following the cleanup of `ci-health` project: https://github.com/gradle/ci-health/pull/234, we now run the job on GitHub actions (to leverage `create-pull-request` action) instead of TeamCity


Example run: https://github.com/blindpirate/gradle/actions/runs/17724905942/job/50363672080
