### PR TITLE
Remove redundant ClassLoaderScope.originalScope method

### DIFF
--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/tracker/internal/PluginVersionTracker.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/tracker/internal/PluginVersionTracker.java
@@ -35,7 +35,7 @@ public class PluginVersionTracker {
     final Map<ClassLoaderScope, Map<String, String>> pluginVersionsPerScope = new ConcurrentHashMap<>();
 
     public void setPluginVersionAt(ClassLoaderScope scope, String pluginId, String pluginVersion) {
-        Map<String, String> pluginVersions = pluginVersionsPerScope.computeIfAbsent(scope.getOriginalScope(), ignored -> new ConcurrentHashMap<>());
+        Map<String, String> pluginVersions = pluginVersionsPerScope.computeIfAbsent(scope, ignored -> new ConcurrentHashMap<>());
         if (pluginVersions.containsKey(pluginId)) {
             throw new IllegalStateException("Plugin version already set for " + pluginId);
         }
@@ -45,7 +45,7 @@ public class PluginVersionTracker {
     @Nullable
     public String findPluginVersionAt(ClassLoaderScope scope, String pluginId) {
         while (scope != null) {
-            String pluginVersion = pluginVersionsPerScope.getOrDefault(scope.getOriginalScope(), emptyMap()).get(pluginId);
+            String pluginVersion = pluginVersionsPerScope.getOrDefault(scope, emptyMap()).get(pluginId);
             if (pluginVersion != null) {
                 return pluginVersion;
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/AbstractClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/AbstractClassLoaderScope.java
@@ -93,9 +93,4 @@ public abstract class AbstractClassLoaderScope implements ClassLoaderScope {
     public ClassLoaderScope createLockedChild(String name, @Nullable ClassLoaderScopeOrigin origin, ClassPath localClasspath, @Nullable HashCode classpathImplementationHash, @Nullable Function<ClassLoader, ClassLoader> localClassLoaderFactory) {
         return new ImmutableClassLoaderScope(id.child(name), this, origin, localClasspath, classpathImplementationHash, localClassLoaderFactory, classLoaderCache, listener);
     }
-
-    @Override
-    public ClassLoaderScope getOriginalScope() {
-        return this;
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ClassLoaderScope.java
@@ -121,5 +121,4 @@ public interface ClassLoaderScope {
      */
     void onReuse();
 
-    ClassLoaderScope getOriginalScope();
 }


### PR DESCRIPTION
As the only implementation always returns the same instance