### PR TITLE
Avoid UnsupportedOperationException on unknown architectures on 9.2

### DIFF
--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
@@ -67,7 +67,13 @@ public class ConsoleConfigureAction {
     }
 
     private static void configureAutoConsole(OutputEventRenderer renderer, ConsoleMetaData consoleMetaData, OutputStream stdout, OutputStream stderr) {
-        if ("windows-aarch64".equals(Platform.current().getId())) {
+        boolean isWindowsAArch64 = false;
+        try { // fixing https://github.com/gradle/gradle/issues/35521 for 9.2.1 to be removed for 9.3.0 because https://github.com/gradle/gradle/pull/35402 makes this obsolete again
+            isWindowsAArch64 = "windows-aarch64".equals(Platform.current().getId());
+        } catch (UnsupportedOperationException unsupportedOperationException) {
+            // unknown os / arch
+        }
+        if (isWindowsAArch64) {
             renderer.addPlainConsole(stdout, stderr);
         } else if (consoleMetaData.isStdOut() && consoleMetaData.isStdErr()) {
             // Redirect stderr to stdout when both stdout and stderr are attached to a console. Assume that they are attached to the same console
@@ -113,7 +119,13 @@ public class ConsoleConfigureAction {
     }
 
     private static void configureRichConsole(OutputEventRenderer renderer, ConsoleMetaData consoleMetaData, OutputStream stdout, OutputStream stderr, boolean verbose) {
-        if ("windows-aarch64".equals(Platform.current().getId())) {
+        boolean isWindowsAArch64 = false;
+        try { // fixing https://github.com/gradle/gradle/issues/35521 for 9.2.1 to be removed for 9.3.0 because https://github.com/gradle/gradle/pull/35402 makes this obsolete again
+            isWindowsAArch64 = "windows-aarch64".equals(Platform.current().getId());
+        } catch (UnsupportedOperationException unsupportedOperationException) {
+            // unknown os / arch
+        }
+        if (isWindowsAArch64) {
             LOGGER.warn("Rich console output is not supported on Windows ARM64. Falling back to plain console output.");
             renderer.addPlainConsole(stdout, stderr);
         } else if (consoleMetaData.isStdOut() && consoleMetaData.isStdErr()) {


### PR DESCRIPTION
Fixes #35521
Later versions don't need this fix as #35402 removes the need to disable the rich console on Windows ARM64/AArch64