### PR TITLE
Add variants of providers that take default value

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -84,11 +84,31 @@ public interface ProviderFactory {
     /**
      * Creates a {@link Provider} whose value is fetched from the environment variable with the given name.
      *
+     * @param variableName The name of the environment variable.
+     * @param defaultValue The value to use if the environment variable is not set.
+     * @return The provider. Never returns null.
+     * @since 6.1
+     */
+    Provider<String> environmentVariable(String variableName, String defaultValue);
+
+    /**
+     * Creates a {@link Provider} whose value is fetched from the environment variable with the given name.
+     *
      * @param variableName The provider for the name of the environment variable; when the given provider has no value, the returned provider has no value.
      * @return The provider. Never returns null.
      * @since 6.1
      */
     Provider<String> environmentVariable(Provider<String> variableName);
+
+    /**
+     * Creates a {@link Provider} whose value is fetched from the environment variable with the given name.
+     *
+     * @param variableName The provider for the name of the environment variable; when the given provider has no value, the returned provider has no value.
+     * @param defaultValue The value to use if the environment variable is not set.
+     * @return The provider. Never returns null.
+     * @since 6.1
+     */
+    Provider<String> environmentVariable(Provider<String> variableName, Provider<String> defaultValue);
 
     /**
      * Creates a {@link Provider} whose value is a name-to-value map of the environment variables with the names starting with the given prefix.
@@ -123,10 +143,30 @@ public interface ProviderFactory {
      * Creates a {@link Provider} whose value is fetched from system properties using the given property name.
      *
      * @param propertyName the name of the system property
+     * @param defaultValue The value to use if the system property is not set.
+     * @return the provider for the system property, never returns null
+     * @since 6.1
+     */
+    Provider<String> systemProperty(String propertyName, String defaultValue);
+
+    /**
+     * Creates a {@link Provider} whose value is fetched from system properties using the given property name.
+     *
+     * @param propertyName the name of the system property
      * @return the provider for the system property, never returns null
      * @since 6.1
      */
     Provider<String> systemProperty(Provider<String> propertyName);
+
+    /**
+     * Creates a {@link Provider} whose value is fetched from system properties using the given property name.
+     *
+     * @param propertyName the name of the system property
+     * @param defaultValue The value to use if the system property is not set.
+     * @return the provider for the system property, never returns null
+     * @since 6.1
+     */
+    Provider<String> systemProperty(Provider<String> propertyName, Provider<String> defaultValue);
 
     /**
      * Creates a {@link Provider} whose value is a name-to-value map of the system properties with the names starting with the given prefix.
@@ -161,10 +201,30 @@ public interface ProviderFactory {
      * Creates a {@link Provider} whose value is fetched from the Gradle property of the given name.
      *
      * @param propertyName the name of the Gradle property
+     * @param defaultValue The value to use if the Gradle property is not set.
+     * @return the provider for the Gradle property, never returns null
+     * @since 6.2
+     */
+    Provider<String> gradleProperty(String propertyName, String defaultValue);
+
+    /**
+     * Creates a {@link Provider} whose value is fetched from the Gradle property of the given name.
+     *
+     * @param propertyName the name of the Gradle property
      * @return the provider for the Gradle property, never returns null
      * @since 6.2
      */
     Provider<String> gradleProperty(Provider<String> propertyName);
+
+    /**
+     * Creates a {@link Provider} whose value is fetched from the Gradle property of the given name.
+     *
+     * @param propertyName the name of the Gradle property
+     * @param defaultValue The value to use if the Gradle property is not set.
+     * @return the provider for the Gradle property, never returns null
+     * @since 6.2
+     */
+    Provider<String> gradleProperty(Provider<String> propertyName, String defaultValue);
 
     /**
      * Creates a {@link Provider} whose value is a name-to-value map of the Gradle properties with the names starting with the given prefix.


### PR DESCRIPTION
Add an overload that allows creating enviroment variable, system property, or gradle property providers with a default value if the item is not set.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
