### PR TITLE
Remove dynamic task container accesses from DM tests

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -434,7 +434,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
                     }
                 }
                 artifacts {
-                    compile jar
+                    compile tasks.jar
                 }
             }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
@@ -786,7 +786,10 @@ task test {
             dependencies { compile project(':') }
             task jar1(type: Jar) { destinationDirectory = buildDir; archiveBaseName = '1' }
             task jar2(type: Jar) { destinationDirectory = buildDir; archiveBaseName = '2' }
-            artifacts { compile jar1; 'default' jar2 }
+            artifacts {
+                compile tasks.jar1
+                'default' tasks.jar2
+            }
 '''
         resolve.prepare("compile")
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -86,9 +86,9 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
                 outputs.file("\${project.name}-util")
             }
             dependencies {
-                compile utilJar.outputs.files
-                compile utilClasses.outputs.files
-                compile utilDir.outputs.files
+                compile tasks.utilJar.outputs.files
+                compile tasks.utilClasses.outputs.files
+                compile tasks.utilDir.outputs.files
                 compile 'org:test:1.0'
                 compile 'org:test2:1.0'
             }
@@ -117,7 +117,7 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
                 outputs.file("\${project.name}.jar")
             }
             artifacts {
-                compile file: file('ui.jar'), builtBy: jar
+                compile file: file('ui.jar'), builtBy: tasks.jar
             }
         """
 
@@ -218,9 +218,9 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
                 outputs.file("\${project.name}-util")
             }
             dependencies {
-                compile utilJar.outputs.files
-                compile utilClasses.outputs.files
-                compile utilDir.outputs.files
+                compile tasks.utilJar.outputs.files
+                compile tasks.utilClasses.outputs.files
+                compile tasks.utilDir.outputs.files
                 compile 'org:test:1.0'
                 compile 'org:test2:1.0'
             }
@@ -249,7 +249,7 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
                 outputs.file("\${project.name}.classes")
             }
             artifacts {
-                compile file: file('ui.classes'), builtBy: classes
+                compile file: file('ui.classes'), builtBy: tasks.classes
             }
         """
 
@@ -784,9 +784,9 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
                 outputs.file("\${project.name}-util")
             }
             dependencies {
-                compile utilJar.outputs.files
-                compile utilClasses.outputs.files
-                compile utilDir.outputs.files
+                compile tasks.utilJar.outputs.files
+                compile tasks.utilClasses.outputs.files
+                compile tasks.utilDir.outputs.files
                 compile 'org:test:1.0'
                 compile 'org:test2:1.0'
             }
@@ -815,7 +815,7 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
                 outputs.file("\${project.name}.classes")
             }
             artifacts {
-                compile file: file('ui.classes'), builtBy: classes
+                compile file: file('ui.classes'), builtBy: tasks.classes
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CacheResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CacheResolveIntegrationTest.groovy
@@ -102,7 +102,7 @@ task deleteCacheFiles(type: Delete) {
             repositories {
                 ivy { url = "${repo2.uri}" }
             }
-            retrieve.dependsOn(':a:retrieve')
+            tasks.retrieve.dependsOn(':a:retrieve')
         """
 
         when:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
@@ -40,7 +40,7 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
             task lib
             dependencies {
                 compile project(':child')
-                compile files('main-lib.jar') { builtBy lib }
+                compile files('main-lib.jar') { builtBy tasks.lib }
             }
             task direct { inputs.files configurations.compile }
             task artifactView { inputs.files configurations.compile.incoming.artifactView { }.files }
@@ -61,10 +61,10 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
                 create('default').extendsFrom compile
             }
             artifacts {
-                compile file: file('child.jar'), builtBy: jar
+                compile file: file('child.jar'), builtBy: tasks.jar
             }
             dependencies {
-                compile files('child-lib.jar') { builtBy lib }
+                compile files('child-lib.jar') { builtBy tasks.lib }
             }
         """
 
@@ -96,10 +96,10 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
             task jar
             task lib
             artifacts {
-                compile file: file("\${project.name}.jar"), builtBy: jar
+                compile file: file("\${project.name}.jar"), builtBy: tasks.jar
             }
             dependencies {
-                compile files("\${project.name}-lib.jar") { builtBy lib }
+                compile files("\${project.name}-lib.jar") { builtBy tasks.lib }
             }
         """
 
@@ -143,10 +143,10 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
                 conf
             }
             artifacts {
-                conf file: file("\${project.name}.jar"), builtBy: jar
+                conf file: file("\${project.name}.jar"), builtBy: tasks.jar
             }
             dependencies {
-                conf files("\${project.name}-lib.jar") { builtBy lib }
+                conf files("\${project.name}-lib.jar") { builtBy tasks.lib }
             }
         """
 
@@ -384,7 +384,7 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
                 create('default').extendsFrom compile
             }
             artifacts {
-                compile file: jar.outputs.files.singleFile, builtBy: jar
+                compile file: tasks.jar.outputs.files.singleFile, builtBy: tasks.jar
             }
             dependencies {
                 compile 'test:test:1.0'
@@ -435,7 +435,7 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
                 create('default').extendsFrom compile
             }
             artifacts {
-                compile file: jar.outputs.files.singleFile, builtBy: jar
+                compile file: tasks.jar.outputs.files.singleFile, builtBy: tasks.jar
             }
             dependencies {
                 compile 'test:test:1.0'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
@@ -61,7 +61,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
                     content = providers.systemProperty("\${project.name}Content").orElse("content")
                     output = layout.buildDirectory.file("\${project.name}.out")
                 }
-                configurations.default.outgoing.artifact(producer.output)
+                configurations.default.outgoing.artifact(tasks.producer.output)
             }
             repositories {
                 maven { url = uri('${remoteRepo.uri}') }
@@ -76,7 +76,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
                 implementation project(':a')
                 implementation project(':b')
                 implementation "group:lib1:6500"
-                implementation files('a.thing', additionalFile.output)
+                implementation files('a.thing', tasks.additionalFile.output)
             }
         """
     }
@@ -181,7 +181,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
                     content = providers.systemProperty("\${project.name}Content").orElse("0")
                     output = layout.buildDirectory.file("\${project.name}.out")
                 }
-                configurations.default.outgoing.artifact(producer.output)
+                configurations.default.outgoing.artifact(tasks.producer.output)
             }
             configurations {
                 implementation
@@ -1040,7 +1040,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
             dependencies { implementation project(':producer') }
             dependencies { implementation files('thing.blue') }
             dependencies { implementation 'test:test:12' }
-            jar.dependsOn(resolve)
+            tasks.jar.dependsOn(tasks.resolve)
         """
 
         file("buildSrc/thing.blue").createFile()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerProviderIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerProviderIntegrationTest.groovy
@@ -94,7 +94,7 @@ class DependencyHandlerProviderIntegrationTest extends AbstractHttpDependencyRes
             }
         }
 
-        checkDeps.dependsOn resolve
+        tasks.checkDeps.dependsOn tasks.resolve
 
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -391,7 +391,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
 
             artifacts {
                 runtimeElements (file("artifact.txt")) {
-                    builtBy build
+                    builtBy tasks.build
                 }
             }
         """
@@ -772,7 +772,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
             group = "org.utils"
             version = '3.0'
 
-            jar.archiveVersion = '3.0'
+            tasks.jar.archiveVersion = '3.0'
         """
 
         file("impl/build.gradle") << """
@@ -1342,7 +1342,7 @@ Required by:
         }
 
         configurations.runtimeElements.outgoing {
-            artifact jar
+            artifact tasks.jar
         }
 
         def moduleId(String group, String name, String version) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DirectoryOutputArtifactIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DirectoryOutputArtifactIntegrationTest.groovy
@@ -170,7 +170,7 @@ class DirectoryOutputArtifactIntegrationTest extends AbstractIntegrationSpec {
         }
 
         artifacts {
-            compile file:file("$buildDir/someDir"), builtBy: generateFiles
+            compile file: file("$buildDir/someDir"), builtBy: tasks.generateFiles
         }
         '''
 
@@ -209,7 +209,7 @@ class DirectoryOutputArtifactIntegrationTest extends AbstractIntegrationSpec {
         }
 
         artifacts {
-            compile_output file:compileJava.destinationDirectory.asFile.get(), builtBy: compileJava
+            compile_output file: tasks.compileJava.destinationDirectory.asFile.get(), builtBy: tasks.compileJava
         }
         '''
         file('b/src/main/java/Hello.java') << 'public class Hello {}'
@@ -264,7 +264,7 @@ class DirectoryOutputArtifactIntegrationTest extends AbstractIntegrationSpec {
         }
 
         artifacts {
-            compile_output file:compileJava.destinationDirectory.asFile.get(), builtBy: compileJava
+            compile_output file: tasks.compileJava.destinationDirectory.asFile.get(), builtBy: tasks.compileJava
         }
         """
         file('b/src/main/java/Hello.java') << '''import org.apache.commons.lang3.StringUtils;

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FileDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FileDependencyResolveIntegrationTest.groovy
@@ -43,14 +43,14 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
             $common
             dependencies {
                 compile project(path: ':sub', configuration: 'compile')
-                compile files('main.jar') { builtBy jar }
+                compile files('main.jar') { builtBy tasks.jar }
             }
         """
 
         file("sub/build.gradle") << """
             $common
             dependencies {
-                compile files('sub.jar') { builtBy jar }
+                compile files('sub.jar') { builtBy tasks.jar }
             }
         """
 
@@ -88,7 +88,7 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
             $common
             dependencies {
                 compile project(path: ':sub', configuration: 'compile')
-                compile fileTree(dir: projectDir, include: '*.jar', builtBy: [jar])
+                compile fileTree(dir: projectDir, include: '*.jar', builtBy: [tasks.jar])
             }
 
             // Nothing built yet, result should be empty
@@ -98,7 +98,7 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
         file("sub/build.gradle") << """
             $common
             dependencies {
-                compile fileTree(dir: projectDir, include: '*.jar', builtBy: [jar])
+                compile fileTree(dir: projectDir, include: '*.jar', builtBy: [tasks.jar])
             }
         """
 
@@ -176,14 +176,14 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
             dependencies {
                 compile project(path: ':sub', configuration: 'conf')
                 conf project(path: ':sub', configuration: 'conf')
-                conf jar.outputs.files
+                conf tasks.jar.outputs.files
             }
         """
 
         file("sub/build.gradle") << """
             $common
             dependencies {
-                conf jar.outputs.files
+                conf tasks.jar.outputs.files
                 conf project(path: ':', configuration: 'conf')
             }
         """
@@ -225,14 +225,14 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
             $common
             dependencies {
                 compile project(path: ':sub', configuration: 'compile', transitive: false)
-                compile jar.outputs.files
+                compile tasks.jar.outputs.files
             }
         """
 
         file("sub/build.gradle") << """
             $common
             dependencies {
-                compile jar.outputs.files
+                compile tasks.jar.outputs.files
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FilteredConfigurationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FilteredConfigurationIntegrationTest.groovy
@@ -174,10 +174,10 @@ class FilteredConfigurationIntegrationTest extends AbstractDependencyResolutionT
                 outputs.file file("\${project.name}-lib.jar")
             }
             artifacts {
-                compile file: jar.outputs.files.singleFile, builtBy: jar
+                compile file: tasks.jar.outputs.files.singleFile, builtBy: tasks.jar
             }
             dependencies {
-                compile lib.outputs.files
+                compile tasks.lib.outputs.files
                 compile project(':child1')
             }
 
@@ -198,10 +198,10 @@ class FilteredConfigurationIntegrationTest extends AbstractDependencyResolutionT
                 outputs.file file("\${project.name}-lib.jar")
             }
             artifacts {
-                compile file: jar.outputs.files.singleFile, builtBy: jar
+                compile file: tasks.jar.outputs.files.singleFile, builtBy: tasks.jar
             }
             dependencies {
-                compile lib.outputs.files
+                compile tasks.lib.outputs.files
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -60,7 +60,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
                 archiveBaseName = 'a'
                 destinationDirectory = buildDir
             }
-            artifacts { api jar }
+            artifacts { api tasks.jar }
         """
 
         file("b/build.gradle") << """
@@ -117,7 +117,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
                 }
             }
             task jar(type: Jar) { archiveBaseName = 'a' }
-            artifacts { api jar }
+            artifacts { api tasks.jar }
         """
 
         file("b/build.gradle") << """
@@ -179,8 +179,8 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
                 archiveBaseName = 'A2'
             }
             artifacts {
-                configA1 A1jar
-                configA2 A2jar
+                configA1 tasks.A1jar
+                configA2 tasks.A2jar
             }
         """
 
@@ -242,7 +242,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
             dependencies { compile project(path: ':b', configuration: 'compile') }
             task aJar(type: Jar) { }
             gradle.taskGraph.whenReady { project.version = 'late' }
-            artifacts { compile aJar }
+            artifacts { compile tasks.aJar }
         '''
 
         file('b/build.gradle') << '''
@@ -253,7 +253,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
             configurations { compile }
             task bJar(type: Jar) { }
             gradle.taskGraph.whenReady { project.version = 'transitive-late' }
-            artifacts { compile bJar }
+            artifacts { compile tasks.bJar }
         '''
 
         file('build.gradle') << '''
@@ -302,9 +302,9 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
                 }
             }
             task aJar(type: Jar) {
-                dependsOn configureJar
+                dependsOn tasks.configureJar
             }
-            artifacts { compile aJar }
+            artifacts { compile tasks.aJar }
         '''
 
         file('build.gradle') << '''
@@ -351,7 +351,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
             dependencies { deps 'group:externalA:1.5' }
             task xJar(type: Jar) { archiveBaseName='x' }
             task yJar(type: Jar) { archiveBaseName='y' }
-            artifacts { 'default' xJar, yJar }
+            artifacts { 'default' tasks.xJar, tasks.yJar }
         """
 
         file("b/build.gradle") << """
@@ -482,7 +482,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
             }
             task jar(type: Jar)
             artifacts {
-                'default' jar
+                'default' tasks.jar
             }
         """
 
@@ -545,7 +545,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
                     attributes {
                         attribute(Category.CATEGORY_ATTRIBUTE, named(Category, "foo"))
                     }
-                    outgoing.artifact(jar)
+                    outgoing.artifact(tasks.jar)
                 }
             }
         """
@@ -606,7 +606,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
             }
 
             artifacts {
-                delegate.default zip
+                delegate.default tasks.zip
             }
         """
         file("b/build.gradle") << """
@@ -697,9 +697,9 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
                 archiveFileName = 'A3.jar'
             }
             artifacts {
-                configOne A1jar
-                configTwo A2jar
-                configTwo A3jar
+                configOne tasks.A1jar
+                configTwo tasks.A2jar
+                configTwo tasks.A3jar
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishAndResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishAndResolveIntegrationTest.groovy
@@ -135,7 +135,7 @@ class PublishAndResolveIntegrationTest extends AbstractDependencyResolutionTest 
                 into "${safePath(ivyRepo.moduleDir('org.gradle.test', 'api'), '1.1')}"
             }
             ${taskWhichResolves('api', '1.1')}
-            ${resolveTask}.dependsOn customPublish
+            tasks.${resolveTask}.dependsOn tasks.customPublish
         """
 
         expect:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactDeclarationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactDeclarationIntegrationTest.groovy
@@ -385,7 +385,7 @@ class ArtifactDeclarationIntegrationTest extends AbstractIntegrationSpec {
                 outputFile.set(layout.buildDirectory.file("a.jar"))
             }
             artifacts {
-                compile classes.outputFile
+                compile tasks.classes.outputFile
             }
         """
 
@@ -424,7 +424,7 @@ class ArtifactDeclarationIntegrationTest extends AbstractIntegrationSpec {
                 outputDir.set(layout.buildDirectory.dir("classes"))
             }
             artifacts {
-                compile classes.outputDir
+                compile tasks.classes.outputDir
             }
         """
 
@@ -538,7 +538,7 @@ class ArtifactDeclarationIntegrationTest extends AbstractIntegrationSpec {
                 task jar
                 compile(artifact) {
                     name = "thing"
-                    builtBy jar
+                    builtBy tasks.jar
                 }
             }
             assert configurations.compile.artifacts.collect { it.file.name }  == ["lib1.jar"]

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DependencyHandlerApiResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DependencyHandlerApiResolveIntegrationTest.groovy
@@ -36,7 +36,7 @@ class DependencyHandlerApiResolveIntegrationTest extends AbstractIntegrationSpec
             }
 
             task verifyTestKitJars {
-                dependsOn resolveLibs
+                dependsOn tasks.resolveLibs
             }
         """
 
@@ -50,7 +50,7 @@ class DependencyHandlerApiResolveIntegrationTest extends AbstractIntegrationSpec
                 testImplementation gradleTestKit()
             }
 
-            verifyTestKitJars {
+            tasks.verifyTestKitJars {
                 doLast {
                     def jarFiles = libsDir.listFiles()
                     def testKitFunctionalJar = jarFiles.find { it.name.startsWith('$GRADLE_TEST_KIT_JAR_BASE_NAME') }
@@ -84,7 +84,7 @@ class DependencyHandlerApiResolveIntegrationTest extends AbstractIntegrationSpec
             dependencies {
                 testImplementation gradleApi()
             }
-            verifyTestKitJars {
+            tasks.verifyTestKitJars {
                 doLast {
                     def jarFiles = libsDir.listFiles()
                     def testKitFunctionalJar = jarFiles.find { it.name.startsWith('$GRADLE_TEST_KIT_JAR_BASE_NAME') }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
@@ -186,7 +186,7 @@ baz:1.0 requested
         """
         resolve.prepare()
         buildFile << """
-            checkDeps {
+            tasks.checkDeps {
                 doLast {
                     def result = configurations.conf.incoming.resolutionResult
                     result.allComponents {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
@@ -273,11 +273,11 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
                     outgoing {
                         variants {
                             var1 {
-                                artifact oneJar
+                                artifact tasks.oneJar
                                 attributes.attribute(flavor, 'one')
                             }
                             var2 {
-                                artifact twoJar
+                                artifact tasks.twoJar
                                 attributes.attribute(flavor, 'two')
                             }
                         }
@@ -310,11 +310,11 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
                     outgoing {
                         variants {
                             var1 {
-                                artifact oneJar
+                                artifact tasks.oneJar
                                 attributes.attribute(flavor, 'one')
                             }
                             var2 {
-                                artifact twoJar
+                                artifact tasks.twoJar
                                 attributes.attribute(flavor, 'two')
                             }
                         }
@@ -394,11 +394,11 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
                     outgoing {
                         variants {
                             var1 {
-                                artifact oneJar
+                                artifact tasks.oneJar
                                 attributes.attribute(flavor, 'one')
                             }
                             var2 {
-                                artifact twoJar
+                                artifact tasks.twoJar
                                 attributes.attribute(flavor, 'two')
                             }
                         }
@@ -428,11 +428,11 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
                     outgoing {
                         variants {
                             var1 {
-                                artifact oneJar
+                                artifact tasks.oneJar
                                 attributes.attribute(flavor, 'one')
                             }
                             var2 {
-                                artifact twoJar
+                                artifact tasks.twoJar
                                 attributes.attribute(flavor, 'two')
                             }
                         }
@@ -499,11 +499,11 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
                     outgoing {
                         variants {
                             var1 {
-                                artifact oneJar
+                                artifact tasks.oneJar
                                 attributes.attribute(flavor, 'one')
                             }
                             var2 {
-                                artifact twoJar
+                                artifact tasks.twoJar
                                 attributes.attribute(flavor, 'two')
                             }
                         }
@@ -526,11 +526,11 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
                     outgoing {
                         variants {
                             var1 {
-                                artifact oneJar
+                                artifact tasks.oneJar
                                 attributes.attribute(flavor, 'one')
                             }
                             var2 {
-                                artifact twoJar
+                                artifact tasks.twoJar
                                 attributes.attribute(flavor, 'two')
                             }
                         }
@@ -1147,8 +1147,8 @@ Searched in the following locations:
                 compile project(':c')
             }
             configurations.default.outgoing.variants {
-                v1 { artifact jar1 }
-                v2 { artifact jar2 }
+                v1 { artifact tasks.jar1 }
+                v2 { artifact tasks.jar2 }
             }
         """
 
@@ -1157,14 +1157,14 @@ Searched in the following locations:
 
             configurations.compile.attributes.attribute(usage, "broken")
             task jar1(type: Jar)
-            artifacts { compile jar1 }
+            artifacts { compile tasks.jar1 }
         """
 
         file("c/build.gradle") << """
             $common
 
             task jar1(type: Jar)
-            artifacts { compile jar1 }
+            artifacts { compile tasks.jar1 }
         """
 
         given:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
@@ -598,11 +598,11 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
             configurations.compile.outgoing.variants {
                 free {
                     attributes.attribute(flavor, 'free')
-                    artifact freeJar
+                    artifact tasks.freeJar
                 }
                 paid {
                     attributes.attribute(flavor, 'paid')
-                    artifact paidJar
+                    artifact tasks.paidJar
                 }
             }
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -298,9 +298,9 @@ include 'a', 'b'
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                freeDebug fooJar
-                freeRelease fooJar
-                bar barJar
+                freeDebug tasks.fooJar
+                freeRelease tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -506,7 +506,7 @@ Configuration 'bar' declares attribute 'flavor' with value 'free':
                destinationDirectory = buildDir
             }
             artifacts {
-                'default' barJar
+                'default' tasks.barJar
             }
         """
 
@@ -823,9 +823,9 @@ All of them match the consumer attributes:
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                'default' defaultJar
-                foo fooJar
-                bar barJar
+                'default' tasks.defaultJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -883,9 +883,9 @@ All of them match the consumer attributes:
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                'default' defaultJar
-                foo fooJar
-                bar barJar
+                'default' tasks.defaultJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -1107,8 +1107,8 @@ The only attribute distinguishing these variants is 'extra'. Add this attribute 
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                debug fooJar
-                compile barJar
+                debug tasks.fooJar
+                compile tasks.barJar
             }
         """
 
@@ -1263,8 +1263,8 @@ All of them match the consumer attributes:
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -1344,8 +1344,8 @@ All of them match the consumer attributes:
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -1426,8 +1426,8 @@ All of them match the consumer attributes:
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar, foo2Jar
-                bar barJar, bar2Jar
+                foo tasks.fooJar, tasks.foo2Jar
+                bar tasks.barJar, tasks.bar2Jar
             }
         """
 
@@ -1515,8 +1515,8 @@ The only attribute distinguishing these variants is 'extra'. Add this attribute 
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -1605,8 +1605,8 @@ The only attribute distinguishing these variants is 'extra'. Add this attribute 
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                _compileFreeDebug(fooJar)
-                _compileFreeRelease(barJar)
+                _compileFreeDebug(tasks.fooJar)
+                _compileFreeRelease(tasks.barJar)
             }
         """
 
@@ -1776,8 +1776,8 @@ The only attribute distinguishing these variants is 'extra'. Add this attribute 
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -1837,9 +1837,9 @@ The only attribute distinguishing these variants is 'extra'. Add this attribute 
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                'default' defaultJar
-                foo fooJar
-                bar barJar
+                'default' tasks.defaultJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -1860,8 +1860,8 @@ The only attribute distinguishing these variants is 'extra'. Add this attribute 
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         '''
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -131,7 +131,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                         attribute(Attribute.of('attr', String), "incorrect")
                     }
                     outgoing {
-                        artifact(wrongZip)
+                        artifact(tasks.wrongZip)
                     }
                 }
                 consumable("foo") {
@@ -140,7 +140,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                         attribute(Attribute.of('attr', String), "correct")
                     }
                     outgoing {
-                        artifact(firstZip)
+                        artifact(tasks.firstZip)
                     }
                 }
             }
@@ -207,7 +207,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                         attribute(Attribute.of('attr', String), "incorrect")
                     }
                     outgoing {
-                        artifact(wrongZip)
+                        artifact(tasks.wrongZip)
                     }
                 }
                 consumable("foo") {
@@ -216,10 +216,10 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                         attribute(Attribute.of('attr', String), "correct")
                     }
                     outgoing {
-                        artifact(firstZip)
+                        artifact(tasks.firstZip)
                         variants {
                             secondary {
-                                artifact(secondZip)
+                                artifact(tasks.secondZip)
                                 attributes {
                                     attribute(Attribute.of("another", String), "value")
                                 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -124,8 +124,8 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
             }
             artifacts {
                 'default' file('b-default.jar')
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -216,9 +216,9 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                foo2 foo2Jar
-                bar barJar
+                foo tasks.fooJar
+                foo2 tasks.foo2Jar
+                bar tasks.barJar
             }
         """
 
@@ -290,9 +290,9 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                foo2 foo2Jar
-                bar barJar
+                foo tasks.fooJar
+                foo2 tasks.foo2Jar
+                bar tasks.barJar
             }
         """
 
@@ -376,9 +376,9 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
                archiveBaseName = 'b-bar'
             }
             artifacts {
-                foo fooJar
-                foo2 foo2Jar
-                bar barJar
+                foo tasks.fooJar
+                foo2 tasks.foo2Jar
+                bar tasks.barJar
             }
         """
 
@@ -485,10 +485,10 @@ All of them match the consumer attributes:
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                foo2 foo2Jar
-                bar barJar
-                bar2 bar2Jar
+                foo tasks.fooJar
+                foo2 tasks.foo2Jar
+                bar tasks.barJar
+                bar2 tasks.bar2Jar
             }
         """
 
@@ -568,8 +568,8 @@ All of them match the consumer attributes:
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                foo2 foo2Jar
+                foo tasks.fooJar
+                foo2 tasks.foo2Jar
             }
         """
 
@@ -648,8 +648,8 @@ All of them match the consumer attributes:
                 }
                 tasks.withType(Jar) { destinationDirectory = buildDir }
                 artifacts {
-                    foo fooJar
-                    bar barJar
+                    foo tasks.fooJar
+                    bar tasks.barJar
                 }
             }
 
@@ -723,8 +723,8 @@ All of them match the consumer attributes:
                 }
                 tasks.withType(Jar) { destinationDirectory = buildDir }
                 artifacts {
-                    foo fooJar
-                    bar barJar
+                    foo tasks.fooJar
+                    bar tasks.barJar
                 }
             }
 
@@ -783,8 +783,8 @@ All of them match the consumer attributes:
                 }
                 tasks.withType(Jar) { destinationDirectory = buildDir }
                 artifacts {
-                    foo fooJar
-                    bar barJar
+                    foo tasks.fooJar
+                    bar tasks.barJar
                 }
             }
         """
@@ -841,8 +841,8 @@ All of them match the consumer attributes:
                 }
                 tasks.withType(Jar) { destinationDirectory = buildDir }
                 artifacts {
-                    foo fooJar
-                    bar barJar
+                    foo tasks.fooJar
+                    bar tasks.barJar
                 }
             }
 
@@ -902,8 +902,8 @@ All of them match the consumer attributes:
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -970,8 +970,8 @@ All of them match the consumer attributes:
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -996,8 +996,8 @@ All of them match the consumer attributes:
             }
             tasks.withType(Jar) { destinationDirectory = buildDir }
             artifacts {
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -1088,10 +1088,10 @@ All of them match the consumer attributes:
                 c4 { attributes { attribute(flavor, objects.named(Flavor, 'full')); $release } }
             }
             artifacts {
-                c1 fooJar
-                c2 fooJar
-                c3 foo2Jar
-                c4 barJar
+                c1 tasks.fooJar
+                c2 tasks.fooJar
+                c3 tasks.foo2Jar
+                c4 tasks.barJar
             }
         """
 
@@ -1148,7 +1148,7 @@ All of them match the consumer attributes:
                archiveBaseName = 'b-bar'
             }
             artifacts {
-                bar barJar
+                bar tasks.barJar
             }
         """
 
@@ -1210,7 +1210,7 @@ All of them match the consumer attributes:
                archiveBaseName = 'b-bar'
             }
             artifacts {
-                bar barJar
+                bar tasks.barJar
             }
         """
 
@@ -1283,8 +1283,8 @@ All of them match the consumer attributes:
                archiveBaseName = 'b-bar'
             }
             artifacts {
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 
@@ -1356,8 +1356,8 @@ All of them match the consumer attributes:
                archiveBaseName = 'b-bar'
             }
             artifacts {
-                foo fooJar
-                bar barJar
+                foo tasks.fooJar
+                bar tasks.barJar
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachingDependencyMetadataInMemoryIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachingDependencyMetadataInMemoryIntegrationTest.groovy
@@ -47,11 +47,11 @@ class CachingDependencyMetadataInMemoryIntegrationTest extends AbstractHttpDepen
                 }
             }
             //runs second, purges repo
-            task purgeRepo(type: Delete, dependsOn: resolveOne) {
+            task purgeRepo(type: Delete, dependsOn: tasks.resolveOne) {
                 delete "${mavenRepo.uri}"
             }
             //runs last, still works even though local repo is empty
-            task resolveTwo(dependsOn: purgeRepo) {
+            task resolveTwo(dependsOn: tasks.purgeRepo) {
                 def files = configurations.two
                 doLast {
                     println "Resolved " + files*.name
@@ -85,7 +85,7 @@ class CachingDependencyMetadataInMemoryIntegrationTest extends AbstractHttpDepen
         file("build.gradle") << """
             $common
 
-            resolveConf.dependsOn(':impl:resolveConf')
+            tasks.resolveConf.dependsOn(':impl:resolveConf')
         """
 
         file("impl/build.gradle") << common

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ConcurrentBuildsCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ConcurrentBuildsCachingIntegrationTest.groovy
@@ -61,15 +61,15 @@ task block1 {
         ${blockingServer.callFromBuild("block1")}
     }
 }
-block1.mustRunAfter a
-b.mustRunAfter block1
+tasks.block1.mustRunAfter tasks.a
+tasks.b.mustRunAfter tasks.block1
 
 task block2 {
     doLast {
         ${blockingServer.callFromBuild("block2")}
     }
 }
-block2.mustRunAfter b
+tasks.block2.mustRunAfter tasks.b
 """
         // Ensure scripts are compiled
         run("help")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ForceRealizedMetadataIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ForceRealizedMetadataIntegrationTest.groovy
@@ -115,7 +115,7 @@ class ForceRealizedMetadataIntegrationTest extends AbstractHttpDependencyResolut
         direct.publish()
 
         buildFile << """
-            resolveSources {
+            tasks.resolveSources {
                 expectedFiles = ['direct-1.0-sources.jar', 'transitive-1.0-sources.jar']
             }
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ParallelDependencyResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/ParallelDependencyResolutionIntegrationTest.groovy
@@ -165,13 +165,13 @@ class ParallelDependencyResolutionIntegrationTest extends AbstractHttpDependency
                 output.set(file("out"))
             }
             task longRunning {
-                dependsOn producer
+                dependsOn tasks.producer
                 doLast {
                     ${blockingServer.callFromBuild("longRunning")}
                 }
             }
             artifacts {
-                "default"(producer.output)
+                "default"(tasks.producer.output)
             }
         """
 
@@ -186,7 +186,7 @@ class ParallelDependencyResolutionIntegrationTest extends AbstractHttpDependency
             task consumer {
                 inputs.files configurations.default
                 outputs.file file("out")
-                dependsOn guard
+                dependsOn tasks.guard
                 doLast {
                     ${blockingServer.callFromBuild("consumer")}
                 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/DerivedVariantsResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/DerivedVariantsResolutionIntegrationTest.groovy
@@ -95,10 +95,10 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         direct.publish()
 
         buildFile << """
-            resolveSources {
+            tasks.resolveSources {
                 expectedFiles = []
             }
-            resolveJavadoc {
+            tasks.resolveJavadoc {
                 expectedFiles = []
             }
         """
@@ -149,7 +149,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         direct.publish()
 
         buildFile << """
-            resolveSources {
+            tasks.resolveSources {
                 expectedFiles = ['direct-1.0-sources.jar', 'transitive-1.0-sources.jar']
             }
         """
@@ -202,7 +202,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         direct.publish()
 
         buildFile << """
-            resolveJavadoc {
+            tasks.resolveJavadoc {
                 expectedFiles = ['direct-1.0-javadoc.jar', 'transitive-1.0-javadoc.jar']
             }
         """
@@ -271,7 +271,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         direct.publish()
 
         buildFile << """
-            resolveJavadoc {
+            tasks.resolveJavadoc {
                 expectedFiles = ['direct-1.0-javadoc.jar', 'transitive-1.0-javadoc.jar']
             }
         """
@@ -287,7 +287,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
 
         and:
         buildFile << """
-            resolveSources {
+            tasks.resolveSources {
                 expectedFiles = ['direct-1.0-sources.jar', 'transitive-1.0-sources.jar']
             }
         """
@@ -321,7 +321,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         direct.publish()
 
         buildFile << """
-            resolveSources {
+            tasks.resolveSources {
                 expectedFiles = ['transitive-1.0-sources.jar']
             }
         """
@@ -340,10 +340,10 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         direct.publish()
 
         buildFile << """
-            resolveSources {
+            tasks.resolveSources {
                 expectedFiles = []
             }
-            resolveJavadoc {
+            tasks.resolveJavadoc {
                 expectedFiles = []
             }
         """
@@ -366,7 +366,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         direct.publish()
 
         buildFile << """
-            resolveSources {
+            tasks.resolveSources {
                 expectedFiles = ['direct-1.0-sources.jar', 'transitive-1.0-sources.jar']
             }
         """
@@ -389,7 +389,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         direct.publish()
 
         buildFile << """
-            resolveJavadoc {
+            tasks.resolveJavadoc {
                 expectedFiles = ['direct-1.0-javadoc.jar', 'transitive-1.0-javadoc.jar']
             }
         """
@@ -412,7 +412,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         direct.publish()
 
         buildFile << """
-            resolveSources {
+            tasks.resolveSources {
                 expectedFiles = ['direct-1.0-sources.jar', 'transitive-1.0-sources.jar']
             }
         """
@@ -428,7 +428,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
 
         and:
         buildFile << """
-            resolveJavadoc {
+            tasks.resolveJavadoc {
                 expectedFiles = ['direct-1.0-javadoc.jar', 'transitive-1.0-javadoc.jar']
             }
         """
@@ -448,7 +448,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         direct.publish()
 
         buildFile << """
-            resolveSources {
+            tasks.resolveSources {
                 expectedFiles = ['transitive-1.0-sources.jar']
             }
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/MultiProjectVariantResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/MultiProjectVariantResolutionIntegrationTest.groovy
@@ -82,7 +82,7 @@ class MultiProjectVariantResolutionIntegrationTest extends AbstractIntegrationSp
                         }
                     }.files)
                 }
-                
+
                 tasks.register('resolveAll', Resolve) {
                     artifacts.from(configurations.producerArtifacts)
                     artifacts.from(configurations.producerArtifacts.incoming.artifactView {
@@ -192,7 +192,7 @@ Artifacts
 
     def 'consumer resolves jar variant of producer'() {
         file('consumer/build.gradle') << '''
-            resolve {
+            tasks.resolve {
                 expectations = [ 'producer-jar.txt' ]
             }
         '''
@@ -202,7 +202,7 @@ Artifacts
 
     def 'consumer resolves javadoc variant of producer'() {
         file('consumer/build.gradle') << '''
-            resolveJavadoc {
+            tasks.resolveJavadoc {
                 expectations = [ 'producer-javadoc.txt' ]
             }
         '''
@@ -212,7 +212,7 @@ Artifacts
 
     def 'consumer resolves other variant of producer'() {
         file('consumer/build.gradle') << '''
-            resolveOther {
+            tasks.resolveOther {
                 expectations = [ 'producer-other.txt' ]
             }
         '''
@@ -222,7 +222,7 @@ Artifacts
 
     def 'consumer resolves all variants of producer'() {
         file('consumer/build.gradle') << '''
-            resolveAll {
+            tasks.resolveAll {
                 expectations = [ 'producer-jar.txt', 'producer-javadoc.txt', 'producer-other.txt' ]
             }
         '''
@@ -246,7 +246,7 @@ Artifacts
             }
         '''
         file('consumer/build.gradle') << '''
-            resolve {
+            tasks.resolve {
                 expectations = ['producer-jar.txt', 'direct-jar.txt', 'transitive-jar.txt']
             }
         '''
@@ -270,7 +270,7 @@ Artifacts
             }
         '''
         file('consumer/build.gradle') << '''
-            resolveJavadoc {
+            tasks.resolveJavadoc {
                 expectations = ['producer-javadoc.txt', 'direct-javadoc.txt', 'transitive-javadoc.txt']
             }
         '''
@@ -294,7 +294,7 @@ Artifacts
             }
         '''
         file('consumer/build.gradle') << '''
-            resolveOther {
+            tasks.resolveOther {
                 expectations = ['producer-other.txt', 'direct-other.txt', 'transitive-other.txt']
             }
         '''
@@ -318,7 +318,7 @@ Artifacts
             }
         '''
         file('consumer/build.gradle') << '''
-            resolveOther {
+            tasks.resolveOther {
                 expectations = ['producer-other.txt']
             }
         '''

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
@@ -44,7 +44,7 @@ class ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponen
                 }
             }
 
-            checkDeps.doLast {
+            tasks.checkDeps.doLast {
                 assert candidates == ${candidates}
             }
 """
@@ -398,7 +398,7 @@ Required by:
                 }
             }
 
-            checkDeps.doLast {
+            tasks.checkDeps.doLast {
                 def artifacts = configurations.conf.incoming.artifacts.artifacts
                 assert artifacts.size() == 2
                 assert artifacts[0].id.componentIdentifier.version == '${chosen}'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesProcessingIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesProcessingIntegTest.groovy
@@ -81,7 +81,7 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
                 }
             }
 
-            checkDeps.doLast {
+            tasks.checkDeps.doLast {
                 assert extraRuleCandidates == ['1.1']
             }
 """
@@ -252,7 +252,7 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
                 }
             }
 
-            checkDeps.doLast {
+            tasks.checkDeps.doLast {
                 assert rule1candidates == ['2.0']
                 assert rule2candidates == ['2.0']
             }
@@ -309,7 +309,7 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
         buildFile.text = """
             $commonBuildFile
 
-            checkDeps.doLast {
+            tasks.checkDeps.doLast {
                 assert status11 == 'milestone'
                 assert branch11 == 'test'
             }
@@ -349,7 +349,7 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
         buildFile.text = """
             $commonBuildFile
 
-            checkDeps.doLast {
+            tasks.checkDeps.doLast {
                 assert status11 == 'release'
                 assert branch11 == 'master'
             }
@@ -455,7 +455,7 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
                 }
             }
 
-            checkDeps.doLast {
+            tasks.checkDeps.doLast {
                 assert candidates == ['1.2', '1.2', '1.2', '1.2']
             }
         """
@@ -491,7 +491,7 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
                 }
             }
 
-            checkDeps.doLast {
+            tasks.checkDeps.doLast {
                 def artifacts = configurations.conf.incoming.artifacts.artifacts
                 assert artifacts.size() == 1
                 assert artifacts[0].id.componentIdentifier.version == '1.1'
@@ -544,7 +544,7 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
                 }
             }
 
-            checkDeps.doLast {
+            tasks.checkDeps.doLast {
                 def artifacts = configurations.conf.incoming.artifacts.artifacts
                 assert artifacts.size() == 1
                 assert artifacts[0].id.componentIdentifier.version == '1.1'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomPackagingResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomPackagingResolveIntegrationTest.groovy
@@ -46,7 +46,7 @@ dependencies {
 task deleteDir(type: Delete) {
     delete 'libs'
 }
-task retrieve(type: Copy, dependsOn: deleteDir) {
+task retrieve(type: Copy, dependsOn: tasks.deleteDir) {
     into 'libs'
     from configurations.compile
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
@@ -152,7 +152,7 @@ repositories { maven { url = '${mavenHttpRepo.uri}' } }
 dependencies { implementation '${groupId}:${artifactId}:1.0' }
 task retrieve {}
 ['compile', 'runtime'].each { cp ->
-   retrieve.dependsOn(tasks.create("retrieve\${cp.capitalize()}Classpath", Sync) {
+   tasks.retrieve.dependsOn(tasks.create("retrieve\${cp.capitalize()}Classpath", Sync) {
       into "\${cp}Classpath"
       from configurations.getByName("\${cp}Classpath")
    })

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -523,12 +523,12 @@ task retrieve(type: Sync) {
             $common
 
             //imposing an artificial order so that the parallel build retrieves sequentially, GRADLE-2788
-            retrieve.dependsOn ":a:retrieve"
+            tasks.retrieve.dependsOn ":a:retrieve"
         """
 
         file("a/build.gradle") << """
             $common
-            tasks.getByName("retrieve").dependsOn ":b:retrieve"
+            tasks.retrieve.dependsOn ":b:retrieve"
         """
 
         file("b/build.gradle") << common

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
@@ -303,7 +303,7 @@ dependencies {
             }
 
             def rules1 = provider { rulesInvoked }
-            resolve.doLast {
+            tasks.resolve.doLast {
                 assert rules1.get() == [ '1.0', '1.0', '1.0', '1.0', '1.0' ]
                 assert VerifyingRule.ruleInvoked
             }
@@ -385,7 +385,7 @@ dependencies {
 
             def rules1 = provider { rulesInvoked }
             def rules2 = provider { rulesUninvoked }
-            resolve.doLast {
+            tasks.resolve.doLast {
                 assert rules1.get().sort() == [ 1, 2, 3 ]
                 assert rules2.get().empty
                 assert InvokedRule.ruleInvoked
@@ -460,7 +460,7 @@ dependencies {
     }
 }
 
-resolve.doLast {
+tasks.resolve.doLast {
     assert plainRuleInvoked
     assert mavenRuleInvoked
     assert !ivyRuleInvoked
@@ -690,7 +690,7 @@ task downloadRules {
     }
 }
 
-resolve.dependsOn(downloadRules)
+tasks.resolve.dependsOn(tasks.downloadRules)
 
 """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/IvySpecificComponentMetadataRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/IvySpecificComponentMetadataRulesIntegrationTest.groovy
@@ -77,7 +77,7 @@ dependencies {
     }
 }
 
-resolve.doLast { assert IvyRule.ruleInvoked }
+tasks.resolve.doLast { assert IvyRule.ruleInvoked }
 """
         when:
         repositoryInteractions {
@@ -171,7 +171,7 @@ dependencies {
     }
 }
 
-resolve.doLast { assert IvyRule.ruleInvoked }
+tasks.resolve.doLast { assert IvyRule.ruleInvoked }
 """
 
         when:
@@ -220,7 +220,7 @@ dependencies {
     }
 }
 
-resolve.doLast { assert ruleInvoked }
+tasks.resolve.doLast { assert ruleInvoked }
 """
 
         then:
@@ -242,7 +242,7 @@ dependencies {
     }
 }
 
-resolve.doLast { assert ruleInvoked }
+tasks.resolve.doLast { assert ruleInvoked }
 """
 
         then:
@@ -278,7 +278,7 @@ dependencies {
     }
 }
 
-resolve.doLast { assert ruleInvoked }
+tasks.resolve.doLast { assert ruleInvoked }
 """
 
         when:
@@ -326,7 +326,7 @@ dependencies {
     }
 }
 
-resolve.doLast { assert ruleInvoked }
+tasks.resolve.doLast { assert ruleInvoked }
 """
 
         and:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -1023,7 +1023,7 @@ group:projectB:2.2;release
         addDependenciesTo(otherBuildFile)
         otherBuildFile << """
             // this is for parallel execution
-            checkDeps.mustRunAfter(rootProject.checkDeps)
+            tasks.checkDeps.mustRunAfter(rootProject.tasks.checkDeps)
         """
         given:
         def supplierInteractions = withPerVersionStatusSupplier(file("buildSrc/src/main/groovy/MP.groovy"))

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactFilterIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactFilterIntegrationTest.groovy
@@ -38,7 +38,7 @@ class ArtifactFilterIntegrationTest extends AbstractHttpDependencyResolutionTest
                 configurations.create('default')
                 task jar {}
                 artifacts {
-                    'default' file('libInclude.jar'), { builtBy jar }
+                    'default' file('libInclude.jar'), { builtBy tasks.jar }
                 }
             }
 
@@ -46,7 +46,7 @@ class ArtifactFilterIntegrationTest extends AbstractHttpDependencyResolutionTest
                 configurations.create('default')
                 task jar {}
                 artifacts {
-                    'default' file('libExclude.jar'), { builtBy jar }
+                    'default' file('libExclude.jar'), { builtBy tasks.jar }
                 }
             }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -671,8 +671,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
                 }
 
                 artifacts {
-                    implementation producer.out1
-                    implementation producer.out2
+                    implementation tasks.producer.out1
+                    implementation tasks.producer.out2
                 }
 
                 task resolve(type: ShowFileCollection) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -543,7 +543,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                     identifier = "2"
                 }
                 task resolve {
-                    dependsOn(resolveHash, resolveSize)
+                    dependsOn(tasks.resolveHash, tasks.resolveSize)
                 }
             }
 
@@ -653,7 +653,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                     identifier = "2"
                 }
                 task resolve {
-                    dependsOn(resolveSize, resolveHash)
+                    dependsOn(tasks.resolveSize, tasks.resolveHash)
                 }
             }
 
@@ -732,13 +732,13 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                 task resolve2(type: Resolve) {
                     identifier = "2"
                 }
-                configure([resolve1, resolve2]) {
+                configure([tasks.resolve1, tasks.resolve2]) {
                     artifacts = configurations.compile.incoming.artifactView {
                         attributes { it.attribute(artifactType, 'value') }
                     }.artifacts
                 }
                 task resolve {
-                    dependsOn(resolve1, resolve2)
+                    dependsOn(tasks.resolve1, tasks.resolve2)
                 }
             }
 
@@ -853,7 +853,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                     identifier = "2"
                 }
                 task resolve {
-                    dependsOn(resolveSize, resolveHash)
+                    dependsOn(tasks.resolveSize, tasks.resolveHash)
                 }
             }
 
@@ -1325,7 +1325,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                     destinationDirectory = buildDir
                 }
                 artifacts {
-                    compile jar1
+                    compile tasks.jar1
                 }
             }
 
@@ -1372,7 +1372,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                     destinationDirectory = buildDir
                 }
                 artifacts {
-                    compile jar1
+                    compile tasks.jar1
                 }
             }
 
@@ -2027,7 +2027,7 @@ resultsFile:
                     }.artifacts
                 }
                 task resolve {
-                    dependsOn(resolveGreen, resolveBlue)
+                    dependsOn(tasks.resolveGreen, tasks.resolveBlue)
                 }
             }
         """
@@ -2455,8 +2455,8 @@ resultsFile:
                     destinationDirectory = buildDir
                 }
                 artifacts {
-                    compile jar1
-                    compile jar2
+                    compile tasks.jar1
+                    compile tasks.jar2
                 }
             }
         """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
@@ -470,7 +470,7 @@ class ArtifactTransformExecutionBuildOperationIntegrationTest extends AbstractIn
                         }
                     }
                 }
-                resolve.dependsOn(':consumer1:resolve')
+                tasks.resolve.dependsOn(':consumer1:resolve')
             }
         """
 
@@ -535,7 +535,7 @@ class ArtifactTransformExecutionBuildOperationIntegrationTest extends AbstractIn
                         }
                     }
                 }
-                resolve.dependsOn(':consumer1:resolve')
+                tasks.resolve.dependsOn(':consumer1:resolve')
             }
         """
 
@@ -599,7 +599,7 @@ class ArtifactTransformExecutionBuildOperationIntegrationTest extends AbstractIn
                         }
                     }
                 }
-                resolve.dependsOn(':consumer1:resolve')
+                tasks.resolve.dependsOn(':consumer1:resolve')
             }
         """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -184,7 +184,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
             task jars
 
             dependencies {
-                compile files([a, b]) { builtBy jars }
+                compile files([a, b]) { builtBy tasks.jars }
             }
 
             ${configurationAndTransform('FileSizer')}
@@ -235,7 +235,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
 
                 artifacts {
-                    compile jar1, jar2
+                    compile tasks.jar1, tasks.jar2
                 }
             }
 
@@ -296,7 +296,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
 
                 artifacts {
-                    compile blueThing.output
+                    compile tasks.blueThing.output
                 }
             }
 
@@ -404,7 +404,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                     archiveFileName = 'common.jar'
                 }
                 artifacts {
-                    compile jar
+                    compile tasks.jar
                     compile file("common-file.jar")
                 }
             }
@@ -426,7 +426,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
 
                 artifacts {
-                    compile jar1, jar2
+                    compile tasks.jar1, tasks.jar2
                 }
             }
 
@@ -478,8 +478,8 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                     compile.outgoing.variants {
                         files {
                             attributes.attribute(Attribute.of('artifactType', String), 'jar')
-                            artifact jar1
-                            artifact zip1
+                            artifact tasks.jar1
+                            artifact tasks.zip1
                         }
                     }
                 }
@@ -584,8 +584,8 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                     compile.outgoing.variants {
                         files {
                             attributes.attribute(Attribute.of('artifactType', String), 'size')
-                            artifact jar1
-                            artifact jar2
+                            artifact tasks.jar1
+                            artifact tasks.jar2
                         }
                     }
                 }
@@ -644,12 +644,12 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                         java7 {
                             attributes.attribute(Attribute.of('javaVersion', String), '7')
                             attributes.attribute(Attribute.of('color', String), 'green')
-                            artifact jar1
+                            artifact tasks.jar1
                         }
                         java8 {
                             attributes.attribute(Attribute.of('javaVersion', String), '8')
                             attributes.attribute(Attribute.of('color', String), 'red')
-                            artifact jar2
+                            artifact tasks.jar2
                         }
                     }
                 }
@@ -748,12 +748,12 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                         java7 {
                             attributes.attribute(Attribute.of('javaVersion', String), '7')
                             attributes.attribute(Attribute.of('color', String), 'green')
-                            artifact jar1
+                            artifact tasks.jar1
                         }
                         java8 {
                             attributes.attribute(Attribute.of('javaVersion', String), '8')
                             attributes.attribute(Attribute.of('color', String), 'red')
-                            artifact jar2
+                            artifact tasks.jar2
                         }
                     }
                 }
@@ -1016,8 +1016,8 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
             }
 
             dependencies {
-                api1 files(producer1)
-                api2 files(producer2)
+                api1 files(tasks.producer1)
+                api2 files(tasks.producer2)
             }
         """)
 
@@ -1068,13 +1068,13 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                             attribute(artifactType, "jar")
                             attribute(extraAttribute, "preferred")
                         }
-                        artifact jar
+                        artifact tasks.jar
                     }
                     secondary {
                         attributes {
                             attribute(artifactType, "intermediate")
                         }
-                        artifact jar
+                        artifact tasks.jar
                     }
                 }
             }
@@ -1245,7 +1245,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
 
                 artifacts {
-                    compile(jar1)
+                    compile(tasks.jar1)
                 }
             }
 
@@ -1337,17 +1337,17 @@ Found the following transformation chains:
                         variant1 {
                             attributes.attribute(buildType, 'release')
                             attributes.attribute(flavor, 'free')
-                            artifact jar1
+                            artifact tasks.jar1
                         }
                         variant2 {
                             attributes.attribute(buildType, 'release')
                             attributes.attribute(flavor, 'paid')
-                            artifact jar1
+                            artifact tasks.jar1
                         }
                         variant3 {
                             attributes.attribute(buildType, 'debug')
                             attributes.attribute(flavor, 'free')
-                            artifact jar1
+                            artifact tasks.jar1
                         }
                     }
                 }
@@ -1577,7 +1577,7 @@ Found the following transformation chains:
                 task jar1(type: Jar) { archiveFileName = 'jar1.jar' }
                 task jar2(type: Jar) { archiveFileName = 'jar2.jar' }
                 tasks.withType(Jar) { destinationDirectory = buildDir }
-                artifacts { compile jar1, jar2 }
+                artifacts { compile tasks.jar1, tasks.jar2 }
             }
 
             abstract class Hasher implements TransformAction<TransformParameters.None> {
@@ -2218,7 +2218,7 @@ Found the following transformation chains:
                     archiveFileName = 'lib.jar'
                 }
                 artifacts {
-                    compile jar
+                    compile tasks.jar
                 }
             }
 
@@ -2543,7 +2543,7 @@ Found the following transformation chains:
                 }
 
                 dependencies {
-                    compile files(lib1)
+                    compile files(tasks.lib1)
                 }
                 artifacts {
                     compile file1
@@ -2646,7 +2646,7 @@ Found the following transformation chains:
                     destinationDirectory = buildDir
                 }
                 artifacts {
-                    compile jar
+                    compile tasks.jar
                 }
             }
 
@@ -2713,7 +2713,7 @@ Found the following transformation chains:
                     destinationDirectory = buildDir
                 }
                 artifacts {
-                    compile jar
+                    compile tasks.jar
                 }
             }
 
@@ -2771,7 +2771,7 @@ Found the following transformation chains:
                 }
 
                 artifacts {
-                    compile jar
+                    compile tasks.jar
                 }
             }
 
@@ -2784,7 +2784,7 @@ Found the following transformation chains:
                 ${configurationAndTransform()}
 
                 task dependent {
-                    dependsOn resolve
+                    dependsOn tasks.resolve
                 }
             }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformOfDirectoriesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformOfDirectoriesIntegrationTest.groovy
@@ -49,7 +49,7 @@ class ArtifactTransformOfDirectoriesIntegrationTest extends AbstractDependencyRe
         taskTypeLogsInputFileCollectionContent()
         transformDirectoryDependency()
         buildFile << """
-            producer.content = "" // generate missing directory
+            tasks.producer.content = "" // generate missing directory
         """
 
         when:
@@ -82,7 +82,7 @@ class ArtifactTransformOfDirectoriesIntegrationTest extends AbstractDependencyRe
                 compile
             }
             dependencies {
-                compile files(producer.output)
+                compile files(tasks.producer.output)
 
                 registerTransform(MakeSize) {
                     from.attribute(artifactType, 'directory')

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -154,7 +154,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
                     destinationDirectory = buildDir
                 }
                 artifacts {
-                    compile jar
+                    compile tasks.jar
                 }
             }
 
@@ -398,7 +398,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
                     destinationDirectory = buildDir
                 }
                 artifacts {
-                    compile jar2
+                    compile tasks.jar2
                 }
             }
 
@@ -460,7 +460,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
                         }.artifacts
                         inputs.files(artifacts.artifactFiles)
 
-                        dependsOn(beforeResolve)
+                        dependsOn(tasks.beforeResolve)
 
                         def projectName = project.name
                         doLast {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -375,7 +375,7 @@ project(':common') {
                     additional {
                         attributes {
                             attribute(color, 'purple')
-                            artifact(producer.output)
+                            artifact(tasks.producer.output)
                         }
                     }
                 }
@@ -557,7 +557,7 @@ project(':common') {
         setupBuildWithTransformOfExternalDependencyThatUsesDifferentTransformForUpstreamDependencies()
 
         buildFile << """
-            resolveArtifacts.collection = view
+            tasks.resolveArtifacts.collection = view
         """
 
         when:
@@ -583,8 +583,8 @@ project(':common') {
         setupBuildWithTransformOfExternalDependencyThatUsesDifferentTransformForUpstreamDependencies()
 
         buildFile << """
-            resolveArtifacts.collection = view
-            resolveArtifacts.dependsOn {
+            tasks.resolveArtifacts.collection = view
+            tasks.resolveArtifacts.dependsOn {
                 view.forEach { println("artifact = " + it) }
                 []
             }
@@ -684,7 +684,7 @@ project(':common') {
                         one {
                             attributes.attribute(flavor, 'bland')
                             attributes.attribute(selectable, 'yes')
-                            artifact(producer.output)
+                            artifact(tasks.producer.output)
                         }
                         two {
                             attributes.attribute(flavor, 'cloying')
@@ -1405,7 +1405,7 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
         setupBuildWithTwoSteps()
         buildFile << """
             project(':common') {
-                producer.doLast {
+                tasks.producer.doLast {
                     throw new RuntimeException("broken")
                 }
             }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesParallelIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesParallelIntegrationTest.groovy
@@ -55,7 +55,7 @@ class ArtifactTransformWithDependenciesParallelIntegrationTest extends AbstractH
                         sleep(500)
                     }
                 }
-                tasks.producer.dependsOn(slow)
+                tasks.producer.dependsOn(tasks.slow)
             }
             project(':consumer') {
                 dependencies {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -185,7 +185,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 task tool(type: FileProducer) {
                     output = file("build/tool-\${project.name}.jar")
                 }
-                ext.inputFiles = files(tool.output)
+                ext.inputFiles = files(tasks.tool.output)
             }
 
             project(':a') {
@@ -281,7 +281,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 task producer(type: Producer) {
                     outputFile = file("build/\${project.name}.jar")
                 }
-                artifacts."default" producer.outputFile
+                artifacts."default" tasks.producer.outputFile
             }
 
             class Producer extends DefaultTask {
@@ -337,7 +337,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 task tool(type: FileProducer) {
                     output = file("build/tool-\${project.name}.jar")
                 }
-                ext.inputFile = tool.output
+                ext.inputFile = tasks.tool.output
             }
         """
         setupBuildWithColorTransform {
@@ -390,7 +390,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 task tool(type: DirProducer) {
                     output = file("build/tool-\${project.name}-dir")
                 }
-                ext.inputDir = tool.output
+                ext.inputDir = tasks.tool.output
             }
         """
         setupBuildWithColorTransform {
@@ -445,7 +445,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                     output = file("build/tool-\${project.name}.jar")
                     doLast { throw new RuntimeException('broken') }
                 }
-                ext.inputFiles = files(tool.output)
+                ext.inputFiles = files(tasks.tool.output)
             }
 
             project(':a') {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ConcurrentBuildsArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ConcurrentBuildsArtifactTransformIntegrationTest.groovy
@@ -122,9 +122,9 @@ task block2 {
     }
 }
 
-block1.mustRunAfter redThings
-blueThings.mustRunAfter block1
-block2.mustRunAfter blueThings
+tasks.block1.mustRunAfter tasks.redThings
+tasks.blueThings.mustRunAfter tasks.block1
+tasks.block2.mustRunAfter tasks.blueThings
 """
         // Ensure build scripts compiled
         run("help")
@@ -179,9 +179,9 @@ task block2 {
     }
 }
 
-redThings.mustRunAfter block1
-redThings.mustRunAfter block2
-blueThings.mustRunAfter redThings
+tasks.redThings.mustRunAfter tasks.block1
+tasks.redThings.mustRunAfter tasks.block2
+tasks.blueThings.mustRunAfter tasks.redThings
 """
         // Ensure build scripts compiled
         run("help")
@@ -236,9 +236,9 @@ task block2 {
     }
 }
 
-redThings.mustRunAfter block1
-redThings.mustRunAfter block2
-blueThings.mustRunAfter redThings
+tasks.redThings.mustRunAfter tasks.block1
+tasks.redThings.mustRunAfter tasks.block2
+tasks.blueThings.mustRunAfter tasks.redThings
 """
         // Ensure build scripts compiled
         run("help")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
@@ -88,8 +88,8 @@ class TransformLoggingIntegrationTest extends AbstractConsoleGroupedTaskFunction
                     destinationDirectory = buildDir
                 }
                 artifacts {
-                    compile jar1
-                    compile jar2
+                    compile tasks.jar1
+                    compile tasks.jar2
                 }
             }
 

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -71,7 +71,7 @@ allprojects {
         ${builder.producerConfigOverrides}
     }
     artifacts {
-        implementation producer.output
+        implementation tasks.producer.output
     }
 
     task resolve(type: ShowFileCollection) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -79,7 +79,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
                 runtimeOnly 'org:foo:1.0'
             }
 
-            jar.doLast {
+            tasks.jar.doLast {
                 println 'from jar task'
             }
 
@@ -90,7 +90,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
                 }
             }
 
-            build.dependsOn resolve
+            tasks.build.dependsOn tasks.resolve
 
             logger.lifecycle('from build.gradle')
 
@@ -233,7 +233,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
     def "captures output from buildSrc"() {
         given:
         configureNestedBuild('buildSrc')
-        file('buildSrc/build.gradle') << "jar.dependsOn 'foo'"
+        file('buildSrc/build.gradle') << "tasks.jar.dependsOn 'foo'"
         file("build.gradle") << ""
 
         when:

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
@@ -107,7 +107,7 @@ class PluginBuilder {
         prepareToExecute()
         buildFile << buildScript
         buildFile << """
-            jar {
+            tasks.jar {
                 archiveFileName = "$testFile.name"
                 destinationDirectory = file("${TextUtil.escapeString(testFile.parentFile.absolutePath)}")
             }


### PR DESCRIPTION
We will eventually want to deprecate the behavior of dynamically looking up tasks from the task container when doing dynamic lookups against a project. This gets ahead of the curve for dependency management tests


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
