### PR TITLE
Upgrade commons-lang3 3.20.0, close #35740

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
         api("com.google.code.findbugs:jsr305:3.0.2")
         api("org.jspecify:jspecify:1.0.0")
         api("commons-io:commons-io:2.14.0")
-        api("org.apache.commons:commons-lang3:3.17.0")
+        api("org.apache.commons:commons-lang3:3.20.0")
         api("javax.activation:activation:1.1.1")
         api("jakarta.xml.bind:jakarta.xml.bind-api:4.0.2")
         api("com.sun.xml.bind:jaxb-impl:4.0.5")

--- a/packaging/distributions-dependencies/build.gradle.kts
+++ b/packaging/distributions-dependencies/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
         api(libs.commonsCompress)       { version { strictly("1.26.1") } }
         api(libs.commonsHttpclient)     { version { strictly("4.5.14") } }
         api(libs.commonsIo)             { version { strictly("2.15.1") }}
-        api(libs.commonsLang)           { version { strictly("3.17.0") }}
+        api(libs.commonsLang)           { version { strictly("3.20.0") }}
         api(libs.commonsMath)           { version { strictly("3.6.1") }}
         api(libs.eclipseSisuPlexus)     { version { strictly("0.3.5"); because("transitive dependency of Maven modules to process POM metadata") }}
         api(libs.errorProneAnnotations) { version { strictly("2.42.0") } } // don't forget to upgrade errorprone in gradlebuild.code-quality.gradle.kts

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/TextUtil.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/TextUtil.java
@@ -16,6 +16,7 @@
 
 package org.gradle.util.internal;
 
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.UncheckedException;
@@ -353,7 +354,7 @@ public class TextUtil {
 
     // TODO: This should probably also live in GUtil to be with other camel/kebab case methods
     public static String screamingSnakeToKebabCase(String text) {
-        return StringUtils.replace(text.toLowerCase(Locale.ENGLISH), "_", "-");
+        return Strings.CS.replace(text.toLowerCase(Locale.ENGLISH), "_", "-");
     }
 
     /**

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -17,7 +17,7 @@
 package org.gradle.plugins.ide.internal.tooling;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.GradleInternal;
@@ -286,7 +286,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
             } else if (entry instanceof ProjectDependency) {
                 final ProjectDependency projectDependency = (ProjectDependency) entry;
                 // By removing the leading "/", this is no longer a "path" as defined by Eclipse
-                final String path = StringUtils.removeStart(projectDependency.getPath(), "/");
+                final String path = Strings.CS.removeStart(projectDependency.getPath(), "/");
                 boolean isProjectOpen = projectOpenStatus.getOrDefault(path, true);
                 if (!isProjectOpen) {
                     final File source = projectDependency.getPublicationSourcePath() == null ? null : projectDependency.getPublicationSourcePath().getFile();

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJvmVendorSpec.java
@@ -17,7 +17,7 @@
 package org.gradle.jvm.toolchain.internal;
 
 import com.google.common.base.Objects;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
 import org.gradle.internal.jvm.inspection.JvmVendor;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
@@ -52,7 +52,7 @@ public class DefaultJvmVendorSpec extends JvmVendorSpec implements Predicate<Jvm
     private DefaultJvmVendorSpec(String match, String description) {
         this.match = match;
         this.matchingVendor = null;
-        this.matcher = vendor -> StringUtils.containsIgnoreCase(vendor.getRawVendor(), match);
+        this.matcher = vendor -> Strings.CI.contains(vendor.getRawVendor(), match);
         this.description = description;
     }
 
@@ -121,7 +121,7 @@ public class DefaultJvmVendorSpec extends JvmVendorSpec implements Predicate<Jvm
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
         if (match != null) {
-            matcher = vendor -> StringUtils.containsIgnoreCase(vendor.getRawVendor(), match);
+            matcher = vendor -> Strings.CI.contains(vendor.getRawVendor(), match);
         } else if (matchingVendor != null) {
             matcher = vendor -> vendor.getKnownVendor() == matchingVendor;
         } else {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ArtifactFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ArtifactFile.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.dsl;
 
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
 
@@ -40,7 +41,7 @@ public class ArtifactFile {
         boolean done = false;
 
         if (version != null) {
-            int startVersion = StringUtils.lastIndexOf(name, "-" + version);
+            int startVersion = Strings.CS.lastIndexOf(name, "-" + version);
             if (startVersion >= 0) {
                 int endVersion = startVersion + version.length() + 1;
                 if (endVersion == name.length()) {
@@ -52,7 +53,7 @@ public class ArtifactFile {
                     classifier = StringUtils.substringBeforeLast(tail, ".");
                     extension = StringUtils.substringAfterLast(tail, ".");
                     done = true;
-                } else if (endVersion < name.length() && StringUtils.lastIndexOf(name, ".") == endVersion) {
+                } else if (endVersion < name.length() && Strings.CS.lastIndexOf(name, ".") == endVersion) {
                     extension = name.substring(endVersion + 1);
                     name = name.substring(0, startVersion);
                     done = true;

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.cache.MonitoredCleanupAction;
@@ -63,7 +63,7 @@ public class WrapperDistributionCleanupAction implements MonitoredCleanupAction 
     private static final Logger LOGGER = LoggerFactory.getLogger(WrapperDistributionCleanupAction.class);
 
     private static final ImmutableMap<String, Pattern> JAR_FILE_PATTERNS_BY_PREFIX;
-    private static final String BUILD_RECEIPT_ZIP_ENTRY_PATH = StringUtils.removeStart(DefaultGradleVersion.RESOURCE_NAME, "/");
+    private static final String BUILD_RECEIPT_ZIP_ENTRY_PATH = Strings.CS.removeStart(DefaultGradleVersion.RESOURCE_NAME, "/");
 
     static {
         Set<String> prefixes = ImmutableSet.of(


### PR DESCRIPTION
Motivation:

Current commons-lang3 3.17.0 suffers from this vulnerability: https://github.com/advisories/GHSA-j288-q9x7-2f5v.

As a result, gradle currently triggers vulnerability scan tools.

<!--- The issue this PR addresses -->
<!-- Fixes #35740 -->

### Context
<!--- Why do you believe many users will benefit from this change? -->

Easily solve a vulnerability reported by scan tools on all gradle deployments. 

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
