### PR TITLE
Provide a useful error message when starting tests under a JUnit TEST

### DIFF
--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestDefinitionProcessor.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestDefinitionProcessor.java
@@ -161,7 +161,7 @@ public final class JUnitPlatformTestDefinitionProcessor extends AbstractJUnitTes
 
         private void processAllTestDefinitions() {
             LauncherDiscoveryRequest discoveryRequest = createLauncherDiscoveryRequest();
-            TestExecutionListener executionListener = new JUnitPlatformTestExecutionListener(resultProcessor, clock, idGenerator, spec.getBaseDefinitionsDir());
+            JUnitPlatformTestExecutionListener executionListener = new JUnitPlatformTestExecutionListener(resultProcessor, clock, idGenerator, spec.getBaseDefinitionsDir());
             Launcher launcher = Objects.requireNonNull(launcherSession).getLauncher();
             if (spec.isDryRun()) {
                 TestPlan testPlan = launcher.discover(discoveryRequest);
@@ -169,6 +169,7 @@ public final class JUnitPlatformTestDefinitionProcessor extends AbstractJUnitTes
             } else {
                 launcher.execute(discoveryRequest, executionListener);
             }
+            executionListener.throwAnyFatalExceptions();
         }
 
         private Class<?> loadClass(String className) {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/nonclassbased/UsesOnlyTestDynamicNonClassBasedTestingIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/nonclassbased/UsesOnlyTestDynamicNonClassBasedTestingIntegrationTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.nonclassbased
+
+class UsesOnlyTestDynamicNonClassBasedTestingIntegrationTest extends AbstractNonClassBasedTestingIntegrationTest {
+    @Override
+    List<TestEngines> getEnginesToSetup() {
+        return [TestEngines.USES_ONLY_TEST_RESOURCE_BASED_DYNAMIC]
+    }
+
+    def "test-only dynamic resource-based test engine fails with a reasonable error message"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing.suites.test {
+                ${enableEngineForSuite()}
+
+                targets.all {
+                    testTask.configure {
+                        testDefinitionDirs.from("$DEFAULT_DEFINITIONS_LOCATION")
+                    }
+                }
+            }
+        """
+
+        file("${DEFAULT_DEFINITIONS_LOCATION}/SomeTestSpec.rbt") << """<?xml version="1.0" encoding="UTF-8" ?>
+            <tests>
+                <test name="foo" />
+            </tests>
+        """
+
+        when:
+        fails("test")
+
+        then:
+        failureHasCause("Test process encountered an unexpected problem.")
+        failureHasCause(~/Could not complete execution for Gradle Test Executor \d+\./)
+        failureHasCause("Closest started ancestor 'Test SomeTestSpec.rbt - foo' is not a container. " +
+                "This likely means the JUnit Platform TestEngine 'uses-only-test-dynamic-rbt-engine' tried to start a test under a non-container parent.")
+    }
+}

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -323,7 +323,8 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec implements Verif
 
         then:
         failure.assertHasCause("Test process encountered an unexpected problem.")
-        failure.assertHasCause("Could not execute test class 'com.example.Foo'.")
+        failure.assertHasCause("Could not execute test class 'com.example.Foo'")
+        failure.assertHasCause("Could not load test class 'com.example.Foo'.")
 
         testResults.testPathPreNormalized(':').onlyRoot()
             .assertHasResult(TestResult.ResultType.FAILURE)

--- a/platforms/jvm/testing-jvm/src/testFixtures/groovy/testengines/TestEnginesFixture.groovy
+++ b/platforms/jvm/testing-jvm/src/testFixtures/groovy/testengines/TestEnginesFixture.groovy
@@ -90,6 +90,7 @@ trait TestEnginesFixture {
         RESOURCE_AND_CLASS_BASED("resource-and-class-engine"),
         FAILS_DISCOVERY_RESOURCE_BASED("fails-discovery-rbt-engine"),
         FAILS_EXECUTION_RESOURCE_BASED("fails-execution-rbt-engine"),
+        USES_ONLY_TEST_RESOURCE_BASED_DYNAMIC("uses-only-test-dynamic-rbt-engine"),
         MATCHES_NOTHING_ENGINE("matches-nothing-engine")
 
         private final String name

--- a/platforms/jvm/testing-jvm/src/testFixtures/resources/testengines/uses-only-test-dynamic-rbt-engine/test-engine-build/src/main/java/org/gradle/testing/testengine/engine/UsesOnlyTestDynamicResourceBasedTestEngine.java
+++ b/platforms/jvm/testing-jvm/src/testFixtures/resources/testengines/uses-only-test-dynamic-rbt-engine/test-engine-build/src/main/java/org/gradle/testing/testengine/engine/UsesOnlyTestDynamicResourceBasedTestEngine.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.testengine.engine;
+
+import org.gradle.testing.testengine.descriptor.ResourceBasedTestDescriptor;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.engine.support.descriptor.EngineDescriptor;
+import org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolver;
+
+import java.util.stream.Collectors;
+
+public class UsesOnlyTestDynamicResourceBasedTestEngine implements TestEngine {
+    public static final Logger LOGGER = LoggerFactory.getLogger(UsesOnlyTestDynamicResourceBasedTestEngine.class);
+
+    public static final String ENGINE_ID = "uses-only-test-dynamic-rbt-engine";
+    public static final String ENGINE_NAME = "Resource Based Test Engine (Dynamic, uses only TEST)";
+
+    @Override
+    public String getId() {
+        return ENGINE_ID;
+    }
+
+    @Override
+    public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+        LOGGER.info(() -> {
+            String selectorsMsg = discoveryRequest.getSelectorsByType(DiscoverySelector.class).stream()
+                .map(Object::toString)
+                .collect(Collectors.joining("\n\t", "\t", ""));
+            return "Discovering tests with engine: " + uniqueId + " using selectors:\n" + selectorsMsg;
+        });
+
+        EngineDescriptor engineDescriptor = new EngineDescriptor(uniqueId, ENGINE_NAME);
+
+        EngineDiscoveryRequestResolver.builder()
+            // Pass false to only create TEST descriptors, not CONTAINER_AND_TEST
+            .addSelectorResolver(new ResourceBasedSelectorResolver(false))
+            .build()
+            .resolve(discoveryRequest, engineDescriptor);
+
+        return engineDescriptor;
+    }
+
+    @Override
+    public void execute(ExecutionRequest executionRequest) {
+        LOGGER.info(() -> "Executing tests with engine: " + executionRequest.getRootTestDescriptor().getUniqueId());
+
+        EngineExecutionListener listener = executionRequest.getEngineExecutionListener();
+        executionRequest.getRootTestDescriptor().getChildren().forEach(test -> {
+            if (test instanceof ResourceBasedTestDescriptor) {
+                listener.executionStarted(test);
+                LOGGER.info(() -> "Executing resource-based test: " + test);
+
+                TestDescriptor dynamicTest = new AbstractTestDescriptor(
+                    test.getUniqueId().append("dynamicTest", "dynamic-test"),
+                    "Dynamic Test"
+                ) {
+                    @Override
+                    public Type getType() {
+                        return Type.TEST;
+                    }
+                };
+                test.addChild(dynamicTest);
+                listener.dynamicTestRegistered(dynamicTest);
+                listener.executionStarted(dynamicTest);
+                listener.executionFinished(dynamicTest, TestExecutionResult.successful());
+
+                listener.executionFinished(test, TestExecutionResult.successful());
+            } else {
+                throw new IllegalStateException("Cannot execute test: " + test + " of type: " + test.getClass().getName());
+            }
+        });
+    }
+}

--- a/platforms/jvm/testing-jvm/src/testFixtures/resources/testengines/uses-only-test-dynamic-rbt-engine/test-engine-build/src/main/resources/META-INF/services/org.junit.platform.engine.TestEngine
+++ b/platforms/jvm/testing-jvm/src/testFixtures/resources/testengines/uses-only-test-dynamic-rbt-engine/test-engine-build/src/main/resources/META-INF/services/org.junit.platform.engine.TestEngine
@@ -1,0 +1,1 @@
+org.gradle.testing.testengine.engine.UsesOnlyTestDynamicResourceBasedTestEngine

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestDescriptor.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestDescriptor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks.testing;
 
-import com.google.common.base.Strings;
 import org.gradle.api.internal.tasks.testing.source.DefaultNoSource;
 import org.gradle.api.tasks.testing.source.TestSource;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -54,7 +53,7 @@ public class DefaultTestDescriptor extends AbstractTestDescriptor {
 
     @Override
     public String toString() {
-        return "Test " + getName() + (Strings.isNullOrEmpty(className) ? "" : ("(" + className + ")"));
+        return "Test " + getName() + ((className == null || className.isEmpty()) ? "" : ("(" + className + ")"));
     }
 
     @Override


### PR DESCRIPTION
This is likely incorrect behavior
(https://github.com/junit-team/junit-framework/issues/5168) and previously resulted in an opaque error from TestEventReporterAsListener.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
