### PR TITLE
Return more detailed exception for processes killed with signals

### DIFF
--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -113,6 +113,7 @@ abstract class ExternalModulesExtension(bundleGroovyMajor: Int) {
     val jgitSshAgent = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache.agent"
     val jna = "net.java.dev.jna:jna"
     val jnaPlatform = "net.java.dev.jna:jna-platform"
+    val jnrConstants = "com.github.jnr:jnr-constants"
     val joda = "joda-time:joda-time"
     val jsch = "com.github.mwiede:jsch"
     val jsr305 = "com.google.code.findbugs:jsr305"
@@ -285,6 +286,7 @@ abstract class ExternalModulesExtension(bundleGroovyMajor: Int) {
         jcommander to License.Apache2,
         jetbrainsAnnotations to License.Apache2,
         jgit to License.EDL,
+        jnrConstants to License.Apache2,
         joda to License.Apache2,
         jsch to License.BSDStyle,
         jsr305 to License.BSD3,

--- a/packaging/distributions-dependencies/build.gradle.kts
+++ b/packaging/distributions-dependencies/build.gradle.kts
@@ -176,6 +176,7 @@ dependencies {
         api(libs.trove4j)               { version { strictly("1.0.20200330") }}
         api(libs.jna)                   { version { strictly(jnaVersion) }}
         api(libs.jnaPlatform)           { version { strictly(jnaVersion) }}
+        api(libs.jnrConstants)          { version { strictly("0.10.4") } }
 
         // TODO upgrade this AGP version to recent version
         api(libs.agp)                   { version { strictly("3.0.0"); because("We use 3.0.0 for internal performance test") }}

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -147,6 +147,7 @@ dependencies {
         // Used for its nullability annotations, not needed at runtime
         exclude("org.checkerframework", "checker-qual")
     }
+    implementation(libs.jnrConstants)
 
     compileOnly(libs.kotlinStdlib) {
         because("it needs to forward calls from instrumented code to the Kotlin standard library")

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getDistributionSizeMiB() {
-        return 222
+        return 224
     }
 
     @Requires(UnitTestPreconditions.StableGroovy) // cannot link to public javadocs of Groovy snapshots like https://docs.groovy-lang.org/docs/groovy-4.0.5-SNAPSHOT/html/gapi/

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/BinDistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/BinDistributionIntegrationSpec.groovy
@@ -34,7 +34,7 @@ class BinDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getDistributionSizeMiB() {
-        return 129
+        return 130
     }
 
     def binZipContents() {

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
     protected static final NATIVE_PLATFORM_BINARIES = 16
-    protected static final THIRD_PARTY_LIB_COUNT = 112
+    protected static final THIRD_PARTY_LIB_COUNT = 113
 
     @Shared
     String baseVersion = GradleVersion.current().baseVersion.version

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -38,7 +38,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
 
     @Override
     int getDistributionSizeMiB() {
-        return 129
+        return 130
     }
 
     /**


### PR DESCRIPTION
Fixes
* #7446 

Note:
1. For Windows, there is [NTSTATUS](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55), but I haven't found a good java API to expose more detailed information. There is [some coverage](https://github.com/siq/jcifs/blob/7205f7b5beff18ce010ee7f76250214063445f5e/src/jcifs/smb/NtStatus.java#L21), but I don't think it's worth it to copy it.
2. I've added a detailed description only for SIGKILL since it's a common case. I haven't found any other codes that are not self-explanatory (e.g., SIGTEM or SIGABRT) and happen often enough.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
