### PR TITLE
Add export DEVELOCITY_ACCESS_KEY

### DIFF
--- a/.teamcity/scripts/configure_build_env_on_ec2.sh
+++ b/.teamcity/scripts/configure_build_env_on_ec2.sh
@@ -34,6 +34,7 @@ AWS_REGION=$(curl -s "http://169.254.169.254/latest/meta-data/placement/region")
 if [[ "$AWS_REGION" == us-* ]]; then
   echo "For $AWS_REGION switching to user teamcityus access token"
   echo "##teamcity[setParameter name='env.DEVELOCITY_ACCESS_KEY' value='%ge.gradle.org.access.key.us%;%gbt-td.grdev.net.access.key%']"
+  export DEVELOCITY_ACCESS_KEY="${DEVELOCITY_ACCESS_KEY_US}"
 fi
 
 # Execute pre-build script based on BUILD_TYPE_ID


### PR DESCRIPTION
The following code not enough to set the `DEVELOCITY_ACCESS_KEY` for current bash process, so we need an extra `export DEVELOCITY_ACCESS_KEY`.

```
echo "##teamcity[setParameter name='env.DEVELOCITY_ACCESS_KEY' value='%ge.gradle.org.access.key.us%;%gbt-td.grdev.net.access.key%']"
```

Example: https://ge.gradle.org/s/p7lyu2svbwfui/custom-values