### PR TITLE
Fix IDEs not respecting attributes for source artifacts/run transformers

### DIFF
--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProvider.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.plugins.ide.idea.model.Dependency;
 import org.gradle.plugins.ide.idea.model.FilePath;
@@ -102,6 +103,7 @@ public class IdeaDependenciesProvider {
 
     private IdeaDependenciesVisitor visitDependencies(IdeaModule ideaModule, GeneratedIdeaScope scope) {
         ProjectInternal projectInternal = (ProjectInternal) ideaModule.getProject();
+        final ObjectFactory objects = projectInternal.getObjects();
         final DependencyHandler handler = projectInternal.getDependencies();
         final Collection<Configuration> plusConfigurations = getPlusConfigurations(ideaModule, scope);
         final Collection<Configuration> minusConfigurations = getMinusConfigurations(ideaModule, scope);
@@ -109,7 +111,7 @@ public class IdeaDependenciesProvider {
 
         final IdeaDependenciesVisitor visitor = new IdeaDependenciesVisitor(ideaModule, scope.name());
         return projectInternal.getOwner().fromMutableState(p -> {
-            new IdeDependencySet(handler, javaModuleDetector, plusConfigurations, minusConfigurations, false, gradleApiSourcesResolver).visit(visitor);
+            new IdeDependencySet(objects, handler, javaModuleDetector, plusConfigurations, minusConfigurations, false, gradleApiSourcesResolver).visit(visitor);
             return visitor;
         });
     }

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.DocsType
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
+import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.IvyHttpModule
@@ -311,18 +312,14 @@ dependencies {
         given:
         executer.withEnvironmentVars('GRADLE_REPO_OVERRIDE': "$server.uri/")
 
-        buildFile """
-            apply plugin: "java"
-            apply plugin: "idea"
-            apply plugin: "eclipse"
-
+        buildFile << withIdePlugins("""
             dependencies {
                 implementation gradleApi()
             }
 
             idea.module.downloadSources = false
             eclipse.classpath.downloadSources = false
-            """
+            """)
         when:
         succeeds ideTask
 
@@ -336,15 +333,11 @@ dependencies {
         given:
         executer.withEnvironmentVars('GRADLE_REPO_OVERRIDE': "$server.uri/")
 
-        buildFile """
-            apply plugin: "java"
-            apply plugin: "idea"
-            apply plugin: "eclipse"
-
+        buildFile << withIdePlugins("""
             dependencies {
                 implementation gradleApi()
             }
-            """
+            """)
         when:
         args("--offline")
         succeeds ideTask
@@ -354,21 +347,18 @@ dependencies {
         ideFileContainsGradleApi("gradle-api")
     }
 
-    @Requires(UnitTestPreconditions.StableGroovy) // localGroovy() version cannot be swapped-out when a snapshot Groovy build is used
+    @Requires(UnitTestPreconditions.StableGroovy)
+    // localGroovy() version cannot be swapped-out when a snapshot Groovy build is used
     def "sources for localGroovy() are downloaded and attached"() {
         given:
         def repo = givenGroovyExistsInGradleRepo()
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$repo.uri/")
 
-        buildFile """
-            apply plugin: "java"
-            apply plugin: "idea"
-            apply plugin: "eclipse"
-
+        buildFile << withIdePlugins("""
             dependencies {
                 implementation localGroovy()
             }
-            """
+            """)
 
         when:
         succeeds ideTask
@@ -386,21 +376,18 @@ dependencies {
         ideFileContainsEntry("groovy-xml-${groovyVersion}.jar", ["groovy-xml-${groovyVersion}-sources.jar"], [])
     }
 
-    @Requires(UnitTestPreconditions.StableGroovy) // localGroovy() version cannot be swapped-out when a snapshot Groovy build is used
+    @Requires(UnitTestPreconditions.StableGroovy)
+    // localGroovy() version cannot be swapped-out when a snapshot Groovy build is used
     def "sources for localGroovy() are downloaded and attached when using gradleApi()"() {
         given:
         def repo = givenGroovyExistsInGradleRepo()
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$repo.uri/")
 
-        buildFile """
-            apply plugin: "java"
-            apply plugin: "idea"
-            apply plugin: "eclipse"
-
+        buildFile << withIdePlugins("""
             dependencies {
                 implementation gradleApi()
             }
-            """
+            """)
 
         when:
         succeeds ideTask
@@ -418,15 +405,11 @@ dependencies {
         def repo = givenGroovyExistsInGradleRepo()
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$repo.uri/")
 
-        buildFile """
-            apply plugin: "java"
-            apply plugin: "idea"
-            apply plugin: "eclipse"
-
+        buildFile << withIdePlugins("""
             dependencies {
                 implementation gradleTestKit()
             }
-            """
+            """)
 
         when:
         succeeds ideTask
@@ -439,18 +422,14 @@ dependencies {
         given:
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$server.uri/")
 
-        buildFile """
-            apply plugin: "java"
-            apply plugin: "idea"
-            apply plugin: "eclipse"
-
+        buildFile << withIdePlugins("""
             dependencies {
                 implementation localGroovy()
             }
 
             idea.module.downloadSources = false
             eclipse.classpath.downloadSources = false
-            """
+            """)
 
         when:
         succeeds ideTask
@@ -463,15 +442,11 @@ dependencies {
         given:
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$server.uri/")
 
-        buildFile """
-            apply plugin: "java"
-            apply plugin: "idea"
-            apply plugin: "eclipse"
-
+        buildFile << withIdePlugins("""
             dependencies {
                 implementation localGroovy()
             }
-            """
+            """)
 
         when:
         args("--offline")
@@ -481,7 +456,8 @@ dependencies {
         ideFileContainsNoSourcesAndJavadocEntry()
     }
 
-    @Requires(UnitTestPreconditions.StableGroovy) // localGroovy() version cannot be swapped-out when a snapshot Groovy build is used
+    @Requires(UnitTestPreconditions.StableGroovy)
+    // localGroovy() version cannot be swapped-out when a snapshot Groovy build is used
     def "does not add project repository to download localGroovy() sources"() {
         given:
         def repo = givenGroovyExistsInGradleRepo()
@@ -490,15 +466,11 @@ dependencies {
             dependencyResolutionManagement { repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS }
         """
 
-        buildFile """
-            apply plugin: "java"
-            apply plugin: "idea"
-            apply plugin: "eclipse"
-
+        buildFile << withIdePlugins("""
             dependencies {
                 implementation localGroovy()
             }
-        """
+        """)
 
         when:
         succeeds ideTask
@@ -508,6 +480,7 @@ dependencies {
     }
 
     def "correct sources and javadoc variants are selected from maven"() {
+        given:
         def repo = mavenHttpRepo
         def art = repo.module('some', 'module', '1.0')
         addClassesVariant(art, 'api-variant', Usage.JAVA_API, 'module-1.0-variant.jar', ['custom-attribute': 'variant'])
@@ -519,11 +492,7 @@ dependencies {
             .withModuleMetadata()
             .publish()
 
-        buildFile.text = buildScriptSnippet"""
-            apply plugin: 'java'
-            apply plugin: 'idea'
-            apply plugin: 'eclipse'
-
+        buildFile.text = withIdePlugins """
             dependencies {
                 implementation('some:module:1.0') {
                     attributes {
@@ -549,6 +518,88 @@ dependencies {
         then:
         succeeds ideTask
         ideFileContainsEntry("module-1.0-variant.jar", "module-1.0-sources-variant.jar", "module-1.0-javadoc-variant.jar")
+    }
+
+    def "sources variant is selected when javadoc variant is not available"() {
+        given:
+        def repo = mavenHttpRepo
+        def art = repo.module('some', 'module', '1.0')
+        addClassesVariant(art, 'api-variant', Usage.JAVA_API, 'module-1.0-variant.jar', ['custom-attribute': 'variant'])
+        addClassesVariant(art, 'runtime-variant', Usage.JAVA_RUNTIME, 'module-1.0-variant.jar', ['custom-attribute': 'variant'])
+        addDocumentVariant(art, 'sources-variant', DocsType.SOURCES, null, ['custom-attribute': 'variant'])
+        art
+            .withSourceAndJavadoc() // Default version
+            .withModuleMetadata()
+            .publish()
+
+        buildFile.text = withIdePlugins """
+            dependencies {
+                implementation('some:module:1.0') {
+                    attributes {
+                        attribute(Attribute.of('custom-attribute', String), 'variant')
+                    }
+                }
+            }
+
+            eclipse.classpath.downloadJavadoc = true
+            idea.module.downloadJavadoc = true
+        """
+
+        when:
+        useMavenRepo(repo)
+
+        and:
+        art.pom.expectGet()
+        art.moduleMetadata.expectGet()
+        art.artifact(classifier: 'variant').expectGet()
+        art.artifact(classifier: 'sources-variant').expectGet()
+        art.artifact(classifier: 'javadoc').expectHead()
+        art.artifact(classifier: 'javadoc').expectGet()
+
+        then:
+        succeeds ideTask
+        ideFileContainsEntry("module-1.0-variant.jar", "module-1.0-sources-variant.jar", "module-1.0-javadoc.jar")
+    }
+
+    def "javadoc variant is selected when sources variant is not available"() {
+        given:
+        def repo = mavenHttpRepo
+        def art = repo.module('some', 'module', '1.0')
+        addClassesVariant(art, 'api-variant', Usage.JAVA_API, 'module-1.0-variant.jar', ['custom-attribute': 'variant'])
+        addClassesVariant(art, 'runtime-variant', Usage.JAVA_RUNTIME, 'module-1.0-variant.jar', ['custom-attribute': 'variant'])
+        addDocumentVariant(art, 'javadoc-variant', DocsType.JAVADOC, null, ['custom-attribute': 'variant'])
+        art
+            .withSourceAndJavadoc() // Default version
+            .withModuleMetadata()
+            .publish()
+
+        buildFile.text = withIdePlugins """
+            dependencies {
+                implementation('some:module:1.0') {
+                    attributes {
+                        attribute(Attribute.of('custom-attribute', String), 'variant')
+                    }
+                }
+            }
+
+            eclipse.classpath.downloadJavadoc = true
+            idea.module.downloadJavadoc = true
+        """
+
+        when:
+        useMavenRepo(repo)
+
+        and:
+        art.pom.expectGet()
+        art.moduleMetadata.expectGet()
+        art.artifact(classifier: 'variant').expectGet()
+        art.artifact(classifier: 'sources').expectHead()
+        art.artifact(classifier: 'sources').expectGet()
+        art.artifact(classifier: 'javadoc-variant').expectGet()
+
+        then:
+        succeeds ideTask
+        ideFileContainsEntry("module-1.0-variant.jar", ["module-1.0-sources.jar"], ["module-1.0-javadoc-variant.jar"])
     }
 
     void assertSourcesDirectoryDoesNotExistInDistribution() {
@@ -585,6 +636,15 @@ dependencies {
         module.allowAll()
     }
 
+    String withIdePlugins(@GroovyBuildScriptLanguage String append) {
+        """
+    apply plugin: "java"
+    apply plugin: "idea"
+    apply plugin: "eclipse"
+
+""" + append
+    }
+
     private useIvyRepo(def repo) {
         buildFile << """repositories { ivy { url = "$repo.uri" } }"""
     }
@@ -609,7 +669,7 @@ dependencies {
             attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
             attribute(Category.CATEGORY_ATTRIBUTE.name, Category.DOCUMENTATION)
             attribute(DocsType.DOCS_TYPE_ATTRIBUTE.name, type)
-            attributes.forEach(k, v) -> attribute(k, v)
+            attributes.forEach (k, v) -> attribute(k, v)
             if (filename == null) {
                 artifact(module.artifactId + '-' + module.version + '-' + name + '.jar')
             } else {
@@ -617,13 +677,14 @@ dependencies {
             }
         }
     }
+
     private static void addClassesVariant(MavenHttpModule module, String name, String type, String filename = null, Map<String, String> attributes = [:]) {
         module.withVariant(name) {
             useDefaultArtifacts = false
             attribute(Usage.USAGE_ATTRIBUTE.name, type)
             attribute(Category.CATEGORY_ATTRIBUTE.name, Category.LIBRARY)
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name, LibraryElements.JAR)
-            attributes.forEach(k, v) -> attribute(k, v)
+            attributes.forEach (k, v) -> attribute(k, v)
             if (filename == null) {
                 artifact(module.artifactId + '-' + module.version + '-' + name + '.jar')
             } else {
@@ -641,11 +702,7 @@ dependencies {
     }
 
     String getBaseBuildScript() {
-        """
-apply plugin: "java"
-apply plugin: "idea"
-apply plugin: "eclipse"
-
+        withIdePlugins("""
 dependencies {
     implementation("some:module:1.0")
 }
@@ -668,7 +725,7 @@ task resolve {
         runtimeClasspath.each { println it }
     }
 }
-"""
+""")
     }
 
     abstract String getIdeTask()

--- a/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
+++ b/platforms/ide/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
@@ -125,6 +125,13 @@ dependencies {
         javadocArtifact.expectHead()
         javadocArtifact.expectGetBroken()
 
+        // Source and javadoc artifacts are queried twice because of their broken state.
+        sourceArtifact.expectHead()
+        sourceArtifact.expectGetBroken()
+
+        javadocArtifact.expectHead()
+        javadocArtifact.expectGetBroken()
+
         then:
         succeeds ideTask
         ideFileContainsNoSourcesAndJavadocEntry()

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -77,7 +77,7 @@ public class EclipseDependenciesCreator {
     public List<AbstractClasspathEntry> createDependencyEntries() {
         EclipseDependenciesVisitor visitor = new EclipseDependenciesVisitor(classpath.getProject());
         Set<Configuration> testConfigurations = classpath.getTestConfigurations().getOrElse(Collections.emptySet());
-        new IdeDependencySet(classpath.getProject().getDependencies(), ((ProjectInternal) classpath.getProject()).getServices().get(JavaModuleDetector.class), classpath.getPlusConfigurations(), classpath.getMinusConfigurations(), inferModulePath, gradleApiSourcesResolver, testConfigurations).visit(visitor);
+        new IdeDependencySet(classpath.getProject().getObjects(), classpath.getProject().getDependencies(), ((ProjectInternal) classpath.getProject()).getServices().get(JavaModuleDetector.class), classpath.getPlusConfigurations(), classpath.getMinusConfigurations(), inferModulePath, gradleApiSourcesResolver, testConfigurations).visit(visitor);
         return visitor.getDependencies();
     }
 

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpClasspathAttributeSupport.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpClasspathAttributeSupport.java
@@ -64,7 +64,7 @@ public class WtpClasspathAttributeSupport {
 
     private static Set<File> collectFilesFromConfigs(EclipseClasspath classpath, Set<Configuration> configs, Set<Configuration> minusConfigs) {
         WtpClasspathAttributeDependencyVisitor visitor = new WtpClasspathAttributeDependencyVisitor(classpath);
-        new IdeDependencySet(classpath.getProject().getDependencies(), ((ProjectInternal) classpath.getProject()).getServices().get(JavaModuleDetector.class),
+        new IdeDependencySet(classpath.getProject().getObjects(), classpath.getProject().getDependencies(), ((ProjectInternal) classpath.getProject()).getServices().get(JavaModuleDetector.class),
             configs, minusConfigs, false, NullGradleApiSourcesResolver.INSTANCE, classpath.getTestConfigurations().getOrElse(Collections.emptySet())).visit(visitor);
         return visitor.getFiles();
     }

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpComponentFactory.java
@@ -89,7 +89,7 @@ public class WtpComponentFactory {
 
     private List<WbDependentModule> getEntriesFromConfigurations(Project project, Set<Configuration> plusConfigurations, Set<Configuration> minusConfigurations, EclipseWtpComponent wtp, String deployPath) {
         WtpDependenciesVisitor visitor = new WtpDependenciesVisitor(project, wtp, deployPath);
-        new IdeDependencySet(project.getDependencies(), ((ProjectInternal) project).getServices().get(JavaModuleDetector.class),
+        new IdeDependencySet(project.getObjects(), project.getDependencies(), ((ProjectInternal) project).getServices().get(JavaModuleDetector.class),
             plusConfigurations, minusConfigurations, false, NullGradleApiSourcesResolver.INSTANCE).visit(visitor);
         return visitor.getEntries();
     }


### PR DESCRIPTION
Fixes:
 - https://github.com/gradle/gradle/issues/35065

IDEs don't support artifact transformers or attributes for source and javadoc artifacts.

It all boils down to IdeDependencySet [not using ArtifactView for aux artifacts](https://github.com/gradle/gradle/blob/e68a9cbfbbcfbed70072015ead835f8b319196ba/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java#L184-L201). It does for the [primary artifact](https://github.com/gradle/gradle/blob/e68a9cbfbbcfbed70072015ead835f8b319196ba/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java#L148-L156). 

I've written an [integration test](https://github.com/LexManos/gradle/commit/744930bd2e1a16cbb08c64ab87bbd0f5399b1248) to illustrate the issue.

I have the changes necessary to make it function, I'm sure I'm missing some fundamental style/concepts in your project. But I was requested to open this as a PR so I did.