### PR TITLE
Only inherit DEVELOCITY_ACCESS_KEY when present

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -115,7 +115,9 @@ fun Test.filterEnvironmentVariables(inheritDevelocityAccessToken: Boolean) {
     }
 
     if (inheritDevelocityAccessToken) {
-        environment["DEVELOCITY_ACCESS_KEY"] = System.getenv("DEVELOCITY_ACCESS_KEY")
+        System.getenv("DEVELOCITY_ACCESS_KEY")?.let {
+            environment["DEVELOCITY_ACCESS_KEY"] = it
+        }
     }
 }
 


### PR DESCRIPTION
This prevents failures in the smoke tests when it is not set

### Context
Tried to run smoke tests locally and couldn't due to this. While I could just set the variable, we should try to keep the smoke tests runnable by those who don't have access to one of the keys as well.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
