### PR TITLE
Hardcode 9.2 release date

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -10,7 +10,7 @@
 <meta name="twitter:description" content="We are excited to announce Gradle @version@.">
 <meta name="twitter:image" content="https://gradle.org/images/releases/gradle-default.png">
 
-We are excited to announce Gradle @version@ (released [@releaseDate@](https://gradle.org/releases/)).
+We are excited to announce Gradle @version@ (released [2025-10-29](https://gradle.org/releases/)).
 
 This release introduces support for [running Gradle on Windows ARM (ARM64) devices](#windows-on-arm-support), making it easier to build on ARM-based systems.
 


### PR DESCRIPTION
This prevents it from changing under `/current/` since there are documentation updates.