### PR TITLE
Bump timeout for windows docs test

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/DocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/DocsTest.kt
@@ -86,7 +86,7 @@ class DocsTest(
             "docs:docsTest docs:checkSamples",
             os = os,
             arch = os.defaultArch,
-            timeout = 60,
+            timeout = if (os == Os.WINDOWS) 90 else 60,
             extraParameters =
                 listOf(
                     buildScanTagParam(docsTestType.docsTestName),


### PR DESCRIPTION
While we are investigating https://github.com/gradle/gradle-private/issues/4920