### PR TITLE
Use test framework names in HtmlTestPathRootExecutionResult

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractJvmFailFastIntegrationSpec.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractJvmFailFastIntegrationSpec.groovy
@@ -62,12 +62,12 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractTestingMultiVe
         gradleHandle.waitForFailure()
 
         and:
-        GenericTestExecutionResult testResults = resultsFor("tests/test", testFramework)
+        GenericTestExecutionResult testResults = resultsFor()
+        testResults.assertTestPathsExecuted(":pkg.FailedTest:failTest", ":pkg.OtherTest:passingTest")
 
         TestPathExecutionResult gradleTest = testResults.testPath("")
         gradleTest.rootNames == ['Gradle Test Run :test']
         gradleTest.onlyRoot().assertChildCount(2, 1)
-        gradleTest.onlyRoot().assertOnlyChildrenExecuted("pkg.FailedTest", "pkg.OtherTest")
 
         TestPathExecutionResult failedTest = testResults.testPath("pkg.FailedTest")
         failedTest.onlyRoot().assertChildCount(1, 1)

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestFilteringIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestFilteringIntegrationTest.groovy
@@ -246,7 +246,7 @@ abstract class AbstractTestFilteringIntegrationTest extends AbstractTestingMulti
 
         then:
         GenericTestExecutionResult testResult = resultsFor("tests/test", testFramework)
-        testResult.testPath("", "").onlyRoot().assertOnlyChildrenExecuted("Foo1Test", "Foo2Test")
+        testResult.assertTestPathsExecuted(":Foo1Test:pass1", ":Foo2Test:pass2")
         testResult.testPath("Foo1Test", "pass1").onlyRoot().assertHasResult(passedTestOutcome)
         testResult.testPath("Foo2Test", "pass2").onlyRoot().assertHasResult(passedTestOutcome)
     }
@@ -365,7 +365,7 @@ abstract class AbstractTestFilteringIntegrationTest extends AbstractTestingMulti
         """
 
         when:
-        succeedsWithTestTaskArguments(stringArrayOf(command))
+        succeedsWithTestTaskArguments(command.toArray(String[]::new))
 
         then:
         GenericTestExecutionResult testResult = resultsFor("tests/test", testFramework)
@@ -418,8 +418,8 @@ abstract class AbstractTestFilteringIntegrationTest extends AbstractTestingMulti
         succeedsWithTestTaskArguments('test', '--tests', '*ATest*', '--tests', '*BTest*', '--info')
 
         then:
-        GenericTestExecutionResult testResult = resultsFor("tests/test", testFramework)
-        testResult.testPath("", "").onlyRoot().assertOnlyChildrenExecuted("ATest")
+        GenericTestExecutionResult testResult = resultsFor()
+        testResult.assertTestPathsExecuted(":ATest:test")
 
         where:
         includeType                   | includeConfig
@@ -444,8 +444,8 @@ abstract class AbstractTestFilteringIntegrationTest extends AbstractTestingMulti
         succeedsWithTestTaskArguments('test', '--info')
 
         then:
-        GenericTestExecutionResult testResult = resultsFor("tests/test", testFramework)
-        testResult.testPath("", "").onlyRoot().assertOnlyChildrenExecuted("BTest")
+        GenericTestExecutionResult testResult = resultsFor()
+        testResult.assertTestPathsExecuted(":BTest:test")
     }
 
     def "invoking filter.includePatterns not disable include/exclude filter"() {
@@ -464,8 +464,8 @@ abstract class AbstractTestFilteringIntegrationTest extends AbstractTestingMulti
         succeedsWithTestTaskArguments('test', '--info')
 
         then:
-        GenericTestExecutionResult testResult = resultsFor("tests/test", testFramework)
-        testResult.testPath("", "").onlyRoot().assertOnlyChildrenExecuted("BTest")
+        GenericTestExecutionResult testResult = resultsFor()
+        testResult.assertTestPathsExecuted(":BTest:test")
     }
 
     def "can exclude tests"() {
@@ -485,8 +485,8 @@ abstract class AbstractTestFilteringIntegrationTest extends AbstractTestingMulti
         executedAndNotSkipped(":test")
 
         and:
-        GenericTestExecutionResult testResult = resultsFor("tests/test", testFramework)
-        testResult.testPath("", "").onlyRoot().assertOnlyChildrenExecuted("ATest", "CTest")
+        GenericTestExecutionResult testResult = resultsFor()
+        testResult.assertTestPathsExecuted(":ATest:test", ":CTest:test")
         testResult.testPath("ATest", "test").onlyRoot().assertHasResult(passedTestOutcome)
         testResult.testPath("CTest", "test").onlyRoot().assertHasResult(passedTestOutcome)
     }
@@ -512,7 +512,4 @@ abstract class AbstractTestFilteringIntegrationTest extends AbstractTestingMulti
         """
     }
 
-    private String[] stringArrayOf(List<String> strings) {
-        return strings.toArray()
-    }
 }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec.groovy
@@ -25,7 +25,6 @@ abstract class AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec extends Abst
     abstract TestSourceGenerator getTestSourceGenerator()
     abstract String getSingularCategoryOrTagName()
     abstract String getPluralCategoryOrTagName()
-    abstract String[] normalizeTestMethodNames(String... methodNames)
 
     def setup() {
         executer.noExtraLogging()
@@ -93,13 +92,13 @@ abstract class AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec extends Abst
         results.assertAtLeastTestPathsExecuted('NoCatTests', 'SomeTests', 'SomeOtherCatTests')
         results.testPath('SomeOtherCatTests').onlyRoot()
             .assertChildCount(2, 0)
-            .assertChildrenExecuted(normalizeTestMethodNames('someOtherOk1', 'someOtherOk2'))
+            .assertChildrenExecuted('someOtherOk1', 'someOtherOk2')
         results.testPath("NoCatTests").onlyRoot()
             .assertChildCount(2, 0)
-            .assertChildrenExecuted(normalizeTestMethodNames('noCatOk1', 'noCatOk2'))
+            .assertChildrenExecuted('noCatOk1', 'noCatOk2')
         results.testPath("SomeTests").onlyRoot()
             .assertChildCount(3, 0)
-            .assertChildrenExecuted(normalizeTestMethodNames('noCatOk3', 'noCatOk4', 'someOtherCatOk2'))
+            .assertChildrenExecuted('noCatOk3', 'noCatOk4', 'someOtherCatOk2')
     }
 
     def "can include categories or tags only"() {
@@ -153,9 +152,9 @@ abstract class AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec extends Abst
         results.assertAtLeastTestPathsExecuted('CategoryATests', 'SomeTests')
         results.testPath('CategoryATests').onlyRoot()
             .assertChildCount(4, 0)
-            .assertChildrenExecuted(normalizeTestMethodNames('catAOk1', 'catAOk2', 'catAOk3', 'catAOk4'))
+            .assertChildrenExecuted('catAOk1', 'catAOk2', 'catAOk3', 'catAOk4')
         results.testPath("SomeTests").onlyRoot().assertChildCount(1, 0)
-        results.testPath("SomeTests").onlyRoot().assertChildrenExecuted(normalizeTestMethodNames('catAOk1'))
+        results.testPath("SomeTests").onlyRoot().assertChildrenExecuted('catAOk1')
     }
 
     def "emits warning when specifying a conflicting include/exclude"() {
@@ -202,7 +201,7 @@ abstract class AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec extends Abst
         def results = resultsFor(testDirectory)
         results.testPath('CategoryATests').onlyRoot()
             .assertChildCount(4, 0)
-            .assertChildrenExecuted(normalizeTestMethodNames('catAOk1', 'catAOk2', 'catAOk3', 'catAOk4'))
+            .assertChildrenExecuted('catAOk1', 'catAOk2', 'catAOk3', 'catAOk4')
     }
 
     def "emits warning when specifying multiple conflicting includes/excludes"() {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/AbstractJUnit4CategoriesOrTagsCoverageIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/AbstractJUnit4CategoriesOrTagsCoverageIntegrationTest.groovy
@@ -32,11 +32,6 @@ abstract class AbstractJUnit4CategoriesOrTagsCoverageIntegrationTest extends Abs
 
     abstract boolean supportsCategoryOnNestedClass()
 
-    @Override
-    String[] normalizeTestMethodNames(String... methodNames) {
-        return methodNames
-    }
-
     def "can specify both includes and excludes for categories"() {
         given:
         testSources.with {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4TestFilteringSamplesIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4TestFilteringSamplesIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.junit.junit4
 
+import org.gradle.api.internal.tasks.testing.report.generic.GenericTestExecutionResult
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.Sample
@@ -35,7 +36,7 @@ class JUnit4TestFilteringSamplesIntegrationTest extends AbstractIntegrationSpec 
         run("test")
 
         then:
-        def result = new DefaultTestExecutionResult(sample.dir)
+        def result = new DefaultTestExecutionResult(sample.dir, GenericTestExecutionResult.TestFramework.JUNIT4)
         result.assertTestClassesExecuted("SomeIntegTest", "SomeOtherTest")
         result.testClass("SomeIntegTest").assertTestsExecuted("test1", "test2")
         result.testClass("SomeOtherTest").assertTestsExecuted("quickUiCheck")

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterCategoriesOrTagsCoverageIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterCategoriesOrTagsCoverageIntegrationTest.groovy
@@ -28,11 +28,6 @@ class JUnitJupiterCategoriesOrTagsCoverageIntegrationTest extends AbstractJUnitC
     String singularCategoryOrTagName = "tag"
     String pluralCategoryOrTagName = "tags"
 
-    @Override
-    String[] normalizeTestMethodNames(String... methodNames) {
-        return methodNames.collect { it +'()' }.toArray(new String[0])
-    }
-
     def "can specify include and exclude tags"() {
         given:
         testSources.with {
@@ -135,14 +130,14 @@ class JUnitJupiterCategoriesOrTagsCoverageIntegrationTest extends AbstractJUnitC
         results.assertAtLeastTestPathsExecuted('TagATests', 'TagADTests', 'MixedTests')
         results.testPath("TagATests").onlyRoot()
             .assertChildCount(4, 0)
-            .assertChildrenExecuted('tagAOk1()', 'tagAOk2()', 'tagAOk3()', 'tagAOk4()')
+            .assertChildrenExecuted('tagAOk1', 'tagAOk2', 'tagAOk3', 'tagAOk4')
         results.testPath("TagADTests").onlyRoot()
             .assertChildCount(3, 0)
-            .assertChildrenExecuted('tagAOk1()', 'tagAOk2()', 'tagDOk4()')
+            .assertChildrenExecuted('tagAOk1', 'tagAOk2', 'tagDOk4')
         results.testPath("MixedTests").onlyRoot()
             .assertChildCount(2, 0)
-            .assertChildrenExecuted('tagAOk1()')
-            .assertChildrenSkipped('ignoredWithTagA()')
+            .assertChildrenExecuted('tagAOk1')
+            .assertChildrenSkipped('ignoredWithTagA')
     }
 
     def "can combine tags with custom extension"() {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformParameterizedTestIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformParameterizedTestIntegrationTest.groovy
@@ -97,8 +97,6 @@ class JUnitPlatformParameterizedTestIntegrationTest extends JUnitPlatformIntegra
         then:
         def result = resultsFor(testDirectory)
 
-        result.testPath("TestSuite").onlyRoot()
-            .assertChildrenExecuted("PassingWithDisabledParameterizedTest", "OnlyDisabledParameterizedTest")
         result.testPathPreNormalized(":TestSuite:PassingWithDisabledParameterizedTest").onlyRoot()
             .assertChildCount(4, 0)
         result.testPathPreNormalized(":TestSuite:PassingWithDisabledParameterizedTest").onlyRoot()

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
@@ -78,7 +78,7 @@ class TestNGParallelSuiteIntegrationTest extends MultiVersionIntegrationSpec imp
         run("test")
 
         then:
-        def result = new DefaultTestExecutionResult(testDirectory)
+        def result = new DefaultTestExecutionResult(testDirectory, testFramework)
         result.testClass("Foo0Test").assertTestsExecuted("test")
         result.testClass("Foo199Test").assertTestsExecuted("test")
     }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
@@ -17,6 +17,7 @@
 
 package org.gradle.testing.testng
 
+import org.gradle.api.internal.tasks.testing.report.generic.GenericTestExecutionResult
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
@@ -79,7 +80,7 @@ class TestNGSuiteIntegrationTest extends MultiVersionIntegrationSpec {
         when:
         succeeds("test")
         then:
-        def result = new DefaultTestExecutionResult(testDirectory)
+        def result = new DefaultTestExecutionResult(testDirectory, GenericTestExecutionResult.TestFramework.TEST_NG)
         result.testClass("FooTest").assertTestsExecuted("foo")
     }
 

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.integtests
 
+import org.gradle.api.internal.tasks.testing.report.generic.GenericTestExecutionResult
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.ScalaCoverage
@@ -192,7 +193,7 @@ sourceSets.main.java {
 
         file('build').assertDoesNotExist()
 
-        def results = new DefaultTestExecutionResult(file(), 'target')
+        def results = new DefaultTestExecutionResult(file(), 'target', '', '', 'test', GenericTestExecutionResult.TestFramework.SPOCK)
         results.assertTestClassesExecuted('PersonTest')
         results.testClass('PersonTest').assertTestsExecuted('ok')
     }

--- a/testing/internal-testing/src/main/groovy/org/gradle/api/internal/tasks/testing/report/generic/GenericTestExecutionResult.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/api/internal/tasks/testing/report/generic/GenericTestExecutionResult.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.tasks.testing.report.generic
 
+import java.util.regex.Pattern
+
 interface GenericTestExecutionResult {
     /**
      * Asserts that the given test paths (and only the given test paths) were executed.
@@ -75,6 +77,8 @@ interface GenericTestExecutionResult {
         CUSTOM,
         ;
 
+        private static final Pattern BASIC_PARAMS_PATTERN = Pattern.compile("\\(.*\\)");
+
         /**
          * Given the name of a test method, returns the name of the test case that would be reported by this test
          * framework.
@@ -89,7 +93,14 @@ interface GenericTestExecutionResult {
          */
         String getTestCaseName(String testMethodName) {
             return switch (this) {
-                case JUNIT_JUPITER, KOTLIN_TEST -> testMethodName + "()"
+                case JUNIT_JUPITER, KOTLIN_TEST -> {
+                    // Don't add "()" if the method name already appears to have parameters
+                    if (testMethodName =~ BASIC_PARAMS_PATTERN) {
+                        yield testMethodName
+                    } else {
+                        yield testMethodName + "()"
+                    }
+                }
                 default -> testMethodName;
             };
         }


### PR DESCRIPTION
Also avoid adding parens if they're already present so they can work with parameterized test results

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
