### PR TITLE
Allow two nodes in the same component to capabiltiy conflict

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsBugsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsBugsIntegrationTest.groovy
@@ -46,8 +46,9 @@ class DependencyConstraintsBugsIntegrationTest extends AbstractHttpDependencyRes
                 id 'java-library'
             }
 
+            ${mavenCentralRepository()}
+
             repositories {
-                ${mavenCentralRepository()}
                 maven {
                    url = file("./ktor-repo/")
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -267,6 +267,9 @@ class EdgeState implements DependencyGraphEdge {
 
         for (VariantGraphResolveState targetVariant : targetVariants.getVariants()) {
             NodeState targetNodeState = resolveState.getNode(targetComponent, targetVariant, targetVariants.isSelectedByVariantAwareResolution());
+            while (targetNodeState.getReplacement() != null) {
+                targetNodeState = targetNodeState.getReplacement();
+            }
             this.targetNodes.add(targetNodeState);
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilityConflictResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilityConflictResolver.java
@@ -91,12 +91,12 @@ public class CapabilityConflictResolver {
         ImmutableList<Candidate> candidates = discoverCandidates(group, name, nodes);
         SelectedCandidate winner = findSelectedCandidate(group, name, candidates);
         if (winner != null) {
-            // Evict any node from the same component as the selected node, so we don't attach edges to it.
-            // TODO #19788: Eviction currently causes broken graphs.
+            // Evict any node from the same component as the selected node, so we make sure to attach
+            // edges to the winning node instead.
             for (Candidate candidate : candidates) {
                 if (candidate.node.getComponent().getComponentId().equals(winner.node.getComponent().getComponentId())) {
                     if (candidate.node != winner.node) {
-                        candidate.node.evict();
+                        candidate.node.replaceWith(winner.node);
                     }
                 }
             }


### PR DESCRIPTION
Capability conflict resolution was based on prior code for module conflict resolution. The nature of module conflict resolution means that if one module wins, all nodes in that module wins. However, capability conflict detection is by definition node-based. Two nodes in the same component may conflict with each other. We had a broken attempt at handling this, the 'evicted' field for a node, but we never consulted that field when selecting variants. So, what would end up happening is we would resolve the conflict and mark a node as evicted. However, we would then clear any remaining edges pointing to it without proper bookkeeping. This lead to edges in the graph without a target node, as we never connected the evicted node's incoming edge.

In this commit, we ensure edges that would point to an evicted node properly point to the replacement node.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
