### PR TITLE
Reduce performance DB connections (3 -> 1)

### DIFF
--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -764,7 +764,7 @@
     "linux" : 3311
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.corefeature.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
+  "scenario" : "org.gradle.performance.crossbuild.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 225

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -437,7 +437,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.corefeature.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
+    "testId" : "org.gradle.performance.crossbuild.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {

--- a/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
@@ -78,7 +78,7 @@ class TestPerformanceTest(
                 listOf(
                     "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for IDEA",
                     "org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel true)",
-                    "org.gradle.performance.regression.corefeature.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
+                    "org.gradle.performance.crossbuild.TaskAvoidancePerformanceTest.help with lazy and eager tasks",
                 ),
             )
 

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/buildscan/BuildScanPluginPerformanceTest.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/buildscan/BuildScanPluginPerformanceTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.performance
+package org.gradle.performance.buildscan
 
+import org.gradle.performance.AbstractBuildScanPluginPerformanceTest
 import org.gradle.performance.fixture.GradleBuildExperimentSpec
 
 class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceTest {

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/buildscan/BuildScanPluginResourceCapturingPerformanceTest.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/buildscan/BuildScanPluginResourceCapturingPerformanceTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.performance
+package org.gradle.performance.buildscan
 
+import org.gradle.performance.AbstractBuildScanPluginPerformanceTest
 import org.gradle.performance.fixture.GradleBuildExperimentSpec
 
 class BuildScanPluginResourceCapturingPerformanceTest extends AbstractBuildScanPluginPerformanceTest {

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/buildscan/InjectDevelocityPlugin.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/buildscan/InjectDevelocityPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.performance
+package org.gradle.performance.buildscan
 
 import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.ScenarioContext

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/buildscan/ManageLocalCacheState.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/buildscan/ManageLocalCacheState.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.performance
+package org.gradle.performance.buildscan
 
 import org.gradle.profiler.BuildContext
 import org.gradle.profiler.BuildMutator

--- a/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/buildscan/SaveScanSpoolFile.groovy
+++ b/platforms/enterprise/enterprise-plugin-performance/src/performanceTest/groovy/org/gradle/performance/buildscan/SaveScanSpoolFile.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.performance
+package org.gradle.performance.buildscan
 
 import org.apache.commons.io.FileUtils
 import org.gradle.profiler.BuildContext

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/TaskAvoidancePerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/TaskAvoidancePerformanceTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.performance.regression.corefeature
+package org.gradle.performance.crossbuild
 
 import org.gradle.performance.AbstractCrossBuildPerformanceTest
 import org.gradle.performance.annotations.RunFor


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/4975

In the past, we had 3 performance DBs:

- Cross version store
- Cross build store
- GradleVsMaven store (Removed in https://github.com/gradle/gradle/pull/36134)

Given a perf test scenario, how did we determine which DB to use? We had to query all DBs, which opened 3 DB connections, even when 99% of the scenarios are in cross version store - this is stupid.

This PR moves all cross build perf tests (2 classes only) to specific package:

- `org.gradle.performance.buildscan`
- `org.gradle.performance.crossbuild`

So we can simply determine which store by doing a simple package name match.

This PR also adds profiling log to performance DB operations because it helps us find where is the inefficiency.

