### PR TITLE
[prone] fix `Finally` in `MetadataExtractor`

### DIFF
--- a/platforms/software/antlr/build.gradle.kts
+++ b/platforms/software/antlr/build.gradle.kts
@@ -4,12 +4,6 @@ plugins {
 
 description = "Adds support for generating parsers from Antlr grammars."
 
-errorprone {
-    disabledChecks.addAll(
-        "Finally", // 1 occurrences
-    )
-}
-
 dependencies {
     api(projects.core)
     api(projects.coreApi)

--- a/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrExecuter.java
+++ b/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrExecuter.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Lists;
 import org.gradle.api.GradleException;
 import org.gradle.api.plugins.antlr.internal.antlr2.GenerationPlan;
 import org.gradle.api.plugins.antlr.internal.antlr2.GenerationPlanBuilder;
-import org.gradle.api.plugins.antlr.internal.antlr2.MetadataExtractor;
 import org.gradle.api.plugins.antlr.internal.antlr2.XRef;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.os.OperatingSystem;
@@ -38,6 +37,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import static org.gradle.api.plugins.antlr.internal.AntlrSpec.PACKAGE_ARG;
+import static org.gradle.api.plugins.antlr.internal.antlr2.MetadataExtractor.extractMetadata;
 
 public class AntlrExecuter implements RequestHandler<AntlrSpec, AntlrResult> {
 
@@ -203,7 +203,7 @@ public class AntlrExecuter implements RequestHandler<AntlrSpec, AntlrResult> {
     private static class Antlr2Tool extends AntlrTool {
         @Override
         public AntlrResult doProcess(AntlrSpec spec) throws ClassNotFoundException {
-            XRef xref = new MetadataExtractor().extractMetadata(spec.getGrammarFiles());
+            XRef xref = extractMetadata(spec.getGrammarFiles());
             List<GenerationPlan> generationPlans = new GenerationPlanBuilder(spec.getOutputDirectory()).buildGenerationPlans(xref);
             for (GenerationPlan generationPlan : generationPlans) {
                 List<String> generationPlanArguments = Lists.newArrayList(spec.getArguments());

--- a/platforms/software/antlr/src/test/groovy/org/gradle/api/plugins/antlr/internal/antlr2/MetadataExtractorTest.groovy
+++ b/platforms/software/antlr/src/test/groovy/org/gradle/api/plugins/antlr/internal/antlr2/MetadataExtractorTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.api.plugins.antlr.internal.antlr2
 
 import spock.lang.Specification
 
+import static org.gradle.api.plugins.antlr.internal.antlr2.MetadataExtractor.getPackageName;
+
 class MetadataExtractorTest extends Specification {
 
     def "parses package information when defined in a separate line"() {
@@ -43,7 +45,7 @@ class MetadataExtractorTest extends Specification {
         atom:   INT
             ;"""
         expect:
-        "org.acme" == new MetadataExtractor().getPackageName(new StringReader(grammar))
+        "org.acme" == getPackageName(new StringReader(grammar))
     }
 
     def "parses package information when header is declared as one-liner"() {
@@ -67,7 +69,7 @@ class MetadataExtractorTest extends Specification {
         atom:   INT
             ;"""
         expect:
-        "org.acme" == new MetadataExtractor().getPackageName(new StringReader(grammar))
+        "org.acme" == getPackageName(new StringReader(grammar))
     }
 
     def "parses package information with header block in cpp syntax"() {
@@ -100,6 +102,6 @@ import org.hibernate.hql.internal.ast.ErrorReporter;
         atom:   INT
             ;"""
         expect:
-        "org.hibernate.hql.internal.antlr" == new MetadataExtractor().getPackageName(new StringReader(grammar))
+        "org.hibernate.hql.internal.antlr" == getPackageName(new StringReader(grammar))
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things




item.


MetadataExtractorTest > parses package information when defined in a separate line FAILED
    org.spockframework.runtime.ConditionFailedWithExceptionError at MetadataExtractorTest.groovy:48
        Caused by: java.lang.NoClassDefFoundError at MetadataExtractorTest.groovy:48
            Caused by: java.lang.ClassNotFoundException at MetadataExtractorTest.groovy:48
