### PR TITLE
Validate settings precompiled script plugins' plugins

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -240,7 +240,7 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
         )
     }
 
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/17246")
+    @Issue("https://github.com/gradle/gradle/issues/17246")
     @Test
     fun `fails the build with help message for plugin spec with version in settings plugin`() {
 
@@ -261,17 +261,13 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
             """
         )
 
+        executer.expectDocumentedDeprecationWarning(
+            "Using 'version' in precompiled settings script plugins has been deprecated. This will fail with an error in Gradle 10. " +
+                "The version of the plugin is determined by the dependency in the precompiled script plugin's build file. " +
+                "Remove 'version' from the plugin request for 'a.plugin' in 'src/main/kotlin/invalid-plugin.settings.gradle.kts'. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate_version_in_precompiled_settings_script_plugins"
+        )
         build("assemble")
-
-        // TODO Should fail:
-        //    assertThat(
-        //        buildFailureOutput("assemble"),
-        //        containsMultiLineString(
-        //            """
-        //            Invalid plugin request [id: 'a.plugin', version: '1.0']. Plugin requests from precompiled scripts must not include a version number. Please remove the version from the offending request. Make sure the module containing the requested plugin 'a.plugin' is an implementation dependency of root project 'invalid-plugin'.
-        //            """
-        //        )
-        //    )
     }
 
     @Issue("https://github.com/gradle/gradle/issues/14437")
@@ -309,7 +305,7 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
         build("assemble")
     }
 
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/17246")
+    @Issue("https://github.com/gradle/gradle/issues/17246")
     @Test
     fun `raises a deprecation warning with help message for plugin spec with apply false in settings plugin`() {
 
@@ -335,13 +331,12 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
             """
         )
 
-        // TODO Should raise a deprecation warning:
-        //        executer.expectDocumentedDeprecationWarning(
-        //        "'apply false' in precompiled script plugins has been deprecated. This will fail with an error in Gradle 10. " +
-        //            "'apply false' does not do anything as the plugin will already be added to the classpath when added as a dependency to the precompiled script plugin's build file. " +
-        //            "Remove 'apply false' from the plugin request for 'a.plugin' in 'src/main/kotlin/invalid-plugin.settings.gradle.kts'. " +
-        //            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate_apply_false_in_precompiled_script_plugins"
-        //        )
+        executer.expectDocumentedDeprecationWarning(
+            "'apply false' in precompiled script plugins has been deprecated. This will fail with an error in Gradle 10. " +
+                "'apply false' does not do anything as the plugin will already be added to the classpath when added as a dependency to the precompiled script plugin's build file. " +
+                "Remove 'apply false' from the plugin request for 'a.plugin' in 'src/main/kotlin/invalid-plugin.settings.gradle.kts'. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecate_apply_false_in_precompiled_script_plugins"
+        )
         build("assemble")
     }
 

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ExtractPrecompiledScriptPluginPlugins.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ExtractPrecompiledScriptPluginPlugins.kt
@@ -36,7 +36,6 @@ import org.gradle.kotlin.dsl.execution.ProgramSource
 import org.gradle.kotlin.dsl.execution.ProgramTarget
 import org.gradle.kotlin.dsl.provider.plugins.precompiled.PrecompiledScriptPlugin
 import org.gradle.kotlin.dsl.provider.plugins.precompiled.scriptPluginFilesOf
-import org.gradle.kotlin.dsl.support.KotlinScriptType
 import java.io.File
 
 
@@ -83,10 +82,7 @@ fun extractPrecompiledScriptPluginPluginsTo(outputDir: File, scriptPlugins: List
 
 private
 fun pluginsBlockOf(scriptPlugin: PrecompiledScriptPlugin): Program.Plugins? =
-    when (scriptPlugin.scriptType) {
-        KotlinScriptType.PROJECT -> pluginsBlockOf(parse(scriptPlugin))
-        else -> null
-    }
+    pluginsBlockOf(parse(scriptPlugin))
 
 
 private

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -124,6 +124,25 @@ plugins {
 }
 ----
 
+[[deprecate_version_in_precompiled_settings_script_plugins]]
+==== Deprecation of `version` in precompiled settings script plugins
+The use of `version` in <<implementing_gradle_plugins_precompiled.adoc#implementing_precompiled_plugins, precompiled script plugins>> has been deprecated and will become an error in Gradle 10.0.0.
+
+Using `version` does not have any effect in precompiled script plugins and can lead to confusion for users who expect it to change the version of the plugin being applied.
+Plugins used in precompiled script plugins are already available on the classpath and have their versions determined by the precompiled script plugin's build file.
+
+To fix this deprecation, remove the `version` call for the plugin declaration in the precompiled script plugin:
+.my-plugin.gradle.kts
+[source,kotlin]
+----
+plugins {
+    // Before:
+    id("org.gradle.test-retry") version "x.y.z"
+    // After:
+    id("org.gradle.test-retry")
+}
+----
+
 [[changes_9.3.0]]
 == Upgrading from 9.2.0 and earlier
 


### PR DESCRIPTION
Only as a deprecation for now, will become an error in Gradle 10.

Deprecation for #17246.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
