### PR TITLE
Moves build-logic checks entirely to the build logic check build and …

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/BuildLogicTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/BuildLogicTest.kt
@@ -11,8 +11,8 @@ class BuildLogicTest(
     stage: Stage,
 ) : OsAwareBaseGradleBuildType(os = Os.LINUX, stage = stage, init = {
         id(buildTypeId(model))
-        name = "Build-logic test"
-        description = "Run :build-logic:test"
+        name = "Build-logic checks"
+        description = "Run check on all build-logic builds"
 
         features {
             publishBuildStatusToGithub(model)
@@ -21,11 +21,11 @@ class BuildLogicTest(
         applyDefaults(
             model,
             this,
-            ":build-logic:test",
+            "checkBuildLogic",
             extraParameters =
                 listOf(
                     stage.getBuildScanCustomValueParam(),
-                    buildScanTagParam("BuildLogitTest"),
+                    buildScanTagParam("BuildLogicTest"),
                     "-Dorg.gradle.java.installations.auto-download=false",
                     "-Porg.gradle.java.installations.auto-download=false",
                 ).joinToString(" "),

--- a/build-logic-commons/build.gradle.kts
+++ b/build-logic-commons/build.gradle.kts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 description = "Provides a set of plugins that are shared between the Gradle and build-logic builds"
 
 tasks.register("check") {

--- a/build-logic-settings/build.gradle.kts
+++ b/build-logic-settings/build.gradle.kts
@@ -15,3 +15,7 @@
  */
 
 description = "Provides settings plugins for configuring global build configuration"
+
+tasks.register("check") {
+    dependsOn(subprojects.map { "${it.name}:check" })
+}

--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -89,12 +89,18 @@ fun TaskContainer.registerEarlyFeedbackRootLifecycleTasks() {
         dependsOn(":base-services:createBuildReceipt")
     }
 
+    register("checkBuildLogic") {
+        description = "Run check on all build logic builds - to be run locally and on CI for early feedback"
+        group = "verification"
+        dependsOn(
+            gradle.includedBuilds.map { it.task(":check") }
+        )
+    }
+
     register(sanityCheck) {
         description = "Run all basic checks (without tests) - to be run locally and on CI for early feedback"
         group = "verification"
         dependsOn(
-            gradle.includedBuild("build-logic-commons").task(":check"),
-            gradle.includedBuild("build-logic").task(":check"),
             ":docs:checkstyleApi",
             ":internal-build-reports:allIncubationReportsZip",
             ":architecture-test:checkBinaryCompatibility",


### PR DESCRIPTION
…out of sanityCheck

The tests that run as part of build-logic:check take more time than most other checks

Since https://github.com/gradle/gradle/pull/35636, we've started running the tests again as part of sanityCheck.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
