### PR TITLE
Give docsTest more memory

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/MoreMemorySampleModifier.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/MoreMemorySampleModifier.java
@@ -47,7 +47,7 @@ public class MoreMemorySampleModifier implements SampleModifier {
         File propertiesFile = new File(projectDir, "gradle.properties");
         Properties properties = propertiesFile.exists() ? GUtil.loadProperties(propertiesFile) : new Properties();
         String existingArgs = properties.getProperty(ORG_GRADLE_JVMARGS, "");
-        properties.setProperty(ORG_GRADLE_JVMARGS, "-Xmx512m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError " + existingArgs);
+        properties.setProperty(ORG_GRADLE_JVMARGS, "-Xmx1024m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError " + existingArgs);
         GUtil.saveProperties(properties, propertiesFile);
     }
 }


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/4927

We now see frequent OOM in docsTest, [example](https://ge.gradle.org/s/j3y4uhzqfoyxg/tests/task/:docs:docsTest/details/org.gradle.docs.samples.bucket.Bucket25/snippet-dependency-management-declaring-configurations-kmp_groovy_build?focused-execution=1&top-execution=2#L194), [history](https://ge.gradle.org/scans/tests?search.startTimeMax=1763308799999&search.startTimeMin=1762617600000&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.docs.samples.bucket.Bucket25&tests.expandedTests=WzQsMCwyXQ&tests.test=snippet-dependency-management-declaring-configurations-kmp_groovy_build), let's start with giving them more memory.