### PR TITLE
Print failed scenario's url for troubleshooting

### DIFF
--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
@@ -21,6 +21,7 @@ import org.gradle.performance.results.CrossVersionResultsStore;
 import org.gradle.performance.results.DefaultPerformanceFlakinessDataProvider;
 import org.gradle.performance.results.PerformanceDatabase;
 import org.gradle.performance.results.PerformanceFlakinessDataProvider;
+import org.gradle.performance.results.PerformanceTestExecutionResult;
 import org.gradle.performance.results.ResultsStoreHelper;
 
 import java.util.Set;
@@ -51,6 +52,7 @@ public class DefaultReportGenerator extends AbstractReportGenerator<AllResultsSt
         executionDataProvider.getReportScenarios()
             .forEach(scenario -> {
                 if (scenario.isBuildFailed()) {
+                    System.out.println("Build failed for " + scenario.getName() + scenario.getTeamCityExecutions().stream().map(PerformanceTestExecutionResult::getWebUrl).collect(Collectors.joining(", ")));
                     failureCollector.scenarioFailed();
                 } else if (scenario.isRegressed()) {
                     Set<PerformanceFlakinessDataProvider.ScenarioRegressionResult> regressionResults = scenario.getCurrentExecutions().stream()


### PR DESCRIPTION
We're currently blocked by a strange performance test failure: a scenario was "failed" (not regressed) but we couldn't find it. Print the detail in the report.