### PR TITLE
Clarify version notation in compatibility matrix

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
@@ -40,15 +40,15 @@ See the table below for the Java version supported by a specific Gradle release:
 |===
 |Java version | Support for toolchains | Support for running Gradle
 
-| 8 | N/A | 2.0 to 8.14.*
-| 9 | N/A | 4.3 to 8.14.*
-| 10| N/A | 4.7 to 8.14.*
-| 11| N/A | 5.0 to 8.14.*
-| 12| N/A | 5.4 to 8.14.*
-| 13| N/A | 6.0 to 8.14.*
-| 14| N/A | 6.3 to 8.14.*
-| 15| 6.7 | 6.7 to 8.14.*
-| 16| 7.0 | 7.0 to 8.14.*
+| 8 | N/A | 2.0 to 8.14.x
+| 9 | N/A | 4.3 to 8.14.x
+| 10| N/A | 4.7 to 8.14.x
+| 11| N/A | 5.0 to 8.14.x
+| 12| N/A | 5.4 to 8.14.x
+| 13| N/A | 6.0 to 8.14.x
+| 14| N/A | 6.3 to 8.14.x
+| 15| 6.7 | 6.7 to 8.14.x
+| 16| 7.0 | 7.0 to 8.14.x
 | 17| 7.3 | 7.3 and after
 | 18| 7.5 | 7.5 and after
 | 19| 7.6 | 7.6 and after


### PR DESCRIPTION
<!--- Compatibility Matrix contains mysterious asterisks -->
<!-- Fixes #35548 -->

### Context
<!--- The previous use of * was unclear and inconsistent with standard version notation. This update ensures better readability for users referencing supported Gradle versions. -->
<!---[ Link to relevant issues or forum discussions here](https://docs.gradle.org/current/userguide/compatibility.html) -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.


Signed-off-by: Abhay Singh <theabhayrajavat@example.com>