### PR TITLE
Extract 'testJavaVersion' param

### DIFF
--- a/.teamcity/src/main/kotlin/common/CommonExtensions.kt
+++ b/.teamcity/src/main/kotlin/common/CommonExtensions.kt
@@ -334,7 +334,7 @@ fun functionalTestExtraParameters(
         )
     return (
         listOf(
-            "-PtestJavaVersion=$testJvmVersion",
+            "-PtestJavaVersion=%testJavaVersion%",
             "-PtestJavaVendor=$testJvmVendor",
         ) +
             buildScanTags.map { buildScanTagParam(it) } +

--- a/.teamcity/src/main/kotlin/common/PerformanceTestExtensions.kt
+++ b/.teamcity/src/main/kotlin/common/PerformanceTestExtensions.kt
@@ -50,12 +50,11 @@ fun performanceTestCommandLine(
     extraParameters: String = "",
     os: Os = Os.LINUX,
     arch: Arch = Arch.AMD64,
-    testJavaVersion: String = os.perfTestJavaVersion.major.toString(),
     testJavaVendor: String = os.perfTestJavaVendor.name.lowercase(),
 ) = listOf(
     "$task${if (extraParameters.isEmpty()) "" else " $extraParameters"}",
     "-PperformanceBaselines=$baselines",
-    "-PtestJavaVersion=$testJavaVersion",
+    "-PtestJavaVersion=%testJavaVersion%",
     "-PtestJavaVendor=$testJavaVendor",
     "-PautoDownloadAndroidStudio=true",
     "-PrunAndroidStudioInHeadlessMode=true",

--- a/.teamcity/src/main/kotlin/configurations/BuildDistributions.kt
+++ b/.teamcity/src/main/kotlin/configurations/BuildDistributions.kt
@@ -14,6 +14,10 @@ class BuildDistributions(
         name = "Build Distributions"
         description = "Creation and verification of the distribution and documentation"
 
+        params {
+            param("testJavaVersion", LINUX.buildJavaVersion.major.toString())
+        }
+
         applyDefaults(
             model,
             this,
@@ -22,7 +26,7 @@ class BuildDistributions(
                 listOf(
                     stage.getBuildScanCustomValueParam(),
                     buildScanTagParam("BuildDistributions"),
-                    "-PtestJavaVersion=${LINUX.buildJavaVersion.major}",
+                    "-PtestJavaVersion=%testJavaVersion%",
                     "-Dorg.gradle.java.installations.auto-download=false",
                     "-Porg.gradle.java.installations.auto-download=false",
                 ).joinToString(" "),

--- a/.teamcity/src/main/kotlin/configurations/DocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/DocsTest.kt
@@ -85,6 +85,10 @@ class DocsTest(
             javaCrash = false
         }
 
+        params {
+            param("testJavaVersion", testJava.version.major.toString())
+        }
+
         applyTestDefaults(
             model,
             this,
@@ -97,7 +101,7 @@ class DocsTest(
                     buildScanTagParam(docsTestType.docsTestName),
                     parallelizationMethod.extraBuildParameters,
                     "-PenableConfigurationCacheForDocsTests=${docsTestType.ccEnabled}",
-                    "-PtestJavaVersion=${testJava.version.major}",
+                    "-PtestJavaVersion=%testJavaVersion%",
                     "-PtestJavaVendor=${testJava.vendor.name.lowercase()}",
                 ).joinToString(" "),
         )

--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -92,6 +92,10 @@ class FlakyTestQuarantine(
             }
         }
 
+        params {
+            param("testJavaVersion", testCoverage.testJvmVersion.major.toString())
+        }
+
         val extraParameters =
             functionalTestExtraParameters(
                 listOf("FlakyTestQuarantine"),

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -86,6 +86,10 @@ class FunctionalTest(
         this.id(id)
         val testTasks = getTestTaskName(testCoverage, subprojects)
 
+        params {
+            param("testJavaVersion", testCoverage.testJvmVersion.major.toString())
+        }
+
         val assembledExtraParameters =
             mutableListOf(
                 stage.getBuildScanCustomValueParam(testCoverage),

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTestsPass.kt
@@ -17,6 +17,7 @@
 package configurations
 
 import common.applyDefaultSettings
+import jetbrains.buildServer.configs.kotlin.ParameterDisplay
 import model.CIBuildModel
 import model.TestCoverage
 import projects.FunctionalTestProject
@@ -33,6 +34,16 @@ class FunctionalTestsPass(
 
         dependencies {
             snapshotDependencies(functionalTestProject.functionalTests)
+        }
+
+        params {
+            text(
+                "reverse.dep.*.testJavaVersion",
+                functionalTestProject.testCoverage.testJvmVersion.major.toString(),
+                display = ParameterDisplay.NORMAL,
+                allowEmpty = true,
+                description = "Set to 'true' if you want to skip all dependency builds",
+            )
         }
     }) {
     val testCoverage: TestCoverage = functionalTestProject.testCoverage

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -72,6 +72,7 @@ class PerformanceTest(
                 )
                 param("env.PERFORMANCE_CHANNEL", performanceTestBuildSpec.channel())
                 param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
+                param("testJavaVersion", os.perfTestJavaVersion.major.toString())
                 when (os) {
                     Os.WINDOWS -> param("env.PATH", "%env.PATH%;C:/Program Files/7-zip")
                     else -> param("env.PATH", "%env.PATH%:/opt/swift/4.2.3/usr/bin:/opt/swift/4.2.4-RELEASE-ubuntu18.04/usr/bin")

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -31,6 +31,10 @@ class SmokeTests(
             requiresNotEc2Agent()
         }
 
+        params {
+            param("testJavaVersion", testJava.version.major.toString())
+        }
+
         applyTestDefaults(
             model,
             this,
@@ -40,7 +44,7 @@ class SmokeTests(
                 listOf(
                     stage.getBuildScanCustomValueParam(),
                     buildScanTagParam("SmokeTests"),
-                    "-PtestJavaVersion=${testJava.version.major}",
+                    "-PtestJavaVersion=%testJavaVersion%",
                     "-PtestJavaVendor=${testJava.vendor.name.lowercase()}",
                     "-PflakyTests=$flakyTestStrategy",
                 ).joinToString(" "),

--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -51,6 +51,13 @@ class CheckProject(
                         "e.g. `-PrerunAllTests` or `--no-build-cache`",
             )
             text(
+                "testJavaVersion",
+                "should-be-overwritten",
+                display = ParameterDisplay.NORMAL,
+                allowEmpty = true,
+                description = "The java version to use for test, e.g. '17', '21'",
+            )
+            text(
                 "reverse.dep.*.skip.build",
                 "",
                 display = ParameterDisplay.NORMAL,

--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -56,13 +56,6 @@ abstract class AdHocPerformanceScenario(
                     "Which performance test to run. Should be the fully qualified class name dot (unrolled) method name. " +
                         "E.g. org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel true)",
             )
-            text(
-                "testJavaVersion",
-                "17",
-                display = ParameterDisplay.PROMPT,
-                allowEmpty = false,
-                description = "The java version to run the performance tests, e.g. 8/11/17",
-            )
             select(
                 "testJavaVendor",
                 JvmVendor.OPENJDK.name.lowercase(),
@@ -103,7 +96,6 @@ abstract class AdHocPerformanceScenario(
                             """--warmups %warmups% --runs %runs% --checks %checks% --profiler %profiler% %additional.gradle.parameters%""",
                             os,
                             arch,
-                            "%testJavaVersion%",
                             "%testJavaVendor%",
                         ) + buildToolGradleParameters(isContinue = false)
                     ).joinToString(separator = " ")

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -19,7 +19,6 @@ package util
 import common.Arch
 import common.BuildToolBuildJvm
 import common.JvmVendor
-import common.JvmVersion
 import common.KillProcessMode.KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS
 import common.KillProcessMode.KILL_PROCESSES_STARTED_BY_GRADLE
 import common.Os
@@ -45,7 +44,6 @@ class RerunFlakyTest(
         description = "Allows you to rerun a selected flaky test 10 times"
         id(id)
         val testJvmVendorParameter = "testJavaVendor"
-        val testJvmVersionParameter = "testJavaVersion"
         val testTaskParameterName = "testTask"
         val testNameParameterName = "testName"
         val testTaskOptionsParameterName = "testTaskOptions"
@@ -59,7 +57,7 @@ class RerunFlakyTest(
                 listOf("RerunFlakyTest"),
                 os,
                 arch,
-                "%$testJvmVersionParameter%",
+                "%testJavaVersion%",
                 "%$testJvmVendorParameter%",
             )
         val parameters =
@@ -104,13 +102,6 @@ class RerunFlakyTest(
                 description =
                     "The name of the test to run, as should be passed to --tests. " +
                         "Can't contain spaces since there are problems with Teamcity's escaping, you can use * instead.",
-            )
-            text(
-                testJvmVersionParameter,
-                JvmVersion.JAVA_11.major.toString(),
-                display = ParameterDisplay.PROMPT,
-                allowEmpty = false,
-                description = "Java version to run the test with",
             )
             select(
                 testJvmVendorParameter,

--- a/.teamcity/src/test/kotlin/BuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/BuildTypeTest.kt
@@ -113,7 +113,7 @@ class BuildTypeTest {
                 "%additional.gradle.parameters%",
                 "--continue",
                 "-DbuildScan.PartOf=PlatformJava25AdoptiumWindowsAmd64,PullRequestFeedback,ReadyforNightly,ReadyforRelease",
-                "-PtestJavaVersion=25",
+                "-PtestJavaVersion=%testJavaVersion%",
                 "-PtestJavaVendor=openjdk",
                 "-Dscan.tag.FunctionalTest",
                 "-Dscan.value.coverageOs=windows",

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -84,7 +84,7 @@ class PerformanceTestBuildTypeTest {
         val expectedRunnerParams =
             listOf(
                 "-PperformanceBaselines=%performance.baselines%",
-                "-PtestJavaVersion=17",
+                "-PtestJavaVersion=%testJavaVersion%",
                 "-PtestJavaVendor=openjdk",
                 "-PautoDownloadAndroidStudio=true",
                 "-PrunAndroidStudioInHeadlessMode=true",
@@ -161,7 +161,7 @@ class PerformanceTestBuildTypeTest {
         val expectedRunnerParams =
             listOf(
                 "-PperformanceBaselines=%performance.baselines%",
-                "-PtestJavaVersion=17",
+                "-PtestJavaVersion=%testJavaVersion%",
                 "-PtestJavaVendor=openjdk",
                 "-PautoDownloadAndroidStudio=true",
                 "-PrunAndroidStudioInHeadlessMode=true",


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/4931

This PR creates a param `testJavaVersion`, which could be overwritten via TeamCity parameter.
