### PR TITLE
Re-enable the custom build init template test

### DIFF
--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/specs/internal/BuildInitSpecsIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/specs/internal/BuildInitSpecsIntegrationTest.groovy
@@ -26,12 +26,11 @@ import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.test.preconditions.UnitTestPreconditions
-import spock.lang.Ignore
 
 @Requires(UnitTestPreconditions.Jdk17OrLater)
 class BuildInitSpecsIntegrationTest extends AbstractInitIntegrationSpec implements TestsBuildInitSpecsViaPlugin, JavaToolchainFixture {
     private static final String DECLARATIVE_JVM_PLUGIN_ID = "org.gradle.experimental.jvm-ecosystem-init"
-    private static final String DECLARATIVE_PLUGIN_VERSION = "0.1.48"
+    private static final String DECLARATIVE_PLUGIN_VERSION = "0.1.50"
     private static final String DECLARATIVE_PLUGIN_SPEC = "$DECLARATIVE_JVM_PLUGIN_ID:$DECLARATIVE_PLUGIN_VERSION"
 
     // Just need an arbitrary Plugin<Settings> here, so use the Declarative Prototype.  Note that we can't use JVM, because
@@ -252,7 +251,6 @@ class BuildInitSpecsIntegrationTest extends AbstractInitIntegrationSpec implemen
         assertWrapperGenerated()
     }
 
-    @Ignore("Temporarily disabled until a version of the prototypes is available with definitions declared unsafe")
     @LeaksFileHandles
     @Requires(value = [
         IntegTestPreconditions.Java17HomeAvailable,
@@ -277,7 +275,7 @@ class BuildInitSpecsIntegrationTest extends AbstractInitIntegrationSpec implemen
 }
 
 plugins {
-    id("org.gradle.experimental.jvm-ecosystem").version("0.1.47")
+    id("org.gradle.experimental.jvm-ecosystem").version("0.1.49")
 }
 
 rootProject.name = "example-java-app"


### PR DESCRIPTION
This test was disabled in https://github.com/gradle/gradle/pull/35926 due to breaking changes.  The custom build init template projects have now been updated, so we update the versions and re-enable the test.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
