### PR TITLE
Use ClassValue in DefaultClassMap to avoid leaking classloaders

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -251,40 +252,56 @@ public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemory
     }
 
     /**
-     * Retains strong references to the keys and values via the key's ClassLoader. This allows the ClassLoader to be collected.
+     * Stores each value so that it lives only as long as its key {@link Class}, allowing classes and
+     * their classloaders to be garbage collected. The storage scope depends on how the class was loaded.
      */
     private static class DefaultClassMap<V> extends AbstractCrossBuildInMemoryCache<Class<?>, V> {
-        // Currently retains strong references to types that are not loaded using a VisitableURLClassLoader
-        // This is fine for JVM types, but a problem when a custom ClassLoader is used (which should probably be deprecated instead of supported)
-        private final Map<Class<?>, V> leakyValues = new ConcurrentHashMap<>();
+        // Holds values for classes from custom classloaders, tying each entry's lifetime to its class.
+        // ClassValue can only compute its entry, never have it set, so the value goes in an AtomicReference that retainValue sets.
+        private final ClassValue<AtomicReference<V>> classValueCache = new ClassValue<AtomicReference<V>>() {
+            @Override
+            protected AtomicReference<V> computeValue(Class<?> type) {
+                return new AtomicReference<>();
+            }
+        };
+
+        // Bootstrap classes are never unloaded, so a strong reference here cannot leak a classloader.
+        private final Map<Class<?>, V> bootstrapClassLoaderValues = new ConcurrentHashMap<>();
 
         @Override
         protected void retainValuesFromCurrentSession(Stream<V> values) {
-            // Ignore
+            // Ignore: each value is retained for the lifetime of its key class
         }
 
         @Override
         protected void discardRetainedValues() {
-            throw new UnsupportedOperationException();
+            // Class-scoped entries are collected with their classes; only the bootstrap map must be cleared explicitly
+            bootstrapClassLoaderValues.clear();
         }
 
         @Override
         protected void retainValue(Class<?> key, V v) {
-            getCacheScope(key).put(key, v);
+            ClassLoader classLoader = key.getClassLoader();
+            if (classLoader == null) {
+                bootstrapClassLoaderValues.put(key, v);
+            } else if (classLoader instanceof VisitableURLClassLoader) {
+                ((VisitableURLClassLoader) classLoader).getUserData(this, ConcurrentHashMap::new).put(key, v);
+            } else {
+                classValueCache.get(key).set(v);
+            }
         }
 
         @Nullable
         @Override
         protected V maybeGetRetainedValue(Class<?> key) {
-            return getCacheScope(key).get(key);
-        }
-
-        private Map<Class<?>, V> getCacheScope(Class<?> type) {
-            ClassLoader classLoader = type.getClassLoader();
-            if (classLoader instanceof VisitableURLClassLoader) {
-                return ((VisitableURLClassLoader) classLoader).getUserData(this, ConcurrentHashMap::new);
+            ClassLoader classLoader = key.getClassLoader();
+            if (classLoader == null) {
+                return bootstrapClassLoaderValues.get(key);
+            } else if (classLoader instanceof VisitableURLClassLoader) {
+                return ((VisitableURLClassLoader) classLoader).<Map<Class<?>, V>>getUserData(this, ConcurrentHashMap::new).get(key);
+            } else {
+                return classValueCache.get(key).get();
             }
-            return leakyValues;
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactoryTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.cache.internal
 
 import org.gradle.internal.session.BuildSessionLifecycleListener
+import org.gradle.test.fixtures.ConcurrentTestUtil
 
+import java.lang.ref.WeakReference
 import java.util.function.Function
 
 class DefaultCrossBuildInMemoryCacheFactoryTest extends AbstractCrossBuildInMemoryCacheTest {
@@ -95,5 +97,29 @@ class DefaultCrossBuildInMemoryCacheFactoryTest extends AbstractCrossBuildInMemo
 
         cache.put(String, c)
         cache.getIfPresent(String) == c
+    }
+
+    def "does not retain a class loaded by a custom classloader after the session ends"() {
+        given:
+        def cache = factory.newClassMap()
+        // A GroovyClassLoader is not a VisitableURLClassLoader, so the value is stored via ClassValue
+        def loader = new GroovyClassLoader(getClass().classLoader)
+        def type = loader.parseClass("class Leaky {}")
+        cache.get(type, { new Object() } as Function)
+        def typeRef = new WeakReference<Class<?>>(type)
+
+        when: "the session ends and every test-side reference to the class is dropped"
+        listenerManager.getBroadcaster(BuildSessionLifecycleListener).beforeComplete()
+        loader.clearCache()
+        type = null
+        loader = null
+
+        then: "the class can be unloaded even though the cache is still alive"
+        ConcurrentTestUtil.poll(10) {
+            System.gc()
+            // Keep the cache reachable, so the test checks the cache's retention rather than GC of the cache itself
+            assert cache != null
+            assert typeRef.get() == null
+        }
     }
 }


### PR DESCRIPTION
`DefaultClassMap` stored a value for every key class in a static `ConcurrentHashMap` (`leakyValues`). For a class loaded by a classloader other than a `VisitableURLClassLoader` — for example an ASM-generated type — that strong reference lived for the whole daemon and kept the class, and its classloader, from being garbage collected. #35028 asked for `ClassValue` here.

The storage scope now follows the lifetime of the key class:

- bootstrap classes (`null` classloader): a `ConcurrentHashMap`, since these classes are never unloaded;
- `VisitableURLClassLoader`: the classloader's user data, as before, so the entries are released with the classloader;
- any other classloader: a `ClassValue`, so each entry is collected together with its class.

Fixes #35028

### Scope

This is a targeted change to one branch of `DefaultClassMap`. It does **not** address the Worker API classloader growth discussed in #34957. The worker classloaders there are themselves `VisitableURLClassLoader`s, handled by the unchanged user-data branch, and they are retained through soft references rather than this map.

### Verification

- [x] Unit test in `DefaultCrossBuildInMemoryCacheFactoryTest`: a class loaded by a throwaway classloader is stored in the cache, the session ends, and after GC the class is unloaded. The test fails on the old `leakyValues` map and passes with `ClassValue`.

### Note on #34957

I reproduced the #34957 Worker API scenario on `master` and on this branch — 8 builds with distinct worker classpaths against a single daemon. The live `VisitableURLClassLoader` count grows identically on both (so this change has no effect there), and the growth disappears under `-XX:SoftRefLRUPolicyMSPerMB=0`. The accumulation is therefore soft-reference caching, reclaimed under memory pressure, not a strong leak.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
