### PR TITLE
Align VFS internal properties with others

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -114,9 +114,9 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
      *
      * @see org.gradle.initialization.StartParameterBuildOptions.WatchFileSystemOption
      */
-    public static final InternalFlag VFS_DROP_PROPERTY = new InternalFlag("org.gradle.vfs.drop");
+    public static final InternalFlag VFS_DROP_PROPERTY = new InternalFlag("org.gradle.internal.vfs.drop");
     private static final int DEFAULT_MAX_HIERARCHIES_TO_WATCH = 50;
-    public static final IntegerInternalOption MAX_HIERARCHIES_TO_WATCH_PROPERTY = new IntegerInternalOption("org.gradle.vfs.watch.hierarchies.max", DEFAULT_MAX_HIERARCHIES_TO_WATCH);
+    public static final IntegerInternalOption MAX_HIERARCHIES_TO_WATCH_PROPERTY = new IntegerInternalOption("org.gradle.internal.vfs.watch.hierarchies.max", DEFAULT_MAX_HIERARCHIES_TO_WATCH);
     private static final int FILE_HASHER_MEMORY_CACHE_SIZE = 400000;
 
     public static boolean isDropVfs(InternalOptions options) {


### PR DESCRIPTION
- Preparation for https://github.com/gradle/gradle/pull/35357

We have these two flags for Virtual File System:
- `org.gradle.vfs.drop`
- `org.gradle.vfs.watch.hierarchies.max`

They are not documented anywhere in the user guide, but are used in our tests. They are read via InternalOptions mechanism.

As part of cleaning up the `InternalOptions` infrastructure, we are aligning the naming of the flags with others, changin their prefix to `org.gradle.internal.`.