### PR TITLE
Publish build scan from smoke tests

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -275,6 +275,12 @@ fun Test.addOsAsInputs() {
 
 fun Test.isUnitTest() = listOf("test", "writePerformanceScenarioDefinitions", "writeTmpPerformanceScenarioDefinitions").contains(name)
 
+/**
+ * If enabled, test JVM will inherit the DEVELOCITY_ACCESS_TOKEN
+ * environment variable. This allows build scans to be published for integration tests.
+ */
+fun Test.inheritDevelocityAccessTokenEnv() = setOf("smoke-test").contains(project.name)
+
 fun Test.usesEmbeddedExecuter() = systemProperties["org.gradle.integtest.executer"]?.equals("embedded") ?: false
 
 fun Test.configureRerun() {
@@ -304,7 +310,7 @@ fun configureTests() {
     tasks.withType<Test>().configureEach {
 
         configureAndroidUserHome()
-        filterEnvironmentVariables()
+        filterEnvironmentVariables(inheritDevelocityAccessTokenEnv())
 
         maxParallelForks = project.maxParallelForks
 
@@ -463,7 +469,7 @@ fun Test.configureAndroidUserHome() {
  *
  * @return A property that contains the reduced value.
  */
-fun <T: Any> reduceBooleanFlagValues(flags: Map<Property<Boolean>, T>, combiner: (T, T) -> T): Provider<T> {
+fun <T : Any> reduceBooleanFlagValues(flags: Map<Property<Boolean>, T>, combiner: (T, T) -> T): Provider<T> {
     return flags.entries
         .map { entry ->
             entry.key.map {
@@ -476,7 +482,7 @@ fun <T: Any> reduceBooleanFlagValues(flags: Map<Property<Boolean>, T>, combiner:
             })
         }
         .reduce { acc, next ->
-            acc.zip(next) { left , right ->
+            acc.zip(next) { left, right ->
                 when {
                     !left.isPresent -> right
                     !right.isPresent -> left

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -108,16 +108,20 @@ val credentialsKeywords = listOf(
 )
 
 
-fun Test.filterEnvironmentVariables() {
+fun Test.filterEnvironmentVariables(inheritDevelocityAccessToken: Boolean) {
     environment = makePropagatedEnvironment()
     environment.forEach { (key, _) ->
         require(credentialsKeywords.none { key.contains(it, true) }) { "Found sensitive data in filtered environment variables: $key" }
+    }
+
+    if (inheritDevelocityAccessToken) {
+        environment["DEVELOCITY_ACCESS_KEY"] = System.getenv("DEVELOCITY_ACCESS_KEY")
     }
 }
 
 
 private
-fun makePropagatedEnvironment(): Map<String, String> {
+fun makePropagatedEnvironment(): MutableMap<String, String> {
     val result = HashMap<String, String>()
     for (key in propagatedEnvironmentVariables) {
         val value = System.getenv(key)

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedDevelocityPlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedDevelocityPlugin.java
@@ -33,6 +33,8 @@ public final class AutoAppliedDevelocityPlugin {
 
     public static final PluginId ID = new DefaultPluginId("com.gradle.develocity");
     public static final PluginId BUILD_SCAN_PLUGIN_ID = new DefaultPluginId("com.gradle.build-scan");
+    public static final PluginId CONVENTIONS_PLUGIN_ID = new DefaultPluginId("io.github.gradle.develocity-conventions-plugin");
+    public static final String CONVENTIONS_PLUGIN_VERSION = "0.12.1";
 
     public static final PluginId GRADLE_ENTERPRISE_PLUGIN_ID = new DefaultPluginId("com.gradle.enterprise");
     public static final String GRADLE_ENTERPRISE_PLUGIN_ARTIFACT_NAME = "gradle-enterprise-gradle-plugin";

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/internal/scan/config/fixtures/ApplyDevelocityPluginFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/internal/scan/config/fixtures/ApplyDevelocityPluginFixture.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.scan.config.fixtures
 
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedDevelocityPlugin
 
+import static org.gradle.plugin.management.internal.autoapply.AutoAppliedDevelocityPlugin.CONVENTIONS_PLUGIN_VERSION
 import static org.gradle.plugin.management.internal.autoapply.AutoAppliedDevelocityPlugin.VERSION
 
 /**
@@ -26,6 +27,7 @@ import static org.gradle.plugin.management.internal.autoapply.AutoAppliedDeveloc
 class ApplyDevelocityPluginFixture {
     private static final String APPLY_DEVELOCITY_PLUGIN = """plugins {
         |    id("${AutoAppliedDevelocityPlugin.ID}") version("${VERSION}")
+        |    id("${AutoAppliedDevelocityPlugin.CONVENTIONS_PLUGIN_ID}").version("${CONVENTIONS_PLUGIN_VERSION}")
         |}""".stripMargin()
 
     static void applyDevelocityPlugin(File settingsFile) {

--- a/testing/internal-integ-testing/src/test/groovy/org/gradle/internal/scan/config/fixtures/ApplyDevelocityPluginFixtureTest.groovy
+++ b/testing/internal-integ-testing/src/test/groovy/org/gradle/internal/scan/config/fixtures/ApplyDevelocityPluginFixtureTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.scan.config.fixtures
 import spock.lang.Specification
 
 import static org.gradle.plugin.management.internal.autoapply.AutoAppliedDevelocityPlugin.VERSION
+import static org.gradle.plugin.management.internal.autoapply.AutoAppliedDevelocityPlugin.CONVENTIONS_PLUGIN_VERSION
 
 class ApplyDevelocityPluginFixtureTest extends Specification {
 
@@ -35,6 +36,7 @@ class ApplyDevelocityPluginFixtureTest extends Specification {
         then:
         file.text =="""plugins {
             |    id("com.gradle.develocity") version("${VERSION}")
+            |    id("io.github.gradle.develocity-conventions-plugin").version("${CONVENTIONS_PLUGIN_VERSION}")
             |}
             |
             |includeBuild '../lib'""".stripMargin()
@@ -65,6 +67,7 @@ class ApplyDevelocityPluginFixtureTest extends Specification {
             |
             |plugins {
             |    id("com.gradle.develocity") version("${VERSION}")
+            |    id("io.github.gradle.develocity-conventions-plugin").version("${CONVENTIONS_PLUGIN_VERSION}")
             |}
             |
             |includeBuild '../lib'""".stripMargin()

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -92,6 +92,7 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest implements 
             "-DkotlinVersion=$kotlinVersion",
             "-DjavaVersion=${AGP_VERSIONS.getMinimumJavaVersionFor(agpVersion).majorVersion}",
             "-DbuildToolsVersion=${AGP_VERSIONS.getBuildToolsVersionFor(agpVersion)}",
+            "-Dscan.tag.SantaTrackerSmokeTest",
             "--stacktrace"
         ] + tasks.toList()
 


### PR DESCRIPTION
Part of https://github.com/gradle/gradle-private/issues/4856

Previously, some santaTracker smoke tests could be as slow as 30m but we had no idea what they are doing. This PR makes it possible to publish build scan inside the smoke tests. The published build scan will have `SantaTrackerSmokeTest` build scan tag.