### PR TITLE
Bump to Swift 6 for testing where possible

### DIFF
--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalCompileIntegrationTest.groovy
@@ -114,7 +114,7 @@ class SwiftIncrementalCompileIntegrationTest extends AbstractInstalledToolChainI
         failure.assertHasErrorOutput("error: invalid redeclaration of 'sum(a:b:)'")
     }
 
-    @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4_OR_OLDER)
+    @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4)
     def 'removing a file rebuilds everything'() {
         given:
         def outputs = new CompilationOutputsFixture(file("build/obj/main/debug"), [".o"])

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerSwiftBuildExportIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerSwiftBuildExportIntegrationTest.groovy
@@ -191,7 +191,7 @@ let package = Package(
     }
 
     // See https://github.com/gradle/gradle-native/issues/1007
-    @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4_OR_OLDER)
+    @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4)
     def "produces manifest for Swift component with declared Swift language version"() {
         given:
         buildFile << """

--- a/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -724,14 +724,14 @@ public class AvailableToolChains {
                     return getVersion().getMajor() == 3;
                 case SWIFTC_4:
                     return getVersion().getMajor() == 4;
-                case SWIFTC_4_OR_OLDER:
-                    return getVersion().getMajor() <= 4;
                 case SWIFTC_5:
                     return getVersion().getMajor() == 5;
                 case SWIFTC_5_OR_OLDER:
                     return getVersion().getMajor() <= 5;
                 case SWIFTC_6:
                     return getVersion().getMajor() == 6;
+                case SWIFTC_6_OR_OLDER:
+                    return getVersion().getMajor() <= 6;
                 default:
                     return false;
             }

--- a/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/ToolChainRequirement.java
+++ b/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/ToolChainRequirement.java
@@ -57,14 +57,14 @@ public enum ToolChainRequirement {
     SWIFTC_3,
     // Any Swift 4.x compiler
     SWIFTC_4,
-    // Any available Swift compiler <= 4
-    SWIFTC_4_OR_OLDER,
     // Any Swift 5.x compiler
     SWIFTC_5,
     // Any available Swift compiler <= 5
     SWIFTC_5_OR_OLDER,
     // Any Swift 6.x compiler
     SWIFTC_6,
+    // Any available Swift compiler <= 6
+    SWIFTC_6_OR_OLDER,
     // Supports building 32-bit binaries
     SUPPORTS_32,
     // Supports building both 32-bit and 64-bit binaries

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestComponentIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestComponentIntegrationTest.groovy
@@ -31,7 +31,7 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 
 @Requires(UnitTestPreconditions.HasXCTest)
-@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5_OR_OLDER)
+@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_6_OR_OLDER)
 abstract class AbstractSwiftXCTestComponentIntegrationTest extends AbstractSwiftComponentIntegrationTest implements SwiftTaskNames {
     def "check task warns when current operating system family is excluded"() {
         given:

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestIntegrationTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 
-@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5_OR_OLDER)
+@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_6_OR_OLDER)
 @Requires(UnitTestPreconditions.HasXCTest)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 abstract class AbstractSwiftXCTestIntegrationTest extends AbstractNativeUnitTestIntegrationTest implements XCTestExecutionResult, SwiftTaskNames {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestErrorHandlingIntegrationTest.groovy
@@ -35,7 +35,7 @@ import org.gradle.util.internal.VersionNumber
 import static org.gradle.integtests.fixtures.TestExecutionResult.EXECUTION_FAILURE
 import static org.gradle.util.Matchers.containsText
 
-@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5_OR_OLDER)
+@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_6_OR_OLDER)
 @Requires(UnitTestPreconditions.HasXCTest)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftXCTestErrorHandlingIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
@@ -42,7 +42,7 @@ import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 
-@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5_OR_OLDER)
+@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_6_OR_OLDER)
 @Requires(UnitTestPreconditions.HasXCTest)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class SwiftXCTestIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements XCTestExecutionResult, SwiftTaskNames {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestDependenciesIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestDependenciesIntegrationTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 
-@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5_OR_OLDER)
+@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_6_OR_OLDER)
 @Requires(UnitTestPreconditions.HasXCTest)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class XCTestDependenciesIntegrationTest extends AbstractNativeDependenciesIntegrationTest implements SwiftTaskNames {

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestTestFrameworkIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestTestFrameworkIntegrationTest.groovy
@@ -29,12 +29,12 @@ import org.gradle.testing.AbstractTestFrameworkIntegrationTest
 
 import static org.gradle.test.preconditions.UnitTestPreconditions.HasXCTest
 
-@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5_OR_OLDER)
+@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_6_OR_OLDER)
 @Requires(HasXCTest)
 @DoesNotSupportNonAsciiPaths(reason = "Swift sometimes fails when executed from non-ASCII directory")
 class XCTestTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegrationTest {
     def setup() {
-        def toolChain = AvailableToolChains.getToolChain(ToolChainRequirement.SWIFTC_5_OR_OLDER)
+        def toolChain = AvailableToolChains.getToolChain(ToolChainRequirement.SWIFTC_6_OR_OLDER)
 
         File initScript = file("init.gradle") << """
 allprojects { p ->

--- a/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestWithApplicationDependenciesIntegrationTest.groovy
+++ b/platforms/native/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestWithApplicationDependenciesIntegrationTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 
-@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_5_OR_OLDER)
+@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_6_OR_OLDER)
 @Requires(UnitTestPreconditions.HasXCTest)
 @DoesNotSupportNonAsciiPaths(reason = "swiftc does not support these paths")
 class XCTestWithApplicationDependenciesIntegrationTest extends AbstractNativeUnitTestComponentDependenciesIntegrationTest implements SwiftTaskNames {


### PR DESCRIPTION
Also remove `SWIFTC_4_OR_OLDER` (just use `SWIFTC_4`)

I tried to remove `SWIFTC_5_OR_OLDER` but had issues with the C++ interoperability breaking. I don't need to fix this for our puposes so I left those alone, but at some point we will need to deal with that. It seems like we're not even using the proper interop mode documented at https://www.swift.org/documentation/cxx-interop/#enabling-c-interoperability ...

### Context
We need to run the XCTest integration tests locally, but getting Swift 5 to work on modern macOS is nearly impossible with our current Swift integration.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
