### PR TITLE
Disable intermediate model caching for IP by default

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/AbstractIsolatedProjectsToolingApiIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/AbstractIsolatedProjectsToolingApiIntegrationTest.groovy
@@ -24,10 +24,11 @@ import org.gradle.internal.cc.impl.fixtures.ToolingApiSpec
 class AbstractIsolatedProjectsToolingApiIntegrationTest extends AbstractIsolatedProjectsIntegrationTest implements ToolingApiSpec, ProjectDirectoryCreator {
 
     static final String CONFIGURE_ON_DEMAND_FOR_TOOLING = "-Dorg.gradle.internal.isolated-projects.configure-on-demand=tooling"
+    static final String CACHING_FOR_TOOLING = "-Dorg.gradle.internal.isolated-projects.caching=tooling"
 
     @Override
     void withIsolatedProjects(String... moreExecuterArgs) {
-        executer.withArguments(ENABLE_CLI, CONFIGURE_ON_DEMAND_FOR_TOOLING, *moreExecuterArgs)
+        executer.withArguments(ENABLE_CLI, CONFIGURE_ON_DEMAND_FOR_TOOLING, CACHING_FOR_TOOLING, *moreExecuterArgs)
     }
 
     @Override

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsBuildOperationsIntegrationTest.groovy
@@ -385,7 +385,7 @@ class IsolatedProjectsBuildOperationsIntegrationTest extends AbstractIsolatedPro
     }
 
     private def fetchAllModels() {
-        executer.withArguments(ENABLE_CLI)
+        withIsolatedProjects()
         return runBuildAction(new FetchCustomModelForEachProject())
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/buildtree/BuildModelParametersProvider.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/buildtree/BuildModelParametersProvider.kt
@@ -67,7 +67,7 @@ object BuildModelParametersProvider {
 
     @JvmStatic
     val isolatedProjectsCaching =
-        InvocationScenarioParameter.Option("org.gradle.internal.isolated-projects.caching", InvocationScenarioParameter.TOOLING)
+        InvocationScenarioParameter.Option("org.gradle.internal.isolated-projects.caching", InvocationScenarioParameter.NONE)
 
     private
     val resilientModelBuilding =

--- a/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
@@ -75,7 +75,7 @@ class BuildModelParametersProviderTest extends Specification {
             isolatedProjects: true,
             parallelProjectConfiguration: true,
             parallelToolingApiActions: true,
-            intermediateModelCache: models,
+            intermediateModelCache: false,
             invalidateCoupledProjects: true,
             modelAsProjectDependency: true,
             resilientModelBuilding: false
@@ -108,7 +108,7 @@ class BuildModelParametersProviderTest extends Specification {
             isolatedProjects: true,
             parallelProjectConfiguration: true,
             parallelToolingApiActions: true,
-            intermediateModelCache: models,
+            intermediateModelCache: false,
             invalidateCoupledProjects: true,
             modelAsProjectDependency: true,
             resilientModelBuilding: false
@@ -150,7 +150,7 @@ class BuildModelParametersProviderTest extends Specification {
             isolatedProjects: true,
             parallelProjectConfiguration: ipParallelExpected,
             parallelToolingApiActions: ipParallelExpected,
-            intermediateModelCache: models,
+            intermediateModelCache: false,
             invalidateCoupledProjects: true,
             modelAsProjectDependency: true,
             resilientModelBuilding: false

--- a/platforms/documentation/docs/src/docs/userguide/reference/structuring-builds/isolated_projects.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/structuring-builds/isolated_projects.adoc
@@ -101,6 +101,13 @@ These constraints are not final and can change at any time.
 
 == ChangeLog
 
+=== Gradle 9.3.0
+
+==== Disable tooling model caching by default
+
+Tooling model caching applies to scenarios like IDE sync.
+As it currently has known problems, we disable it for now to simplify early adoption.
+
 === Gradle 9.2.0
 
 ==== Additional APIs treated as incompatible with Isolated Projects


### PR DESCRIPTION
As there are known issues with both parallel IP and caching IP, and the team's focus is on the parallel IP, we are disabling the caching for now to simplify the initial early adoption and troubleshooting of observed problems.