### PR TITLE
Decouple ProjectExecutionServices from mutable Project instance

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsInternal.java
@@ -16,10 +16,10 @@
 
 package org.gradle.api.internal;
 
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.execution.SelfDescribingSpec;
 import org.gradle.api.specs.AndSpec;
 import org.gradle.api.tasks.TaskOutputs;
+import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.properties.PropertyVisitor;
 import org.jspecify.annotations.NullMarked;
 
@@ -37,7 +37,7 @@ public interface TaskOutputsInternal extends TaskOutputs {
 
     AndSpec<? super TaskInternal> getUpToDateSpec();
 
-    void setPreviousOutputFiles(FileCollection previousOutputFiles);
+    void setPreviousOutputFiles(Lazy<Set<File>> previousOutputFiles);
 
     /**
      * Returns the output files and directories recorded during the previous execution of the task.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -34,6 +34,7 @@ import org.gradle.api.internal.tasks.properties.OutputUnpacker;
 import org.gradle.api.specs.AndSpec;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
+import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.properties.OutputFilePropertyType;
 import org.gradle.internal.properties.PropertyValue;
 import org.gradle.internal.properties.PropertyVisitor;
@@ -58,7 +59,7 @@ public class DefaultTaskOutputs implements TaskOutputsEnterpriseInternal {
     private boolean storeInCache = true;
     private final List<SelfDescribingSpec<TaskInternal>> cacheIfSpecs = new LinkedList<>();
     private final List<SelfDescribingSpec<TaskInternal>> doNotCacheIfSpecs = new LinkedList<>();
-    private FileCollection previousOutputFiles;
+    private Lazy<Set<File>> previousOutputFiles;
     private final FilePropertyContainer<TaskOutputFilePropertyRegistration> registeredFileProperties = FilePropertyContainer.create();
     private final TaskInternal task;
     private final TaskMutator taskMutator;
@@ -206,7 +207,7 @@ public class DefaultTaskOutputs implements TaskOutputsEnterpriseInternal {
     }
 
     @Override
-    public void setPreviousOutputFiles(FileCollection previousOutputFiles) {
+    public void setPreviousOutputFiles(Lazy<Set<File>> previousOutputFiles) {
         this.previousOutputFiles = previousOutputFiles;
     }
 
@@ -215,7 +216,7 @@ public class DefaultTaskOutputs implements TaskOutputsEnterpriseInternal {
         if (previousOutputFiles == null) {
             throw new IllegalStateException("Task history is currently not available for this task.");
         }
-        return previousOutputFiles.getFiles();
+        return previousOutputFiles.get();
     }
 
     private static class HasDeclaredOutputsVisitor implements PropertyVisitor {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -16,8 +16,7 @@
 package org.gradle.api.internal.tasks.execution;
 
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecuterResult;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
@@ -61,8 +60,6 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
     private final InputFingerprinter inputFingerprinter;
     private final ListenerManager listenerManager;
     private final ReservedFileSystemLocationRegistry reservedFileSystemLocationRegistry;
-    private final FileCollectionFactory fileCollectionFactory;
-    private final TaskDependencyFactory taskDependencyFactory;
     private final PathToFileResolver fileResolver;
     private final MissingTaskDependencyDetector missingTaskDependencyDetector;
 
@@ -70,30 +67,24 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         ExecutionHistoryStore executionHistoryStore,
         BuildOperationRunner buildOperationRunner,
         AsyncWorkTracker asyncWorkTracker,
-        org.gradle.api.execution.TaskActionListener actionListener,
-        TaskCacheabilityResolver taskCacheabilityResolver,
         ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
         ExecutionEngine executionEngine,
         InputFingerprinter inputFingerprinter,
         ListenerManager listenerManager,
         ReservedFileSystemLocationRegistry reservedFileSystemLocationRegistry,
-        FileCollectionFactory fileCollectionFactory,
-        TaskDependencyFactory taskDependencyFactory,
-        PathToFileResolver fileResolver,
+        FileResolver fileResolver,
         MissingTaskDependencyDetector missingTaskDependencyDetector
     ) {
         this.executionHistoryStore = executionHistoryStore;
         this.buildOperationRunner = buildOperationRunner;
         this.asyncWorkTracker = asyncWorkTracker;
-        this.actionListener = actionListener;
-        this.taskCacheabilityResolver = taskCacheabilityResolver;
+        this.actionListener = listenerManager.getBroadcaster(org.gradle.api.execution.TaskActionListener.class);
+        this.taskCacheabilityResolver = new DefaultTaskCacheabilityResolver(fileResolver);
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
         this.executionEngine = executionEngine;
         this.inputFingerprinter = inputFingerprinter;
         this.listenerManager = listenerManager;
         this.reservedFileSystemLocationRegistry = reservedFileSystemLocationRegistry;
-        this.fileCollectionFactory = fileCollectionFactory;
-        this.taskDependencyFactory = taskDependencyFactory;
         this.fileResolver = fileResolver;
         this.missingTaskDependencyDetector = missingTaskDependencyDetector;
     }
@@ -108,13 +99,11 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
             buildOperationRunner,
             classLoaderHierarchyHasher,
             executionHistoryStore,
-            fileCollectionFactory,
             fileResolver,
             inputFingerprinter,
             listenerManager,
             reservedFileSystemLocationRegistry,
             taskCacheabilityResolver,
-            taskDependencyFactory,
             missingTaskDependencyDetector
         );
         try {

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -30,7 +30,6 @@ import org.gradle.api.internal.tasks.execution.ProblemsTaskPathTrackingTaskExecu
 import org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter;
 import org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter;
 import org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter;
-import org.gradle.execution.plan.ExecutionNodeAccessHierarchies;
 import org.gradle.execution.plan.MissingTaskDependencyDetector;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.execution.taskgraph.TaskListenerInternal;
@@ -86,11 +85,6 @@ public class ProjectExecutionServices implements ServiceRegistrationProvider {
         this.fileResolver = fileResolver;
         this.runtimeClasspathNormalization = runtimeClasspathNormalization;
         this.reservedFileSystemLocationRegistry = reservedFileSystemLocationRegistry;
-    }
-
-    @Provides
-    MissingTaskDependencyDetector createMissingTaskDependencyDetector(ExecutionNodeAccessHierarchies hierarchies) {
-        return new MissingTaskDependencyDetector(hierarchies.getOutputHierarchy(), hierarchies.createInputHierarchy());
     }
 
     @Provides

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeExecutor.java
@@ -25,6 +25,12 @@ import org.gradle.api.internal.tasks.execution.DefaultTaskExecutionContext;
 
 public class DefaultNodeExecutor implements NodeExecutor {
 
+    private final MissingTaskDependencyDetector missingTaskDependencyDetector;
+
+    public DefaultNodeExecutor(MissingTaskDependencyDetector missingTaskDependencyDetector) {
+        this.missingTaskDependencyDetector = missingTaskDependencyDetector;
+    }
+
     @Override
     public boolean execute(Node node, NodeExecutionContext context) {
         if (node instanceof SelfExecutingNode) {
@@ -38,10 +44,9 @@ public class DefaultNodeExecutor implements NodeExecutor {
         }
     }
 
-    private static void executeLocalTaskNode(Node node, NodeExecutionContext context, LocalTaskNode localTaskNode) {
+    private void executeLocalTaskNode(Node node, NodeExecutionContext context, LocalTaskNode localTaskNode) {
         TaskInternal task = localTaskNode.getTask();
         TaskStateInternal state = task.getState();
-        MissingTaskDependencyDetector missingTaskDependencyDetector = context.getService(MissingTaskDependencyDetector.class);
         TaskExecutionContext ctx = new DefaultTaskExecutionContext(
             localTaskNode,
             localTaskNode.getTaskProperties(),

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
@@ -22,6 +22,8 @@ import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.util.internal.TextUtil;
 
 import java.util.ArrayDeque;
@@ -49,6 +51,7 @@ import static org.gradle.internal.deprecation.Documentation.userManual;
  * consuming a parent directory of the produced output.
  * </p>
  */
+@ServiceScope(Scope.Build.class)
 public class MissingTaskDependencyDetector {
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchies.InputNodeAccessHierarchy inputHierarchy;

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/DefaultRuntimeClasspathFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/DefaultRuntimeClasspathFingerprinter.java
@@ -29,8 +29,8 @@ import org.gradle.internal.fingerprint.impl.AbstractFileCollectionFingerprinter;
 
 import java.util.Map;
 
-public class DefaultClasspathFingerprinter extends AbstractFileCollectionFingerprinter implements ClasspathFingerprinter {
-    public DefaultClasspathFingerprinter(
+public class DefaultRuntimeClasspathFingerprinter extends AbstractFileCollectionFingerprinter implements ClasspathFingerprinter {
+    public DefaultRuntimeClasspathFingerprinter(
         ResourceSnapshotterCacheService cacheService,
         ResourceFilter classpathResourceFilter,
         ResourceEntryFilter manifestAttributeResourceEntryFilter,

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileCollectionFingerprinterRegistrations.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileCollectionFingerprinterRegistrations.java
@@ -27,7 +27,7 @@ import org.gradle.internal.execution.FileCollectionFingerprinter;
 import org.gradle.internal.execution.impl.FingerprinterRegistration;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
-import org.gradle.internal.fingerprint.classpath.impl.DefaultClasspathFingerprinter;
+import org.gradle.internal.fingerprint.classpath.impl.DefaultRuntimeClasspathFingerprinter;
 import org.gradle.internal.fingerprint.classpath.impl.DefaultCompileClasspathFingerprinter;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 import org.gradle.internal.service.scopes.Scope;
@@ -119,7 +119,7 @@ public class FileCollectionFingerprinterRegistrations {
     ) {
         return ImmutableList.of(
             new IgnoredPathFileCollectionFingerprinter(normalizedContentHasher),
-            new DefaultClasspathFingerprinter(
+            new DefaultRuntimeClasspathFingerprinter(
                 resourceSnapshotterCacheService,
                 resourceFilter,
                 metaInfFilter,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -63,7 +63,7 @@ import org.gradle.internal.file.FileSystemDefaultExcludesProvider;
 import org.gradle.internal.file.Stat;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter;
-import org.gradle.internal.fingerprint.classpath.impl.DefaultClasspathFingerprinter;
+import org.gradle.internal.fingerprint.classpath.impl.DefaultRuntimeClasspathFingerprinter;
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.impl.FileCollectionFingerprinterRegistrations;
 import org.gradle.internal.hash.DefaultFileHasher;
@@ -299,7 +299,7 @@ public class VirtualFileSystemServices extends AbstractGradleModuleServices {
 
         @Provides
         ClasspathFingerprinter createClasspathFingerprinter(ResourceSnapshotterCacheService resourceSnapshotterCacheService, StringInterner stringInterner) {
-            return new DefaultClasspathFingerprinter(resourceSnapshotterCacheService, ResourceFilter.FILTER_NOTHING, ResourceEntryFilter.FILTER_NOTHING, PropertiesFileFilter.FILTER_NOTHING, stringInterner, LineEndingSensitivity.DEFAULT);
+            return new DefaultRuntimeClasspathFingerprinter(resourceSnapshotterCacheService, ResourceFilter.FILTER_NOTHING, ResourceEntryFilter.FILTER_NOTHING, PropertiesFileFilter.FILTER_NOTHING, stringInterner, LineEndingSensitivity.DEFAULT);
         }
 
         @Provides

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/DefaultRuntimeClasspathFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/DefaultRuntimeClasspathFingerprinterTest.groovy
@@ -37,7 +37,7 @@ import spock.lang.Specification
 
 @CleanupTestDirectory(fieldName = "tmpDir")
 @UsesNativeServices
-class DefaultClasspathFingerprinterTest extends Specification {
+class DefaultRuntimeClasspathFingerprinterTest extends Specification {
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
@@ -48,7 +48,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
     def snapshotter = new DefaultFileCollectionSnapshotter(fileSystemAccess, TestFiles.fileSystem())
     TestInMemoryIndexedCache<HashCode, HashCode> resourceHashesCache = new TestInMemoryIndexedCache<>(new HashCodeSerializer())
     def cacheService = new DefaultResourceSnapshotterCacheService(resourceHashesCache)
-    def fingerprinter = new DefaultClasspathFingerprinter(
+    def fingerprinter = new DefaultRuntimeClasspathFingerprinter(
         cacheService,
         ResourceFilter.FILTER_NOTHING,
         ResourceEntryFilter.FILTER_NOTHING,


### PR DESCRIPTION
Currently, nodes in an execution graph can provide their owning project, as context. Services from this owning project are used to build a ProjectExecutionServices, which then provides services that nodes can use during execution.
    
In practice, most services that are required for task execution do not depend on project state. Only a small subset of services are actually derived from project state.
    
As part of Isolated Projects, we want to avoid passing around and handling mutable project instances. By having the task execution services derive from the project's service registry, we run the risk of access project-scoped services without capturing the correct resources.
    
This commit updates ProjectExecutionServices to explicitly accept the project-scoped state it needs to be initialized. This way, we can build the execution services based off of the build scoped services, and allow the execution services to be customized using the small subset of services that a project uses.
    
Eventually, we may be able to avoid caching ProjectExecutionServices instances on the project itself, improving scalability, as we might not necessarily need an instance of these services per project.
    
In any case, this commit moves us towards the goal of removing references to the Project interface from the execution engine, so that the engine can live outside of the context of a "project".

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
