### PR TITLE
Simplify `CompositeStoppable` usage

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/TextReportRenderer.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/TextReportRenderer.java
@@ -83,7 +83,7 @@ public class TextReportRenderer implements ReportRenderer {
         try {
             if (close) {
                 //noinspection DataFlowIssue
-                CompositeStoppable.stoppable(textOutput).stop();
+                CompositeStoppable.stopAll(textOutput);
             }
         } finally {
             textOutput = null;

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DefaultConfigurationCache.kt
@@ -498,20 +498,21 @@ class DefaultConfigurationCache internal constructor(
         StructuredMessage.forText(String.format(Locale.US, message, *args))
 
     override fun stop() {
-        val stoppable = CompositeStoppable.stoppable()
-        stoppable.addIfInitialized(lazyBuildTreeModelSideEffects)
-        stoppable.addIfInitialized(lazyIntermediateModels)
-        stoppable.addIfInitialized(lazyProjectMetadata)
-        stoppable.addIfInitialized(storeDelegate)
-        stoppable.addIfInitialized(entryStoreDelegate)
-        stoppable.stop()
+        CompositeStoppable()
+            .addIfInitialized(lazyBuildTreeModelSideEffects)
+            .addIfInitialized(lazyIntermediateModels)
+            .addIfInitialized(lazyProjectMetadata)
+            .addIfInitialized(storeDelegate)
+            .addIfInitialized(entryStoreDelegate)
+            .stop()
     }
 
     private
-    fun CompositeStoppable.addIfInitialized(closeable: Lazy<*>) {
+    fun CompositeStoppable.addIfInitialized(closeable: Lazy<*>): CompositeStoppable {
         if (closeable.isInitialized()) {
-            add(closeable.value!!)
+            return add(closeable.value!!)
         }
+        return this
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -277,7 +277,7 @@ class ConfigurationCacheFingerprintWriter(
                 buildScopedSink.write(it)
             }
         }
-        CompositeStoppable.stoppable(buildScopedWriter, projectScopedWriter).stop()
+        CompositeStoppable.stopAll(buildScopedWriter, projectScopedWriter)
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/models/BuildTreeModelSideEffectStore.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/models/BuildTreeModelSideEffectStore.kt
@@ -91,6 +91,6 @@ class BuildTreeModelSideEffectStore(
     }
 
     override fun close() {
-        CompositeStoppable.stoppable(valuesStore).stop()
+        CompositeStoppable.stopAll(valuesStore)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/models/ProjectStateStore.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/models/ProjectStateStore.kt
@@ -177,6 +177,6 @@ abstract class ProjectStateStore<K, V>(
     }
 
     override fun close() {
-        CompositeStoppable.stoppable(valuesStore).stop()
+        CompositeStoppable.stopAll(valuesStore)
     }
 }

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -57,7 +57,7 @@ import org.gradle.internal.build.NestedRootBuildRunner.createNestedBuildTree
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier
-import org.gradle.internal.concurrent.CompositeStoppable.stoppable
+import org.gradle.internal.concurrent.CompositeStoppable
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.resource.TextFileResourceLoader
@@ -220,7 +220,7 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
                 yield(loader.scriptPluginPluginsFor(plugin))
             }
         } finally {
-            stoppable(loader).stop()
+            CompositeStoppable.stopAll(loader)
         }
     }
 

--- a/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorker.java
+++ b/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorker.java
@@ -51,7 +51,7 @@ public class IsolatedClassloaderWorker extends AbstractClassLoaderWorker {
             workerClasspathGroovy.shutdown();
             // TODO: we should just cache these classloaders and eject/stop them when they are no longer in use
             if (!reuseClassloader) {
-                CompositeStoppable.stoppable(workerClassLoader).stop();
+                CompositeStoppable.stopAll(workerClassLoader);
                 this.workerClassLoader = null;
             }
         }

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
@@ -75,7 +75,7 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
     public void close() {
         lock.lock();
         try {
-            CompositeStoppable.stoppable(dirCaches.values()).stop();
+            CompositeStoppable.stopAll(dirCaches.values());
         } finally {
             dirCaches.clear();
             lock.unlock();

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/streams/DefaultValueStore.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/streams/DefaultValueStore.java
@@ -111,7 +111,7 @@ public class DefaultValueStore<T> implements ValueStore<T>, Closeable {
     @Override
     public void close() throws IOException {
         try {
-            CompositeStoppable.stoppable().add(sinks).add(availableSources.values()).stop();
+            new CompositeStoppable().add(sinks).add(availableSources.values()).stop();
         } finally {
             sinks.clear();
             availableSinks.clear();

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractFileLockManagerTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractFileLockManagerTest.groovy
@@ -67,7 +67,7 @@ abstract class AbstractFileLockManagerTest extends Specification {
     }
 
     def cleanup() {
-        CompositeStoppable.stoppable(openedLocks.toArray()).stop()
+        CompositeStoppable.stopAll(openedLocks)
     }
 
     def "readFile throws integrity exception when not cleanly unlocked file"() {

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionTest.groovy
@@ -59,7 +59,7 @@ class DefaultFileLockManagerContentionTest extends ConcurrentSpec {
     List<Closeable> openedLocks = []
 
     def cleanup() {
-        CompositeStoppable.stoppable(openedLocks).add(contentionHandler, contentionHandler2).stop()
+        new CompositeStoppable().add(openedLocks).add(contentionHandler).add(contentionHandler2).stop()
     }
 
     def "lock manager is notified while holding an exclusive lock when another lock manager in same process requires lock with mode #lockMode"() {

--- a/platforms/core-execution/worker-main/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/platforms/core-execution/worker-main/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -123,7 +123,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
         } finally {
             try {
                 loggingManager.removeOutputEventListener(workerLogEventListener);
-                CompositeStoppable.stoppable(connection, basicWorkerServices).stop();
+                CompositeStoppable.stopAll(connection, basicWorkerServices);
                 loggingManager.stop();
             } catch (Throwable t) {
                 // We're failing while shutting down, so log whatever might have happened.

--- a/platforms/core-runtime/build-process-services/src/test/groovy/org/gradle/internal/installation/CurrentGradleInstallationLocatorTest.groovy
+++ b/platforms/core-runtime/build-process-services/src/test/groovy/org/gradle/internal/installation/CurrentGradleInstallationLocatorTest.groovy
@@ -41,7 +41,7 @@ class CurrentGradleInstallationLocatorTest extends Specification {
     }
 
     def cleanup() {
-        CompositeStoppable.stoppable(loaders).stop()
+        CompositeStoppable.stopAll(loaders)
     }
 
     def "determines Gradle home by class bundled in JAR located in valid distribution subdirectory '#jarDirectory'"() {

--- a/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/buildprocess/BuildProcessState.java
+++ b/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/buildprocess/BuildProcessState.java
@@ -63,6 +63,6 @@ public class BuildProcessState implements Closeable {
     @Override
     public void close() {
         // Force the user home services to be stopped first, because the dependencies between the user home services and the global services are not preserved currently
-        CompositeStoppable.stoppable(services.get(GradleUserHomeScopeServiceRegistry.class), services).stop();
+        CompositeStoppable.stopAll(services.get(GradleUserHomeScopeServiceRegistry.class), services);
     }
 }

--- a/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/session/BuildSessionState.java
+++ b/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/session/BuildSessionState.java
@@ -75,6 +75,6 @@ public class BuildSessionState implements Closeable {
 
     @Override
     public void close() {
-        CompositeStoppable.stoppable(sessionScopeServices, (Closeable) () -> userHomeScopeServiceRegistry.release(userHomeServices)).stop();
+        CompositeStoppable.stopAll(sessionScopeServices, (Closeable) () -> userHomeScopeServiceRegistry.release(userHomeServices));
     }
 }

--- a/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
+++ b/platforms/core-runtime/build-state/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
@@ -65,7 +65,7 @@ public class CrossBuildSessionState implements Closeable {
 
     @Override
     public void close() {
-        CompositeStoppable.stoppable(services).stop();
+        CompositeStoppable.stopAll(services);
     }
 
     private class Services implements ServiceRegistrationProvider {

--- a/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
+++ b/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
@@ -49,7 +49,7 @@ public abstract class ClassLoaderUtils {
 
     public static void tryClose(@Nullable ClassLoader classLoader) {
         if (classLoader != null) {
-            CompositeStoppable.stoppable(classLoader).stop();
+            CompositeStoppable.stopAll(classLoader);
         }
     }
 

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DaemonClient.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DaemonClient.java
@@ -264,7 +264,7 @@ public class DaemonClient implements BuildActionExecutor<BuildActionParameters, 
             }
         } finally {
             // Stop cancelling before sending end-of-input
-            CompositeStoppable.stoppable(cancelForwarder, inputForwarder).stop();
+            CompositeStoppable.stopAll(cancelForwarder, inputForwarder);
         }
     }
 

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DaemonStopClientExecuter.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DaemonStopClientExecuter.java
@@ -44,7 +44,7 @@ public class DaemonStopClientExecuter {
             DaemonStopClient daemonStopClient = clientServices.get(DaemonStopClient.class);
             action.accept(daemonStopClient);
         } finally {
-            CompositeStoppable.stoppable(clientServices).stop();
+            CompositeStoppable.stopAll(clientServices);
         }
     }
 }

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
@@ -260,7 +260,7 @@ public class DefaultDaemonStarter implements DaemonStarter {
                 handle.waitForFinish();
                 LOGGER.debug("Gradle daemon process is now detached.");
             } finally {
-                CompositeStoppable.stoppable(execActionFactory).stop();
+                CompositeStoppable.stopAll(execActionFactory);
             }
 
             return daemonGreeter.parseDaemonOutput(outputConsumer.getProcessOutput(), args);

--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/NotifyDaemonClientExecuter.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/client/NotifyDaemonClientExecuter.java
@@ -44,7 +44,7 @@ public class NotifyDaemonClientExecuter {
             NotifyDaemonAboutChangedPathsClient daemonStopClient = clientServices.get(NotifyDaemonAboutChangedPathsClient.class);
             action.accept(daemonStopClient);
         } finally {
-            CompositeStoppable.stoppable(clientServices).stop();
+            CompositeStoppable.stopAll(clientServices);
         }
     }
 }

--- a/platforms/core-runtime/concurrent/src/main/java/org/gradle/internal/concurrent/DefaultExecutorFactory.java
+++ b/platforms/core-runtime/concurrent/src/main/java/org/gradle/internal/concurrent/DefaultExecutorFactory.java
@@ -45,7 +45,7 @@ public class DefaultExecutorFactory implements ExecutorFactory, Stoppable {
     @Override
     public void stop() {
         try {
-            CompositeStoppable.stoppable(executors).stop();
+            CompositeStoppable.stopAll(executors);
         } finally {
             executors.clear();
         }

--- a/platforms/core-runtime/daemon-server/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
+++ b/platforms/core-runtime/daemon-server/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
@@ -126,7 +126,7 @@ public class DaemonMain extends EntryPoint {
             DaemonStopState stopState = daemon.stopOnExpiration(expirationStrategy, parameters.getPeriodicCheckIntervalMs());
             daemonProcessState.stopped(stopState);
         } finally {
-            CompositeStoppable.stoppable(daemon, daemonProcessState).stop();
+            CompositeStoppable.stopAll(daemon, daemonProcessState);
             //TODO This should actually be used in `GradleUserHomeCleanupService`, but this is in core and core can't use the classes to get the proper daemon log dir name.
             cleanupOldLogFiles(daemonBaseDir);
         }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/ForegroundDaemonAction.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/ForegroundDaemonAction.java
@@ -58,7 +58,7 @@ public class ForegroundDaemonAction implements Runnable {
             daemonRegistry.markState(daemon.getAddress(), Idle);
             daemon.stopOnExpiration(expirationStrategy, configuration.getPeriodicCheckIntervalMs());
         } finally {
-            CompositeStoppable.stoppable(daemon, daemonProcessState).stop();
+            CompositeStoppable.stopAll(daemon, daemonProcessState);
         }
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/Daemon.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/Daemon.java
@@ -215,7 +215,7 @@ public class Daemon implements Stoppable {
             // 3. stop accepting new connections
             // 4. wait for commands in progress to finish (except for abandoned long running commands, like running a build)
 
-            CompositeStoppable.stoppable(stateCoordinator, registryUpdater, connector, connectionHandler).stop();
+            CompositeStoppable.stopAll(stateCoordinator, registryUpdater, connector, connectionHandler);
         } finally {
             lifecycleLock.unlock();
         }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonTcpServerConnector.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonTcpServerConnector.java
@@ -101,7 +101,7 @@ public class DaemonTcpServerConnector implements DaemonServerConnector {
             lifecycleLock.unlock();
         }
 
-        CompositeStoppable.stoppable(acceptor, incomingConnector).stop();
+        CompositeStoppable.stopAll(acceptor, incomingConnector);
     }
 
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DefaultDaemonConnection.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DefaultDaemonConnection.java
@@ -159,7 +159,7 @@ public class DefaultDaemonConnection implements DaemonConnection {
         // 3. Stop receiving incoming messages. Blocks until the receive thread has finished. This will notify the stdin and receive queues to signal end of input.
         // 4. Stop the receive queue, to unblock any threads blocked in receive().
         // 5. Stop handling stdin. Blocks until the handler has finished. Discards any queued input.
-        CompositeStoppable.stoppable(disconnectQueue, connection, executor, receiveQueue, stdinQueue, cancelQueue).stop();
+        CompositeStoppable.stopAll(disconnectQueue, connection, executor, receiveQueue, stdinQueue, cancelQueue);
     }
 
     @Override

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManager.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManager.java
@@ -88,7 +88,7 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
     @Override
     public DefaultLoggingManager stop() {
         try {
-            CompositeStoppable.stoppable(slf4jLoggingSystem, javaUtilLoggingSystem, stdOutLoggingSystem, stdErrLoggingSystem).stop();
+            CompositeStoppable.stopAll(slf4jLoggingSystem, javaUtilLoggingSystem, stdOutLoggingSystem, stdErrLoggingSystem);
             for (StandardOutputListener stdoutListener : stdoutListeners) {
                 loggingOutput.removeStandardOutputListener(stdoutListener);
             }

--- a/platforms/core-runtime/messaging/src/integTest/groovy/org/gradle/internal/remote/UnicastMessagingIntegrationTest.groovy
+++ b/platforms/core-runtime/messaging/src/integTest/groovy/org/gradle/internal/remote/UnicastMessagingIntegrationTest.groovy
@@ -215,13 +215,14 @@ class UnicastMessagingIntegrationTest extends ConcurrentSpec {
             connection.addIncoming(RemoteService2.class, value)
         }
 
-        void setupOutgoingService1(){
+        void setupOutgoingService1() {
             outgoingService1 = connection.addOutgoing(RemoteService1)
         }
 
-        void setupOutgoingService2(){
+        void setupOutgoingService2() {
             outgoingService2 = connection.addOutgoing(RemoteService2)
         }
+
         abstract void stop()
     }
 
@@ -264,7 +265,7 @@ class UnicastMessagingIntegrationTest extends ConcurrentSpec {
         void stop() {
             lock.lock()
             try {
-                CompositeStoppable.stoppable(acceptor, connection).stop()
+                CompositeStoppable.stopAll(acceptor, connection)
             } finally {
                 connection = null
                 acceptor = null

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/actor/internal/DefaultActorFactory.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/actor/internal/DefaultActorFactory.java
@@ -55,7 +55,7 @@ public class DefaultActorFactory implements ActorFactory, Stoppable {
     public void stop() {
         synchronized (lock) {
             try {
-                CompositeStoppable.stoppable(nonBlockingActors.values()).add(blockingActors.values()).stop();
+                new CompositeStoppable().add(nonBlockingActors.values()).add(blockingActors.values()).stop();
             } finally {
                 nonBlockingActors.clear();
             }
@@ -162,7 +162,7 @@ public class DefaultActorFactory implements ActorFactory, Stoppable {
         @Override
         public void stop() {
             try {
-                CompositeStoppable.stoppable(dispatch, executor, failureHandler).stop();
+                CompositeStoppable.stopAll(dispatch, executor, failureHandler);
             } finally {
                 stopped(this);
             }

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHubBackedObjectConnection.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHubBackedObjectConnection.java
@@ -147,7 +147,7 @@ public class MessageHubBackedObjectConnection implements ObjectConnection {
     @Override
     public void stop() {
         // TODO:ADAM - need to cleanup completion too, if not used
-        CompositeStoppable.stoppable(hub, connection).stop();
+        CompositeStoppable.stopAll(hub, connection);
     }
 
     @Override

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/remote/internal/inet/SocketConnection.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/remote/internal/inet/SocketConnection.java
@@ -145,12 +145,7 @@ public class SocketConnection<T> implements RemoteConnection<T> {
 
     @Override
     public void stop() {
-        CompositeStoppable.stoppable(new Closeable() {
-            @Override
-            public void close() throws IOException {
-                flush();
-            }
-        }, instr, outstr, socket).stop();
+        CompositeStoppable.stopAll((Closeable) () -> flush(), instr, outstr, socket);
     }
 
     private static class SocketInputStream extends InputStream {

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/remote/internal/inet/TcpIncomingConnector.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/remote/internal/inet/TcpIncomingConnector.java
@@ -86,7 +86,7 @@ public class TcpIncomingConnector implements IncomingConnector {
 
             @Override
             public void requestStop() {
-                CompositeStoppable.stoppable(serverSocket).stop();
+                CompositeStoppable.stopAll(serverSocket);
             }
 
             @Override
@@ -144,7 +144,7 @@ public class TcpIncomingConnector implements IncomingConnector {
                     LOGGER.error("Could not accept remote connection.", e);
                 }
             } finally {
-                CompositeStoppable.stoppable(serverSocket).stop();
+                CompositeStoppable.stopAll(serverSocket);
             }
         }
 

--- a/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/platforms/extensibility/unit-test-fixtures/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -58,6 +58,7 @@ import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.buildtree.RunTasksRequirements;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.composite.IncludedBuildInternal;
+import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.id.UniqueId;
@@ -89,8 +90,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Function;
-
-import static org.gradle.internal.concurrent.CompositeStoppable.stoppable;
 
 public class ProjectBuilderImpl {
     private static ServiceRegistry globalServices;
@@ -202,7 +201,7 @@ public class ProjectBuilderImpl {
 
         project.getExtensions().getExtraProperties().set(
             "ProjectBuilder.stoppable",
-            stoppable(
+            new CompositeStoppable().add(
                 (Stoppable) workerLeaseService::runAsIsolatedTask,
                 (Stoppable) workerLease::leaseFinish,
                 buildServices,

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutor.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutor.java
@@ -43,7 +43,7 @@ public class DefaultAsyncConsumerActionExecutor implements AsyncConsumerActionEx
 
     @Override
     public void stop() {
-        CompositeStoppable.stoppable(lifecycle, executor, actionExecutor).stop();
+        CompositeStoppable.stopAll(lifecycle, executor, actionExecutor);
     }
 
     @Override

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/CachingToolingImplementationLoader.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/CachingToolingImplementationLoader.java
@@ -56,7 +56,7 @@ public class CachingToolingImplementationLoader implements ToolingImplementation
     @Override
     public void close() {
         try {
-            CompositeStoppable.stoppable(connections.asMap().values()).stop();
+            CompositeStoppable.stopAll(connections.asMap().values());
         } finally {
             connections.invalidateAll();
         }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/SynchronizedToolingImplementationLoader.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/SynchronizedToolingImplementationLoader.java
@@ -62,7 +62,7 @@ public class SynchronizedToolingImplementationLoader implements ToolingImplement
     public void close() {
         lock.lock();
         try {
-            CompositeStoppable.stoppable(delegate).stop();
+            CompositeStoppable.stopAll(delegate);
         } finally {
             lock.unlock();
         }

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -303,7 +303,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
             compilerGroovyLoader.discardTypesFrom(astTransformClassLoader);
             //Discard the compile loader
             compileClasspathLoader.shutdown();
-            CompositeStoppable.stoppable(classPathLoader, astTransformClassLoader).stop();
+            CompositeStoppable.stopAll(classPathLoader, astTransformClassLoader);
         }
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompileTask.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AnnotationProcessingCompileTask.java
@@ -166,6 +166,6 @@ class AnnotationProcessingCompileTask implements JavaCompiler.CompilationTask {
     }
 
     private void cleanupProcessors() {
-        CompositeStoppable.stoppable(processorClassloader).stop();
+        CompositeStoppable.stopAll(processorClassloader);
     }
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ResourceCleaningCompilationTask.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ResourceCleaningCompilationTask.java
@@ -56,7 +56,7 @@ class ResourceCleaningCompilationTask implements JavaCompiler.CompilationTask {
         try {
             return delegate.call();
         } finally {
-            CompositeStoppable.stoppable(fileManager).stop();
+            CompositeStoppable.stopAll(fileManager);
             cleanupZipCache();
         }
     }

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -754,7 +754,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
         try {
             super.executeTests();
         } finally {
-            CompositeStoppable.stoppable(getTestFramework()).stop();
+            CompositeStoppable.stopAll(getTestFramework());
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/DefaultBinaryStore.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/DefaultBinaryStore.java
@@ -130,7 +130,7 @@ class DefaultBinaryStore implements BinaryStore, Closeable {
                     RandomAccessFile randomAccess = new RandomAccessFile(inputFile, "r");
                     randomAccess.seek(offset);
                     decoder = new StringDeduplicatingKryoBackedDecoder(new RandomAccessFileInputStream(randomAccess));
-                    resources = new CompositeStoppable().add(randomAccess, decoder);
+                    resources = new CompositeStoppable().add(randomAccess).add(decoder);
                 }
                 return readAction.read(decoder);
             } catch (Exception e) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactoryTest.groovy
@@ -77,10 +77,10 @@ class ResolutionResultsStoreFactoryTest extends Specification {
         [store.file, store2.file, store3.file].each { it.exists() }
 
         when:
-        new CompositeStoppable().add(store, store2, store3)
+        CompositeStoppable.stopAll(store, store2, store3)
 
         then:
-        [store.file, store2.file, store3.file].each { !it.exists() }
+        [store.file, store2.file, store3.file].each { it === null }
     }
 
     def "provides stores"() {

--- a/platforms/software/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpClientFactory.java
+++ b/platforms/software/resources-sftp/src/main/java/org/gradle/internal/resource/transport/sftp/SftpClientFactory.java
@@ -181,7 +181,7 @@ public class SftpClientFactory implements Stoppable {
     public void stop() {
         synchronized (lock) {
             try {
-                CompositeStoppable.stoppable(allClients).stop();
+                CompositeStoppable.stopAll(allClients);
             } finally {
                 allClients.clear();
                 idleClients.clear();

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/LifecycleTrackingGroupTestEventReporter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/LifecycleTrackingGroupTestEventReporter.java
@@ -46,7 +46,7 @@ class LifecycleTrackingGroupTestEventReporter extends LifecycleTrackingTestEvent
     public void close() {
         super.close();
         // Now that it's safe, stop all children
-        CompositeStoppable.stoppable(children).stop();
+        CompositeStoppable.stopAll(children);
         children.clear();
     }
 

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/MaxNParallelTestDefinitionProcessor.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/MaxNParallelTestDefinitionProcessor.java
@@ -87,7 +87,7 @@ public class MaxNParallelTestDefinitionProcessor<D extends TestDefinition> imple
     @Override
     public void stop() {
         try {
-            CompositeStoppable.stoppable(processors).add(actors).add(resultProcessorActor).stop();
+            new CompositeStoppable().add(processors).add(actors).add(resultProcessorActor).stop();
         } catch (DispatchException e) {
             throw UncheckedException.throwAsUncheckedException(e.getCause());
         }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericHtmlTestReportGenerator.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericHtmlTestReportGenerator.java
@@ -133,7 +133,7 @@ public abstract class GenericHtmlTestReportGenerator implements TestReportGenera
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
         } finally {
-            CompositeStoppable.stoppable(outputReaders).stop();
+            CompositeStoppable.stopAll(outputReaders);
         }
         return reportsDirectory.resolve("index.html");
     }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/serializable/SerializableTestResultStore.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/serializable/SerializableTestResultStore.java
@@ -295,7 +295,7 @@ public final class SerializableTestResultStore {
                 // Write a 0 id to terminate the file
                 resultsEncoder.writeSmallLong(0);
             } finally {
-                CompositeStoppable.stoppable(resultsEncoder, outputWriter).stop();
+                CompositeStoppable.stopAll(resultsEncoder, outputWriter);
             }
             // Move the temporary results file to the final location, if successful
             Files.move(temporaryResultsFile, serializedResultsFile, StandardCopyOption.REPLACE_EXISTING);

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/serializable/TestOutputReader.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/serializable/TestOutputReader.java
@@ -211,6 +211,6 @@ public final class TestOutputReader implements Closeable {
 
     @Override
     public void close() throws IOException {
-        CompositeStoppable.stoppable(channelPool).stop();
+        CompositeStoppable.stopAll(channelPool);
     }
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -178,7 +178,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         subscribed.stream()
             .flatMap(it -> it.getListeners().stream())
             .forEach(this::unsubscribe);
-        CompositeStoppable.stoppable(subscribed).stop();
+        CompositeStoppable.stopAll(subscribed);
     }
 
     private void unsubscribe(Object listener) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildControllers.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildControllers.java
@@ -126,7 +126,7 @@ class DefaultBuildControllers implements BuildControllers {
 
     @Override
     public void close() {
-        CompositeStoppable.stoppable(controllers.values()).stop();
+        CompositeStoppable.stopAll(controllers.values());
     }
 
     private static Comparator<BuildIdentifier> idComparator() {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -271,7 +271,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
 
     @Override
     public void stop() {
-        CompositeStoppable.stoppable(buildsByPath.values()).stop();
+        CompositeStoppable.stopAll(buildsByPath.values());
     }
 
     private void assertNameDoesNotClashWithRootSubproject(IncludedBuildState includedBuild) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -131,7 +131,7 @@ public class DefaultIncludedBuildTaskGraph implements BuildTreeWorkGraphControll
 
     @Override
     public void close() throws IOException {
-        CompositeStoppable.stoppable(executorService);
+        CompositeStoppable.stopAll(executorService);
     }
 
     private <T> T withState(Function<DefaultBuildTreeWorkGraph, T> action) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -67,7 +67,7 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
             BuildTreeFinishExecutor finishExecutor = new DoNothingBuildFinishExecutor(exceptionAnalyser);
             buildTreeLifecycleController = buildTreeLifecycleControllerFactory.createController(getBuildController(), workExecutor, finishExecutor);
         } catch (Throwable t) {
-            CompositeStoppable.stoppable().addFailure(t).add(buildScopeServices).stop();
+            new CompositeStoppable().addFailure(t).add(buildScopeServices).stop();
             throw UncheckedException.throwAsUncheckedException(t);
         }
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -75,7 +75,7 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
                 new DefaultBuildTreeFinishExecutor(buildStateRegistry, exceptionAnalyser, buildLifecycleController));
             this.buildTreeLifecycleController = buildTreeLifecycleControllerFactory.createRootBuildController(buildLifecycleController, workExecutor, finishExecutor);
         } catch (Throwable t) {
-            CompositeStoppable.stoppable().addFailure(t).add(buildScopeServices).stop();
+            new CompositeStoppable().addFailure(t).add(buildScopeServices).stop();
             throw UncheckedException.throwAsUncheckedException(t);
         }
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -76,7 +76,7 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
             BuildTreeFinishExecutor buildTreeFinishExecutor = new DefaultBuildTreeFinishExecutor(buildStateRegistry, exceptionAnalyser, buildLifecycleController);
             buildTreeLifecycleController = buildTreeLifecycleControllerFactory.createController(buildLifecycleController, buildTreeWorkExecutor, buildTreeFinishExecutor);
         } catch (Throwable t) {
-            CompositeStoppable.stoppable().addFailure(t).add(buildServices).stop();
+            new CompositeStoppable().addFailure(t).add(buildServices).stop();
             throw UncheckedException.throwAsUncheckedException(t);
         }
     }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -473,7 +473,7 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
         }
 
         void stop() {
-            CompositeStoppable.stoppable(buildTaskGraph, planExecutor, workerLeaseService, coordinationService, execFactory).stop()
+            CompositeStoppable.stopAll(buildTaskGraph, planExecutor, workerLeaseService, coordinationService, execFactory)
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -105,7 +105,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
                 projectsById.remove(project.getComponentIdentifier());
                 projectsByPath.remove(project.getIdentityPath());
             }
-            CompositeStoppable.stoppable(registry.projectsByPath.values()).stop();
+            CompositeStoppable.stopAll(registry.projectsByPath.values());
             registry.projectsByPath.clear();
         }
     }
@@ -198,7 +198,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
     @Override
     public void close() {
-        CompositeStoppable.stoppable(projectsByPath.values()).stop();
+        CompositeStoppable.stopAll(projectsByPath.values());
     }
 
     private static class DefaultBuildProjectRegistry implements BuildProjectRegistry {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/SplitFileContentCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/SplitFileContentCacheFactory.java
@@ -41,7 +41,7 @@ public class SplitFileContentCacheFactory implements FileContentCacheFactory, Cl
 
     @Override
     public void close() throws IOException {
-        CompositeStoppable.stoppable(localFactory).stop();
+        CompositeStoppable.stopAll(localFactory);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/deployment/internal/DefaultDeploymentRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/deployment/internal/DefaultDeploymentRegistry.java
@@ -168,7 +168,7 @@ public class DefaultDeploymentRegistry implements DeploymentRegistryInternal, Pe
         lock.lock();
         try {
             LOGGER.debug("Stopping {} deployment handles", deployments.size());
-            CompositeStoppable.stoppable(deployments.values()).stop();
+            CompositeStoppable.stopAll(deployments.values());
         } finally {
             LOGGER.debug("Stopped deployment handles");
             stopped = true;

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServiceRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServiceRegistry.java
@@ -56,7 +56,7 @@ public class ProjectExecutionServiceRegistry implements AutoCloseable {
 
     @Override
     public void close() {
-        CompositeStoppable.stoppable(projectRegistries.asMap().values()).stop();
+        CompositeStoppable.stopAll(projectRegistries.asMap().values());
     }
 
     private static class DefaultNodeExecutionContext implements NodeExecutionContext, Closeable {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultPlanExecutor.java
@@ -91,7 +91,7 @@ public class DefaultPlanExecutor implements PlanExecutor, Stoppable {
     @Override
     public void stop() {
         try {
-            CompositeStoppable.stoppable(queue, executor).stop();
+            CompositeStoppable.stopAll(queue, executor);
         } finally {
             stats.report();
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeState.java
@@ -47,6 +47,6 @@ public class BuildTreeState implements Closeable {
 
     @Override
     public void close() {
-        CompositeStoppable.stoppable(services).stop();
+        CompositeStoppable.stopAll(services);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -90,7 +90,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
 
     @Override
     public void close() {
-        CompositeStoppable.stoppable(executor, cache).stop();
+        CompositeStoppable.stopAll(executor, cache);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/DefaultGradleUserHomeScopeServiceRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/DefaultGradleUserHomeScopeServiceRegistry.java
@@ -32,7 +32,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static java.lang.System.getProperty;
-import static org.gradle.internal.concurrent.CompositeStoppable.stoppable;
+import static org.gradle.internal.concurrent.CompositeStoppable.stopAll;
 
 /**
  * Reuses the services for the most recent Gradle user home dir. Could instead cache several most recent and clean these up on memory pressure, however in practise there is only a single user home dir associated with a given build process.
@@ -78,7 +78,7 @@ public class DefaultGradleUserHomeScopeServiceRegistry implements GradleUserHome
                     Services otherServices = servicesForHomeDir.values().iterator().next();
                     if (otherServices.count == 0) {
                         // Other home dir cached and not in use, clean it up
-                        stoppable(otherServices.registry).stop();
+                        stopAll(otherServices.registry);
                         servicesForHomeDir.clear();
                     }
                 }
@@ -130,7 +130,7 @@ public class DefaultGradleUserHomeScopeServiceRegistry implements GradleUserHome
                 );
 
             if (--activeService.getValue().count == 0 && (servicesForHomeDir.size() > 1 || !getProperty(REUSE_USER_HOME_SERVICES, "true").equals("true"))) {
-                stoppable(activeService.getValue().registry).stop();
+                stopAll(activeService.getValue().registry);
                 servicesForHomeDir.remove(activeService.getKey());
             }
         } finally {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultClientExecHandleBuilderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultClientExecHandleBuilderFactory.java
@@ -91,7 +91,7 @@ public class DefaultClientExecHandleBuilderFactory implements ClientExecHandleBu
 
         @Override
         public void stop() {
-            CompositeStoppable.stoppable(delegate.executor).stop();
+            CompositeStoppable.stopAll(delegate.executor);
         }
 
         /**

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/ExecOutputHandleRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/ExecOutputHandleRunner.java
@@ -85,7 +85,7 @@ public class ExecOutputHandleRunner implements Runnable {
                     writeBuffer(buffer, nread);
                 }
             }
-            CompositeStoppable.stoppable(inputStream, outputStream).stop();
+            CompositeStoppable.stopAll(inputStream, outputStream);
         } catch (Throwable t) {
             if (!closed && !wasInterrupted(t)) {
                 LOGGER.error(String.format("Could not %s.", displayName), t);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcess.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcess.java
@@ -24,8 +24,8 @@ import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.remote.ConnectionAcceptor;
 import org.gradle.internal.remote.ObjectConnection;
-import org.gradle.process.ProcessExecutionException;
 import org.gradle.process.ExecResult;
+import org.gradle.process.ProcessExecutionException;
 import org.gradle.process.internal.ExecHandle;
 import org.gradle.process.internal.ExecHandleListener;
 import org.gradle.process.internal.health.memory.JvmMemoryStatus;
@@ -239,15 +239,13 @@ public class DefaultWorkerProcess implements WorkerProcess {
     }
 
     private void cleanup() {
-        CompositeStoppable stoppable;
+        CompositeStoppable stoppable = new CompositeStoppable();
         lock.lock();
         try {
-            stoppable = CompositeStoppable.stoppable(connection, new Stoppable() {
-                @Override
-                public void stop() {
-                    execHandle.abort();
-                }
-            }, acceptor);
+            stoppable
+                .add(connection)
+                .add((Stoppable) () -> execHandle.abort())
+                .add(acceptor);
         } finally {
             this.connection = null;
             this.acceptor = null;

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AllResultsStore.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AllResultsStore.java
@@ -45,6 +45,6 @@ public class AllResultsStore implements ResultsStore, Closeable {
 
     @Override
     public void close() {
-        CompositeStoppable.stoppable(crossVersion, crossBuild, gradleVsMaven).stop();
+        CompositeStoppable.stopAll(crossVersion, crossBuild, gradleVsMaven);
     }
 }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CompositeResultsStore.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CompositeResultsStore.java
@@ -76,6 +76,6 @@ public class CompositeResultsStore implements ResultsStore {
 
     @Override
     public void close() {
-        CompositeStoppable.stoppable(stores).stop();
+        CompositeStoppable.stopAll(stores);
     }
 }

--- a/testing/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/RedirectStdinExtension.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/RedirectStdinExtension.groovy
@@ -66,7 +66,7 @@ class RedirectStdinExtension implements IAnnotationDrivenExtension<RedirectStdIn
         }
 
         private void closePipe() {
-            CompositeStoppable.stoppable(stdinPipe, emulatedSystemIn).stop();
+            CompositeStoppable.stopAll(stdinPipe, emulatedSystemIn);
             stdinPipe = null;
             emulatedSystemIn = null;
         }


### PR DESCRIPTION
- Remove multiple ways of instantiating it
- Introduce more direct way of stopping services
- Make `DefaultServiceRegistry` slightly cheaper (reduces 250kb on `codeQuality`)

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
