### PR TITLE
Add internal javadoc for Project display name

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -875,6 +875,15 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         return projectToEvaluate;
     }
 
+    /**
+     * Returns the display name of this project in a human-readable format.
+     * <p>
+     * Currently:
+     * <ul>
+     *     <li>For the root project: {@code root project 'projectName'}</li>
+     *     <li>For subprojects: {@code project ':identity:path:of:project'}</li>
+     * </ul>
+     */
     @Override
     public String getDisplayName() {
         return owner.getDisplayName().getDisplayName();


### PR DESCRIPTION
The display name of the project is not exactly a public contract, but it's also what `Project.toString()` evaluates to. The latter is used ubiquitously for print debugging and in our own tests.

Without the javadoc, one has to go through multiple hoops to discover the implementation in a non-trivial location:
https://github.com/gradle/gradle/blob/2879727a0a4d76fd2498d9d0780bbbb99b5744e9/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java#L289-L296