### PR TITLE
Rename HasBuildModel to Definition

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/WorkingWithFilesIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/WorkingWithFilesIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.declarativedsl
 
 import org.gradle.api.internal.plugins.BuildModel
-import org.gradle.api.internal.plugins.HasBuildModel
+import org.gradle.api.internal.plugins.Definition
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.polyglot.PolyglotDslTest
 import org.gradle.integtests.fixtures.polyglot.PolyglotTestFixture
@@ -208,11 +208,11 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
 
                 import org.gradle.api.file.DirectoryProperty;
                 import org.gradle.api.file.RegularFileProperty;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 @Restricted
-                public abstract class ${implementationTypeClassName} implements HasBuildModel<${implementationTypeClassName}.ModelType> {
+                public abstract class ${implementationTypeClassName} implements ${Definition.class.simpleName}<${implementationTypeClassName}.ModelType> {
                     @Restricted
                     public abstract DirectoryProperty getDir();
 
@@ -244,11 +244,11 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
                 import org.gradle.api.provider.ListProperty;
                 import org.gradle.api.file.Directory;
                 import org.gradle.api.file.RegularFile;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 @Restricted
-                public abstract class ${implementationTypeClassName} implements HasBuildModel<${implementationTypeClassName}.ModelType> {
+                public abstract class ${implementationTypeClassName} implements ${Definition.class.simpleName}<${implementationTypeClassName}.ModelType> {
                     @Restricted
                     public abstract ListProperty<Directory> getDirs();
 
@@ -280,11 +280,11 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
                 import org.gradle.api.file.Directory;
                 import org.gradle.api.file.RegularFileProperty;
                 import org.gradle.api.provider.Property;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 @Restricted
-                public interface ${implementationTypeClassName} extends HasBuildModel<${implementationTypeClassName}.ModelType> {
+                public interface ${implementationTypeClassName} extends ${Definition.class.simpleName}<${implementationTypeClassName}.ModelType> {
                     @Restricted
                     Directory getDir();
 
@@ -311,11 +311,11 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
                 import org.gradle.api.file.DirectoryProperty;
                 import org.gradle.api.file.RegularFile;
                 import org.gradle.api.provider.Property;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 @Restricted
-                public interface ${implementationTypeClassName} extends HasBuildModel<${implementationTypeClassName}.ModelType> {
+                public interface ${implementationTypeClassName} extends ${Definition.class.simpleName}<${implementationTypeClassName}.ModelType> {
                     @Restricted
                     DirectoryProperty getDir();
 
@@ -345,13 +345,13 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
                 import org.gradle.api.file.RegularFileProperty;
                 import org.gradle.api.model.ObjectFactory;
                 import org.gradle.api.provider.Property;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 import javax.inject.Inject;
 
                 @Restricted
-                public abstract class ${implementationTypeClassName} implements HasBuildModel<${implementationTypeClassName}.ModelType> {
+                public abstract class ${implementationTypeClassName} implements ${Definition.class.simpleName}<${implementationTypeClassName}.ModelType> {
 
                     private final Property<Directory> dir;
                     private final Property<RegularFile> file;
@@ -398,13 +398,13 @@ class WorkingWithFilesIntegrationTest extends AbstractIntegrationSpec implements
                 import org.gradle.api.file.RegularFile;
                 import org.gradle.api.file.DirectoryProperty;
                 import org.gradle.api.file.RegularFileProperty;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 import javax.inject.Inject;
 
                 @Restricted
-                public abstract class ${implementationTypeClassName} implements HasBuildModel<${implementationTypeClassName}.ModelType> {
+                public abstract class ${implementationTypeClassName} implements ${Definition.class.simpleName}<${implementationTypeClassName}.ModelType> {
 
                     private Directory dir;
                     private RegularFile file;

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/software/schemaFromProjectFeatures.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/software/schemaFromProjectFeatures.kt
@@ -18,7 +18,7 @@ package org.gradle.internal.declarativedsl.software
 
 import org.gradle.api.Project
 import org.gradle.api.internal.DynamicObjectAware
-import org.gradle.api.internal.plugins.HasBuildModel
+import org.gradle.api.internal.plugins.Definition
 import org.gradle.api.internal.plugins.TargetTypeInformation.BuildModelTargetTypeInformation
 import org.gradle.api.internal.plugins.TargetTypeInformation.DefinitionTargetTypeInformation
 import org.gradle.api.internal.project.ProjectInternal
@@ -216,7 +216,7 @@ fun projectFeatureConfiguringFunctions(projectFeatureImplementations: ProjectFea
         val featureImplementations = buildSet {
             classWithSupertypes.forEach { supertype ->
                 projectFeatureImplementations.bindingToDefinition[supertype.classifier]?.let(::addAll)
-                if (supertype.classifier == HasBuildModel::class) {
+                if (supertype.classifier == Definition::class) {
                     val buildModelWithSupertypes = supertype.arguments.single().type.let { listOf(it) + (it?.classifier as? KClass<*>)?.allSupertypes.orEmpty() }
                     buildModelWithSupertypes.forEach { buildModelSupertype ->
                         projectFeatureImplementations.bindingByModelType[buildModelSupertype?.classifier]?.let(::addAll)

--- a/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/ProjectFeatureFixture.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/ProjectFeatureFixture.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.declarativedsl.settings
 
 import org.gradle.api.internal.plugins.BuildModel
-import org.gradle.api.internal.plugins.HasBuildModel
+import org.gradle.api.internal.plugins.Definition
 import org.gradle.api.internal.plugins.ProjectFeatureBindingBuilder
 import org.gradle.api.internal.plugins.ProjectFeatureBindingRegistration
 import org.gradle.test.fixtures.plugin.PluginBuilder
@@ -394,13 +394,13 @@ trait ProjectFeatureFixture extends ProjectTypeFixture {
             return """
                 package org.gradle.test;
 
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
                 import org.gradle.api.provider.Property;
                 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
                 @Restricted
-                public interface ${implementationTypeClassName} extends HasBuildModel<${implementationTypeClassName}.FeatureModel> {
+                public interface ${implementationTypeClassName} extends ${Definition.class.simpleName}<${implementationTypeClassName}.FeatureModel> {
                     @Restricted
                     Property<String> getText();
 
@@ -446,11 +446,11 @@ trait ProjectFeatureFixture extends ProjectTypeFixture {
 
                 import org.gradle.api.provider.Property;
                 import org.gradle.declarative.dsl.model.annotations.Restricted;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 @Restricted
-                public interface ${publicTypeClassName} extends HasBuildModel<${publicTypeClassName}.FeatureModel> {
+                public interface ${publicTypeClassName} extends ${Definition.class.simpleName}<${publicTypeClassName}.FeatureModel> {
                     @Restricted
                     Property<String> getText();
 
@@ -498,11 +498,11 @@ trait ProjectFeatureFixture extends ProjectTypeFixture {
 
                 import org.gradle.api.provider.Property;
                 import org.gradle.declarative.dsl.model.annotations.Restricted;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 @Restricted
-                public interface ${implementationTypeClassName} extends HasBuildModel<${implementationTypeClassName}.${buildModelPublicTypeClassName}> {
+                public interface ${implementationTypeClassName} extends Definition<${implementationTypeClassName}.${buildModelPublicTypeClassName}> {
                     @Restricted
                     Property<String> getText();
 

--- a/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/ProjectTypeFixture.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/internal/declarativedsl/settings/ProjectTypeFixture.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.declarativedsl.settings
 import groovy.transform.SelfType
 import org.gradle.api.internal.plugins.BindsProjectType
 import org.gradle.api.internal.plugins.BuildModel
-import org.gradle.api.internal.plugins.HasBuildModel
+import org.gradle.api.internal.plugins.Definition
 import org.gradle.api.internal.plugins.ProjectTypeBindingBuilder
 import org.gradle.api.internal.plugins.ProjectTypeBindingRegistration
 import org.gradle.api.internal.plugins.software.RegistersProjectFeatures
@@ -463,13 +463,13 @@ trait ProjectTypeFixture {
                 import org.gradle.api.model.ObjectFactory;
                 import org.gradle.api.provider.ListProperty;
                 import org.gradle.api.provider.Property;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 import javax.inject.Inject;
 
                 @Restricted
-                public abstract class ${implementationTypeClassName} implements HasBuildModel<${implementationTypeClassName}.ModelType> ${maybeImplementsPublicType()} {
+                public abstract class ${implementationTypeClassName} implements ${Definition.class.simpleName}<${implementationTypeClassName}.ModelType> ${maybeImplementsPublicType()} {
                     private final Foo foo;
                     private boolean isFooConfigured = false;
 
@@ -491,7 +491,7 @@ trait ProjectTypeFixture {
                         action.execute(foo);
                     }
 
-                    public abstract static class Foo implements HasBuildModel<FooBuildModel> {
+                    public abstract static class Foo implements ${Definition.class.simpleName}<FooBuildModel> {
                         public Foo() { }
 
                         @Restricted
@@ -530,12 +530,12 @@ trait ProjectTypeFixture {
                 import org.gradle.api.Named;
                 import org.gradle.api.NamedDomainObjectContainer;
                 import org.gradle.api.provider.Property;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 import java.util.stream.Collectors;
 
-                public abstract class ${implementationTypeClassName} implements HasBuildModel<${implementationTypeClassName}.ModelType> ${maybeImplementsPublicType()} {
+                public abstract class ${implementationTypeClassName} implements ${Definition.class.simpleName}<${implementationTypeClassName}.ModelType> ${maybeImplementsPublicType()} {
                     public abstract NamedDomainObjectContainer<Foo> getFoos();
 
                     public abstract static class Foo implements Named {
@@ -629,11 +629,11 @@ trait ProjectTypeFixture {
 
                 import org.gradle.api.provider.Property;
                 import org.gradle.api.Action;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 @Restricted
-                public interface ${publicTypeClassName} extends HasBuildModel<${publicTypeClassName}.ModelType> {
+                public interface ${publicTypeClassName} extends ${Definition.class.simpleName}<${publicTypeClassName}.ModelType> {
                     @Restricted
                     Property<String> getId();
 
@@ -684,13 +684,13 @@ trait ProjectTypeFixture {
                 import org.gradle.api.provider.ListProperty;
                 import org.gradle.api.provider.Property;
                 import org.gradle.api.tasks.Nested;
-                import ${HasBuildModel.class.name};
+                import ${Definition.class.name};
                 import ${BuildModel.class.name};
 
                 import javax.inject.Inject;
 
                 @Restricted
-                public abstract class ${implementationTypeClassName} implements HasBuildModel<${implementationTypeClassName}.ModelType> ${maybeImplementsPublicType()} {
+                public abstract class ${implementationTypeClassName} implements ${Definition.class.simpleName}<${implementationTypeClassName}.ModelType> ${maybeImplementsPublicType()} {
                     @Inject
                     public ${implementationTypeClassName}() { }
 

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/KotlinDslDclSchemaCollector.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/KotlinDslDclSchemaCollector.kt
@@ -20,7 +20,7 @@ import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.initialization.ClassLoaderScope
-import org.gradle.api.internal.plugins.HasBuildModel
+import org.gradle.api.internal.plugins.Definition
 import org.gradle.api.internal.plugins.TargetTypeInformation
 import org.gradle.api.reflect.TypeOf
 import org.gradle.declarative.dsl.evaluation.InterpretationSequence
@@ -144,7 +144,7 @@ internal class DefaultKotlinDslDclSchemaCollector : KotlinDslDclSchemaCollector 
             val targetType = when (val target = implementation.targetDefinitionType) {
                 is TargetTypeInformation.DefinitionTargetTypeInformation ->  TypeOf.typeOf(target.definitionType)
                 is TargetTypeInformation.BuildModelTargetTypeInformation<*> ->
-                    parameterizedTypeOfRawGenericClass(listOf(TypeProjection(target.buildModelType, TypeProjectionKind.OUT)), HasBuildModel::class.java)
+                    parameterizedTypeOfRawGenericClass(listOf(TypeProjection(target.buildModelType, TypeProjectionKind.OUT)), Definition::class.java)
                 else -> error("Unexpected target type $target")
             }
             ProjectFeatureEntry(name, TypeOf.typeOf(implementation.definitionPublicType), targetType)

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/DclInterpreterIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/DclInterpreterIntegrationTest.kt
@@ -19,7 +19,7 @@ package org.gradle.kotlin.dsl.dcl
 import org.gradle.api.internal.plugins.BindsProjectFeature
 import org.gradle.api.internal.plugins.BindsProjectType
 import org.gradle.api.internal.plugins.BuildModel
-import org.gradle.api.internal.plugins.HasBuildModel
+import org.gradle.api.internal.plugins.Definition
 import org.gradle.api.internal.plugins.ProjectFeatureBindingBuilder
 import org.gradle.api.internal.plugins.ProjectFeatureBindingRegistration
 import org.gradle.api.internal.plugins.ProjectTypeBindingBuilder
@@ -99,7 +99,7 @@ class DclInterpreterIntegrationTest : AbstractKotlinIntegrationTest() {
             assertOutputContains(
                 """
                 |    @Incubating
-                |    fun org.gradle.api.internal.plugins.HasBuildModel<out com.example.MyFeatureBuildModel>.`myNestedFeature`(configure: Action<in com.example.MyNestedFeatureDefinition>) {
+                |    fun org.gradle.api.internal.plugins.Definition<out com.example.MyFeatureBuildModel>.`myNestedFeature`(configure: Action<in com.example.MyNestedFeatureDefinition>) {
                 |        applyProjectType(this, "myNestedFeature", configure)
                 |    }
                 """.trimMargin()
@@ -125,7 +125,7 @@ class DclInterpreterIntegrationTest : AbstractKotlinIntegrationTest() {
                 import javax.inject.Inject
                 import ${BindsProjectType::class.qualifiedName}
                 import ${BindsProjectFeature::class.qualifiedName}
-                import ${HasBuildModel::class.qualifiedName}
+                import ${Definition::class.qualifiedName}
                 import ${BuildModel::class.qualifiedName}
                 import ${ProjectTypeBindingRegistration::class.qualifiedName}
                 import ${ProjectTypeBindingBuilder::class.qualifiedName}
@@ -175,13 +175,13 @@ class DclInterpreterIntegrationTest : AbstractKotlinIntegrationTest() {
                 }
 
                 interface MyExtensionBuildModel : BuildModel
-                abstract class MyExtension : HasBuildModel<MyExtensionBuildModel> {
+                abstract class MyExtension : ${Definition::class.simpleName}<MyExtensionBuildModel> {
                     abstract val myElements: NamedDomainObjectContainer<MyElement>
                 }
 
                 interface MyFeatureBuildModel : BuildModel
 
-                abstract class MyFeatureDefinition : HasBuildModel<MyFeatureBuildModel>
+                abstract class MyFeatureDefinition : ${Definition::class.simpleName}<MyFeatureBuildModel>
 
                 abstract class MyNestedFeatureDefinition : MyFeatureDefinition()
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
@@ -22,7 +22,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.internal.DynamicObjectAware
-import org.gradle.api.internal.plugins.HasBuildModel
+import org.gradle.api.internal.plugins.Definition
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Provider
@@ -145,7 +145,7 @@ fun applyProjectFeature(
             target.objects.newInstance<ProjectFeatureSupportInternal.DefaultProjectFeatureDefinitionContext.Factory>()
                 .create(target)
 
-        is HasBuildModel<*> -> ProjectFeatureSupportInternal.getContext(target)
+        is Definition<*> -> ProjectFeatureSupportInternal.getContext(target)
         else -> throw IllegalArgumentException("Unexpected definition object $target, cannot get context to apply the feature")
     }
     val projectFeatures = context.projectFeatureRegistry.projectFeatureImplementations.getValue(name)

--- a/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/antlr/AntlrGrammarsDefinition.java
+++ b/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/antlr/AntlrGrammarsDefinition.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.plugins.antlr;
 
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.jspecify.annotations.NonNull;
 
-public interface AntlrGrammarsDefinition extends AntlrConfiguration, HasBuildModel<@NonNull AntlrGeneratedSources> {
+public interface AntlrGrammarsDefinition extends AntlrConfiguration, Definition<@NonNull AntlrGeneratedSources> {
 }

--- a/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/checkstyle/CheckstyleSourceSetDefinition.java
+++ b/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/checkstyle/CheckstyleSourceSetDefinition.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.plugins.checkstyle;
 
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.jspecify.annotations.NonNull;
 
-public interface CheckstyleSourceSetDefinition extends CheckstyleDefinition, HasBuildModel<@NonNull CheckstyleModel> {
+public interface CheckstyleSourceSetDefinition extends CheckstyleDefinition, Definition<@NonNull CheckstyleModel> {
 }

--- a/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/demo/quality/DemoCodeQualityDefinition.java
+++ b/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/demo/quality/DemoCodeQualityDefinition.java
@@ -16,13 +16,13 @@
 
 package org.gradle.api.plugins.demo.quality;
 
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.api.provider.Property;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public interface DemoCodeQualityDefinition extends HasBuildModel<DemoCodeQualityModel> {
+public interface DemoCodeQualityDefinition extends Definition<DemoCodeQualityModel> {
     @Restricted
     Property<Boolean> getIgnoreFailures();
 }

--- a/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/instrumentation/InstrumentClassesDefinition.java
+++ b/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/instrumentation/InstrumentClassesDefinition.java
@@ -18,12 +18,12 @@ package org.gradle.api.plugins.instrumentation;
 
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 import org.jspecify.annotations.NonNull;
 
 @Restricted
-public interface InstrumentClassesDefinition extends HasBuildModel<@NonNull InstrumentClassesModel> {
+public interface InstrumentClassesDefinition extends Definition<@NonNull InstrumentClassesModel> {
     @Restricted
     RegularFileProperty getConfigFile();
     @Restricted

--- a/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/java/GroovyProjectType.java
+++ b/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/java/GroovyProjectType.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.plugins.java;
 
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.jspecify.annotations.NonNull;
 
-public interface GroovyProjectType extends HasToolChain, HasGroovySources, HasJavaTarget, HasLibraryDependencies, HasBuildModel<@NonNull GroovyLibraryModel> {
+public interface GroovyProjectType extends HasToolChain, HasGroovySources, HasJavaTarget, HasLibraryDependencies, Definition<@NonNull GroovyLibraryModel> {
 }

--- a/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/java/HasSources.java
+++ b/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/java/HasSources.java
@@ -19,14 +19,14 @@ package org.gradle.api.plugins.java;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public interface HasSources<Model extends HasInputSources> {
     NamedDomainObjectContainer<? extends Sources<Model>> getSources();
 
-    interface Sources<Model extends HasInputSources> extends Named, HasResources, HasBuildModel<Model> {
+    interface Sources<Model extends HasInputSources> extends Named, HasResources, Definition<Model> {
         SourceDirectorySet getSourceDirectories();
     }
 }

--- a/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/java/JavaProjectType.java
+++ b/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/java/JavaProjectType.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.plugins.java;
 
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.jspecify.annotations.NonNull;
 
-public interface JavaProjectType extends HasToolChain, HasJavaSources, HasJavaTarget, HasLibraryDependencies, HasBuildModel<@NonNull JavaLibraryModel> {
+public interface JavaProjectType extends HasToolChain, HasJavaSources, HasJavaTarget, HasLibraryDependencies, Definition<@NonNull JavaLibraryModel> {
 }

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/Definition.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/Definition.java
@@ -19,5 +19,5 @@ package org.gradle.api.internal.plugins;
 /**
  * A marker interface for definition objects that have a build model.
  */
-public interface HasBuildModel<T extends BuildModel> {
+public interface Definition<T extends BuildModel> {
 }

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/DslBindingBuilder.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/DslBindingBuilder.java
@@ -19,17 +19,17 @@ package org.gradle.api.internal.plugins;
 /**
  * A builder for configuring a DSL binding for a project type or project feature.
  *
- * @param <T> the type of the project type or project feature definition object
- * @param <V> the type of the build model object for this project type or project feature
+ * @param <OwnDefinition> the type of the project type or project feature definition object
+ * @param <OwnBuildModel> the type of the build model object for this project type or project feature
  */
-public interface DslBindingBuilder<T extends HasBuildModel<V>, V extends BuildModel> {
+public interface DslBindingBuilder<OwnDefinition extends Definition<OwnBuildModel>, OwnBuildModel extends BuildModel> {
     /**
      * Specify the implementation type to use when creating instances of the definition object in the DSL.
      *
      * @param implementationType the implementation type to use
      * @return this builder
      */
-    DslBindingBuilder<T, V> withDefinitionImplementationType(Class<? extends T> implementationType);
+    DslBindingBuilder<OwnDefinition, OwnBuildModel> withDefinitionImplementationType(Class<? extends OwnDefinition> implementationType);
 
     /**
      * Specify the implementation type to use when creating instances of the build model object.
@@ -37,5 +37,5 @@ public interface DslBindingBuilder<T extends HasBuildModel<V>, V extends BuildMo
      * @param implementationType the implementation type to use
      * @return this builder
      */
-    DslBindingBuilder<T, V> withBuildModelImplementationType(Class<? extends V> implementationType);
+    DslBindingBuilder<OwnDefinition, OwnBuildModel> withBuildModelImplementationType(Class<? extends OwnBuildModel> implementationType);
 }

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/DslBindingBuilderInternal.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/DslBindingBuilderInternal.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.plugins;
 
-public interface DslBindingBuilderInternal<T extends HasBuildModel<V>, V extends BuildModel> extends DslBindingBuilder<T, V> {
+public interface DslBindingBuilderInternal<T extends Definition<V>, V extends BuildModel> extends DslBindingBuilder<T, V> {
 
     ProjectFeatureBinding<T, V> build();
 }

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureApplicationContext.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureApplicationContext.java
@@ -54,7 +54,7 @@ public interface ProjectFeatureApplicationContext {
      * Allows a {@link ProjectFeatureApplyAction} or {@link ProjectTypeApplyAction} to access the build model object of a given
      * definition object.
      */
-    <T extends HasBuildModel<V>, V extends BuildModel> V getBuildModel(T definition);
+    <T extends Definition<V>, V extends BuildModel> V getBuildModel(T definition);
 
     /**
      * Creates, registers, and returns a new build model instance for the given {@code definition} instance.
@@ -65,13 +65,13 @@ public interface ProjectFeatureApplicationContext {
      * <p>
      * A build model must be registered for a definition before {@link ProjectFeatureDefinitionContext#getBuildModel()} is used on it.
      *
-     * @see ProjectFeatureApplicationContext#registerBuildModel(HasBuildModel, Class) the other overload to create a build model of a specific implementation type.
+     * @see ProjectFeatureApplicationContext#registerBuildModel(Definition, Class) the other overload to create a build model of a specific implementation type.
      *
      * @throws IllegalStateException if there is already a build model instance registered for the definition.
      */
-    default <T extends HasBuildModel<V>, V extends BuildModel> V registerBuildModel(T definition) {
+    default <T extends Definition<V>, V extends BuildModel> V registerBuildModel(T definition) {
         @SuppressWarnings("rawtypes")
-        TypeParameterInspection<HasBuildModel, BuildModel> inspection = new DefaultTypeParameterInspection<>(HasBuildModel.class, BuildModel.class, BuildModel.NONE.class);
+        TypeParameterInspection<Definition, BuildModel> inspection = new DefaultTypeParameterInspection<>(Definition.class, BuildModel.class, BuildModel.NONE.class);
         Class<V> modelType = inspection.parameterTypeFor(definition.getClass());
         if (modelType == null) {
             throw new IllegalArgumentException("Cannot determine build model type for " + definition.getClass());
@@ -88,9 +88,9 @@ public interface ProjectFeatureApplicationContext {
      * <p>
      * A build model must be registered for a definition before {@link ProjectFeatureDefinitionContext#getBuildModel()} is used on it.
      *
-     * @see ProjectFeatureApplicationContext#registerBuildModel(HasBuildModel, Class) the other overload to create a build model of a specific implementation type.
+     * @see ProjectFeatureApplicationContext#registerBuildModel(Definition, Class) the other overload to create a build model of a specific implementation type.
      *
      * @throws IllegalStateException if there is already a build model instance registered for the definition.
      */
-    <T extends HasBuildModel<V>, V extends BuildModel> V registerBuildModel(T definition, Class<? extends V> implementationType);
+    <T extends Definition<V>, V extends BuildModel> V registerBuildModel(T definition, Class<? extends V> implementationType);
 }

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureApplyAction.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureApplyAction.java
@@ -19,10 +19,10 @@ package org.gradle.api.internal.plugins;
 /**
  * An action that applies configuration from a project feature definition to its build model.
  *
- * @param <Definition> the type of the project feature definition
+ * @param <OwnDefinition> the type of the project feature definition
  * @param <OwnBuildModel> the type of the project feature's own build model
  * @param <ParentDefinition> the type of the parent project feature definition
  */
-public interface ProjectFeatureApplyAction<Definition, OwnBuildModel, ParentDefinition> {
-    void transform(ProjectFeatureApplicationContext context, Definition definition, OwnBuildModel buildModel, ParentDefinition parentDefinition);
+public interface ProjectFeatureApplyAction<OwnDefinition, OwnBuildModel, ParentDefinition> {
+    void transform(ProjectFeatureApplicationContext context, OwnDefinition definition, OwnBuildModel buildModel, ParentDefinition parentDefinition);
 }

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureBinding.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureBinding.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.plugins;
 
 import java.util.Optional;
 
-public interface ProjectFeatureBinding<T extends HasBuildModel<V>, V extends BuildModel> {
+public interface ProjectFeatureBinding<T extends Definition<V>, V extends BuildModel> {
     TargetTypeInformation<?> targetDefinitionType();
     Class<T> getDslType();
     Optional<Class<? extends T>> getDslImplementationType();

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureBindingBuilder.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureBindingBuilder.java
@@ -33,19 +33,19 @@ public interface ProjectFeatureBindingBuilder {
      * @param bindingTypeInformation type information about the parent object the feature can be bound to
      * @param transform the transform that maps the definition to the build model and implements the build logic associated with the feature
      * @return a {@link DslBindingBuilder} that can be used to further configure the binding
-     * @param <Definition> the type of the definition object for this feature
+     * @param <OwnDefinition> the type of the definition object for this feature
      * @param <OwnBuildModel> the type of the build model object for this feature
      * @param <TargetDefinition> the type of the parent definition object this feature can be bound to
      */
     <
-        Definition extends HasBuildModel<OwnBuildModel>,
+        OwnDefinition extends Definition<OwnBuildModel>,
         OwnBuildModel extends BuildModel,
-        TargetDefinition extends HasBuildModel<?>
+        TargetDefinition extends Definition<?>
         >
-    DslBindingBuilder<Definition, OwnBuildModel> bindProjectFeature(
+    DslBindingBuilder<OwnDefinition, OwnBuildModel> bindProjectFeature(
         String name,
-        ModelBindingTypeInformation<Definition, OwnBuildModel, TargetDefinition> bindingTypeInformation,
-        ProjectFeatureApplyAction<Definition, OwnBuildModel, TargetDefinition> transform
+        ModelBindingTypeInformation<OwnDefinition, OwnBuildModel, TargetDefinition> bindingTypeInformation,
+        ProjectFeatureApplyAction<OwnDefinition, OwnBuildModel, TargetDefinition> transform
     );
 
     /**
@@ -57,20 +57,20 @@ public interface ProjectFeatureBindingBuilder {
      * @param targetDefinitionClass the class of the parent definition object this feature can be bound to
      * @param transform the transform that maps the definition to the build model and implements the build logic associated with the feature
      * @return a {@link DslBindingBuilder} that can be used to further configure the binding
-     * @param <Definition> the type of the definition object for this feature
+     * @param <OwnDefinition> the type of the definition object for this feature
      * @param <OwnBuildModel> the type of the build model object for this feature
      * @param <TargetDefinition> the type of the parent definition object this feature can be bound to
      */
     default <
-        Definition extends HasBuildModel<OwnBuildModel>,
+        OwnDefinition extends Definition<OwnBuildModel>,
         OwnBuildModel extends BuildModel,
-        TargetDefinition extends HasBuildModel<?>
+        TargetDefinition extends Definition<?>
         >
-    DslBindingBuilder<Definition, OwnBuildModel> bindProjectFeatureToDefinition(
+    DslBindingBuilder<OwnDefinition, OwnBuildModel> bindProjectFeatureToDefinition(
         String name,
-        Class<Definition> definitionClass,
+        Class<OwnDefinition> definitionClass,
         Class<TargetDefinition> targetDefinitionClass,
-        ProjectFeatureApplyAction<Definition, OwnBuildModel, TargetDefinition> transform
+        ProjectFeatureApplyAction<OwnDefinition, OwnBuildModel, TargetDefinition> transform
     ) {
         return bindProjectFeature(name, bindingToTargetDefinition(definitionClass, targetDefinitionClass), transform);
     }
@@ -84,20 +84,20 @@ public interface ProjectFeatureBindingBuilder {
      * @param targetBuildModelClass the class of the build model type of the parent definition object this feature can be bound to
      * @param transform the transform that maps the definition to the build model and implements the build logic associated with the feature
      * @return a {@link DslBindingBuilder} that can be used to further configure the binding
-     * @param <Definition> the type of the definition object for this feature
+     * @param <OwnDefinition> the type of the definition object for this feature
      * @param <OwnBuildModel> the type of the build model object for this feature
      * @param <TargetBuildModel> the type of the build model type of the parent definition object this feature can be bound to
      */
     default <
-        Definition extends HasBuildModel<OwnBuildModel>,
+        OwnDefinition extends Definition<OwnBuildModel>,
         OwnBuildModel extends BuildModel,
         TargetBuildModel extends BuildModel
         >
-    DslBindingBuilder<Definition, OwnBuildModel> bindProjectFeatureToBuildModel(
+    DslBindingBuilder<OwnDefinition, OwnBuildModel> bindProjectFeatureToBuildModel(
         String name,
-        Class<Definition> definitionClass,
+        Class<OwnDefinition> definitionClass,
         Class<TargetBuildModel> targetBuildModelClass,
-        ProjectFeatureApplyAction<Definition, OwnBuildModel, HasBuildModel<TargetBuildModel>> transform
+        ProjectFeatureApplyAction<OwnDefinition, OwnBuildModel, Definition<TargetBuildModel>> transform
     ) {
         return bindProjectFeature(name, bindingToTargetBuildModel(definitionClass, targetBuildModelClass), transform);
     }
@@ -109,17 +109,17 @@ public interface ProjectFeatureBindingBuilder {
      * @param definition the class of the project feature definition object
      * @param targetDefinition the class of the parent definition object this feature can be bound to
      * @return type information about the binding
-     * @param <Definition> the type of the definition object for this feature
+     * @param <OwnDefinition> the type of the definition object for this feature
      * @param <OwnBuildModel> the type of the build model object for this feature
      * @param <TargetDefinition> the type of the parent definition object this feature can be bound to
      */
     static <
-        Definition extends HasBuildModel<OwnBuildModel>,
+        OwnDefinition extends Definition<OwnBuildModel>,
         OwnBuildModel extends BuildModel,
-        TargetDefinition extends HasBuildModel<?>
+        TargetDefinition extends Definition<?>
         >
-    ModelBindingTypeInformation<Definition, OwnBuildModel, TargetDefinition> bindingToTargetDefinition(
-        Class<Definition> definition,
+    ModelBindingTypeInformation<OwnDefinition, OwnBuildModel, TargetDefinition> bindingToTargetDefinition(
+        Class<OwnDefinition> definition,
         Class<TargetDefinition> targetDefinition
     ) {
         return new ModelBindingTypeInformation<>(definition, new DefinitionTargetTypeInformation<>(targetDefinition));
@@ -133,17 +133,17 @@ public interface ProjectFeatureBindingBuilder {
      * @param definition the class of the project feature definition object
      * @param targetBuildModel the class of the build model type of the parent definition object this feature can be bound to
      * @return type information about the binding
-     * @param <Definition> the type of the definition object for this feature
+     * @param <OwnDefinition> the type of the definition object for this feature
      * @param <OwnBuildModel> the type of the build model object for this feature
      * @param <TargetBuildModel> the type of the build model type of the parent definition object this feature can be bound to
      */
     static <
-        Definition extends HasBuildModel<OwnBuildModel>,
+        OwnDefinition extends Definition<OwnBuildModel>,
         OwnBuildModel extends BuildModel,
         TargetBuildModel extends BuildModel
         >
-    ModelBindingTypeInformation<Definition, OwnBuildModel, HasBuildModel<TargetBuildModel>> bindingToTargetBuildModel(
-        Class<Definition> definition,
+    ModelBindingTypeInformation<OwnDefinition, OwnBuildModel, Definition<TargetBuildModel>> bindingToTargetBuildModel(
+        Class<OwnDefinition> definition,
         Class<TargetBuildModel> targetBuildModel
     ) {
         return new ModelBindingTypeInformation<>(definition, new BuildModelTargetTypeInformation<>(targetBuildModel));
@@ -153,28 +153,28 @@ public interface ProjectFeatureBindingBuilder {
      * Type information about a binding between a project feature definition object
      * and a parent definition object in the build.
      *
-     * @param <Definition> the type of the definition object for this feature
+     * @param <OwnDefinition> the type of the definition object for this feature
      * @param <OwnBuildModel> the type of the build model object for this feature
      * @param <TargetDefinition> the type of the parent definition object this feature can be bound to
      */
     class ModelBindingTypeInformation<
-        Definition extends HasBuildModel<OwnBuildModel>,
+        OwnDefinition extends Definition<OwnBuildModel>,
         OwnBuildModel extends BuildModel,
-        TargetDefinition extends HasBuildModel<?>
+        TargetDefinition extends Definition<?>
         > {
 
-        private final Class<Definition> definitionType;
+        private final Class<OwnDefinition> definitionType;
         private final TargetTypeInformation<TargetDefinition> targetType;
 
         public ModelBindingTypeInformation(
-            Class<Definition> definitionType,
+            Class<OwnDefinition> definitionType,
             TargetTypeInformation<TargetDefinition> targetType
         ) {
             this.definitionType = definitionType;
             this.targetType = targetType;
         }
 
-        public Class<Definition> getDefinitionType() {
+        public Class<OwnDefinition> getDefinitionType() {
             return definitionType;
         }
 

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/ProjectTypeBindingBuilder.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/ProjectTypeBindingBuilder.java
@@ -30,14 +30,14 @@ public interface ProjectTypeBindingBuilder {
      * @param buildModelType the class of the build model object for this project type
      * @param transform the transform that maps the definition to the build model and implements the build logic associated with the feature
      * @return a {@link DslBindingBuilder} that can be used to further configure the binding
-     * @param <T> the type of the project type definition object
-     * @param <V> the type of the build model object for this project type
+     * @param <OwnDefinition> the type of the project type definition object
+     * @param <OwnBuildModel> the type of the build model object for this project type
      */
-    <T extends HasBuildModel<V>, V extends BuildModel> DslBindingBuilder<T, V> bindProjectType(
+    <OwnDefinition extends Definition<OwnBuildModel>, OwnBuildModel extends BuildModel> DslBindingBuilder<OwnDefinition, OwnBuildModel> bindProjectType(
         String name,
-        Class<T> dslType,
-        Class<V> buildModelType,
-        ProjectTypeApplyAction<T, V> transform
+        Class<OwnDefinition> dslType,
+        Class<OwnBuildModel> buildModelType,
+        ProjectTypeApplyAction<OwnDefinition, OwnBuildModel> transform
     );
 
     /**
@@ -48,12 +48,12 @@ public interface ProjectTypeBindingBuilder {
      * @param dslType the class of the project type definition object
      * @param transform the transform that maps the definition to the build model and implements the build logic associated with the feature
      * @return a {@link DslBindingBuilder} that can be used to further configure the binding
-     * @param <T> the type of the project type definition object
-     * @param <V> the type of the build model object for this project type
+     * @param <OwnDefinition> the type of the project type definition object
+     * @param <OwnBuildModel> the type of the build model object for this project type
      */
-    <T extends HasBuildModel<V>, V extends BuildModel> DslBindingBuilder<T, V> bindProjectType(
+    <OwnDefinition extends Definition<OwnBuildModel>, OwnBuildModel extends BuildModel> DslBindingBuilder<OwnDefinition, OwnBuildModel> bindProjectType(
         String name,
-        Class<T> dslType,
-        ProjectTypeApplyAction<T, V> transform
+        Class<OwnDefinition> dslType,
+        ProjectTypeApplyAction<OwnDefinition, OwnBuildModel> transform
     );
 }

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/TargetTypeInformation.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/api/internal/plugins/TargetTypeInformation.java
@@ -47,7 +47,7 @@ public interface TargetTypeInformation<T> {
         }
     }
 
-    class BuildModelTargetTypeInformation<T extends BuildModel> implements TargetTypeInformation<HasBuildModel<T>> {
+    class BuildModelTargetTypeInformation<T extends BuildModel> implements TargetTypeInformation<Definition<T>> {
         public final Class<T> buildModelType;
 
         public BuildModelTargetTypeInformation(Class<T> buildModelType) {

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/BoundProjectFeatureImplementation.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/BoundProjectFeatureImplementation.java
@@ -17,7 +17,7 @@
 package org.gradle.plugin.software.internal;
 
 import org.gradle.api.internal.plugins.BuildModel;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 
-public interface BoundProjectFeatureImplementation<T extends HasBuildModel<V>, V extends BuildModel> extends ProjectFeatureImplementation<T, V> {
+public interface BoundProjectFeatureImplementation<T extends Definition<V>, V extends BuildModel> extends ProjectFeatureImplementation<T, V> {
 }

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/DefaultDslBindingBuilder.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/DefaultDslBindingBuilder.java
@@ -19,7 +19,7 @@ package org.gradle.plugin.software.internal;
 import org.gradle.api.internal.plugins.BuildModel;
 import org.gradle.api.internal.plugins.DslBindingBuilder;
 import org.gradle.api.internal.plugins.DslBindingBuilderInternal;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.api.internal.plugins.ProjectFeatureBinding;
 import org.gradle.api.internal.plugins.ProjectFeatureApplyAction;
 import org.gradle.api.internal.plugins.TargetTypeInformation;
@@ -32,7 +32,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @NullMarked
-public class DefaultDslBindingBuilder<T extends HasBuildModel<V>, V extends BuildModel> implements DslBindingBuilderInternal<T, V> {
+public class DefaultDslBindingBuilder<T extends Definition<V>, V extends BuildModel> implements DslBindingBuilderInternal<T, V> {
     private final Class<T> dslType;
     private final TargetTypeInformation<?> targetDefinitionType;
     private final Class<V> buildModelType;
@@ -56,7 +56,7 @@ public class DefaultDslBindingBuilder<T extends HasBuildModel<V>, V extends Buil
         this.transform = transform;
     }
 
-    private static <T extends HasBuildModel<V>, V extends BuildModel> ProjectFeatureBinding<T, V> bindingOf(
+    private static <T extends Definition<V>, V extends BuildModel> ProjectFeatureBinding<T, V> bindingOf(
         Class<T> dslType,
         @Nullable Class<? extends T> dslImplementationType,
         Path path,

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/DefaultProjectFeatureBindingBuilder.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/DefaultProjectFeatureBindingBuilder.java
@@ -20,7 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.internal.plugins.BuildModel;
 import org.gradle.api.internal.plugins.DslBindingBuilder;
 import org.gradle.api.internal.plugins.DslBindingBuilderInternal;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.api.internal.plugins.ProjectFeatureBinding;
 import org.gradle.api.internal.plugins.ProjectFeatureBindingBuilder;
 import org.gradle.api.internal.plugins.ProjectFeatureBindingBuilderInternal;
@@ -37,16 +37,16 @@ public class DefaultProjectFeatureBindingBuilder implements ProjectFeatureBindin
 
     @Override
     public <
-        Definition extends HasBuildModel<OwnBuildModel>,
+        OwnDefinition extends Definition<OwnBuildModel>,
         OwnBuildModel extends BuildModel,
-        TargetDefinition extends HasBuildModel<?>
+        TargetDefinition extends Definition<?>
         >
-    DslBindingBuilder<Definition, OwnBuildModel> bindProjectFeature(
+    DslBindingBuilder<OwnDefinition, OwnBuildModel> bindProjectFeature(
         String name,
-        ModelBindingTypeInformation<Definition, OwnBuildModel, TargetDefinition> bindingTypeInformation,
-        ProjectFeatureApplyAction<Definition, OwnBuildModel, TargetDefinition> transform
+        ModelBindingTypeInformation<OwnDefinition, OwnBuildModel, TargetDefinition> bindingTypeInformation,
+        ProjectFeatureApplyAction<OwnDefinition, OwnBuildModel, TargetDefinition> transform
     ) {
-        DslBindingBuilderInternal<Definition, OwnBuildModel> builder = new DefaultDslBindingBuilder<>(
+        DslBindingBuilderInternal<OwnDefinition, OwnBuildModel> builder = new DefaultDslBindingBuilder<>(
             bindingTypeInformation.getDefinitionType(),
             getBuildModelClass(bindingTypeInformation.getDefinitionType()),
             bindingTypeInformation.getTargetType(),

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/DefaultProjectTypeBindingBuilder.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/DefaultProjectTypeBindingBuilder.java
@@ -21,7 +21,7 @@ import org.gradle.api.Project;
 import org.gradle.api.internal.plugins.BuildModel;
 import org.gradle.api.internal.plugins.DslBindingBuilder;
 import org.gradle.api.internal.plugins.DslBindingBuilderInternal;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.api.internal.plugins.ProjectFeatureApplicationContext;
 import org.gradle.api.internal.plugins.ProjectFeatureBinding;
 import org.gradle.api.internal.plugins.ProjectFeatureApplyAction;
@@ -38,7 +38,7 @@ public class DefaultProjectTypeBindingBuilder implements ProjectTypeBindingBuild
     private final List<DslBindingBuilderInternal<?, ?>> bindings = new ArrayList<>();
 
     @Override
-    public <T extends HasBuildModel<V>, V extends BuildModel> DslBindingBuilder<T, V> bindProjectType(String name, Class<T> dslType, Class<V> buildModelType, ProjectTypeApplyAction<T, V> transform) {
+    public <T extends Definition<V>, V extends BuildModel> DslBindingBuilder<T, V> bindProjectType(String name, Class<T> dslType, Class<V> buildModelType, ProjectTypeApplyAction<T, V> transform) {
         ProjectFeatureApplyAction<T, V, ?> featureTransform = (ProjectFeatureApplicationContext context, T definition, V buildModel, Object parentDefinition) ->
             transform.transform(context, definition, buildModel);
 
@@ -54,7 +54,7 @@ public class DefaultProjectTypeBindingBuilder implements ProjectTypeBindingBuild
     }
 
     @Override
-    public <T extends HasBuildModel<V>, V extends BuildModel> DslBindingBuilder<T, V> bindProjectType(String name, Class<T> dslType, ProjectTypeApplyAction<T, V> transform) {
+    public <T extends Definition<V>, V extends BuildModel> DslBindingBuilder<T, V> bindProjectType(String name, Class<T> dslType, ProjectTypeApplyAction<T, V> transform) {
         return bindProjectType(name, dslType, ModelTypeUtils.getBuildModelClass(dslType), transform);
     }
 

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/ModelTypeUtils.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/ModelTypeUtils.java
@@ -17,15 +17,15 @@
 package org.gradle.plugin.software.internal;
 
 import org.gradle.api.internal.plugins.BuildModel;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.internal.inspection.DefaultTypeParameterInspection;
 import org.gradle.internal.inspection.TypeParameterInspection;
 import org.jspecify.annotations.NonNull;
 
 public class ModelTypeUtils {
-    public static <Definition extends HasBuildModel<OwnBuildModel>, OwnBuildModel extends BuildModel> @NonNull Class<OwnBuildModel> getBuildModelClass(Class<Definition> definition) {
+    public static <OwnDefinition extends Definition<OwnBuildModel>, OwnBuildModel extends BuildModel> @NonNull Class<OwnBuildModel> getBuildModelClass(Class<OwnDefinition> definition) {
         @SuppressWarnings("rawtypes")
-        TypeParameterInspection<HasBuildModel, BuildModel> inspection = new DefaultTypeParameterInspection<>(HasBuildModel.class, BuildModel.class, BuildModel.NONE.class);
+        TypeParameterInspection<Definition, BuildModel> inspection = new DefaultTypeParameterInspection<>(Definition.class, BuildModel.class, BuildModel.NONE.class);
         Class<OwnBuildModel> ownBuildModel = inspection.parameterTypeFor(definition);
         if (ownBuildModel == null) {
             throw new IllegalArgumentException("Cannot determine build model type for " + definition);

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/ProjectFeatureSupportInternal.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/ProjectFeatureSupportInternal.java
@@ -19,7 +19,7 @@ package org.gradle.plugin.software.internal;
 import org.gradle.api.Named;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.plugins.BuildModel;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.extensibility.ExtensibleDynamicObject;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
@@ -179,7 +179,7 @@ public class ProjectFeatureSupportInternal {
     }
 
 
-    public static <T extends HasBuildModel<V>, V extends BuildModel> V createBuildModelInstance(ObjectFactory objectFactory, T definition, ProjectFeatureImplementation<T, V> projectFeature) {
+    public static <T extends Definition<V>, V extends BuildModel> V createBuildModelInstance(ObjectFactory objectFactory, T definition, ProjectFeatureImplementation<T, V> projectFeature) {
         return createBuildModelInstance(objectFactory, definition, projectFeature.getBuildModelImplementationType());
     }
 

--- a/platforms/core-configuration/project-features/src/main/kotlin/org/gradle/plugin/software/internal/TargetTypeInformationChecks.kt
+++ b/platforms/core-configuration/project-features/src/main/kotlin/org/gradle/plugin/software/internal/TargetTypeInformationChecks.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.plugin.software.internal
 
-import org.gradle.api.internal.plugins.HasBuildModel
+import org.gradle.api.internal.plugins.Definition
 import org.gradle.api.internal.plugins.TargetTypeInformation
 import org.gradle.api.internal.plugins.TargetTypeInformation.BuildModelTargetTypeInformation
 import org.gradle.api.internal.plugins.TargetTypeInformation.DefinitionTargetTypeInformation
@@ -31,8 +31,8 @@ object TargetTypeInformationChecks {
                 expectedTargetDefinitionType.definitionType.isAssignableFrom(actualTargetDefinitionType)
 
             is BuildModelTargetTypeInformation<*> ->
-                HasBuildModel::class.java.isAssignableFrom(actualTargetDefinitionType) &&
-                    actualTargetDefinitionType.kotlin.allSupertypes.find { it.classifier == HasBuildModel::class }
+                Definition::class.java.isAssignableFrom(actualTargetDefinitionType) &&
+                    actualTargetDefinitionType.kotlin.allSupertypes.find { it.classifier == Definition::class }
                         ?.let { (it.arguments.singleOrNull()?.type?.classifier as? KClass<*>)?.java?.let(expectedTargetDefinitionType.buildModelType::isAssignableFrom) }
                     ?: false
 

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultBoundProjectFeatureImplementation.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultBoundProjectFeatureImplementation.java
@@ -20,7 +20,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.plugins.BuildModel;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.api.internal.plugins.ProjectFeatureApplyAction;
 import org.gradle.api.internal.plugins.TargetTypeInformation;
 import org.jspecify.annotations.Nullable;
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Represents a resolved project type implementation.  Used by declarative DSL to understand which model types should be exposed for
  * which project types.
  */
-public class DefaultBoundProjectFeatureImplementation<T extends HasBuildModel<V>, V extends BuildModel> implements BoundProjectFeatureImplementation<T, V> {
+public class DefaultBoundProjectFeatureImplementation<T extends Definition<V>, V extends BuildModel> implements BoundProjectFeatureImplementation<T, V> {
     private final String featureName;
     private final Class<T> definitionPublicType;
     private final Class<? extends T> definitionImplementationType;

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultProjectFeatureApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultProjectFeatureApplicator.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.plugins.BuildModel;
 import org.gradle.api.internal.plugins.DslObject;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.plugins.ProjectFeatureApplicationContext;
 import org.gradle.api.internal.plugins.software.SoftwareType;
@@ -117,7 +117,7 @@ public class DefaultProjectFeatureApplicator implements ProjectFeatureApplicator
         return ((ExtensionAware) parentDefinition).getExtensions().getByName(projectFeature.getFeatureName());
     }
 
-    private <T extends HasBuildModel<V>, V extends BuildModel> T instantiateBoundFeatureObjectsAndApply(Object parentDefinition, BoundProjectFeatureImplementation<T, V> projectFeature) {
+    private <T extends Definition<V>, V extends BuildModel> T instantiateBoundFeatureObjectsAndApply(Object parentDefinition, BoundProjectFeatureImplementation<T, V> projectFeature) {
         T definition = createDefinitionObject(parentDefinition, projectFeature);
         V buildModelInstance = ProjectFeatureSupportInternal.createBuildModelInstance(objectFactory, definition, projectFeature);
         ProjectFeatureSupportInternal.attachDefinitionContext(definition, buildModelInstance, this, projectFeatureRegistry, objectFactory);

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultProjectFeatureRegistry.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultProjectFeatureRegistry.java
@@ -25,7 +25,7 @@ import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.plugins.BindsProjectFeature;
 import org.gradle.api.internal.plugins.BindsProjectType;
 import org.gradle.api.internal.plugins.BuildModel;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.api.internal.plugins.ProjectFeatureBinding;
 import org.gradle.api.internal.plugins.ProjectFeatureBindingBuilderInternal;
 import org.gradle.api.internal.plugins.ProjectFeatureBindingRegistration;
@@ -93,7 +93,7 @@ public class DefaultProjectFeatureRegistry extends CompatibleProjectFeatureRegis
         return projectFeatureImplementationsBuilder.build();
     }
 
-    private <T extends HasBuildModel<V>, V extends BuildModel> void registerFeature(
+    private <T extends Definition<V>, V extends BuildModel> void registerFeature(
         RegisteringPluginKey registeringPlugin,
         Class<? extends Plugin<Project>> pluginClass,
         ProjectFeatureBinding<T, V> binding,

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/ProjectFeatureApplicationContextInternal.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/ProjectFeatureApplicationContextInternal.java
@@ -18,7 +18,7 @@ package org.gradle.plugin.software.internal;
 
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.plugins.BuildModel;
-import org.gradle.api.internal.plugins.HasBuildModel;
+import org.gradle.api.internal.plugins.Definition;
 import org.gradle.api.internal.plugins.ProjectFeatureApplicationContext;
 import org.gradle.internal.Cast;
 
@@ -33,12 +33,12 @@ public interface ProjectFeatureApplicationContextInternal extends ProjectFeature
     ProjectFeatureApplicator getProjectFeatureApplicator();
 
     @Override
-    default <T extends HasBuildModel<V>, V extends BuildModel> V getBuildModel(T definition) {
+    default <T extends Definition<V>, V extends BuildModel> V getBuildModel(T definition) {
         return Cast.uncheckedNonnullCast(ProjectFeatureSupportInternal.getContext((DynamicObjectAware) definition).getBuildModel());
     }
 
     @Override
-    default <T extends HasBuildModel<V>, V extends BuildModel> V registerBuildModel(T definition, Class<? extends V> implementationType) {
+    default <T extends Definition<V>, V extends BuildModel> V registerBuildModel(T definition, Class<? extends V> implementationType) {
         ProjectFeatureSupportInternal.ProjectFeatureDefinitionContext maybeContext = ProjectFeatureSupportInternal.tryGetContext(definition);
         if (maybeContext != null) {
             throw new IllegalStateException("Definition object '" + definition + "' already has a registered build model '" + maybeContext.getBuildModel()

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/software/internal/DefaultProjectFeatureApplicatorTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/plugin/software/internal/DefaultProjectFeatureApplicatorTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.DynamicObjectAware
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.plugins.BuildModel
 import org.gradle.api.internal.plugins.ExtensionContainerInternal
-import org.gradle.api.internal.plugins.HasBuildModel
+import org.gradle.api.internal.plugins.Definition
 import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.internal.plugins.software.SoftwareType
 import org.gradle.api.internal.tasks.properties.InspectionScheme
@@ -228,6 +228,6 @@ class DefaultProjectFeatureApplicatorTest extends Specification {
 
     private interface DefinitionWithExtensions extends DynamicObjectAware, ExtensionAware {}
 
-    private interface Foo extends HasBuildModel<Bar>, DynamicObjectAware {}
+    private interface Foo extends Definition<Bar>, DynamicObjectAware {}
     private static class Bar implements BuildModel {}
 }


### PR DESCRIPTION
Rename `HasBuildModel` to `Definition` for clarity.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
