### PR TITLE
Fix parallel tests using new fixture

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGracefulDegradationIntegrationTest.groovy
@@ -127,7 +127,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
 
         and:
         problems.assertResultConsoleSummaryHasNoProblems(result)
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             totalProblemsCount = 1
             withProblem(INVOCATION_OF_TASK_PROJECT_AT_EXECUTION_TIME)
             withIncompatibleTask(":a", "Project access.")
@@ -174,7 +174,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
 
         and:
         problems.assertResultConsoleSummaryHasNoProblems(result)
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             totalProblemsCount = expectedProblems.size()
             expectedProblems.forEach { withProblem(it) }
             withIncompatibleTask(":a", degradationReason)
@@ -202,7 +202,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         and:
         // feature degradation is reported as a report problem, but it is silently suppressed from the console
         problems.assertResultConsoleSummaryHasNoProblems(result)
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             totalProblemsCount = 1
             withProblem("Feature 'source dependencies' is incompatible with the configuration cache.")
         }
@@ -239,7 +239,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
             totalProblemsCount = 1
             withProblem("Build file 'build.gradle': line 17: invocation of 'Task.project' at execution time is unsupported with the configuration cache.")
         }
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             // gracefully degraded task appears in the report
             withProblem(INVOCATION_OF_TASK_PROJECT_AT_EXECUTION_TIME)
             withProblem(INVOCATION_OF_TASK_PROJECT_AT_EXECUTION_TIME)
@@ -269,7 +269,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
 
         and:
         problems.assertResultConsoleSummaryHasNoProblems(result)
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             totalProblemsCount = 1
             withProblem(INVOCATION_OF_TASK_PROJECT_AT_EXECUTION_TIME)
             withIncompatibleTask(":included:foo", "Project access.")
@@ -335,7 +335,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
 
         and:
         problems.assertResultConsoleSummaryHasNoProblems(result)
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             totalProblemsCount = 1
             withProblem(INVOCATION_OF_TASK_PROJECT_AT_EXECUTION_TIME)
             withIncompatibleTask(":included:foo", "Project access.")
@@ -371,7 +371,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
 
         and:
         problems.assertResultConsoleSummaryHasNoProblems(result)
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             totalProblemsCount = 0
             withIncompatibleTask(":$build:foo", "Because reasons.")
         }
@@ -546,7 +546,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
         // no problems on the console
         problems.assertResultConsoleSummaryHasNoProblems(result)
         // but problems should be in CC report
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             totalProblemsCount = 1
             withProblem(INVOCATION_OF_TASK_PROJECT_AT_EXECUTION_TIME)
             withIncompatibleTask(":foo", "Because reasons.")
@@ -580,7 +580,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
 
         and:
         problems.assertResultConsoleSummaryHasNoProblems(result)
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             totalProblemsCount = 0
             withIncompatibleTask(":foo", "Because reasons.")
         }
@@ -648,7 +648,7 @@ class ConfigurationCacheGracefulDegradationIntegrationTest extends AbstractConfi
             totalProblemsCount = 1
             withProblem("Build file 'build.gradle': line 17: invocation of 'Task.project' at execution time is unsupported with the configuration cache")
         }
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             totalProblemsCount = 1
             withProblem(INVOCATION_OF_TASK_PROJECT_AT_EXECUTION_TIME)
             withIncompatibleTask(":bar", "Project access.")

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheReadOnlyIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheReadOnlyIntegrationTest.groovy
@@ -136,7 +136,7 @@ class ConfigurationCacheReadOnlyIntegrationTest extends AbstractConfigurationCac
         postBuildOutputContains(CONFIGURATION_CACHE_DISABLED_READ_ONLY_REASON)
 
         problems.assertResultConsoleSummaryHasNoProblems(result)
-        problems.htmlReport(result).assertContents {
+        problems.htmlReport(result.output).assertContents {
             totalProblemsCount = 1
             withProblem("invocation of 'Task.project' at execution time is unsupported")
         }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsExecutionResultFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsExecutionResultFixture.groovy
@@ -33,25 +33,6 @@ final class ConfigurationCacheProblemsExecutionResultFixture extends Configurati
         super(rootDir)
     }
 
-    ConfigurationCacheReportFixture htmlReport(ExecutionResult result) {
-        return super.htmlReport(result.output)
-    }
-
-    ConfigurationCacheReportFixture htmlReport(ExecutionFailure failure) {
-        return super.htmlReport(failure.error)
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated use {@link #htmlReport(ExecutionResult)} or {@link #htmlReport(ExecutionFailure)}
-     */
-    @Override
-    @Deprecated
-    ConfigurationCacheReportFixture htmlReport(String output) {
-        return super.htmlReport(output)
-    }
-
     void assertFailureHasProblems(
         ExecutionFailure failure,
         @DelegatesTo(value = HasConfigurationCacheProblemsSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> specClosure
@@ -66,7 +47,7 @@ final class ConfigurationCacheProblemsExecutionResultFixture extends Configurati
         assertNoProblemsSummary(failure.output)
         assertFailureDescription(failure, failureDescriptionMatcherForProblems(spec))
 
-        htmlReport(failure).assertContents(spec)
+        htmlReport(failure.error).assertContents(spec)
     }
 
     void assertFailureHasTooManyProblems(
@@ -83,7 +64,7 @@ final class ConfigurationCacheProblemsExecutionResultFixture extends Configurati
         assertNoProblemsSummary(failure.output)
         assertFailureDescription(failure, failureDescriptionMatcherForTooManyProblems(spec))
 
-        htmlReport(failure).assertContents(spec)
+        htmlReport(failure.error).assertContents(spec)
     }
 
     void assertResultHasProblems(
@@ -103,8 +84,7 @@ final class ConfigurationCacheProblemsExecutionResultFixture extends Configurati
             assertNoProblemsSummary(result.output)
         }
 
-        // Don't let Groovy to pick up more precise overload, we don't want to use htmlReport(ExecutionFailure) here.
-        htmlReport(result as ExecutionResult).assertContents(spec)
+        htmlReport(result.output).assertContents(spec)
     }
 
     void assertResultConsoleSummaryHasNoProblems(ExecutionResult result) {


### PR DESCRIPTION
The nice API doesn't really work. It turns out that the result of the successful parallel execution, `ParallelExecutionResult`, also implements `ExecutionFailure`, which causes Groovy to select a wrong overload that looks up the URL in the stderr.

The easiest solution is to remove the overloads and use the correct stream explicitly.

Fixes gradle/gradle-private#4979