### PR TITLE
Remove skipBuildLogicTests flag

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/BuildLogicTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/BuildLogicTest.kt
@@ -21,7 +21,7 @@ class BuildLogicTest(
         applyDefaults(
             model,
             this,
-            ":build-logic:test -PskipBuildLogicTests=false",
+            ":build-logic:test",
             extraParameters =
                 listOf(
                     stage.getBuildScanCustomValueParam(),

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -54,7 +54,6 @@ import gradlebuild.basics.BuildParams.PREDICTIVE_TEST_SELECTION_ENABLED
 import gradlebuild.basics.BuildParams.RERUN_ALL_TESTS
 import gradlebuild.basics.BuildParams.RUN_ANDROID_STUDIO_IN_HEADLESS_MODE
 import gradlebuild.basics.BuildParams.RUN_BROKEN_CONFIGURATION_CACHE_DOCS_TESTS
-import gradlebuild.basics.BuildParams.SKIP_BUILD_LOGIC_TESTS
 import gradlebuild.basics.BuildParams.STUDIO_HOME
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_DOGFOODING_TAG
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_ENABLED
@@ -122,7 +121,6 @@ object BuildParams {
     const val PERFORMANCE_DEPENDENCY_BUILD_IDS = "org.gradle.performance.dependencyBuildIds"
     const val PERFORMANCE_MAX_PROJECTS = "maxProjects"
     const val RERUN_ALL_TESTS = "rerunAllTests"
-    const val SKIP_BUILD_LOGIC_TESTS = "skipBuildLogicTests"
     const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
     const val TEST_DISTRIBUTION_DOGFOODING_TAG = "testDistributionDogfoodingTag"
     const val TEST_DISTRIBUTION_ENABLED = "enableTestDistribution"
@@ -278,9 +276,6 @@ val Project.flakyTestStrategy: FlakyTestStrategy
 
 val Project.ignoreIncomingBuildReceipt: Provider<Boolean>
     get() = gradleProperty(BUILD_IGNORE_INCOMING_BUILD_RECEIPT).presence()
-
-val Project.skipBuildLogicTests: Boolean
-    get() = gradleProperty(SKIP_BUILD_LOGIC_TESTS).getOrElse("true") == "true"
 
 val Project.performanceDependencyBuildIds: Provider<String>
     get() = gradleProperty(PERFORMANCE_DEPENDENCY_BUILD_IDS).orElse("")

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import gradlebuild.basics.skipBuildLogicTests
 
 plugins {
     id("java-library")
@@ -56,6 +55,5 @@ tasks.validatePlugins {
 }
 
 tasks.withType<Test>().configureEach {
-    enabled = !skipBuildLogicTests
     useJUnitPlatform()
 }


### PR DESCRIPTION
We run build logic tests as a separate build now.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
