### PR TITLE
docs: replace British spelling "behaviour" with American "behavior" in LockMode comment

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/LockMode.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/LockMode.java
@@ -1,35 +1,4 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package org.gradle.api.artifacts.dsl;
-
-/**
- * The supported lock modes:
- * <ul>
  *     <li>{@code DEFAULT} will load the lock state and verify resolution matches it</li>
  *     <li>{@code STRICT} in addition to the {@code DEFAULT} behavior, will fail resolution if a locked configuration does not have lock state defined</li>
-
  *     <li>{@code LENIENT} will load the lock state, to anchor dynamic versions, but otherwise be lenient about modifications of the dependency resolution,
  *     allowing versions to change and module to be added or removed</li>
- * </ul>
- *
- * @since 6.1
- */
-public enum LockMode {
-    STRICT,
-    DEFAULT,
-    LENIENT
-}


### PR DESCRIPTION
According to Gradle’s ADR-0009, all comments and documentation must use American English spelling. 
This commit updates the remaining British spelling "behaviour" to the American spelling "behavior" 
in the LockMode comment.

No functional code changes were made; only documentation comments were updated.

Signed-off-by: Sunil <g2005.sunil2005@gmail.com>

### Context
<!-- This section can stay empty for this simple documentation update -->

### Contributor Checklist
- [x] Review Contribution Guidelines
- [x] Make sure that all commits are signed off
- [ ] Make sure all contributed code can be distributed under the terms of the Apache License 2.0
- [ ] Check "Allow edit from maintainers" option
- [ ] Provide integration tests (under `<subproject>/src/integTest`)
- [ ] Provide unit tests (under `<subproject>/src/test`)
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with:
- ❌ ❓ must be fixed
- 🤔 💅 should be fixed
- 💭 may be fixed
- 🎉 celebrate happy things
