### PR TITLE
Mark containers as skipped/failed based on children in HTML report

### DIFF
--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/PerRootTabRenderer.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/PerRootTabRenderer.java
@@ -346,29 +346,22 @@ public abstract class PerRootTabRenderer extends ReportRenderer<TestTreeModel, S
 
         private static TestResult.ResultType getResultType(PerRootInfo info) {
             if (info.getChildren().isEmpty()) {
-                // There should only be one result for leaf nodes
+                // For leaf nodes, we use the result type of the single result
                 if (info.getResults().size() > 1) {
                     throw new IllegalStateException("Leaf nodes should only have one result");
                 }
                 return info.getResults().get(0).getResultType();
             }
-            // For container nodes, merge result types, with FAILURE > SUCCESS > SKIPPED.
-            // Skipped is less than success because if there is any non-skipped child, the container is not skipped.
-            TestResult.ResultType bestType = TestResult.ResultType.SKIPPED;
-            for (SerializableTestResult result : info.getResults()) {
-                if (result.getResultType() == TestResult.ResultType.FAILURE) {
-                    // Promote to failure and stop checking, as we can't change any further
-                    bestType = TestResult.ResultType.FAILURE;
-                    break;
-                } else if (result.getResultType() == TestResult.ResultType.SUCCESS) {
-                    // Promote to success, keep checking in case there is a failure
-                    bestType = TestResult.ResultType.SUCCESS;
-                } else if (result.getResultType() != TestResult.ResultType.SKIPPED) {
-                    throw new IllegalStateException("Unknown result type: " + result.getResultType());
-                }
-                // If it's skipped, do nothing, as we either leave as skipped, or would not change from success to skipped
+            // For container nodes, we use the worst result type of its children
+            // This ignores the container's result because containers made out of all skipped tests
+            // may be marked as successful in the result, but we want to show them as skipped if all their children are skipped.
+            if (info.getFailedLeafCount() > 0) {
+                return TestResult.ResultType.FAILURE;
             }
-            return bestType;
+            if (info.getSkippedLeafCount() > 0) {
+                return TestResult.ResultType.SKIPPED;
+            }
+            return TestResult.ResultType.SUCCESS;
         }
 
         private static String getStatusClass(TestResult.ResultType resultType) {


### PR DESCRIPTION
This is a regression from the previous HTML report generation, as most containers report successful, not skipped, for all-skipped children. This makes it look correct again.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
