### PR TITLE
Fix FlakyTestQuarantine

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -53,7 +53,7 @@ class FlakyTestQuarantineProject(
         model.stages
             .filter { it.stageName <= StageName.READY_FOR_RELEASE }
             .flatMap { it.functionalTests }
-            .filter { it.os == os }
+            .filter { it.os == os && !it.testType.crossVersionTests }
             .forEach {
                 buildType(FlakyTestQuarantine(model, stage, it))
             }


### PR DESCRIPTION
This PR resolves two issues:

1. FlakyTestQuarantine for smoke tests [fails with error](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_SmokeTest_GradleBuildSmokeTests_FlakyTestQuarantine/104308179?hideTestsFromDependencies=true): `No tests found for given includes`.

2. Remove FlakyTestQuarantine for AllCrossVersionTests because of [the timeout](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_AllVersionsCrossVersion_11/104308161?buildTab=overview&hideTestsFromDependencies=true) and ["too many artifacts" error](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_FlakyQuarantine_Check_AllVersionsCrossVersion_10/104308173?buildTab=overview&hideTestsFromDependencies=true). We need a better design (probably bucket splits) for AllCrossVersionTest_FlakyTestQuarantine.
