### PR TITLE
Optimize ASM class name conversion by using precompiled DOT_PATTERN

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGenerator.java
@@ -20,7 +20,10 @@ import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
 
+import java.util.regex.Pattern;
+
 public class AsmClassGenerator {
+    private static final Pattern DOT_PATTERN = Pattern.compile("\\.");
 
     private final ClassWriter visitor;
     private final String generatedTypeName;
@@ -31,7 +34,7 @@ public class AsmClassGenerator {
         this.targetType = targetType;
         visitor = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
         generatedTypeName = targetType.getName() + classNameSuffix;
-        generatedType = Type.getType("L" + generatedTypeName.replaceAll("\\.", "/") + ";");
+        generatedType = Type.getType("L" + DOT_PATTERN.matcher(generatedTypeName).replaceAll("/") + ";");
     }
 
     public ClassWriter getVisitor() {


### PR DESCRIPTION
Replaced the use of String.replaceAll("\\.", "/") with a compiled Pattern constant to avoid unnecessary regular-expression recompilation. This improves performance and makes the intent clearer. The class now uses DOT_PATTERN.matcher(...).replaceAll("/") when constructing the ASM internal type name. No behavioral changes — purely an optimization and readability improvement.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
