### PR TITLE
Trigger legacy release branches nightly and weekly

### DIFF
--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -16,28 +16,6 @@ val DslContext.uuidPrefix: String
 data class VersionedSettingsBranch(
     val branchName: String,
 ) {
-    /**
-     * 0~23.
-     * To avoid nightly promotion jobs running at the same time,
-     * we run each branch on different hours.
-     * master - 0:00
-     * release - 1:00
-     * release6x - 2:00
-     * release7x - 3:00
-     * ...
-     * releaseNx - (N-4):00
-     */
-    val nightlyPromotionTriggerHour: Int? = determineNightlyPromotionTriggerHour(branchName)
-
-    /**
-     * Whether the <a href="https://www.jetbrains.com/help/teamcity/configuring-vcs-triggers.html">VCS trigger</a>
-     * should be enabled, i.e. when new commits are pushed to this branch, should a ReadyForNightly job
-     * be triggered automatically?
-     *
-     * Currently, we only enable VCS trigger for `master`/`release`/`releaseNx` branches.
-     */
-    val enableVcsTriggers: Boolean = nightlyPromotionTriggerHour != null
-
     companion object {
         private const val MASTER_BRANCH = "master"
 
@@ -54,22 +32,6 @@ data class VersionedSettingsBranch(
         private val OLD_RELEASE_PATTERN = "release(\\d+)x".toRegex()
 
         fun fromDslContext(): VersionedSettingsBranch = VersionedSettingsBranch(DslContext.getParameter("branch"))
-
-        private fun determineNightlyPromotionTriggerHour(branchName: String) =
-            when (branchName) {
-                MASTER_BRANCH -> 0
-                RELEASE_BRANCH -> 1
-                else -> {
-                    val matchResult = OLD_RELEASE_PATTERN.find(branchName)
-                    if (matchResult == null) {
-                        null
-                    } else {
-                        (matchResult.groupValues[1].toInt() - 4).apply {
-                            require(this in 2..23)
-                        }
-                    }
-                }
-            }
     }
 
     val isMainBranch: Boolean

--- a/.teamcity/src/main/kotlin/configurations/StageTriggers.kt
+++ b/.teamcity/src/main/kotlin/configurations/StageTriggers.kt
@@ -76,7 +76,7 @@ class StageTrigger(
         }
 
         if (generateTriggers) {
-            val enableTriggers = model.branch.enableVcsTriggers
+            val enableTriggers = model.branch.isMainBranch || model.branch.isLegacyRelease
             if (stage.trigger == Trigger.EACH_COMMIT) {
                 val effectiveTriggerBranches = mutableListOf(model.branch.branchName)
 

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlyDocumentation.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlyDocumentation.kt
@@ -34,19 +34,9 @@ class PublishNightlyDocumentation(
             "Promotes the latest successful documentation changes on '${branch.branchName}' from Ready for Nightly as a new nightly documentation snapshot"
 
         triggers {
-            branch.nightlyPromotionTriggerHour?.let { triggerHour ->
+            branch.determineNightlyPromotionTriggerHour()?.let { triggerHour ->
                 schedule {
-                    schedulingPolicy =
-                        daily {
-                            this.hour = triggerHour
-                        }
-                    triggerBuild = always()
-                    withPendingChangesOnly = true
-                    enabled = branch.enableVcsTriggers
-                    // https://www.jetbrains.com/help/teamcity/2022.04/configuring-schedule-triggers.html#general-syntax-1
-                    // We want it to be triggered only when there're pending changes in the specific vcs root, i.e. GradleMaster/GradleRelease
-                    triggerRules = "+:root=${VersionedSettingsBranch.fromDslContext().vcsRootId()}:."
-                    branchFilter = "+:<default>"
+                    scheduledTrigger(branch, policy = daily { this.hour = triggerHour }, pendingChangesOnly = true)
                 }
             }
         }

--- a/.teamcity/src/main/kotlin/promotion/SanityCheck.kt
+++ b/.teamcity/src/main/kotlin/promotion/SanityCheck.kt
@@ -27,7 +27,7 @@ object SanityCheck : BuildType({
     triggers {
         vcs {
             branchFilter = ""
-            enabled = VersionedSettingsBranch.fromDslContext().enableVcsTriggers
+            enabled = VersionedSettingsBranch.fromDslContext().isMainBranch
         }
     }
 

--- a/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
+++ b/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
@@ -38,7 +38,7 @@ object StartReleaseCycleTest : BasePromotionBuildType(cleanCheckout = false) {
             }
         }
 
-        val enableTriggers = VersionedSettingsBranch.fromDslContext().enableVcsTriggers
+        val enableTriggers = VersionedSettingsBranch.fromDslContext().isMainBranch
         triggers {
             vcs {
                 branchFilter = "+:master"

--- a/.teamcity/src/test/kotlin/VersionedSettingsBranchTest.kt
+++ b/.teamcity/src/test/kotlin/VersionedSettingsBranchTest.kt
@@ -1,13 +1,10 @@
 import common.VersionedSettingsBranch
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
+import promotion.determineNightlyPromotionTriggerHour
 
 /*
  * Copyright 2023 the original author or authors.
@@ -41,8 +38,7 @@ class VersionedSettingsBranchTest {
         expectedNightlyPromotionTriggerHour: Int?,
     ) {
         val vsb = VersionedSettingsBranch(branchName)
-        assertTrue(vsb.enableVcsTriggers)
-        assertEquals(expectedNightlyPromotionTriggerHour, vsb.nightlyPromotionTriggerHour)
+        assertEquals(expectedNightlyPromotionTriggerHour, vsb.determineNightlyPromotionTriggerHour())
     }
 
     @ParameterizedTest
@@ -55,14 +51,6 @@ class VersionedSettingsBranchTest {
     )
     fun branchesWithVcsTriggerDisabled(branchName: String) {
         val vsb = VersionedSettingsBranch(branchName)
-        assertFalse(vsb.enableVcsTriggers)
-        assertNull(vsb.nightlyPromotionTriggerHour)
-    }
-
-    @Test
-    fun invalidBranches() {
-        Assertions.assertThrows(Exception::class.java) {
-            VersionedSettingsBranch("release28x")
-        }
+        assertNull(vsb.determineNightlyPromotionTriggerHour())
     }
 }


### PR DESCRIPTION
In the past, the scheduled trigger rule is:

- For `master`/`release`, we trigger them at midnight, but only when there is pending changes.
- For old release branches, we trigger them at weekend unconditionally, but not midnight.

This PR updates the rule to be:

- For old release branches, we trigger them at:
  - Weekend unconditionally
  - Midnight if there is pending change

This is helpful when old release branch is pushed and we'd like to see a nightly next day.