### PR TITLE
Revert #34262 (Escape double quotes in Java arguments on windows)

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -332,55 +332,6 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         !allJvmArgsFile.text.contains("-Dfoo=bar")
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/6072")
-    def "can handle arguments with quotes and spaces"() {
-        buildFile """
-            apply plugin: 'java'
-
-            task demo(type: JavaExec) {
-                classpath = sourceSets.main.runtimeClasspath
-                mainClass = 'com.example.demo.DemoApplication'
-                jvmArgumentProviders.add(objects.newInstance(MyApplicationJvmArguments))
-                argumentProviders.add(objects.newInstance(MyOtherApplicationArguments))
-                systemProperties = [foo: '"1 2"']
-            }
-
-            abstract class MyApplicationJvmArguments implements CommandLineArgumentProvider {
-
-                @Override
-                Iterable<String> asArguments() {
-                    return ['-Dbar="3 4"']
-                }
-            }
-
-            abstract class MyOtherApplicationArguments implements CommandLineArgumentProvider {
-
-                @Override
-                Iterable<String> asArguments() {
-                    return ['baz="5 6"']
-                }
-            }
-        """
-        file("src/main/java/com/example/demo/DemoApplication.java") << """
-            package com.example.demo;
-
-            public class DemoApplication {
-
-                public static void main(String[] args) {
-                    System.getProperties().entrySet().forEach(System.out::println);
-                    System.out.println("Arguments: " + String.join(" ", args));
-                }
-            }
-        """
-
-        expect:
-        succeeds("demo")
-
-        outputContains('foo="1 2"')
-        outputContains('bar="3 4"')
-        outputContains('Arguments: baz="5 6"')
-    }
-
     private void assertOutputFileIs(String text) {
         assert file("out.txt").text == text
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -28,7 +28,6 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.internal.jvm.JavaModuleDetector;
-import org.gradle.internal.os.OperatingSystem;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaForkOptions;
@@ -110,15 +109,6 @@ public class JavaExecHandleBuilder implements BaseExecHandleBuilder, ProcessArgu
         }
 
         return allArgs;
-    }
-
-    private static List<String> escapeQuotes(List<String> allArgs) {
-        if (OperatingSystem.current().isWindows()) {
-            return allArgs.stream().map(listItem ->
-                listItem.replaceAll("\"", "\\\\\"")).collect(Collectors.toList());
-        } else {
-            return allArgs; // No escaping needed on non-Windows systems
-        }
     }
 
     private void addClassicJavaRunArgs(FileCollection classpath, List<String> allArgs) {
@@ -378,7 +368,7 @@ public class JavaExecHandleBuilder implements BaseExecHandleBuilder, ProcessArgu
     private List<String> getAllArguments(FileCollection realClasspath) {
         List<String> arguments = new ArrayList<>(getAllJvmArgs(realClasspath));
         arguments.addAll(execHandleBuilder.getAllArguments());
-        return escapeQuotes(arguments);
+        return arguments;
     }
 
     public List<CommandLineArgumentProvider> getJvmArgumentProviders() {


### PR DESCRIPTION
Although #34262 fixed the issue where quotes were being stripped from arguments, it introduced breaking behavior when the expectation is that the quotes _should_ be stripped while processing the arguments.  In other words, there are cases where the expectation is that the quotes are stripped and there are cases where the expectation is that they should be preserved.  We don't have a good way to guess which the user wants, so changing the behavior becomes a breaking change for someone.

We're reverting this for now to return to the previous behavior.  We may consider doing something to improve the situation in Gradle 10.0.

Reverts #34262 
Fixes https://github.com/gradle/gradle-private/issues/4847

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
