### PR TITLE
Ignore flaky android docs test for now

### DIFF
--- a/platforms/documentation/docs/build.gradle.kts
+++ b/platforms/documentation/docs/build.gradle.kts
@@ -724,6 +724,9 @@ tasks.named<Test>("docsTest") {
     filter {
         // TODO(https://github.com/gradle/gradle/issues/22538)
         excludeTestsMatching("org.gradle.docs.samples.*.snippet-groovy-cross-compilation_*_crossCompilation")
+        // disable while we're working on https://github.com/gradle/gradle-private/issues/4910
+        excludeTestsMatching("*snippet-dependency-management-declaring-configurations-android_*")
+        excludeTestsMatching("*snippet-dependency-management-declaring-configurations-kmp_*")
     }
 
     if (project.configurationCacheEnabledForDocsTests) {


### PR DESCRIPTION
[These tests](https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.docs.samples.bucket.Bucket24&tests.test=snippet-dependency-management-declaring-configurations-kmp_kotlin_build) are very flaky. While we're working on https://github.com/gradle/gradle-private/issues/4910, let's ignore them.