### PR TITLE
Skip KotlinDslPluginCrossVersionSmokeTest with Java 25

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -17,18 +17,18 @@
 package org.gradle.kotlin.dsl.plugins.dsl
 
 import org.gradle.api.JavaVersion
+import org.gradle.internal.jvm.Jvm
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.support.expectedKotlinDslPluginsVersion
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions.NotEmbeddedExecutor
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.not
 import org.junit.Assume.assumeThat
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
-import org.junit.experimental.categories.Category
 import java.io.File
 
 /**
@@ -54,6 +54,7 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
             System.getProperty("java.runtime.version"),
             not(containsString("beta"))
         )
+        assumeTrue("Older Kotlin can't run with Java 25", Jvm.current().javaVersion!!.compareTo(JavaVersion.VERSION_25) < 0)
     }
 
     @Test
@@ -84,9 +85,11 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
 
             assertThat(
                 output,
-                containsString("This version of Gradle expects version '$expectedKotlinDslPluginsVersion' of the `kotlin-dsl` plugin " +
-                    "but version '$oldestSupportedKotlinDslPluginVersion' has been applied to project ':buildSrc'. " +
-                    "Let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic.")
+                containsString(
+                    "This version of Gradle expects version '$expectedKotlinDslPluginsVersion' of the `kotlin-dsl` plugin " +
+                        "but version '$oldestSupportedKotlinDslPluginVersion' has been applied to project ':buildSrc'. " +
+                        "Let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic."
+                )
             )
 
             assertThat(


### PR DESCRIPTION
Previously we skip these tests with `beta` Java version. Now Java 25 becomes GA and it fails with:

```
Error:	
e: java.lang.IllegalArgumentException: 25	
	at org.jetbrains.kotlin.com.intellij.util.lang.JavaVersion.parse(JavaVersion.java:305)
```