### PR TITLE
Remove mention of a Problems API concept from the user guide that is already removed from the API

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/reporting_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/reporting_problems.adoc
@@ -33,7 +33,7 @@ include::sample[dir="snippets/developingPlugins/problemReporting/kotlin/buildSrc
 ====
 
 <1> Inject the `Problem` service into the plugin.
-<2> Create a `ProblemReporter` for the plugin (use the plugin ID as the namespace).
+<2> Create a `ProblemReporter` for the plugin.
 <3> Report a recoverable problem so the build can continue.
 <4> Add optional extra data to the problem.
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes https://github.com/gradle/gradle/issues/35698


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
