### PR TITLE
Separate performance baselines for RfN and RfR

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -70,6 +70,7 @@ class PerformanceTest(
                     allowEmpty = true,
                     description = "The baselines you want to run performance tests against. Empty means default baseline.",
                 )
+                param("env.PERFORMANCE_STAGE", stage.stageName.toString())
                 param("env.PERFORMANCE_CHANNEL", performanceTestBuildSpec.channel())
                 param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
                 when (os) {

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -33,7 +33,8 @@ import gradlebuild.basics.BuildParams.BUNDLE_GROOVY_MAJOR
 import gradlebuild.basics.BuildParams.CI_ENVIRONMENT_VARIABLE
 import gradlebuild.basics.BuildParams.DEBUG_DAEMON
 import gradlebuild.basics.BuildParams.DEBUG_LAUNCHER
-import gradlebuild.basics.BuildParams.DEFAULT_PERFORMANCE_BASELINES
+import gradlebuild.basics.BuildParams.DEFAULT_RFN_PERFORMANCE_BASELINES
+import gradlebuild.basics.BuildParams.DEFAULT_RFR_PERFORMANCE_BASELINES
 import gradlebuild.basics.BuildParams.ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS
 import gradlebuild.basics.BuildParams.FLAKY_TEST
 import gradlebuild.basics.BuildParams.GRADLE_INSTALL_PATH
@@ -49,6 +50,7 @@ import gradlebuild.basics.BuildParams.PERFORMANCE_DB_URL
 import gradlebuild.basics.BuildParams.PERFORMANCE_DB_USERNAME
 import gradlebuild.basics.BuildParams.PERFORMANCE_DEPENDENCY_BUILD_IDS
 import gradlebuild.basics.BuildParams.PERFORMANCE_MAX_PROJECTS
+import gradlebuild.basics.BuildParams.PERFORMANCE_STAGE_ENV
 import gradlebuild.basics.BuildParams.PERFORMANCE_TEST_VERBOSE
 import gradlebuild.basics.BuildParams.PREDICTIVE_TEST_SELECTION_ENABLED
 import gradlebuild.basics.BuildParams.RERUN_ALL_TESTS
@@ -94,7 +96,8 @@ object BuildParams {
     const val BUILD_VCS_NUMBER = "BUILD_VCS_NUMBER"
     const val BUILD_VERSION_QUALIFIER = "versionQualifier"
     const val CI_ENVIRONMENT_VARIABLE = "CI"
-    const val DEFAULT_PERFORMANCE_BASELINES = "defaultPerformanceBaselines"
+    const val DEFAULT_RFN_PERFORMANCE_BASELINES = "defaultRfnPerformanceBaselines"
+    const val DEFAULT_RFR_PERFORMANCE_BASELINES = "defaultRfrPerformanceBaselines"
     const val GRADLE_INSTALL_PATH = "gradle_installPath"
 
 
@@ -121,6 +124,7 @@ object BuildParams {
     const val PERFORMANCE_DB_USERNAME = "org.gradle.performance.db.username"
     const val PERFORMANCE_DEPENDENCY_BUILD_IDS = "org.gradle.performance.dependencyBuildIds"
     const val PERFORMANCE_MAX_PROJECTS = "maxProjects"
+    const val PERFORMANCE_STAGE_ENV = "PERFORMANCE_STAGE"
     const val RERUN_ALL_TESTS = "rerunAllTests"
     const val SKIP_BUILD_LOGIC_TESTS = "skipBuildLogicTests"
     const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
@@ -252,8 +256,11 @@ val Project.buildVersionQualifier: Provider<String>
     get() = gradleProperty(BUILD_VERSION_QUALIFIER)
 
 
-val Project.defaultPerformanceBaselines: Provider<String>
-    get() = gradleProperty(DEFAULT_PERFORMANCE_BASELINES)
+val Project.defaultRfnPerformanceBaselines: Provider<String>
+    get() = gradleProperty(DEFAULT_RFN_PERFORMANCE_BASELINES)
+
+val Project.defaultRfrPerformanceBaselines: Provider<String>
+    get() = gradleProperty(DEFAULT_RFR_PERFORMANCE_BASELINES)
 
 
 // null means no limit: use all available executors
@@ -288,6 +295,9 @@ val Project.performanceDependencyBuildIds: Provider<String>
 
 val Project.performanceBaselines: String?
     get() = stringPropertyOrNull(PERFORMANCE_BASELINES)
+
+val Project.performanceStage: Provider<String>
+    get() = environmentVariable(PERFORMANCE_STAGE_ENV)
 
 val Project.performanceChannel: Provider<String>
     get() = environmentVariable(PERFORMANCE_CHANNEL_ENV).orElse(provider {

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -21,7 +21,8 @@ import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import gradlebuild.basics.buildBranch
 import gradlebuild.basics.buildCommitId
 import gradlebuild.basics.capitalize
-import gradlebuild.basics.defaultPerformanceBaselines
+import gradlebuild.basics.defaultRfnPerformanceBaselines
+import gradlebuild.basics.defaultRfrPerformanceBaselines
 import gradlebuild.basics.getBuildEnvironmentExtension
 import gradlebuild.basics.includePerformanceTestScenarios
 import gradlebuild.basics.logicalBranch
@@ -29,6 +30,7 @@ import gradlebuild.basics.performanceBaselines
 import gradlebuild.basics.performanceChannel
 import gradlebuild.basics.performanceDependencyBuildIds
 import gradlebuild.basics.performanceGeneratorMaxProjects
+import gradlebuild.basics.performanceStage
 import gradlebuild.basics.performanceTestVerbose
 import gradlebuild.basics.propertiesForPerformanceDb
 import gradlebuild.basics.releasedVersionsFile
@@ -37,6 +39,8 @@ import gradlebuild.basics.toolchainInstallationPaths
 import gradlebuild.integrationtests.addDependenciesAndConfigurations
 import gradlebuild.integrationtests.ide.AndroidStudioProvisioningExtension
 import gradlebuild.integrationtests.ide.AndroidStudioProvisioningPlugin
+import gradlebuild.integrationtests.ide.DEFAULT_ANDROID_STUDIO_VERSION
+import gradlebuild.jvm.JvmCompileExtension
 import gradlebuild.performance.Config.performanceTestAndroidStudioJvmArgs
 import gradlebuild.performance.generator.tasks.AbstractProjectGeneratorTask
 import gradlebuild.performance.generator.tasks.JvmProjectGeneratorTask
@@ -47,8 +51,6 @@ import gradlebuild.performance.tasks.DefaultCommandExecutor
 import gradlebuild.performance.tasks.DetermineBaselines
 import gradlebuild.performance.tasks.PerformanceTest
 import gradlebuild.performance.tasks.PerformanceTestReport
-import gradlebuild.integrationtests.ide.DEFAULT_ANDROID_STUDIO_VERSION
-import gradlebuild.jvm.JvmCompileExtension
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -326,7 +328,7 @@ class PerformanceTestPlugin : Plugin<Project> {
 
         determineBaselines.configure {
             configuredBaselines = extension.baselines
-            defaultBaselines = project.defaultPerformanceBaselines
+            defaultBaselines = if (project.performanceStage.orNull == "READY_FOR_RELEASE") project.defaultRfrPerformanceBaselines else project.defaultRfnPerformanceBaselines
             logicalBranch = project.logicalBranch
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,9 +24,11 @@ develocity.internal.testdistribution.queryResponseTimeout=PT20S
 systemProp.develocity.internal.testacceleration.enableCustomValues=true
 # If enabled, the build logs whenever a WorkerReadyMessage is received. This should help analyzing the problem of remote executors being in wrong state.
 systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
-# Default performance baseline
-defaultPerformanceBaselines=9.3.0-commit-33148c064ff
-#-----------------------------------------till here^
+# Default ReadyForNightly performance baseline
+defaultRfnPerformanceBaselines=9.3.0-commit-33148c064ff
+# Default ReadyForRelease performance baseline
+defaultRfrPerformanceBaselines=9.3.0-commit-33148c064ff
+#--------------------------------------------till here^
 systemProp.dependency.analysis.test.analysis=false
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
Previously, performance tests in ReadyForNightly and ReadyForRelease share the same baseline. If we rebaseline to unblock some tiny performance regression in ReadyForNightly, it may accidentally overwrite the baseline for ReadyForRelease too.

We've decided to separate performance baselines for ReadyForRelease and ReadyForNightly so we can rebaseline one baseline without affecting another.