### PR TITLE
Add status indicators to root tabs

### DIFF
--- a/platforms/core-runtime/report-rendering/src/main/java/org/gradle/reporting/TabsRenderer.java
+++ b/platforms/core-runtime/report-rendering/src/main/java/org/gradle/reporting/TabsRenderer.java
@@ -25,7 +25,11 @@ public class TabsRenderer<T> extends ReportRenderer<T, SimpleHtmlWriter> {
     private final List<TabDefinition> tabs = new ArrayList<TabDefinition>();
 
     public void add(String title, ReportRenderer<T, SimpleHtmlWriter> contentRenderer) {
-        tabs.add(new TabDefinition(title, contentRenderer));
+        tabs.add(new TabDefinition(title, "", contentRenderer));
+    }
+
+    public void add(String title, String tabClass, ReportRenderer<T, SimpleHtmlWriter> contentRenderer) {
+        tabs.add(new TabDefinition(title, tabClass, contentRenderer));
     }
 
     public void clear() {
@@ -38,7 +42,7 @@ public class TabsRenderer<T> extends ReportRenderer<T, SimpleHtmlWriter> {
             htmlWriterWriter.startElement("ul").attribute("class", "tabLinks");
                 for (TabDefinition tab : this.tabs) {
                     htmlWriterWriter.startElement("li");
-                    htmlWriterWriter.startElement("a").attribute("href", "#").characters(tab.title).endElement();
+                    htmlWriterWriter.startElement("a").attribute("class", tab.tabClass).attribute("href", "#").characters(tab.title).endElement();
                     htmlWriterWriter.endElement();
                 }
             htmlWriterWriter.endElement();
@@ -54,10 +58,12 @@ public class TabsRenderer<T> extends ReportRenderer<T, SimpleHtmlWriter> {
 
     private class TabDefinition {
         final String title;
+        private final String tabClass;
         final ReportRenderer<T, SimpleHtmlWriter> renderer;
 
-        private TabDefinition(String title, ReportRenderer<T, SimpleHtmlWriter> renderer) {
+        private TabDefinition(String title, String tabClass, ReportRenderer<T, SimpleHtmlWriter> renderer) {
             this.title = title;
+            this.tabClass = tabClass;
             this.renderer = renderer;
         }
     }

--- a/platforms/core-runtime/report-rendering/src/test/groovy/org/gradle/reporting/TabsRendererTest.groovy
+++ b/platforms/core-runtime/report-rendering/src/test/groovy/org/gradle/reporting/TabsRendererTest.groovy
@@ -35,15 +35,18 @@ class TabsRendererTest extends Specification {
 
         and:
         renderer.add('tab 1', contentRenderer)
-        renderer.add('tab 2', contentRenderer)
+        renderer.add('tab 2', 'tabClass', contentRenderer)
 
         when:
         renderer.render("test", htmlBuilder)
 
         def html = html(writer.toString());
         then:
-        html.select("div.tab-container > ul > li > a").find { it.text() == "tab 1" }
-        html.select("div.tab-container > ul > li > a").find { it.text() == "tab 2" }
+        def tab1 = html.select("div.tab-container > ul > li > a").find { it.text() == "tab 1" }
+        tab1.attr("class") == ""
+
+        def tab2 = html.select("div.tab-container > ul > li > a").find { it.text() == "tab 2" }
+        tab2.attr("class") == "tabClass"
 
         // There is a <ul> for the tabs above, so this starts from 2 and not 1 for the :nth-child selector
         html.select("div.tab-container > div:nth-child(2) > h2").find { it.text() == "tab 1" }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericPageRenderer.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericPageRenderer.java
@@ -186,7 +186,21 @@ final class GenericPageRenderer extends TabbedPageRenderer<TestTreeModel> {
                     directlyBelowRootTabsRenderer.add("run " + (i + 1), perRootInfoTabsRenderers.get(i));
                 }
             }
-            rootTabsRenderer.add(rootDisplayNames.get(rootIndex), new ReportRenderer<TestTreeModel, SimpleHtmlWriter>() {
+            String rootState = "successGroup";
+            for (PerRootInfo info : infos) {
+                if (info.getFailedLeafCount() > 0) {
+                    // Failures are the most serious state
+                    rootState = "failureGroup";
+                    break;
+                }
+                if (info.getSkippedLeafCount() == info.getTotalLeafCount()) {
+                    // If everything is skipped, show that
+                    rootState = "skippedGroup";
+                    break;
+                }
+            }
+
+            rootTabsRenderer.add(rootDisplayNames.get(rootIndex), rootState, new ReportRenderer<TestTreeModel, SimpleHtmlWriter>() {
                 @Override
                 public void render(TestTreeModel model, SimpleHtmlWriter output) throws IOException {
                     String displayName = SerializableTestResult.getCombinedDisplayName(infos.get(0).getResults());

--- a/platforms/software/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/generic/style.css
+++ b/platforms/software/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/generic/style.css
@@ -133,3 +133,22 @@ div.metadata td {
     font-size: 0.9em;
     cursor: pointer;
 }
+
+.successGroup::before {
+    content: "\23FA";
+    margin-right: 8px;
+    color: #008000;
+    display: inline-block;
+}
+.failureGroup::before {
+    content: "\2297";
+    margin-right: 8px;
+    color: #b60808;
+    display: inline-block;
+}
+.skippedGroup::before {
+    content: "\2296";
+    margin-right: 8px;
+    color: #c09853;
+    display: inline-block;
+}

--- a/testing/internal-testing/src/main/groovy/org/gradle/api/internal/tasks/testing/report/generic/GenericHtmlTestExecutionResult.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/api/internal/tasks/testing/report/generic/GenericHtmlTestExecutionResult.groovy
@@ -26,6 +26,7 @@ import com.google.common.collect.Multimaps
 import com.google.common.collect.Multisets
 import com.google.common.collect.Sets
 import com.google.common.collect.Streams
+import org.gradle.api.Action
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.internal.lazy.Lazy
 import org.gradle.util.Path
@@ -90,6 +91,14 @@ class GenericHtmlTestExecutionResult implements GenericTestExecutionResult {
      */
     Set<Path> getExecutedTestPaths() {
         return executedTestPathsLazy.get()
+    }
+
+    GenericTestExecutionResult assertHtml(String cssQuery, Action<Collection<?>> action) {
+        def parsedHtml = Jsoup.parse(htmlReportDirectory.toPath().resolve("index.html").toFile(), null)
+        def matched = parsedHtml.select(cssQuery)
+        assert matched : "Queried HTML report for $cssQuery"
+        action.execute(matched)
+        return this
     }
 
     @SuppressWarnings('GroovyAssignabilityCheck')

--- a/testing/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.integtests.fixtures
 
+import org.gradle.api.Action
 import org.gradle.api.internal.tasks.testing.report.generic.GenericHtmlTestExecutionResult
 import org.gradle.api.internal.tasks.testing.report.generic.GenericTestExecutionResult.TestFramework
 import org.gradle.api.internal.tasks.testing.report.generic.TestPathExecutionResult
@@ -55,6 +56,16 @@ class HtmlTestExecutionResult implements TestExecutionResult {
         return delegate.executedTestPaths.findAll { isTestClass(it) }
             .collect { it.name }
             .toSet()
+    }
+
+    /**
+     * Assert that the elements returned by the CSS query are what would be expected.
+     *
+     * Assertions are performed in the given action.
+     */
+    TestExecutionResult assertHtml(String cssQuery, Action<Collection<?>> action) {
+        delegate.assertHtml(cssQuery, action)
+        return this
     }
 
     TestExecutionResult assertTestClassesExecuted(String... testClasses) {


### PR DESCRIPTION
Partial mitigation for https://github.com/gradle/gradle/issues/35959

Looks something like this:
<img width="1109" height="169" alt="image" src="https://github.com/user-attachments/assets/3cd59869-a079-40e1-978c-bc0648fd2b7d" />

When something has failures, you get the failure indicator. When everything is skipped, you get the skipped indicator. Everything else is success. 


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
