### PR TITLE
 Get rid of eager reading of generated source directories

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheBuildOperationsIntegrationTest.groovy
@@ -245,13 +245,6 @@ class ConfigurationCacheBuildOperationsIntegrationTest extends AbstractConfigura
         outputContains('In script plugin')
         buildLogicBuiltAndWorkGraphStoredAndLoaded()
 
-        // TODO - should get a cache hit for this build (https://github.com/gradle/gradle/issues/23267)
-        when:
-        configurationCacheRun 'help'
-
-        then:
-        buildLogicBuiltAndWorkGraphStoredAndLoaded()
-
         when:
         configurationCacheRun 'help'
 

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
 class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
@@ -1036,7 +1035,7 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Requires(IntegTestPreconditions.NotConfigCached)
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/23267")
+    @Issue("https://github.com/gradle/gradle/issues/23267")
     def "hits configuration cache when no changes are present"() {
         given:
         enablePrecompiledPluginsInBuildSrc()
@@ -1066,10 +1065,7 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
         run("help")
 
         then:
-        // The state should be loaded here
-        configurationCacheFixture.assertStateRecreated {
-            pluginInputChanged("org.gradle.groovy-gradle-plugin")
-        }
+        configurationCacheFixture.assertStateLoaded()
     }
 
     private String packagePrecompiledPlugin(String pluginFile, String pluginContent = REGISTER_SAMPLE_TASK) {

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -17,10 +17,12 @@
 package org.gradle.plugin.devel.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
+import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
 class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
@@ -1031,6 +1033,43 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         pluginName << ["org.gradle.my-plugin", "org.gradle"]
+    }
+
+    @Requires(IntegTestPreconditions.NotConfigCached)
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/23267")
+    def "hits configuration cache when no changes are present"() {
+        given:
+        enablePrecompiledPluginsInBuildSrc()
+
+        buildFile("buildSrc/src/main/groovy/plugins/foo.gradle", """
+            plugins {
+                id("java")
+            }
+        """)
+
+        buildFile """
+            plugins {
+                id("foo")
+            }
+        """
+        def configurationCacheFixture = new ConfigurationCacheFixture(this)
+
+        when:
+        executer.withConfigurationCacheEnabled()
+        run("help")
+
+        then:
+        configurationCacheFixture.assertStateStored()
+
+        when:
+        executer.withConfigurationCacheEnabled()
+        run("help")
+
+        then:
+        // The state should be loaded here
+        configurationCacheFixture.assertStateRecreated {
+            pluginInputChanged("org.gradle.groovy-gradle-plugin")
+        }
     }
 
     private String packagePrecompiledPlugin(String pluginFile, String pluginContent = REGISTER_SAMPLE_TASK) {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -357,6 +357,10 @@ class ConfigurationCacheFixture {
             reasons.add("an input to task '${invalidationDetails.changedTask}' has changed")
         }
 
+        if (invalidationDetails.changedPlugin != null) {
+            reasons.add("an input to plugin '${invalidationDetails.changedPlugin}' has changed")
+        }
+
         assert details.createsModels || details.runsTasks
         def messages = reasons.collect { reason ->
             if (details.createsModels) {
@@ -466,6 +470,7 @@ class ConfigurationCacheFixture {
         String changedGradleProperty
         String changedSystemProperty
         String changedTask
+        String changedPlugin
 
         void fileChanged(String name) {
             changedFiles.add(name)
@@ -473,6 +478,10 @@ class ConfigurationCacheFixture {
 
         void taskInputChanged(String name) {
             changedTask = name
+        }
+
+        void pluginInputChanged(String name) {
+            changedPlugin = name
         }
 
         void startParameterProjectPropertiesChanged(String message) {


### PR DESCRIPTION
We're reading plugin source set eagerly, which is probably fine, because we generate plugin descriptors that way. However, we also add generated plugin adapter sources as plugin sources later. This caused problems with task registration blocks - they were resolving sources again, causing the generated sources directory to become a CC input.

This commit reuses eagerly resolved plugin files in task registration blocks too, so it no longer includes the generated source directory.

Overall, the structure doesn't follow modern Gradle best practices and should be lazy-fied completely (imagine a task that generates a precompiled script plugin).

Fixes #23267
