### PR TITLE
Profile SQL executions

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
@@ -19,6 +19,7 @@ package configurations
 import common.Os
 import common.applyDefaultSettings
 import jetbrains.buildServer.configs.kotlin.ParameterDisplay
+import jetbrains.buildServer.configs.kotlin.PublishMode
 import jetbrains.buildServer.configs.kotlin.ReuseBuilds
 import model.CIBuildModel
 import model.PerformanceTestType
@@ -66,6 +67,7 @@ class PerformanceTestsPass(
                     "performanceTestReport"
                 }
 
+            publishArtifacts = PublishMode.ALWAYS
             artifactRules = """
 testing/$performanceProjectName/build/performance-test-results.zip
 """

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/SQLProfilingData.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/SQLProfilingData.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Represents metadata and performance metrics for a SQL execution.
+ *
+ * @param name The logical name of the operation (e.g., "insertExecution").
+ * @param sql The raw SQL statement executed.
+ * @param params A list of key parameters used in the query for identification.
+ * @param result A string summary of the execution outcome. This unifies various JDBC
+ * return types: Booleans (success), Integers (rows affected),
+ * int[] (batch update counts), or ResultSets (presence of data).
+ * @param durationMs The time taken to execute the operation in milliseconds.
+ */
+record SQLProfilingData(
+    String name,
+    String sql,
+    List<?> params,
+    String result,
+    long durationMs
+) {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public static SQLProfilingData create(String name, String sql, List<?> params, Object rawResult, long startTimeMs) {
+        return new SQLProfilingData(name, sql, params, summarize(rawResult), System.currentTimeMillis() - startTimeMs);
+    }
+
+    /**
+     * Converts various JDBC return types into a human-readable string summary.
+     */
+    private static String summarize(Object result) {
+        if (result == null) {
+            return "null";
+        }
+        if (result instanceof Boolean) {
+            return result.toString();
+        }
+        if (result instanceof Integer) {
+            return "rows: " + result;
+        }
+        if (result instanceof int[] batch) {
+            return "batch rows: " + Arrays.stream(batch).sum();
+        }
+        if (result instanceof java.sql.ResultSet) {
+            return "ResultSet returned";
+        }
+        if (result instanceof String) {
+            return (String) result;
+        }
+        return result.getClass().getSimpleName() + ": " + result.toString();
+    }
+
+    public String toJson() {
+        try {
+            return MAPPER.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/4977#event-21563433464

Performance DB queries might be inefficient but we have no metrics to track them. This PR does:

1. Print profiling data around every SQL operation with the format `[Profiling] {name=aaa, sql=bbb, params=[], result=ddd, durationMs=123}`. The reason we use JSON is that SQL include many commas and it would make CSV output hard to read.
2. When we run performance report generation task, it captures the lines of stdout, strips the `[Profiling] ` prefix, and writes them into `profiling.txt`. It's part of performance report dir so it would be automatically collected by TeamCity artifact.

The [artifact publish mode is also set to "always"](https://www.jetbrains.com/help/teamcity/2025.07/configuring-general-settings.html?Configuring%20General%20Settings#General+Build+Configuration+Settings) so that the artifact will be uploaded even when build runs into timeout.

Example of the profiling data can be found [here](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_PerformanceTestTestLinux_Trigger/106728180?buildTab=artifacts#%2Fperformance-test-results.zip;%2Fperformance-test-results.zip!%2Freport).