### PR TITLE
Fix Windows path resolution in ArchUnitFixture using URL.toURI()

### DIFF
--- a/testing/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixture.java
+++ b/testing/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixture.java
@@ -57,6 +57,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.CodeSource;
@@ -610,6 +611,10 @@ public interface ArchUnitFixture {
         if (codeSource == null) {
             return null;
         }
-        return Paths.get(codeSource.getLocation().getPath());
+        try {
+            return Paths.get(codeSource.getLocation().toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Failed to convert CodeSource location to URI", e);
+        }
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #35722 


### Context
<!--- Why do you believe many users will benefit from this change? -->
On Windows, `codeSource.getLocation().getPath()` produces invalid file paths for architecture tests.  
Switching to `toURI()` resolves the path in an OS-independent way.  
This fixes failing tests when running `gradlew :architecture-test:test` on Windows.

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
