### PR TITLE
Make inputs of AndroidHomeWarmupTask optional

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/androidhomewarmup/AndroidHomeWarmupTask.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/androidhomewarmup/AndroidHomeWarmupTask.kt
@@ -21,6 +21,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.provider.Provider
@@ -46,9 +47,11 @@ abstract class AndroidHomeWarmupTask : DefaultTask() {
     @get:Inject
     abstract val execOperations: ExecOperations
 
+    @get:Optional
     @get:Input
     val androidHome: Provider<String> = project.providers.environmentVariable("ANDROID_HOME")
 
+    @get:Optional
     @get:Input
     val androidSdkRoot: Provider<String> = project.providers.environmentVariable("ANDROID_SDK_ROOT")
 


### PR DESCRIPTION
When `ANDROID_HOME` or `ANDROID_SDK_ROOT` env don't exist (like locally) the task fails with:

```
  - Type 'gradlebuild.integrationtests.androidhomewarmup.AndroidHomeWarmupTask' property 'androidHome' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    For more information, please refer to https://docs.gradle.org/9.4.0-milestone-2/userguide/validation_problems.html#missing_annotation in the Gradle documentation.
  - Type 'gradlebuild.integrationtests.androidhomewarmup.AndroidHomeWarmupTask' property 'androidSdkRoot' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
```