### PR TITLE
Update Documentation: add disclaimer about Gradle -bin distro

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/gradle_wrapper.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/gradle_wrapper.adoc
@@ -260,7 +260,6 @@ $ ./gradlew wrapper --gradle-version latest   // MacOs, Linux
 ----
 $ gradlew.bat wrapper --gradle-version latest // Windows
 ----
-[subs="attributes"]
 ----
 include::{snippetsPath}/wrapper/simple/tests/wrapperGradleVersionUpgrade.out[]
 ----

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/gradle_wrapper.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/gradle_wrapper.adoc
@@ -64,6 +64,7 @@ include::{snippetsPath}/wrapper/simple/tests/wrapperCommandLine.out[]
 [TIP]
 ====
 To make the Wrapper files available to other developers and execution environments, you need to check them into version control.
+
 Wrapper files, including the JAR file, are small.
 Adding the JAR file to version control is expected.
 Some organizations do not allow projects to submit binary files to version control, and there is no workaround available.
@@ -79,10 +80,18 @@ The generated Wrapper properties file, `gradle/wrapper/gradle-wrapper.properties
 
 The following is an example of the generated distribution URL in `gradle/wrapper/gradle-wrapper.properties`:
 
-[source,text]
+[source,properties,subs="attributes"]
 ----
 distributionUrl=https\://services.gradle.org/distributions/gradle-{gradleVersion}-bin.zip
 ----
+
+[TIP]
+====
+Use the `-bin` distribution for most builds.
+
+The `-bin` distribution contains only the runtime needed to build and run Gradle.
+It’s smaller to download and faster to cache on CI systems compared to the `-all` distribution, which also includes Gradle’s full source code and documentation.
+====
 
 All of those aspects are configurable at the time of generating the Wrapper files with the help of the following command line options:
 
@@ -132,7 +141,7 @@ You would like to generate the Wrapper with version {gradleVersion} and use the 
 
 The following command-line execution captures those requirements:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ gradle wrapper --gradle-version {gradleVersion} --distribution-type all
 ----
@@ -143,7 +152,7 @@ include::{snippetsPath}/wrapper/simple/tests/wrapperCommandLine.out[]
 
 As a result, you can find the desired information (the generated distribution URL) in the Wrapper properties file:
 
-[source,text]
+[source,properties,subs="attributes"]
 ----
 distributionUrl=https\://services.gradle.org/distributions/gradle-{gradleVersion}-all.zip
 ----
@@ -251,23 +260,21 @@ $ ./gradlew wrapper --gradle-version latest   // MacOs, Linux
 ----
 $ gradlew.bat wrapper --gradle-version latest // Windows
 ----
-
+[subs="attributes"]
 ----
 include::{snippetsPath}/wrapper/simple/tests/wrapperGradleVersionUpgrade.out[]
 ----
 
 The following command upgrades the Wrapper to a specific version:
 
-[source, bash]
+[source,bash,subs="attributes"]
 ----
 $ ./gradlew wrapper --gradle-version {gradleVersion} // MacOs, Linux
 ----
-
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ gradlew.bat wrapper --gradle-version {gradleVersion} // Windows
 ----
-
 ----
 include::{snippetsPath}/wrapper/simple/tests/wrapperGradleVersionUpgrade.out[]
 ----
@@ -301,7 +308,7 @@ include::sample[dir="snippets/wrapper/customized-task/groovy",files="build.gradl
 
 With the configuration in place, running `./gradlew wrapper --gradle-version {gradleVersion}` is enough to produce a `distributionUrl` value in the Wrapper properties file that will request the `-all` distribution:
 
-[source,text]
+[source,properties,subs="attributes"]
 ----
 distributionUrl=https\://services.gradle.org/distributions/gradle-{gradleVersion}-all.zip
 ----
@@ -340,7 +347,7 @@ TIP: Shared credentials embedded in `distributionUrl` should only be used in a c
 
 To specify the HTTP Basic Authentication credentials in `distributionUrl`, add the following line:
 
-[source,text]
+[source,properties]
 ----
 distributionUrl=https://username:password@somehost/path/to/gradle-distribution.zip
 ----
@@ -367,7 +374,7 @@ You can also reference the link:https://gradle.org/release-checksums/[list of Gr
 
 Add the downloaded (SHA-256 checksum) hash sum to `gradle-wrapper.properties` using the `distributionSha256Sum` property or use `--gradle-distribution-sha256-sum` on the command-line:
 
-[source,text]
+[source,properties]
 ----
 distributionSha256Sum=371cb9fbebbe9880d147f59bab36d61eee122854ef8c9ee1ecf12b82368bcf10
 ----
@@ -400,20 +407,24 @@ You can manually verify the checksum of the Wrapper JAR to ensure that it has no
 
 Manually verifying the checksum of the Wrapper JAR on Linux:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ cd gradle/wrapper
 ----
+[source,bash,subs="attributes"]
 ----
 $ curl --location --output gradle-wrapper.jar.sha256 \
        https://services.gradle.org/distributions/gradle-{gradleVersion}-wrapper.jar.sha256
 ----
+[source,bash]
 ----
 $ echo " gradle-wrapper.jar" >> gradle-wrapper.jar.sha256
 ----
+[source,bash]
 ----
 $ sha256sum --check gradle-wrapper.jar.sha256
 ----
+[source,text]
 ----
 gradle-wrapper.jar: OK
 ----
@@ -424,6 +435,7 @@ Manually verifying the checksum of the Wrapper JAR on macOS:
 ----
 $ cd gradle/wrapper
 ----
+[source,bash,subs="attributes"]
 ----
 $ curl --location --output gradle-wrapper.jar.sha256 \
        https://services.gradle.org/distributions/gradle-{gradleVersion}-wrapper.jar.sha256
@@ -440,7 +452,7 @@ gradle-wrapper.jar: OK
 
 Manually verifying the checksum of the Wrapper JAR on Windows (using PowerShell):
 
-[source,powershell]
+[source,powershell,subs="attributes"]
 ----
 > $expected = Invoke-RestMethod -Uri https://services.gradle.org/distributions/gradle-{gradleVersion}-wrapper.jar.sha256
 ----

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/gradle_wrapper.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/gradle_wrapper.adoc
@@ -406,7 +406,7 @@ You can manually verify the checksum of the Wrapper JAR to ensure that it has no
 
 Manually verifying the checksum of the Wrapper JAR on Linux:
 
-[source,bash,subs="attributes"]
+[source,bash]
 ----
 $ cd gradle/wrapper
 ----

--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -130,15 +130,16 @@ The following table lists the officially supported platforms for Gradle:
 |===
 | OS | Architecture
 
-
-| link:https://en.wikipedia.org/wiki/Windows_10[Windows 10] + link:https://en.wikipedia.org/wiki/Windows_11[Windows 11]| `amd64`
+| Ubuntu 22 | `amd64`
+| Windows 10 | `amd64`
+| Windows 11 | `amd64`
+| | `aarch64`
+| macOS 12 | `amd64`
 |  | `aarch64`
-| link:https://ubuntu.com/[Ubuntu 22] | `amd64`
+| Ubuntu 16 | `amd64`
 |  | `aarch64`
-| link:https://en.wikipedia.org/wiki/MacOS_version_history#Overview[macOS 13] + link:https://en.wikipedia.org/wiki/MacOS_version_history#Overview[macOS 14]| `amd64`
-|  | `aarch64`
-| link:https://alpinelinux.org/releases/[Alpine 3.20] | `amd64`
-| link:https://en.wikipedia.org/wiki/CentOS_Stream[CentOS Stream 9] | `amd64`
+| Alpine 3.20 | `amd64`
+| CentOS 9 | `amd64`
 |===
 
 NOTE: Currently, all Gradle tests run with the default file-systems of the platform, i.e. `ext4` for Ubuntu, Amazon Linux and CentOS, `NTFS` for Windows, and `APFS` for macOS.

--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -130,16 +130,15 @@ The following table lists the officially supported platforms for Gradle:
 |===
 | OS | Architecture
 
-| Ubuntu 22 | `amd64`
-| Windows 10 | `amd64`
-| Windows 11 | `amd64`
-| | `aarch64`
-| macOS 12 | `amd64`
+
+| link:https://en.wikipedia.org/wiki/Windows_10[Windows 10] + link:https://en.wikipedia.org/wiki/Windows_11[Windows 11]| `amd64`
 |  | `aarch64`
-| Ubuntu 16 | `amd64`
+| link:https://ubuntu.com/[Ubuntu 22] | `amd64`
 |  | `aarch64`
-| Alpine 3.20 | `amd64`
-| CentOS 9 | `amd64`
+| link:https://en.wikipedia.org/wiki/MacOS_version_history#Overview[macOS 13] + link:https://en.wikipedia.org/wiki/MacOS_version_history#Overview[macOS 14]| `amd64`
+|  | `aarch64`
+| link:https://alpinelinux.org/releases/[Alpine 3.20] | `amd64`
+| link:https://en.wikipedia.org/wiki/CentOS_Stream[CentOS Stream 9] | `amd64`
 |===
 
 NOTE: Currently, all Gradle tests run with the default file-systems of the platform, i.e. `ext4` for Ubuntu, Amazon Linux and CentOS, `NTFS` for Windows, and `APFS` for macOS.


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- Update gradle_wrapper.adoc page with `-bin` versus `-all` disclaimer
- Fix `gradleVersion`
