### PR TITLE
Fix documentation part5_add_dataflow_action link

### DIFF
--- a/platforms/documentation/docs/src/main/resources/header.html
+++ b/platforms/documentation/docs/src/main/resources/header.html
@@ -257,7 +257,7 @@
                         <li><a href="../userguide/part2_add_extension.html">2. Adding an Extension</a></li>
                         <li><a href="../userguide/part3_create_custom_task.html">3. Creating a Custom Task</a></li>
                         <li><a href="../userguide/part4_unit_test.html">4. Writing a Unit Test</a></li>
-                        <li><a href="../userguide/part5_add_dataflow_Action.html">5. Adding a DataFlow Action</a></li>
+                        <li><a href="../userguide/part5_add_dataflow_action.html">5. Adding a DataFlow Action</a></li>
                         <li><a href="../userguide/part6_functional_test.html">6. Writing a Functional Test</a></li>
                         <li><a href="../userguide/part7_use_consumer_project.html">7. Using a Consumer Project</a></li>
                         <li><a href="../userguide/part8_publish_locally.html">8. Publish the Plugin</a></li>


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
This fixes a broken link in the documentation nav bar [in this section](https://docs.gradle.org/current/userguide/part1_gradle_init_plugin.html). 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
