### PR TITLE
Update NullAway and ErrorProne

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.code-quality.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.code-quality.gradle.kts
@@ -123,7 +123,7 @@ project.plugins.withType<JavaBasePlugin> {
         // don't forget to update the version in distributions-dependencies/build.gradle.kts
         // 2.31.0 is the latest version that works with JDK 11
         addErrorProneDependency("com.google.errorprone:error_prone_core:2.31.0")
-        addErrorProneDependency("com.uber.nullaway:nullaway:0.12.7")
+        addErrorProneDependency("com.uber.nullaway:nullaway:0.12.10")
 
         project.tasks.named<JavaCompile>(this.compileJavaTaskName) {
             options.errorprone {

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.code-quality.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.code-quality.gradle.kts
@@ -53,12 +53,14 @@ val errorproneExtension = project.extensions.create<ErrorProneProjectExtension>(
         "JdkObsolete", // Most of the checks are good, but we do not want to replace all LinkedLists without a good reason
 
         // NEVER
-        "MissingSummary", // We have another mechanism to check Javadocs on public API
+        "AssignmentExpression", // Not using it is more a matter of taste.
+        "EffectivelyPrivate", // It is still useful to distinguish between public interface and implementation details of inner classes even though it isn't enforced.
         "InjectOnConstructorOfAbstractClass", // We use abstract injection as a pattern
-        "JavaxInjectOnAbstractMethod", // We use abstract injection as a pattern
-        "JavaUtilDate", // We are fine with using Date
-        "StringSplitter", // We are fine with using String.split() as is
         "InlineMeSuggester", // Only suppression seems to actually "fix" this, so make it global
+        "JavaUtilDate", // We are fine with using Date
+        "JavaxInjectOnAbstractMethod", // We use abstract injection as a pattern
+        "MissingSummary", // We have another mechanism to check Javadocs on public API
+        "StringSplitter", // We are fine with using String.split() as is
     )
 
     nullawayEnabled.convention(false)
@@ -121,8 +123,7 @@ project.plugins.withType<JavaBasePlugin> {
         }
 
         // don't forget to update the version in distributions-dependencies/build.gradle.kts
-        // 2.31.0 is the latest version that works with JDK 11
-        addErrorProneDependency("com.google.errorprone:error_prone_core:2.31.0")
+        addErrorProneDependency("com.google.errorprone:error_prone_core:2.42.0")
         addErrorProneDependency("com.uber.nullaway:nullaway:0.12.10")
 
         project.tasks.named<JavaCompile>(this.compileJavaTaskName) {

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -340,7 +340,10 @@
             <trusting group="org.scala-sbt.jline"/>
          </trusted-key>
          <trusted-key id="EC9430D24E1FC30468C773FDCA1952B1E682D8A6" group="org.jodd"/>
-         <trusted-key id="EE0CA873074092F806F59B65D364ABAA39A47320" group="com.google.errorprone"/>
+         <trusted-key id="EE0CA873074092F806F59B65D364ABAA39A47320">
+            <trusting group="com.google.errorprone"/>
+            <trusting group="com.google.googlejavaformat" name="google-java-format"/>
+         </trusted-key>
          <trusted-key id="EF97D052DF6F6975A4E8C495AB9BC6BE0524BAD3">
             <trusting group="com.github.jnr"/>
             <trusting group="com.headius"/>
@@ -621,11 +624,6 @@
       </component>
       <component group="com.google.errorprone" name="error_prone_annotations" version="2.13.1">
          <artifact name="error_prone_annotations-2.13.1.jar">
-            <pgp value="EE0CA873074092F806F59B65D364ABAA39A47320"/>
-         </artifact>
-      </component>
-      <component group="com.google.googlejavaformat" name="google-java-format" version="1.19.1">
-         <artifact name="google-java-format-1.19.1.jar">
             <pgp value="EE0CA873074092F806F59B65D364ABAA39A47320"/>
          </artifact>
       </component>

--- a/packaging/distributions-dependencies/build.gradle.kts
+++ b/packaging/distributions-dependencies/build.gradle.kts
@@ -82,7 +82,7 @@ dependencies {
         api(libs.commonsLang)           { version { strictly("3.17.0") }}
         api(libs.commonsMath)           { version { strictly("3.6.1") }}
         api(libs.eclipseSisuPlexus)     { version { strictly("0.3.5"); because("transitive dependency of Maven modules to process POM metadata") }}
-        api(libs.errorProneAnnotations) { version { strictly("2.36.0") } } // don't forget to upgrade errorprone in gradlebuild.code-quality.gradle.kts
+        api(libs.errorProneAnnotations) { version { strictly("2.42.0") } } // don't forget to upgrade errorprone in gradlebuild.code-quality.gradle.kts
         api(libs.fastutil)              { version { strictly("8.5.2") }}
         api(libs.gradleFileEvents)      { version { strictly("0.2.8") }}
         api(libs.gradleProfiler)        { version { strictly("0.23.0-alpha-1") }}

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AntFileCollectionBuilder.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AntFileCollectionBuilder.java
@@ -37,6 +37,7 @@ public class AntFileCollectionBuilder implements AntBuilderAware {
     public Object addToAntBuilder(Object node, String childNodeName) {
         final DynamicObject dynamicObject = new BeanDynamicObject(node);
         dynamicObject.invokeMethod(childNodeName == null ? "resources" : childNodeName, new Closure(this) {
+            @SuppressWarnings("unused") // Magic Groovy method
             public Object doCall(Object ignore) {
                 for (File file : files) {
                     dynamicObject.invokeMethod("file", Collections.singletonMap("file", AntUtil.maskFilename(file.getAbsolutePath())));

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AntFileCollectionMatchingTaskBuilder.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AntFileCollectionMatchingTaskBuilder.java
@@ -55,9 +55,11 @@ public class AntFileCollectionMatchingTaskBuilder implements AntBuilderAware {
         }
 
         dynamicObject.invokeMethod("or", new Closure<Void>(this) {
+            @SuppressWarnings("unused") // Magic Groovy method
             public Object doCall(Object ignore) {
                 for (final DirectoryTree fileTree : existing) {
                     dynamicObject.invokeMethod("and", new Closure<Void>(this) {
+                        @SuppressWarnings("unused") // Magic Groovy method
                         public Object doCall(Object ignore) {
                             dynamicObject.invokeMethod("gradleBaseDirSelector", Collections.singletonMap("baseDir", fileTree.getDir()));
                             fileTree.getPatterns().addToAntBuilder(node, null);

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AntFileSetBuilder.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AntFileSetBuilder.java
@@ -41,6 +41,7 @@ public class AntFileSetBuilder implements AntBuilderAware {
             }
 
             dynamicObject.invokeMethod(nodeName == null ? "fileset" : nodeName, Collections.singletonMap("dir", AntUtil.maskFilename(tree.getDir().getAbsolutePath())), new Closure<Void>(this) {
+                @SuppressWarnings("unused") // Magic Groovy method
                 public Object doCall(Object ignore) {
                     return tree.getPatterns().addToAntBuilder(node, null);
                 }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AntFileTreeBuilder.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AntFileTreeBuilder.java
@@ -36,6 +36,7 @@ public class AntFileTreeBuilder implements AntBuilderAware {
     public Object addToAntBuilder(Object node, String childNodeName) {
         final DynamicObject dynamicObject = new BeanDynamicObject(node);
         dynamicObject.invokeMethod(childNodeName == null ? "resources" : childNodeName, new Closure(this) {
+            @SuppressWarnings("unused") // Magic Groovy method
             public Object doCall(Object ignore) {
                 for (Map.Entry<String, File> entry : files.entrySet()) {
                     String name = entry.getKey();

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultIsolatableFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultIsolatableFactory.java
@@ -73,7 +73,7 @@ public class DefaultIsolatableFactory extends AbstractValueProcessor implements 
 
         @Override
         public Isolatable<?> booleanValue(Boolean value) {
-            return value.equals(Boolean.TRUE) ? BooleanValueSnapshot.TRUE : BooleanValueSnapshot.FALSE;
+            return value ? BooleanValueSnapshot.TRUE : BooleanValueSnapshot.FALSE;
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
@@ -71,7 +71,7 @@ public class DefaultValueSnapshotter extends AbstractValueProcessor implements V
 
         @Override
         public ValueSnapshot booleanValue(Boolean value) {
-            return value.equals(Boolean.TRUE) ? BooleanValueSnapshot.TRUE : BooleanValueSnapshot.FALSE;
+            return value ? BooleanValueSnapshot.TRUE : BooleanValueSnapshot.FALSE;
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/core/rule/describe/SimpleModelRuleDescriptor.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/core/rule/describe/SimpleModelRuleDescriptor.java
@@ -17,6 +17,8 @@
 package org.gradle.model.internal.core.rule.describe;
 
 import com.google.common.base.Objects;
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
@@ -46,7 +48,8 @@ public class SimpleModelRuleDescriptor extends AbstractModelRuleDescriptor {
         this(Factories.constant(STRING_INTERNER.intern(descriptor)));
     }
 
-    public SimpleModelRuleDescriptor(final String descriptor, final Object... args) {
+    @FormatMethod
+    public SimpleModelRuleDescriptor(@FormatString final String descriptor, final Object... args) {
         this(new Factory<String>() {
             @Override
             public String create() {

--- a/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/BuildCacheClientModule.java
+++ b/platforms/core-execution/build-cache-example-client/src/main/java/org/gradle/caching/example/BuildCacheClientModule.java
@@ -387,18 +387,17 @@ class BuildCacheClientModule extends AbstractModule {
             @Override
             public void ensureDirectoryForTree(TreeType type, File root) throws IOException {
                 switch (type) {
-                    case DIRECTORY:
+                    case DIRECTORY -> {
                         FileUtils.forceMkdir(root.getParentFile());
                         FileUtils.cleanDirectory(root);
-                        break;
-                    case FILE:
+                    }
+                    case FILE -> {
                         FileUtils.forceMkdir(root.getParentFile());
                         if (root.exists()) {
                             FileUtils.forceDelete(root);
                         }
-                        break;
-                    default:
-                        throw new AssertionError();
+                    }
+                    default -> throw new AssertionError();
                 }
             }
         };

--- a/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/platforms/core-runtime/build-operations-trace/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -164,7 +164,7 @@ public class BuildOperationTrace implements Stoppable {
 
         InternalOptions internalOptions = new DefaultInternalOptions(startParameter.getSystemPropertiesArgs());
         String basePath = internalOptions.getOption(TRACE_OPTION).get();
-        if (basePath == null || basePath.equals(Boolean.FALSE.toString())) {
+        if (basePath == null || basePath.equals("false")) {
             this.outputTree = false;
             this.listener = null;
             this.writer = null;

--- a/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/BuildProfileServices.java
+++ b/platforms/core-runtime/build-profile/src/main/java/org/gradle/profile/BuildProfileServices.java
@@ -25,6 +25,7 @@ public class BuildProfileServices extends AbstractGradleModuleServices {
     @Override
     public void registerBuildTreeServices(ServiceRegistration registration) {
         registration.addProvider(new ServiceRegistrationProvider() {
+            @SuppressWarnings("unused")
             public void configure(ServiceRegistration serviceRegistration, StartParameter startParameter) {
                 if (startParameter.isProfile()) {
                     serviceRegistration.add(BuildProfile.class);
@@ -38,6 +39,7 @@ public class BuildProfileServices extends AbstractGradleModuleServices {
     @Override
     public void registerBuildServices(ServiceRegistration registration) {
         registration.addProvider(new ServiceRegistrationProvider() {
+            @SuppressWarnings("unused")
             public void configure(ServiceRegistration serviceRegistration, StartParameter startParameter) {
                 if (startParameter.isProfile()) {
                     serviceRegistration.add(ProfileService.class, ProfileEventAdapter.class);

--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
@@ -51,11 +51,7 @@ public abstract class Cached<T> {
 
     private static class Deferred<T> extends Cached<T> implements java.io.Serializable, EvaluationOwner {
 
-        /*
-         * TODO-RC fields are volatile as a workaround for call sites still unwisely using Cached from multiple threads.
-         *
-         * @see: https://github.com/gradle/gradle/issues/31239
-         */
+        // TODO(https://github.com/gradle/gradle/issues/31239) fields are volatile as a workaround for call sites still unwisely using Cached from multiple threads.
         private volatile @Nullable Callable<T> computation;
         private volatile @Nullable Try<T> result;
 

--- a/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/annotations/ReplacesEagerProperty.java
+++ b/platforms/core-runtime/internal-instrumentation-api/src/main/java/org/gradle/internal/instrumentation/api/annotations/ReplacesEagerProperty.java
@@ -59,7 +59,7 @@ public @interface ReplacesEagerProperty {
     /**
      * Deprecation configuration for the replaced accessors
      */
-    ReplacedDeprecation deprecation() default @ReplacedDeprecation();
+    ReplacedDeprecation deprecation() default @ReplacedDeprecation;
 
     /**
      * A custom interception adapter for a property that is used for bytecode upgrade.

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/exceptions/ExceptionMetadataHelper.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/exceptions/ExceptionMetadataHelper.java
@@ -42,14 +42,12 @@ public final class ExceptionMetadataHelper {
     public static Map<String, String> getMetadata(Throwable t) {
         Map<String, String> metadata = new LinkedHashMap<>();
 
-        if (t instanceof TaskExecutionException) {
-            TaskExecutionException taskExecutionException = (TaskExecutionException) t;
+        if (t instanceof TaskExecutionException taskExecutionException) {
             String taskPath = ((TaskInternal) taskExecutionException.getTask()).getIdentityPath().asString();
             metadata.put(METADATA_KEY_TASK_PATH, taskPath);
         }
 
-        if (t instanceof ScriptCompilationException) {
-            ScriptCompilationException sce = (ScriptCompilationException) t;
+        if (t instanceof ScriptCompilationException sce) {
             metadata.put(METADATA_KEY_SCRIPT_FILE, sce.getScriptSource().getFileName());
             Integer sceLineNumber = sce.getLineNumber();
             if (sceLineNumber != null) {
@@ -57,8 +55,7 @@ public final class ExceptionMetadataHelper {
             }
         }
 
-        if (t instanceof LocationAwareException) {
-            LocationAwareException lae = (LocationAwareException) t;
+        if (t instanceof LocationAwareException lae) {
             metadata.put(METADATA_KEY_SOURCE_DISPLAY_NAME, lae.getSourceDisplayName());
             Integer laeLineNumber = lae.getLineNumber();
             if (laeLineNumber != null) {
@@ -79,8 +76,7 @@ public final class ExceptionMetadataHelper {
     }
 
     public static List<? extends Throwable> extractCauses(Throwable t) {
-        if (t instanceof MultiCauseException) {
-            MultiCauseException mce = (MultiCauseException) t;
+        if (t instanceof MultiCauseException mce) {
             List<? extends Throwable> mceCauses = mce.getCauses();
             if (mceCauses != null && !mceCauses.isEmpty()) {
                 return mceCauses;

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/exceptions/PlaceholderExceptions.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/exceptions/PlaceholderExceptions.java
@@ -27,8 +27,8 @@ public class PlaceholderExceptions {
 
     @UsedByScanPlugin
     public static String getExceptionClassName(Throwable t) {
-        if (t instanceof PlaceholderExceptionSupport) {
-            return ((PlaceholderExceptionSupport) t).getExceptionClassName();
+        if (t instanceof PlaceholderExceptionSupport pes) {
+            return pes.getExceptionClassName();
         } else {
             return t.getClass().getName();
         }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/test/impl/DefaultTestTaskPropertiesService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/test/impl/DefaultTestTaskPropertiesService.java
@@ -163,8 +163,8 @@ public class DefaultTestTaskPropertiesService implements TestTaskPropertiesServi
     }
 
     private <T> Set<T> getOrEmpty(TestFrameworkOptions options, Function<JUnitPlatformOptions, Set<T>> extractor) {
-        return options instanceof JUnitPlatformOptions
-            ? extractor.apply((JUnitPlatformOptions) options)
+        return options instanceof JUnitPlatformOptions junitPlatformOptions
+            ? extractor.apply(junitPlatformOptions)
             : ImmutableSet.of();
     }
 

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluator.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionResultEvaluator.java
@@ -210,11 +210,7 @@ class TestExecutionResultEvaluator implements BuildOperationListener {
         }
 
         public String getDescription() {
-            StringBuilder stringBuilder = new StringBuilder("Test ")
-                .append(className).append("#").append(name)
-                .append(" (Task: ").append(taskPath).append(")");
-            return stringBuilder.toString();
-
+            return "Test " + className + "#" + name + " (Task: " + taskPath + ")";
         }
     }
 }

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoCheck.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoCheck.java
@@ -61,9 +61,10 @@ public class AntJacocoCheck implements Action<AntBuilderDelegate> {
         final Map<String, Object> emptyArgs = Collections.emptyMap();
         try {
             antBuilder.invokeMethod("jacocoReport", new Object[]{Collections.emptyMap(), new Closure<Object>(this, this) {
-                @SuppressWarnings("UnusedDeclaration")
+                @SuppressWarnings("unused") // Magic Groovy method
                 public Object doCall(Object ignore) {
                     antBuilder.invokeMethod("executiondata", new Object[]{emptyArgs, new Closure<Object>(this, this) {
+                        @SuppressWarnings("unused") // Magic Groovy method
                         public Object doCall(Object ignore) {
                             params.getExecutionData().filter(File::exists).addToAntBuilder(antBuilder, "resources");
                             return Void.class;
@@ -71,8 +72,10 @@ public class AntJacocoCheck implements Action<AntBuilderDelegate> {
                     }});
                     Map<String, Object> structureArgs = ImmutableMap.<String, Object>of("name", params.getProjectName().get());
                     antBuilder.invokeMethod("structure", new Object[]{structureArgs, new Closure<Object>(this, this) {
+                        @SuppressWarnings("unused") // Magic Groovy method
                         public Object doCall(Object ignore) {
                             antBuilder.invokeMethod("classfiles", new Object[]{emptyArgs, new Closure<Object>(this, this) {
+                                @SuppressWarnings("unused") // Magic Groovy method
                                 public Object doCall(Object ignore) {
                                     params.getAllClassesDirs().filter(File::exists).addToAntBuilder(antBuilder, "resources");
                                     return Void.class;
@@ -86,6 +89,7 @@ public class AntJacocoCheck implements Action<AntBuilderDelegate> {
                                 sourcefilesArgs = Collections.singletonMap("encoding", encoding);
                             }
                             antBuilder.invokeMethod("sourcefiles", new Object[]{sourcefilesArgs, new Closure<Object>(this, this) {
+                                @SuppressWarnings("unused") // Magic Groovy method
                                 public Object doCall(Object ignore) {
                                     params.getAllSourcesDirs().filter(File::exists).addToAntBuilder(antBuilder, "resources");
                                     return Void.class;
@@ -102,12 +106,12 @@ public class AntJacocoCheck implements Action<AntBuilderDelegate> {
                             "violationsproperty", VIOLATIONS_ANT_PROPERTY);
 
                         antBuilder.invokeMethod("check", new Object[] {checkArgs, new Closure<Object>(this, this) {
-                            @SuppressWarnings("UnusedDeclaration")
+                            @SuppressWarnings("unused") // Magic Groovy method
                             public Object doCall(Object ignore) {
                                 for (final JacocoViolationRule rule : rules) {
                                     Map<String, Object> ruleArgs = ImmutableMap.<String, Object>of("element", rule.getElement(), "includes", Joiner.on(':').join(rule.getIncludes()), "excludes", Joiner.on(':').join(rule.getExcludes()));
                                     antBuilder.invokeMethod("rule", new Object[] {ruleArgs, new Closure<Object>(this, this) {
-                                        @SuppressWarnings("UnusedDeclaration")
+                                        @SuppressWarnings("unused") // Magic Groovy method
                                         public Object doCall(Object ignore) {
                                             for (JacocoLimit limit : rule.getLimits()) {
                                                 Map<String, Object> limitArgs = new HashMap<String, Object>();

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoReport.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoReport.java
@@ -41,9 +41,10 @@ public class AntJacocoReport implements Action<AntBuilderDelegate> {
         ));
         final Map<String, Object> emptyArgs = Collections.emptyMap();
         antBuilder.invokeMethod("jacocoReport", new Object[]{Collections.emptyMap(), new Closure<Object>(this, this) {
-            @SuppressWarnings("UnusedDeclaration")
+            @SuppressWarnings("unused") // Magic Groovy method
             public Object doCall(Object ignore) {
                 antBuilder.invokeMethod("executiondata", new Object[]{emptyArgs, new Closure<Object>(this, this) {
+                    @SuppressWarnings("unused") // Magic Groovy method
                     public Object doCall(Object ignore) {
                         params.getExecutionData().filter(File::exists).addToAntBuilder(antBuilder, "resources");
                         return Void.class;
@@ -51,8 +52,10 @@ public class AntJacocoReport implements Action<AntBuilderDelegate> {
                 }});
                 Map<String, Object> structureArgs = ImmutableMap.<String, Object>of("name", params.getProjectName().get());
                 antBuilder.invokeMethod("structure", new Object[]{structureArgs, new Closure<Object>(this, this) {
+                    @SuppressWarnings("unused") // Magic Groovy method
                     public Object doCall(Object ignore) {
                         antBuilder.invokeMethod("classfiles", new Object[]{emptyArgs, new Closure<Object>(this, this) {
+                            @SuppressWarnings("unused") // Magic Groovy method
                             public Object doCall(Object ignore) {
                                 params.getAllClassesDirs().filter(File::exists).addToAntBuilder(antBuilder, "resources");
                                 return Void.class;
@@ -66,6 +69,7 @@ public class AntJacocoReport implements Action<AntBuilderDelegate> {
                             sourcefilesArgs = Collections.singletonMap("encoding", encoding);
                         }
                         antBuilder.invokeMethod("sourcefiles", new Object[]{sourcefilesArgs, new Closure<Object>(this, this) {
+                            @SuppressWarnings("unused") // Magic Groovy method
                             public Object doCall(Object ignore) {
                                 params.getAllSourcesDirs().filter(File::exists).addToAntBuilder(antBuilder, "resources");
                                 return Void.class;

--- a/platforms/jvm/java-compiler-plugin/src/main/java/org/gradle/internal/compiler/java/listeners/constants/ConstantsTreeVisitor.java
+++ b/platforms/jvm/java-compiler-plugin/src/main/java/org/gradle/internal/compiler/java/listeners/constants/ConstantsTreeVisitor.java
@@ -20,6 +20,7 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.ModuleTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePathScanner;
@@ -33,8 +34,6 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.Elements;
 import java.util.Objects;
 import java.util.Set;
-
-import static com.sun.source.tree.Tree.Kind.METHOD_INVOCATION;
 
 public class ConstantsTreeVisitor extends TreePathScanner<ConstantsVisitorContext, ConstantsVisitorContext> {
 
@@ -85,7 +84,7 @@ public class ConstantsTreeVisitor extends TreePathScanner<ConstantsVisitorContex
 
     @Override
     public ConstantsVisitorContext visitVariable(VariableTree node, ConstantsVisitorContext context) {
-        if (isAccessibleConstantVariableDeclaration(node) && node.getInitializer() != null && node.getInitializer().getKind() != METHOD_INVOCATION) {
+        if (isAccessibleConstantVariableDeclaration(node) && node.getInitializer() != null && !(node.getInitializer() instanceof MethodInvocationTree)) {
             // We now just check, that constant declaration is not `static {}` or `CONSTANT = methodInvocation()`,
             // but it could be further optimized to check if expression is one that can be inlined or not.
             return super.visitVariable(node, new ConstantsVisitorContext(context.getVisitedClass(), consumer::consumeAccessibleDependent));

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/GroovydocAntAction.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/GroovydocAntAction.java
@@ -74,7 +74,7 @@ public abstract class GroovydocAntAction extends AntWorkAction<GroovydocParamete
                 ));
 
                 ant.invokeMethod("groovydoc", new Object[]{args, new Closure<Object>(this, this) {
-                    @SuppressWarnings("UnusedVariable")
+                    @SuppressWarnings("unused") // Magic Groovy method
                     public Object doCall(Object ignore) {
                         for (Groovydoc.Link link : parameters.getLinks().get()) {
                             ant.invokeMethod("link", new Object[]{

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -517,7 +517,7 @@ public class PomReader implements PomParent {
             return new MavenDependencyKey(getGroupId(), getArtifactId(), getType(), getClassifier());
         }
 
-        /* (non-Javadoc)
+        /**
          * @see org.apache.ivy.plugins.parser.m2.PomDependencyMgt#getGroupId()
          */
         @Override
@@ -527,7 +527,7 @@ public class PomReader implements PomParent {
             return replaceProps(val);
         }
 
-        /* (non-Javadoc)
+        /**
          * @see org.apache.ivy.plugins.parser.m2.PomDependencyMgt#getArtifactId()
          */
         @Override
@@ -537,7 +537,7 @@ public class PomReader implements PomParent {
             return replaceProps(val);
         }
 
-        /* (non-Javadoc)
+        /**
          * @see org.apache.ivy.plugins.parser.m2.PomDependencyMgt#getVersion()
          */
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/AntBuilderDelegate.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/AntBuilderDelegate.java
@@ -142,6 +142,7 @@ public class AntBuilderDelegate extends BuilderSupport {
 
     public void invokeMethod(String methodName, Map<String, Object> parameters, Runnable closure) {
         invokeMethod(methodName, new Object[]{parameters, new Closure<Object>(this, this) {
+            @SuppressWarnings("unused") // Magic Groovy method
             public Object doCall(Object ignored) {
                 closure.run();
                 return null;

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -185,9 +185,14 @@ public class DefaultSettingsLoader implements SettingsLoader {
     }
 
     private void failOnMissingProjectDirectory(String projectPath, String projectDir) {
-        String template = "Configuring project '%s' without an existing directory is not allowed. The configured projectDirectory '%s' does not exist, can't be written to or is not a directory.";
         throw problems.getInternalReporter().throwing(
-            new GradleException(String.format(template, projectPath, projectDir)),
+            new GradleException(
+                String.format(
+                    "Configuring project '%s' without an existing directory is not allowed. The configured projectDirectory '%s' does not exist, can't be written to or is not a directory.",
+                    projectPath,
+                    projectDir
+                )
+            ),
             ProblemId.create("confituring-project-with-invalid-directory", "Configuring project with invalid directory", GradleCoreProblemGroup.configurationUsage()),
             spec ->
                 spec.solution("Make sure the project directory exists and is writable.")


### PR DESCRIPTION
I mostly used my own judgement and personal taste when deciding to disable any of the new diagnostics, but tried to enable as much of them as possible. In particular, I didn't look at anything specific that has no violations in the codebase today.

New enabled diagnostics:
* [`BooleanLiteral`](https://errorprone.info/bugpattern/BooleanLiteral) - complains about `Boolean.TRUE`/`Boolean.FALSE`
* [`StatementSwitchToExpressionSwitch`](https://errorprone.info/bugpattern/StatementSwitchToExpressionSwitch) - modernizes the code
* [`PatternMatchingInstanceof`](https://errorprone.info/bugpattern/PatternMatchingInstanceof) - same as the above
* [`AlmostJavadoc`](https://errorprone.info/bugpattern/AlmostJavadoc) complains about javadoc-like comments
* [`InlineFormatString`](https://errorprone.info/bugpattern/InlineFormatString) complains about format strings in variables - not sure how much value it brings, but not very invasive either.
* [`PreferInstanceofOverGetKind`](https://errorprone.info/bugpattern/PreferInstanceofOverGetKind) - a very specific one, I don't have any opinion about it.
* [`AnnotateFormatMethod`](https://errorprone.info/bugpattern/AnnotateFormatMethod)
* [`UnnecessaryStringBuilder`](https://errorprone.info/bugpattern/UnnecessaryStringBuilder) - was useful in the place it fired
* More unused method detection

New disabled diagnostics:
* [`AssignmentExpression`](https://errorprone.info/bugpattern/AssignmentExpression) - IMO, this is fine to use.
* [`EffectivelyPrivate`](https://errorprone.info/bugpattern/EffectivelyPrivate) - I personally prefer to have public-vs-private distinction in inner classes as a form of documentation.