### PR TITLE
Filter out unique snapshot versions as snapshots

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenRepositoryContentDescriptor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenRepositoryContentDescriptor.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MavenVersionUtils;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.internal.Actions;
 
@@ -50,7 +51,7 @@ class DefaultMavenRepositoryContentDescriptor extends DefaultRepositoryContentDe
         if (!snapshots || !releases) {
             Action<? super ArtifactResolutionDetails> action = details -> {
                 if (!details.isVersionListing()) {
-                    String version = details.getComponentId().getVersion();
+                    String version = MavenVersionUtils.toEffectiveVersion(details.getComponentId().getVersion());
                     if (snapshots && !version.endsWith("-SNAPSHOT")) {
                         details.notFound();
                         return;


### PR DESCRIPTION
This is correct for two reasons: Maven behaves in this way, and we perform resolution similar to a snapshot (replacing the timestamp with -SNAPSHOT in the directory) for these versions.

Fixes #31888

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
