### PR TITLE
Eclipse should respect order of dependencies in build path

### DIFF
--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -265,7 +265,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
             classpathEntries = classpath.getEntries();
         }
 
-        final Map<String, DefaultEclipseProjectDependency> projectDependencyMap = new HashMap<>();
+        final Map<String, DefaultEclipseProjectDependency> projectDependencyMap = new LinkedHashMap<>();
 
         for (ClasspathEntry entry : classpathEntries) {
             //we don't handle Variables at the moment because users didn't request it yet


### PR DESCRIPTION
Issue #35520

Fixed the issue and added tests.  

### Context
Update to ensure values retrieved from hash map are the same order as inserted.
Doesn't affect idea as class path doesn't go through a hash map.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
