### PR TITLE
Add develocity-ext-hetzner access key to promotion builds

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -46,7 +46,10 @@ abstract class BasePromotionBuildType(
         paramsForBuildToolBuild(BuildToolBuildJvm, Os.LINUX)
 
         params {
-            password("env.DEVELOCITY_ACCESS_KEY", "%ge.gradle.org.access.key%;%develocity.grdev.net.access.key%")
+            password(
+                "env.DEVELOCITY_ACCESS_KEY",
+                "%ge.gradle.org.access.key%;%develocity.grdev.net.access.key%;%develocity-ext-hetzner.grdev.net.access.key%",
+            )
             password("env.ORG_GRADLE_PROJECT_botGradleGitHubToken", "%github.bot-gradle.token%")
         }
 


### PR DESCRIPTION
This works with https://github.com/gradle/gradle-promote/pull/294, we publish build scan to different DV servers based on the environment.