### PR TITLE
Doc update jar manifest provider

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/java_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/java_plugin.adoc
@@ -795,3 +795,19 @@ include::sample[dir="snippets/java/apt/groovy", files="build.gradle[tags=annotat
 
 The whole set of JVM plugins leverage <<variant_aware_resolution.adoc#sec:understanding-variant-selection,variant aware resolution>> for the dependencies used.
 They also install a set of attributes compatibility and disambiguation rules to <<variant_attributes.adoc#sec:jvm-default-attributes,configure the Gradle attributes>> for the specifics of the JVM ecosystem.
+
+== Configuring the JAR Manifest with Providers
+
+You can supply values for manifest attributes using lazy-evaluated `Provider`s. This is useful, for example, when you want to defer the resolution of system properties or project properties until execution time, which supports configuration cache compatibility.
+
+[source,groovy]
+----
+jar {
+    manifest {
+        attributes(
+            'Built-By': providers.systemProperty('user.name'),
+            'Implementation-Version': providers.provider { version }
+        )
+    }
+}
+----


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #25266

### Context
This PR enhances the Javadoc of the `Jar.manifest(Action<? super Manifest>)` method to explicitly document that manifest attribute values can be of type `Provider<?>`. This allows for lazy evaluation of attribute values, which supports Gradle’s configuration caching by deferring computation until manifest creation. Clear documentation benefits users implementing manifest customizations and helps avoid configuration-time evaluation warnings.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate agreement with the Developer Certificate of Origin (DCO).
- [x] Ensure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE).
- [x] Check "Allow edits from maintainers" option in the pull request to enable Gradle team updates if needed.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify user-facing changes.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify internal logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with  
- ❌ ❓**must** be fixed  
- 🤔 💅 **should** be fixed  
- 💭 **may** be fixed  
- 🎉 celebrate happy things  
