### PR TITLE
Do not override Develocity Edge from Edge discovery

### DIFF
--- a/.teamcity/src/main/kotlin/common/CommonExtensions.kt
+++ b/.teamcity/src/main/kotlin/common/CommonExtensions.kt
@@ -205,8 +205,6 @@ fun BuildType.paramsForBuildToolBuild(
 ) {
     params {
         param("env.BOT_TEAMCITY_GITHUB_TOKEN", "%github.bot-teamcity.token%")
-        param("env.GRADLE_CACHE_REMOTE_SERVER", "%gradle.cache.remote.server%")
-
         param("env.JAVA_HOME", javaHome(buildJvm, os, arch))
         param("env.ANDROID_HOME", os.androidHome)
         param("env.ANDROID_SDK_ROOT", os.androidHome)


### PR DESCRIPTION
<img width="264" height="266" alt="image" src="https://github.com/user-attachments/assets/c968b456-31c2-42a5-8887-cdbba51b7caa" />

Fully from cache, 18m => 3m

Previously builds complained with:
> A build cache server address was configured overriding the result of Edge discovery.