### PR TITLE
Add EC2 post build step to functional test builds

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -200,8 +200,8 @@ fun applyDefaults(
         extraSteps()
         killProcessStep(buildType, KILL_PROCESSES_STARTED_BY_GRADLE, os, arch, executionMode = ExecutionMode.ALWAYS)
         checkCleanM2AndAndroidUserHome(os, buildType)
-        buildType.addEc2PostBuild(os)
     }
+    buildType.addEc2PostBuild(os)
 
     applyDefaultDependencies(model, buildType)
 }
@@ -247,6 +247,7 @@ fun applyTestDefaults(
         extraSteps()
         checkCleanM2AndAndroidUserHome(os, buildType)
     }
+    buildType.addEc2PostBuild(os)
 
     applyDefaultDependencies(model, buildType)
 }

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -111,6 +111,7 @@ class ApplyDefaultConfigurationTest {
                 "MARK_BUILD_SUCCESSFUL_ON_RETRY_SUCCESS",
                 "KILL_PROCESSES_STARTED_BY_GRADLE",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME",
+                "EC2_POST_BUILD",
             ),
             steps.items.map(BuildStep::name),
         )


### PR DESCRIPTION
This PR adds the missing `EC2_POST_BUILD` step to functional test builds.