### PR TITLE
Check ref of remote project

### DIFF
--- a/.teamcity/scripts/CheckRemoteProjectRef.java
+++ b/.teamcity/scripts/CheckRemoteProjectRef.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.file.*;
+import java.util.*;
+
+/**
+ * Validates that remote project refs specified in gradle.properties are tagged.
+ */
+public class CheckRemoteProjectRef {
+    static void die(String m) {
+        System.err.println(m);
+        System.exit(1);
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            die("At least one property name must be provided\nUsage: java CheckRemoteProjectRef.java <property-name> [property-name ...]");
+        }
+        var props = new Properties();
+        try (var in = Files.newInputStream(Path.of("gradle.properties"))) {
+            props.load(in);
+        }
+        for (var name : args) {
+            var value = props.getProperty(name);
+            if (value == null || value.isBlank()) {
+                die("Property '" + name + "' not found in gradle.properties");
+            }
+            validate(name, value.trim());
+        }
+    }
+
+    static void validate(String name, String value) throws Exception {
+        int i = value.indexOf('#');
+        if (i < 1 || i == value.length() - 1) {
+            die(name + " must be in format: <repository-url>#<commit-sha>, got: " + value);
+        }
+        var repo = value.substring(0, i);
+        var sha = value.substring(i + 1).trim();
+        if (sha.isEmpty()) {
+            die(name + " must be in format: <repository-url>#<commit-sha>, got: " + value);
+        }
+
+        System.out.println("Checking if commit " + sha + " is tagged in " + repo);
+        var r = exec("git", "ls-remote", "--tags", repo);
+        if (r.code != 0) {
+            die("Failed to list tags from " + repo + ": " + r.out);
+        }
+
+        var tags = new ArrayList<String>();
+        for (var line : r.out.split("\n")) {
+            line = line.trim();
+            if (line.isEmpty()) {
+                continue;
+            }
+            var parts = line.split("\t");
+            if (parts.length != 2) {
+                continue;
+            }
+            if (parts[0].trim().startsWith(sha)) {
+                tags.add(parts[1].trim().replaceFirst("^refs/tags/", "").replaceFirst("\\^\\{\\}$", ""));
+            }
+        }
+        if (tags.isEmpty()) {
+            die("Commit " + sha + " in repository " + repo
+                    + " is not tagged. Please ensure the commit is tagged before using it in smoke tests.");
+        }
+        System.out.println("✓ Commit " + sha + " is tagged: " + String.join(", ", tags));
+    }
+
+    static Res exec(String... cmd) throws Exception {
+        var p = new ProcessBuilder(cmd).redirectErrorStream(true).start();
+        var out = new String(p.getInputStream().readAllBytes());
+        return new Res(out, p.waitFor());
+    }
+
+    record Res(String out, int code) {
+    }
+}

--- a/.teamcity/src/main/kotlin/configurations/CheckRemoteProjectRef.kt
+++ b/.teamcity/src/main/kotlin/configurations/CheckRemoteProjectRef.kt
@@ -1,0 +1,49 @@
+package configurations
+
+import common.BuildToolBuildJvm
+import common.Os
+import common.applyDefaultSettings
+import common.javaHome
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
+import model.CIBuildModel
+import model.Stage
+
+val remoteProjectRefs =
+    listOf(
+        "androidSmokeTestProjectRef",
+        "buildBuilderProjectRef",
+        "nowInAndroidBuildProjectRef",
+        "largeAndroidBuildProjectRef",
+        "largeAndroidBuild2ProjectRef",
+        "excludeRuleMergingBuildProjectRef",
+        "springBootAppProjectRef",
+        "largeNativeBuildProjectRef",
+    )
+
+class CheckRemoteProjectRef(
+    model: CIBuildModel,
+    stage: Stage,
+) : OsAwareBaseGradleBuildType(
+        os = Os.LINUX,
+        stage = stage,
+        init = {
+            id("${model.projectId}_CheckRemoteProjectRef")
+            name = "CheckRemoteProjectRef"
+            description = "Check remote project refs in gradle.properties"
+
+            applyDefaultSettings(artifactRuleOverride = "")
+
+            val os = os
+
+            steps {
+                script {
+                    name = "CheckRemoteProjectRef"
+                    scriptContent =
+                        "${javaHome(
+                            BuildToolBuildJvm,
+                            os,
+                        )}/bin/java .teamcity/scripts/CheckRemoteProjectRef.java ${remoteProjectRefs.joinToString(" ")}"
+                }
+            }
+        },
+    )

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -14,6 +14,7 @@ import common.toCapitalized
 import configurations.BuildDistributions
 import configurations.BuildLogicTest
 import configurations.CheckLinks
+import configurations.CheckRemoteProjectRef
 import configurations.CheckTeamCityKotlinDSL
 import configurations.CompileAll
 import configurations.DocsTestType
@@ -142,6 +143,7 @@ data class CIBuildModel(
                         SpecificBuild.Gradleception,
                         SpecificBuild.CheckLinks,
                         SpecificBuild.CheckTeamCityKotlinDSL,
+                        SpecificBuild.CheckRemoteProjectRef,
                         SpecificBuild.SmokeTestsMaxJavaVersion,
                         SpecificBuild.ConfigCacheAndroidProjectSmokeTests,
                         SpecificBuild.GradleBuildSmokeTests,
@@ -653,6 +655,13 @@ enum class SpecificBuild {
             stage: Stage,
             flakyTestStrategy: FlakyTestStrategy,
         ): OsAwareBaseGradleBuildType = CheckTeamCityKotlinDSL(model, stage)
+    },
+    CheckRemoteProjectRef {
+        override fun create(
+            model: CIBuildModel,
+            stage: Stage,
+            flakyTestStrategy: FlakyTestStrategy,
+        ): OsAwareBaseGradleBuildType = CheckRemoteProjectRef(model, stage)
     },
     TestPerformanceTest {
         override fun create(

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -357,9 +357,7 @@ performanceTest.registerTestProject("bigCppMulti", CppMultiProjectGeneratorTask)
 
 // Build-builder projects
 tasks.register("buildBuilder", RemoteProject) {
-    remoteUri = 'https://github.com/gradle/build-builder.git'
-    // From master branch
-    ref = '76349287aac653e500a4c2581707cae98fe85e79'
+    setRemoteUriAndRefFromGradleProperty("buildBuilderProjectRef")
 }
 
 tasks.register("installBuildBuilder", GradleBuild) {
@@ -410,21 +408,15 @@ performanceTest.registerTestProject("bigSwiftApp", BuildBuilderGenerator) {
 
 // === Android ===
 performanceTest.registerAndroidTestProject("largeAndroidBuild", RemoteProject) {
-    remoteUri = 'https://github.com/gradle/perf-android-large.git'
-    // From android-84 branch
-    ref = "99e95eb1aa1d9c190ed1162f2b7915e765650f49"
+    setRemoteUriAndRefFromGradleProperty("largeAndroidBuildProjectRef")
 }
 
 performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) {
-    remoteUri = 'https://github.com/gradle/perf-android-large-2.git'
-    // Pinned from android-73-kotlin-16 branch
-    ref = "16d64faa6055a281874329ff95fbcdd6861b7248"
+    setRemoteUriAndRefFromGradleProperty("largeAndroidBuild2ProjectRef")
 }
 
 performanceTest.registerAndroidTestProject("nowInAndroidBuild", RemoteProject) {
-    remoteUri = 'https://github.com/android/nowinandroid.git'
-    // Pinned from main branch
-    ref = "25d80b459815e34d5da4c7618fec7280fd48d9f9" // latest of March 28th, 2025
+    setRemoteUriAndRefFromGradleProperty("nowInAndroidBuildProjectRef")
     doLast {
         setMaxWorkers(outputDirectory, 8)
     }
@@ -465,23 +457,17 @@ private void setParallel(File projectDirectory, boolean parallel) {
 }
 
 performanceTest.registerTestProject("excludeRuleMergingBuild", RemoteProject) {
-    remoteUri = 'https://github.com/gradle/performance-comparisons.git'
-    // From master branch
-    ref = "b0eb05ab058e55e3aad5935d499c9079284c2592"
+    setRemoteUriAndRefFromGradleProperty("excludeRuleMergingBuildProjectRef")
     subdirectory = 'exclude-merging'
 }
 
 performanceTest.registerTestProject("springBootApp", RemoteProject) {
-    remoteUri = 'https://github.com/gradle/performance-comparisons.git'
-    // From master branch
-    ref = "4f5fcfbd5a9f03aae0386e12f0ceddfae8100d5a"
+    setRemoteUriAndRefFromGradleProperty("springBootAppProjectRef")
     subdirectory = 'parallel-downloads'
 }
 
 performanceTest.registerTestProject("largeNativeBuild", RemoteProject) {
-    remoteUri = 'https://github.com/gradle/perf-native-large'
-    // From master branch
-    ref = "08a06b5f4943a5a892a178baddc27e1884e7c03c"
+    setRemoteUriAndRefFromGradleProperty("largeNativeBuildProjectRef")
     finalizedBy 'largeNativeBuildPrebuilt'
 }
 

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/RemoteProject.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/RemoteProject.groovy
@@ -70,6 +70,27 @@ abstract class RemoteProject extends DefaultTask {
     abstract Property<String> getSubdirectory()
 
     /**
+     * Convenience method to set both remoteUri and ref from a gradle property.
+     *
+     * The property value should be in the format: <repository-url>#<commit-sha>
+     * Example: "https://github.com/user/repo.git#abc123def456"
+     *
+     * @param propertyName The name of the gradle property containing both URI and ref separated by '#'
+     */
+    void setRemoteUriAndRefFromGradleProperty(String propertyName) {
+        def provider = project.providers.gradleProperty(propertyName)
+        def parsed = provider.map { String value ->
+            String[] parts = value.split("#", 2)
+            if (parts.length != 2) {
+                throw new IllegalArgumentException("$propertyName must be in format: <repository-url>#<commit-sha>, got: $value")
+            }
+            return parts
+        }
+        remoteUri.set(parsed.map { parts -> parts[0] })
+        ref.set(parsed.map { parts -> parts[1] })
+    }
+
+    /**
      * Directory where the project template should be copied.
      */
     @OutputDirectory

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,3 +36,17 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 # workaround until the Shadow plugin fixes IP violation in the develocity integration area
 # https://github.com/GradleUp/shadow/issues/1835
 com.gradleup.shadow.enableDevelocityIntegration=false
+
+# Android smoke test project repository and commit
+androidSmokeTestProjectRef=https://github.com/gradle/nowinandroid.git#e117bd4ee30c7eb1ab3bbdc47f73a3fd0317b64b
+
+# Build-builder project repository and commit
+buildBuilderProjectRef=https://github.com/gradle/build-builder.git#76349287aac653e500a4c2581707cae98fe85e79
+
+# Performance test project repositories and commits
+nowInAndroidBuildProjectRef=https://github.com/gradle/nowinandroid.git#25d80b459815e34d5da4c7618fec7280fd48d9f9
+largeAndroidBuildProjectRef=https://github.com/gradle/perf-android-large.git#99e95eb1aa1d9c190ed1162f2b7915e765650f49
+largeAndroidBuild2ProjectRef=https://github.com/gradle/perf-android-large-2.git#16d64faa6055a281874329ff95fbcdd6861b7248
+excludeRuleMergingBuildProjectRef=https://github.com/gradle/performance-comparisons.git#b0eb05ab058e55e3aad5935d499c9079284c2592
+springBootAppProjectRef=https://github.com/gradle/performance-comparisons.git#4f5fcfbd5a9f03aae0386e12f0ceddfae8100d5a
+largeNativeBuildProjectRef=https://github.com/gradle/perf-native-large.git#08a06b5f4943a5a892a178baddc27e1884e7c03c

--- a/testing/smoke-test/build.gradle.kts
+++ b/testing/smoke-test/build.gradle.kts
@@ -77,18 +77,14 @@ androidHomeWarmup {
 tasks {
 
     /**
-     * Anroid project git URI.
-     * Currently points to a clone of Now in Android.
+     * Android project git URI and commit.
+     * Configured via gradle property: androidSmokeTestProjectRef=https://github.com/gradle/nowinandroid.git#<commitId>
      *
-     * Note that you can change it to `file:///path/to/your/nowinandroid-clone/.git`
+     * Note that you can change it to `file:///path/to/your/nowinandroid-clone/.git#<commitId>`
      * if you need to iterate quickly on changes to it.
      */
-    val androidProjectGitUri = "https://github.com/gradle/nowinandroid.git"
-
     val androidProject by registering(RemoteProject::class) {
-        remoteUri = androidProjectGitUri
-        // latest https://github.com/gradle/nowinandroid/tree/smoke-tests-main as of 2025-12-17
-        ref = "e117bd4ee30c7eb1ab3bbdc47f73a3fd0317b64b"
+        setRemoteUriAndRefFromGradleProperty("androidSmokeTestProjectRef")
     }
 
     val gradleBuildCurrent by registering(RemoteProject::class) {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4980

1. Extract the remote project url/ref to `gradle.properties`. 
2. Add a GitHub action to check the commit exists as a tag with `git ls-remote --tags $repoUrl`.

The next plan is to make `check_merge` a required check for merge PRs.
