### PR TITLE
Allow ProjectComponentIdentifiers to be used as task inputs

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyManagementResultsAsInputsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyManagementResultsAsInputsIntegrationTest.groovy
@@ -19,10 +19,12 @@ package org.gradle.integtests.resolve
 import groovy.test.NotYetImplemented
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DefaultComponentSelectionDescriptor
 import org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult
 import org.gradle.api.internal.attributes.AttributesFactory
+import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.internal.Describables
 import org.gradle.internal.component.external.model.DefaultImmutableCapability
@@ -31,6 +33,7 @@ import org.gradle.internal.component.external.model.DefaultModuleComponentIdenti
 import org.gradle.internal.component.external.model.ImmutableCapabilities
 import org.gradle.internal.component.local.model.DefaultLibraryComponentSelector
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Path
 import spock.lang.Issue
 
 class DependencyManagementResultsAsInputsIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -214,6 +217,9 @@ class DependencyManagementResultsAsInputsIntegrationTest extends AbstractHttpDep
             import ${DefaultModuleIdentifier.name}
             import ${DefaultModuleVersionIdentifier.name}
             import ${DefaultModuleComponentIdentifier.name}
+            import ${DefaultProjectComponentIdentifier.name}
+            import ${ProjectIdentity.name}
+            import ${Path.name}
             import ${DefaultImmutableCapability.name}
             import ${DefaultModuleComponentArtifactIdentifier.name}
             import ${AttributesFactory.name}
@@ -269,6 +275,7 @@ class DependencyManagementResultsAsInputsIntegrationTest extends AbstractHttpDep
         "AttributeContainer"           | "services.get(AttributesFactory).of(Attribute.of('some', String.class), System.getProperty('n'))"
         "Capability"                   | "new DefaultImmutableCapability('group', System.getProperty('n'), '1.0')"
         "ModuleComponentIdentifier"    | "new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('group', System.getProperty('n')),'1.0')"
+        "ProjectComponentIdentifier"   | "new DefaultProjectComponentIdentifier(ProjectIdentity.forRootProject(Path.ROOT, System.getProperty('n')))"
         "ComponentArtifactIdentifier"  | "new DefaultModuleComponentArtifactIdentifier(new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('group', System.getProperty('n')),'1.0'), System.getProperty('n') + '-1.0.jar', 'jar', null)"
         "ResolvedVariantResult"        | "new DefaultResolvedVariantResult(new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('group', System.getProperty('n')), '1.0'), Describables.of('variantName'), services.get(AttributesFactory).of(Attribute.of('some', String.class), System.getProperty('n')), ImmutableCapabilities.of(new DefaultImmutableCapability('group', System.getProperty('n'), '1.0')), null)"
         // For ResolvedComponentResult

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
@@ -105,6 +105,7 @@ public class DependencyManagementValueSnapshotterSerializerRegistry extends Defa
         register(ComponentFileArtifactIdentifier.class, new ComponentFileArtifactIdentifierSerializer());
         register(TransformedComponentFileArtifactIdentifier.class, new TransformedComponentFileArtifactIdentifierSerializer());
         register(DefaultModuleComponentIdentifier.class, Cast.uncheckedCast(componentIdentifierSerializer));
+        register(DefaultProjectComponentIdentifier.class, Cast.uncheckedCast(componentIdentifierSerializer));
         register(AttributeContainer.class, attributeContainerSerializer);
         registerWithFactory(ResolvedVariantResult.class, () -> new ResolvedVariantResultSerializer(componentIdentifierSerializer, attributeContainerSerializer));
         register(ComponentSelectionDescriptorInternal.class, new ComponentSelectionDescriptorSerializer(componentSelectionDescriptorFactory));


### PR DESCRIPTION
Previously, we only allowed ModuleComponentIdentifiers to be used as task inputs. Plenty of dependency graphs include project components, so it is very useful to be able to include these as task inputs

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
