### PR TITLE
Move `DynamicCallContextTracker` to `Build` scope

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildModelControllerServices.kt
@@ -25,6 +25,7 @@ import org.gradle.api.internal.project.DynamicLookupRoutine
 import org.gradle.api.internal.project.ProjectRegistry
 import org.gradle.configuration.ProjectsPreparer
 import org.gradle.configuration.ScriptPluginFactory
+import org.gradle.configuration.internal.DefaultDynamicCallContextTracker
 import org.gradle.configuration.internal.DynamicCallContextTracker
 import org.gradle.configuration.project.BuildScriptProcessor
 import org.gradle.configuration.project.ConfigureActionsProjectEvaluator
@@ -177,6 +178,11 @@ class DefaultBuildModelControllerServices(
                 buildModelParameters,
                 instantiator
             )
+        }
+
+        @Provides
+        fun createDynamicCallContextTracker(): DynamicCallContextTracker {
+            return DefaultDynamicCallContextTracker()
         }
 
         @Provides

--- a/subprojects/core/src/main/java/org/gradle/configuration/internal/DynamicCallContextTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/internal/DynamicCallContextTracker.java
@@ -35,7 +35,7 @@ import java.util.function.Consumer;
  */
 // TODO: consider transforming this to a more generic tool for tracking the events
 //       of entering and leaving some generic context (marked with a key?)
-@ServiceScope(Scope.CrossBuildSession.class)
+@ServiceScope(Scope.Build.class)
 public interface DynamicCallContextTracker {
     /**
      * Notifies the tracker that the control flow entered the context of a new dynamic call.

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CoreCrossBuildSessionServices.java
@@ -18,9 +18,7 @@ package org.gradle.internal.service.scopes;
 
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultCollectionCallbackActionDecorator;
-import org.gradle.configuration.internal.DefaultDynamicCallContextTracker;
 import org.gradle.configuration.internal.DefaultListenerBuildOperationDecorator;
-import org.gradle.configuration.internal.DynamicCallContextTracker;
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator;
 import org.gradle.internal.code.DefaultUserCodeApplicationContext;
 import org.gradle.internal.code.UserCodeApplicationContext;
@@ -58,7 +56,6 @@ public class CoreCrossBuildSessionServices implements ServiceRegistrationProvide
     void configure(ServiceRegistration registration) {
         registration.add(ResourceLockCoordinationService.class, DefaultResourceLockCoordinationService.class);
         registration.add(WorkerLeaseService.class, ProjectParallelExecutionController.class, DefaultWorkerLeaseService.class);
-        registration.add(DynamicCallContextTracker.class, DefaultDynamicCallContextTracker.class);
     }
 
     @Provides


### PR DESCRIPTION
Issue: #35342

DynamicCallContextTracker keeps state (enter/leave listeners) that is relevant in the context of a build. We should either change it to manage said listeners separately per build, or we should make it a `Build` scope service. 

This change set does that.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
