### PR TITLE
Drop Santa-Tracker performance test template

### DIFF
--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -30,21 +30,11 @@
       "coverage" : {
         "per_commit" : [ "linux", "windows", "macOs" ]
       }
-    }, {
-      "testProject" : "santaTrackerAndroidBuild",
-      "coverage" : {
-        "per_commit" : [ "linux", "windows", "macOs" ]
-      }
     } ]
   }, {
     "testId" : "org.gradle.performance.regression.android.AndroidIncrementalExecutionPerformanceTest.abi change with configuration caching",
     "groups" : [ {
       "testProject" : "nowInAndroidBuild",
-      "coverage" : {
-        "per_commit" : [ "linux", "windows", "macOs" ]
-      }
-    }, {
-      "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
         "per_commit" : [ "linux", "windows", "macOs" ]
       }
@@ -56,21 +46,11 @@
       "coverage" : {
         "per_commit" : [ "linux", "windows", "macOs" ]
       }
-    }, {
-      "testProject" : "santaTrackerAndroidBuild",
-      "coverage" : {
-        "per_commit" : [ "linux", "windows", "macOs" ]
-      }
     } ]
   }, {
     "testId" : "org.gradle.performance.regression.android.AndroidIncrementalExecutionPerformanceTest.non-abi change with configuration caching",
     "groups" : [ {
       "testProject" : "nowInAndroidBuild",
-      "coverage" : {
-        "per_commit" : [ "linux", "windows", "macOs" ]
-      }
-    }, {
-      "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
         "per_commit" : [ "linux", "windows", "macOs" ]
       }
@@ -95,11 +75,6 @@
       "coverage" : {
         "per_day" : [ "linux" ]
       }
-    }, {
-      "testProject" : "santaTrackerAndroidBuild",
-      "coverage" : {
-        "per_day" : [ "linux" ]
-      }
     } ]
   }, {
     "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.clean phthalic:assembleDebug with clean transforms cache",
@@ -118,11 +93,6 @@
       }
     }, {
       "testProject" : "nowInAndroidBuild",
-      "coverage" : {
-        "per_commit" : [ "linux" ]
-      }
-    }, {
-      "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
         "per_commit" : [ "linux" ]
       }
@@ -152,11 +122,6 @@
       }
     }, {
       "testProject" : "nowInAndroidBuild",
-      "coverage" : {
-        "per_commit" : [ "linux" ]
-      }
-    }, {
-      "testProject" : "santaTrackerAndroidBuild",
       "coverage" : {
         "per_commit" : [ "linux" ]
       }

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -430,15 +430,6 @@ performanceTest.registerAndroidTestProject("nowInAndroidBuild", RemoteProject) {
     }
 }
 
-performanceTest.registerAndroidTestProject("santaTrackerAndroidBuild", RemoteProject) {
-    remoteUri = 'https://github.com/gradle/santa-tracker-android.git'
-    // Pinned from main branch
-    ref = '3f5f79b06da263670c77a734ec2db6220dcf311c'
-    doLast {
-        addGoogleServicesJson(outputDirectory)
-    }
-}
-
 performanceTest.registerAndroidTestProject("uberMobileApp", RemoteProject) {
     remoteUri = 'https://github.com/gradle/android-build-eval.git'
     subdirectory = 'mobile_app1'
@@ -471,84 +462,6 @@ private void setMaxHeap(File projectDirectory, String maxHeap) {
 private void setParallel(File projectDirectory, boolean parallel) {
     new File(projectDirectory, "gradle.properties") << "\norg.gradle.parallel=${parallel}\n"
 
-}
-
-private void addGoogleServicesJson(File outputDirectory) {
-    new File(outputDirectory, 'santa-tracker/google-services.json').text = """
-{
-  "project_info": {
-    "project_number": "012345678912",
-    "firebase_url": "https://example.com",
-    "project_id": "example",
-    "storage_bucket": "example.example.com"
-  },
-  "client": [
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:012345678912:android:0123456789abcdef",
-        "android_client_info": {
-          "package_name": "com.google.android.apps.santatracker.debug"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "foo.example.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "012345678901234567890123456789012345678"
-        }
-      ],
-      "services": {
-        "analytics_service": {
-          "status": 1
-        },
-        "appinvite_service": {
-          "status": 1,
-          "other_platform_oauth_client": []
-        },
-        "ads_service": {
-          "status": 2
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:012345678912:android:0123456789abcdef",
-        "android_client_info": {
-          "package_name": "com.google.android.apps.santatracker.debug"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "foo.example.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "012345678901234567890123456789012345678"
-        }
-      ],
-      "services": {
-        "analytics_service": {
-          "status": 1
-        },
-        "appinvite_service": {
-          "status": 1,
-          "other_platform_oauth_client": []
-        },
-        "ads_service": {
-          "status": 2
-        }
-      }
-    }
-  ],
-  "configuration_version": "1"
-}
-"""
 }
 
 performanceTest.registerTestProject("excludeRuleMergingBuild", RemoteProject) {

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -39,7 +39,6 @@ class AndroidTestProject implements TestProject {
     public static final List<AndroidTestProject> ANDROID_TEST_PROJECTS = [
         LARGE_ANDROID_BUILD,
         LARGE_ANDROID_BUILD_2,
-        IncrementalAndroidTestProject.SANTA_TRACKER,
         IncrementalAndroidTestProject.NOW_IN_ANDROID,
         IncrementalAndroidTestProject.UBER_MOBILE_APP
     ]

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/IncrementalAndroidTestProject.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/IncrementalAndroidTestProject.groovy
@@ -24,12 +24,6 @@ class IncrementalAndroidTestProject extends AndroidTestProject implements Increm
 
     private static final String ENABLE_AGP_IDE_MODE_ARG = "-Pandroid.injected.invoked.from.ide=true"
 
-    static final SANTA_TRACKER = new IncrementalAndroidTestProject(
-        templateName: 'santaTrackerAndroidBuild',
-        pathToChange: 'common/src/main/java/com/google/android/apps/santatracker/AudioPlayer.kt',
-        taskToRunForChange: ':santa-tracker:assembleDebug'
-    )
-
     static final NOW_IN_ANDROID = new IncrementalAndroidTestProject(
         templateName: 'nowInAndroidBuild',
         pathToChange: 'core/model/src/main/kotlin/com/google/samples/apps/nowinandroid/core/model/data/Topic.kt',

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
@@ -22,11 +22,7 @@ import org.gradle.performance.annotations.Scenario
 import org.gradle.performance.fixture.AndroidTestProject
 import org.gradle.performance.fixture.IncrementalAndroidTestProject
 import org.gradle.performance.regression.corefeature.AbstractIncrementalExecutionPerformanceTest
-import org.gradle.profiler.BuildContext
-import org.gradle.profiler.BuildMutator
 import org.gradle.test.fixtures.file.LeaksFileHandles
-
-import java.util.jar.JarOutputStream
 
 import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
@@ -34,7 +30,7 @@ import static org.gradle.performance.results.OperatingSystem.MAC_OS
 import static org.gradle.performance.results.OperatingSystem.WINDOWS
 
 @RunFor(
-    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX, WINDOWS, MAC_OS], testProjects = ["santaTrackerAndroidBuild", "nowInAndroidBuild"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX, WINDOWS, MAC_OS], testProjects = ["nowInAndroidBuild"])
 )
 @LeaksFileHandles("The TAPI keeps handles to the distribution it starts open in the test JVM")
 class AndroidIncrementalExecutionPerformanceTest extends AbstractIncrementalExecutionPerformanceTest implements AndroidPerformanceTestFixture {
@@ -54,16 +50,6 @@ class AndroidIncrementalExecutionPerformanceTest extends AbstractIncrementalExec
 
     def "abi change#configurationCaching"() {
         given:
-        if (configurationCachingEnabled && IncrementalAndroidTestProject.SANTA_TRACKER == testProject) {
-            runner.addBuildMutator { settings ->
-                new BuildMutator() {
-                    @Override
-                    void beforeBuild(BuildContext context) {
-                        SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.workingDir)
-                    }
-                }
-            }
-        }
         testProject.configureForAbiChange(runner)
         enableConfigurationCaching(configurationCachingEnabled)
 
@@ -80,16 +66,6 @@ class AndroidIncrementalExecutionPerformanceTest extends AbstractIncrementalExec
 
     def "non-abi change#configurationCaching"() {
         given:
-        if (configurationCachingEnabled && IncrementalAndroidTestProject.SANTA_TRACKER == testProject) {
-            runner.addBuildMutator { settings ->
-                new BuildMutator() {
-                    @Override
-                    void beforeBuild(BuildContext context) {
-                        SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.workingDir)
-                    }
-                }
-            }
-        }
         testProject.configureForNonAbiChange(runner)
         enableConfigurationCaching(configurationCachingEnabled)
 
@@ -119,35 +95,5 @@ class AndroidIncrementalExecutionPerformanceTest extends AbstractIncrementalExec
         where:
         configurationCachingEnabled << [true, false]
         configurationCaching = configurationCachingMessage(configurationCachingEnabled)
-    }
-}
-
-class SantaTrackerConfigurationCacheWorkaround {
-    static void beforeBuild(File workingDir) {
-        workingDir.listFiles().findAll { new File(it, "settings.gradle").exists() }.forEach { projectDir ->
-            // Workaround for Android Gradle plugin checking for the presence of these directories at configuration time,
-            // which invalidates configuration cache if their presence changes. Create these directories before the first build.
-            // See: https://android.googlesource.com/platform/tools/base/+/studio-master-dev/build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/ShaderCompile.java#120
-            // TODO: remove this once AGP stops checking for the existence of these directories at configuration time
-            workingDir.listFiles().findAll { it.isDirectory() && new File(it, "build.gradle").exists() }.each {
-                new File(it, "build/intermediates/merged_shaders/debug/out").mkdirs()
-                new File(it, "build/intermediates/merged_shaders/debugUnitTest/out").mkdirs()
-                new File(it, "build/intermediates/merged_shaders/debugAndroidTest/out").mkdirs()
-                new File(it, "build/intermediates/merged_shaders/release/out").mkdirs()
-                new File(it, "build/intermediates/merged_shaders/releaseAndroidTest/out").mkdirs()
-            }
-        }
-        File androidAnalyticsSetting = new File(System.getProperty("user.home"), ".android/analytics.settings")
-        if (!androidAnalyticsSetting.exists()) {
-            androidAnalyticsSetting.parentFile.mkdirs()
-            androidAnalyticsSetting.createNewFile()
-        }
-        workingDir.listFiles().findAll { it.name.contains("gradleUserHome") }.forEach { gradleUserHome ->
-            def androidFakeDependency = new File(gradleUserHome, "android/FakeDependency.jar")
-            if (!androidFakeDependency.exists()) {
-                androidFakeDependency.parentFile.mkdirs()
-                new JarOutputStream(new FileOutputStream(androidFakeDependency)).close()
-            }
-        }
     }
 }

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -52,7 +52,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
 
     @RunFor([
         @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = "largeAndroidBuild", iterationMatcher = "run help"),
-        @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild", "nowInAndroidBuild"], iterationMatcher = "run assembleDebug"),
+        @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = ["largeAndroidBuild", "nowInAndroidBuild"], iterationMatcher = "run assembleDebug"),
         @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = "largeAndroidBuild", iterationMatcher = ".*phthalic.*"),
         // @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = "largeAndroidBuild2", iterationMatcher = ".*module21.*"),
     ])
@@ -82,7 +82,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
     }
 
     @RunFor([
-        @Scenario(type = PER_DAY, operatingSystems = LINUX, testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild", "nowInAndroidBuild"], iterationMatcher = "clean assemble.*"),
+        @Scenario(type = PER_DAY, operatingSystems = LINUX, testProjects = ["largeAndroidBuild", "nowInAndroidBuild"], iterationMatcher = "clean assemble.*"),
         @Scenario(type = PER_DAY, operatingSystems = LINUX, testProjects = "largeAndroidBuild", iterationMatcher = "clean phthalic.*")
     ])
     def "clean #tasks with clean transforms cache"() {
@@ -141,8 +141,6 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
     private void configureBuildForProject(AndroidTestProject testProject) {
         if (IncrementalAndroidTestProject.NOW_IN_ANDROID == testProject) {
             configureRunnerSpecificallyForNowInAndroid()
-        } else if (IncrementalAndroidTestProject.SANTA_TRACKER == testProject) {
-            configureRunnerSpecificallyForSantaTracker()
         }
     }
 
@@ -165,10 +163,6 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
         }
         runner.addBuildMutator { is -> new SupplementaryRepositoriesMutator(is) }
         runner.addBuildMutator { is -> new AgpAndKgpVersionMutator(is, agpVersion, kgpVersion) }
-    }
-
-    private void configureRunnerSpecificallyForSantaTracker() {
-        runner.args.add("-DkotlinVersion=$kgpVersion")
     }
 
     private class TestFinalizerMutator implements BuildMutator {

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioPerformanceTest.groovy
@@ -30,7 +30,7 @@ import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.results.OperatingSystem.LINUX
 
 @RunFor(
-    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild", "nowInAndroidBuild"])
+    @Scenario(type = PER_COMMIT, operatingSystems = [LINUX], testProjects = ["largeAndroidBuild", "nowInAndroidBuild"])
 )
 class RealLifeAndroidStudioPerformanceTest extends AbstractCrossVersionPerformanceTest implements AndroidPerformanceTestFixture {
 


### PR DESCRIPTION
The Santa Tracker project is largely outdated and almost impossible to move to AGP 9.x without a significant overhaul.
We kept it barely working with AGP 8.x in our fork.

AGP 9.x only supports running with Gradle 9.x.

For performance tests we already use NowInAndroid, which is more modern and is currently kept up to date by Google folks.

Part of
* https://github.com/gradle/gradle/issues/35423

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
