### PR TITLE
Add .kotlin to .gitignore generated by 'gradle init'

### DIFF
--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BasicTypeInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BasicTypeInitIntegrationTest.groovy
@@ -87,6 +87,9 @@ existingIgnores
 
 # Ignore Gradle build output directory
 build
+
+# Ignore Kotlin plugin data
+.kotlin
 """)
 
         where:

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
@@ -56,7 +56,7 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
     }
 
     private static Set<String> getGitignoresToAppend(File gitignoreFile) {
-        Set<String> result = Sets.newLinkedHashSet(Arrays.asList(".gradle", "build"));
+        Set<String> result = Sets.newLinkedHashSet(Arrays.asList(".gradle", "build", ".kotlin"));
         if (gitignoreFile.exists()) {
             try (BufferedReader reader = new BufferedReader(new FileReader(gitignoreFile))){
                 result.removeAll(reader.lines().filter(it -> result.contains(it)).collect(Collectors.toSet()));
@@ -73,6 +73,8 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
             result.add("# Ignore Gradle project-specific cache directory");
         } else if (entry.startsWith("build")) {
             result.add("# Ignore Gradle build output directory");
+        } else if (entry.startsWith(".kotlin")) {
+            result.add("# Ignore Kotlin plugin data");
         }
         result.add(entry);
 

--- a/platforms/software/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
+++ b/platforms/software/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
@@ -82,7 +82,7 @@ ${getGeneratedGitignoreContent()}""")
 ${getGeneratedGitignoreContent(entry)}""")
 
         where:
-        entry << ['.gradle', 'build']
+        entry << ['.gradle', '.kotlin', 'build']
     }
 
     private static String getGeneratedGitignoreContent(String excludingEntry = null) {
@@ -100,6 +100,15 @@ ${getGeneratedGitignoreContent(entry)}""")
             }
             builder << '''# Ignore Gradle build output directory
 build
+'''
+        }
+
+        if (excludingEntry != '.kotlin') {
+            if (builder.length() > 0) {
+                builder << '\n'
+            }
+            builder << '''# Ignore Kotlin plugin data
+.kotlin
 '''
         }
 


### PR DESCRIPTION
Since Kotlin 2.0, '.kotlin' directory contains temporary files of Kotlin Gradle Plugin.

Fixes #35261

### Context
See #35261

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
