### PR TITLE
Add 'architecture' and 'operatingSystem' to JVM-specific attributes

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/dependency-management/controlling-dependency-resolution/variant_attributes.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/dependency-management/controlling-dependency-resolution/variant_attributes.adoc
@@ -139,6 +139,16 @@ In addition to the ecosystem independent attributes defined above, the JVM ecosy
 | Indicates the name of the link:{javadocPath}/org/gradle/testing/base/TestSuite.html[TestSuite] that produced this output.
 | Value is the name of the Suite.
 | No default, no compatibility
+
+| link:{javadocPath}/org/gradle/nativeplatform/MachineArchitecture.html#ARCHITECTURE_ATTRIBUTE[`org.gradle.native.architecture`]
+| Indicates that native binaries are included requiring the defined target architecture
+| `MachineArchitecture` values built from constants defined in link:{javadocPath}/org/gradle/nativeplatform/MachineArchitecture.html[MachineArchitecture]
+| None
+
+| link:{javadocPath}/org/gradle/nativeplatform/OperatingSystemFamily.html#OPERATING_SYSTEM_ATTRIBUTE[`org.gradle.native.operatingSystem`]
+| Indicates that native binaries are included requiring the defined operating system
+| `OperatingSystemFamily` values built from constants defined in link:{javadocPath}/org/gradle/nativeplatform/OperatingSystemFamily.html[OperatingSystemFamily]
+| None
 |===
 
 The JVM ecosystem also contains a number of compatibility and disambiguation rules over the different attributes.


### PR DESCRIPTION
Make it official that `org.gradle.native.architecture` and `org.gradle.native.operatingSystem` are attributes that can be used in the JVM ecosystem.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

See https://github.com/gradle/gradle/issues/34845#issuecomment-3293230632

Also the [documentation here](https://docs.gradle.org/current/userguide/component_metadata_rules.html#sec:adding-variants-jars) uses these attributes in a JVM context.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- ~Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.~
- ~Provide unit tests (under `<subproject>/src/test`) to verify logic.~
- ~Update User Guide, DSL Reference, and Javadoc for public-facing changes.~
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
