### PR TITLE
Normalize line endings to properly cache between machines

### DIFF
--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Checkstyle.java
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.Describables;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.util.internal.ClosureBackedAction;
+import org.gradle.work.NormalizeLineEndings;
 import org.gradle.workers.WorkQueue;
 import org.jspecify.annotations.Nullable;
 
@@ -184,6 +185,7 @@ public abstract class Checkstyle extends AbstractCodeQualityTask implements Repo
      */
     @Override
     @ToBeReplacedByLazyProperty
+    @NormalizeLineEndings
     @PathSensitive(PathSensitivity.RELATIVE)
     public FileTree getSource() {
         return super.getSource();

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -89,6 +89,7 @@ import org.gradle.process.ProcessForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
 import org.gradle.util.internal.ConfigureUtil;
+import org.gradle.work.NormalizeLineEndings;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -1276,6 +1277,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      */
     @InputFiles
     @SkipWhenEmpty
+    @NormalizeLineEndings
     @IgnoreEmptyDirectories
     @PathSensitive(PathSensitivity.RELATIVE)
     @ToBeReplacedByLazyProperty(comment = "Should this be kept as it is?")


### PR DESCRIPTION
Fixes #36006 

### Context
Improved build caching between machine types
https://github.com/gradle/gradle/issues/36006

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
