### PR TITLE
Add a Gradle property to set the Develocity server URL

### DIFF
--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -167,6 +167,7 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isProblemReportGenerationEnabled());
             encoder.writeBoolean(startParameter.isTaskGraph());
             encoder.writeBoolean(startParameter.isDaemonJvmCriteriaConfigured());
+            encoder.writeNullableString(startParameter.getDevelocityUrl());
         }
 
         private void writeTaskRequests(Encoder encoder, List<TaskExecutionRequest> taskRequests) throws Exception {
@@ -265,6 +266,7 @@ public class BuildActionSerializer {
             startParameter.enableProblemReportGeneration(decoder.readBoolean());
             startParameter.setTaskGraph(decoder.readBoolean());
             startParameter.setDaemonJvmCriteriaConfigured(decoder.readBoolean());
+            startParameter.setDevelocityUrl(decoder.readNullableString());
 
             return startParameter;
         }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginConfig.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginConfig.java
@@ -18,12 +18,16 @@ package org.gradle.internal.enterprise;
 
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Information eagerly conveyed about the plugin from Gradle to the plugin.
  */
 @ServiceScope(Scope.BuildTree.class)
 public interface GradleEnterprisePluginConfig {
+
+    @Nullable
+    String getDevelocityUrl();
 
     enum BuildScanRequest {
         NONE, // no explicit request

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginAdapter.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginAdapter.java
@@ -65,6 +65,7 @@ public class DefaultGradleEnterprisePluginAdapter implements GradleEnterprisePlu
 
     private final BuildOperationNotificationListenerRegistrar buildOperationNotificationListenerRegistrar;
 
+    @Nullable
     private transient GradleEnterprisePluginService pluginService;
 
     public DefaultGradleEnterprisePluginAdapter(
@@ -112,6 +113,11 @@ public class DefaultGradleEnterprisePluginAdapter implements GradleEnterprisePlu
     }
 
     private void createPluginService() {
+        String injectedDevelocityUrl = config.getDevelocityUrl();
+        if (injectedDevelocityUrl != null) {
+            // We might want to stop setting this system property if the Develocity plugin is new enough to read the URL from the configuration directly.
+            System.setProperty("com.gradle.scan.server", injectedDevelocityUrl);
+        }
         pluginService = pluginServiceFactory.create(config, requiredServices, buildState);
         pluginServiceRef.set(pluginService);
         buildOperationNotificationListenerRegistrar.register(pluginService.getBuildOperationNotificationListener());

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginConfig.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginConfig.java
@@ -18,6 +18,7 @@ package org.gradle.internal.enterprise.impl;
 
 import org.gradle.StartParameter;
 import org.gradle.api.internal.BuildType;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.internal.enterprise.GradleEnterprisePluginConfig;
 
 public class DefaultGradleEnterprisePluginConfig implements GradleEnterprisePluginConfig {
@@ -25,11 +26,13 @@ public class DefaultGradleEnterprisePluginConfig implements GradleEnterprisePlug
     private final BuildScanRequest buildScanRequest;
     private final boolean taskExecutingBuild;
     private final boolean autoApplied;
+    private final String develocityUrl;
 
     public DefaultGradleEnterprisePluginConfig(StartParameter startParameter, BuildType buildType, GradleEnterprisePluginAutoAppliedStatus autoAppliedStatus) {
         this.buildScanRequest = buildScanRequest(startParameter);
         this.taskExecutingBuild = buildType == BuildType.TASKS;
         this.autoApplied = autoAppliedStatus.isAutoApplied();
+        this.develocityUrl = ((StartParameterInternal) startParameter).getDevelocityUrl();
     }
 
     @Override
@@ -45,6 +48,11 @@ public class DefaultGradleEnterprisePluginConfig implements GradleEnterprisePlug
     @Override
     public boolean isAutoApplied() {
         return autoApplied;
+    }
+
+    @Override
+    public String getDevelocityUrl() {
+        return develocityUrl;
     }
 
     private BuildScanRequest buildScanRequest(StartParameter startParameter) {

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterpriseAutoAppliedPluginRegistry.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterpriseAutoAppliedPluginRegistry.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.enterprise.impl;
 
-import org.gradle.StartParameter;
+import com.google.common.base.Strings;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
@@ -56,8 +56,8 @@ public class GradleEnterpriseAutoAppliedPluginRegistry implements AutoAppliedPlu
 
     private static boolean shouldApplyDevelocityPlugin(Settings settings) {
         Gradle gradle = settings.getGradle();
-        StartParameter startParameter = gradle.getStartParameter();
-        return startParameter.isBuildScan() && gradle.getParent() == null;
+        StartParameterInternal startParameter = (StartParameterInternal) gradle.getStartParameter();
+        return (startParameter.isBuildScan() || !Strings.isNullOrEmpty(startParameter.getDevelocityUrl())) && gradle.getParent() == null;
     }
 
     private static PluginRequestInternal createDevelocityPluginRequest() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -57,6 +57,7 @@ public class StartParameterInternal extends StartParameter {
     private boolean propertyUpgradeReportEnabled;
     private boolean enableProblemReportGeneration = true;
     private boolean daemonJvmCriteriaConfigured = false;
+    private @Nullable String develocityUrl;
 
     public StartParameterInternal() {
     }
@@ -330,6 +331,14 @@ public class StartParameterInternal extends StartParameter {
 
     public void setDaemonJvmCriteriaConfigured(boolean daemonJvmCriteriaConfigured) {
         this.daemonJvmCriteriaConfigured = daemonJvmCriteriaConfigured;
+    }
+
+    public String getDevelocityUrl() {
+        return develocityUrl;
+    }
+
+    public void setDevelocityUrl(@Nullable String develocityUrl) {
+        this.develocityUrl = develocityUrl;
     }
 
     public BuildLayoutConfiguration toBuildLayoutConfiguration() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -63,6 +63,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         new WatchFileSystemOption(),
         new VfsVerboseLoggingOption(),
         new BuildScanOption(),
+        new DevelocityUrlOption(),
         new DependencyLockingWriteOption(),
         new DependencyVerificationWriteOption(),
         new DependencyVerificationModeOption(),
@@ -357,6 +358,21 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
             } else {
                 settings.setNoBuildScan(true);
             }
+        }
+    }
+
+    public static class DevelocityUrlOption extends StringBuildOption<StartParameterInternal> {
+       public static final String LONG_OPTION = "develocity-url";
+        public static final String GRADLE_PROPERTY = "org.gradle.develocity.url";
+
+        public DevelocityUrlOption() {
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION,
+                "Specify the URL of the Develocity server to use for Build Scans."));
+        }
+
+        @Override
+        public void applyTo(String value, StartParameterInternal settings, Origin origin) {
+            settings.setDevelocityUrl(value);
         }
     }
 


### PR DESCRIPTION
When we set the Develocity server URL
- The Develocity plugin is Auto-applied
- The Develocity plugin is configured to use the Develocity server URL

What currently doesn't work is to set the Develocity server URL from an environment variable, due to the current infrastructure for Gradle properties.