### PR TITLE
Make performance tests fail stage

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -77,7 +77,7 @@ private val performanceRegressionTestCoverages =
             PerformanceTestType.PER_COMMIT,
             Os.WINDOWS,
             numberOfBuckets = 10,
-            failsStage = false,
+            failsStage = true,
         ),
         PerformanceTestCoverage(
             7,
@@ -85,7 +85,7 @@ private val performanceRegressionTestCoverages =
             Os.MACOS,
             Arch.AARCH64,
             numberOfBuckets = 5,
-            failsStage = false,
+            failsStage = true,
         ),
     )
 


### PR DESCRIPTION
Previously, `ReadyForNightly` trigger didn't fail if windows/mac performance test trigger fail:

[Example](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Stage_ReadyforNightly_Trigger/103325372)

```
      <depend-on sourceBuildTypeId="RootProjectId_Check_PerformanceTest6_Trigger">
        <options>
          <option name="run-build-if-dependency-failed" value="RUN" />
          <option name="run-build-if-dependency-failed-to-start" value="RUN" />
        </options>
      </depend-on>
      <depend-on sourceBuildTypeId="RootProjectId_Check_PerformanceTest7_Trigger">
        <options>
          <option name="run-build-if-dependency-failed" value="RUN" />
          <option name="run-build-if-dependency-failed-to-start" value="RUN" />
        </options>
      </depend-on>
```

This PR makes them fail the build:

```
      <depend-on sourceBuildTypeId="RootProjectId_Check_PerformanceTest6_Trigger">
        <options>
          <option name="run-build-if-dependency-failed" value="RUN_ADD_PROBLEM" />
        </options>
      </depend-on>
      <depend-on sourceBuildTypeId="RootProjectId_Check_PerformanceTest7_Trigger">
        <options>
          <option name="run-build-if-dependency-failed" value="RUN_ADD_PROBLEM" />
        </options>
      </depend-on>
```