### PR TITLE
Generate thread dumps for FlakyTestQuarantine after 30m

### DIFF
--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -15,6 +15,8 @@
  */
 
 import gradlebuild.basics.BuildEnvironment
+import gradlebuild.basics.FlakyTestStrategy
+import gradlebuild.basics.flakyTestStrategy
 import java.time.Duration
 
 // Lifecycle tasks used to fan out the build into multiple builds in a CI pipeline.
@@ -59,7 +61,7 @@ fun setupTimeoutMonitorOnCI() {
 }
 
 fun determineTimeoutMillis() = when {
-    isRequestedTask(compileAllBuild) || isRequestedTask(sanityCheck) || isRequestedTask(quickTest) -> Duration.ofMinutes(30).toMillis()
+    isRequestedTask(compileAllBuild) || isRequestedTask(sanityCheck) || isRequestedTask(quickTest) || flakyTestStrategy == FlakyTestStrategy.ONLY -> Duration.ofMinutes(30).toMillis()
     isRequestedTask(smokeTest) -> Duration.ofHours(1).plusMinutes(30).toMillis()
     isRequestedTask(docsTest) -> Duration.ofMinutes(45).toMillis()
     else -> Duration.ofHours(2).plusMinutes(45).toMillis()


### PR DESCRIPTION
FlakyTestQuarantine builds usually run very fast (10~20m). If a build runs for >30m, it's likely to be hanging. This PR generates thread dumps for all FlakyTestQuarantine builds if they're longer than 30m.