### PR TITLE
Using JarFile instead of JarInputStream to scan for module information

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/internal/jvm/JavaModuleDetectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/jvm/JavaModuleDetectorTest.groovy
@@ -34,11 +34,11 @@ class JavaModuleDetectorTest extends Specification {
     JavaModuleDetector moduleDetector = new JavaModuleDetector(cacheFactory, TestFiles.fileCollectionFactory())
 
     def "detects modules on classpath"() {
-        def path = path('lib.jar', 'module.jar', 'classes', 'classes-module', 'automaticModule.jar', 'mrjarModule.jar')
+        def path = path('lib.jar', 'module.jar', 'classes', 'classes-module', 'automaticModule.jar', 'mrjarModule.jar', 'automaticLateManifestModule.jar')
 
         expect:
         inferClasspath(path) == ['lib.jar', 'classes']
-        inferModulePath(path) == ['module.jar', 'classes-module', 'automaticModule.jar', 'mrjarModule.jar']
+        inferModulePath(path) == ['module.jar', 'classes-module', 'automaticModule.jar', 'mrjarModule.jar', 'automaticLateManifestModule.jar']
     }
 
     def "filters out directories that do not exist"() {
@@ -84,6 +84,12 @@ class JavaModuleDetectorTest extends Specification {
                     jar << JarUtils.jarWithContents(('META-INF/MANIFEST.MF'): manifest.join('\n') + '\n', ('module-info.class'): '')
                 } else if (entry.startsWith('mrjar')) {
                     jar << JarUtils.jarWithContents(('META-INF/MANIFEST.MF'): manifest.join('\n') + '\n', ('META-INF/versions/10/module-info.class'): '')
+                } else if (entry.contains('LateManifest')) {
+                    jar << JarUtils.jarWithContents(
+                        ('EarlyClass1.class'): '',
+                        ('EarlyClass2.class'): '',
+                        ('META-INF/MANIFEST.MF'): manifest.join('\n') + '\n'
+                    )
                 } else {
                     jar << JarUtils.jarWithContents(('META-INF/MANIFEST.MF'): manifest.join('\n') + '\n')
                 }


### PR DESCRIPTION
The current behavior of `JavaModuleDetector` is suboptimal, because it uses `JarInputStream` to scan through the entries in the jar file, which might require decompressing the whole archive for no reason. `JarFile` is more efficient since it just checks the entries. Also, the JDK uses `JarFile` to read jars and not `JarInputStream`, so the change also makes jar scanning consistent with the JDK (even if it is very unlikely to find a jar file where the entries read by `JarFile` are not the same as with `JarInputStream`). Additionally, `JarInputStream` is incorrect, because it can't find the `MANIFEST.MF` if it is not the first or the second entry, despite the fact that the spec doesn't have such constraint on jar files.

This also mostly fixes #30589. Partially, because the fact if a jar is modularized or not is cached, and if it is already cached, then this change has no effect. However, the two methods can only differ for jar files which are currently improperly handled by Gradle. If you want me to address the caching issue by invalidating cache (say, saving the property for a different key), then I would be happy to apply the changes.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
