### PR TITLE
Refuse connections from non-Gradle processes

### DIFF
--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonTcpServerConnector.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonTcpServerConnector.java
@@ -51,7 +51,8 @@ public class DaemonTcpServerConnector implements DaemonServerConnector {
         this.incomingConnector = new TcpIncomingConnector(
                 executorFactory,
                 inetAddressFactory,
-                new UUIDGenerator()
+                new UUIDGenerator(),
+                10
         );
     }
 

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/remote/internal/inet/TcpOutgoingConnector.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/remote/internal/inet/TcpOutgoingConnector.java
@@ -31,10 +31,13 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class TcpOutgoingConnector implements OutgoingConnector {
+    static final byte[] CONNECTION_PREAMBLE = "Gradle Magic".getBytes(StandardCharsets.UTF_8);
     private static final Logger LOGGER = LoggerFactory.getLogger(TcpOutgoingConnector.class);
     private static final int CONNECT_TIMEOUT = 10000;
 
@@ -84,9 +87,9 @@ public class TcpOutgoingConnector implements OutgoingConnector {
         SocketChannel socketChannel = SocketChannel.open();
         try {
             socketChannel.socket().connect(new InetSocketAddress(candidate, address.getPort()), CONNECT_TIMEOUT);
-
             if (!detectSelfConnect(socketChannel)) {
                 SocketBlockingUtil.configureNonblocking(socketChannel);
+                socketChannel.write(ByteBuffer.wrap(CONNECTION_PREAMBLE));
                 return socketChannel;
             }
             socketChannel.close();

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/remote/services/MessagingServices.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/remote/services/MessagingServices.java
@@ -62,7 +62,8 @@ public class MessagingServices implements ServiceRegistrationProvider {
         return new TcpIncomingConnector(
                 executorFactory,
                 inetAddressFactory,
-                idGenerator
+                idGenerator,
+                10
         );
     }
 


### PR DESCRIPTION
Gradle uses TCP sockets to allow its worker processes to connect back to the daemon. The ports for those sockets are randomly assigned by the operating system and on a busy CI machine, a port might have been used for a different purpose before. There might still be clients programs trying to connect to that port, e.g. because of insufficient cleanup in a previous test. Until now, Gradle's test infrastructure would crash if a non-Gradle program connected to one of these worker ports.

This change makes Gradle more resilient by requiring a special handshake before a connection is accepted.

Fixes #27801


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
