### PR TITLE
Deincubate AbstractArchiveTask.useFileSystemPermissions()

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -144,6 +144,8 @@ See the User Manual section on the "[Feature Lifecycle](userguide/feature_lifecy
 
 The following are the features that have been promoted in this Gradle release.
 
+* [`useFileSystemPermissions()`](javadoc/org/gradle/api/tasks/bundling/AbstractArchiveTask.html#useFileSystemPermissions()) in `AbstractArchiveTask`
+
 <!--
 ### Example promoted
 -->

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -17,7 +17,6 @@ package org.gradle.api.tasks.bundling;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFilePermissions;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DirectoryProperty;
@@ -338,7 +337,6 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      *
      * @since 9.0.0
      */
-    @Incubating
     public void useFileSystemPermissions() {
         getFilePermissions().set(getProject().getProviders().provider(() -> null));
         getDirPermissions().set(getProject().getProviders().provider(() -> null));


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/35597