### PR TITLE
Fix misleading Worker API documentation about daemon persistence

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/unused/worker_api.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/unused/worker_api.adoc
@@ -236,8 +236,9 @@ For instance, external libraries may rely on certain system properties to be set
 Or a library might not be compatible with the version of JDK that Gradle is running with and may need to be run with a different version.
 
 The Worker API can accommodate this using the `processIsolation()` method that causes the work to execute in a separate "worker daemon".
-These worker processes will be session-scoped and can be reused within the same build session, but they won't persist across builds.
-However, if system resources get low, Gradle will stop unused worker daemons.
+These worker processes are session-scoped, meaning they live only for the duration of a single build and can be reused within that build.
+They do not persist across multiple builds.
+Gradle will stop these worker daemons when the build completes or if system resources get low during the build.
 
 To utilize a worker daemon, use the `processIsolation()` method when creating the `WorkQueue`.
 You may also want to configure custom settings for the new process:


### PR DESCRIPTION
- Clarified that worker processes are session-scoped (single build only)
- Added explicit statement that they do not persist across multiple builds
- Corrected when worker daemons are stopped (build completion or low resources)
- Removed ambiguous language about daemon lifecycle

Fixes #28479

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
