### PR TITLE
Deprecate 'apply false' in precompiled script plugins

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -52,6 +52,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import spock.lang.Issue
 import java.io.File
 
 
@@ -271,6 +272,77 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
         //            """
         //        )
         //    )
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/14437")
+    @Test
+    fun `raises a deprecation warning with help message for plugin spec with apply false`() {
+
+        withDefaultSettings().appendText(
+            """
+            rootProject.name = "invalid-plugin"
+            """
+        )
+
+        withKotlinDslPlugin()
+
+        withPrecompiledKotlinScript(
+            "a.plugin.gradle.kts",
+            ""
+        )
+
+        withPrecompiledKotlinScript(
+            "invalid-plugin.gradle.kts",
+            """
+            plugins {
+                id("a.plugin") apply false
+            }
+            """
+        )
+
+        executer.expectDocumentedDeprecationWarning(
+            "'apply false' in precompiled script plugins has been deprecated. This will fail with an error in Gradle 10. " +
+                "'apply false' does not do anything as the plugin will already be added to the classpath when added as a dependency to the precompiled script plugin's build file. " +
+                "Remove 'apply false' from the plugin request for 'a.plugin' in 'src/main/kotlin/invalid-plugin.gradle.kts'. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate_apply_false_in_precompiled_script_plugins"
+        )
+        build("assemble")
+    }
+
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/17246")
+    @Test
+    fun `raises a deprecation warning with help message for plugin spec with apply false in settings plugin`() {
+
+        withDefaultSettings().appendText(
+            """
+            rootProject.name = "invalid-plugin"
+            """
+        )
+
+        withKotlinDslPlugin()
+
+        withPrecompiledKotlinScript(
+            "a.plugin.settings.gradle.kts",
+            ""
+        )
+
+        withPrecompiledKotlinScript(
+            "invalid-plugin.settings.gradle.kts",
+            """
+            plugins {
+                id("a.plugin") apply false
+            }
+            """
+        )
+
+        // TODO Should raise a deprecation warning:
+        //        executer.expectDocumentedDeprecationWarning(
+        //        "'apply false' in precompiled script plugins has been deprecated. This will fail with an error in Gradle 10. " +
+        //            "'apply false' does not do anything as the plugin will already be added to the classpath when added as a dependency to the precompiled script plugin's build file. " +
+        //            "Remove 'apply false' from the plugin request for 'a.plugin' in 'src/main/kotlin/invalid-plugin.settings.gradle.kts'. " +
+        //            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate_apply_false_in_precompiled_script_plugins"
+        //        )
+        build("assemble")
     }
 
     @Test

--- a/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_precompiled.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/implementing_gradle_plugins_precompiled.adoc
@@ -245,6 +245,9 @@ include::sample[dir="snippets/plugins/precompiledScriptPlugins-externalPlugins/g
 
 The plugin version in this case is defined in the dependency declaration.
 
+The `version "..."` and `apply false` syntax are not supported in precompiled script plugins. The version for the plugin is determined by the version declared in the plugin's build file.
+If a plugin needs to be on the classpath but not applied, it can be left out of the `plugins {}` block and only added as a dependency in the plugin's build file.
+
 [[project_pre_compiled_plugins]]
 == Example of a precompiled script plugin in the `Project` scope
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -106,6 +106,24 @@ Zinc has been updated to https://github.com/sbt/zinc/releases/tag/v1.12.0[1.12.0
 This API will be removed in Gradle 10 with no direct replacement.
 `DomainObjectCollection.matching(Spec)` is a similar API for selecting elements without evaluating the contents of the container immediately.
 
+[[deprecate_apply_false_in_precompiled_script_plugins]]
+==== Deprecation of `apply false` in precompiled script plugins
+The use of `apply false` in <<implementing_gradle_plugins_precompiled.adoc#implementing_precompiled_plugins, precompiled script plugins>> has been deprecated and will become an error in Gradle 10.0.0.
+
+Using `apply false` does not have any effect in precompiled script plugins (the plugin is still applied), and it can lead to confusion for users who expect it to prevent the plugin from being applied.
+Plugins used in precompiled script plugins are already available on the classpath, so using `apply false` would do nothing.
+
+To fix this deprecation, remove the plugin declaration from the precompiled script plugin:
+.my-plugin.gradle.kts
+[source,kotlin]
+----
+plugins {
+    // Delete the following line to remove the deprecation warning:
+    id("org.gradle.test-retry") apply false
+    // The plugin will still be on the classpath, but it will not be applied as part of this precompiled script plugin.
+}
+----
+
 [[changes_9.3.0]]
 == Upgrading from 9.2.0 and earlier
 


### PR DESCRIPTION
This does not actually do anything as mentioned in the issue

Deprecation for #14437

Similar to the version warning, this doesn't work for settings plugins, so I left a similar test in linking to the same issue.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
