### PR TITLE
Remove "Promoted version X" service message

### DIFF
--- a/build-logic-commons/module-identity/src/main/kotlin/gradlebuild/identity/tasks/BuildReceipt.kt
+++ b/build-logic-commons/module-identity/src/main/kotlin/gradlebuild/identity/tasks/BuildReceipt.kt
@@ -16,7 +16,6 @@
 
 package gradlebuild.identity.tasks
 
-import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.util.ReproduciblePropertiesWriter
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -121,10 +120,5 @@ abstract class BuildReceipt : DefaultTask() {
                 " timestamp: ${buildTimestamp.get()}," +
                 " snapshot: ${snapshot.get()})"
         )
-        if (BuildEnvironment.isCiServer) {
-            lifecycle(
-                "##teamcity[buildStatus text='{build.status.text}, Promoted version ${version.get()}']"
-            )
-        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-promote/issues/296

This PR moves the service message `Promoted version X` from `gradle/gradle` build to the promotion build.

Also see https://github.com/gradle/gradle-promote/pull/297