### PR TITLE
chore: update Jackson version to 2.20.1 in .teamcity/pom.xml

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -5,7 +5,7 @@
     <properties>
         <mockk.version>1.14.6</mockk.version>
         <bytebuddy.version>1.17.8</bytebuddy.version>
-        <jackson.version>2.20.0</jackson.version>
+        <jackson.version>2.20.1</jackson.version>
         <junit.version>5.11.3</junit.version>
         <dslContextParameter.branch>master</dslContextParameter.branch>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary
This PR updates the Jackson library version from 2.20.0 to 2.20.1 in the .teamcity/pom.xml file.

## Details
- Updates the `jackson.version` property from 2.20.0 to 2.20.1
- This is a patch version update that likely includes bug fixes and minor improvements

## Why
Keeping dependencies up-to-date is important for security, stability, and access to the latest features. This update ensures we're using the latest patch version of Jackson 2.20.