### PR TITLE
Let `DefaultFileLockContentHandler` always access sets under a lock

### DIFF
--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandler.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandler.java
@@ -218,13 +218,23 @@ public class DefaultFileLockContentionHandler implements FileLockContentionHandl
     @Override
     public boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed, FileLockReleasedSignal signal) {
         assert port != UNKNOWN_PORT;
-        if (port == unlocksConfirmedFrom.getOrDefault(lockId, UNKNOWN_PORT)) {
-            //the unlock was confirmed we are waiting
+
+        if (timeElapsed < PING_DELAY) {
             return false;
         }
-        if (timeElapsed < PING_DELAY && port == unlocksRequestedFrom.getOrDefault(lockId, UNKNOWN_PORT)) {
-            //the unlock was just requested but not yet confirmed, give it some more time
-            return false;
+
+        lock.lock();
+        try {
+            if (port == unlocksConfirmedFrom.getOrDefault(lockId, UNKNOWN_PORT)) {
+                //the unlock was confirmed we are waiting
+                return false;
+            }
+            if (port == unlocksRequestedFrom.getOrDefault(lockId, UNKNOWN_PORT)) {
+                //the unlock was just requested but not yet confirmed, give it some more time
+                return false;
+            }
+        } finally {
+            lock.unlock();
         }
 
         boolean pingSentSuccessfully = getCommunicator().pingOwner(inetAddressProvider.getCommunicationAddress(), port, lockId, displayName);


### PR DESCRIPTION
Follow-up to #34933

Before #34933, Gradle was using `java.util.HashMap` instances that, while increasing boxing overhead, seemed more resilient to unlocked access.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
