### PR TITLE
Fix writing build operation trace with IP

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/configuration/ConfigurationTargetIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/ConfigurationTargetIdentifier.java
@@ -19,9 +19,10 @@ package org.gradle.configuration;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.plugins.PluginAwareInternal;
-import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
@@ -71,27 +72,27 @@ public abstract class ConfigurationTargetIdentifier {
         }
     }
 
-    public static ConfigurationTargetIdentifier of(final ProjectInternal project) {
+    public static ConfigurationTargetIdentifier of(ProjectIdentity projectIdentity) {
         return new ConfigurationTargetIdentifier() {
             @Override
             public Type getTargetType() {
                 return Type.PROJECT;
             }
 
-            @Nullable
             @Override
             public String getTargetPath() {
-                return project.getProjectPath().asString();
+                return projectIdentity.getProjectPath().asString();
             }
 
             @Override
             public String getBuildPath() {
-                return project.getGradle().getIdentityPath().asString();
+                return projectIdentity.getBuildPath().asString();
             }
         };
     }
 
     public static ConfigurationTargetIdentifier of(final SettingsInternal settings) {
+        Path buildPath = settings.getGradle().getOwner().getIdentityPath();
         return new ConfigurationTargetIdentifier() {
             @Override
             public Type getTargetType() {
@@ -106,12 +107,13 @@ public abstract class ConfigurationTargetIdentifier {
 
             @Override
             public String getBuildPath() {
-                return settings.getGradle().getIdentityPath().asString();
+                return buildPath.asString();
             }
         };
     }
 
     public static ConfigurationTargetIdentifier of(final GradleInternal gradle) {
+        Path buildPath = gradle.getOwner().getIdentityPath();
         return new ConfigurationTargetIdentifier() {
             @Override
             public Type getTargetType() {
@@ -126,7 +128,7 @@ public abstract class ConfigurationTargetIdentifier {
 
             @Override
             public String getBuildPath() {
-                return gradle.getIdentityPath().asString();
+                return buildPath.asString();
             }
         };
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -366,7 +366,7 @@ public class ProjectScopeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected ConfigurationTargetIdentifier createConfigurationTargetIdentifier() {
-        return ConfigurationTargetIdentifier.of(project);
+        return ConfigurationTargetIdentifier.of(project.getProjectIdentity());
     }
 
     @Provides


### PR DESCRIPTION
### Problem

When running a Gradle build with IP enabled and while writing a build operation trace, the build can fail with an exception, because some build operations fail to serialize correctly. It's likely a combination of things, including the fact that we have started writing the trace asynchronously recently (https://github.com/gradle/gradle/pull/31031).

Specifically, when a Project-scoped instance of `ConfigurationTargetIdentifier` is getting written to the trace, we serialize it's `buildPath` [property](https://github.com/gradle/gradle/blob/17d862f4287114de22d5bc6e6bf53551f1a9bd23/subprojects/core/src/main/java/org/gradle/configuration/ConfigurationTargetIdentifier.java#L89), which relies on accessing `project.gradle` ([source](https://github.com/gradle/gradle/blob/17d862f4287114de22d5bc6e6bf53551f1a9bd23/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingGradle.kt#L163-L164)). When running with IP, this results in a service-lookup, because we wrap Gradle instances for cross-project access validation.

<details><summary>Full stacktrace</summary>
<p>

```
java.lang.RuntimeException: Failure when writing build operation trace
        at org.gradle.internal.operations.trace.BuildOperationTrace$AsyncExecutor.checkForException(BuildOperationTrace.java:767)
        at org.gradle.internal.operations.trace.BuildOperationTrace$AsyncExecutor.close(BuildOperationTrace.java:761)
        at org.gradle.internal.IoActions.closeQuietly(IoActions.java:120)
        at org.gradle.internal.operations.trace.BuildOperationTrace$AsyncTraceWriter.complete(BuildOperationTrace.java:698)
        at org.gradle.internal.operations.trace.BuildOperationTrace.stop(BuildOperationTrace.java:217)
        at org.gradle.internal.concurrent.CompositeStoppable.stop(CompositeStoppable.java:116)
        at org.gradle.internal.service.DefaultServiceRegistry$ManagedObjectServiceProvider.stop(DefaultServiceRegistry.java:644)
        at org.gradle.internal.concurrent.CompositeStoppable.stop(CompositeStoppable.java:116)
        at org.gradle.internal.service.DefaultServiceRegistry$OwnServices.stop(DefaultServiceRegistry.java:457)
        at org.gradle.internal.concurrent.CompositeStoppable.stop(CompositeStoppable.java:116)
        at org.gradle.internal.service.DefaultServiceRegistry$CompositeServiceProvider.stop(DefaultServiceRegistry.java:1083)
        at org.gradle.internal.concurrent.CompositeStoppable.stop(CompositeStoppable.java:116)
        at org.gradle.internal.service.DefaultServiceRegistry.close(DefaultServiceRegistry.java:300)
        at org.gradle.internal.concurrent.CompositeStoppable$1.stop(CompositeStoppable.java:100)
        at org.gradle.internal.concurrent.CompositeStoppable.stop(CompositeStoppable.java:116)
        at org.gradle.internal.session.CrossBuildSessionState.close(CrossBuildSessionState.java:68)
        at org.gradle.internal.buildprocess.execution.BuildSessionLifecycleBuildActionExecutor.execute(BuildSessionLifecycleBuildActionExecutor.java:69)
        at org.gradle.internal.buildprocess.execution.BuildSessionLifecycleBuildActionExecutor.execute(BuildSessionLifecycleBuildActionExecutor.java:45)
        at org.gradle.internal.buildprocess.execution.StartParamsValidatingActionExecutor.execute(StartParamsValidatingActionExecutor.java:57)
        at org.gradle.internal.buildprocess.execution.StartParamsValidatingActionExecutor.execute(StartParamsValidatingActionExecutor.java:32)
        at org.gradle.internal.buildprocess.execution.SessionFailureReportingActionExecutor.execute(SessionFailureReportingActionExecutor.java:51)
        at org.gradle.internal.buildprocess.execution.SessionFailureReportingActionExecutor.execute(SessionFailureReportingActionExecutor.java:39)
        at org.gradle.internal.buildprocess.execution.SetupLoggingActionExecutor.execute(SetupLoggingActionExecutor.java:47)
        at org.gradle.internal.buildprocess.execution.SetupLoggingActionExecutor.execute(SetupLoggingActionExecutor.java:31)
        at org.gradle.launcher.daemon.server.exec.ExecuteBuild.doBuild(ExecuteBuild.java:70)
        at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.WatchForDisconnection.execute(WatchForDisconnection.java:39)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.ResetDeprecationLogger.execute(ResetDeprecationLogger.java:29)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.RequestStopIfSingleUsedDaemon.execute(RequestStopIfSingleUsedDaemon.java:35)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.ForwardClientInput.lambda$execute$0(ForwardClientInput.java:40)
        at org.gradle.internal.daemon.clientinput.ClientInputForwarder.forwardInput(ClientInputForwarder.java:80)
        at org.gradle.launcher.daemon.server.exec.ForwardClientInput.execute(ForwardClientInput.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.LogAndCheckHealth.execute(LogAndCheckHealth.java:64)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.LogToClient.doBuild(LogToClient.java:63)
        at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.EstablishBuildEnvironment.doBuild(EstablishBuildEnvironment.java:84)
        at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.StartBuildOrRespondWithBusy$1.run(StartBuildOrRespondWithBusy.java:52)
        at org.gradle.launcher.daemon.server.DaemonStateCoordinator.lambda$runCommand$0(DaemonStateCoordinator.java:321)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
Caused by: java.io.UncheckedIOException: com.fasterxml.jackson.databind.JsonMappingException: Build-scoped services has been closed. (through reference chain: com.google.common.collect.RegularImmutableMap["details"]->org.gradle.configuration.BuildOperationScriptPlugin$OperationDetails["buildPath"])
        at org.gradle.internal.operations.trace.BuildOperationTrace$DefaultTraceWriter.write(BuildOperationTrace.java:269)
        at org.gradle.internal.operations.trace.BuildOperationTrace$AsyncTraceWriter.lambda$write$0(BuildOperationTrace.java:690)
        at org.gradle.internal.operations.trace.BuildOperationTrace$AsyncExecutor.lambda$execute$0(BuildOperationTrace.java:733)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Build-scoped services has been closed. (through reference chain: com.google.common.collect.RegularImmutableMap["details"]->org.gradle.configuration.BuildOperationScriptPlugin$OperationDetails["buildPath"])
        at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:402)
        at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:361)
        at com.fasterxml.jackson.databind.ser.std.StdSerializer.wrapAndThrow(StdSerializer.java:323)
        at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:778)
        at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:183)
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serializeFields(MapSerializer.java:808)
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serializeWithoutTypeInfo(MapSerializer.java:764)
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:720)
        at com.fasterxml.jackson.databind.ser.std.MapSerializer.serialize(MapSerializer.java:35)
        at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:502)
        at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:341)
        at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4793)
        at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:3997)
        at org.gradle.internal.operations.trace.BuildOperationTrace$DefaultTraceWriter.write(BuildOperationTrace.java:264)
        ... 2 more
Caused by: java.lang.IllegalStateException: Build-scoped services has been closed.
        at org.gradle.internal.service.DefaultServiceRegistry.serviceRequested(DefaultServiceRegistry.java:307)
        at org.gradle.internal.service.DefaultServiceRegistry.getService(DefaultServiceRegistry.java:347)
        at org.gradle.internal.service.DefaultServiceRegistry.find(DefaultServiceRegistry.java:341)
        at org.gradle.internal.service.DefaultServiceRegistry.get(DefaultServiceRegistry.java:326)
        at org.gradle.internal.service.DefaultServiceRegistry.get(DefaultServiceRegistry.java:321)
        at org.gradle.internal.cc.impl.CrossProjectConfigurationReportingGradle$Companion.from(CrossProjectConfigurationReportingGradle.kt:376)
        at org.gradle.internal.cc.impl.ProblemReportingCrossProjectModelAccess.gradleInstanceForProject(ProblemReportingCrossProjectModelAccess.kt:118)
        at org.gradle.api.internal.project.DefaultProject.getGradle(DefaultProject.java:373)
        at org.gradle.configuration.ConfigurationTargetIdentifier$1.getBuildPath(ConfigurationTargetIdentifier.java:89)
        at org.gradle.configuration.BuildOperationScriptPlugin$OperationDetails.getBuildPath(BuildOperationScriptPlugin.java:132)
        at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:688)
        at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:770)
        ... 12 more
```

</p>
</details> 

### Solution

Reduce the state captured by the `ConfigurationTargetIdentifier` operations:
- `Project` -> `ProjectIdentity`
- `Settings` -> build path
- `Gradle` -> build path

These values are known early in the build logic and project configuration, lightweight and don't carry complex dependencies.