### PR TITLE
Improve performance of dependency resolution involving strict version constraints

### DIFF
--- a/platforms/software/dependency-management/build.gradle.kts
+++ b/platforms/software/dependency-management/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     api(projects.buildOption)
     api(projects.buildProcessServices)
     api(projects.classloaders)
+    api(projects.collections)
     api(projects.concurrent)
     api(projects.core)
     api(projects.coreApi)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/strict/StrictVersionConstraints.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/strict/StrictVersionConstraints.java
@@ -16,17 +16,15 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.strict;
 
-import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.internal.collect.PersistentSet;
 import org.jspecify.annotations.NullMarked;
-
-import java.util.Set;
 
 @NullMarked
 @SuppressWarnings("ReferenceEquality") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
 public class StrictVersionConstraints {
 
-    public static final StrictVersionConstraints EMPTY = new StrictVersionConstraints(ImmutableSet.of()) {
+    public static final StrictVersionConstraints EMPTY = new StrictVersionConstraints(PersistentSet.of()) {
         @Override
         public StrictVersionConstraints union(StrictVersionConstraints other) {
             return other;
@@ -58,20 +56,20 @@ public class StrictVersionConstraints {
         }
     };
 
-    private final ImmutableSet<ModuleIdentifier> modules;
+    private final PersistentSet<ModuleIdentifier> modules;
 
-    private StrictVersionConstraints(ImmutableSet<ModuleIdentifier> modules) {
+    private StrictVersionConstraints(PersistentSet<ModuleIdentifier> modules) {
         this.modules = modules;
     }
 
-    public static StrictVersionConstraints of(ImmutableSet<ModuleIdentifier> modules) {
+    public static StrictVersionConstraints of(PersistentSet<ModuleIdentifier> modules) {
         if (modules.isEmpty()) {
             return EMPTY;
         }
         return new StrictVersionConstraints(modules);
     }
 
-    public ImmutableSet<ModuleIdentifier> getModules() {
+    public PersistentSet<ModuleIdentifier> getModules() {
         return modules;
     }
 
@@ -91,35 +89,25 @@ public class StrictVersionConstraints {
             // this happens quite a lot!
             return this;
         }
-        if (this.modules.equals(other.modules)) {
+        PersistentSet<ModuleIdentifier> union = this.modules.union(other.modules);
+        if (union == this.modules) {
             return this;
         }
-        ImmutableSet.Builder<ModuleIdentifier> builder = ImmutableSet.builderWithExpectedSize(modules.size() + other.modules.size());
-        builder.addAll(modules);
-        builder.addAll(other.modules);
-        return of(builder.build());
+        return of(union);
     }
 
     public StrictVersionConstraints intersect(StrictVersionConstraints other) {
-        if (other.modules == modules) {
-            return this;
-        }
         if (other == EMPTY) {
             return EMPTY;
         }
-
-        Set<ModuleIdentifier> smaller = (modules.size() < other.modules.size()) ? modules : other.modules;
-        Set<ModuleIdentifier> larger = (smaller == modules) ? other.modules : modules;
-        ImmutableSet.Builder<ModuleIdentifier> builder = ImmutableSet.builderWithExpectedSize(smaller.size());
-
-        // Iterating over the smaller set to minimize the number of contains() checks
-        for (ModuleIdentifier module : smaller) {
-            if (larger.contains(module)) {
-                builder.add(module);
-            }
+        if (this == other) {
+            return this;
         }
-
-        return of(builder.build());
+        PersistentSet<ModuleIdentifier> intersect = this.modules.intersect(other.modules);
+        if (intersect == this.modules) {
+            return this;
+        }
+        return of(intersect);
     }
 
     @Override
@@ -131,26 +119,24 @@ public class StrictVersionConstraints {
         if (other == EMPTY) {
             return this;
         }
-
-        if (this == other || this == EMPTY) {
+        if (this == other) {
             return EMPTY;
         }
-
-        ImmutableSet.Builder<ModuleIdentifier> builder = ImmutableSet.builderWithExpectedSize(modules.size());
-        for (ModuleIdentifier module : modules) {
-            if (!other.modules.contains(module)) {
-                builder.add(module);
-            }
+        PersistentSet<ModuleIdentifier> diff = this.modules.except(other.modules);
+        if (diff == this.modules) {
+            return this;
         }
-        return of(builder.build());
+        return of(diff);
     }
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         StrictVersionConstraints that = (StrictVersionConstraints) o;
         return modules.equals(that.modules);
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeStateTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeStateTest.groovy
@@ -16,13 +16,13 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 
-import com.google.common.collect.ImmutableSet
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.strict.StrictVersionConstraints
 import org.gradle.api.specs.Specs
+import org.gradle.internal.collect.PersistentSet
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.component.model.VariantGraphResolveState
@@ -239,7 +239,7 @@ class NodeStateTest extends Specification {
     }
 
     private static StrictVersionConstraints modules(List<String> names) {
-        StrictVersionConstraints.of(ImmutableSet.copyOf(
+        StrictVersionConstraints.of(PersistentSet.copyOf(
             names.collect { DefaultModuleIdentifier.newId("org", it) }
         ))
     }


### PR DESCRIPTION
By replacing expensive `ImmutableSet` copying operations with `PersistentSet` updates in `StrictVersionConstraints`.

This change saves `1s` of configuration time (~7%) in the `gradle/gradle` build running `codeQuality`: 

<img width="1542" height="838" alt="strict-version-constraints-benchmark" src="https://github.com/user-attachments/assets/7fca9a57-e92f-43e8-aeef-0d6c31d7edd1" />


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
