### PR TITLE
Add DownloadGitRepoToEc2Agent build type

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/DownloadGitRepoToEc2Agent.kt
+++ b/.teamcity/src/main/kotlin/configurations/DownloadGitRepoToEc2Agent.kt
@@ -1,0 +1,26 @@
+package configurations
+
+import common.applyDefaultSettings
+import jetbrains.buildServer.configs.kotlin.BuildStep
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
+
+object DownloadGitRepoToEc2Agent : BuildType({
+    val id = "Util_DownloadGitRepoToEc2Agent"
+    name = "Download Git Repo to EC2 Agent"
+    description = "Do nothing but downloading gradle/gradle repo to EC2 agents"
+
+    applyDefaultSettings(artifactRuleOverride = "")
+
+    params {
+        param("defaultBranchName", "master")
+    }
+
+    steps {
+        script {
+            name = "DO_NOTHING"
+            executionMode = BuildStep.ExecutionMode.ALWAYS
+            scriptContent = "echo 'Repo downloaded'"
+        }
+    }
+})

--- a/.teamcity/src/main/kotlin/util/UtilProject.kt
+++ b/.teamcity/src/main/kotlin/util/UtilProject.kt
@@ -2,6 +2,7 @@ package util
 
 import common.Arch
 import common.Os
+import configurations.DownloadGitRepoToEc2Agent
 import jetbrains.buildServer.configs.kotlin.Project
 
 object UtilProject : Project({
@@ -13,6 +14,7 @@ object UtilProject : Project({
     buildType(RerunFlakyTest(Os.MACOS, Arch.AMD64))
     buildType(RerunFlakyTest(Os.MACOS, Arch.AARCH64))
     buildType(WarmupEc2Agent)
+    buildType(DownloadGitRepoToEc2Agent)
     buildType(UpdateWrapper)
 
     buildType(PublishKotlinDslPlugin)


### PR DESCRIPTION
Part of https://github.com/gradle/dev-infrastructure/pull/2701

Created a build that does nothing but downloading the git repo to EC2 agents. This is to be used in EC2 AMI warmup builds.