### PR TITLE
Update best_practices_dependencies.adoc

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_dependencies.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_dependencies.adoc
@@ -18,7 +18,7 @@
 [[use_version_catalogs]]
 == Use Version Catalogs to Centralize Dependency Versions
 
-Use Version Catalogs provide a centralized, declarative way to manage dependency versions throughout a build.
+Version Catalogs provide a centralized, declarative way to manage dependency versions throughout a build.
 
 === Explanation
 


### PR DESCRIPTION
Fixed a minor error.
"Use Version Catalogs provide" becomes "Version Catalogs provide"

