### PR TITLE
Update performance test to declare definition as unsafe

### DIFF
--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/DeclarativeDslTestProjectGenerator.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/DeclarativeDslTestProjectGenerator.groovy
@@ -339,7 +339,7 @@ class DeclarativeDslTestProjectGenerator extends AbstractTestProjectGenerator {
 
                                 context.getProject().getPlugins().apply(ApplicationPlugin.class);
                             }
-                        );
+                        ).withUnsafeDefinition();
                     }
                 }
 


### PR DESCRIPTION
With #35926 we changed the API such that you have to explicitly declare the definition as unsafe.  Part of the definition extends `org.gradle.api.artifacts.dsl.Dependencies` which injects some services, making it unsafe and causing a failure.

This explicitly marks the definition as unsafe to fix the failure.  

We might look into changing the template so that the definition is safe in follow up work.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
