### PR TITLE
Mark flaky IsolatedProjectsAndroidProjectSyncTest

### DIFF
--- a/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/IsolatedProjectsAndroidProjectSyncTest.groovy
+++ b/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/IsolatedProjectsAndroidProjectSyncTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.ide.sync
 
 import org.gradle.ide.sync.fixtures.IsolatedProjectsIdeSyncFixture
 import org.gradle.integtests.fixtures.versions.AndroidGradlePluginVersions
+import org.gradle.test.fixtures.Flaky
 
+@Flaky(because = "https://github.com/gradle/gradle-private/issues/4661")
 class IsolatedProjectsAndroidProjectSyncTest extends AbstractIdeSyncTest {
 
     // https://developer.android.com/build/releases/gradle-plugin


### PR DESCRIPTION
It's very flaky now: https://ge.gradle.org/scans/tests?search.startTimeMax=1761062399999&search.startTimeMin=1760371200000&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.ide.sync.IsolatedProjectsAndroidProjectSyncTest&tests.test=can%20sync%20simple%20Android%20build%20without%20problems