### PR TITLE
Align ProjectState.parent with Project.parent

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/RelevantProjectsRegistry.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/RelevantProjectsRegistry.kt
@@ -57,7 +57,7 @@ class RelevantProjectsRegistry(
         if (!projects.add(project)) {
             return
         }
-        val parent = project.buildParent
+        val parent = project.parent
         if (parent != null) {
             collect(parent, projects)
         }

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/AbstractUniqueProjectNameProvider.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/AbstractUniqueProjectNameProvider.java
@@ -33,7 +33,7 @@ public abstract class AbstractUniqueProjectNameProvider implements UniqueProject
     /**
      * Finds the "parent" project based on the build-tree path of the current project.
      * <p>
-     * This is different from looking up the {@link ProjectState#getBuildParent() parent project} inside a given build,
+     * This is different from looking up the {@link ProjectState#getParent() parent project} inside a given build,
      * because a root project of a build does not have a parent. In the context of project hiearachy shown in the IDE, however,
      * we are looking for the "parent" project based on the build-tree path.
      * This means that the <b>"parent" project might belong to a different build.</b>

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
@@ -122,8 +122,8 @@ public class GradleBuildBuilder implements BuildScopeModelBuilder {
             .setProjectIdentifier(id)
             .setBuildTreePath(project.getIdentityPath().asString())
             .setProjectDirectory(project.getProjectDir());
-        if (project.getBuildParent() != null) {
-            converted.setParent(convertedProjects.get(project.getBuildParent()));
+        if (project.getParent() != null) {
+            converted.setParent(convertedProjects.get(project.getParent()));
         }
         convertedProjects.put(project, converted);
         for (ProjectState child : project.getChildProjects()) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -307,13 +307,6 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         @Nullable
         @Override
         public ProjectState getParent() {
-            Path identityPath = identity.getBuildTreePath();
-            return identityPath.getParent() == null ? null : projectsByPath.get(identityPath.getParent());
-        }
-
-        @Nullable
-        @Override
-        public ProjectState getBuildParent() {
             if (descriptor.getParent() != null) {
                 // Identity path of parent can be different to identity path parent, if the names are tweaked in the settings file
                 // Ideally they would be exactly the same, always
@@ -402,7 +395,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         @Override
         public void ensureConfigured() {
             // Need to configure intermediate parent projects for configure-on-demand
-            ProjectState parent = getBuildParent();
+            ProjectState parent = getParent();
             if (parent != null) {
                 parent.ensureConfigured();
             }
@@ -411,7 +404,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
         @Override
         public void ensureSelfConfigured() {
-            ProjectState parent = getBuildParent();
+            ProjectState parent = getParent();
             if (parent != null) {
                 ((ProjectStateImpl) parent).controller.assertConfigured();
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectLifecycleController.java
@@ -68,7 +68,7 @@ public class ProjectLifecycleController implements Closeable {
         IProjectFactory projectFactory
     ) {
         controller.transition(State.NotCreated, State.Created, () -> {
-            ProjectState parent = owner.getBuildParent();
+            ProjectState parent = owner.getParent();
             ProjectInternal parentModel = parent == null ? null : parent.getMutableModel();
             ServiceRegistryFactory serviceRegistryFactory = domainObject -> {
                 LoggingManagerFactory loggingManagerFactory = buildServices.get(LoggingManagerFactory.class);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -45,17 +45,12 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
     BuildState getOwner();
 
     /**
-     * Returns the parent of this project in the project tree. Note that this is not the same as {@link Project#getParent()}, use {@link #getBuildParent()} for that.
+     * Returns the parent of this project, as per {@link Project#getParent()}.
+     * <p>
+     * This will be null for the root project of any build in the build tree.
      */
     @Nullable
     ProjectState getParent();
-
-    /**
-     * Returns the parent of this project, as per {@link Project#getParent()}. This will be null for the root project of a build in the tree, even if the project is not
-     * at the root of the project tree.
-     */
-    @Nullable
-    ProjectState getBuildParent();
 
     /**
      * Returns the direct children of this project, in public iteration order.

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -160,7 +160,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
     @Provides
     protected PluginRegistry createPluginRegistry(PluginRegistry rootRegistry) {
         PluginRegistry parentRegistry;
-        ProjectState parent = project.getOwner().getBuildParent();
+        ProjectState parent = project.getOwner().getParent();
         if (parent == null) {
             parentRegistry = rootRegistry.createChild(project.getBaseClassLoaderScope());
         } else {


### PR DESCRIPTION
Replaces the implementation of `ProjectState.parent` with `ProjectState.buildParent`, which is aligned with the public version from `Project.parent` and behaves intuitively.

---

The sneaky `ProjectState.parent` method does not do what most Gradle developers expect. Instead of returning null for the root project of an included build, this method returns the **root project of some other included build**, depending on where the current build is located in the build tree.

The only legitimate-looking use case for this behavior seems to be in the areas of tooling model builders, when IDEs expect projects (across the build-tree) to have unique names. With a recent refactoring (https://github.com/gradle/gradle/pull/35270), this implementation no longer relies on the `ProjectState.parent`.

There were only two more uses of `ProjectState.parent`, but they didn't seem legitimate. One was in the area of `Project` instance comparison/sorting, where we used the "parent" computation to compute project "depth". This was refactored in https://github.com/gradle/gradle/pull/35268 to avoid the usage of `ProjectState.parent` and also align the implementation with the public counter-part -- `Project.depth`.

This leaves only the last usage of `ProjectState.parent`, which is a bug that is addressed in this PR: the usage in the `RelevantProjectsRegistry` for determining dependencies between projects. The changes in the PR look like that file is not touched, but that is only because we don't change the call-site of `project.parent`, but instead change the meaning of that call.
