### PR TITLE
Enable NullAway in multiple projects

### DIFF
--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: microsoft # no temurin available
-          java-version: 21.0.1
+          java-version: 21
       - uses: actions/download-artifact@v8
         with:
           name: build-receipt.properties

--- a/platforms/core-configuration/input-tracking/src/main/java/org/gradle/internal/configuration/inputs/InstrumentedInputs.java
+++ b/platforms/core-configuration/input-tracking/src/main/java/org/gradle/internal/configuration/inputs/InstrumentedInputs.java
@@ -28,7 +28,6 @@ public class InstrumentedInputs {
      * @deprecated do not use outside of this class
      */
     @Deprecated
-    @SuppressWarnings("NullAway") // https://github.com/uber/NullAway/issues/681, this method may be heavily used
     public static InstrumentedInputsListener listener() {
         // TODO(mlopatkin): Reduce the visibility of this method once everything moves into this project.
         return LISTENER.get();

--- a/platforms/core-configuration/java-api-extractor/build.gradle.kts
+++ b/platforms/core-configuration/java-api-extractor/build.gradle.kts
@@ -21,3 +21,7 @@ gradleModule {
 // Should not be part of the public API
 // TODO Find a proper way to configure this
 configurations.remove(configurations.apiStubElements.get())
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ApiMemberSelector.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ApiMemberSelector.java
@@ -54,6 +54,9 @@ public class ApiMemberSelector extends ClassVisitor {
     private final boolean apiIncludesPackagePrivateMembers;
 
     private boolean isInnerClass;
+    // TODO: Replace the suppression with an @Initializer-style annotation
+    //  (https://github.com/uber/NullAway/wiki/Supported-Annotations#initialization).
+    @SuppressWarnings("NullAway")
     private ClassMember classMember;
     private boolean thisClassIsPrivateInnerClass;
 
@@ -69,7 +72,7 @@ public class ApiMemberSelector extends ClassVisitor {
     }
 
     @Override
-    public void visit(int version, int access, String name, @Nullable String signature, @Nullable String superName, @Nullable String[] interfaces) {
+    public void visit(int version, int access, String name, @Nullable String signature, @Nullable String superName, String @Nullable [] interfaces) {
         super.visit(version, access, name, signature, superName, interfaces);
         classMember = new ClassMember(version, access, name, signature, superName, interfaces);
         isInnerClass = (access & ACC_SUPER) == ACC_SUPER;
@@ -96,7 +99,7 @@ public class ApiMemberSelector extends ClassVisitor {
 
     @Nullable
     @Override
-    public MethodVisitor visitMethod(int access, String name, String desc, @Nullable String signature, @Nullable String[] exceptions) {
+    public MethodVisitor visitMethod(int access, String name, String desc, @Nullable String signature, String @Nullable [] exceptions) {
         if ("<clinit>".equals(name)) {
             // discard static initializers
             return null;

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ApiMemberSelector.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/ApiMemberSelector.java
@@ -54,9 +54,6 @@ public class ApiMemberSelector extends ClassVisitor {
     private final boolean apiIncludesPackagePrivateMembers;
 
     private boolean isInnerClass;
-    // TODO: Replace the suppression with an @Initializer-style annotation
-    //  (https://github.com/uber/NullAway/wiki/Supported-Annotations#initialization).
-    @SuppressWarnings("NullAway")
     private ClassMember classMember;
     private boolean thisClassIsPrivateInnerClass;
 
@@ -71,6 +68,7 @@ public class ApiMemberSelector extends ClassVisitor {
         return thisClassIsPrivateInnerClass;
     }
 
+    @Initializer
     @Override
     public void visit(int version, int access, String name, @Nullable String signature, @Nullable String superName, String @Nullable [] interfaces) {
         super.visit(version, access, name, signature, superName, interfaces);

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/FieldMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/FieldMember.java
@@ -33,8 +33,12 @@ public class FieldMember extends TypedMember implements Comparable<FieldMember> 
     }
 
     @Override
+    // The explicit @Nullable type argument is required to compare the nullable 'value' fields, but it
+    // makes NullAway reject Ordering.arbitrary() (a Comparator<Object>) for a @Nullable type variable,
+    // so the suppression is needed as well.
+    @SuppressWarnings("NullAway")
     public int compareTo(FieldMember o) {
-        return super.compare(o).compare(value, o.value, Ordering.arbitrary()).result();
+        return super.compare(o).<@Nullable Object>compare(value, o.value, Ordering.arbitrary()).result();
     }
 
     @Override

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/Initializer.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/Initializer.java
@@ -33,5 +33,5 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.METHOD)
-@interface Initializer {
+public @interface Initializer {
 }

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/Initializer.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/Initializer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.tools.api.impl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method that initializes {@code @NonNull} fields which are not set in the constructor.
+ *
+ * <p>NullAway treats fields assigned in an initializer method as initialized. This is used for ASM
+ * visitor callbacks (such as {@code ClassVisitor.visit(...)}) that the framework guarantees to call
+ * before the populated fields are read — something NullAway cannot infer from the constructor alone.
+ *
+ * <p>NullAway recognizes any annotation whose simple name is {@code Initializer}; see the
+ * <a href="https://github.com/uber/NullAway/wiki/Supported-Annotations#initialization">NullAway documentation</a>.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.METHOD)
+@interface Initializer {
+}

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/JavaApiMemberWriter.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/JavaApiMemberWriter.java
@@ -50,7 +50,7 @@ public class JavaApiMemberWriter implements ApiMemberWriter {
     }
 
     @Override
-    public ModuleVisitor writeModule(String name, int access, String version) {
+    public ModuleVisitor writeModule(String name, int access, @Nullable String version) {
         return apiMemberAdapter.visitModule(name, access, version);
     }
 

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/MethodMember.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/MethodMember.java
@@ -35,7 +35,7 @@ public class MethodMember extends TypedMember implements Comparable<MethodMember
     @Nullable
     private AnnotationValue<?> annotationDefaultValue;
 
-    public MethodMember(int access, String name, String typeDesc, String signature, String @Nullable [] exceptions) {
+    public MethodMember(int access, String name, String typeDesc, @Nullable String signature, String @Nullable [] exceptions) {
         super(access, name, signature, typeDesc);
         if (exceptions != null && exceptions.length > 0) {
             this.exceptions.addAll(Arrays.asList(exceptions));

--- a/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/SortingAnnotationVisitor.java
+++ b/platforms/core-configuration/java-api-extractor/src/main/java/org/gradle/internal/tools/api/impl/SortingAnnotationVisitor.java
@@ -20,6 +20,8 @@ import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Opcodes;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.LinkedList;
 import java.util.List;
 
@@ -28,6 +30,7 @@ public class SortingAnnotationVisitor extends AnnotationVisitor {
     private final List<AnnotationValue<?>> annotationValues = new LinkedList<>();
     private final AnnotationMember annotation;
 
+    @Nullable
     private SortingAnnotationVisitor parentVisitor;
     @Nullable
     private String annotationValueName;
@@ -72,7 +75,7 @@ public class SortingAnnotationVisitor extends AnnotationVisitor {
     public void visitEnd() {
         if (annotationValueName != null) {
             AnnotationAnnotationValue value = new AnnotationAnnotationValue(annotationValueName, annotation);
-            parentVisitor.annotationValues.add(value);
+            requireNonNull(parentVisitor).annotationValues.add(value);
             annotationValueName = null;
         } else if (arrayValueName != null) {
             ArrayAnnotationValue value = new ArrayAnnotationValue(

--- a/platforms/core-execution/build-cache-packaging/build.gradle.kts
+++ b/platforms/core-execution/build-cache-packaging/build.gradle.kts
@@ -37,3 +37,7 @@ gradleModule {
         worker = true
     }
 }
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-execution/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
+++ b/platforms/core-execution/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
@@ -72,6 +72,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Objects.requireNonNull;
 import static org.gradle.internal.file.FileMetadata.AccessType.DIRECT;
 import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
 
@@ -144,7 +145,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
         entity.visitOutputTrees((treeName, type, root) -> {
             FileSystemSnapshot treeSnapshots = snapshots.get(treeName);
             try {
-                long entryCount = packTree(treeName, type, treeSnapshots, tarOutput);
+                long entryCount = packTree(treeName, type, requireNonNull(treeSnapshots), tarOutput);
                 entries.addAndGet(entryCount);
             } catch (Exception ex) {
                 throw new RuntimeException(String.format("Could not pack tree '%s': %s", treeName, ex.getMessage()), ex);

--- a/platforms/core-execution/build-cache/build.gradle.kts
+++ b/platforms/core-execution/build-cache/build.gradle.kts
@@ -53,3 +53,7 @@ gradleModule {
 }
 
 
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
@@ -70,6 +70,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import static java.util.Objects.requireNonNull;
 
 public class DefaultBuildCacheController implements BuildCacheController {
     @VisibleForTesting
@@ -145,7 +146,9 @@ public class DefaultBuildCacheController implements BuildCacheController {
                 result.set(remoteResult);
             }
         });
-        return result.get();
+        // TODO: Drop requireNonNull once https://github.com/uber/NullAway/issues/681 is fixed
+        //  (the AtomicReference is initialized with Optional.empty() and only set to non-null values).
+        return requireNonNull(result.get());
     }
 
     @Override

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
@@ -70,7 +70,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import static java.util.Objects.requireNonNull;
 
 public class DefaultBuildCacheController implements BuildCacheController {
     @VisibleForTesting
@@ -146,9 +145,7 @@ public class DefaultBuildCacheController implements BuildCacheController {
                 result.set(remoteResult);
             }
         });
-        // TODO: Drop requireNonNull once https://github.com/uber/NullAway/issues/681 is fixed
-        //  (the AtomicReference is initialized with Optional.empty() and only set to non-null values).
-        return requireNonNull(result.get());
+        return result.get();
     }
 
     @Override

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/BaseLocalBuildCacheServiceHandle.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/BaseLocalBuildCacheServiceHandle.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import static java.util.Objects.requireNonNull;
 
 public class BaseLocalBuildCacheServiceHandle implements LocalBuildCacheServiceHandle {
 
@@ -46,7 +47,9 @@ public class BaseLocalBuildCacheServiceHandle implements LocalBuildCacheServiceH
     public Optional<BuildCacheLoadResult> maybeLoad(BuildCacheKey key, Function<File, BuildCacheLoadResult> unpackFunction) {
         AtomicReference<Optional<BuildCacheLoadResult>> result = new AtomicReference<>(Optional.empty());
         service.loadLocally(key, file -> result.set(Optional.ofNullable(unpackFunction.apply(file))));
-        return result.get();
+        // TODO: Drop requireNonNull once https://github.com/uber/NullAway/issues/681 is fixed
+        //  (the AtomicReference is initialized with Optional.empty() and only set to non-null values).
+        return requireNonNull(result.get());
     }
 
     @Override

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/BaseLocalBuildCacheServiceHandle.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/BaseLocalBuildCacheServiceHandle.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import static java.util.Objects.requireNonNull;
 
 public class BaseLocalBuildCacheServiceHandle implements LocalBuildCacheServiceHandle {
 
@@ -47,9 +46,7 @@ public class BaseLocalBuildCacheServiceHandle implements LocalBuildCacheServiceH
     public Optional<BuildCacheLoadResult> maybeLoad(BuildCacheKey key, Function<File, BuildCacheLoadResult> unpackFunction) {
         AtomicReference<Optional<BuildCacheLoadResult>> result = new AtomicReference<>(Optional.empty());
         service.loadLocally(key, file -> result.set(Optional.ofNullable(unpackFunction.apply(file))));
-        // TODO: Drop requireNonNull once https://github.com/uber/NullAway/issues/681 is fixed
-        //  (the AtomicReference is initialized with Optional.empty() and only set to non-null values).
-        return requireNonNull(result.get());
+        return result.get();
     }
 
     @Override

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/BuildCacheServicesConfiguration.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/BuildCacheServicesConfiguration.java
@@ -22,10 +22,12 @@ import org.jspecify.annotations.Nullable;
 
 public final class BuildCacheServicesConfiguration {
 
+    @Nullable
     private final LocalBuildCacheService local;
     private final boolean localPush;
 
     private final String buildPath;
+    @Nullable
     private final BuildCacheService remote;
     private final boolean remotePush;
 

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/OpFiringRemoteBuildCacheServiceHandle.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/internal/controller/service/OpFiringRemoteBuildCacheServiceHandle.java
@@ -34,6 +34,7 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 
 import java.io.IOException;
 import java.io.InputStream;
+import static java.util.Objects.requireNonNull;
 
 public class OpFiringRemoteBuildCacheServiceHandle extends BaseRemoteBuildCacheServiceHandle {
 
@@ -159,7 +160,8 @@ public class OpFiringRemoteBuildCacheServiceHandle extends BaseRemoteBuildCacheS
         }
 
         IOException getIOException() {
-            return (IOException) getCause();
+            // The only constructor takes a non-null cause.
+            return (IOException) requireNonNull(getCause());
         }
     }
 

--- a/platforms/core-execution/file-watching/build.gradle.kts
+++ b/platforms/core-execution/file-watching/build.gradle.kts
@@ -48,3 +48,7 @@ gradleModule {
 }
 
 
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
@@ -228,6 +228,7 @@ public class DefaultFileWatcherRegistry implements FileWatcherRegistry {
     private static class MutableFileWatchingStatistics {
         private boolean unknownEventEncountered;
         private int numberOfReceivedEvents;
+        @Nullable
         private Throwable errorWhileReceivingFileChanges;
 
         public Optional<Throwable> getErrorWhileReceivingFileChanges() {

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -161,7 +161,7 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
                 fileWatcher.startWatching(directoriesToStartWatching);
             }
         } catch (NativeException e) {
-            if (e.getMessage().contains("Already watching path: ")) {
+            if (e.getMessage() != null && e.getMessage().contains("Already watching path: ")) {
                 throw new WatchingNotSupportedException("Unable to watch same file twice via different paths: " + e.getMessage(), e);
             }
             throw e;

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildFinishedFileSystemWatchingBuildOperationType.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildFinishedFileSystemWatchingBuildOperationType.java
@@ -44,6 +44,7 @@ public interface BuildFinishedFileSystemWatchingBuildOperationType extends Build
             }
 
             @Override
+            @Nullable
             public FileSystemWatchingStatistics getStatistics() {
                 return null;
             }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildStartedFileSystemWatchingBuildOperationType.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildStartedFileSystemWatchingBuildOperationType.java
@@ -39,6 +39,7 @@ public interface BuildStartedFileSystemWatchingBuildOperationType extends BuildO
             }
 
             @Override
+            @Nullable
             public FileSystemWatchingStatistics getStatistics() {
                 return null;
             }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/FileWatchingFilter.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/FileWatchingFilter.java
@@ -83,6 +83,8 @@ public class FileWatchingFilter implements FileSystemAccess.WriteListener {
         }
     }
 
+    // TODO: Drop the suppression once https://github.com/uber/NullAway/issues/681 is fixed.
+    @SuppressWarnings("NullAway")
     public boolean shouldWatchLocation(String location) {
         return !locationsWrittenByCurrentBuild.get().contains(location);
     }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/FileWatchingFilter.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/FileWatchingFilter.java
@@ -83,8 +83,6 @@ public class FileWatchingFilter implements FileSystemAccess.WriteListener {
         }
     }
 
-    // TODO: Drop the suppression once https://github.com/uber/NullAway/issues/681 is fixed.
-    @SuppressWarnings("NullAway")
     public boolean shouldWatchLocation(String location) {
         return !locationsWrittenByCurrentBuild.get().contains(location);
     }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -16,6 +16,10 @@
 
 package org.gradle.internal.watch.vfs.impl;
 
+import static java.util.Objects.requireNonNull;
+
+import org.jspecify.annotations.Nullable;
+
 import com.google.common.collect.ImmutableList;
 import net.rubygrapefruit.platform.NativeException;
 import org.gradle.fileevents.internal.InotifyInstanceLimitTooLowException;
@@ -72,7 +76,9 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
      */
     private final Set<File> watchableHierarchiesRegisteredEarly = new LinkedHashSet<>();
 
+    @Nullable
     private FileWatcherRegistry watchRegistry;
+    @Nullable
     private Exception reasonForNotWatchingFiles;
     private boolean stateInvalidatedAtStartOfBuild;
 
@@ -100,7 +106,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
             SnapshotCollectingDiffListener diffListener = new SnapshotCollectingDiffListener();
             SnapshotHierarchy newRoot = updateFunction.update(diffListener);
             return withWatcherChangeErrorHandling(newRoot, () -> diffListener.publishSnapshotDiff((removedSnapshots, addedSnapshots) ->
-                watchRegistry.virtualFileSystemContentsChanged(removedSnapshots, addedSnapshots, newRoot)
+                requireNonNull(watchRegistry).virtualFileSystemContentsChanged(removedSnapshots, addedSnapshots, newRoot)
             ));
         }
     }
@@ -174,6 +180,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                                           }
 
                                           @Override
+                                          @Nullable
                                           public FileSystemWatchingStatistics getStatistics() {
                                               return statisticsSinceLastBuild;
                                           }
@@ -204,7 +211,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
             }
             return withWatcherChangeErrorHandling(
                 currentRoot,
-                () -> watchRegistry.registerWatchableHierarchy(watchableHierarchy, currentRoot)
+                () -> requireNonNull(watchRegistry).registerWatchableHierarchy(watchableHierarchy, currentRoot)
             );
         });
     }
@@ -238,7 +245,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                         } else {
                             // We'll clean this up further after the daemon has finished with the build, see afterBuildFinished()
                             newRoot = withWatcherChangeErrorHandling(currentRoot, () ->
-                                watchRegistry.updateVfsBeforeBuildFinished(currentRoot, maximumNumberOfWatchedHierarchies, unsupportedFileSystems));
+                                requireNonNull(watchRegistry).updateVfsBeforeBuildFinished(currentRoot, maximumNumberOfWatchedHierarchies, unsupportedFileSystems));
                         }
                         statisticsDuringBuild = new DefaultFileSystemWatchingStatistics(statistics, newRoot);
                         if (vfsLogging == VfsLogging.VERBOSE) {
@@ -275,6 +282,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                         }
 
                         @Override
+                        @Nullable
                         public FileSystemWatchingStatistics getStatistics() {
                             return statisticsDuringBuild;
                         }

--- a/platforms/core-execution/normalization-java/build.gradle.kts
+++ b/platforms/core-execution/normalization-java/build.gradle.kts
@@ -44,3 +44,7 @@ listOf(configurations["apiElements"], configurations["runtimeElements"]).forEach
     }
 }
 
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
+++ b/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
@@ -82,6 +82,7 @@ public class AbiExtractingClasspathResourceHasher implements ResourceHasher {
         });
     }
 
+    @Nullable
     @Override
     public HashCode hash(ZipEntryContext zipEntryContext) throws IOException {
         ZipEntry zipEntry = zipEntryContext.getEntry();
@@ -123,7 +124,7 @@ public class AbiExtractingClasspathResourceHasher implements ResourceHasher {
         FULL_HASH() {
             @Nullable
             @Override
-            HashCode handle(RegularFileSnapshot fileSnapshot, IoFunction<RegularFileSnapshot, HashCode> function) {
+            HashCode handle(RegularFileSnapshot fileSnapshot, IoFunction<RegularFileSnapshot, @Nullable HashCode> function) {
                 try {
                     return function.apply(fileSnapshot);
                 } catch (Exception e) {
@@ -134,7 +135,7 @@ public class AbiExtractingClasspathResourceHasher implements ResourceHasher {
 
             @Nullable
             @Override
-            HashCode handle(ZipEntryContent zipEntry, IoFunction<ZipEntryContent, HashCode> function) {
+            HashCode handle(ZipEntryContent zipEntry, IoFunction<ZipEntryContent, @Nullable HashCode> function) {
                 try {
                     return function.apply(zipEntry);
                 } catch (Exception e) {
@@ -146,22 +147,22 @@ public class AbiExtractingClasspathResourceHasher implements ResourceHasher {
         NONE() {
             @Nullable
             @Override
-            HashCode handle(RegularFileSnapshot fileSnapshot, IoFunction<RegularFileSnapshot, HashCode> function) throws IOException {
+            HashCode handle(RegularFileSnapshot fileSnapshot, IoFunction<RegularFileSnapshot, @Nullable HashCode> function) throws IOException {
                 return function.apply(fileSnapshot);
             }
 
             @Nullable
             @Override
-            HashCode handle(ZipEntryContent zipEntry, IoFunction<ZipEntryContent, HashCode> function) throws IOException {
+            HashCode handle(ZipEntryContent zipEntry, IoFunction<ZipEntryContent, @Nullable HashCode> function) throws IOException {
                 return function.apply(zipEntry);
             }
         };
 
         @Nullable
-        abstract HashCode handle(RegularFileSnapshot fileSnapshot, IoFunction<RegularFileSnapshot, HashCode> function) throws IOException;
+        abstract HashCode handle(RegularFileSnapshot fileSnapshot, IoFunction<RegularFileSnapshot, @Nullable HashCode> function) throws IOException;
 
         @Nullable
         @SuppressWarnings("ExposedPrivateType")
-        abstract HashCode handle(ZipEntryContent zipEntry, IoFunction<ZipEntryContent, HashCode> function) throws IOException;
+        abstract HashCode handle(ZipEntryContent zipEntry, IoFunction<ZipEntryContent, @Nullable HashCode> function) throws IOException;
     }
 }

--- a/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/CachingResourceHasher.java
+++ b/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/CachingResourceHasher.java
@@ -51,6 +51,7 @@ public class CachingResourceHasher implements ResourceHasher {
         return resourceSnapshotterCacheService.hashFile(fileSnapshotContext, delegate, delegateConfigurationHash);
     }
 
+    @Nullable
     @Override
     public HashCode hash(ZipEntryContext zipEntryContext) throws IOException {
         return delegate.hash(zipEntryContext);

--- a/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/FallbackHandlingResourceHasher.java
+++ b/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/FallbackHandlingResourceHasher.java
@@ -120,7 +120,7 @@ abstract class FallbackHandlingResourceHasher implements ResourceHasher {
 
     private static class CachingZipEntry implements ZipEntry {
         private final ZipEntry delegate;
-        private byte[] content;
+        private byte @Nullable [] content;
 
         public CachingZipEntry(ZipEntry delegate) {
             this.delegate = delegate;

--- a/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/FallbackHandlingResourceHasher.java
+++ b/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/FallbackHandlingResourceHasher.java
@@ -145,7 +145,7 @@ abstract class FallbackHandlingResourceHasher implements ResourceHasher {
         }
 
         @Override
-        public <T> T withInputStream(IoFunction<InputStream, T> action) throws IOException {
+        public <T extends @Nullable Object> T withInputStream(IoFunction<InputStream, T> action) throws IOException {
             return action.apply(new ByteArrayInputStream(getContent()));
         }
 

--- a/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasher.java
+++ b/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasher.java
@@ -39,6 +39,7 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
 import static java.lang.String.join;
+import static java.util.Objects.requireNonNull;
 
 public class MetaInfAwareClasspathResourceHasher extends FallbackHandlingResourceHasher {
     private static final Logger LOGGER = LoggerFactory.getLogger(MetaInfAwareClasspathResourceHasher.class);
@@ -105,7 +106,7 @@ public class MetaInfAwareClasspathResourceHasher extends FallbackHandlingResourc
         Map<String, Attributes> entries = manifest.getEntries();
         Set<String> names = new TreeSet<>(manifest.getEntries().keySet());
         for (String name : names) {
-            hashManifestAttributes(entries.get(name), name, hasher);
+            hashManifestAttributes(requireNonNull(entries.get(name)), name, hasher);
         }
         return hasher.hash();
     }

--- a/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
+++ b/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
@@ -100,6 +100,8 @@ public class ZipHasher implements RegularFileSnapshotContextHasher, Configurable
         }
     }
 
+    // The withInputStream callback below discards its result; the explicit null return is intentional.
+    @SuppressWarnings("NullAway")
     private void fingerprintZipEntries(String parentName, String rootParentName, List<FileSystemLocationFingerprint> fingerprints, ZipInput input) throws IOException {
         fingerprints.add(newZipMarker(parentName));
         for (ZipEntry zipEntry : input) {

--- a/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
+++ b/platforms/core-execution/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
@@ -100,8 +100,6 @@ public class ZipHasher implements RegularFileSnapshotContextHasher, Configurable
         }
     }
 
-    // The withInputStream callback below discards its result; the explicit null return is intentional.
-    @SuppressWarnings("NullAway")
     private void fingerprintZipEntries(String parentName, String rootParentName, List<FileSystemLocationFingerprint> fingerprints, ZipInput input) throws IOException {
         fingerprints.add(newZipMarker(parentName));
         for (ZipEntry zipEntry : input) {

--- a/platforms/core-execution/snapshots/build.gradle.kts
+++ b/platforms/core-execution/snapshots/build.gradle.kts
@@ -49,3 +49,7 @@ gradleModule {
 }
 
 
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
@@ -40,6 +40,7 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
     private final FileSystemSnapshot roots;
     private final ImmutableMultimap<String, HashCode> rootHashes;
     private final HashCode strategyConfigurationHash;
+    @Nullable
     private HashCode hash;
 
     public static CurrentFileCollectionFingerprint from(FileSystemSnapshot roots, FingerprintingStrategy strategy, @Nullable  FileCollectionFingerprint candidate) {

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
@@ -42,6 +42,7 @@ public class MerkleDirectorySnapshotBuilder implements DirectorySnapshotBuilder 
 
     private final Deque<Directory> directoryStack = new ArrayDeque<>();
     private final boolean sortingRequired;
+    @Nullable
     private FileSystemLocationSnapshot result;
 
     public static DirectorySnapshotBuilder sortingRequired() {
@@ -72,6 +73,7 @@ public class MerkleDirectorySnapshotBuilder implements DirectorySnapshotBuilder 
     }
 
     @Override
+    @Nullable
     public FileSystemLocationSnapshot leaveDirectory() {
         FileSystemLocationSnapshot snapshot = directoryStack.removeLast().fold();
         if (snapshot != null) {
@@ -91,6 +93,7 @@ public class MerkleDirectorySnapshotBuilder implements DirectorySnapshotBuilder 
     }
 
     @Override
+    @Nullable
     public FileSystemLocationSnapshot getResult() {
         return result;
     }

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/RelativePathTracker.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/RelativePathTracker.java
@@ -17,6 +17,9 @@
 package org.gradle.internal.snapshot;
 
 import org.gradle.internal.RelativePathSupplier;
+import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -28,6 +31,7 @@ import java.util.Iterator;
  */
 public class RelativePathTracker implements RelativePathSupplier {
     private final Deque<String> segments = new ArrayDeque<>();
+    @Nullable
     private String rootName;
 
     public void enter(FileSystemLocationSnapshot snapshot) {
@@ -48,7 +52,8 @@ public class RelativePathTracker implements RelativePathSupplier {
             name = rootName;
             rootName = null;
         }
-        return name;
+        // enter()/leave() are balanced by contract, so the name is non-null in correct usage.
+        return requireNonNull(name);
     }
 
     @Override

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/ClassImplementationSnapshot.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/ClassImplementationSnapshot.java
@@ -50,7 +50,7 @@ public class ClassImplementationSnapshot extends ImplementationSnapshot {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -38,6 +38,8 @@ import org.gradle.internal.snapshot.SnapshottingFilter;
 import org.jspecify.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -257,7 +259,7 @@ public class DirectorySnapshotter {
     private static class PathVisitor extends DirectorySnapshotterStatistics.CollectingFileVisitor {
         private final RelativePathTracker pathTracker = new RelativePathTracker();
         private final FilteredTrackingMerkleDirectorySnapshotBuilder builder;
-        private final SnapshottingFilter.DirectoryWalkerPredicate predicate;
+        private final SnapshottingFilter.@Nullable DirectoryWalkerPredicate predicate;
         private final AtomicBoolean hasBeenFiltered;
         private final FileHasher hasher;
         private final Interner<String> stringInterner;
@@ -521,7 +523,7 @@ public class DirectorySnapshotter {
         }
 
         public FileSystemLocationSnapshot getResult() {
-            return builder.getResult();
+            return requireNonNull(builder.getResult());
         }
     }
 }

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -38,7 +38,6 @@ import org.gradle.internal.snapshot.SnapshottingFilter;
 import org.jspecify.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -128,6 +127,11 @@ public class DirectorySnapshotter {
             PathVisitor visitor = new PathVisitor(predicate, hasBeenFiltered, hasher, stringInterner, defaultExcludes, collector, EMPTY_SYMBOLIC_LINK_MAPPING, previouslyKnownSnapshots, unfilteredSnapshotRecorder);
             Files.walkFileTree(rootPath, DONT_FOLLOW_SYMLINKS, Integer.MAX_VALUE, visitor);
             FileSystemLocationSnapshot result = visitor.getResult();
+            if (result == null) {
+                // The root is always visited (PathVisitor.shouldVisitDirectory() never filters it),
+                // so a completed walk of an existing directory always produces a result.
+                throw new IllegalStateException(String.format("Snapshotting '%s' did not produce a result. It must be an existing directory.", absolutePath));
+            }
             if (!hasBeenFiltered.get()) {
                 unfilteredSnapshotRecorder.accept(result);
             }
@@ -522,8 +526,9 @@ public class DirectorySnapshotter {
             return intern(lastSep < 0 ? absolutePath : absolutePath.substring(lastSep + 1));
         }
 
+        @Nullable
         public FileSystemLocationSnapshot getResult() {
-            return requireNonNull(builder.getResult());
+            return builder.getResult();
         }
     }
 }

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FilteredTrackingMerkleDirectorySnapshotBuilder.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FilteredTrackingMerkleDirectorySnapshotBuilder.java
@@ -81,6 +81,7 @@ public class FilteredTrackingMerkleDirectorySnapshotBuilder implements Directory
     }
 
     @Override
+    @Nullable
     public FileSystemLocationSnapshot leaveDirectory() {
         FileSystemLocationSnapshot directorySnapshot = delegate.leaveDirectory();
         boolean leftLevelUnfiltered = isCurrentLevelUnfiltered.removeLast();

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/LambdaImplementationSnapshot.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/LambdaImplementationSnapshot.java
@@ -107,7 +107,7 @@ public class LambdaImplementationSnapshot extends ImplementationSnapshot {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/UnknownImplementationSnapshot.java
+++ b/platforms/core-execution/snapshots/src/main/java/org/gradle/internal/snapshot/impl/UnknownImplementationSnapshot.java
@@ -74,6 +74,7 @@ public class UnknownImplementationSnapshot extends ImplementationSnapshot {
     }
 
     @Override
+    @Nullable
     public HashCode getClassLoaderHash() {
         return null;
     }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -206,7 +206,6 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, ProjectPar
         return getRegistries().getProjectLockRegistry().getResourceLocksByCurrentThread();
     }
 
-    @SuppressWarnings("NullAway") // TODO(https://github.com/uber/NullAway/issues/681) Can't infer that AtomicReference holds non-nullable type
     private Registries getRegistries() {
         return registries.get();
     }

--- a/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationListenerManager.java
+++ b/platforms/core-runtime/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationListenerManager.java
@@ -57,7 +57,6 @@ public class DefaultBuildOperationListenerManager implements BuildOperationListe
         }
     };
 
-    @SuppressWarnings("NullAway") // TODO(https://github.com/uber/NullAway/issues/681) Can't infer that AtomicReference holds non-nullable type
     private ImmutableList<ProgressShieldingBuildOperationListener> getListeners() {
         return DefaultBuildOperationListenerManager.this.listeners.get();
     }

--- a/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntry.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntry.java
@@ -59,7 +59,7 @@ public interface ZipEntry {
      * This method or {@link #getContent()} may or may not support being called more than once per entry.
      * Use {@link #canReopen()} to determine if more than one call is supported.
      */
-    <T> T withInputStream(IoFunction<InputStream, T> action) throws IOException;
+    <T extends @Nullable Object> T withInputStream(IoFunction<InputStream, T> action) throws IOException;
 
     /**
      * The size of the content in bytes, or -1 if not known.

--- a/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/impl/FileZipInput.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/impl/FileZipInput.java
@@ -99,7 +99,7 @@ public class FileZipInput implements ZipInput {
         }
 
         @Override
-        public <T> T withInputStream(IoFunction<InputStream, T> action) throws IOException {
+        public <T extends @Nullable Object> T withInputStream(IoFunction<InputStream, T> action) throws IOException {
             InputStream inputStream = getInputStream();
             try {
                 return action.apply(inputStream);

--- a/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/impl/StreamZipInput.java
+++ b/platforms/core-runtime/files/src/main/java/org/gradle/api/internal/file/archive/impl/StreamZipInput.java
@@ -64,7 +64,7 @@ public class StreamZipInput implements ZipInput {
         }
 
         @Override
-        public <T> T withInputStream(IoFunction<InputStream, T> action) throws IOException {
+        public <T extends @Nullable Object> T withInputStream(IoFunction<InputStream, T> action) throws IOException {
             if (opened) {
                 throw new IllegalStateException("The input stream for " + getName() + " has already been opened.  It cannot be reopened again.");
             }

--- a/platforms/core-runtime/internal-instrumentation-processor/build.gradle.kts
+++ b/platforms/core-runtime/internal-instrumentation-processor/build.gradle.kts
@@ -58,3 +58,7 @@ tasks.named<Test>("test").configure {
         )
     }
 }
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -99,12 +99,15 @@ import static org.gradle.internal.instrumentation.processor.modelreader.impl.Typ
 import static org.gradle.internal.instrumentation.processor.modelreader.impl.TypeUtils.extractType;
 import static org.gradle.internal.instrumentation.processor.modelreader.impl.TypeUtils.getTypeParameterOrThrow;
 
+import static java.util.Objects.requireNonNull;
+
 public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodReaderExtension {
 
     private static final TypeName DEFAULT_TYPE = ClassName.get(DefaultValue.class);
     private static final String TO_BE_REPLACED_SETTERS_KEY_PREFIX = "@ToBeReplacedByLazyPropertySetters_";
     private static final String TO_BE_REPLACED_SETTERS_VISITED_KEY_PREFIX = "@ToBeReplacedByLazyPropertySettersVisited_";
 
+    @Nullable
     private final String projectName;
     private final Elements elements;
     private final Types types;
@@ -115,6 +118,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         this.types = processingEnv.getTypeUtils();
     }
 
+    @Nullable
     private static String getProjectName(ProcessingEnvironment processingEnv) {
         String projectName = processingEnv.getOptions().get(PROJECT_NAME_OPTIONS);
         if (projectName == null || projectName.isEmpty()) {
@@ -187,7 +191,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
                 .map(Success::new)
                 .collect(Collectors.toList());
         } catch (IllegalArgumentException failure) {
-            return Collections.singletonList(new InvalidRequest(failure.getMessage()));
+            return Collections.singletonList(new InvalidRequest(requireNonNull(failure.getMessage())));
         }
     }
 
@@ -239,7 +243,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         String implementationMethodPrefix = accessor.accessorType == AccessorType.GETTER ? "get" : "set";
         String interceptorsClassName = getGroovyInterceptorsClassName(accessor.interceptorType);
         List<RequestExtra> extras = Arrays.asList(new RequestExtra.OriginatingElement(method), new RequestExtra.InterceptGroovyCalls(interceptorsClassName, accessor.interceptorType));
-        List<ParameterInfo> callableParameters = prependReceiverParameter(accessor.parameters, extractType(method.getEnclosingElement().asType()));
+        List<ParameterInfo> callableParameters = prependReceiverParameter(accessor.parameters, extractType(requireNonNull(method.getEnclosingElement()).asType()));
         Type returnType = TypeUtils.extractRawType(accessor.returnType);
         return new CallInterceptionRequestImpl(
             extractCallableInfo(callableKindInfo, method, returnType, callableMethodName, callableParameters),
@@ -265,7 +269,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
             .map(v -> types.asElement((TypeMirror) v.getValue()))
             .orElseThrow(() -> new IllegalArgumentException("Missing adapter value"));
         if (!element.getSimpleName().toString().equals(DefaultValue.class.getSimpleName())) {
-            return readAccessorSpecsFromAdapter(element, method.getEnclosingElement(), annotationMirror);
+            return readAccessorSpecsFromAdapter(element, requireNonNull(method.getEnclosingElement()), annotationMirror);
         }
 
         List<AnnotationMirror> replacedAccessors = AnnotationUtils.findAnnotationValueWithDefaults(elements, annotationMirror, "replacedAccessors")
@@ -298,8 +302,8 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         }
 
         String propertyName = getPropertyName(annotatedMethod);
-        String settersKey = TO_BE_REPLACED_SETTERS_KEY_PREFIX + annotatedMethod.getEnclosingElement().asType().toString();
-        String propertySettersVisitedKey = TO_BE_REPLACED_SETTERS_VISITED_KEY_PREFIX + annotatedMethod.getEnclosingElement().asType().toString();
+        String settersKey = TO_BE_REPLACED_SETTERS_KEY_PREFIX + requireNonNull(annotatedMethod.getEnclosingElement()).asType().toString();
+        String propertySettersVisitedKey = TO_BE_REPLACED_SETTERS_VISITED_KEY_PREFIX + requireNonNull(annotatedMethod.getEnclosingElement()).asType().toString();
         Collection<ExecutableElement> setters;
         Set<String> propertySettersVisited = context.computeIfAbsent(propertySettersVisitedKey, key -> new HashSet<>());
         if (isSetterMethodName(annotatedMethod.getSimpleName().toString()) || !propertySettersVisited.add(propertyName)) {
@@ -307,7 +311,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
             // also some booleans have two getters, is and get getter, so lets visit setters only once.
             setters = Collections.emptyList();
         } else {
-            setters = context.computeIfAbsent(settersKey, key -> getAllSetters(annotatedMethod.getEnclosingElement())).get(propertyName);
+            setters = context.computeIfAbsent(settersKey, key -> getAllSetters(requireNonNull(annotatedMethod.getEnclosingElement()))).get(propertyName);
         }
 
         DeprecationSpec deprecationSpec = new DeprecationSpec(false, RemovedIn.UNSPECIFIED, -1, "", false);
@@ -415,8 +419,8 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
     }
 
     private AccessorSpec adapterBridgedMethodToAccessorSpec(ExecutableElement method, AnnotationMirror annotationMirror) {
-        Element innerClass = method.getEnclosingElement();
-        Element topClass = innerClass.getEnclosingElement();
+        Element innerClass = requireNonNull(method.getEnclosingElement());
+        Element topClass = requireNonNull(innerClass.getEnclosingElement());
         PackageElement packageElement = elements.getPackageOf(innerClass);
 
         // Using $$, since internal classes types has $ and due to
@@ -519,13 +523,13 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
                 boolean isFluentSetter = AnnotationUtils.findAnnotationValueWithDefaults(elements, annotation, "fluentSetter")
                     .map(v -> (Boolean) v.getValue())
                     .orElseThrow(() -> new AnnotationReadFailure("Missing 'fluentSetter' attribute"));
-                returnType = isFluentSetter ? TypeName.get(method.getEnclosingElement().asType()) : ClassName.VOID;
+                returnType = isFluentSetter ? TypeName.get(requireNonNull(method.getEnclosingElement()).asType()) : ClassName.VOID;
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported accessor type: " + accessorType);
         }
         String propertyName = getPropertyName(methodName);
-        String generatedClassName = "org.gradle.internal.classpath.generated." + method.getEnclosingElement().getSimpleName() + "_Adapter";
+        String generatedClassName = "org.gradle.internal.classpath.generated." + requireNonNull(method.getEnclosingElement()).getSimpleName() + "_Adapter";
         return new AccessorSpec(
             generatedClassName,
             accessorType,
@@ -653,13 +657,13 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
     }
 
     private static CallableInfo extractCallableInfo(CallableKindInfo kindInfo, ExecutableElement methodElement, Type returnType, String callableName, List<ParameterInfo> parameters) {
-        CallableOwnerInfo owner = new CallableOwnerInfo(extractType(methodElement.getEnclosingElement().asType()), true);
+        CallableOwnerInfo owner = new CallableOwnerInfo(extractType(requireNonNull(methodElement.getEnclosingElement()).asType()), true);
         CallableReturnTypeInfo returnTypeInfo = new CallableReturnTypeInfo(returnType);
         return new CallableInfoImpl(kindInfo, owner, callableName, returnTypeInfo, parameters);
     }
 
     private static ImplementationInfoImpl extractImplementationInfo(AccessorSpec accessor, ExecutableElement method, Type returnType, String interceptedMethodName, String methodPrefix, List<ParameterInfo> parameters) {
-        Type owner = extractType(method.getEnclosingElement().asType());
+        Type owner = extractType(requireNonNull(method.getEnclosingElement()).asType());
         Type implementationOwner = Type.getObjectType(accessor.generatedClassName);
         String implementationName = "access_" + methodPrefix + "_" + interceptedMethodName;
         String implementationDescriptor = Type.getMethodDescriptor(returnType, toArray(owner, parameters));
@@ -720,6 +724,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         private final List<ParameterInfo> parameters;
         private final BinaryCompatibility binaryCompatibility;
         private final DeprecationSpec deprecationSpec;
+        @Nullable
         private final BridgedMethodInfo bridgedMethod;
         private final BytecodeInterceptorType interceptorType;
 

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -191,7 +191,7 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
                 .map(Success::new)
                 .collect(Collectors.toList());
         } catch (IllegalArgumentException failure) {
-            return Collections.singletonList(new InvalidRequest(requireNonNull(failure.getMessage())));
+            return Collections.singletonList(new InvalidRequest(failure.toString()));
         }
     }
 

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
@@ -58,11 +58,15 @@ import static org.gradle.internal.instrumentation.processor.codegen.GradleRefere
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.SET_PROPERTY_SET_VIEW;
 import static org.gradle.internal.instrumentation.processor.codegen.TypeUtils.typeName;
 
+import static java.util.Objects.requireNonNull;
+import org.jspecify.annotations.Nullable;
+
 public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrumentationClassSourceGenerator {
 
     private static final String SELF_PARAMETER_NAME = "self";
 
     @Override
+    @Nullable
     protected String classNameForRequest(CallInterceptionRequest request) {
         return request.getRequestExtras().getByType(PropertyUpgradeRequestExtra.class)
             .map(PropertyUpgradeRequestExtra::getImplementationClassName)
@@ -118,13 +122,14 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
             onProcessedRequest.accept(request);
             return spec;
         } catch (Exception e) {
-            onFailure.accept(new HasFailures.FailureInfo(request, e.getMessage()));
+            onFailure.accept(new HasFailures.FailureInfo(request, requireNonNull(e.getMessage())));
             throw e;
         }
     }
 
     private static MethodSpec mapToBridgedMethod(String methodName, PropertyUpgradeRequestExtra implementationExtra, CallableInfo callable) {
-        BridgedMethodInfo bridgedMethodInfo = implementationExtra.getBridgedMethodInfo();
+        // Only called for requests that carry a bridged method (checked by the caller).
+        BridgedMethodInfo bridgedMethodInfo = requireNonNull(implementationExtra.getBridgedMethodInfo());
         ExecutableElement bridgedMethod = bridgedMethodInfo.getBridgedMethod();
         List<TypeVariableName> typeVariables = bridgedMethod.getTypeParameters().stream()
             .map(element -> TypeVariableName.get((TypeVariable) element.asType()))
@@ -147,7 +152,7 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
         CodeBlock bridgeCall;
         List<AnnotationSpec> annotationSpecs = Collections.emptyList();
         if (bridgedMethodInfo.getBridgeType() == INSTANCE_METHOD_BRIDGE) {
-            TypeName type = TypeName.get(bridgedMethod.getEnclosingElement().asType());
+            TypeName type = TypeName.get(requireNonNull(bridgedMethod.getEnclosingElement()).asType());
             if (type instanceof ParameterizedTypeName) {
                 // To simplify code generation we remove type parameters from the instance type, e.g.:
                 // if we have AbstractExecTask<T>, method parameter has type `AbstractExecTask` without generics
@@ -160,8 +165,8 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
                 : CodeBlock.of("return $L.$N($L)", SELF_PARAMETER_NAME, bridgedMethod.getSimpleName(), passedParameters);
         } else {
             bridgeCall = TypeName.get(bridgedMethod.getReturnType()).equals(TypeName.VOID)
-                ? CodeBlock.of("$T.$N($L)", TypeName.get(bridgedMethod.getEnclosingElement().asType()), bridgedMethod.getSimpleName(), passedParameters)
-                : CodeBlock.of("return $T.$N($L)", TypeName.get(bridgedMethod.getEnclosingElement().asType()), bridgedMethod.getSimpleName(), passedParameters);
+                ? CodeBlock.of("$T.$N($L)", TypeName.get(requireNonNull(bridgedMethod.getEnclosingElement()).asType()), bridgedMethod.getSimpleName(), passedParameters)
+                : CodeBlock.of("return $T.$N($L)", TypeName.get(requireNonNull(bridgedMethod.getEnclosingElement()).asType()), bridgedMethod.getSimpleName(), passedParameters);
         }
         bodyBuilder.addStatement(bridgeCall);
 

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeClassSourceGenerator.java
@@ -122,7 +122,7 @@ public class PropertyUpgradeClassSourceGenerator extends RequestGroupingInstrume
             onProcessedRequest.accept(request);
             return spec;
         } catch (Exception e) {
-            onFailure.accept(new HasFailures.FailureInfo(request, requireNonNull(e.getMessage())));
+            onFailure.accept(new HasFailures.FailureInfo(request, e.toString()));
             throw e;
         }
     }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeRequestExtra.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeRequestExtra.java
@@ -22,6 +22,7 @@ import org.gradle.internal.instrumentation.extensions.property.PropertyUpgradeAn
 import org.gradle.internal.instrumentation.model.RequestExtra;
 
 import javax.lang.model.element.ExecutableElement;
+import org.jspecify.annotations.Nullable;
 
 class PropertyUpgradeRequestExtra implements RequestExtra {
 
@@ -35,6 +36,7 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
     private final DeprecationSpec deprecationSpec;
     private final BinaryCompatibility binaryCompatibility;
     private final String interceptedPropertyName;
+    @Nullable
     private final BridgedMethodInfo bridgedMethodInfo;
 
     public PropertyUpgradeRequestExtra(
@@ -48,7 +50,7 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         TypeName newPropertyType,
         DeprecationSpec deprecationSpec,
         BinaryCompatibility binaryCompatibility,
-        BridgedMethodInfo bridgedMethodInfo
+        @Nullable BridgedMethodInfo bridgedMethodInfo
     ) {
         this.propertyName = propertyName;
         this.methodName = methodName;
@@ -104,6 +106,7 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
         return binaryCompatibility;
     }
 
+    @Nullable
     public BridgedMethodInfo getBridgedMethodInfo() {
         return bridgedMethodInfo;
     }

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/AddGeneratedClassNameFlagFromClassLevelAnnotation.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/AddGeneratedClassNameFlagFromClassLevelAnnotation.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
+import static java.util.Objects.requireNonNull;
+
 public class AddGeneratedClassNameFlagFromClassLevelAnnotation implements RequestPostProcessorExtension {
 
     private final Elements elements;
@@ -68,7 +70,7 @@ public class AddGeneratedClassNameFlagFromClassLevelAnnotation implements Reques
             return Collections.singletonList(originalRequest);
         }
 
-        Element enclosingElement = maybeOriginatingElement.get().getEnclosingElement();
+        Element enclosingElement = requireNonNull(maybeOriginatingElement.get().getEnclosingElement());
         AnnotationUtils.findAnnotationMirror(enclosingElement, generatedClassNameProvidingAnnotation).ifPresent(annotationMirror -> {
             AnnotationValue generatedClassName = AnnotationUtils.findAnnotationValue(annotationMirror, "generatedClassName")
                 .orElseThrow(() -> new IllegalStateException("Annotation " + generatedClassNameProvidingAnnotation + " does not have a generatedClassName attribute"));

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/CompositeInstrumentationCodeGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/CompositeInstrumentationCodeGenerator.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.requireNonNull;
+
 public class CompositeInstrumentationCodeGenerator implements InstrumentationCodeGenerator {
 
     private final Collection<InstrumentationCodeGenerator> generators;
@@ -61,7 +63,7 @@ public class CompositeInstrumentationCodeGenerator implements InstrumentationCod
 
             @Override
             public void buildType(String className, TypeSpec.Builder builder) {
-                generatorByClassName.get(className).buildType(className, builder);
+                requireNonNull(generatorByClassName.get(className)).buildType(className, builder);
             }
 
             @Override

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/GradleLazyType.java
@@ -20,6 +20,9 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 
+import static java.util.Objects.requireNonNull;
+import org.jspecify.annotations.Nullable;
+
 public enum GradleLazyType {
     CONFIGURABLE_FILE_COLLECTION("org.gradle.api.file.ConfigurableFileCollection"),
     FILE_COLLECTION("org.gradle.api.file.FileCollection"),
@@ -38,25 +41,26 @@ public enum GradleLazyType {
     };
 
     @SuppressWarnings("ImmutableEnumChecker")
+    @Nullable
     private final ClassName className;
 
     GradleLazyType(String name) {
         this(ClassName.bestGuess(name));
     }
 
-    GradleLazyType(ClassName className) {
+    GradleLazyType(@Nullable ClassName className) {
         this.className = className;
     }
 
     public ClassName asClassName() {
-        return className;
+        return requireNonNull(className);
     }
 
     public boolean isEqualToRawTypeOf(TypeName typeName) {
         if (typeName instanceof ParameterizedTypeName) {
             typeName = ((ParameterizedTypeName) typeName).rawType;
         }
-        return className.equals(typeName);
+        return requireNonNull(className).equals(typeName);
     }
 
     public static GradleLazyType from(TypeName typeName) {

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/JavadocUtils.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/JavadocUtils.java
@@ -29,9 +29,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.gradle.internal.instrumentation.processor.codegen.TypeUtils.typeName;
+import org.jspecify.annotations.Nullable;
 
 public class JavadocUtils {
 
+    @Nullable
     public static String callableKindForJavadoc(CallInterceptionRequest request) {
         CallableInfo interceptedCallable = request.getInterceptedCallable();
         CallableKindInfo kind = interceptedCallable.getKind();

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/RequestGroupingInstrumentationClassSourceGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/RequestGroupingInstrumentationClassSourceGenerator.java
@@ -29,7 +29,11 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.requireNonNull;
+import org.jspecify.annotations.Nullable;
+
 public abstract class RequestGroupingInstrumentationClassSourceGenerator implements InstrumentationCodeGenerator {
+    @Nullable
     protected abstract String classNameForRequest(CallInterceptionRequest request);
 
     protected abstract Consumer<TypeSpec.Builder> classContentForClass(
@@ -69,7 +73,7 @@ public abstract class RequestGroupingInstrumentationClassSourceGenerator impleme
 
             @Override
             public void buildType(String className, TypeSpec.Builder builder) {
-                classContentByName.get(className).accept(builder);
+                requireNonNull(classContentByName.get(className)).accept(builder);
             }
 
             @Override

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsGenerator.java
@@ -61,9 +61,11 @@ import static org.gradle.internal.instrumentation.processor.codegen.GradleRefere
 import static org.gradle.internal.instrumentation.processor.codegen.JavadocUtils.callableKindForJavadoc;
 import static org.gradle.internal.instrumentation.processor.codegen.JavadocUtils.interceptedCallableLink;
 import static org.gradle.internal.instrumentation.processor.codegen.JavadocUtils.interceptorImplementationLink;
+import org.jspecify.annotations.Nullable;
 
 public class InterceptGroovyCallsGenerator extends RequestGroupingInstrumentationClassSourceGenerator {
     @Override
+    @Nullable
     protected String classNameForRequest(CallInterceptionRequest request) {
         return request.getRequestExtras().getByType(RequestExtra.InterceptGroovyCalls.class)
             .map(RequestExtra.InterceptGroovyCalls::getImplementationClassName)

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/SignatureTree.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/SignatureTree.java
@@ -44,7 +44,9 @@ import static org.gradle.internal.instrumentation.processor.codegen.groovy.Param
 import static org.gradle.internal.instrumentation.processor.codegen.groovy.ParameterMatchEntry.Kind.VARARG;
 
 class SignatureTree {
+    @Nullable
     private CallInterceptionRequest leaf = null;
+    @Nullable
     private LinkedHashMap<ParameterMatchEntry, SignatureTree> childrenByMatchEntry = null;
 
     @Nullable

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGenerator.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/jvmbytecode/InterceptJvmCallsGenerator.java
@@ -65,6 +65,8 @@ import java.util.stream.Stream;
 import static org.gradle.internal.instrumentation.processor.codegen.GradleReferencedType.GENERATED_ANNOTATION;
 import static org.gradle.internal.instrumentation.processor.codegen.TypeUtils.typeName;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Generates a single bytecode rewriter class.
  */
@@ -86,6 +88,7 @@ public class InterceptJvmCallsGenerator extends RequestGroupingInstrumentationCl
     }
 
     @Override
+    @Nullable
     protected String classNameForRequest(CallInterceptionRequest request) {
         return request.getRequestExtras().getByType(RequestExtra.InterceptJvmCalls.class)
             .map(RequestExtra.InterceptJvmCalls::getImplementationClassName)
@@ -333,7 +336,7 @@ public class InterceptJvmCallsGenerator extends RequestGroupingInstrumentationCl
             try {
                 generateCodeForRequest(
                     request,
-                    implTypeFields.get(request.getImplementationInfo().getOwner()),
+                    requireNonNull(implTypeFields.get(request.getImplementationInfo().getOwner())),
                     nested,
                     invocationMatcher,
                     interceptStandard,

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/modelreader/impl/AnnotationCallInterceptionRequestReaderImpl.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/modelreader/impl/AnnotationCallInterceptionRequestReaderImpl.java
@@ -64,6 +64,8 @@ import static org.gradle.internal.instrumentation.processor.modelreader.impl.Typ
 import static org.gradle.internal.instrumentation.processor.modelreader.impl.TypeUtils.extractReturnType;
 import static org.gradle.internal.instrumentation.processor.modelreader.impl.TypeUtils.extractType;
 
+import static java.util.Objects.requireNonNull;
+
 public class AnnotationCallInterceptionRequestReaderImpl implements AnnotatedMethodReaderExtension {
 
     @Override
@@ -99,7 +101,7 @@ public class AnnotationCallInterceptionRequestReaderImpl implements AnnotatedMet
 
     @NonNull
     private static ImplementationInfoImpl extractImplementationInfo(ExecutableElement input) {
-        Type implementationOwner = extractType(input.getEnclosingElement().asType());
+        Type implementationOwner = extractType(requireNonNull(input.getEnclosingElement()).asType());
         String implementationName = input.getSimpleName().toString();
         String implementationDescriptor = extractMethodDescriptor(input);
         return new ImplementationInfoImpl(implementationOwner, implementationName, implementationDescriptor);

--- a/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/modelreader/impl/TypeUtils.java
+++ b/platforms/core-runtime/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/modelreader/impl/TypeUtils.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Objects.requireNonNull;
+
 public class TypeUtils {
     public static Type extractType(TypeMirror typeMirror) {
         return typeMirror.accept(new TypeMirrorToType(), null);
@@ -118,7 +120,7 @@ public class TypeUtils {
 
     public static String elementQualifiedName(Element element) {
         if (element instanceof ExecutableElement) {
-            String enclosingTypeName = ((TypeElement) element.getEnclosingElement()).getQualifiedName().toString();
+            String enclosingTypeName = ((TypeElement) requireNonNull(element.getEnclosingElement())).getQualifiedName().toString();
             return enclosingTypeName + "." + element.getSimpleName();
         } else if (element instanceof TypeElement) {
             return ((TypeElement) element).getQualifiedName().toString();

--- a/platforms/core-runtime/native/build.gradle.kts
+++ b/platforms/core-runtime/native/build.gradle.kts
@@ -47,3 +47,7 @@ jmh {
     warmupIterations = 10
     synchronizeIterations = false
 }
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/EnvironmentModificationResult.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/EnvironmentModificationResult.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.nativeintegration;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Encapsulates what happened when we tried to modify the environment.
  */
@@ -23,13 +25,16 @@ public enum EnvironmentModificationResult {
     SUCCESS(null),
     UNSUPPORTED_ENVIRONMENT("There is no native integration with this operating environment.");
 
+    @Nullable
     private final String reason;
 
-    EnvironmentModificationResult(String reason) {
+    EnvironmentModificationResult(@Nullable String reason) {
         this.reason = reason;
     }
 
     @Override
+    // SUCCESS has a null reason; preserve the original (possibly null) value.
+    @SuppressWarnings("NullAway")
     public String toString() {
         return reason;
     }

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/EnvironmentModificationResult.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/EnvironmentModificationResult.java
@@ -16,25 +16,20 @@
 
 package org.gradle.internal.nativeintegration;
 
-import org.jspecify.annotations.Nullable;
-
 /**
  * Encapsulates what happened when we tried to modify the environment.
  */
 public enum EnvironmentModificationResult {
-    SUCCESS(null),
+    SUCCESS("Environment updated successfully"),
     UNSUPPORTED_ENVIRONMENT("There is no native integration with this operating environment.");
 
-    @Nullable
     private final String reason;
 
-    EnvironmentModificationResult(@Nullable String reason) {
+    EnvironmentModificationResult(String reason) {
         this.reason = reason;
     }
 
     @Override
-    // SUCCESS has a null reason; preserve the original (possibly null) value.
-    @SuppressWarnings("NullAway")
     public String toString() {
         return reason;
     }

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/ProcessEnvironment.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/ProcessEnvironment.java
@@ -17,6 +17,7 @@ package org.gradle.internal.nativeintegration;
 
 import java.io.File;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Provides access to information about the current process.
@@ -99,6 +100,7 @@ public interface ProcessEnvironment {
     /**
      * Returns the OS level PID for the current process, or null if not available.
      */
+    @Nullable
     Long maybeGetPid();
 
     /**

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/FallbackConsoleDetector.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/FallbackConsoleDetector.java
@@ -16,8 +16,11 @@
 
 package org.gradle.internal.nativeintegration.console;
 
+import org.jspecify.annotations.Nullable;
+
 public class FallbackConsoleDetector implements ConsoleDetector {
     @Override
+    @Nullable
     public ConsoleMetaData getConsole() {
         return null;
     }

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/NativePlatformConsoleDetector.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/NativePlatformConsoleDetector.java
@@ -23,6 +23,7 @@ import org.gradle.internal.os.OperatingSystem;
 
 import static net.rubygrapefruit.platform.terminal.Terminals.Output.Stderr;
 import static net.rubygrapefruit.platform.terminal.Terminals.Output.Stdout;
+import org.jspecify.annotations.Nullable;
 
 public class NativePlatformConsoleDetector implements ConsoleDetector {
     private static final int WINDOWS_UTF8_CODEPAGE_ID = 65001;
@@ -34,6 +35,7 @@ public class NativePlatformConsoleDetector implements ConsoleDetector {
     }
 
     @Override
+    @Nullable
     public ConsoleMetaData getConsole() {
         // Dumb terminal doesn't support ANSI control codes.
         // TODO - remove this when we use Terminal rather than JAnsi to render to console

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/WindowsConsoleDetector.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/console/WindowsConsoleDetector.java
@@ -21,9 +21,11 @@ import org.fusesource.jansi.io.WindowsAnsiProcessor;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import org.jspecify.annotations.Nullable;
 
 public class WindowsConsoleDetector implements ConsoleDetector {
     @Override
+    @Nullable
     public ConsoleMetaData getConsole() {
         // Use Jansi's detection mechanism
         try {

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7Symlink.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7Symlink.java
@@ -66,7 +66,7 @@ public class Jdk7Symlink implements Symlink {
             Files.createSymbolicLink(linkFile, sourceFile);
             return true;
         } catch (InternalError e) {
-            if (e.getMessage().contains("Should not get here")) {
+            if (e.getMessage() != null && e.getMessage().contains("Should not get here")) {
                 // probably facing JDK-8046686
                 LOGGER.debug("Unable to create a symlink. Your system is hitting JDK bug id JDK-8046686. Symlink support disabled.", e);
             } else {

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/GenericFileSystem.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/GenericFileSystem.java
@@ -36,10 +36,13 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.UUID;
+import org.jspecify.annotations.Nullable;
+import static java.util.Objects.requireNonNull;
 
 class GenericFileSystem implements FileSystem {
     private static final Logger LOGGER = LoggerFactory.getLogger(GenericFileSystem.class);
 
+    @Nullable
     private Boolean caseSensitive;
     private final boolean canCreateSymbolicLink;
     private final TemporaryFileProvider temporaryFileProvider;
@@ -70,7 +73,7 @@ class GenericFileSystem implements FileSystem {
     @Override
     public boolean isCaseSensitive() {
         initializeCaseSensitive();
-        return caseSensitive;
+        return requireNonNull(caseSensitive);
     }
 
     @Override
@@ -158,7 +161,7 @@ class GenericFileSystem implements FileSystem {
     }
 
     private boolean hasContent(File file, String content) throws IOException {
-        return file.exists() && Files.asCharSource(file, StandardCharsets.UTF_8).readFirstLine().equals(content);
+        return file.exists() && requireNonNull(Files.asCharSource(file, StandardCharsets.UTF_8).readFirstLine()).equals(content);
     }
 
     private void checkJavaIoTmpDirExists() throws IOException {

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/jansi/JansiStorageLocator.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/jansi/JansiStorageLocator.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.nativeintegration.jansi;
 
 import java.io.File;
+import org.jspecify.annotations.Nullable;
 
 public class JansiStorageLocator {
 
@@ -26,6 +27,7 @@ public class JansiStorageLocator {
         this.factory = factory;
     }
 
+    @Nullable
     public JansiStorage locate(File storageDir) {
         JansiLibrary jansiLibrary = factory.create();
 

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/jna/UnsupportedEnvironment.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/jna/UnsupportedEnvironment.java
@@ -26,10 +26,12 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 public class UnsupportedEnvironment implements ProcessEnvironment {
     private static final Logger LOGGER = LoggerFactory.getLogger(UnsupportedEnvironment.class);
 
+    @Nullable
     private final Long pid;
 
     public UnsupportedEnvironment() {
@@ -42,6 +44,7 @@ public class UnsupportedEnvironment implements ProcessEnvironment {
      *
      * This works on Solaris and should work with any Java VM
      */
+    @Nullable
     private Long extractPIDFromRuntimeMXBeanName() {
         Long pid = null;
         String runtimeMXBeanName = ManagementFactory.getRuntimeMXBean().getName();
@@ -107,6 +110,7 @@ public class UnsupportedEnvironment implements ProcessEnvironment {
     }
 
     @Override
+    @Nullable
     public Long maybeGetPid() {
         return pid;
     }

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -77,6 +77,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class NativeServices implements ServiceRegistrationProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(NativeServices.class);
+    @SuppressWarnings("NullAway.Init")
     private static NativeServices instance;
 
     // TODO All this should be static
@@ -292,6 +293,9 @@ public class NativeServices implements ServiceRegistrationProvider {
         }
     }
 
+    // Native-platform exception cause/message inspection is guarded by the surrounding instanceof checks;
+    // nativeIntegration is only used when useNativeIntegrations is true.
+    @SuppressWarnings("NullAway")
     private NativeServices(File userHomeDir, EnumSet<NativeFeatures> requestedFeatures, NativeServicesMode mode) {
         this.userHomeDir = userHomeDir;
 

--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -77,7 +77,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class NativeServices implements ServiceRegistrationProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(NativeServices.class);
-    @SuppressWarnings("NullAway.Init")
+    @Nullable
     private static NativeServices instance;
 
     // TODO All this should be static
@@ -89,6 +89,7 @@ public class NativeServices implements ServiceRegistrationProvider {
     private final boolean useNativeIntegrations;
     private final File userHomeDir;
 
+    @Nullable
     private final Native nativeIntegration;
     private final EnumSet<NativeFeatures> enabledFeatures = EnumSet.noneOf(NativeFeatures.class);
 
@@ -293,9 +294,6 @@ public class NativeServices implements ServiceRegistrationProvider {
         }
     }
 
-    // Native-platform exception cause/message inspection is guarded by the surrounding instanceof checks;
-    // nativeIntegration is only used when useNativeIntegrations is true.
-    @SuppressWarnings("NullAway")
     private NativeServices(File userHomeDir, EnumSet<NativeFeatures> requestedFeatures, NativeServicesMode mode) {
         this.userHomeDir = userHomeDir;
 
@@ -309,11 +307,13 @@ public class NativeServices implements ServiceRegistrationProvider {
                 LOGGER.debug("Native-platform is not available.", ex);
                 useNativeIntegrations = false;
             } catch (NativeException ex) {
-                if (ex.getCause() instanceof UnsatisfiedLinkError && ex.getCause().getMessage().toLowerCase(Locale.ROOT).contains("already loaded in another classloader")) {
+                Throwable cause = ex.getCause();
+                String causeMessage = cause == null ? null : cause.getMessage();
+                if (cause instanceof UnsatisfiedLinkError && causeMessage != null && causeMessage.toLowerCase(Locale.ROOT).contains("already loaded in another classloader")) {
                     LOGGER.debug("Unable to initialize native-platform. Failure: {}", format(ex));
                     useNativeIntegrations = false;
-                } else if (ex.getMessage().equals("Could not extract native JNI library.")
-                    && ex.getCause().getMessage().contains("native-platform.dll (The process cannot access the file because it is being used by another process)")) {
+                } else if ("Could not extract native JNI library.".equals(ex.getMessage())
+                    && causeMessage != null && causeMessage.contains("native-platform.dll (The process cannot access the file because it is being used by another process)")) {
                     //triggered through tooling API of Gradle <2.3 - native-platform.dll is shared by tooling client (<2.3) and daemon (current) and it is locked by the client (<2.3 issue)
                     LOGGER.debug("Unable to initialize native-platform. Failure: {}", format(ex));
                     useNativeIntegrations = false;
@@ -376,6 +376,7 @@ public class NativeServices implements ServiceRegistrationProvider {
     }
 
     @VisibleForTesting
+    @Nullable
     protected static synchronized Native getNative() {
         return checkNotNull(instance).nativeIntegration;
     }
@@ -402,7 +403,7 @@ public class NativeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected ProcessEnvironment createProcessEnvironment(OperatingSystem operatingSystem) {
-        if (useNativeIntegrations) {
+        if (useNativeIntegrations && nativeIntegration != null) {
             try {
                 net.rubygrapefruit.platform.Process process = nativeIntegration.get(Process.class);
                 return new NativePlatformBackedProcessEnvironment(process);
@@ -420,7 +421,7 @@ public class NativeServices implements ServiceRegistrationProvider {
     }
 
     private ConsoleDetector backingConsoleDetector(OperatingSystem operatingSystem) {
-        if (useNativeIntegrations) {
+        if (useNativeIntegrations && nativeIntegration != null) {
             try {
                 Terminals terminals = nativeIntegration.get(Terminals.class);
                 return new NativePlatformConsoleDetector(terminals);
@@ -445,7 +446,7 @@ public class NativeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected WindowsRegistry createWindowsRegistry(OperatingSystem operatingSystem) {
-        if (useNativeIntegrations && operatingSystem.isWindows()) {
+        if (useNativeIntegrations && nativeIntegration != null && operatingSystem.isWindows()) {
             return nativeIntegration.get(WindowsRegistry.class);
         }
         return notAvailable(WindowsRegistry.class, operatingSystem);
@@ -453,7 +454,7 @@ public class NativeServices implements ServiceRegistrationProvider {
 
     @Provides
     public SystemInfo createSystemInfo(OperatingSystem operatingSystem) {
-        if (useNativeIntegrations) {
+        if (useNativeIntegrations && nativeIntegration != null) {
             try {
                 return nativeIntegration.get(SystemInfo.class);
             } catch (NativeIntegrationUnavailableException e) {
@@ -465,7 +466,7 @@ public class NativeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected Memory createMemory(OperatingSystem operatingSystem) {
-        if (useNativeIntegrations) {
+        if (useNativeIntegrations && nativeIntegration != null) {
             try {
                 return nativeIntegration.get(Memory.class);
             } catch (NativeIntegrationUnavailableException e) {
@@ -477,7 +478,7 @@ public class NativeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected ProcessLauncher createProcessLauncher() {
-        if (useNativeIntegrations) {
+        if (useNativeIntegrations && nativeIntegration != null) {
             try {
                 return nativeIntegration.get(ProcessLauncher.class);
             } catch (NativeIntegrationUnavailableException e) {
@@ -489,7 +490,7 @@ public class NativeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected HostnameLookup createHostnameLookup() {
-        if (useNativeIntegrations) {
+        if (useNativeIntegrations && nativeIntegration != null) {
             try {
                 String hostname = nativeIntegration.get(SystemInfo.class).getHostname();
                 return new FixedHostname(hostname);
@@ -528,7 +529,7 @@ public class NativeServices implements ServiceRegistrationProvider {
 
     @Provides
     protected FileSystems createFileSystems(OperatingSystem operatingSystem) {
-        if (useNativeIntegrations) {
+        if (useNativeIntegrations && nativeIntegration != null) {
             try {
                 return nativeIntegration.get(FileSystems.class);
             } catch (NativeIntegrationUnavailableException e) {

--- a/platforms/core-runtime/service-registry-builder/build.gradle.kts
+++ b/platforms/core-runtime/service-registry-builder/build.gradle.kts
@@ -20,3 +20,7 @@ gradleModule {
         worker = true
     }
 }
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-runtime/service-registry-builder/src/main/java/org/gradle/internal/service/ServiceRegistryBuilder.java
+++ b/platforms/core-runtime/service-registry-builder/src/main/java/org/gradle/internal/service/ServiceRegistryBuilder.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.service;
 
 import org.gradle.internal.service.scopes.Scope;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +52,9 @@ public class ServiceRegistryBuilder {
 
     private final List<ServiceRegistry> parents = new ArrayList<ServiceRegistry>();
     private final List<ServiceRegistrationProvider> providers = new ArrayList<ServiceRegistrationProvider>();
+    @Nullable
     private String displayName;
+    @Nullable
     private Class<? extends Scope> scope;
     private boolean strict;
 

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -449,7 +449,6 @@ public class DefaultServiceRegistry extends AbstractServiceRegistry implements C
         }
 
         private PersistentArray<ServiceProvider> getProviders(Class<?> type) {
-            @SuppressWarnings("NullAway") // TODO(https://github.com/uber/NullAway/issues/681) Can't infer that AtomicReference holds non-nullable type
             PersistentMap<Class<?>, PersistentArray<ServiceProvider>> providersByType = services.get().providersByType;
 
             return providersByType.getOrDefault(type, PersistentArray.of());
@@ -486,7 +485,6 @@ public class DefaultServiceRegistry extends AbstractServiceRegistry implements C
                 annotationHandlerCreated((AnnotatedServiceLifecycleHandler) instance);
             }
 
-            @SuppressWarnings("NullAway") // TODO(https://github.com/uber/NullAway/issues/681) Can't infer that AtomicReference holds non-nullable type
             PersistentArray<AnnotatedServiceLifecycleHandler> lifecycleHandlers = services.get().lifecycleHandlers;
 
             for (AnnotatedServiceLifecycleHandler lifecycleHandler : lifecycleHandlers) {

--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ScopedServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/ScopedServiceRegistry.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.service;
 
 import org.gradle.internal.service.scopes.Scope;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A registry validating that all registered services are annotated with a corresponding {@link Scope}.
@@ -26,7 +27,7 @@ class ScopedServiceRegistry extends DefaultServiceRegistry {
     public ScopedServiceRegistry(
         Class<? extends Scope> scope,
         boolean strict,
-        String displayName,
+        @Nullable String displayName,
         ServiceRegistry... parents
     ) {
         super(displayName, parents);

--- a/platforms/core-runtime/wrapper-main/build.gradle.kts
+++ b/platforms/core-runtime/wrapper-main/build.gradle.kts
@@ -144,3 +144,7 @@ tasks.jar {
 }
 
 
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -35,7 +35,7 @@ import java.util.jar.Manifest
 import static org.hamcrest.CoreMatchers.containsString
 
 class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
-    private static final HashCode EXPECTED_WRAPPER_JAR_HASH = HashCode.fromString("7a9ce74cff467ca1bf60a4fcd9f05185acceda4d0f382434d393e17864262c5d")
+    private static final HashCode EXPECTED_WRAPPER_JAR_HASH = HashCode.fromString("2b2e2cee3d8a8e5379b4f1c5902419404e83c1dba5ff55192ad5986e3f44cd6e")
 
     def "generated wrapper scripts use correct line separators"() {
         buildFile << """

--- a/platforms/core-runtime/wrapper-shared/build.gradle.kts
+++ b/platforms/core-runtime/wrapper-shared/build.gradle.kts
@@ -32,3 +32,7 @@ gradleModule {
 }
 
 
+
+errorprone {
+    nullawayEnabled = true
+}

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/internal/file/locking/ExclusiveFileAccessManager.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/internal/file/locking/ExclusiveFileAccessManager.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.file.locking;
 
+import org.jspecify.annotations.Nullable;
 import java.io.Closeable;
 import java.io.File;
 import java.io.RandomAccessFile;
@@ -85,7 +86,7 @@ public class ExclusiveFileAccessManager {
         return System.nanoTime() / (1000L * 1000L);
     }
 
-    private static void maybeCloseQuietly(Closeable closeable) {
+    private static void maybeCloseQuietly(@Nullable Closeable closeable) {
         if (closeable != null) {
             try {
                 closeable.close();

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/BootstrapMainStarter.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/BootstrapMainStarter.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.wrapper;
 
+import org.jspecify.annotations.Nullable;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -38,6 +39,7 @@ public class BootstrapMainStarter {
         ((Closeable) contextClassLoader).close();
     }
 
+    @Nullable
     static File findLauncherJar(File gradleHome) {
         File libDirectory = new File(gradleHome, "lib");
         if (libDirectory.exists() && libDirectory.isDirectory()) {

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/Download.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/Download.java
@@ -35,6 +35,7 @@ import java.net.URLConnection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import org.jspecify.annotations.Nullable;
 
 public class Download implements IDownload {
     public static final String UNKNOWN_VERSION = "0";
@@ -65,11 +66,11 @@ public class Download implements IDownload {
         return result;
     }
 
-    public Download(Logger logger, DownloadProgressListener progressListener, String appName, String appVersion, Map<String, String> systemProperties) {
+    public Download(Logger logger, @Nullable DownloadProgressListener progressListener, String appName, String appVersion, Map<String, String> systemProperties) {
         this(logger, progressListener, appName, appVersion, systemProperties, DEFAULT_NETWORK_TIMEOUT_MILLISECONDS);
     }
 
-    public Download(Logger logger, DownloadProgressListener progressListener, String appName, String appVersion, Map<String, String> systemProperties, int networkTimeout) {
+    public Download(Logger logger, @Nullable DownloadProgressListener progressListener, String appName, String appVersion, Map<String, String> systemProperties, int networkTimeout) {
         this.logger = logger;
         this.appName = appName;
         this.appVersion = appVersion;
@@ -239,10 +240,11 @@ public class Download implements IDownload {
 
     private static class DefaultDownloadProgressListener implements DownloadProgressListener {
         private final Logger logger;
+        @Nullable
         private final DownloadProgressListener delegate;
         private int previousDownloadPercent;
 
-        public DefaultDownloadProgressListener(Logger logger, DownloadProgressListener delegate) {
+        public DefaultDownloadProgressListener(Logger logger, @Nullable DownloadProgressListener delegate) {
             this.logger = logger;
             this.delegate = delegate;
             this.previousDownloadPercent = 0;

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/Install.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/Install.java
@@ -18,6 +18,7 @@ package org.gradle.wrapper;
 
 import org.gradle.internal.file.locking.ExclusiveFileAccessManager;
 
+import org.jspecify.annotations.Nullable;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -38,6 +39,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
+import static java.util.Objects.requireNonNull;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static org.gradle.internal.file.PathTraversalChecker.safePathName;
@@ -75,7 +77,7 @@ public class Install {
             if (distDir.isDirectory() && markerFile.isFile()) {
                 InstallCheck installCheck = verifyDistributionRoot(distDir, distDir.getAbsolutePath());
                 if (installCheck.isVerified()) {
-                    return installCheck.gradleHome;
+                    return requireNonNull(installCheck.gradleHome);
                 }
                 // Distribution is invalid. Try to reinstall.
                 System.err.println(installCheck.failureMessage);
@@ -86,10 +88,10 @@ public class Install {
 
             InstallCheck installCheck = verifyDistributionRoot(distDir, safeUri(distributionUrl).toASCIIString());
             if (installCheck.isVerified()) {
-                setExecutablePermissions(installCheck.gradleHome);
+                setExecutablePermissions(requireNonNull(installCheck.gradleHome));
                 markerFile.createNewFile();
                 localZipFile.delete();
-                return installCheck.gradleHome;
+                return requireNonNull(installCheck.gradleHome);
             }
             // Distribution couldn't be installed.
             throw new RuntimeException(installCheck.failureMessage);
@@ -126,6 +128,7 @@ public class Install {
         } while (failed);
     }
 
+    @Nullable
     private String fetchDistributionSha256Sum(WrapperConfiguration configuration, File localZipFile) {
         URI distribution = configuration.getDistribution();
         try {
@@ -248,7 +251,7 @@ public class Install {
         return InstallCheck.success(gradleHome);
     }
 
-    private void verifyDownloadChecksum(String sourceUrl, File localZipFile, String expectedSum) throws Exception {
+    private void verifyDownloadChecksum(String sourceUrl, File localZipFile, @Nullable String expectedSum) throws Exception {
         if (expectedSum == null) {
             return;
         }
@@ -376,7 +379,9 @@ public class Install {
     }
 
     private static class InstallCheck {
+        @Nullable
         private final File gradleHome;
+        @Nullable
         private final String failureMessage;
 
         private static InstallCheck failure(String message) {
@@ -387,7 +392,7 @@ public class Install {
             return new InstallCheck(gradleHome, null);
         }
 
-        private InstallCheck(File gradleHome, String failureMessage) {
+        private InstallCheck(@Nullable File gradleHome, @Nullable String failureMessage) {
             this.gradleHome = gradleHome;
             this.failureMessage = failureMessage;
         }

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/Install.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/Install.java
@@ -66,7 +66,7 @@ public class Install {
     }
 
     public File createDist(final WrapperConfiguration configuration) throws Exception {
-        final URI distributionUrl = configuration.getDistribution();
+        final URI distributionUrl = requireNonNull(configuration.getDistribution(), "No distribution URL specified in wrapper configuration");
 
         final PathAssembler.LocalDistribution localDistribution = pathAssembler.getDistribution(configuration);
         final File distDir = localDistribution.getDistributionDir();
@@ -111,7 +111,7 @@ public class Install {
 
                 deleteLocalTopLevelDirs(distDir);
 
-                verifyDownloadChecksum(configuration.getDistribution().toASCIIString(), localZipFile, distributionSha256Sum);
+                verifyDownloadChecksum(distributionUrl.toASCIIString(), localZipFile, distributionSha256Sum);
 
                 unzipLocal(localZipFile, distDir);
                 failed = false;
@@ -130,7 +130,7 @@ public class Install {
 
     @Nullable
     private String fetchDistributionSha256Sum(WrapperConfiguration configuration, File localZipFile) {
-        URI distribution = configuration.getDistribution();
+        URI distribution = requireNonNull(configuration.getDistribution());
         try {
             URI distributionUrl = distribution.resolve(distribution.getPath() + SHA_256);
             File tmpZipFile = new File(localZipFile.getParentFile(), localZipFile.getName() + SHA_256);

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/PathAssembler.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/PathAssembler.java
@@ -20,6 +20,8 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.security.MessageDigest;
 
+import static java.util.Objects.requireNonNull;
+
 public class PathAssembler {
     public static final String GRADLE_USER_HOME_STRING = "GRADLE_USER_HOME";
     public static final String PROJECT_STRING = "PROJECT";
@@ -36,16 +38,17 @@ public class PathAssembler {
      * Determines the local locations for the distribution to use given the supplied configuration.
      */
     public LocalDistribution getDistribution(WrapperConfiguration configuration) {
-        String baseName = getDistName(configuration.getDistribution());
+        URI distribution = requireNonNull(configuration.getDistribution(), "No distribution URL specified in wrapper configuration");
+        String baseName = getDistName(distribution);
         String distName = removeExtension(baseName);
-        String rootDirName = rootDirName(distName, configuration);
+        String rootDirName = rootDirName(distName, distribution);
         File distDir = new File(getBaseDir(configuration.getDistributionBase()), configuration.getDistributionPath() + "/" + rootDirName);
         File distZip = new File(getBaseDir(configuration.getZipBase()), configuration.getZipPath() + "/" + rootDirName + "/" + baseName);
         return new LocalDistribution(distDir, distZip);
     }
 
-    private String rootDirName(String distName, WrapperConfiguration configuration) {
-        String urlHash = getHash(Download.safeUri(configuration.getDistribution()).toASCIIString());
+    private String rootDirName(String distName, URI distribution) {
+        String urlHash = getHash(Download.safeUri(distribution).toASCIIString());
         return distName + "/" + urlHash;
     }
 

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
@@ -17,10 +17,15 @@ package org.gradle.wrapper;
 
 import java.net.URI;
 
+import static java.util.Objects.requireNonNull;
+import org.jspecify.annotations.Nullable;
+
 public class WrapperConfiguration {
+    @Nullable
     private URI distribution;
     private String distributionBase = PathAssembler.GRADLE_USER_HOME_STRING;
     private String distributionPath = Install.DEFAULT_DISTRIBUTION_PATH;
+    @Nullable
     private String distributionSha256Sum;
     private String zipBase = PathAssembler.GRADLE_USER_HOME_STRING;
     private String zipPath = Install.DEFAULT_DISTRIBUTION_PATH;
@@ -30,7 +35,7 @@ public class WrapperConfiguration {
     private int retryBackOffMs = Install.DEFAULT_NETWORK_RETRY_BACK_OFF_MS;
 
     public URI getDistribution() {
-        return distribution;
+        return requireNonNull(distribution);
     }
 
     public void setDistribution(URI distribution) {
@@ -69,11 +74,12 @@ public class WrapperConfiguration {
         return retryBackOffMs;
     }
 
+    @Nullable
     public String getDistributionSha256Sum() {
         return distributionSha256Sum;
     }
 
-    public void setDistributionSha256Sum(String distributionSha256Sum) {
+    public void setDistributionSha256Sum(@Nullable String distributionSha256Sum) {
         this.distributionSha256Sum = distributionSha256Sum;
     }
 

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
@@ -41,7 +41,7 @@ public class WrapperConfiguration {
         return distribution;
     }
 
-    public void setDistribution(URI distribution) {
+    public void setDistribution(@Nullable URI distribution) {
         this.distribution = distribution;
     }
 

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
@@ -15,10 +15,9 @@
  */
 package org.gradle.wrapper;
 
-import java.net.URI;
-
-import static java.util.Objects.requireNonNull;
 import org.jspecify.annotations.Nullable;
+
+import java.net.URI;
 
 public class WrapperConfiguration {
     @Nullable
@@ -34,8 +33,12 @@ public class WrapperConfiguration {
     private int retries = Install.DEFAULT_NETWORK_RETRIES;
     private int retryBackOffMs = Install.DEFAULT_NETWORK_RETRY_BACK_OFF_MS;
 
+    /**
+     * Returns the distribution URL, or null if it has not been configured, e.g. because no wrapper properties file was found.
+     */
+    @Nullable
     public URI getDistribution() {
-        return requireNonNull(distribution);
+        return distribution;
     }
 
     public void setDistribution(URI distribution) {

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperExecutor.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperExecutor.java
@@ -17,6 +17,7 @@ package org.gradle.wrapper;
 
 import org.gradle.util.internal.WrapperDistributionUrlConverter;
 
+import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -128,7 +129,9 @@ public class WrapperExecutor {
         return Boolean.parseBoolean(getProperty(propertyName, String.valueOf(defaultValue)));
     }
 
-    private String getProperty(String propertyName, String defaultValue, boolean required) {
+    // Returns null only in the !required branch; callers passing required=true rely on a non-null result.
+    @SuppressWarnings("NullAway")
+    private String getProperty(String propertyName, @Nullable String defaultValue, boolean required) {
         String value = properties.getProperty(propertyName);
         if (value != null) {
             return value;

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperExecutor.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperExecutor.java
@@ -97,6 +97,7 @@ public class WrapperExecutor {
     /**
      * Returns the distribution which this wrapper will use. Returns null if no wrapper meta-data was found in the specified project directory.
      */
+    @Nullable
     public URI getDistribution() {
         return config.getDistribution();
     }


### PR DESCRIPTION
### Context

Part of the ongoing effort to enable NullAway across the codebase project by project (in dependency-topological order), with one commit per project.

This PR enables NullAway (`errorprone { nullawayEnabled = true }`) in 11 projects:

- `:internal-instrumentation-processor`
- `:service-registry-builder`
- `:java-api-extractor`
- `:snapshots`
- `:wrapper-shared`
- `:wrapper-main`
- `:build-cache-packaging`
- `:normalization-java`
- `:file-watching`
- `:native`
- `:build-cache`

### Approach

Annotations-only — no behavior changes (one deliberate exception below):

- `@Nullable` on genuinely optional fields, parameters, and returns (matching already-annotated interfaces where overrides were missing it).
- `requireNonNull(...)` where a value is non-null in correct usage but NullAway cannot prove it (e.g. set-after-construction fields, map lookups known to be present).
- Targeted `@SuppressWarnings("NullAway")` with a justifying comment only where neither fits.

### Notable points for review

- **Wrapper nullability** (`:wrapper-shared`): `WrapperConfiguration.getDistribution()` stays `@Nullable` — a null distribution is a legitimate, documented state (`WrapperExecutor.forProjectDirectory()` without a wrapper properties file; `DistributionFactory` relies on it to fall back to the current Gradle version). `requireNonNull` moved into the callers that genuinely require a configured distribution (`Install.createDist()`, `PathAssembler.getDistribution()`). The setter accepts null to satisfy the accessor-symmetry rule in `KotlinCompatibilityTest`.
- **Wrapper JAR hash**: `EXPECTED_WRAPPER_JAR_HASH` in `WrapperGenerationIntegrationTest` is updated — the `@Nullable` annotations added to wrapper classes intentionally change the `gradle-wrapper.jar` bytecode.
- **NullAway #681 cleanup**: NullAway now infers that `AtomicReference` holds a non-null type (uber/NullAway#681), so the pre-existing workarounds (`requireNonNull` calls and suppressions) are removed in `DefaultBuildCacheController`, `BaseLocalBuildCacheServiceHandle`, `FileWatchingFilter`, `DefaultBuildOperationListenerManager`, `DefaultWorkerLeaseService`, `DefaultServiceRegistry` (×2), and `InstrumentedInputs`.
- **New `@Initializer` annotation** (`:java-api-extractor`): `ApiMemberSelector.classMember` is populated by the ASM `visit()` callback; NullAway treats any annotation named `Initializer` as marking a field initializer, which replaces a blanket suppression.
- **`FieldMember.compareTo` suppression restored**: the Linux CI toolchain no longer flags it, but the Windows ARM toolchain still rejects passing the `@Nullable` `value` fields to `Comparator.compare()` without an explicit `@Nullable` type argument — the previously reviewed suppression is kept.

### Reviewing cheatsheet

Before merging the PR, comments starting with
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
