### PR TITLE
Clarify plugin targets documentation

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/fundamentals/developing-plugins/plugin_introduction_advanced.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/fundamentals/developing-plugins/plugin_introduction_advanced.adoc
@@ -54,8 +54,8 @@ include::sample[dir="snippets/java/fixtures/groovy/lib",files="build.gradle[tag=
 == Plugin Types
 
 Gradle supports *three types of plugins*, each applied at a different phase of the build lifecycle.
-`Init`, `Settings`, and `Project` plugins.
-The most common and popular plugins are `Project` plugins.
+Init, settings, and project plugins.
+The most common and popular plugins are project plugins.
 
 image::plugin-intro-advanced-1.png[]
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_precompiled.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_precompiled.adoc
@@ -114,10 +114,10 @@ plugins {
 ----
 =====
 
-When creating precompiled script plugins intended for `Settings` or `Init` scripts, the filename suffix determines where Gradle applies them:
+When creating precompiled script plugins intended for settings or init scripts, the filename suffix determines where Gradle applies them:
 
 * `.settings.gradle` or `.settings.gradle.kts` → interpreted as `Plugin<Settings>`
-* `.init.gradle` or `.init.gradle.kts` → interpreted as `Plugin<Init>`
+* `.init.gradle` or `.init.gradle.kts` → interpreted as `Plugin<Gradle>`
 * `.gradle` or `.gradle.kts` → interpreted as the default `Plugin<Project>`
 
 IMPORTANT: Groovy pre-compiled script plugins cannot have packages.

--- a/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/plugins.adoc
@@ -348,7 +348,7 @@ Each scope controls different aspects of the build lifecycle and represents an i
 | Affects all builds on a machine. Commonly used to configure enterprise build tooling, inject repositories, or enforce conventions across builds.
 |===
 
-When writing *precompiled script plugins*, Gradle determines the intended plugin target (`Project`, `Settings`, or `Init`) based on the file name of the plugin source file:
+When writing *precompiled script plugins*, Gradle determines the intended plugin target (`Project`, `Settings`, or `Gradle`) based on the file name of the plugin source file:
 
 |===
 | Plugin | Filename Suffix | Applies To | Scope


### PR DESCRIPTION
Fixes #35435

### Context
The documentation uses plugin target names and their respective types interchangeably, leading to considerable confusion. 

While all the other plugin targets and their types are named consistently (e.g., "settings plugin" == "`Settings` plugin" == `Plugin<Settings>`), the init plugins are implemented as `Plugin<Gradle>`, which makes some sentences referring to `` `Init` `` (formatted as code) difficult to understand

To avoid this confusion, this PR updates all sentences containing the code-formatted `` `Init` `` word in one of the following ways:
- If it's used as a type, it's replaced with `` `Gradle` ``.
- If it's used as a plugin target name (i.e., not referring to the type in code), it's replaced with an unformatted "init" word.
  - Additionally, the formatting of other plugin targets mentioned in the same sentence has been adjusted for consistency.

Of course, I'm open to alternative wording, as long as it helps reduce confusion.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
