### PR TITLE
Fix issue with running parameterized suites on JUnit 4.3

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/AbstractJUnit4SuitesIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/AbstractJUnit4SuitesIntegrationTest.groovy
@@ -354,6 +354,7 @@ abstract class AbstractJUnit4SuitesIntegrationTest extends AbstractJUnitSuitesIn
             import org.junit.runners.Parameterized;
             import org.junit.runners.Parameterized.Parameters;
             import org.junit.runner.RunWith;
+            import java.util.Collection;
             import java.util.List;
 
             @RunWith(Parameterized.class)
@@ -364,8 +365,8 @@ abstract class AbstractJUnit4SuitesIntegrationTest extends AbstractJUnitSuitesIn
                 }
 
                 @Parameters
-                public static List<?> data() {
-                   return List.of(0, 1);
+                public static Collection data() {
+                   return List.of(new Object[][] { {0}, {1} });
                 }
 
                 @Test public void pass() {}


### PR DESCRIPTION
Fixes issue where parameterized test suites would fail to initialize on JUnit 4.3.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
