### PR TITLE
Use newer Kotlin version in test

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
@@ -45,7 +45,7 @@ class EmbeddedKotlinProviderTest : AbstractKotlinIntegrationTest() {
     @Test
     @Category(Flaky::class) // https://github.com/gradle/gradle-private/issues/4723
     fun `stdlib and reflect are pinned to the embedded kotlin version for requested plugins`() {
-        val requestedKotlinVersion = "2.0.0"
+        val requestedKotlinVersion = "2.1.21"
         withBuildScript(
             """
             buildscript {


### PR DESCRIPTION
This test verified that an arbitrary kotlin version remains pinned when explicitly requested. The arbitrary kotlin version used previously emitted a deprecation warning. We update the arbitrary kotlin version to one that does not emit a deprecation warning

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
