### PR TITLE
Remove reasons from SelectorState

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -285,7 +285,10 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
             root(":", ":depsub:") {
                 edge("org.utils:impl:1.3", "org.utils:impl:1.5") {
                     forced()
-                    edge("org.utils:api:1.5", "org.utils:api:1.6").selectedByRule()
+                    edge("org.utils:api:1.5", "org.utils:api:1.6") {
+                        forced()
+                        selectedByRule()
+                    }
                 }
             }
         }
@@ -1571,6 +1574,7 @@ Required by:
             root(":", ":depsub:") {
                 edge('org:lib:1.0', 'org:lib:1.1') {
                     artifact(classifier: 'classy')
+                    forced()
                     selectedByRule()
                 }
                 module('org:other:1.0') {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
@@ -122,7 +122,7 @@ baz:1.0 requested
                         if (it.id instanceof ModuleComponentIdentifier && it.id.module == 'leaf') {
                             def selectionReason = it.selectionReason
                             assert selectionReason.conflictResolution
-                            def descriptions = selectionReason.descriptions.reverse()
+                            def descriptions = selectionReason.descriptions
                             assert descriptions.size() > 1
                             descriptions.each {
                                 println "\$it.cause : \$it.description"
@@ -194,7 +194,7 @@ baz:1.0 requested
                         if (it.id instanceof ModuleComponentIdentifier && it.id.module == 'leaf') {
                             def selectionReason = it.selectionReason
                             assert selectionReason.conflictResolution
-                            def descriptions = selectionReason.descriptions.reverse()
+                            def descriptions = selectionReason.descriptions
                             assert descriptions.size() > 1
                             descriptions.each {
                                 println "\$it.cause : \$it.description"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
@@ -113,7 +113,6 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
             resolve.expectGraph {
                 root(":", ":test:") {
                     edge("org.hamcrest:hamcrest-core:2.2", "org.hamcrest:hamcrest:2.2") {
-                        notRequested()
                         byConflictResolution('Explicit selection of org.hamcrest:hamcrest:2.2 variant runtime')
                     }
                 }
@@ -165,7 +164,6 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
             resolve.expectGraph {
                 root(":", ":test:") {
                     edge("org:parent:2.2", "org:child:2.2") {
-                        notRequested()
                         byConflictResolution('Explicit selection of org:child:2.2 variant runtime')
                     }
                 }
@@ -227,7 +225,6 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
             resolve.expectGraph {
                 root(":", ":test:") {
                     edge("org:A:1.0", "org:B:1.0") {
-                        notRequested()
                         byConflictResolution("Explicit selection of org:B:1.0 variant runtime")
                     }
                     module("org:x:1.0") {
@@ -902,7 +899,8 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
         fails(':checkDeps')
 
         then:
-        failure.assertHasCause("Component is the target of multiple version constraints with conflicting requirements")
+        failure.assertHasCause("Module 'org.slf4j:slf4j-simple' has been rejected")
+        failure.assertHasCause("Module 'org.apache.logging.log4j:log4j-slf4j2-impl' has been rejected")
     }
 
     @UnsupportedWithConfigurationCache(because = "Uses allDependencies")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
@@ -138,7 +138,6 @@ class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResol
                     byConflictResolution("between versions 2.0 and 1.0")
                     constraint('org:bar:1.0')
                     constraint('org:foo:1.0', 'org:foo:2.0') {
-                        notRequested()
                         byConstraint()
                         byConflictResolution("between versions 2.0 and 1.0")
                     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
@@ -31,7 +31,9 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Attribu
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.CapabilitySerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentIdentifierSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorFactory;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectorSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolvedComponentResultSerializer;
@@ -105,9 +107,9 @@ public class DependencyManagementValueSnapshotterSerializerRegistry extends Defa
         register(DefaultModuleComponentIdentifier.class, Cast.uncheckedCast(componentIdentifierSerializer));
         register(AttributeContainer.class, attributeContainerSerializer);
         registerWithFactory(ResolvedVariantResult.class, () -> new ResolvedVariantResultSerializer(componentIdentifierSerializer, attributeContainerSerializer));
-        register(ComponentSelectionDescriptor.class, new ComponentSelectionDescriptorSerializer(componentSelectionDescriptorFactory));
+        register(ComponentSelectionDescriptorInternal.class, new ComponentSelectionDescriptorSerializer(componentSelectionDescriptorFactory));
         ComponentSelectionReasonSerializer componentSelectionReasonSerializer = new ComponentSelectionReasonSerializer(componentSelectionDescriptorFactory);
-        register(ComponentSelectionReason.class, componentSelectionReasonSerializer);
+        register(ComponentSelectionReasonInternal.class, componentSelectionReasonSerializer);
         register(ComponentSelector.class, componentSelectorSerializer);
         registerWithFactory(ResolvedComponentResult.class, () -> {
             ResolvedVariantResultSerializer resolvedVariantResultSerializer = new ResolvedVariantResultSerializer(componentIdentifierSerializer, attributeContainerSerializer);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
@@ -17,8 +17,12 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.DependencyMetadata;
+
+import java.util.function.Consumer;
 
 /**
  * A {@link ResolvedGraphDependency} that is used during the resolution of the dependency graph.
@@ -27,9 +31,9 @@ import org.gradle.internal.component.model.DependencyMetadata;
 public interface DependencyGraphEdge extends ResolvedGraphDependency {
     DependencyGraphNode getFrom();
 
-    DependencyGraphSelector getSelector();
-
     boolean isTransitive();
+
+    boolean isFromLock();
 
     ExcludeSpec getExclusions();
 
@@ -44,5 +48,21 @@ public interface DependencyGraphEdge extends ResolvedGraphDependency {
     ImmutableAttributes getAttributes();
 
     boolean isTargetVirtualPlatform();
+
+    /**
+     * The reason this edge contributes to component selection.
+     * Overridden to enforce non-nullability. All edges have reasons, however
+     * the supertype only enforces those reasons to be present in failure cases,
+     * in order to avoid the overhead of serializing reasons for successful edges.
+     * <p>
+     * Prefer {@link #visitSelectionReasons(Consumer)}, which avoids allocations.
+     */
+    @Override
+    ComponentSelectionReasonInternal getReason();
+
+    /**
+     * Visits all reasons this edge contributes to component selection.
+     */
+    void visitSelectionReasons(Consumer<ComponentSelectionDescriptorInternal> visitor);
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphComponent.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphComponent.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.jspecify.annotations.Nullable;
 
@@ -53,7 +53,7 @@ public interface ResolvedGraphComponent {
     /**
      * The reason this component was selected in the graph.
      */
-    ComponentSelectionReason getSelectionReason();
+    ComponentSelectionReasonInternal getSelectionReason();
 
     /**
      * Returns the resolved/selected variant(s) for this component.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.jspecify.annotations.Nullable;
 
@@ -45,7 +45,7 @@ public interface ResolvedGraphDependency {
      * Not null only when failure is not null.
      */
     @Nullable
-    ComponentSelectionReason getReason();
+    ComponentSelectionReasonInternal getReason();
 
     boolean isConstraint();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphVariant.java
@@ -16,12 +16,13 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
+import org.gradle.api.Describable;
 import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.jspecify.annotations.Nullable;
 
-public interface ResolvedGraphVariant {
+public interface ResolvedGraphVariant extends Describable {
     /**
      * Returns a simple id for this node, unique across all nodes in the same graph.
      * This id cannot be used across graphs.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -241,6 +241,7 @@ public class NodeState implements DependencyGraphNode {
         return getDisplayName();
     }
 
+    @Override
     public String getDisplayName() {
         return String.format("'%s' (%s)", component.getComponentId().getDisplayName(), metadata.getDisplayName());
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingComponentSelectionDescriptorFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingComponentSelectionDescriptorFactory.java
@@ -18,23 +18,22 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.gradle.api.artifacts.result.ComponentSelectionCause;
-import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.internal.Describables;
 
 import java.util.concurrent.ExecutionException;
 
 public class CachingComponentSelectionDescriptorFactory implements ComponentSelectionDescriptorFactory {
-    private final Cache<Key, ComponentSelectionDescriptor> descriptors = CacheBuilder.newBuilder()
+    private final Cache<Key, ComponentSelectionDescriptorInternal> descriptors = CacheBuilder.newBuilder()
         .maximumSize(10000)
         .build();
 
     @Override
-    public ComponentSelectionDescriptor newDescriptor(ComponentSelectionCause cause, String reason) {
+    public ComponentSelectionDescriptorInternal newDescriptor(ComponentSelectionCause cause, String reason) {
         return getOrCreate(cause, reason);
     }
 
     @Override
-    public ComponentSelectionDescriptor newDescriptor(ComponentSelectionCause cause) {
+    public ComponentSelectionDescriptorInternal newDescriptor(ComponentSelectionCause cause) {
         try {
             return descriptors.get(new Key(cause, cause.getDefaultReason()), () -> new DefaultComponentSelectionDescriptor(cause));
         } catch (ExecutionException e) {
@@ -42,7 +41,7 @@ public class CachingComponentSelectionDescriptorFactory implements ComponentSele
         }
     }
 
-    private ComponentSelectionDescriptor getOrCreate(ComponentSelectionCause cause, String description) {
+    private ComponentSelectionDescriptorInternal getOrCreate(ComponentSelectionCause cause, String description) {
         try {
             return descriptors.get(new Key(cause, description), () -> newDescriptorInstance(cause, description));
         } catch (ExecutionException e) {
@@ -50,7 +49,7 @@ public class CachingComponentSelectionDescriptorFactory implements ComponentSele
         }
     }
 
-    private ComponentSelectionDescriptor newDescriptorInstance(ComponentSelectionCause cause, String description) {
+    private static ComponentSelectionDescriptorInternal newDescriptorInstance(ComponentSelectionCause cause, String description) {
         return new DefaultComponentSelectionDescriptor(cause, Describables.of(description));
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CompleteComponentResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CompleteComponentResultSerializer.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
@@ -106,7 +105,7 @@ public class CompleteComponentResultSerializer implements ComponentResultSeriali
     @Override
     public void readComponentResult(Decoder decoder, ResolvedComponentVisitor visitor) throws Exception {
         long resultId = decoder.readSmallLong();
-        ComponentSelectionReason reason = reasonSerializer.read(decoder);
+        ComponentSelectionReasonInternal reason = reasonSerializer.read(decoder);
         String repo = decoder.readNullableString();
         ComponentIdentifier componentIdentifier = componentIdSerializer.read(decoder);
         ModuleVersionIdentifier moduleVersionIdentifier = moduleVersionIdSerializer.read(decoder);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionDescriptorFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionDescriptorFactory.java
@@ -16,14 +16,13 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import org.gradle.api.artifacts.result.ComponentSelectionCause;
-import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 @ServiceScope(Scope.BuildSession.class)
 public interface ComponentSelectionDescriptorFactory {
 
-    ComponentSelectionDescriptor newDescriptor(ComponentSelectionCause cause, String reason);
+    ComponentSelectionDescriptorInternal newDescriptor(ComponentSelectionCause cause, String reason);
 
-    ComponentSelectionDescriptor newDescriptor(ComponentSelectionCause cause);
+    ComponentSelectionDescriptorInternal newDescriptor(ComponentSelectionCause cause);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionDescriptorSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionDescriptorSerializer.java
@@ -28,7 +28,7 @@ import java.io.IOException;
  * A thread-safe and reusable serializer for {@link ComponentSelectionDescriptor} if and only if the passed in
  * {@link ComponentSelectionDescriptorFactory} is thread-safe and reusable.
  */
-public class ComponentSelectionDescriptorSerializer implements Serializer<ComponentSelectionDescriptor> {
+public class ComponentSelectionDescriptorSerializer implements Serializer<ComponentSelectionDescriptorInternal> {
 
     private final ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory;
 
@@ -37,7 +37,7 @@ public class ComponentSelectionDescriptorSerializer implements Serializer<Compon
     }
 
     @Override
-    public ComponentSelectionDescriptor read(Decoder decoder) throws IOException {
+    public ComponentSelectionDescriptorInternal read(Decoder decoder) throws IOException {
         ComponentSelectionCause cause = ComponentSelectionCause.values()[decoder.readByte()];
         String desc = decoder.readString();
         String defaultReason = cause.getDefaultReason();
@@ -48,7 +48,7 @@ public class ComponentSelectionDescriptorSerializer implements Serializer<Compon
     }
 
     @Override
-    public void write(Encoder encoder, ComponentSelectionDescriptor value) throws IOException {
+    public void write(Encoder encoder, ComponentSelectionDescriptorInternal value) throws IOException {
         encoder.writeByte((byte) value.getCause().ordinal());
         encoder.writeString(value.getDescription());
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonInternal.java
@@ -15,17 +15,12 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
-import org.gradle.api.Describable;
-import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 
 import java.util.List;
 
 public interface ComponentSelectionReasonInternal extends ComponentSelectionReason {
-    ComponentSelectionReasonInternal setCause(ComponentSelectionDescriptor description);
-    ComponentSelectionReasonInternal addCause(ComponentSelectionDescriptor description);
-    ComponentSelectionReasonInternal addCause(ComponentSelectionCause cause, Describable description);
 
     /**
      * Returns true if any of the {@link #getDescriptions() descriptions} contains a custom description instead of the
@@ -44,4 +39,5 @@ public interface ComponentSelectionReasonInternal extends ComponentSelectionReas
      */
     @Override
     List<ComponentSelectionDescriptorInternal> getDescriptions();
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializer.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -55,7 +54,7 @@ public class DependencyResultSerializer {
             long selectedId = decoder.readSmallLong();
             return new DetachedResolvedGraphDependency(requested, selectedId, null, null, constraint, null);
         } else if (resultByte == FAILED) {
-            ComponentSelectionReason reason = componentSelectionReasonSerializer.read(decoder);
+            ComponentSelectionReasonInternal reason = componentSelectionReasonSerializer.read(decoder);
             ModuleVersionResolveException failure = failures.get(requested);
             return new DetachedResolvedGraphDependency(requested, null, reason, failure, constraint, null);
         } else {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedResolvedGraphDependency.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedResolvedGraphDependency.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
@@ -29,14 +28,14 @@ public class DetachedResolvedGraphDependency implements ResolvedGraphDependency 
 
     private final ComponentSelector requested;
     private final Long selected;
-    private final ComponentSelectionReason reason;
+    private final ComponentSelectionReasonInternal reason;
     private final ModuleVersionResolveException failure;
     private final boolean constraint;
     private final Long targetVariant;
 
     public DetachedResolvedGraphDependency(ComponentSelector requested,
                                            Long selected,
-                                           ComponentSelectionReason reason,
+                                           ComponentSelectionReasonInternal reason,
                                            ModuleVersionResolveException failure,
                                            boolean constraint,
                                            Long targetVariant
@@ -63,7 +62,7 @@ public class DetachedResolvedGraphDependency implements ResolvedGraphDependency 
     }
 
     @Override
-    public ComponentSelectionReason getReason() {
+    public ComponentSelectionReasonInternal getReason() {
         return reason;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultGraphBuilder.java
@@ -27,7 +27,6 @@ import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionCause;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
@@ -55,7 +54,7 @@ public class ResolutionResultGraphBuilder implements ResolvedComponentVisitor {
     private final Long2ObjectMap<DefaultResolvedComponentResult> components = new Long2ObjectOpenHashMap<>();
     private final CachingDependencyResultFactory dependencyResultFactory = new CachingDependencyResultFactory();
     private long id;
-    private ComponentSelectionReason selectionReason;
+    private ComponentSelectionReasonInternal selectionReason;
     private ComponentIdentifier componentId;
     private ModuleVersionIdentifier moduleVersion;
     private String repoName;
@@ -100,7 +99,7 @@ public class ResolutionResultGraphBuilder implements ResolvedComponentVisitor {
     }
 
     @Override
-    public void startVisitComponent(Long id, ComponentSelectionReason selectionReason, @Nullable String repoName, ComponentIdentifier componentId, ModuleVersionIdentifier moduleVersion) {
+    public void startVisitComponent(Long id, ComponentSelectionReasonInternal selectionReason, @Nullable String repoName, ComponentIdentifier componentId, ModuleVersionIdentifier moduleVersion) {
         this.id = id;
         this.selectionReason = selectionReason;
         this.selectedVariants.clear();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentResultSerializer.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
@@ -48,14 +47,14 @@ public class ResolvedComponentResultSerializer implements Serializer<ResolvedCom
     private final Serializer<ComponentIdentifier> componentIdSerializer;
     private final Serializer<ComponentSelector> componentSelectorSerializer;
     private final Serializer<ResolvedVariantResult> resolvedVariantResultSerializer;
-    private final Serializer<ComponentSelectionReason> componentSelectionReasonSerializer;
+    private final Serializer<ComponentSelectionReasonInternal> componentSelectionReasonSerializer;
 
     public ResolvedComponentResultSerializer(
         Serializer<ModuleVersionIdentifier> moduleVersionIdSerializer,
         Serializer<ComponentIdentifier> componentIdSerializer,
         Serializer<ComponentSelector> componentSelectorSerializer,
         Serializer<ResolvedVariantResult> resolvedVariantResultSerializer,
-        Serializer<ComponentSelectionReason> componentSelectionReasonSerializer
+        Serializer<ComponentSelectionReasonInternal> componentSelectionReasonSerializer
     ) {
         this.moduleVersionIdSerializer = moduleVersionIdSerializer;
         this.componentIdSerializer = componentIdSerializer;
@@ -89,7 +88,7 @@ public class ResolvedComponentResultSerializer implements Serializer<ResolvedCom
         encoder.writeSmallInt(id);
         moduleVersionIdSerializer.write(encoder, component.getModuleVersion());
         componentIdSerializer.write(encoder, component.getId());
-        componentSelectionReasonSerializer.write(encoder, component.getSelectionReason());
+        componentSelectionReasonSerializer.write(encoder, ((ResolvedComponentResultInternal) component).getSelectionReason());
         List<ResolvedVariantResult> allVariants = ((ResolvedComponentResultInternal) component).getAvailableVariants();
         Set<ResolvedVariantResult> resolvedVariants = new HashSet<>(component.getVariants());
         encoder.writeSmallInt(allVariants.size());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentVisitor.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.jspecify.annotations.Nullable;
 
@@ -29,7 +28,7 @@ public interface ResolvedComponentVisitor {
     /**
      * Starts visiting a component.
      */
-    void startVisitComponent(Long id, ComponentSelectionReason selectionReason, @Nullable String repoName, ComponentIdentifier componentId, ModuleVersionIdentifier moduleVersion);
+    void startVisitComponent(Long id, ComponentSelectionReasonInternal selectionReason, @Nullable String repoName, ComponentIdentifier componentId, ModuleVersionIdentifier moduleVersion);
 
     /**
      * Visit a selected variant of the component.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ThisBuildTreeOnlyComponentResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ThisBuildTreeOnlyComponentResultSerializer.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphVariant;
@@ -104,7 +103,7 @@ public class ThisBuildTreeOnlyComponentResultSerializer implements ComponentResu
     @Override
     public void readComponentResult(Decoder decoder, ResolvedComponentVisitor visitor) throws Exception {
         long resultId = decoder.readSmallLong();
-        ComponentSelectionReason reason = reasonSerializer.read(decoder);
+        ComponentSelectionReasonInternal reason = reasonSerializer.read(decoder);
         String repo = decoder.readNullableString();
         ComponentGraphResolveState component = readComponentReference(decoder);
         visitor.startVisitComponent(resultId, reason, repo, component.getId(), component.getMetadata().getModuleVersionId());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -23,11 +23,11 @@ import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
@@ -42,7 +42,7 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
 
     private final ModuleVersionIdentifier moduleVersion;
     private Set<ResolvedDependencyResult> dependents = new LinkedHashSet<>();
-    private final ComponentSelectionReason selectionReason;
+    private final ComponentSelectionReasonInternal selectionReason;
     private final ComponentIdentifier componentId;
     private final ImmutableList<ResolvedVariantResult> selectedVariants;
     private final Map<Long, ResolvedVariantResult> selectedVariantsById;
@@ -54,7 +54,7 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
 
     public DefaultResolvedComponentResult(
         ModuleVersionIdentifier moduleVersion,
-        ComponentSelectionReason selectionReason,
+        ComponentSelectionReasonInternal selectionReason,
         ComponentIdentifier componentId,
         ImmutableMap<Long, ResolvedVariantResult> selectedVariants,
         ImmutableList<ResolvedVariantResult> allVariants,
@@ -115,7 +115,7 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
     }
 
     @Override
-    public ComponentSelectionReason getSelectionReason() {
+    public ComponentSelectionReasonInternal getSelectionReason() {
         return selectionReason;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedComponentResultInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolvedComponentResultInternal.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.result;
 
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
@@ -57,4 +58,7 @@ public interface ResolvedComponentResultInternal extends ResolvedComponentResult
      */
     @Nullable
     ResolvedVariantResult getVariant(long id);
+
+    @Override
+    ComponentSelectionReasonInternal getSelectionReason();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentIdResolveResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentIdResolveResult.java
@@ -25,6 +25,7 @@ import org.gradle.internal.resolve.RejectedVersion;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * The result of resolving a module version selector to a particular component id.
@@ -74,9 +75,9 @@ public interface ComponentIdResolveResult extends ResolveResult {
     boolean isRejected();
 
     /**
-     * @return the list of unmatched versions, that is to say versions which were listed but didn't match the selector
+     * @return the set of unmatched versions, that is to say versions which were listed but didn't match the selector
      */
-    Collection<String> getUnmatchedVersions();
+    Set<String> getUnmatchedVersions();
 
     /**
      * @return the list of versions which were considered for this module but rejected.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResult.java
@@ -27,6 +27,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 
 public class DefaultBuildableComponentIdResolveResult extends DefaultResourceAwareResolveResult implements BuildableComponentIdResolveResult {
     private ModuleVersionResolveException failure;
@@ -128,7 +129,7 @@ public class DefaultBuildableComponentIdResolveResult extends DefaultResourceAwa
     }
 
     @Override
-    public Collection<String> getUnmatchedVersions() {
+    public Set<String> getUnmatchedVersions() {
         return safeBuild(unmatchedVersions);
     }
 
@@ -146,9 +147,9 @@ public class DefaultBuildableComponentIdResolveResult extends DefaultResourceAwa
         return true;
     }
 
-    private static <T> Collection<T> safeBuild(ImmutableSet.Builder<T> builder) {
+    private static <T> Set<T> safeBuild(ImmutableSet.Builder<T> builder) {
         if (builder == null) {
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
         return builder.build();
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializerTest.groovy
@@ -16,8 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
-import org.gradle.api.artifacts.result.ComponentSelectionDescriptor
-import org.gradle.api.artifacts.result.ComponentSelectionReason
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.internal.Describables
 import org.gradle.internal.serialize.AbstractDecoder
@@ -81,21 +80,23 @@ class ComponentSelectionReasonSerializerTest extends SerializerSpec {
         withoutDuplicate.length > withDuplicate.length
     }
 
-    void check(ComponentSelectionDescriptor... reasons) {
-        def reason = ComponentSelectionReasons.of(reasons)
+    void check(ComponentSelectionDescriptorInternal... reasons) {
+        def reason = ComponentSelectionReasons.of(ImmutableSet.copyOf(reasons))
         def result = serialize(reason, serializer)
         assert result == reason
     }
 
-    private static ComponentSelectionReason withReason(String reason) {
+    private static ComponentSelectionReasonInternal withReason(String reason) {
         ComponentSelectionReasons.of(ComponentSelectionReasons.SELECTED_BY_RULE.withDescription(Describables.of(reason)))
     }
 
-    private static ComponentSelectionReason withReasons(String... reasons) {
+    private static ComponentSelectionReasonInternal withReasons(String... reasons) {
         int idx = -1
-        ComponentSelectionReasons.of(reasons.collect {
-            reason(++idx).withDescription(Describables.of(it))
-        }.toArray(new ComponentSelectionDescriptorInternal[0]))
+        ComponentSelectionReasons.of(
+            Arrays.asList(reasons).stream()
+                .map(it -> reason(++idx).withDescription(Describables.of(it)))
+                .collect(ImmutableSet.toImmutableSet())
+        )
     }
 
     private static ComponentSelectionDescriptorInternal reason(int idx) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultComponentSelectionReasonTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultComponentSelectionReasonTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.result.ComponentSelectionCause
-import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.internal.Describables
 import spock.lang.Specification
 
@@ -40,11 +40,13 @@ class DefaultComponentSelectionReasonTest extends Specification {
     }
 
     def "requested with other selection reason is not expected"() {
-        given:
-        def reason = ComponentSelectionReasons.requested()
-
         when:
-        addCause(reason, ComponentSelectionCause.CONFLICT_RESOLUTION, "test")
+        def reason = ComponentSelectionReasons.of(
+            ImmutableSet.<ComponentSelectionDescriptorInternal>builder()
+                .addAll(ComponentSelectionReasons.requested().getDescriptions())
+                .add(new DefaultComponentSelectionDescriptor(ComponentSelectionCause.CONFLICT_RESOLUTION, Describables.of("test")))
+                .build()
+        )
 
         then:
         !reason.isExpected()
@@ -52,13 +54,13 @@ class DefaultComponentSelectionReasonTest extends Specification {
 
     def "other selection reason and requested is not expected"() {
         when:
-        def reason = ComponentSelectionReasons.of(new DefaultComponentSelectionDescriptor(ComponentSelectionCause.REQUESTED), new DefaultComponentSelectionDescriptor(ComponentSelectionCause.FORCED))
+        def reason = ComponentSelectionReasons.of(ImmutableSet.of(
+            new DefaultComponentSelectionDescriptor(ComponentSelectionCause.REQUESTED),
+            new DefaultComponentSelectionDescriptor(ComponentSelectionCause.FORCED)
+        ))
 
         then:
         !reason.isExpected()
     }
 
-    def addCause(ComponentSelectionReason reason, ComponentSelectionCause cause, String description) {
-        ((ComponentSelectionReasonInternal) reason).addCause(cause, Describables.of(description))
-    }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultGraphBuilderSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultGraphBuilderSpec.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
-import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
@@ -238,7 +237,7 @@ class ResolutionResultGraphBuilderSpec extends Specification {
 """
     }
 
-    private void node(String module, ComponentSelectionReason reason = ComponentSelectionReasons.requested()) {
+    private void node(String module, ComponentSelectionReasonInternal reason = ComponentSelectionReasons.requested()) {
         def resultId = id(module)
         def componentId = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId("x", module), "1")
         def moduleVersionId = DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId("x", module), "1")

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal
 import org.gradle.api.internal.artifacts.resolver.ResolutionAccess
 import org.gradle.api.internal.artifacts.resolver.ResolutionOutputsInternal
 import org.gradle.api.internal.attributes.AttributeDesugaring
@@ -165,7 +166,7 @@ class DefaultResolutionResultTest extends Specification {
             Stub(ComponentSelector),
             false,
             Stub(ComponentSelectionReason),
-            new DefaultResolvedComponentResult(mid, Stub(ComponentSelectionReason), projectId, ImmutableMap.of(1L, Stub(ResolvedVariantResult)), ImmutableList.of(Stub(ResolvedVariantResult)), null),
+            new DefaultResolvedComponentResult(mid, Stub(ComponentSelectionReasonInternal), projectId, ImmutableMap.of(1L, Stub(ResolvedVariantResult)), ImmutableList.of(Stub(ResolvedVariantResult)), null),
             new ModuleVersionNotFoundException(Stub(ModuleComponentSelector), broken, [])
         )
         def edge = new UnresolvedDependencyEdge(dep)

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/TestComponentDescriptorFactory.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/TestComponentDescriptorFactory.groovy
@@ -18,8 +18,8 @@ package org.gradle.api.internal.artifacts
 
 import groovy.transform.CompileStatic
 import org.gradle.api.artifacts.result.ComponentSelectionCause
-import org.gradle.api.artifacts.result.ComponentSelectionDescriptor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorFactory
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DefaultComponentSelectionDescriptor
 import org.gradle.internal.Describables
 
@@ -27,12 +27,12 @@ import org.gradle.internal.Describables
 class TestComponentDescriptorFactory implements ComponentSelectionDescriptorFactory {
 
     @Override
-    ComponentSelectionDescriptor newDescriptor(ComponentSelectionCause cause, String reason) {
+    ComponentSelectionDescriptorInternal newDescriptor(ComponentSelectionCause cause, String reason) {
         new DefaultComponentSelectionDescriptor(cause, Describables.of(reason))
     }
 
     @Override
-    ComponentSelectionDescriptor newDescriptor(ComponentSelectionCause cause) {
+    ComponentSelectionDescriptorInternal newDescriptor(ComponentSelectionCause cause) {
         new DefaultComponentSelectionDescriptor(cause)
     }
 }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -539,7 +539,7 @@ org:leaf:2.0 -> 1.0
 
         then:
         outputContains """
-org:leaf:1.0 (selected by rule)
+org:leaf:1.0
   Variant runtime:
     | Attribute Name             | Provided     | Requested |
     |----------------------------|--------------|-----------|
@@ -547,6 +547,9 @@ org:leaf:1.0 (selected by rule)
     | org.gradle.libraryelements | jar          |           |
     | org.gradle.status          | release      |           |
     | org.gradle.usage           | java-runtime |           |
+   Selection reasons:
+      - Selected by rule
+      - Forced
 
 org:leaf:1.0
 \\--- org:foo:1.0
@@ -801,7 +804,7 @@ org:foo:1.0 -> 2.0
 
         then:
         outputContains """
-org:baz:2.0 (selected by rule)
+org:baz:2.0
   Variant runtime:
     | Attribute Name             | Provided     | Requested |
     |----------------------------|--------------|-----------|
@@ -809,6 +812,9 @@ org:baz:2.0 (selected by rule)
     | org.gradle.libraryelements | jar          |           |
     | org.gradle.status          | release      |           |
     | org.gradle.usage           | java-runtime |           |
+   Selection reasons:
+      - Selected by rule
+      - Forced
 
 org:baz:1.1 -> 2.0
 \\--- conf
@@ -1357,7 +1363,11 @@ org:middle:1.0 -> 2.0 FAILED
 
         then:
         outputContains """
-org:middle:2.0+ (selected by rule) FAILED
+org:middle:2.0+ FAILED
+   Selection reasons:
+      - Was requested: didn't match version 1.0
+      - Selected by rule
+      - Forced
    Failures:
       - Could not find any version that matches org:middle:2.0+.
         Versions that do not match: 1.0
@@ -2597,13 +2607,15 @@ org:bar: FAILED
    Failures:
       - Could not resolve org:bar:{reject all versions}.
           - Module 'org:bar' has been rejected:
-               Dependency path: 'root project :' (compileClasspath) --> 'org:bar:[1.0,)'
+               Dependency path: 'root project :' (compileClasspath) --> 'org:bar:[1.0,)' because of the following reason: rejected versions 1.2, 1.1, 1.0
                Constraint path: 'root project :' (compileClasspath) --> 'org:bar:{reject all versions}' because of the following reason: Nope, you won't use this
 
 org:bar:{reject all versions} FAILED
 \\--- compileClasspath
 
 org:bar:[1.0,) FAILED
+   Selection reasons:
+      - Was requested: rejected versions 1.2, 1.1, 1.0
    Failures:
       - Could not resolve org:bar:[1.0,). (already reported)
 
@@ -2614,13 +2626,15 @@ org:foo: (by constraint) FAILED
    Failures:
       - Could not resolve org:foo:{reject 1.0 & 1.1 & 1.2}.
           - Cannot find a version of 'org:foo' that satisfies the version constraints:
-               Dependency path: 'root project :' (compileClasspath) --> 'org:foo:[1.0,)'
+               Dependency path: 'root project :' (compileClasspath) --> 'org:foo:[1.0,)' because of the following reason: rejected versions 1.2, 1.1, 1.0
                Constraint path: 'root project :' (compileClasspath) --> 'org:foo:{reject 1.0 & 1.1 & 1.2}'
 
 org:foo:{reject 1.0 & 1.1 & 1.2} FAILED
 \\--- compileClasspath
 
 org:foo:[1.0,) FAILED
+   Selection reasons:
+      - Was requested: rejected versions 1.2, 1.1, 1.0
    Failures:
       - Could not resolve org:foo:[1.0,). (already reported)
 
@@ -2676,8 +2690,8 @@ org:foo:1.0
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
-      - By constraint
       - Was requested: rejected versions 1.2, 1.1
+      - By constraint
 
 org:foo:{reject 1.2} -> 1.0
 \\--- compileClasspath
@@ -2994,8 +3008,8 @@ org:foo:1.5
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
-      - By constraint
       - By ancestor
+      - By constraint
 
 org:foo:{strictly 1.5} -> 1.5
 \\--- compileClasspath


### PR DESCRIPTION
Now a selector does not keep track of all the reasons from edges that use the selector. The previous implementation did not account for when an edge clears its selector. A selector's forced, fromLock, and changing properties also suffer from a similar bug where they are never updated when an edge releases a selector.

Separately:
- We slightly adjust the logic for adding the forced reason. Now we declare the forced reason when a dependency is equivalent to a force. Now, the reason reflects actual forcing behavior.
- We fix a bug where once an edge contributed its reasons to a selector, it didn't subsequently apply its reasons to any new selector it used. This caused some reasons to be 'missed' previously

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
