### PR TITLE
Address test failures from #35425

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
@@ -177,19 +177,18 @@ class PersistentCompositeDependencySubstitutionCrossVersionSpec extends ToolingA
                 ${testImplementationConfiguration} "org.test:buildC:1.0"
                 ${testImplementationConfiguration} "org.buildD:b1:1.0"
             }
-"""
+        """
         def buildD = multiProjectBuildInSubFolder("buildD", ["b1", "buildC"]) {
-            buildFile << """
-                allprojects {
+            [buildFile, project("b1").buildFile, project("buildC").buildFile].each {
+                it << """
                     apply plugin: 'java'
-
                     group = 'org.buildD'
-                }
-"""
+                """
+            }
         }
         settingsFile << """
             includeBuild 'buildD'
-"""
+        """
 
         when:
         def allProjects = withConnection {c -> c.action(new IdeaProjectUtil.GetAllIdeaProjectsAction()).run() }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -1023,6 +1023,10 @@ group:projectB:2.2;release
             ${resolve.configureProject("conf")}
         """
         addDependenciesTo(otherBuildFile)
+        otherBuildFile << """
+            // this is for parallel execution
+            tasks.checkDeps.mustRunAfter(rootProject.tasks.checkDeps)
+        """
 
         given:
         def supplierInteractions = withPerVersionStatusSupplier(file("buildSrc/src/main/groovy/MP.groovy"))


### PR DESCRIPTION
The first failure stems from the interaction between gradle.lifecycle.beforeProject and allprojects. We update the build using allprojects to instead write directly to the build files so it can override the beforeProject defaults The second is due to a removal of a mustRunAfter, affecting parallel tests. The test verified that only a single call to version listing is made, however when executed in parallel multiple calls are made. We add the dependency back to ensure only one task runs at once. Eventually we might want to make the actual implementation resilient to parallel execution, so one request blocks on the other

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
