### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ systemProp.develocity.internal.testacceleration.enableCustomValues=true
 # If enabled, the build logs whenever a WorkerReadyMessage is received. This should help analyzing the problem of remote executors being in wrong state.
 systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 # Default performance baseline
-defaultPerformanceBaselines=9.4.0-commit-e7958f342aa
+defaultPerformanceBaselines=9.4.0-commit-1c08311fc82
 #-----------------------------------------till here^
 systemProp.dependency.analysis.test.analysis=false
 


### PR DESCRIPTION
PR https://github.com/gradle/gradle/pull/35926 included a breaking change in DCL APIs that required changing the performance template in PR https://github.com/gradle/gradle/pull/36052

Now the DCL perf tests can only run with a recent baseline that include the changes from #35926

This was discussed in https://gradle.slack.com/archives/C062ARKUV5L/p1765960574645109?thread_ts=1765918392.508969&cid=C062ARKUV5L

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
