### PR TITLE
Avoid recursion while iterating PersistentList

### DIFF
--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/collect/PersistentList.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/collect/PersistentList.java
@@ -102,8 +102,12 @@ public abstract class PersistentList<T> implements Iterable<T> {
 
         @Override
         public void forEach(Consumer<? super T> consumer) {
-            consumer.accept(head);
-            tail.forEach(consumer);
+            PersistentList<T> cur = this;
+            while (!cur.isEmpty()) {
+                Cons<T> cons = (Cons<T>) cur;
+                consumer.accept(cons.head);
+                cur = cons.tail;
+            }
         }
 
         @Override


### PR DESCRIPTION
Unfortunately, JVM isn't great at eliminating tail recursion, so unnecessary recursive calls may trigger avoidable stack overflows.

We don't have reports from the fields, but changing the implementation just in case.