### PR TITLE
Fix fetch API issue for querying models for a project

### DIFF
--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
@@ -162,7 +162,7 @@ class DefaultBuildController
     }
 
     @Override
-    public <T, M> InternalFetchModelResult<T, M> fetch(@Nullable T target, ModelIdentifier modelIdentifier, @Nullable Object parameter) {
+    public <M> InternalFetchModelResult<M> fetch(@Nullable Object target, ModelIdentifier modelIdentifier, @Nullable Object parameter) {
         try {
             Object model = getModel(target, modelIdentifier, parameter).getModel();
             return createDefaultFetchModelResult(target, uncheckedNonnullCast(model), ImmutableList.of());
@@ -171,10 +171,10 @@ class DefaultBuildController
         }
     }
 
-    private static <T, M> InternalFetchModelResult<T, M> createDefaultFetchModelResult(@Nullable T target, @Nullable M model, Collection<InternalFailure> failures) {
-        return new InternalFetchModelResult<T, M>() {
+    private static <M> InternalFetchModelResult<M> createDefaultFetchModelResult(@Nullable Object target, @Nullable M model, Collection<InternalFailure> failures) {
+        return new InternalFetchModelResult<M>() {
             @Override
-            public @Nullable T getTarget() {
+            public @Nullable Object getTarget() {
                 return target;
             }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/FetchBuildActionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r930/FetchBuildActionCrossVersionSpec.groovy
@@ -26,7 +26,6 @@ import org.gradle.tooling.FetchModelResult
 import org.gradle.tooling.model.Model
 import org.gradle.tooling.model.gradle.BasicGradleProject
 import org.gradle.tooling.model.gradle.GradleBuild
-import org.gradle.util.internal.ToBeImplemented
 
 @TargetGradleVersion(">=9.3.0")
 @ToolingApiVersion(">=9.3.0")
@@ -190,7 +189,6 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
         "fetch(target,modelType,parameterType,parameterInitializer)" | new FetchCustomModelAction()
     }
 
-    @ToBeImplemented
     def "can query models per project"() {
         given:
         settingsFile << "rootProject.name = 'root'"
@@ -204,12 +202,8 @@ class FetchBuildActionCrossVersionSpec extends ToolingApiSpecification {
         }
 
         then:
-        // TODO: Should be
-        // result.modelValue == ["root": "greetings"]
-        // result.failureMessages.isEmpty()
-        // result.causes.isEmpty()
-        result.modelValue == ["root": null]
-        result.failureMessages == ["Don't know how to build models for GradleProject{path=':'}"]
+        result.modelValue == ["root": "greetings"]
+        result.failureMessages.isEmpty()
         result.causes.isEmpty()
     }
 

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/FetchAwareBuildControllerAdapter.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/FetchAwareBuildControllerAdapter.java
@@ -51,22 +51,23 @@ class FetchAwareBuildControllerAdapter extends StreamingAwareBuildControllerAdap
         @Nullable Class<P> parameterType,
         @Nullable Action<? super P> parameterInitializer
     ) {
+        Object originalTarget = unpackModelTarget(target);
         ModelIdentifier modelIdentifier = getModelIdentifierFromModelType(modelType);
         P parameter = parameterInitializer != null ? initializeParameter(parameterType, parameterInitializer) : null;
-        InternalFetchModelResult<T, Object> result = fetch.fetch(target, modelIdentifier, parameter);
-        return adaptResult(modelType, result);
+        InternalFetchModelResult<Object> result = fetch.fetch(originalTarget, modelIdentifier, parameter);
+        return adaptResult(target, modelType, result);
     }
 
-    private <T extends Model, M> FetchModelResult<T, M> adaptResult(Class<M> modelType, InternalFetchModelResult<T, Object> result) {
+    private <T extends Model, M> FetchModelResult<T, M> adaptResult(@Nullable T target, Class<M> modelType, InternalFetchModelResult<Object> result) {
         Object model = result.getModel();
-        M adaptedModel = model != null ? adaptModel(result.getTarget(), modelType, model) : null;
+        M adaptedModel = model != null ? adaptModel(target, modelType, model) : null;
         return new FetchModelResult<T, M>() {
             @Nullable
             List<Failure> failures = null;
 
             @Override
             public T getTarget() {
-                return result.getTarget();
+                return target;
             }
 
             @Override

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalFetchModelResult.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalFetchModelResult.java
@@ -27,9 +27,9 @@ import java.util.Collection;
  * A single item result of a {@link org.gradle.tooling.BuildController#fetch(Collection, Class, Class, Action) fetch}  operation.
  */
 @NullMarked
-public interface InternalFetchModelResult<T, M> extends InternalProtocolInterface {
+public interface InternalFetchModelResult<M> extends InternalProtocolInterface {
     @Nullable
-    T getTarget();
+    Object getTarget();
 
     @Nullable
     M getModel();

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/resiliency/InternalFetchAwareBuildController.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/resiliency/InternalFetchAwareBuildController.java
@@ -31,8 +31,8 @@ import org.jspecify.annotations.Nullable;
  */
 @NullMarked
 public interface InternalFetchAwareBuildController {
-    <T, M> InternalFetchModelResult<T, M> fetch(
-        @Nullable T target,
+    <M> InternalFetchModelResult<M> fetch(
+        @Nullable Object target,
         ModelIdentifier modelIdentifier,
         @Nullable Object parameter
     );


### PR DESCRIPTION
#### Bug
So if you use fetch API to query models per project, i.e. by first querying GradleBuild and then querying some model for a project, you get a failure like:
```
Don't know how to build models for GradleProject{path=':'}
``` 

#### Fix:
We were missing `Object originalTarget = unpackModelTarget(target);` in [FetchAwareBuildControllerAdapter.java](https://github.com/gradle/gradle/pull/35260/files#diff-b31146bfb296deac833befecdfdd8c3e409885998cd20c44be0fc08b555b94f2)

This is part of https://github.com/gradle/gradle/issues/35212