### PR TITLE
Express intent of `shadowJar` configuration in `kotlin-dsl` build file better

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl/build.gradle.kts
@@ -166,7 +166,14 @@ tasks.shadowJar {
     configurations = setOf(project.configurations.shadow.get())
     relocate("kotlin.metadata", "org.gradle.kotlin.dsl.internal.relocated.kotlin.metadata")
     relocate("kotlinx.metadata", "org.gradle.kotlin.dsl.internal.relocated.kotlinx.metadata")
+
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
     mergeServiceFiles()
+    filesMatching("META-INF/services/**") {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+
     exclude("META-INF/kotlin-metadata-jvm.kotlin_module")
     exclude("META-INF/kotlin-metadata.kotlin_module")
     exclude("META-INF/metadata.jvm.kotlin_module")


### PR DESCRIPTION
Addresses a comment made in another issue:
 * https://github.com/gradle/gradle/pull/35598#discussion_r2507689497

The default `duplicatesStrategy` we use (`DuplicatesStrategy.EXCLUDE`) is intended to take precedence over the service file merging performed by the `mergeServiceFiles()` call, so it's unclear what the configuration is meant to do. This PR attempts to convey it more effectively. 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
