### PR TITLE
Fix Groovy compatibility check for Java 25

### DIFF
--- a/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/platforms/jvm/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -88,7 +88,7 @@ class GroovyCoverage {
         allVersions.addAll(FUTURE)
 
         if (javaVersion.isCompatibleWith(JavaVersion.VERSION_25)) {
-            return VersionCoverage.versionsAtLeast(allVersions, '3.0.25')
+            return []
         } else if (javaVersion.isCompatibleWith(JavaVersion.VERSION_24)) {
             return VersionCoverage.versionsAtLeast(allVersions, '3.0.24')
         } else if (javaVersion.isCompatibleWith(JavaVersion.VERSION_15)) {


### PR DESCRIPTION
This is to fix the failure in https://ge.gradle.org/s/mg62mntwojui2