### PR TITLE
Avoid generic "version catalog error" display name

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
@@ -875,7 +875,7 @@ dependencyResolutionManagement {
 
         verifyAll(receivedProblem) {
             fqid == 'dependency-version-catalog:too-many-import-files'
-            contextualLabel == 'Problem: In version catalog testLibs, importing multiple files are not supported.'
+            contextualLabel == "Problem: In version catalog testLibs, ${VersionCatalogProblemId.TOO_MANY_IMPORT_FILES.displayName.uncapitalize()}."
             details == 'The import consists of multiple files'
             solutions == [ 'Only import a single file' ]
         }
@@ -903,7 +903,7 @@ dependencyResolutionManagement {
 
         verifyAll(receivedProblem) {
             fqid == 'dependency-version-catalog:no-import-files'
-            contextualLabel == 'Problem: In version catalog testLibs, no files are resolved to be imported.'
+            contextualLabel == "Problem: In version catalog testLibs, ${VersionCatalogProblemId.NO_IMPORT_FILES.displayName.uncapitalize()}."
             details == 'The imported dependency doesn\'t resolve into any file'
             solutions == [ 'Check the import statement, it should resolve into a single file' ]
         }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -1965,7 +1965,7 @@ Second: 1.1"""
         and:
         verifyAll(receivedProblem) {
             fqid == 'dependency-version-catalog:reserved-alias-name'
-            contextualLabel == "Problem: In version catalog libs, alias '$reserved' is not a valid alias."
+            contextualLabel == "Problem: In version catalog libs, alias '$reserved' is a reserved alias."
             details == "Alias '$reserved' is a reserved name in Gradle which prevents generation of accessors."
             solutions == [ 'Use a different alias which doesn\'t contain any of \'convention\' or \'extensions\'.' ]
         }
@@ -2006,7 +2006,7 @@ Second: 1.1"""
         and:
         verifyAll(receivedProblem) {
             fqid == 'dependency-version-catalog:reserved-alias-name'
-            contextualLabel == "Problem: In version catalog libs, alias '$reserved' is not a valid alias."
+            contextualLabel == "Problem: In version catalog libs, alias '$reserved' is a reserved alias."
             details == "Alias '$reserved' is a reserved name in Gradle which prevents generation of accessors."
             solutions == [ 'Use a different alias which doesn\'t contain \'class\'.' ]
         }
@@ -2047,7 +2047,7 @@ Second: 1.1"""
         and:
         verifyAll(receivedProblem) {
             fqid == 'dependency-version-catalog:reserved-alias-name'
-            contextualLabel == "Problem: In version catalog libs, alias '$reservedName' is not a valid alias."
+            contextualLabel == "Problem: In version catalog libs, alias '$reservedName' is a reserved alias."
             details == "Prefix for dependency shouldn\'t be equal to '$prefix'"
             solutions == [ 'Use a different alias which prefix is not equal to \'bundles\', \'plugins\', or \'versions\'' ]
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/catalog/parser/TomlCatalogFileParser.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/catalog/parser/TomlCatalogFileParser.java
@@ -157,7 +157,7 @@ public class TomlCatalogFileParser {
 
     private static InternalProblemSpec configureVersionCatalogError(InternalProblemSpec builder, String label, VersionCatalogProblemId catalogProblemId, Function<InternalProblemSpec, InternalProblemSpec> locationDefiner) {
         InternalProblemSpec definingLocation = builder
-            .id(screamingSnakeToKebabCase(catalogProblemId.name()), "Dependency version catalog problem", GradleCoreProblemGroup.versionCatalog())
+            .id(screamingSnakeToKebabCase(catalogProblemId.name()), catalogProblemId.getDisplayName(), GradleCoreProblemGroup.versionCatalog())
             .contextualLabel(label)
             .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)));
         InternalProblemSpec definingCategory = locationDefiner.apply(definingLocation);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/VersionCatalogProblemId.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/VersionCatalogProblemId.java
@@ -23,21 +23,31 @@ package org.gradle.api.internal.catalog.problems;
  */
 public enum VersionCatalogProblemId {
 
-    ACCESSOR_NAME_CLASH,
-    CATALOG_FILE_DOES_NOT_EXIST,
-    INVALID_ALIAS_NOTATION,
-    INVALID_DEPENDENCY_NOTATION,
-    INVALID_PLUGIN_NOTATION,
-    INVALID_MODULE_NOTATION,
-    TOO_MANY_IMPORT_FILES,
-    NO_IMPORT_FILES,
-    TOO_MANY_IMPORT_INVOCATION,
-    RESERVED_ALIAS_NAME,
-    TOML_SYNTAX_ERROR,
-    TOO_MANY_ENTRIES,
-    UNDEFINED_ALIAS_REFERENCE,
-    UNDEFINED_VERSION_REFERENCE,
-    UNSUPPORTED_FILE_FORMAT,
-    UNSUPPORTED_FORMAT_VERSION,
-    ALIAS_NOT_FINISHED
+    ACCESSOR_NAME_CLASH("Accessor name clash"),
+    CATALOG_FILE_DOES_NOT_EXIST("Import of external catalog file failed"),
+    INVALID_ALIAS_NOTATION("The alias notation is invalid"),
+    RESERVED_ALIAS_NAME("The alias is reserved"),
+    INVALID_DEPENDENCY_NOTATION("The dependency notation is not valid"),
+    INVALID_PLUGIN_NOTATION("The plugin notation is not valid"),
+    INVALID_MODULE_NOTATION("The module notation is not valid"),
+    TOO_MANY_IMPORT_FILES("Importing multiple files is not supported"),
+    NO_IMPORT_FILES("No files were resolved to be imported"),
+    TOO_MANY_IMPORT_INVOCATION("The 'from' method can only be called once"),
+    TOML_SYNTAX_ERROR("TOML syntax error"),
+    TOO_MANY_ENTRIES("Too many entries"),
+    UNDEFINED_ALIAS_REFERENCE("Bundle declares dependency on non-existent alias"),
+    UNDEFINED_VERSION_REFERENCE("The version reference doesn't exist"),
+    UNSUPPORTED_FILE_FORMAT("The file format is not supported"),
+    UNSUPPORTED_FORMAT_VERSION("The format version is not supported"),
+    ALIAS_NOT_FINISHED("Dependency alias builder was not finished");
+
+    private final String displayName;
+
+    VersionCatalogProblemId(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/catalog/problems/VersionCatalogErrorMessages.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/catalog/problems/VersionCatalogErrorMessages.groovy
@@ -262,7 +262,7 @@ trait VersionCatalogErrorMessages {
 
         @Override
         String build() {
-            """${intro}  - Problem: In version catalog ${catalog}, alias '${alias}' is not a valid alias.
+            """${intro}  - Problem: In version catalog ${catalog}, alias '${alias}' is a reserved alias.
 
     Reason: $message.
 
@@ -522,7 +522,7 @@ ${solution}
 
         @Override
         String build() {
-            """${intro}  - Problem: In version catalog ${catalog}, no files are resolved to be imported.
+            """${intro}  - Problem: In version catalog ${catalog}, ${VersionCatalogProblemId.NO_IMPORT_FILES.displayName.uncapitalize()}.
 
     Reason: The imported dependency doesn't resolve into any file.
 
@@ -540,7 +540,7 @@ ${solution}
 
         @Override
         String build() {
-            """${intro}  - Problem: In version catalog ${catalog}, importing multiple files are not supported.
+            """${intro}  - Problem: In version catalog ${catalog}, ${VersionCatalogProblemId.TOO_MANY_IMPORT_FILES.displayName.uncapitalize()}.
 
     Reason: The import consists of multiple files.
 

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.fixtures.problems
 
+import org.gradle.api.internal.catalog.problems.VersionCatalogProblemId
 import org.gradle.internal.jvm.SupportedJavaVersions
 
 class KnownProblemIds {
@@ -87,14 +88,14 @@ class KnownProblemIds {
         // See compiler.java for the full list of diagnostic codes we use as categories (we replace the dots with dashes)
         'compilation:java:compiler.*' : ['.*'],
         'compilation:java:initialization-failed': ['Java compilation initialization error'],
-        'dependency-version-catalog:alias-not-finished': ['version catalog error'],
-        'dependency-version-catalog:invalid-dependency-notation': ['Dependency version catalog problem'],
-        'dependency-version-catalog:reserved-alias-name': ['version catalog error'],
-        'dependency-version-catalog:catalog-file-does-not-exist': ['version catalog error'],
-        'dependency-version-catalog:toml-syntax-error': ['Dependency version catalog problem'],
-        'dependency-version-catalog:too-many-import-files': ['version catalog error'],
-        'dependency-version-catalog:too-many-import-invocation': ['version catalog error'],
-        'dependency-version-catalog:no-import-files': ['version catalog error'],
+        'dependency-version-catalog:alias-not-finished': [VersionCatalogProblemId.ALIAS_NOT_FINISHED.displayName],
+        'dependency-version-catalog:invalid-dependency-notation': [VersionCatalogProblemId.INVALID_DEPENDENCY_NOTATION.displayName],
+        'dependency-version-catalog:reserved-alias-name': [VersionCatalogProblemId.RESERVED_ALIAS_NAME.displayName],
+        'dependency-version-catalog:catalog-file-does-not-exist': [VersionCatalogProblemId.CATALOG_FILE_DOES_NOT_EXIST.displayName],
+        'dependency-version-catalog:toml-syntax-error': [VersionCatalogProblemId.TOML_SYNTAX_ERROR.displayName],
+        'dependency-version-catalog:too-many-import-files': [VersionCatalogProblemId.TOO_MANY_IMPORT_FILES.displayName],
+        'dependency-version-catalog:too-many-import-invocation': [VersionCatalogProblemId.TOO_MANY_IMPORT_INVOCATION.displayName],
+        'dependency-version-catalog:no-import-files': [VersionCatalogProblemId.NO_IMPORT_FILES.displayName],
         'deprecation:buildsrc-script': ['BuildSrc script has been deprecated.'],
         'deprecation:custom-task-action': ['Custom Task action has been deprecated.'],
         'deprecation:executing-gradle-on-jvm-versions-and-lower': ['Executing Gradle on JVM versions ' + (SupportedJavaVersions.FUTURE_MINIMUM_DAEMON_JAVA_VERSION - 1) + ' and lower has been deprecated.'],


### PR DESCRIPTION
This pull request refactors and improves error reporting and code quality in the `DefaultVersionCatalogBuilder` and related classes. The most significant changes are the introduction of human-friendly display names for version catalog problem IDs, improved error messages that use these display names, code cleanup, and minor nullability and type improvements.

**Error reporting improvements:**

* Added a `displayName` field and accessor to each `VersionCatalogProblemId` in `VersionCatalogProblemId.java`, providing more descriptive, user-friendly error messages.
* Updated error message construction in `DefaultVersionCatalogBuilder.java` to use `getDisplayName()` for problem IDs, and to uncapitalize these messages where appropriate, resulting in clearer and more consistent error output. [[1]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L218-R218) [[2]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L244-R243) [[3]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L257-R256) [[4]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L305-R304)

**Code cleanup and modernization:**

* Refactored repeated logic for applying rich version constraints into a new helper method `configureRequiredRichVersion`, improving code reuse and readability. [[1]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L338-R337) [[2]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L560-R549) [[3]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8R565-R576) [[4]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L614-R607)
* Replaced manual collection of lists with Guava's `toImmutableList()` collector, and removed unused imports for cleaner code. [[1]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L70-R71) [[2]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L441-R433)

**Nullability and type improvements:**

* Annotated several fields with `@Nullable` to better reflect their possible values and improve code safety. [[1]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L128-R133) [[2]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L472-R461) [[3]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L502-R491)
* Removed unnecessary `@NonNull` annotations from private methods for consistency. [[1]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L55) [[2]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L228) [[3]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L412-L420)

**Minor logic corrections:**

* Simplified checks for empty maps by using `isEmpty()` instead of `keySet().isEmpty()`. [[1]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L489-R478) [[2]](diffhunk://#diff-d253d1458a77fd52ff0494c27ddef1cc65cbd7c3f6739ee9ae093661ef4401f8L518-R507)

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
