### PR TITLE
Enforce stricter constraints for Problems API properties

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/TextUtil.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/TextUtil.java
@@ -16,8 +16,8 @@
 
 package org.gradle.util.internal;
 
-import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.UncheckedException;
 import org.jspecify.annotations.Nullable;
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
  */
 public class TextUtil {
     private static final Pattern WHITESPACE = Pattern.compile("\\s*");
+    private static final Pattern LINE_SEPARATORS = Pattern.compile("\r\n|\r|\n");
     private static final Pattern NON_UNIX_LINE_SEPARATORS = Pattern.compile("\r\n|\r");
     private static final Pattern WORD_SEPARATOR = Pattern.compile("\\W+");
     private static final Pattern UPPER_CASE = Pattern.compile("(?=\\p{Upper})");
@@ -82,14 +83,24 @@ public class TextUtil {
     }
 
     /**
-     * Converts all line separators in the specified non-null {@link CharSequence} to the specified line separator.
+     * Converts all line separators in the specified non-null string to the specified line separator.
      */
-    public static String replaceLineSeparatorsOf(CharSequence string, String bySeparator) {
-        return replaceAll("\r\n|\r|\n", string, bySeparator);
+    public static String replaceLineSeparatorsOf(String string, String bySeparator) {
+        if (isMultiLeLine(string)) {
+            return replaceAll(LINE_SEPARATORS, string, bySeparator);
+        } else {
+            return string;
+        }
     }
 
-    private static String replaceAll(String regex, CharSequence inString, String byString) {
-        return replaceAll(Pattern.compile(regex), inString, byString);
+    private static boolean isMultiLeLine(String string) {
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            if (c == '\n' || c == '\r') {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String replaceAll(Pattern pattern, CharSequence inString, String byString) {

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemGroup.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemGroup.java
@@ -68,10 +68,10 @@ public abstract class ProblemGroup {
     public abstract ProblemGroup getParent();
 
     /**
-     * Creates a new root problem i.e. a group with no parent.
+     * Creates a new root problem group i.e. a group with no parent.
      *
-     * @param name the name of the group. The convention is to use kebab-case (ie lower case with hyphens).
-     * @param displayName the user-friendly display name of the group
+     * @param name the name of the group. The convention is to use kebab-case (i.e., lower case with hyphens). Cannot be blank (i.e., {@code null}, empty string, or only whitespaces).
+     * @param displayName the user-friendly display name of the group. Cannot be blank (i.e., {@code null}, empty string, or only whitespaces).
      * @return the new group
      * @since 8.13
      */
@@ -82,9 +82,9 @@ public abstract class ProblemGroup {
     /**
      * Creates a new problem group.
      *
-     * @param name the name of the group. The convention is to use kebab-case (ie lower case with hyphens).
-     * @param displayName the user-friendly display name of the group
-     * @param parent the parent group
+     * @param name the name of the group. The convention is to use kebab-case (ie lower case with hyphens).  Cannot be blank (i.e., {@code null}, empty string, or only whitespaces).
+     * @param displayName the user-friendly display name of the group. Cannot be blank (i.e., {@code null}, empty string, or only whitespaces).
+     * @param parent the parent group. May be {@code null} for root groups.
      * @return the new group
      * @since 8.13
      */

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemId.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemId.java
@@ -83,9 +83,9 @@ public abstract class ProblemId {
     /**
      * Creates a new problem id.
      *
-     * @param name the name of the problem. The convention is to use kebab-case (ie lower case with hyphens).
-     * @param displayName the user-friendly display name of the problem
-     * @param group the group to which the problem belongs
+     * @param name the name of the problem. The convention is to use kebab-case (ie lower case with hyphens). Cannot be blank (i.e., {@code null}, empty string, or only whitespaces).
+     * @param displayName the user-friendly display name of the problem. Cannot be blank (i.e., {@code null}, empty string, or only whitespaces).
+     * @param group the group to which the problem belongs. Cannot be null.
      * @return the new problem id
      * @since 8.13
      */

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
@@ -29,6 +29,8 @@ import org.gradle.api.Incubating;
 public interface ProblemSpec {
     /**
      * Declares a short, but context-dependent message for this problem.
+     * <p>
+     * The label is expected to span a single line. Any newline characters will be removed.
      *
      * @param contextualLabel the short message
      * @return this

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
@@ -32,6 +32,7 @@ import org.gradle.problems.Location;
 import org.gradle.problems.ProblemDiagnostics;
 import org.gradle.problems.buildtree.ProblemStream;
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
+import org.gradle.util.internal.TextUtil;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -198,8 +199,8 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
 
     @Override
     public InternalProblemBuilder contextualLabel(String contextualLabel) {
-        // TODO (donat) enforce contextual label to be a single line
-        this.contextualLabel = contextualLabel;
+        // enforce contextual label to be a single line
+        this.contextualLabel = TextUtil.replaceLineSeparatorsOf(contextualLabel, " ");
         return this;
     }
 

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemGroup.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemGroup.java
@@ -19,6 +19,7 @@ package org.gradle.api.problems.internal;
 import com.google.common.base.Objects;
 import org.gradle.api.Incubating;
 import org.gradle.api.problems.ProblemGroup;
+import org.gradle.util.internal.TextUtil;
 import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
@@ -37,9 +38,19 @@ public class DefaultProblemGroup extends ProblemGroup implements Serializable {
     }
 
     public DefaultProblemGroup(String name, String displayName, @Nullable ProblemGroup parent) {
-        this.name = name;
-        this.displayName = displayName;
+        validateFields(name, displayName);
+        this.name = TextUtil.replaceLineSeparatorsOf(name, "");
+        this.displayName = TextUtil.replaceLineSeparatorsOf(displayName, "");
         this.parent = parent;
+    }
+
+    private static void validateFields(String name, String displayName) {
+        if (TextUtil.isBlank(name)) {
+            throw new IllegalArgumentException("Problem group name must not be blank");
+        }
+        if (TextUtil.isBlank(displayName)) {
+            throw new IllegalArgumentException("Problem group displayName must not be blank");
+        }
     }
 
     @Override

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemId.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemId.java
@@ -19,25 +19,39 @@ package org.gradle.api.problems.internal;
 import com.google.common.base.Objects;
 import org.gradle.api.problems.ProblemGroup;
 import org.gradle.api.problems.ProblemId;
+import org.gradle.util.internal.TextUtil;
 import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
 
 public class DefaultProblemId extends ProblemId implements Serializable {
 
-    private final String id;
+    private final String name;
     private final String displayName;
     private final ProblemGroup parent;
 
-    public DefaultProblemId(String id, String displayName, ProblemGroup parent) {
-        this.id = id;
-        this.displayName = displayName;
+    public DefaultProblemId(String name, String displayName, ProblemGroup parent) {
+        validateFields(name, displayName, parent);
+        this.name = TextUtil.replaceLineSeparatorsOf(name, "");
+        this.displayName = TextUtil.replaceLineSeparatorsOf(displayName, "");
         this.parent = parent;
+    }
+
+    private static void validateFields(String name, String displayName, ProblemGroup parent) {
+        if (TextUtil.isBlank(name)) {
+            throw new IllegalArgumentException("Problem id name must not be blank");
+        }
+        if (TextUtil.isBlank(displayName)) {
+            throw new IllegalArgumentException("Problem id displayName must not be blank");
+        }
+        if (parent == null) {
+            throw new IllegalArgumentException("Problem id parent must not be null");
+        }
     }
 
     @Override
     public String getName() {
-        return id;
+        return name;
     }
 
     @Override
@@ -74,7 +88,7 @@ public class DefaultProblemId extends ProblemId implements Serializable {
 
         ProblemId that = (ProblemId) o;
 
-        if (!id.equals(that.getName())) {
+        if (!name.equals(that.getName())) {
             return false;
         }
         return parent.equals(that.getGroup());
@@ -82,6 +96,6 @@ public class DefaultProblemId extends ProblemId implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id, parent);
+        return Objects.hashCode(name, parent);
     }
 }

--- a/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemBuilderTest.groovy
+++ b/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemBuilderTest.groovy
@@ -140,4 +140,19 @@ class DefaultProblemBuilderTest extends Specification {
         problem.contextualLocations.every { it instanceof TaskLocation }
         problem.contextualLocations.collect { (it as TaskLocation).buildTreePath } == [':taskPath']
     }
+
+    def "newlines from contextual labels are removed"() {
+        given:
+        def problemBuilder = createProblemBuilder()
+
+        when:
+        //noinspection GroovyAssignabilityCheck
+        def problem = problemBuilder
+            .id(problemId)
+            .contextualLabel("line1\nline2\r\nline3")
+            .build()
+
+        then:
+        problem.contextualLabel == "line1 line2 line3"
+    }
 }

--- a/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/ProblemIdAndProblemGroupTest.groovy
+++ b/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/ProblemIdAndProblemGroupTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.problems.internal
+
+import org.gradle.api.problems.ProblemGroup
+import org.gradle.api.problems.ProblemId
+import spock.lang.Specification
+
+class ProblemIdAndProblemGroupTest extends Specification {
+
+    def 'name and displayName cannot be null or empty or only whitespace'() {
+        when:
+        def rootGroup = ProblemGroup.create(rootGroupName, rootGroupDisplayName)
+        def subGroup = ProblemGroup.create(subGroupName, subGroupDisplayName, rootGroup)
+        def id = ProblemId.create(idName, idDisplayName, subGroup)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == expectedMessage
+
+        where:
+        rootGroupName | subGroupName | idName  | rootGroupDisplayName | subGroupDisplayName | idDisplayName || expectedMessage
+        ""            | "valid"      | "valid" | "valid"              | "valid"             | "valid"       || 'Problem group name must not be blank'
+        "  "          | "valid"      | "valid" | "valid"              | "valid"             | "valid"       || 'Problem group name must not be blank'
+        "valid"       | ""           | "valid" | "valid"              | "valid"             | "valid"       || 'Problem group name must not be blank'
+        "valid"       | "  "         | "valid" | "valid"              | "valid"             | "valid"       || 'Problem group name must not be blank'
+        "valid"       | "valid"      | ""      | "valid"              | "valid"             | "valid"       || 'Problem id name must not be blank'
+        "valid"       | "valid"      | "  "    | "valid"              | "valid"             | "valid"       || 'Problem id name must not be blank'
+        "valid"       | "valid"      | "valid" | ""                   | "valid"             | "valid"       || 'Problem group displayName must not be blank'
+        "valid"       | "valid"      | "valid" | "  "                 | "valid"             | "valid"       || 'Problem group displayName must not be blank'
+        "valid"       | "valid"      | "valid" | "valid"              | ""                  | "valid"       || 'Problem group displayName must not be blank'
+        "valid"       | "valid"      | "valid" | "valid"              | "  "                | "valid"       || 'Problem group displayName must not be blank'
+        "valid"       | "valid"      | "valid" | "valid"              | "valid"             | ""            || 'Problem id displayName must not be blank'
+        "valid"       | "valid"      | "valid" | "valid"              | "valid"             | "  "          || 'Problem id displayName must not be blank'
+    }
+
+    def 'multiline names are flattened to a single line'() {
+        when:
+        def rootGroup = ProblemGroup.create("ro\no\r\nt\r\n\r\nGroupName", "ro\no\r\nt\r\n\r\nGroupDisplayName")
+        def subGroup = ProblemGroup.create("su\nb\r\nG\r\n\r\nroupName", "su\nb\r\nG\r\n\r\nroupDisplayName", rootGroup)
+        def id = ProblemId.create("id\nN\r\na\r\n\r\nme", "i\nd\r\nD\r\n\r\nisplayName", subGroup)
+
+        then:
+        id.name == 'idName'
+        id.displayName == 'idDisplayName'
+        id.group.name == 'subGroupName'
+        id.group.displayName == 'subGroupDisplayName'
+        id.group.parent.name == 'rootGroupName'
+        id.group.parent.displayName == 'rootGroupDisplayName'
+    }
+}

--- a/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemHeaderWriter.java
+++ b/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemHeaderWriter.java
@@ -35,11 +35,8 @@ class ProblemHeaderWriter implements PartialProblemWriter {
 
     private String headerFor(RenderOptions options, InternalProblem problem) {
         StringBuilder result = new StringBuilder(options.getPrefix());
-        String displayName = problem.getDefinition().getId().getDisplayName();
-        String name = (displayName == null || displayName.isEmpty()) ? problem.getDefinition().getId().toString() : displayName;
-        name = name.replaceAll("\\r?\\n", " ");
-        result.append(name);
-        if (options.isRenderId() && displayName != null && !displayName.isEmpty()) {
+        result.append(problem.getDefinition().getId().getDisplayName());
+        if (options.isRenderId()) {
             result.append(" (id: ");
             result.append(problem.getDefinition().getId());
             result.append(")");

--- a/platforms/ide/problems-rendering/src/test/groovy/org/gradle/problems/internal/rendering/SimpleProblemWriterTest.groovy
+++ b/platforms/ide/problems-rendering/src/test/groovy/org/gradle/problems/internal/rendering/SimpleProblemWriterTest.groovy
@@ -40,74 +40,6 @@ class SimpleProblemWriterTest extends Specification {
         problemWriter = ProblemWriter.simple()
     }
 
-    def "render problem with no group and id display name"(String displayName) {
-        given:
-        def problem = createProblem { InternalProblemBuilder spec ->
-            spec.id(
-                createId(
-                    "sample-problems",
-                    displayName,
-                    "prototype-project",
-                    displayName
-            ))
-        }
-
-        when:
-        problemWriter.write(problem, writer)
-
-        then:
-        renderedProblem == 'Problem found: sample-problems:prototype-project'
-
-        where:
-        displayName << [null, '']
-    }
-
-    def "render problem with no group display name"(String displayName) {
-        given:
-        def problem = createProblem { InternalProblemBuilder spec ->
-            id(
-                createId(
-                    "sample-problems",
-                    displayName,
-                    "prototype-project",
-                    "Project is a prototype"
-                )
-            )
-        }
-
-        when:
-        problemWriter.write(problem, writer)
-
-        then:
-        renderedProblem == 'Problem found: Project is a prototype (id: sample-problems:prototype-project)'
-
-        where:
-        displayName << [null, '']
-    }
-
-    def "render problem with no id display name"(String displayName) {
-        given:
-        def problem = createProblem { InternalProblemBuilder spec ->
-            spec.id(
-                createId(
-                    "sample-problems",
-                    "Sample Problems",
-                    "prototype-project",
-                    displayName
-            )
-            )
-        }
-
-        when:
-        problemWriter.write(problem, writer)
-
-        then:
-        renderedProblem == 'Problem found: sample-problems:prototype-project'
-
-        where:
-        displayName << [null, '']
-    }
-
     def "render problem with id only"() {
         given:
         def problem = createProblem { InternalProblemBuilder spec ->
@@ -129,7 +61,7 @@ class SimpleProblemWriterTest extends Specification {
                     "sample-problems",
                     "Sample\nProblems",
                     "prototype-project",
-                    "Project\nis a prototype"
+                    "Project\n is a prototype"
                 )
             )
         }
@@ -267,7 +199,7 @@ Problem found: Project is a prototype (id: sample-problems:prototype-project)
     def "render multiline messages for all fields possible"() {
         def problem = createProblem { InternalProblemBuilder spec ->
             spec.id(createId())
-                .contextualLabel("This is a prototype and not${System.lineSeparator()}a guideline for modeling real-life projects")
+                .contextualLabel("This is a prototype and not${System.lineSeparator()}a guideline for modeling real-life projects") // API enforces a single line for contextual label
                 .details("Complex build logic like the Problems API${System.lineSeparator()}usage should integrated into plugins")
                 .solution("Look up the samples index for${System.lineSeparator()}real-life examples")
                 .details("Complex build logic like the Problems API${System.lineSeparator()}usage should integrated into plugins")
@@ -279,8 +211,7 @@ Problem found: Project is a prototype (id: sample-problems:prototype-project)
         then:
         renderedProblem == denormalizeAndStrip('''
 Problem found: Project is a prototype (id: sample-problems:prototype-project)
-  This is a prototype and not
-  a guideline for modeling real-life projects
+  This is a prototype and not a guideline for modeling real-life projects
     Complex build logic like the Problems API
     usage should integrated into plugins
     Solution: Look up the samples index for

--- a/platforms/jvm/plugins-jvm-test-suite/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
+++ b/platforms/jvm/plugins-jvm-test-suite/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
@@ -1040,9 +1040,10 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
         fails("assertCopyCanBeResolved")
         failureDescriptionContains("A problem occurred evaluating root project '${buildFile.parentFile.name}'.")
         failureHasCause("""Method call not allowed
-  Calling configuration method 'copy()' is not allowed for configuration 'testImplementation', which has permitted usage(s):
-  \tDeclarable - this configuration can have dependencies added to it
-  This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'.""")
+  Calling configuration method 'copy()' is not allowed for configuration 'testImplementation'
+    'testImplementation' has the following permitted usage(s):
+    \tDeclarable - this configuration can have dependencies added to it
+    This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'.""")
     }
 
     def "configuring different test suites with different framework versions is allowed"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
@@ -111,7 +111,7 @@ class ConfigurationRolesIntegrationTest extends AbstractIntegrationSpec {
         def expectedUsagesMsg
         if (role == 'canBeResolved = false') {
             expectedUsagesMsg = """\tConsumable - this configuration can be selected by another project as a dependency
-  \tDeclarable - this configuration can have dependencies added to it"""
+    \tDeclarable - this configuration can have dependencies added to it"""
         } else {
             expectedUsagesMsg = "\tDeclarable - this configuration can have dependencies added to it"
         }
@@ -121,9 +121,10 @@ class ConfigurationRolesIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasDescription("Execution failed for task ':checkState'.")
         if ((method as String) in ['getResolvedConfiguration()']) {
             failure.assertHasCause("""Method call not allowed
-  Calling configuration method '$method' is not allowed for configuration 'internal', which has permitted usage(s):
-  $expectedUsagesMsg
-  This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'.""")
+  Calling configuration method '$method' is not allowed for configuration 'internal'
+    'internal' has the following permitted usage(s):
+    $expectedUsagesMsg
+    This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'.""")
         } else {
             failure.assertHasCause("""Resolving dependency configuration 'internal' is not allowed as it is defined as 'canBeResolved=false'.
 Instead, a resolvable ('canBeResolved=true') dependency configuration that extends 'internal' should be resolved.""")

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1272,14 +1272,38 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
             String currentUsageDesc = UsageDescriber.describeCurrentUsage(this);
             String properUsageDesc = ProperMethodUsage.summarizeProperUsage(properUsages);
             @SuppressWarnings("InlineFormatString")
-            String msgTemplate = "Calling configuration method '%s' is not allowed for configuration '%s', which has permitted usage(s):\n" +
-                "%s\n" +
-                "This method is only meant to be called on configurations which allow the %susage(s): '%s'.";
+            String prefixTemplate = "Calling configuration method '%s' is not allowed for configuration '%s'";
+            @SuppressWarnings("InlineFormatString")
+            String suffixTemplate = "This method is only meant to be called on configurations which allow the %susage(s): '%s'.";
+            GradleException ex = new GradleException(
+                String.format(
+                    prefixTemplate + ", which has permitted usage(s):\n%s\n" + suffixTemplate,
+                    methodName,
+                    getName(),
+                    currentUsageDesc,
+                    allowDeprecated ? "" : "(non-deprecated) ",
+                    properUsageDesc
+                )
+            );
 
-            GradleException ex = new GradleException(String.format(msgTemplate, methodName, getName(), currentUsageDesc, allowDeprecated ? "" : "(non-deprecated) ", properUsageDesc));
             ProblemId id = ProblemId.create("method-not-allowed", "Method call not allowed", GradleCoreProblemGroup.configurationUsage());
             throw configurationServices.getProblems().getInternalReporter().throwing(ex, id, spec -> {
-                spec.contextualLabel(ex.getMessage());
+                spec.contextualLabel(
+                    String.format(
+                        prefixTemplate,
+                        methodName,
+                        getName()
+                    )
+                );
+                spec.details(
+                    String.format(
+                        "'%s' has the following permitted usage(s):\n%s\n" + suffixTemplate,
+                        getName(),
+                        currentUsageDesc,
+                        allowDeprecated ? "" : "(non-deprecated) ",
+                        properUsageDesc
+                    )
+                );
                 spec.severity(Severity.ERROR);
             });
         } else if (isExclusivelyDeprecatedUsage(properUsages)) {


### PR DESCRIPTION
The following properties no longer can be blank (ie cannot be `null`, empty string, or a string containing only whitespaces):
- `ProblemId.name`
- `ProblemId.displayName`
- `ProblemGroup.name`
- `ProblemGroup.displayName` 

Besides, the PR forces the following properties to be single-lines (by removing line endings):
- `ProblemId.name`
- `ProblemId.displayName`
- `ProblemGroup.name`
- `ProblemGroup.displayName` 
- `Problem.contextualLabel`

Finally, during the implementation I noticed that `DefaultConfiguration` emits a somewhat inconsistent problem report. Effectively, the entire message was jammed into `contextualLabel`. Now, it is split into two: the first line is presented as `contextualLabel` and the rest is put to `details`. The console rendering is now as follows:

```
Method call not allowed
  Calling configuration method 'copy()' is not allowed for configuration 'testImplementation'
    'testImplementation' has the following permitted usage(s):
    	Declarable - this configuration can have dependencies added to it
    This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'.
```


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
