### PR TITLE
Remove the broadcast lock and reentrance guard when sending events

### DIFF
--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/ListenerManager.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/event/ListenerManager.java
@@ -26,7 +26,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
  * <p>While the methods work with any Object, in general only interfaces should be used as listener types.
  *
  * <p>Implementations are thread-safe: A listener is notified by at most 1 thread at a time, and so do not need to be thread-safe. All listeners
- * of a given type receive events in the same order. Listeners can be added and removed at any time.
+ * of a given type receive events emitted from the same thread in the same order. Listeners can be added and removed at any time.
  */
 @ServiceScope(Scope.Global.class)
 public interface ListenerManager {
@@ -37,7 +37,7 @@ public interface ListenerManager {
      *
      * <p>A listener will be used by a single thread at a time, so the listener implementation does not need to be thread-safe.
      *
-     * <p>The listener will not receive events that are currently being broadcast from some other thread.
+     * <p>The listener may not receive events that are currently being broadcast from some other thread.
      *
      * @param listener the listener to add.
      */


### PR DESCRIPTION
This greatly simplifies the implementation and eliminates a source of deadlocks at a cost of slightly less consistent behavior when multiple threads send events.

Fixes #30990

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
