### PR TITLE
Create ToolingModelContext and propagate isFetch to BuildToolingModelController

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildToolingModelController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationCacheAwareBuildToolingModelController.kt
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.internal.build.BuildToolingModelController
+import org.gradle.internal.buildtree.ToolingModelRequestContext
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
 import org.gradle.tooling.provider.model.internal.ToolingModelScope
 
@@ -30,12 +31,12 @@ class ConfigurationCacheAwareBuildToolingModelController(
 ) : BuildToolingModelController {
     override fun getConfiguredModel(): GradleInternal = delegate.configuredModel
 
-    override fun locateBuilderForTarget(modelName: String, param: Boolean): ToolingModelScope {
-        return wrap(delegate.locateBuilderForTarget(modelName, param))
+    override fun locateBuilderForTarget(toolingModelRequestContext: ToolingModelRequestContext): ToolingModelScope {
+        return wrap(delegate.locateBuilderForTarget(toolingModelRequestContext))
     }
 
-    override fun locateBuilderForTarget(target: ProjectState, modelName: String, param: Boolean): ToolingModelScope {
-        return wrap(delegate.locateBuilderForTarget(target, modelName, param))
+    override fun locateBuilderForTarget(target: ProjectState, toolingModelRequestContext: ToolingModelRequestContext): ToolingModelScope {
+        return wrap(delegate.locateBuilderForTarget(target, toolingModelRequestContext))
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildToolingModelControllerFactory.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultBuildToolingModelControllerFactory.kt
@@ -30,9 +30,9 @@ internal
 class DefaultBuildToolingModelControllerFactory(
     private val modelParameters: BuildModelParameters
 ) : BuildToolingModelControllerFactory {
-    override fun createController(owner: BuildState, lifecycleController: BuildLifecycleController): BuildToolingModelController {
+    override fun createController(owner: BuildState, lifecycleController: BuildLifecycleController, inResilientContext: Boolean): BuildToolingModelController {
         val modelBuilderLookup = lifecycleController.gradle.services.get(ToolingModelBuilderLookup::class.java)
-        val toolingModelController = if (modelParameters.isResilientModelBuilding) {
+        val toolingModelController = if (inResilientContext) {
             ResilientBuildToolingModelController(owner, lifecycleController, modelBuilderLookup)
         } else {
             DefaultBuildToolingModelController(owner, lifecycleController, modelBuilderLookup)

--- a/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
+++ b/platforms/ide/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
@@ -27,6 +27,7 @@ import org.gradle.tooling.internal.provider.action.BuildModelAction;
 import org.gradle.tooling.internal.provider.serialization.PayloadSerializer;
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
 import org.gradle.tooling.provider.model.UnknownModelException;
+import org.gradle.internal.buildtree.ToolingModelRequestContext;
 
 public class BuildModelActionRunner implements BuildActionRunner {
     private final PayloadSerializer payloadSerializer;
@@ -79,7 +80,7 @@ public class BuildModelActionRunner implements BuildActionRunner {
         public Object fromBuildModel(BuildTreeModelController controller) {
             String modelName = buildModelAction.getModelName();
             try {
-                return controller.getModel(BuildTreeModelTarget.ofDefault(), modelName, null);
+                return controller.getModel(BuildTreeModelTarget.ofDefault(), new ToolingModelRequestContext(modelName, null, false));
             } catch (UnknownModelException e) {
                 modelLookupFailure = e;
                 throw e;

--- a/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
+++ b/platforms/ide/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
@@ -71,7 +71,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * workerThreadRegistry.workerThread >> true
-        1 * modelController.getModel(_, 'some.model', null) >> { throw failure }
+        1 * modelController.getModel(_, _) >> { throw failure }
 
         when:
         controller.getModel(null, modelId)
@@ -102,7 +102,7 @@ class DefaultBuildControllerTest extends Specification {
         _ * workerThreadRegistry.workerThread >> true
         _ * target.projectPath >> ":some:path"
         _ * target.rootDir >> rootDir
-        1 * modelController.getModel(_, "some.model", null) >> { BuildTreeModelTarget t, m, p ->
+        1 * modelController.getModel(_, _) >> { BuildTreeModelTarget t, context ->
             assert t.buildRootDir == rootDir && t.projectPath == Path.path(":some:path")
             model
         }
@@ -122,7 +122,7 @@ class DefaultBuildControllerTest extends Specification {
         given:
         _ * workerThreadRegistry.workerThread >> true
         _ * target.rootDir >> rootDir
-        1 * modelController.getModel(_, "some.model", null) >> { BuildTreeModelTarget t, m, p ->
+        1 * modelController.getModel(_, _) >> { BuildTreeModelTarget t, context ->
             assert t instanceof BuildTreeModelTarget.Build && t.buildRootDir == rootDir
             model
         }
@@ -139,7 +139,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * workerThreadRegistry.workerThread >> true
-        1 * modelController.getModel(_, "some.model", null) >> model
+        1 * modelController.getModel(_, _) >> model
 
         when:
         def result = controller.getModel(null, modelId)
@@ -175,7 +175,7 @@ class DefaultBuildControllerTest extends Specification {
 
         given:
         _ * workerThreadRegistry.workerThread >> true
-        1 * modelController.getModel(_, 'some.model', parameter) >> model
+        1 * modelController.getModel(_, _) >> model
 
         when:
         def result = controller.getModel(null, modelId, parameter)

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientKotlinDslScriptsModelBuilderCrossVersionSpec.groovy
@@ -73,8 +73,8 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         when:
         def resilientModels = succeeds {
             action(KotlinModelAction.resilientModel(ROOT_PROJECT_FIRST))
-                    .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
-                    .run()
+                .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
+                .run()
         }
 
         then:
@@ -110,14 +110,14 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         when:
         def model = succeeds {
             action(KotlinModelAction.resilientModel(ROOT_PROJECT_FIRST))
-                    .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
-                    .run()
+                .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
+                .run()
         }
 
         then:
         assertHasScriptModelForFiles(model/*, "settings.gradle.kts"*/)
         assertHasErrorsInScriptModels(model,
-                Pair.of(".", ".*Settings file.*settings\\.gradle\\.kts.*Script compilation error.*"))
+            Pair.of(".", ".*Settings file.*settings\\.gradle\\.kts.*Script compilation error.*"))
         // assertHasJarsInScriptModelClasspath(model, "settings.gradle.kts", "gradle-kotlin-dsl-plugins")
     }
 
@@ -140,14 +140,14 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         when:
         def model = succeeds {
             action(KotlinModelAction.resilientModel(ROOT_PROJECT_FIRST))
-                    .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
-                    .run()
+                .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
+                .run()
         }
 
         then:
         assertHasScriptModelForFiles(model, "settings.gradle.kts", "build.gradle.kts")
         assertHasErrorsInScriptModels(model,
-                Pair.of(".", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"))
+            Pair.of(".", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"))
         assertHasJarsInScriptModelClasspath(model, "build.gradle.kts", "gradle-kotlin-dsl-plugins")
     }
 
@@ -163,14 +163,14 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         when:
         def model = succeeds {
             action(KotlinModelAction.resilientModel(ROOT_PROJECT_FIRST))
-                    .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
-                    .run()
+                .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
+                .run()
         }
 
         then:
         assertHasScriptModelForFiles(model, "settings.gradle.kts", "build.gradle.kts")
         assertHasErrorsInScriptModels(model,
-                Pair.of(".", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"))
+            Pair.of(".", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"))
         assertHasJarsInScriptModelClasspath(model, "build.gradle.kts", "gradle-api")
     }
 
@@ -198,15 +198,15 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         when:
         def model = succeeds {
             action(KotlinModelAction.resilientModel(ROOT_PROJECT_FIRST))
-                    .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
-                    .run()
+                .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
+                .run()
         }
 
         then:
         assertHasScriptModelForFiles(model, "settings.gradle.kts", "included/settings.gradle.kts", "included/build.gradle.kts")
         assertHasErrorsInScriptModels(model,
-                Pair.of(".", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"),
-                Pair.of("included", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"))
+            Pair.of(".", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"),
+            Pair.of("included", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"))
         assertHasJarsInScriptModelClasspath(model, "included/build.gradle.kts", "gradle-kotlin-dsl-plugins")
     }
 
@@ -228,15 +228,15 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         when:
         def model = succeeds {
             action(KotlinModelAction.resilientModel(ROOT_PROJECT_FIRST))
-                    .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
-                    .run()
+                .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
+                .run()
         }
 
         then:
         assertHasScriptModelForFiles(model, "settings.gradle.kts", "included/settings.gradle.kts", "included/build.gradle.kts")
         assertHasErrorsInScriptModels(model,
-                Pair.of(".", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"),
-                Pair.of("included", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"))
+            Pair.of(".", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"),
+            Pair.of("included", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"))
         assertHasJarsInScriptModelClasspath(model, "included/build.gradle.kts", "gradle-api")
     }
 
@@ -269,15 +269,15 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         when:
         def model = succeeds {
             action(KotlinModelAction.resilientModel(ROOT_PROJECT_FIRST))
-                    .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
-                    .run()
+                .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
+                .run()
         }
 
         then:
         assertHasScriptModelForFiles(model, /*"settings.gradle.kts"*/)
         assertHasErrorsInScriptModels(model,
-                Pair.of(".", ".*Settings file.*settings\\.gradle\\.kts.*Script compilation error.*"),
-                Pair.of("included", ".*Settings file.*settings\\.gradle\\.kts.*Script compilation error.*"))
+            Pair.of(".", ".*Settings file.*settings\\.gradle\\.kts.*Script compilation error.*"),
+            Pair.of("included", ".*Settings file.*settings\\.gradle\\.kts.*Script compilation error.*"))
         // assertHasJarsInScriptModelClasspath(model, "settings.gradle.kts", "gradle-kotlin-dsl-plugins")
     }
 
@@ -320,8 +320,8 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         when:
         def resilientModels = succeeds {
             action(KotlinModelAction.resilientModel(ROOT_PROJECT_FIRST))
-                    .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
-                    .run()
+                .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
+                .run()
         }
 
         then:
@@ -378,8 +378,8 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         c << """$breakage"""
         def resilientModels = succeeds {
             action(KotlinModelAction.resilientModel(queryStrategy))
-                    .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
-                    .run()
+                .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
+                .run()
         }
 
         then:
@@ -470,8 +470,8 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         projectPlugin << "throw RuntimeException(\"Failing script\")"
         def resilientModels = succeeds {
             action(KotlinModelAction.resilientModel(queryStrategy))
-                    .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
-                    .run()
+                .withArguments("-Dorg.gradle.internal.resilient-model-building=true")
+                .run()
         }
 
         then:
@@ -587,7 +587,7 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         }
         // At the moment the failure reporting is not consistent and depends on the order of query
         def actualNoOfFailures = resilientModels.failures.size()
-        assert actualNoOfFailures == expectedNoOfFailures : "Expected $expectedNoOfFailures failures, but had ${actualNoOfFailures}"
+        assert actualNoOfFailures == expectedNoOfFailures: "Expected $expectedNoOfFailures failures, but had ${actualNoOfFailures}"
         rootBuildFailure?.with {
             expectFailureToContain(resilientModels.failures[settingsKotlinFile.parentFile], it)
         }
@@ -596,9 +596,9 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         }
 
         where:
-        queryStrategy         | expectedNoOfFailures    | rootBuildFailure                               | includedBuildFailure
-        ROOT_PROJECT_FIRST    | 2                       | "A problem occurred configuring project ':b'." | "Execution failed for task ':build-logic:compileKotlin'."
-        INCLUDED_BUILDS_FIRST | 1                       | "A problem occurred configuring project ':b'." | null
+        queryStrategy         | expectedNoOfFailures | rootBuildFailure                               | includedBuildFailure
+        ROOT_PROJECT_FIRST    | 2                    | "A problem occurred configuring project ':b'." | "Execution failed for task ':build-logic:compileKotlin'."
+        INCLUDED_BUILDS_FIRST | 1                    | "A problem occurred configuring project ':b'." | null
     }
 
     def "build with convention plugins - broken settings convention"() {
@@ -654,8 +654,8 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
 
         assertHasScriptModelForFiles(model, "build-logic/settings.gradle.kts", "build-logic/build.gradle.kts", "build-logic/src/main/kotlin/build-logic.settings.gradle.kts")
         assertHasErrorsInScriptModels(model,
-                Pair.of(".", ".*Execution failed for task ':build-logic:compileKotlin.*"),
-                Pair.of("build-logic", ".*Execution failed for task ':build-logic:compileKotlin.*"))
+            Pair.of(".", ".*Execution failed for task ':build-logic:compileKotlin.*"),
+            Pair.of("build-logic", ".*Execution failed for task ':build-logic:compileKotlin.*"))
     }
 
     @ToBeImplemented
@@ -678,7 +678,7 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         then:
         assertHasScriptModelForFiles(model/*, "settings.gradle.kts", "build.gradle.kts"*/)
         assertHasErrorsInScriptModels(model,
-                Pair.of(".", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"))
+            Pair.of(".", ".*Build file.*build\\.gradle\\.kts.*Script compilation error.*"))
         // assertHasJarsInScriptModelClasspath(model, "build.gradle.kts", "gradle-kotlin-dsl-plugins")
     }
 
@@ -701,7 +701,7 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
             matchProjectFailure(failure, expectedElement.right)
         }
 
-        assert failures.isEmpty() : "Unexpected failures for build roots: ${failures.keySet()}"
+        assert failures.isEmpty(): "Unexpected failures for build roots: ${failures.keySet()}"
     }
 
     private static void matchProjectFailure(String failureMessage, String expectedPattern) {
@@ -715,27 +715,27 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         assert scriptModel != null: "Expected script model for file $expectedFile, but there wasn't one"
 
         def jarFilesInClasspath = scriptModel.classPath.stream()
-                .filter { it.isFile() }
-                .map { it.name }
-                .filter { it.endsWith(".jar") }
-                .collect(Collectors.toList())
+            .filter { it.isFile() }
+            .map { it.name }
+            .filter { it.endsWith(".jar") }
+            .collect(Collectors.toList())
 
         for (String expectedJar : expectedJars) {
             assert jarFilesInClasspath.stream().filter { it.startsWith(expectedJar) }.findFirst().isPresent():
-                    "Expected jar named $expectedJar in the script model classpath for file $expectedFile, " +
-                            "but it wasn't there: ${jarFilesInClasspath.stream().collect(Collectors.joining("\n\t", "\n\t", ""))}"
+                "Expected jar named $expectedJar in the script model classpath for file $expectedFile, " +
+                    "but it wasn't there: ${jarFilesInClasspath.stream().collect(Collectors.joining("\n\t", "\n\t", ""))}"
         }
     }
 
     static void expectFailureToContain(String actualFailure, String expectedFragment) {
-        assert actualFailure.contains(expectedFragment) :
-                "Failure expected to contain \"${expectedFragment}\", but was \"\n${actualFailure}\n\" instead!"
+        assert actualFailure.contains(expectedFragment):
+            "Failure expected to contain \"${expectedFragment}\", but was \"\n${actualFailure}\n\" instead!"
     }
 
     private static void queryResilientKotlinDslScriptsModel(BuildController controller, GradleBuild build, Model target, Map<File, KotlinDslScriptModel> scriptModels, Map<File, Failure> failures) {
         def modelResult = controller.fetch(target, KotlinDslScriptsModel.class)
 
-        assert modelResult.failures.size() <= 1 : "Expected a single failure, but got multiple ones"
+        assert modelResult.failures.size() <= 1: "Expected a single failure, but got multiple ones"
         def failure = modelResult.failures.stream().findAny()
         if (failure.isPresent()) {
             failures[build.buildIdentifier.rootDir] = failure.get()
@@ -758,7 +758,7 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
 
         KotlinModel(Map<File, KotlinDslScriptModel> scriptModels, Map<File, Failure> failures) {
             this.scriptModels = scriptModels
-            this.failures = failures.collectEntries { key, value -> [ key, value.description ]}
+            this.failures = failures.collectEntries { key, value -> [key, value.description] }
         }
     }
 
@@ -779,7 +779,12 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
 
         @Override
         KotlinModel execute(BuildController controller) {
-            GradleBuild rootBuild = controller.getModel(GradleBuild.class)
+            GradleBuild rootBuild
+            if (resilient) {
+                rootBuild = controller.fetch(GradleBuild.class).model
+            } else {
+                rootBuild = controller.getModel(GradleBuild.class)
+            }
             Map<File, KotlinDslScriptModel> scriptModels = [:]
             Map<File, Failure> failures = [:]
 
@@ -844,42 +849,42 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
         }
 
         ComparingModelAssert assertBothModelsExist() {
-            assert originalModel : "Original model for script ${scriptFile} is missing, scripts that have original model are:\n" +
-                        " ${originalCustomModel.scriptModels.keySet()}"
-            assert resilientModel : "Resilient model for script ${scriptFile} is missing, scripts that have resilient model are:\n" +
-                        " ${resilientCustomModel.scriptModels.keySet()}"
+            assert originalModel: "Original model for script ${scriptFile} is missing, scripts that have original model are:\n" +
+                " ${originalCustomModel.scriptModels.keySet()}"
+            assert resilientModel: "Resilient model for script ${scriptFile} is missing, scripts that have resilient model are:\n" +
+                " ${resilientCustomModel.scriptModels.keySet()}"
             return this
         }
 
 
         ComparingModelAssert assertClassPathsAreEqual() {
-            assert resilientModel.classPath == originalModel.classPath : "Class paths are not equal for script ${scriptFile}:\n" +
-                        " - Resilient classPath: ${resilientModel.classPath}\n" +
-                        " - Original classPath:  ${originalModel.classPath}"
+            assert resilientModel.classPath == originalModel.classPath: "Class paths are not equal for script ${scriptFile}:\n" +
+                " - Resilient classPath: ${resilientModel.classPath}\n" +
+                " - Original classPath:  ${originalModel.classPath}"
             return this
         }
 
         ComparingModelAssert assertClassPathsAreEqualIfIgnoringSomeOriginalEntries(Function<String, Boolean> filter) {
             def filteredOriginalClassPath = originalModel.classPath.findAll { filter.apply(TextUtil.normaliseFileSeparators(it.absolutePath)) }
-            assert resilientModel.classPath == filteredOriginalClassPath : "Class paths are not equal after filtering original entries for script ${scriptFile}:\n" +
-                        " - Resilient classPath:         ${resilientModel.classPath}\n" +
-                        " - Filtered original classPath: ${filteredOriginalClassPath}"
+            assert resilientModel.classPath == filteredOriginalClassPath: "Class paths are not equal after filtering original entries for script ${scriptFile}:\n" +
+                " - Resilient classPath:         ${resilientModel.classPath}\n" +
+                " - Filtered original classPath: ${filteredOriginalClassPath}"
             return this
         }
 
         ComparingModelAssert assertClassPathsAreEqualIfIgnoringSomeEntries(Function<String, Boolean> filter) {
             def filteredResilient = resilientModel.classPath.findAll { filter.apply(TextUtil.normaliseFileSeparators(it.absolutePath)) }
             def filteredOriginalClassPath = originalModel.classPath.findAll { filter.apply(TextUtil.normaliseFileSeparators(it.absolutePath)) }
-            assert filteredResilient == filteredOriginalClassPath : "Class paths are not equal after filtering some entries for script ${scriptFile}:\n" +
-                        " - Riltered resilient: ${filteredResilient}\n" +
-                        " - Riltered original:  ${filteredOriginalClassPath}"
+            assert filteredResilient == filteredOriginalClassPath: "Class paths are not equal after filtering some entries for script ${scriptFile}:\n" +
+                " - Riltered resilient: ${filteredResilient}\n" +
+                " - Riltered original:  ${filteredOriginalClassPath}"
             return this
         }
 
         ComparingModelAssert assertResilientModelContainsClassPathEntriesWithPath(String path) {
             def filteredResilient = resilientModel.classPath.findAll { TextUtil.normaliseFileSeparators(it.absolutePath).contains(path) }
-            assert !filteredResilient.isEmpty() : "Resilient Class paths for script ${scriptFile} did not contain entries with path '${path}':\n" +
-                    " - Resilient classPath: ${resilientModel.classPath}"
+            assert !filteredResilient.isEmpty(): "Resilient Class paths for script ${scriptFile} did not contain entries with path '${path}':\n" +
+                " - Resilient classPath: ${resilientModel.classPath}"
             return this
         }
 
@@ -887,8 +892,8 @@ class ResilientKotlinDslScriptsModelBuilderCrossVersionSpec extends ToolingApiSp
             def relevantResilientImports = minusAccessors(resilientModel.implicitImports)
             def relevantOriginalImports = minusAccessors(originalModel.implicitImports)
             assert relevantResilientImports == relevantOriginalImports: "Implicit imports are not equal for script ${scriptFile}:\n" +
-                        " - Resilient imports: $relevantResilientImports\n" +
-                        " - Original imports:  $relevantOriginalImports"
+                " - Resilient imports: $relevantResilientImports\n" +
+                " - Original imports:  $relevantOriginalImports"
             return this
         }
 

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -408,7 +408,7 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
         }
 
         @Override
-        <T> T withToolingModels(Function<? super BuildToolingModelController, T> action) {
+        <T> T withToolingModels(boolean inResilientContext, Function<? super BuildToolingModelController, T> action) {
             throw new UnsupportedOperationException()
         }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -165,8 +165,8 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
     }
 
     @Override
-    public <T> T withToolingModels(Function<? super BuildToolingModelController, T> action) {
-        return getBuildController().withToolingModels(action);
+    public <T> T withToolingModels(boolean inResilientContext, Function<? super BuildToolingModelController, T> action) {
+        return getBuildController().withToolingModels(inResilientContext, action);
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildLifecycleController.java
@@ -108,7 +108,7 @@ public interface BuildLifecycleController {
     /**
      * Runs an action against the tooling model creators of this build. May configure the build as required.
      */
-    <T> T withToolingModels(Function<? super BuildToolingModelController, T> action);
+    <T> T withToolingModels(boolean inResilientContext, Function<? super BuildToolingModelController, T> action);
 
     /**
      * Calls the `buildFinished` hooks and other user code clean up.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -120,7 +120,7 @@ public interface BuildState {
     /**
      * Runs an action against the tooling model creators of this build. May configure the build as required.
      */
-    <T> T withToolingModels(Function<? super BuildToolingModelController, T> action);
+    <T> T withToolingModels(boolean inResilientContext, Function<? super BuildToolingModelController, T> action);
 
     /**
      * Runs whatever work is required prior to discarding the model for this build. Called prior to {@link #resetModel()}.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildToolingModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildToolingModelController.java
@@ -18,6 +18,7 @@ package org.gradle.internal.build;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectState;
+import org.gradle.internal.buildtree.ToolingModelRequestContext;
 import org.gradle.tooling.provider.model.internal.ToolingModelScope;
 
 /**
@@ -29,7 +30,7 @@ public interface BuildToolingModelController {
      */
     GradleInternal getConfiguredModel();
 
-    ToolingModelScope locateBuilderForTarget(String modelName, boolean param);
+    ToolingModelScope locateBuilderForTarget(ToolingModelRequestContext toolingModelContext);
 
-    ToolingModelScope locateBuilderForTarget(ProjectState target, String modelName, boolean param);
+    ToolingModelScope locateBuilderForTarget(ProjectState target, ToolingModelRequestContext toolingModelContext);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildToolingModelControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildToolingModelControllerFactory.java
@@ -21,5 +21,5 @@ import org.gradle.internal.service.scopes.ServiceScope;
 
 @ServiceScope(Scope.BuildTree.class)
 public interface BuildToolingModelControllerFactory {
-    BuildToolingModelController createController(BuildState owner, BuildLifecycleController controller);
+    BuildToolingModelController createController(BuildState owner, BuildLifecycleController controller, boolean inResilientContext);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -323,8 +323,8 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
     }
 
     @Override
-    public <T> T withToolingModels(Function<? super BuildToolingModelController, T> action) {
-        return action.apply(toolingModelControllerFactory.createController(targetBuild(), this));
+    public <T> T withToolingModels(boolean inResilientContext, Function<? super BuildToolingModelController, T> action) {
+        return action.apply(toolingModelControllerFactory.createController(targetBuild(), this, inResilientContext));
     }
 
     private BuildState targetBuild() {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/ResilientBuildToolingModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/ResilientBuildToolingModelController.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
+import org.gradle.internal.buildtree.ToolingModelRequestContext;
 import org.gradle.tooling.provider.model.UnknownModelException;
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup;
 import org.gradle.tooling.provider.model.internal.ToolingModelScope;
@@ -36,7 +37,8 @@ public class ResilientBuildToolingModelController extends DefaultBuildToolingMod
     public ResilientBuildToolingModelController(
         BuildState buildState,
         BuildLifecycleController buildController,
-        ToolingModelBuilderLookup buildScopeLookup) {
+        ToolingModelBuilderLookup buildScopeLookup
+    ) {
         super(buildState, buildController, buildScopeLookup);
     }
 
@@ -59,18 +61,17 @@ public class ResilientBuildToolingModelController extends DefaultBuildToolingMod
             // the model we are building is not a resilient one, no point in pushing further
             throw e;
         }
-
         // swallowing the exception, there is hope of going further
     }
 
     @Override
-    protected ToolingModelScope doLocate(ProjectState target, String modelName, boolean param) {
-        return new ResilientProjectToolingScope(target, modelName, param);
+    protected ToolingModelScope doLocate(ProjectState target, ToolingModelRequestContext toolingModelContext) {
+        return new ResilientProjectToolingScope(target, toolingModelContext);
     }
 
     private static class ResilientProjectToolingScope extends ProjectToolingScope {
-        public ResilientProjectToolingScope(ProjectState target, String modelName, boolean parameter) {
-            super(target, modelName, parameter);
+        public ResilientProjectToolingScope(ProjectState target, ToolingModelRequestContext toolingModelContext) {
+            super(target, toolingModelContext.getModelName(), toolingModelContext.getParameter().isPresent());
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelController.java
@@ -38,7 +38,7 @@ public interface BuildTreeModelController {
      * @throws UnknownModelException when the model builder cannot be found
      */
     @Nullable
-    Object getModel(BuildTreeModelTarget target, String modelName, @Nullable Object parameter) throws UnknownModelException;
+    Object getModel(BuildTreeModelTarget target, ToolingModelRequestContext modelRequestContext) throws UnknownModelException;
 
     boolean queryModelActionsRunInParallel();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/ToolingModelRequestContext.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/ToolingModelRequestContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildtree;
+
+import java.util.Optional;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+public class ToolingModelRequestContext {
+    private final String modelName;
+    @Nullable
+    private final Object parameter;
+    // this is true if the `fetch` API is used.
+    private final boolean inResilientContext;
+
+    public ToolingModelRequestContext(String modelName, @Nullable Object parameter, boolean inResilientContext) {
+        this.modelName = modelName;
+        this.parameter = parameter;
+        this.inResilientContext = inResilientContext;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public Optional<Object> getParameter() {
+        return Optional.ofNullable(parameter);
+    }
+
+    public boolean inResilientContext() {
+        return inResilientContext;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultIntermediateToolingModelProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultIntermediateToolingModelProvider.java
@@ -23,6 +23,7 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildToolingModelController;
 import org.gradle.internal.buildtree.IntermediateBuildActionRunner;
+import org.gradle.internal.buildtree.ToolingModelRequestContext;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -73,7 +74,7 @@ public class DefaultIntermediateToolingModelProvider implements IntermediateTool
         reportToolingModelDependencies(requester, targets);
         BuildState buildState = extractSingleBuildState(targets);
         ToolingModelParameterCarrier carrier = parameter == null ? null : parameterCarrierFactory.createCarrier(parameter);
-        return buildState.withToolingModels(controller -> getModels(controller, targets, modelName, carrier));
+        return buildState.withToolingModels(false, controller -> getModels(controller, targets, modelName, carrier));
     }
 
     private List<Object> getModels(BuildToolingModelController controller, List<ProjectState> targets, String modelName, @Nullable ToolingModelParameterCarrier parameter) {
@@ -86,7 +87,7 @@ public class DefaultIntermediateToolingModelProvider implements IntermediateTool
 
     @Nullable
     private static Object fetchModel(String modelName, BuildToolingModelController controller, ProjectState builderTarget, @Nullable ToolingModelParameterCarrier parameter) {
-        ToolingModelScope toolingModelScope = controller.locateBuilderForTarget(builderTarget, modelName, parameter != null);
+        ToolingModelScope toolingModelScope = controller.locateBuilderForTarget(builderTarget, new ToolingModelRequestContext(modelName, parameter, false));
         return toolingModelScope.getModel(modelName, parameter);
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeModelCreatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeModelCreatorTest.groovy
@@ -37,17 +37,19 @@ class DefaultBuildTreeModelCreatorTest extends Specification {
         def model = new Object()
 
         def modelScope = Mock(ToolingModelScope) {
-            getModel(_, _) >> model
+            getModel(_, _) >> { String modelName, @Nullable ToolingModelParameterCarrier parameter ->
+                model
+            }
         }
         def modelController = Mock(BuildToolingModelController) {
-            locateBuilderForTarget(_, _) >> modelScope
+            locateBuilderForTarget(_) >> modelScope
         }
 
         def buildRootDir = new File("dummy")
         def buildState1 = Stub(BuildState) {
             isImportableBuild() >> true
             getBuildRootDir() >> buildRootDir
-            withToolingModels(_) >> { Function action ->
+            withToolingModels(_, _) >> { boolean b, Function action ->
                 action.apply(modelController)
             }
         }
@@ -111,7 +113,7 @@ class DefaultBuildTreeModelCreatorTest extends Specification {
 
             @Override
             Object fromBuildModel(BuildTreeModelController controller) {
-                return controller.getModel(target, modelName, parameter)
+                return controller.getModel(target, new ToolingModelRequestContext(modelName, parameter, false))
             }
         })
     }


### PR DESCRIPTION
The goal is to avoid use of the `isResilientModelBuilding` property, so we can get rid of it.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
