### PR TITLE
Only give kmp Android tests more memory

### DIFF
--- a/platforms/documentation/docs/src/snippets/dependencyManagement/declaringConfigurations-kmp/groovy/gradle.properties
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/declaringConfigurations-kmp/groovy/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 org.gradle.warning.mode=all
+org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=1024m

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/declaringConfigurations-kmp/kotlin/gradle.properties
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/declaringConfigurations-kmp/kotlin/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 org.gradle.warning.mode=all
+org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=1024m

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/MoreMemorySampleModifier.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/MoreMemorySampleModifier.java
@@ -47,7 +47,17 @@ public class MoreMemorySampleModifier implements SampleModifier {
         File propertiesFile = new File(projectDir, "gradle.properties");
         Properties properties = propertiesFile.exists() ? GUtil.loadProperties(propertiesFile) : new Properties();
         String existingArgs = properties.getProperty(ORG_GRADLE_JVMARGS, "");
-        properties.setProperty(ORG_GRADLE_JVMARGS, "-Xmx1024m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError " + existingArgs);
+        StringBuilder overrideArgs = new StringBuilder(existingArgs);
+        if (!existingArgs.contains("-Xmx")) {
+            overrideArgs.append(" -Xmx512m");
+        }
+        if (!existingArgs.contains("-XX:MaxMetaspaceSize")) {
+            overrideArgs.append(" -XX:MaxMetaspaceSize=512m");
+        }
+        if (!existingArgs.contains("-XX:+HeapDumpOnOutOfMemoryError")) {
+            overrideArgs.append(" -XX:+HeapDumpOnOutOfMemoryError");
+        }
+        properties.setProperty(ORG_GRADLE_JVMARGS, overrideArgs.toString());
         GUtil.saveProperties(properties, propertiesFile);
     }
 }


### PR DESCRIPTION
Attempt to fix https://github.com/gradle/gradle-private/issues/4967

We've seen kmp Android docsTests running out of memory: 

- [example](https://ge.gradle.org/s/7yclt6slguum4/tests/task/:docs:docsTest/details/org.gradle.docs.samples.bucket.Bucket24/snippet-dependency-management-declaring-configurations-kmp_kotlin_build?focused-exception-line=0-1-200&page=eyIwLTEiOjJ9&top-execution=1) 
- [example](https://ge.gradle.org/s/dhk5lqno4zp4g/tests/task/:docs:docsTest/details/org.gradle.docs.samples.bucket.Bucket25/snippet-dependency-management-declaring-configurations-kmp_groovy_build?focused-exception-line=0-1-193&top-execution=1)

We made an attempt in https://github.com/gradle/gradle/pull/35700, but the OOM failures still occur.

This PR reverts the change and only gives kmp tests more memory (they have different `org.gradle.jvmargs` now so that they won't share daemons with other samples).