### PR TITLE
Dogfood artifact cache on xperimental pipeline

### DIFF
--- a/.teamcity/scripts/common.sh
+++ b/.teamcity/scripts/common.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright 2024 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Common functions for EC2 build scripts
+
+# This scripts detects builds running on EC2 by accessing the special ip 169.254.169.254 exposed by AWS instances.
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+exit_if_not_on_ec2_instance() {
+  curl -m 1 -s "http://169.254.169.254/latest/meta-data/instance-id"
+  IS_EC2_INSTANCE=$?
+  if [ $IS_EC2_INSTANCE -ne 0 ]; then
+    echo "Not running on an EC2 instance, skipping the configuration"
+    exit 0
+  fi
+}
+
+# Function to write and execute a build script from environment variable content
+execute_build_script_from_env() {
+  local script_content="$1"
+  echo "${script_content}" > "${TMPDIR}/pre-or-post-build.sh"
+  bash -x "${TMPDIR}/pre-or-post-build.sh"
+}

--- a/.teamcity/scripts/configure_build_env_on_ec2.sh
+++ b/.teamcity/scripts/configure_build_env_on_ec2.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 #
 # Copyright 2024 the original author or authors.
 #
@@ -15,18 +16,20 @@
 # limitations under the License.
 #
 
-# This scripts detects builds running on EC2 by accessing the special ip 169.254.169.254 exposed by AWS instances.
-# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+# Source common functions
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 # In case of running on EC2
 # - we add a TeamCity tag to the build with an instance type of the EC2 instance.
 # - we set GRADLE_RO_DEP_CACHE to '/opt/gradle-cache' if the folder exists.
 
-curl -m 1 -s "http://169.254.169.254/latest/meta-data/instance-id"
-IS_EC2_INSTANCE=$?
-if [ $IS_EC2_INSTANCE -ne 0 ]; then
-  echo "Not running on an EC2 instance, skipping the configuration"
-  exit 0
+exit_if_not_on_ec2_instance
+
+# Execute pre-build script based on BUILD_TYPE_ID
+if [[ "${BUILD_TYPE_ID:-}" == Gradle_Xperimental* ]]; then
+  execute_build_script_from_env "${XPERIMENTAL_EC2_PRE_BUILD_SCRIPT:-}"
+elif [[ "${BUILD_TYPE_ID:-}" == Gradle_Master* ]]; then
+  execute_build_script_from_env "${MASTER_EC2_PRE_BUILD_SCRIPT:-}"
 fi
 
 # TAG

--- a/.teamcity/scripts/post_build_on_ec2.sh
+++ b/.teamcity/scripts/post_build_on_ec2.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2024 The Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+# Source common functions
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+exit_if_not_on_ec2_instance
+
+if [[ "${BUILD_TYPE_ID:-}" == Gradle_Xperimental* ]]; then
+  execute_build_script_from_env "${XPERIMENTAL_EC2_POST_BUILD_SCRIPT:-}"
+elif [[ "${BUILD_TYPE_ID:-}" == Gradle_Master* ]]; then
+  execute_build_script_from_env "${MASTER_EC2_POST_BUILD_SCRIPT:-}"
+fi

--- a/.teamcity/src/main/kotlin/common/CommonExtensions.kt
+++ b/.teamcity/src/main/kotlin/common/CommonExtensions.kt
@@ -112,6 +112,22 @@ fun Requirements.requiresNotSharedHost() {
  */
 const val HIDDEN_ARTIFACT_DESTINATION = ".teamcity/gradle-logs"
 
+fun BuildType.addEc2PostBuild(os: Os = Os.LINUX) {
+    if (os !in listOf(Os.WINDOWS, Os.MACOS)) {
+        steps {
+            exec {
+                name = "EC2_POST_BUILD"
+                executionMode = BuildStep.ExecutionMode.ALWAYS
+                path = ".teamcity/scripts/post_build_on_ec2.sh"
+
+                conditions {
+                    requiresEc2Agent()
+                }
+            }
+        }
+    }
+}
+
 fun BuildType.applyDefaultSettings(
     os: Os = Os.LINUX,
     arch: Arch = Arch.AMD64,
@@ -126,6 +142,8 @@ fun BuildType.applyDefaultSettings(
         build/report-* => $HIDDEN_ARTIFACT_DESTINATION
         build/tmp/teŝt files/** => $HIDDEN_ARTIFACT_DESTINATION/teŝt-files
         build/errorLogs/** => $HIDDEN_ARTIFACT_DESTINATION/errorLogs
+        artifact-cache-metrics => artifact-cache-metrics
+        artifact-cache-report => artifact-cache-report
         build/reports/configuration-cache/**/configuration-cache-report.html
         subprojects/internal-build-reports/build/reports/incubation/all-incubating.html => incubation-reports
         testing/architecture-test/build/reports/binary-compatibility/report.html => binary-compatibility-reports

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -8,6 +8,7 @@ import common.KillProcessMode.KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS
 import common.KillProcessMode.KILL_PROCESSES_STARTED_BY_GRADLE
 import common.Os
 import common.VersionedSettingsBranch
+import common.addEc2PostBuild
 import common.applyDefaultSettings
 import common.buildScanTagParam
 import common.buildToolGradleParameters
@@ -194,6 +195,7 @@ fun applyDefaults(
         extraSteps()
         killProcessStep(buildType, KILL_PROCESSES_STARTED_BY_GRADLE, os, arch, executionMode = ExecutionMode.ALWAYS)
         checkCleanM2AndAndroidUserHome(os, buildType)
+        buildType.addEc2PostBuild(os)
     }
 
     applyDefaultDependencies(model, buildType)

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -81,6 +81,7 @@ class ApplyDefaultConfigurationTest {
                 "GRADLE_RUNNER",
                 "KILL_PROCESSES_STARTED_BY_GRADLE",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME",
+                "EC2_POST_BUILD",
             ),
             steps.items.map(BuildStep::name),
         )


### PR DESCRIPTION
This PR adds the functionalities for dogfooding artifact cache:

1. At the beginning and end of each EC2 Linux build, we'll run `configure_build_env_on_ec2.sh` and `post_build_on_ec2.sh`.
2. The two builds executes build script from env vars. For example, builds in Master pipeline will execute scripts from `MASTER_EC2_PRE_BUILD_SCRIPT` and `MASTER_EC2_POST_BUILD_SCRIPT`.
3. A QuickFeedbackLinuxOnly build will be trigger in Xperimental pipeline upon push events of all branches.