### PR TITLE
Make ReadyForReleaseTrigger depend on flaky test triggers

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/StageTriggers.kt
+++ b/.teamcity/src/main/kotlin/configurations/StageTriggers.kt
@@ -37,7 +37,8 @@ class StageTriggers(
     init {
         triggers = mutableListOf()
         val allDependencies =
-            stageProject.specificBuildTypes + stageProject.performanceTests + stageProject.functionalTests + stageProject.docsTestTriggers
+            stageProject.specificBuildTypes + stageProject.performanceTests + stageProject.functionalTests + stageProject.docsTestTriggers +
+                stageProject.flakyTestQuarantineTriggers
         triggers.add(StageTrigger(model, stage, prevStage, null, allDependencies))
 
         stageWithOsTriggers.getOrDefault(stage.stageName, emptyList()).forEach { targetOs ->

--- a/.teamcity/src/main/kotlin/projects/StageProject.kt
+++ b/.teamcity/src/main/kotlin/projects/StageProject.kt
@@ -54,6 +54,8 @@ class StageProject(
 
     val docsTestTriggers: List<OsAwareBaseGradleBuildType>
 
+    val flakyTestQuarantineTriggers: List<OsAwareBaseGradleBuildType>
+
     init {
         features {
             buildReportTab("Problems Report", "problems-report.html")
@@ -177,10 +179,12 @@ class StageProject(
         docsTestTriggers = docsTestProjects.map { DocsTestTrigger(model, it) }
         docsTestTriggers.forEach(this::buildType)
 
+        flakyTestQuarantineTriggers = mutableListOf()
         if (stage.stageName == StageName.READY_FOR_RELEASE) {
             listOf(Os.LINUX, Os.WINDOWS).forEach {
                 val flakyTestQuarantineProject = FlakyTestQuarantineProject(model, stage, it)
                 val flakyTestQuarantineProjectTrigger = FlakyTestQuarantineTrigger(model, flakyTestQuarantineProject)
+                flakyTestQuarantineTriggers.add(flakyTestQuarantineProjectTrigger)
                 subProject(flakyTestQuarantineProject)
                 buildType(flakyTestQuarantineProjectTrigger)
             }

--- a/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
+++ b/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
@@ -13,6 +13,7 @@ import model.CIBuildModel
 import model.DefaultFunctionalTestBucketProvider
 import model.JsonBasedGradleSubprojectProvider
 import model.QUICK_CROSS_VERSION_BUCKETS
+import model.StageName
 import model.TestCoverage
 import model.TestType
 import model.ignoredSubprojects
@@ -64,7 +65,9 @@ class CIConfigIntegrationTests {
 
             assertEquals(
                 stage.specificBuilds.size + stage.functionalTests.size + stage.performanceTests.size + stage.docsTests.size +
-                    (if (prevStage != null) 1 else 0),
+                    (if (prevStage != null) 1 else 0) +
+                    // flakyTestQuarantineTriggers
+                    if (stage.stageName == StageName.READY_FOR_RELEASE) 2 else 0,
                 it.dependencies.items.size,
                 stage.stageName.stageName,
             )


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4885

This has been broken since https://github.com/gradle/gradle/pull/34272, where we didn't make ReadyForRelease trigger depend on flaky test quarantine projects.