### PR TITLE
Remove duplication from build failure message

### DIFF
--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -484,6 +484,25 @@ Problem found: Project is a prototype (id: sample-problems:prototype-project)
         }
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/35914")
+    def "build failure message does not contain duplicate information"() {
+        given:
+        disableProblemsApiCheck()
+        def solution = 'Look up the samples index for real-life examples'
+        withReportProblemTask """
+            ${problemIdScript()}
+            problems.getReporter().throwing(new RuntimeException(), problemId) { spec ->
+                spec.solution("$solution")
+            }
+        """
+
+        when:
+        fails('reportProblem')
+
+        then:
+        errorOutput.count(solution) == 1
+    }
+
     static String problemIdScript() {
         """${ProblemGroup.name} problemGroup = ${ProblemGroup.name}.create("generic", "group label");
            ${ProblemId.name} problemId = ${ProblemId.name}.create("type", "label", problemGroup)"""

--- a/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemBodyWriter.java
+++ b/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemBodyWriter.java
@@ -49,7 +49,7 @@ class ProblemBodyWriter implements PartialProblemWriter {
         }
 
         // print solutions
-        if (!problem.getSolutions().isEmpty()) {
+        if (options.isRenderSolutions() && !problem.getSolutions().isEmpty()) {
             for (String solution : problem.getSolutions()) {
                 output.printf("%n");
 

--- a/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemWriter.java
+++ b/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/ProblemWriter.java
@@ -59,7 +59,7 @@ public abstract class ProblemWriter {
     public static ProblemWriter simple() {
         return new SimpleProblemWriter(
             ProblemWriterRegistry.INSTANCE,
-            new RenderOptions("Problem found: ", true)
+            new RenderOptions("Problem found: ", true, true)
         );
     }
 
@@ -70,7 +70,7 @@ public abstract class ProblemWriter {
     public static ProblemWriter grouping() {
         return new GroupingProblemWriter(
             ProblemWriterRegistry.INSTANCE,
-            new RenderOptions("", false));
+            new RenderOptions("", false, false));
     }
 
     /**

--- a/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/RenderOptions.java
+++ b/platforms/ide/problems-rendering/src/main/java/org/gradle/problems/internal/rendering/RenderOptions.java
@@ -23,13 +23,16 @@ class RenderOptions {
 
     private final String prefix;
     private final boolean renderId;
+    private final boolean renderSolutions;
 
     public RenderOptions(
         String prefix,
-        boolean renderId
+        boolean renderId,
+        boolean renderSolutions
     ) {
         this.prefix = prefix;
         this.renderId = renderId;
+        this.renderSolutions = renderSolutions;
     }
 
     /**
@@ -44,5 +47,12 @@ class RenderOptions {
      */
     public boolean isRenderId() {
         return renderId;
+    }
+
+    /**
+     * Whether to render the solutions with the problem.
+     */
+    public boolean isRenderSolutions() {
+        return renderSolutions;
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -287,4 +287,29 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec imp
             ]
         }
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/35914")
+    def "build failure message does not contain duplicate information"() {
+        setup:
+        disableProblemsApiCheck()
+
+        buildFile << """
+            class FooTask extends DefaultTask {
+               @InputFiles
+               FileCollection bar
+
+               @TaskAction
+               def go() {
+               }
+            }
+
+            task foo(type: FooTask)
+        """
+
+        when:
+        fails "foo"
+
+        then:
+        errorOutput.count("Mark property 'bar' as optional") == 1
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -22,6 +22,8 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
+import org.gradle.api.problems.ProblemGroup;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
@@ -405,7 +407,11 @@ public class BuildExceptionReporter implements Action<Throwable> {
 
         Collection<InternalProblem> all = failure.getProblems();
         for (InternalProblem problem : all) {
-            resolutions.addAll(problem.getSolutions());
+            // TODO (donat) integrate type validation failure rendering with problems-rendering and get rid of the special-casing here
+            ProblemGroup group = problem.getDefinition().getId().getGroup();
+            if (!GradleCoreProblemGroup.validation().type().equals(group) && !GradleCoreProblemGroup.validation().property().equals(group)) {
+                resolutions.addAll(problem.getSolutions());
+            }
         }
 
         for (Failure cause : failure.getCauses()) {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes
- https://github.com/gradle/gradle/issues/36091

Relates to 
- https://github.com/gradle/gradle/issues/35914

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

This PR addresses two duplication issues in build exception reporting.

1) There's a general issue with builds failing because of a `ProblemReporter.throwing()` call. The build failure message contains a rendered version of the problem, which accidentally includes the data in the `Problem.solutions` property. This causes a duplication as the same information is displayed in `* Try:` section of the build failure. The PR adjusts the rendering implementation such that the problem rendering for build failures shouldn't include `Problem.solutions`.

2) Type validation failures are integrated with the problems API but not with the problems rendering. The validation infrastructure builds a complex message string describing the problem, the reason, and - most importantly - the solutions. To remove the duplication, the PR removes `Problem.solutions` from the build failure message if the associated problem's group is `GradleCoreProblemGroups.validation()`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
