### PR TITLE
Fix issue with nested classes not handling exclude filters

### DIFF
--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -77,7 +77,7 @@ public class TestSelectionMatcher {
         return mayMatchClass(includePatterns, fullQualifiedName);
     }
 
-    private boolean mayExcludeClass(String fullQualifiedName) {
+    public boolean mayExcludeClass(String fullQualifiedName) {
         if (buildScriptExcludePatterns.isEmpty()) {
             return false;
         }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilter.java
@@ -66,7 +66,7 @@ public class DefaultTestFilter implements TestFilter {
     private TestFilter addToFilteringSet(Set<String> filter, String className, String methodName) {
         validateName(className);
         if (methodName == null || methodName.trim().isEmpty()) {
-            filter.add(className + ".*");
+            filter.add(className);
         } else {
             filter.add(className + "." + methodName);
         }

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilterTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/DefaultTestFilterTest.groovy
@@ -46,7 +46,7 @@ class DefaultTestFilterTest extends Specification {
         spec.includeTest("acme.FooTest", "bar")
         spec.includeTest("acme.BarTest", null)
 
-        then: spec.includePatterns == ["acme.FooTest.bar", "acme.BarTest.*"] as Set
+        then: spec.includePatterns == ["acme.FooTest.bar", "acme.BarTest"] as Set
     }
 
     def "prevents empty names"() {


### PR DESCRIPTION
This fixes an issue where JUnit 5 nested classes were not being excluded properly because we would match on an included parent class and improperly determine that the excluded class should be included.

Note that this also fixes an underlying issue with the pattern matching when including/excluding a test class.  Adding a classname like `com.foo.SampleTest` resulted in a pattern like `com.foo.SampleTest.*` which would never match on a classname (only on a method name).  We now use a pattern without the wild card which means the pattern is `com.foo.SampleTest`.  There is an edge case where `com.foo.SampleTest` _could_ match on a class named `foo` in the `com` package with a method named `SampleTest`, but this seems exotic enough that it's not worth the additional complexity to handle it.

Fixes #31304 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
