### PR TITLE
Remove duplicate SantaTrackerSmokeTests

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -189,7 +189,6 @@ data class CIBuildModel(
                 specificBuilds =
                     listOf(
                         SpecificBuild.SmokeTestsMinJavaVersion,
-                        SpecificBuild.SantaTrackerSmokeTests,
                     ),
                 functionalTests =
                     listOf(


### PR DESCRIPTION
This caused the error:

```
BuildType 'Gradle_Master_Check_SmokeTest_SantaTrackerSmokeTests': id 'Gradle_Master_Check_SmokeTest_SantaTrackerSmokeTests' is already used in BuildType(id='Gradle_Master_Check_SmokeTest_SantaTrackerSmokeTests', name='Smoke Tests with 3rd Party Plugins (santaTrackerSmokeTest) - Java17 Linux')
```