### PR TITLE
Limit engines used for archTest to just ArchUnit

### DIFF
--- a/build-logic/buildquality/src/main/kotlin/gradlebuild.arch-test.gradle.kts
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild.arch-test.gradle.kts
@@ -47,8 +47,6 @@ notForAccessorGeneration {
 testing {
     suites {
         create("archTest", JvmTestSuite::class) {
-            useJUnitJupiter()
-
             project.jvmCompile {
                 addCompilationFrom(sources)
             }
@@ -64,6 +62,9 @@ testing {
             targets {
                 all {
                     testTask.configure {
+                        useJUnitPlatform {
+                            includeEngines("archunit")
+                        }
                         testClassesDirs += sharedArchTestClasses.filter { it.isDirectory }
                         classpath += sourceSets["main"].output.classesDirs
                         systemProperty("package.cycle.exclude.patterns", packageCyclesExtension.excludePatterns.get().joinToString(","))


### PR DESCRIPTION
Other engines were being invoked for discovery, especially Spock, which cost about 0.4s of time for each archTest on my machine. We don't use these for this task, which only runs PackageCycleTest.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
