### PR TITLE
Always group tests using the highest non-root node

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.tasks.testing.report.VerifiesGenericTestReportRes
 import org.gradle.api.internal.tasks.testing.report.generic.GenericTestExecutionResult
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
+import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
@@ -75,11 +76,6 @@ Feature: Another Thing
         executedAndNotSkipped(":test")
 
         and:
-        // Output from XML report generation:
-        outputContains(
-            "Expected all results for grouping node :RunCukesTest:feature_classpath_features/my_thing.feature" +
-                " to have the same display name, but found: Another Thing and My Thing"
-        )
         def testResults = resultsFor()
         testResults.assertTestPathsExecuted(
             ":RunCukesTest:feature_classpath_features/my_thing.feature:A Scenario",
@@ -87,6 +83,10 @@ Feature: Another Thing
         // "Another Thing" comes first due to lexical ordering of '_' vs ':'
         testResults.testPath(":RunCukesTest:feature_classpath_features/my_thing.feature").onlyRoot()
             .assertDisplayName(Matchers.is("Another Thing / My Thing"))
+
+        def xmlResults = new JUnitXmlTestExecutionResult(testDirectory)
+        xmlResults.assertTestClassesExecuted("RunCukesTest")
+        xmlResults.testClass("RunCukesTest").assertTestsExecuted("A Scenario")
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2739")

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModelResultsProvider.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModelResultsProvider.java
@@ -37,7 +37,6 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.serialize.Serializer;
-import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -105,7 +104,7 @@ public final class TestTreeModelResultsProvider implements TestResultsProvider {
                             " but found: " + perRootInfo.getResults().size()
                     );
                 }
-                TestTreeModel groupingNode = findGroupingNode(parentOfPath, leaf, perRootInfo.getResults().get(0).getClassName());
+                TestTreeModel groupingNode = findGroupingNode(parentOfPath, leaf);
                 leavesByGroupingNode.put(groupingNode, perRootInfo);
             }
         });
@@ -245,16 +244,13 @@ public final class TestTreeModelResultsProvider implements TestResultsProvider {
     }
 
     private static TestTreeModel findGroupingNode(
-        Map<org.gradle.util.Path, TestTreeModel> parentOfPath, TestTreeModel leaf, @Nullable String className
+        Map<org.gradle.util.Path, TestTreeModel> parentOfPath, TestTreeModel leaf
     ) {
         TestTreeModel current = leaf;
         TestTreeModel parent;
         while ((parent = parentOfPath.get(current.getPath())) != null) {
             org.gradle.util.Path parentPath = parent.getPath();
-            if (className != null && className.equals(parentPath.getName())) {
-                return parent;
-            }
-            // Pick highest non-root node if no class name match
+            // Pick highest non-root node
             // But don't group the leaf using itself, that doesn't make sense.
             boolean parentHasParent = parentOfPath.containsKey(parentPath);
             if (!parentHasParent && current != leaf) {

--- a/testing/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitXmlTestExecutionResult.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitXmlTestExecutionResult.groovy
@@ -74,11 +74,11 @@ class JUnitXmlTestExecutionResult implements TestExecutionResult {
         }
     }
 
-    TestClassExecutionResult testClass(String testClass) {
+    JUnitTestClassExecutionResult testClass(String testClass) {
         return new JUnitTestClassExecutionResult(findTestClass(testClass), testClass, testClass, outputAssociation)
     }
 
-    TestClassExecutionResult testClassStartsWith(String testClass) {
+    JUnitTestClassExecutionResult testClassStartsWith(String testClass) {
         def matching = findTestClassStartsWith(testClass)
         return new JUnitTestClassExecutionResult(matching[1], matching[0], matching[0], outputAssociation)
     }


### PR DESCRIPTION
This behavior more closely matches surefire.

Fixes #15075

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
