### PR TITLE
Fix super invocation for type annotation processing

### DIFF
--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ApiMemberSelector.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ApiMemberSelector.java
@@ -116,7 +116,7 @@ public class ApiMemberSelector extends ClassVisitor {
                 public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
                     TypeAnnotationMember ann = new TypeAnnotationMember(desc, visible, typeRef, typePath);
                     methodMember.addTypeAnnotation(ann);
-                    return new SortingAnnotationVisitor(ann, super.visitAnnotation(desc, visible));
+                    return new SortingAnnotationVisitor(ann, super.visitTypeAnnotation(typeRef, typePath, desc, visible));
                 }
 
                 @Override


### PR DESCRIPTION
The previous version from #35658 was using the wrong super call, but without consequences as both are no-op in the current setup.