### PR TITLE
Update timeout for FlakyTestQuarantine builds

### DIFF
--- a/.teamcity/src/main/kotlin/common/CommonExtensions.kt
+++ b/.teamcity/src/main/kotlin/common/CommonExtensions.kt
@@ -32,6 +32,7 @@ import jetbrains.buildServer.configs.kotlin.CheckoutMode
 import jetbrains.buildServer.configs.kotlin.Dependencies
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.PublishMode
 import jetbrains.buildServer.configs.kotlin.RelativeId
 import jetbrains.buildServer.configs.kotlin.Requirements
 import jetbrains.buildServer.configs.kotlin.buildSteps.GradleBuildStep
@@ -128,6 +129,11 @@ fun BuildType.addEc2PostBuild(os: Os = Os.LINUX) {
     }
 }
 
+fun BuildTypeSettings.setArtifactRules(rules: String) {
+    artifactRules = rules
+    publishArtifacts = PublishMode.ALWAYS
+}
+
 fun BuildType.applyDefaultSettings(
     os: Os = Os.LINUX,
     arch: Arch = Arch.AMD64,
@@ -151,7 +157,7 @@ fun BuildType.applyDefaultSettings(
         build/reports/problems/problems-report.html
         """.trimIndent()
 
-    artifactRules = artifactRuleOverride ?: defaultArtifactRules
+    setArtifactRules(artifactRuleOverride ?: defaultArtifactRules)
     paramsForBuildToolBuild(buildJvm, os, arch)
     params {
         // The promotion job doesn't have a branch, so %teamcity.build.branch% doesn't work.

--- a/.teamcity/src/main/kotlin/common/PerformanceTestExtensions.kt
+++ b/.teamcity/src/main/kotlin/common/PerformanceTestExtensions.kt
@@ -27,12 +27,13 @@ fun BuildType.applyPerformanceTestSettings(
     timeout: Int = 30,
 ) {
     applyDefaultSettings(os = os, arch = arch, timeout = timeout)
-    artifactRules =
+    setArtifactRules(
         """
         build/report-*-performance-tests.zip => .
         build/report-*-performance.zip => $HIDDEN_ARTIFACT_DESTINATION
         build/report-*PerformanceTest.zip => $HIDDEN_ARTIFACT_DESTINATION
-        """.trimIndent()
+        """.trimIndent(),
+    )
     detectHangingBuilds = false
     requirements {
         requiresNotEc2Agent()

--- a/.teamcity/src/main/kotlin/configurations/BuildDistributions.kt
+++ b/.teamcity/src/main/kotlin/configurations/BuildDistributions.kt
@@ -3,6 +3,7 @@ package configurations
 import common.Os.LINUX
 import common.buildScanTagParam
 import common.getBuildScanCustomValueParam
+import common.setArtifactRules
 import model.CIBuildModel
 import model.Stage
 
@@ -32,9 +33,10 @@ class BuildDistributions(
             publishBuildStatusToGithub(model)
         }
 
-        artifactRules =
+        setArtifactRules(
             """$artifactRules
 packaging/distributions-full/build/distributions/*.zip => distributions
 platforms/core-runtime/base-services/build/generated-resources/build-receipt/org/gradle/build-receipt.properties
-"""
+""",
+        )
     })

--- a/.teamcity/src/main/kotlin/configurations/CompileAll.kt
+++ b/.teamcity/src/main/kotlin/configurations/CompileAll.kt
@@ -3,6 +3,7 @@ package configurations
 import common.Os
 import common.buildScanTagParam
 import common.getBuildScanCustomValueParam
+import common.setArtifactRules
 import model.CIBuildModel
 import model.Stage
 
@@ -31,10 +32,11 @@ class CompileAll(
                 ).joinToString(" "),
         )
 
-        artifactRules =
+        setArtifactRules(
             """$artifactRules
 platforms/core-runtime/base-services/build/generated-resources/build-receipt/org/gradle/build-receipt.properties
-"""
+""",
+        )
     }) {
     companion object {
         fun buildTypeId(model: CIBuildModel) = buildTypeId(model.projectId)

--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -77,7 +77,7 @@ class FlakyTestQuarantine(
         name = "Flaky Test Quarantine - ${testCoverage.asName()}"
         description = "Run all flaky tests skipped multiple times"
 
-        applyDefaultSettings(os = os, arch = arch, buildJvm = BuildToolBuildJvm, timeout = 180)
+        applyDefaultSettings(os = os, arch = arch, buildJvm = BuildToolBuildJvm, timeout = 60)
 
         if (os == Os.LINUX) {
             steps {

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -29,6 +29,7 @@ import common.gradleWrapper
 import common.killProcessStep
 import common.performanceTestCommandLine
 import common.removeSubstDirOnWindows
+import common.setArtifactRules
 import common.substDirOnWindows
 import jetbrains.buildServer.configs.kotlin.BuildStep
 import jetbrains.buildServer.configs.kotlin.BuildSteps
@@ -60,7 +61,7 @@ class PerformanceTest(
             val buildTypeThis = this
             val performanceTestTaskNames = getPerformanceTestTaskNames(performanceSubProject, testProjects, performanceTestTaskSuffix)
             applyPerformanceTestSettings(os = os, arch = arch, timeout = type.timeout)
-            artifactRules = INDIVIDUAL_PERFORAMCE_TEST_ARTIFACT_RULES
+            setArtifactRules(INDIVIDUAL_PERFORAMCE_TEST_ARTIFACT_RULES)
 
             params {
                 text(

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
@@ -18,6 +18,7 @@ package configurations
 
 import common.Os
 import common.applyDefaultSettings
+import common.setArtifactRules
 import jetbrains.buildServer.configs.kotlin.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.ReuseBuilds
 import model.CIBuildModel
@@ -66,9 +67,11 @@ class PerformanceTestsPass(
                     "performanceTestReport"
                 }
 
-            artifactRules = """
+            setArtifactRules(
+                """
 testing/$performanceProjectName/build/performance-test-results.zip
-"""
+""",
+            )
             if (performanceTestProject.performanceTests.any { it.testProjects.isNotEmpty() }) {
                 val dependencyBuildIds =
                     performanceTestProject.performanceTests

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -24,7 +24,10 @@ class SmokeTests(
         name = "Smoke Tests with 3rd Party Plugins ($task) - ${testJava.version.toCapitalized()} Linux$suffix"
         description = "Smoke tests against third party plugins to see if they still work with the current Gradle version"
 
-        tcParallelTests(splitNumber)
+        if (flakyTestStrategy != FlakyTestStrategy.ONLY) {
+            // No need to split in FlakyTestQuarantine
+            tcParallelTests(splitNumber)
+        }
 
         requirements {
             // Smoke tests is usually heavy and the build time is twice on EC2 agents
@@ -35,7 +38,7 @@ class SmokeTests(
             model,
             this,
             ":smoke-test:$task",
-            timeout = 120,
+            timeout = if (flakyTestStrategy == FlakyTestStrategy.ONLY) 30 else 120,
             extraParameters =
                 listOf(
                     stage.getBuildScanCustomValueParam(),

--- a/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
@@ -24,6 +24,7 @@ import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
 import common.gradleWrapper
 import common.killProcessStep
+import common.setArtifactRules
 import common.skipConditionally
 import jetbrains.buildServer.configs.kotlin.BuildSteps
 import model.CIBuildModel
@@ -69,7 +70,7 @@ class TestPerformanceTest(
         description = "Tries to run an adhoc performance test without a database connection to verify this is still working"
 
         applyPerformanceTestSettings()
-        artifactRules = INDIVIDUAL_PERFORAMCE_TEST_ARTIFACT_RULES
+        setArtifactRules(INDIVIDUAL_PERFORAMCE_TEST_ARTIFACT_RULES)
 
         steps {
             killProcessStep(buildTypeThis, KILL_ALL_GRADLE_PROCESSES, os)

--- a/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
@@ -18,6 +18,7 @@ package promotion
 
 import common.gradleWrapper
 import common.promotionBuildParameters
+import common.setArtifactRules
 import jetbrains.buildServer.configs.kotlin.BuildSteps
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.RelativeId
@@ -33,7 +34,7 @@ abstract class BasePublishGradleDistribution(
     cleanCheckout: Boolean = true,
 ) : BasePromotionBuildType(cleanCheckout) {
     init {
-        artifactRules =
+        setArtifactRules(
             """
             **/build/git-checkout/platforms/core-runtime/base-services/build/generated-resources/build-receipt/org/gradle/build-receipt.properties
             **/build/git-checkout/build/distributions/*.zip => promote-build-distributions
@@ -41,7 +42,8 @@ abstract class BasePublishGradleDistribution(
             **/build/releases-data-checkout/data/releases.xml
             **/smoke-tests/build/reports/tests/** => post-smoke-tests
             **/build/version-info.properties => version-info.properties
-            """.trimIndent()
+            """.trimIndent(),
+        )
 
         dependencies {
             snapshot(RelativeId("Check_Stage_${this@BasePublishGradleDistribution.triggerName}_Trigger")) {

--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -12,6 +12,7 @@ import common.gradleWrapper
 import common.killProcessStep
 import common.performanceTestCommandLine
 import common.removeSubstDirOnWindows
+import common.setArtifactRules
 import common.substDirOnWindows
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.ParameterDisplay
@@ -26,7 +27,7 @@ abstract class AdHocPerformanceScenario(
         id(id)
 
         applyPerformanceTestSettings(os = os, arch = arch, timeout = 420)
-        artifactRules = INDIVIDUAL_PERFORAMCE_TEST_ARTIFACT_RULES
+        setArtifactRules(INDIVIDUAL_PERFORAMCE_TEST_ARTIFACT_RULES)
 
         params {
             text(


### PR DESCRIPTION
Currently, all flaky test quarantine builds inherit old timeout config, which is 180 min. After we split them, most builds can finish in 30m, with some slow builds (like Windows NoDaemon) need slightly more than 30m to finish. 

This PR changes:

1. Set the default timeout for FlakyTestQuarantine to be 60 min.
2. Set smoke test under FlakyTestQuarantine mode with timeout=30m and parallelism=1.
3. Update all artifact rules publish mode, because we have need to get timeout logs uploaded as artifacts even when the builds run into timeout.