### PR TITLE
Introduce gradleDistribution repository

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -42,6 +42,36 @@ For Java, Groovy, Kotlin, and Android compatibility, see the [full compatibility
 
 <!-- Do not add breaking changes or deprecations here! Add them to the upgrade guide instead. -->
 
+### Gradle Distribution Repository
+
+This release introduces the `gradleDistribution()` repository, which allows select bundled dependencies to be resolved directly from the Gradle distribution without requiring network access.
+The `gradleDistribution()` repository can be used like any other repository:
+
+```kotlin
+plugins {
+    id("java-library")
+}
+
+repositories {
+    gradleDistribution()
+}
+
+dependencies {
+    implementation("org.apache.groovy:groovy:4+")
+}
+```
+
+By running `./gradlew dependencies --configuration runtimeClasspath`, we can see this resolves
+to the Groovy version bundled with Gradle:
+
+```
+runtimeClasspath - Runtime classpath of source set 'main'.
+\--- org.apache.groovy:groovy:4+ -> 4.0.29
+```
+
+The versions of dependencies bundled with Gradle may change between minor releases.
+For this reason, dynamic versions should always be used when resolving dependencies from the `gradleDistribution()` repository.
+
 ### Bearer Token Authentication for Wrapper Download
 
 When downloading Gradle distributions from an HTTPS backend (or even from an HTTP one, but the secure version is preferred), the Wrapper now also supports Bearer token authentication.

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/declaring_repositories_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/declaring_repositories_basics.adoc
@@ -116,6 +116,47 @@ When such a repository is configured, Gradle completely bypasses its dependency 
 Additionally, using local Maven or Ivy repositories makes build reproducibility much harder to achieve.
 Therefore, their use should be restricted to prototyping rather than production builds.
 
+[[sec:declaring-distribution-repository]]
+== Declaring a Gradle distribution repository
+
+In some cases, it may be useful to resolve dependencies that are already bundled with Gradle.
+Gradle permits a select set of dependencies from its distribution to be resolved using the `gradleDistribution()` repository.
+
+====
+include::sample[dir="snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/kotlin",files="build.gradle.kts[tags=gradle-distribution-repository]"]
+include::sample[dir="snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/groovy",files="build.gradle[tags=gradle-distribution-repository]"]
+====
+
+To resolve a dependency from the distribution, declare a module dependency like any other:
+
+====
+include::sample[dir="snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/kotlin",files="build.gradle.kts[tags=declare-distribution-dependency]"]
+include::sample[dir="snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/groovy",files="build.gradle[tags=declare-distribution-dependency]"]
+====
+
+By running `./gradlew dependencies --configuration runtimeClasspath`, we can see this resolves
+to the Groovy version bundled with Gradle:
+
+====
+include::sample[dir="snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/tests",files="dependencies.out"]
+====
+
+NOTE: The versions of dependencies bundled in the Gradle distribution may change across minor versions.
+When resolving dependencies from the distribution repository, it is important to use dynamic versions to avoid resolution failures when upgrading Gradle versions.
+
+Currently, Gradle supports resolving the following dependencies from the distribution repository:
+
+* `org.apache.groovy:groovy:4+`
+* `org.apache.groovy:groovy-ant:4+`
+* `org.apache.groovy:groovy-astbuilder:4+`
+* `org.apache.groovy:groovy-datetime:4+`
+* `org.apache.groovy:groovy-dateutil:4+`
+* `org.apache.groovy:groovy-groovydoc:4+`
+* `org.apache.groovy:groovy-json:4+`
+* `org.apache.groovy:groovy-nio:4+`
+* `org.apache.groovy:groovy-templates:4+`
+* `org.apache.groovy:groovy-xml:4+`
+
 [[sec:declaring-multiple-repositories]]
 == Declaring multiple repositories
 

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/groovy/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id("java-library")
+}
+
+// tag::gradle-distribution-repository[]
+repositories {
+    gradleDistribution()
+}
+// end::gradle-distribution-repository[]
+
+// tag::declare-distribution-dependency[]
+dependencies {
+    implementation("org.apache.groovy:groovy:4+")
+}
+// end::declare-distribution-dependency[]

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "gradle-distribution-repository"

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/kotlin/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("java-library")
+}
+
+// tag::gradle-distribution-repository[]
+repositories {
+    gradleDistribution()
+}
+// end::gradle-distribution-repository[]
+
+// tag::declare-distribution-dependency[]
+dependencies {
+    implementation("org.apache.groovy:groovy:4+")
+}
+// end::declare-distribution-dependency[]

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "gradle-distribution-repository"

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/tests/dependencies.out
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/tests/dependencies.out
@@ -1,0 +1,14 @@
+
+> Task :dependencies
+
+------------------------------------------------------------
+Root project 'gradle-distribution-repository'
+------------------------------------------------------------
+
+runtimeClasspath - Runtime classpath of source set 'main'.
+\--- org.apache.groovy:groovy:4+ -> 4.0.29
+
+A web-based, searchable dependency report is available by adding the --scan option.
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/tests/gradle-distribution-repository.sample.conf
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/declaringRepositories-gradleDistributionRepository/tests/gradle-distribution-repository.sample.conf
@@ -1,0 +1,3 @@
+executable: gradle
+args: dependencies --configuration runtimeClasspath
+expected-output-file: dependencies.out

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/api/internal/artifacts/repositories/distribution/DefaultAvailableDistributionModulesTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/api/internal/artifacts/repositories/distribution/DefaultAvailableDistributionModulesTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.classpath.DefaultModuleRegistry
 import org.gradle.api.internal.classpath.ModuleRegistry
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.internal.installation.GradleInstallation
+import org.gradle.util.internal.VersionNumber
 import spock.lang.Specification
 
 /**
@@ -32,12 +33,32 @@ class DefaultAvailableDistributionModulesTest extends Specification {
 
     private final DefaultAvailableDistributionModules underTest = new DefaultAvailableDistributionModules(moduleRegistry)
 
+    def "exposes a known set of top-level modules"() {
+        expect:
+        // This test serves as a reminder to update the public documentation describing
+        // which modules we explicitly support as being available for resolution from
+        // the distribution repository. If this list changes, be sure to update the
+        // declaring_repositories_basics.adoc page.
+        underTest.getTopLevelModules().collect { it.getModuleIdentifier().toString() + ":" + VersionNumber.parse(it.version).major + "+" } as Set == ([
+            "org.apache.groovy:groovy:4+",
+            "org.apache.groovy:groovy-ant:4+",
+            "org.apache.groovy:groovy-astbuilder:4+",
+            "org.apache.groovy:groovy-datetime:4+",
+            "org.apache.groovy:groovy-dateutil:4+",
+            "org.apache.groovy:groovy-groovydoc:4+",
+            "org.apache.groovy:groovy-json:4+",
+            "org.apache.groovy:groovy-nio:4+",
+            "org.apache.groovy:groovy-templates:4+",
+            "org.apache.groovy:groovy-xml:4+"
+        ])
+    }
+
     def "exposes a known set of modules"() {
         given:
         def groovyVersion = GroovySystem.version
 
         expect:
-        // This list serves as documentation/control over which dependencies the
+        // This test serves as documentation/control over which dependencies the
         // `gradleDistribution()` repository allows users to resolve from the distribution.
         // If you PR changes this list, you've changed user-facing behavior.
         // * No dependency may be removed from this list without deprecation.
@@ -56,7 +77,6 @@ class DefaultAvailableDistributionModulesTest extends Specification {
             "org.apache.groovy:groovy-astbuilder:${groovyVersion}",
             "org.apache.ant:ant-antlr:1.10.15",
             "org.apache.groovy:groovy:${groovyVersion}",
-            "org.apache.groovy:groovy-bom:${groovyVersion}",
             "org.apache.groovy:groovy-templates:${groovyVersion}",
             "org.apache.groovy:groovy-dateutil:${groovyVersion}",
             "org.apache.groovy:groovy-ant:${groovyVersion}"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/api/internal/artifacts/repositories/distribution/DefaultAvailableDistributionModulesTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/api/internal/artifacts/repositories/distribution/DefaultAvailableDistributionModulesTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.distribution
+
+import org.gradle.api.internal.classpath.DefaultModuleRegistry
+import org.gradle.api.internal.classpath.ModuleRegistry
+import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
+import org.gradle.internal.installation.GradleInstallation
+import spock.lang.Specification
+
+/**
+ * Tests {@link DefaultAvailableDistributionModules}.
+ */
+class DefaultAvailableDistributionModulesTest extends Specification {
+
+    private final testInstallation = new GradleInstallation(IntegrationTestBuildContext.INSTANCE.gradleHomeDir)
+    private final ModuleRegistry moduleRegistry = new DefaultModuleRegistry(testInstallation)
+
+    private final DefaultAvailableDistributionModules underTest = new DefaultAvailableDistributionModules(moduleRegistry)
+
+    def "exposes a known set of modules"() {
+        given:
+        def groovyVersion = GroovySystem.version
+
+        expect:
+        // This list serves as documentation/control over which dependencies the
+        // `gradleDistribution()` repository allows users to resolve from the distribution.
+        // If you PR changes this list, you've changed user-facing behavior.
+        // * No dependency may be removed from this list without deprecation.
+        // * Any dependency added to this list should be done so with careful consideration.
+        underTest.getAvailableModules().collect { it.getDisplayName() } as Set == ([
+            "org.apache.groovy:groovy-nio:${groovyVersion}",
+            "org.apache.groovy:groovy-docgenerator:${groovyVersion}",
+            "org.apache.ant:ant-launcher:1.10.15",
+            "org.apache.ant:ant:1.10.15",
+            "com.thoughtworks.qdox:qdox:1.12.1",
+            "com.github.javaparser:javaparser-core:3.27.1",
+            "org.apache.groovy:groovy-json:${groovyVersion}",
+            "org.apache.groovy:groovy-groovydoc:${groovyVersion}",
+            "org.apache.groovy:groovy-datetime:${groovyVersion}",
+            "org.apache.groovy:groovy-xml:${groovyVersion}",
+            "org.apache.groovy:groovy-astbuilder:${groovyVersion}",
+            "org.apache.ant:ant-antlr:1.10.15",
+            "org.apache.groovy:groovy:${groovyVersion}",
+            "org.apache.groovy:groovy-bom:${groovyVersion}",
+            "org.apache.groovy:groovy-templates:${groovyVersion}",
+            "org.apache.groovy:groovy-dateutil:${groovyVersion}",
+            "org.apache.groovy:groovy-ant:${groovyVersion}"
+        ] as Set)
+    }
+
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/GradleDistributionRepositoryResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/GradleDistributionRepositoryResolveIntegrationTest.groovy
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.internal.VersionNumber
+
+/**
+ * Tests {@link org.gradle.api.artifacts.dsl.RepositoryHandler#gradleDistribution()}.
+ */
+class GradleDistributionRepositoryResolveIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can resolve dependency from the gradle distribution"() {
+        buildFile << """
+            ${gradleDistributionRepository()}
+
+            configurations {
+                conf
+            }
+
+            dependencies {
+                conf("org.apache.groovy:groovy:\${GroovySystem.version}")
+            }
+
+            ${resolveTask}
+        """
+
+        when:
+        succeeds("resolve")
+
+        then:
+        outputContains("[groovy-${GroovySystem.version}.jar]")
+    }
+
+    def "attributes are attached to resolved variant"() {
+        buildFile << """
+            ${gradleDistributionRepository()}
+
+            configurations {
+                conf
+            }
+
+            dependencies {
+                conf("org.apache.groovy:groovy:\${GroovySystem.version}")
+            }
+        """
+
+        when:
+        succeeds("dependencyInsight", "--configuration", "conf", "--dependency", "groovy")
+
+        then:
+        outputContains("""org.apache.groovy:groovy:${GroovySystem.version}
+  Variant runtime:
+    | Attribute Name             | Provided     | Requested |
+    |----------------------------|--------------|-----------|
+    | org.gradle.category        | library      |           |
+    | org.gradle.libraryelements | jar          |           |
+    | org.gradle.usage           | java-runtime |           |""")
+    }
+
+    def "fails to resolve variant if incompatible attributes are requested"() {
+        buildFile << """
+            ${gradleDistributionRepository()}
+
+            configurations {
+                conf {
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, named(Usage, Usage.JAVA_API))
+                    }
+                }
+            }
+
+            dependencies {
+                conf("org.apache.groovy:groovy:\${GroovySystem.version}")
+            }
+
+            ${resolveTask}
+        """
+
+        when:
+        fails("resolve")
+
+        then:
+        failure.assertHasCause("""No matching variant of org.apache.groovy:groovy:${GroovySystem.version} was found. The consumer was configured to find attribute 'org.gradle.usage' with value 'java-api' but:
+  - Variant 'runtime':
+      - Incompatible because this component declares attribute 'org.gradle.usage' with value 'java-runtime' and the consumer needed attribute 'org.gradle.usage' with value 'java-api'""")
+    }
+
+    def "fails to resolve dependency from gradle distribution using different version than is present"() {
+        int major = VersionNumber.parse(GroovySystem.version).major
+        buildFile << """
+            ${gradleDistributionRepository()}
+
+            configurations {
+                conf
+            }
+
+            dependencies {
+                conf("org.apache.groovy:groovy:${major}.0.0")
+            }
+
+            ${resolveTask}
+        """
+
+        when:
+        fails("resolve")
+
+        then:
+        failure.assertHasCause("Could not find org.apache.groovy:groovy:4.0.0")
+    }
+
+    def "can resolve dynamic versioned dependencies from the gradle distribution"() {
+        int major = VersionNumber.parse(GroovySystem.version).major
+        buildFile << """
+            ${gradleDistributionRepository()}
+
+            configurations {
+                conf
+            }
+
+            dependencies {
+                conf("org.apache.groovy:groovy:${major}+")
+            }
+
+            ${resolveTask}
+        """
+
+        when:
+        succeeds("resolve")
+
+        then:
+        outputContains("[groovy-${GroovySystem.version}.jar]")
+    }
+
+    def "fails to resolve dynamic version from distribution when requested version does not match version in distribution"() {
+        buildFile << """
+            ${gradleDistributionRepository()}
+
+            configurations {
+                conf
+            }
+
+            dependencies {
+                conf("org.apache.groovy:groovy:3+")
+            }
+
+            ${resolveTask}
+        """
+
+        when:
+        fails("resolve")
+
+        then:
+        failure.assertHasCause("""Could not find any version that matches org.apache.groovy:groovy:3+.
+Versions that do not match: ${GroovySystem.version}""")
+    }
+
+    def "fails to resolve explicit artifacts from distribution repository"() {
+        buildFile << """
+            ${gradleDistributionRepository()}
+
+            configurations {
+                conf
+            }
+
+            dependencies {
+                conf("org.apache.groovy:groovy:\${GroovySystem.version}:cls")
+            }
+
+            ${resolveTask}
+        """
+
+        when:
+        fails("resolve")
+
+        then:
+        failure.assertHasCause("Could not resolve org.apache.groovy:groovy:${GroovySystem.version}")
+        failure.assertHasCause("Cannot request explicit artifact from distribution repository.")
+    }
+
+    def "can fallback to later repositories if dependency not found in distribution repository"() {
+        mavenRepo.module("org", "foo").publish()
+
+        buildFile << """
+            ${gradleDistributionRepository()}
+            ${mavenTestRepository()}
+
+            configurations {
+                conf
+            }
+
+            dependencies {
+                conf("org:foo:1.0")
+            }
+
+            ${resolveTask}
+        """
+
+        when:
+        succeeds("resolve")
+
+        then:
+        outputContains("[foo-1.0.jar]")
+    }
+
+    def "dependencies resolved from distribution repository can enter capability conflicts"() {
+        mavenRepo.module("org", "foo")
+            .withoutDefaultVariants()
+            .withVariant("runtime") {
+                capability("org", "foo", "1.0")
+                capability("org.apache.groovy", "groovy", "4.0.0")
+            }
+            .withModuleMetadata()
+            .publish()
+
+
+        buildFile << """
+            ${gradleDistributionRepository()}
+            ${mavenTestRepository()}
+
+            configurations {
+                conf
+            }
+
+            dependencies {
+                conf("org:foo:1.0")
+                conf("org.apache.groovy:groovy:\${GroovySystem.version}")
+            }
+
+            ${resolveTask}
+        """
+
+        when:
+        fails("resolve")
+
+        then:
+        failure.assertHasCause("""Module 'org:foo' has been rejected:
+   Cannot select module with conflict on capability 'org.apache.groovy:groovy:4.0.0' also provided by ['org.apache.groovy:groovy:${GroovySystem.version}' (runtime)]""")
+        failure.assertHasCause("""Module 'org.apache.groovy:groovy' has been rejected:
+   Cannot select module with conflict on capability 'org.apache.groovy:groovy:${GroovySystem.version}' also provided by ['org:foo:1.0' (runtime)]""")
+    }
+
+    String gradleDistributionRepository() {
+        """
+            repositories {
+                gradleDistribution()
+            }
+        """
+    }
+
+    String getResolveTask(String confName = "conf") {
+        """
+            tasks.register("resolve") {
+                def files = configurations.${confName}.incoming.files
+                doLast {
+                    println(files*.name)
+                }
+            }
+        """
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/BaseRepositoryFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/BaseRepositoryFactory.java
@@ -33,6 +33,8 @@ public interface BaseRepositoryFactory {
 
     FlatDirectoryArtifactRepository createFlatDirRepository();
 
+    ArtifactRepository createGradleDistributionRepository();
+
     ArtifactRepository createGradlePluginPortal();
 
     MavenArtifactRepository createMavenLocalRepository();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -57,30 +57,18 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultConfigurationResolver;
-import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.ResolutionExecutor;
 import org.gradle.api.internal.artifacts.ivyservice.ShortCircuitingResolutionExecutor;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorParser;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
-import org.gradle.api.internal.artifacts.ivyservice.modulecache.FileStoreAndIndexProvider;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultLocalComponentRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DependencyGraphResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder;
-import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
 import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory;
 import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQueryFactory;
 import org.gradle.api.internal.artifacts.repositories.DefaultBaseRepositoryFactory;
 import org.gradle.api.internal.artifacts.repositories.DefaultUrlArtifactRepository;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
-import org.gradle.api.internal.artifacts.repositories.distribution.AvailableDistributionModules;
-import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
-import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
-import org.gradle.api.internal.artifacts.repositories.metadata.MavenVariantAttributesFactory;
-import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFinder;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformInvocationFactory;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformRegistrationFactory;
@@ -106,20 +94,16 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.internal.InternalProblems;
-import org.gradle.api.provider.ProviderFactory;
 import org.gradle.cache.Cache;
 import org.gradle.cache.ManualEvictionInMemoryCache;
-import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.build.BuildModelLifecycleListener;
 import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy;
-import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.model.GraphVariantSelector;
 import org.gradle.internal.component.resolution.failure.ResolutionFailureHandler;
 import org.gradle.internal.component.resolution.failure.transform.TransformedVariantConverter;
@@ -131,7 +115,6 @@ import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.workspace.MutableWorkspaceProvider;
 import org.gradle.internal.execution.workspace.impl.NonLockingMutableWorkspaceProvider;
-import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -146,8 +129,6 @@ import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.resource.local.FileResourceListener;
-import org.gradle.internal.resource.local.FileResourceRepository;
-import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 import org.gradle.internal.service.Provides;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistrationProvider;
@@ -259,6 +240,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(ArtifactTypeRegistry.class);
             registration.add(GlobalDependencyResolutionRules.class);
             registration.add(PublishArtifactNotationParserFactory.class);
+            registration.add(BaseRepositoryFactory.class, DefaultBaseRepositoryFactory.class);
         }
 
         @Provides
@@ -365,63 +347,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         @Provides
         DefaultUrlArtifactRepository.Factory createDefaultUrlArtifactRepositoryFactory(FileResolver fileResolver) {
             return new DefaultUrlArtifactRepository.Factory(fileResolver);
-        }
-
-        @Provides
-        BaseRepositoryFactory createBaseRepositoryFactory(
-            LocalMavenRepositoryLocator localMavenRepositoryLocator,
-            FileResolver fileResolver,
-            FileCollectionFactory fileCollectionFactory,
-            RepositoryTransportFactory repositoryTransportFactory,
-            LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder,
-            FileStoreAndIndexProvider fileStoreAndIndexProvider,
-            VersionSelectorScheme versionSelectorScheme,
-            AuthenticationSchemeRegistry authenticationSchemeRegistry,
-            IvyContextManager ivyContextManager,
-            AttributesFactory attributesFactory,
-            ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-            InstantiatorFactory instantiatorFactory,
-            FileResourceRepository fileResourceRepository,
-            MavenMutableModuleMetadataFactory metadataFactory,
-            IvyMutableModuleMetadataFactory ivyMetadataFactory,
-            IsolatableFactory isolatableFactory,
-            ObjectFactory objectFactory,
-            CollectionCallbackActionDecorator callbackDecorator,
-            NamedObjectInstantiator instantiator,
-            DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
-            ChecksumService checksumService,
-            ProviderFactory providerFactory,
-            VersionParser versionParser,
-            AvailableDistributionModules availableModules,
-            MavenVariantAttributesFactory mavenAttributesFactory
-        ) {
-            return new DefaultBaseRepositoryFactory(
-                localMavenRepositoryLocator,
-                fileResolver,
-                fileCollectionFactory,
-                repositoryTransportFactory,
-                locallyAvailableResourceFinder,
-                fileStoreAndIndexProvider.getArtifactIdentifierFileStore(),
-                fileStoreAndIndexProvider.getExternalResourceFileStore(),
-                new GradlePomModuleDescriptorParser(versionSelectorScheme, moduleIdentifierFactory, fileResourceRepository, metadataFactory),
-                new GradleModuleMetadataParser(attributesFactory, moduleIdentifierFactory, instantiator),
-                authenticationSchemeRegistry,
-                ivyContextManager,
-                moduleIdentifierFactory,
-                instantiatorFactory,
-                fileResourceRepository,
-                metadataFactory,
-                ivyMetadataFactory,
-                isolatableFactory,
-                objectFactory,
-                callbackDecorator,
-                urlArtifactRepositoryFactory,
-                checksumService,
-                providerFactory,
-                versionParser,
-                availableModules,
-                mavenAttributesFactory
-            );
         }
 
         @Provides

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -76,8 +76,10 @@ import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQueryFac
 import org.gradle.api.internal.artifacts.repositories.DefaultBaseRepositoryFactory;
 import org.gradle.api.internal.artifacts.repositories.DefaultUrlArtifactRepository;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
+import org.gradle.api.internal.artifacts.repositories.distribution.AvailableDistributionModules;
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenVariantAttributesFactory;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFinder;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformInvocationFactory;
@@ -389,7 +391,9 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
             ChecksumService checksumService,
             ProviderFactory providerFactory,
-            VersionParser versionParser
+            VersionParser versionParser,
+            AvailableDistributionModules availableModules,
+            MavenVariantAttributesFactory mavenAttributesFactory
         ) {
             return new DefaultBaseRepositoryFactory(
                 localMavenRepositoryLocator,
@@ -414,7 +418,9 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 urlArtifactRepositoryFactory,
                 checksumService,
                 providerFactory,
-                versionParser
+                versionParser,
+                availableModules,
+                mavenAttributesFactory
             );
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -29,6 +29,8 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExternalModuleDependencyMetadataConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ProjectDependencyMetadataConverter;
+import org.gradle.api.internal.artifacts.repositories.distribution.AvailableDistributionModules;
+import org.gradle.api.internal.artifacts.repositories.distribution.DefaultAvailableDistributionModules;
 import org.gradle.api.internal.artifacts.transform.CacheableTransformTypeAnnotationHandler;
 import org.gradle.api.internal.artifacts.transform.InputArtifactAnnotationHandler;
 import org.gradle.api.internal.artifacts.transform.InputArtifactDependenciesAnnotationHandler;
@@ -74,6 +76,7 @@ class DependencyManagementGlobalScopeServices implements ServiceRegistrationProv
         registration.add(ExcludeRuleConverter.class, DefaultExcludeRuleConverter.class);
         registration.add(PropertyAnnotationHandler.class, InjectAnnotationHandler.class, InputArtifactAnnotationHandler.class);
         registration.add(PropertyAnnotationHandler.class, InjectAnnotationHandler.class, InputArtifactDependenciesAnnotationHandler.class);
+        registration.add(AvailableDistributionModules.class, DefaultAvailableDistributionModules.class);
     }
 
     @Provides

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -48,10 +48,11 @@ import static org.gradle.util.internal.CollectionUtils.flattenCollections;
 
 public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer implements RepositoryHandlerInternal {
 
-    public static final String GRADLE_PLUGIN_PORTAL_REPO_NAME = "Gradle Central Plugin Repository";
-    public static final String GOOGLE_REPO_NAME = "Google";
+    private static final String GRADLE_DISTRIBUTION_REPO_NAME = "Gradle Distribution";
+    private static final String GRADLE_PLUGIN_PORTAL_REPO_NAME = "Gradle Central Plugin Repository";
+    private static final String GOOGLE_REPO_NAME = "Google";
 
-    public static final String FLAT_DIR_DEFAULT_NAME = "flatDir";
+    private static final String FLAT_DIR_DEFAULT_NAME = "flatDir";
     private static final String MAVEN_REPO_DEFAULT_NAME = "maven";
     private static final String IVY_REPO_DEFAULT_NAME = "ivy";
 
@@ -83,6 +84,11 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
             modifiedArgs.put("dirs", flattenCollections(modifiedArgs.get("dirs")));
         }
         return flatDir(new ConfigureByMapAction<>(modifiedArgs));
+    }
+
+    @Override
+    public ArtifactRepository gradleDistribution() {
+        return addRepository(repositoryFactory.createGradleDistributionRepository(), GRADLE_DISTRIBUTION_REPO_NAME);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -201,7 +201,9 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
             DefaultBuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> localResult = new DefaultBuildableModuleComponentMetaDataResolveResult<>();
             delegate.getLocalAccess().resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, localResult);
             if (localResult.hasResult()) {
-                localResult.applyTo(result, resolveStateFactory::stateFor);
+                localResult.applyTo(result, metadata ->
+                    resolveStateFactory.stateFor(attachRepositorySource(metadata))
+                );
                 return;
             }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/DistributionRepositoryDescriptor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/DistributionRepositoryDescriptor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.descriptor;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Descriptor for repositories that load components from Gradle distribution modules.
+ */
+@NullMarked
+public class DistributionRepositoryDescriptor extends RepositoryDescriptor {
+
+    public DistributionRepositoryDescriptor(String id, String name) {
+        super(id, name);
+    }
+
+    @Override
+    public Type getType() {
+        return Type.DISTRIBUTION;
+    }
+
+    @Override
+    protected void addProperties(ImmutableSortedMap.Builder<String, Object> builder) {
+
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/RepositoryDescriptor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/RepositoryDescriptor.java
@@ -32,7 +32,8 @@ public abstract class RepositoryDescriptor {
     public enum Type {
         MAVEN,
         IVY,
-        FLAT_DIR
+        FLAT_DIR,
+        DISTRIBUTION
     }
 
     private final String id;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/AvailableDistributionModules.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/AvailableDistributionModules.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.distribution;
+
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * All modules from the Gradle distribution that are available to depend on
+ * via dependency management.
+ */
+@ServiceScope(Scope.Global.class)
+public interface AvailableDistributionModules {
+
+    /**
+     * Get the distribution module identified by the given ID, or null
+     * if no module with that ID exists, or the distribution module with
+     * that ID is not available.
+     */
+    @Nullable AvailableModule getModule(ModuleComponentIdentifier id);
+
+    /**
+     * Get the version of the distribution module belonging to the module
+     * with the given ID, or null if no such available distribution module
+     * exists.
+     */
+    @Nullable String getModuleVersion(ModuleIdentifier moduleId);
+
+    /**
+     * A distribution module that is available to depend on by the user.
+     */
+    interface AvailableModule {
+
+        /**
+         * The internal name of the module.
+         */
+        String getName();
+
+        /**
+         * The public alias for the module. This is the ID that the user
+         * identifies this module with.
+         */
+        ModuleComponentIdentifier getId();
+
+        /**
+         * Get the classpath that implements this module.
+         */
+        ClassPath getImplementationClasspath();
+
+        /**
+         * Get all first-level modules that this module depends on.
+         */
+        List<AvailableModule> getDependencies();
+
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/DefaultAvailableDistributionModules.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/DefaultAvailableDistributionModules.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.distribution;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.DependencyClassPathProvider;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.internal.classpath.Module;
+import org.gradle.api.internal.classpath.ModuleRegistry;
+import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
+import org.jspecify.annotations.Nullable;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Default implementation of {@link AvailableDistributionModules}, which makes available
+ * a pre-determined set of top-level modules, plus their transitive dependencies.
+ */
+public class DefaultAvailableDistributionModules implements AvailableDistributionModules {
+
+    /**
+     * All top-level modules we have decided to allow users to depend on. All modules in this list,
+     * and all of their transitive dependencies, will be available to users via the Gradle
+     * distribution repository.
+     */
+    private static final List<String> EXPOSED_TOP_LEVEL_MODULES = ImmutableList.<String>builder()
+        .addAll(DependencyClassPathProvider.GROOVY_MODULES)
+        .build();
+
+    private final ImmutableMap<ModuleIdentifier, AvailableModule> availableModules;
+
+    @Inject
+    public DefaultAvailableDistributionModules(
+        ModuleRegistry moduleRegistry
+    ) {
+        this.availableModules = collectAvailableModules(moduleRegistry);
+    }
+
+    private static ImmutableMap<ModuleIdentifier, AvailableModule> collectAvailableModules(ModuleRegistry moduleRegistry) {
+        Iterable<Module> topLevelModules = Iterables.transform(EXPOSED_TOP_LEVEL_MODULES, moduleRegistry::getModule);
+
+        // Discover the transitive closure of all modules we will make available.
+        List<Module> allAccessibleModules = moduleRegistry.getRuntimeModules(topLevelModules);
+        ImmutableMap.Builder<String, Module> builder = ImmutableMap.builderWithExpectedSize(allAccessibleModules.size());
+        for (Module module : allAccessibleModules) {
+            builder.put(module.getName(), module);
+        }
+        ImmutableMap<String, Module> modulesByName = builder.build();
+
+        // Recursively build `AvailableModule` instances to expose.
+        Map<String, AvailableModule> availableModulesByName = new HashMap<>(allAccessibleModules.size());
+        for (String topLevelModuleName : EXPOSED_TOP_LEVEL_MODULES) {
+            getOrCreateModule(topLevelModuleName, modulesByName, availableModulesByName);
+        }
+
+        // Map each `AvailableModule` instance by their alias ID.
+        ImmutableMap.Builder<ModuleIdentifier, AvailableModule> availableModules = ImmutableMap.builderWithExpectedSize(availableModulesByName.size());
+        for (AvailableModule module : availableModulesByName.values()) {
+            availableModules.put(module.getId().getModuleIdentifier(), module);
+        }
+
+        return availableModules.build();
+    }
+
+    private static AvailableModule getOrCreateModule(
+        String name,
+        ImmutableMap<String, Module> modulesByName,
+        Map<String, AvailableModule> availableModulesByName
+    ) {
+        AvailableModule module = availableModulesByName.get(name);
+        if (module == null) {
+            module = doCreateAvailableModule(name, modulesByName, availableModulesByName);
+            availableModulesByName.put(name, module);
+        }
+        return module;
+    }
+
+    private static AvailableModule doCreateAvailableModule(
+        String name,
+        ImmutableMap<String, Module> modulesByName,
+        Map<String, AvailableModule> availableModulesByName
+    ) {
+        Module module = modulesByName.get(name);
+        Module.ModuleAlias alias = module.getAlias();
+        if (alias == null) {
+            throw new IllegalStateException("Module '" + name + "' has no alias");
+        }
+        ModuleComponentIdentifier id = toModuleVersionId(alias);
+
+        List<String> dependencyNames = module.getDependencyNames();
+        ImmutableList.Builder<AvailableModule> dependencies = ImmutableList.builderWithExpectedSize(dependencyNames.size());
+        for (String dependencyName : dependencyNames) {
+            dependencies.add(getOrCreateModule(dependencyName, modulesByName, availableModulesByName));
+        }
+
+        return new DefaultAvailableModule(
+            name,
+            id,
+            module.getImplementationClasspath(),
+            dependencies.build()
+        );
+    }
+
+    private static ModuleComponentIdentifier toModuleVersionId(Module.ModuleAlias alias) {
+        ModuleIdentifier moduleId = DefaultModuleIdentifier.newId(alias.getGroup(), alias.getName());
+        return DefaultModuleComponentIdentifier.newId(moduleId, alias.getVersion());
+    }
+
+    @Override
+    public @Nullable AvailableModule getModule(ModuleComponentIdentifier id) {
+        AvailableModule module = availableModules.get(id.getModuleIdentifier());
+        if (module != null && module.getId().getVersion().equals(id.getVersion())) {
+            return module;
+        }
+
+        return null;
+    }
+
+    @Override
+    public @Nullable String getModuleVersion(ModuleIdentifier moduleId) {
+        AvailableModule module = availableModules.get(moduleId);
+        if (module != null) {
+            return module.getId().getVersion();
+        }
+
+        return null;
+    }
+
+    /**
+     * Exposed so we can verify in tests that the list of available modules does not change,
+     * or that if it does, we are aware of the change.
+     */
+    @VisibleForTesting
+    public ImmutableCollection<ModuleComponentIdentifier> getAvailableModules() {
+        return availableModules.values().stream()
+            .map(AvailableModule::getId)
+            .collect(ImmutableList.toImmutableList());
+    }
+
+    private static class DefaultAvailableModule implements AvailableModule {
+
+        private final String name;
+        private final ModuleComponentIdentifier id;
+        private final ClassPath classpath;
+        private final List<AvailableModule> dependencies;
+
+        public DefaultAvailableModule(
+            String name,
+            ModuleComponentIdentifier id,
+            ClassPath classpath,
+            List<AvailableModule> dependencies
+        ) {
+            this.name = name;
+            this.id = id;
+            this.classpath = classpath;
+            this.dependencies = dependencies;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public ModuleComponentIdentifier getId() {
+            return id;
+        }
+
+        @Override
+        public ClassPath getImplementationClasspath() {
+            return classpath;
+        }
+
+        @Override
+        public List<AvailableModule> getDependencies() {
+            return dependencies;
+        }
+
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/DefaultAvailableDistributionModules.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/DefaultAvailableDistributionModules.java
@@ -47,7 +47,7 @@ public class DefaultAvailableDistributionModules implements AvailableDistributio
      * and all of their transitive dependencies, will be available to users via the Gradle
      * distribution repository.
      */
-    private static final List<String> EXPOSED_TOP_LEVEL_MODULES = ImmutableList.<String>builder()
+    private static final ImmutableList<String> EXPOSED_TOP_LEVEL_MODULES = ImmutableList.<String>builder()
         .addAll(DependencyClassPathProvider.GROOVY_MODULES)
         .build();
 
@@ -159,6 +159,15 @@ public class DefaultAvailableDistributionModules implements AvailableDistributio
         return availableModules.values().stream()
             .map(AvailableModule::getId)
             .collect(ImmutableList.toImmutableList());
+    }
+
+    @VisibleForTesting
+    public ImmutableCollection<ModuleComponentIdentifier> getTopLevelModules() {
+        return EXPOSED_TOP_LEVEL_MODULES.stream().map(x ->
+            availableModules.values().stream()
+                .filter(it -> it.getName().equals(x)).findFirst().get()
+                .getId()
+        ).collect(ImmutableList.toImmutableList());
     }
 
     private static class DefaultAvailableModule implements AvailableModule {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/GradleDistributionRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/GradleDistributionRepository.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.distribution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.api.internal.artifacts.NamedVariantIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepositoryAccess;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.artifacts.repositories.AbstractResolutionAwareArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.descriptor.DistributionRepositoryDescriptor;
+import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenVariantAttributesFactory;
+import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
+import org.gradle.api.internal.attributes.AttributesFactory;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
+import org.gradle.api.internal.component.ArtifactType;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.internal.action.InstantiatingAction;
+import org.gradle.internal.component.external.model.ComponentVariant;
+import org.gradle.internal.component.external.model.DefaultConfigurationMetadata;
+import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier;
+import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
+import org.gradle.internal.component.external.model.ExternalModuleVariantGraphResolveMetadata;
+import org.gradle.internal.component.external.model.GradleDependencyMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.NoOpDerivationStrategy;
+import org.gradle.internal.component.external.model.VariantDerivationStrategy;
+import org.gradle.internal.component.external.model.VariantMetadataRules;
+import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
+import org.gradle.internal.component.model.ComponentOverrideMetadata;
+import org.gradle.internal.component.model.DefaultIvyArtifactName;
+import org.gradle.internal.component.model.ImmutableModuleSources;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.ModuleConfigurationMetadata;
+import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.resolve.ModuleVersionResolveException;
+import org.gradle.internal.resolve.result.BuildableArtifactFileResolveResult;
+import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
+import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
+import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
+import org.gradle.util.GradleVersion;
+import org.jspecify.annotations.Nullable;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A repository that resolves components from Gradle distribution modules.
+ */
+public class GradleDistributionRepository extends AbstractResolutionAwareArtifactRepository<RepositoryDescriptor> {
+
+    private final InstantiatorFactory instantiatorFactory;
+    private final AvailableDistributionModules availableModules;
+    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
+    private final MavenVariantAttributesFactory mavenAttributesFactory;
+
+    public GradleDistributionRepository(
+        ObjectFactory objectFactory,
+        VersionParser versionParser,
+        InstantiatorFactory instantiatorFactory,
+        AvailableDistributionModules availableModules,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+        MavenVariantAttributesFactory mavenAttributesFactory
+    ) {
+        super(objectFactory, versionParser);
+        this.instantiatorFactory = instantiatorFactory;
+        this.availableModules = availableModules;
+        this.moduleIdentifierFactory = moduleIdentifierFactory;
+        this.mavenAttributesFactory = mavenAttributesFactory;
+    }
+
+    @Override
+    protected RepositoryDescriptor createDescriptor() {
+        String id = GradleVersion.current().getVersion();
+        return new DistributionRepositoryDescriptor(id, getName());
+    }
+
+    @Override
+    public ConfiguredModuleComponentRepository createResolver() {
+        return new DistributionModuleComponentRepository(
+            getDescriptor(),
+            instantiatorFactory.inject(),
+            availableModules,
+            moduleIdentifierFactory,
+            mavenAttributesFactory
+        );
+    }
+
+    private static class DistributionModuleComponentRepository implements ConfiguredModuleComponentRepository {
+
+        private final RepositoryDescriptor descriptor;
+        private final Instantiator instantiator;
+        private final ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> repositoryAccess;
+
+        public DistributionModuleComponentRepository(
+            RepositoryDescriptor descriptor,
+            Instantiator instantiator,
+            AvailableDistributionModules availableModules,
+            ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+            MavenVariantAttributesFactory mavenAttributesFactory
+        ) {
+            this.descriptor = descriptor;
+            this.instantiator = instantiator;
+            this.repositoryAccess = new DistributionRepositoryAccess(availableModules, moduleIdentifierFactory, mavenAttributesFactory);
+        }
+
+        @Override
+        public boolean isDynamicResolveMode() {
+            return false;
+        }
+
+        @Override
+        public boolean isLocal() {
+            return true;
+        }
+
+        @Override
+        public void setComponentResolvers(ComponentResolvers resolver) {
+            // Ignore, we don't need to resolve any additional components.
+        }
+
+        @Override
+        public Instantiator getComponentMetadataInstantiator() {
+            return instantiator;
+        }
+
+        @Override
+        public String getId() {
+            return descriptor.getId();
+        }
+
+        @Override
+        public String getName() {
+            return descriptor.getName();
+        }
+
+        @Override
+        public ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> getLocalAccess() {
+            return repositoryAccess;
+        }
+
+        @Override
+        public ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> getRemoteAccess() {
+            return repositoryAccess;
+        }
+
+        @Override
+        public Map<ComponentArtifactIdentifier, ResolvableArtifact> getArtifactCache() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @Nullable InstantiatingAction<ComponentMetadataSupplierDetails> getComponentMetadataSupplier() {
+            return null;
+        }
+
+        @Override
+        public boolean isContinueOnConnectionFailure() {
+            return false;
+        }
+
+        @Override
+        public boolean isRepositoryDisabled() {
+            return false;
+        }
+
+    }
+
+    private static class DistributionRepositoryAccess implements ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> {
+
+        private final AvailableDistributionModules availableModules;
+        private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
+        private final MavenVariantAttributesFactory mavenAttributeFactory;
+
+        public DistributionRepositoryAccess(
+            AvailableDistributionModules availableModules,
+            ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+            MavenVariantAttributesFactory mavenAttributeFactory
+        ) {
+            this.availableModules = availableModules;
+            this.moduleIdentifierFactory = moduleIdentifierFactory;
+            this.mavenAttributeFactory = mavenAttributeFactory;
+        }
+
+        @Override
+        public void listModuleVersions(ModuleComponentSelector selector, ComponentOverrideMetadata overrideMetadata, BuildableModuleVersionListingResolveResult result) {
+            String version = availableModules.getModuleVersion(selector.getModuleIdentifier());
+            if (version != null) {
+                result.listed(Collections.singletonList(version));
+            } else {
+                result.failed(new ModuleVersionResolveException(selector, () -> String.format("No module available for '%s'.", selector)));
+            }
+        }
+
+        @Override
+        public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
+            AvailableDistributionModules.AvailableModule module = availableModules.getModule(moduleComponentIdentifier);
+            if (module == null) {
+                // The distribution does not provide this dependency, or we do not expose it.
+                result.missing();
+                return;
+            }
+
+            if (requestMetaData.getArtifact() != null) {
+                throw new UnsupportedOperationException("Cannot request explicit artifact from distribution repository.");
+            }
+
+            ModuleVersionIdentifier moduleVersionId = moduleIdentifierFactory.moduleWithVersion(moduleComponentIdentifier.getModuleIdentifier(), moduleComponentIdentifier.getVersion());
+            result.resolved(new DistributionModuleComponentResolveMetadata(moduleComponentIdentifier, moduleVersionId, module, ImmutableModuleSources.of(), mavenAttributeFactory));
+        }
+
+        @Override
+        public void resolveArtifactsWithType(ComponentArtifactResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
+            // This is a legacy resolution mechanism.
+            // Distribution repositories should never support this.
+        }
+
+        @Override
+        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactFileResolveResult result) {
+            if (!(artifact.getId() instanceof DistributionFileArtifactIdentifier)) {
+                return;
+            }
+            result.resolved(((DistributionFileArtifactIdentifier) artifact.getId()).getFile());
+        }
+
+        @Override
+        public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+            if (availableModules.getModule(moduleComponentIdentifier) != null) {
+                return MetadataFetchingCost.FAST;
+            } else {
+                return MetadataFetchingCost.CHEAP;
+            }
+        }
+
+    }
+
+    /**
+     * Metadata for a component derived from a {@link AvailableDistributionModules.AvailableModule module} of a Gradle distribution.
+     */
+    private static class DistributionModuleComponentResolveMetadata implements ModuleComponentResolveMetadata {
+
+        private final ModuleComponentIdentifier id;
+        private final ModuleVersionIdentifier moduleVersionId;
+        private final AvailableDistributionModules.AvailableModule module;
+        private final ModuleSources sources;
+        private final MavenVariantAttributesFactory mavenAttributesFactory;
+
+        public DistributionModuleComponentResolveMetadata(
+            ModuleComponentIdentifier id,
+            ModuleVersionIdentifier moduleVersionId,
+            AvailableDistributionModules.AvailableModule module,
+            ModuleSources sources,
+            MavenVariantAttributesFactory mavenAttributesFactory
+        ) {
+            this.id = id;
+            this.moduleVersionId = moduleVersionId;
+            this.module = module;
+            this.sources = sources;
+            this.mavenAttributesFactory = mavenAttributesFactory;
+        }
+
+        @Override
+        public ModuleComponentIdentifier getId() {
+            return id;
+        }
+
+        @Override
+        public MutableModuleComponentResolveMetadata asMutable() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ModuleComponentResolveMetadata withSources(ModuleSources sources) {
+            return new DistributionModuleComponentResolveMetadata(id, moduleVersionId, module, sources, mavenAttributesFactory);
+        }
+
+        @Override
+        public ModuleComponentResolveMetadata withDerivationStrategy(VariantDerivationStrategy derivationStrategy) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @Nullable ModuleConfigurationMetadata getConfiguration(String name) {
+            return null;
+        }
+
+        @Override
+        public ImmutableList<? extends ComponentVariant> getVariants() {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public @Nullable AttributesFactory getAttributesFactory() {
+            return null;
+        }
+
+        @Override
+        public VariantMetadataRules getVariantMetadataRules() {
+            return VariantMetadataRules.noOp();
+        }
+
+        @Override
+        public VariantDerivationStrategy getVariantDerivationStrategy() {
+            return NoOpDerivationStrategy.getInstance();
+        }
+
+        @Override
+        public boolean isExternalVariant() {
+            return false;
+        }
+
+        @Override
+        public boolean isComponentMetadataRuleCachingEnabled() {
+            return false;
+        }
+
+        @Override
+        public ModuleVersionIdentifier getModuleVersionId() {
+            return moduleVersionId;
+        }
+
+        @Override
+        public ModuleSources getSources() {
+            return sources;
+        }
+
+        @Override
+        public ImmutableAttributesSchema getAttributesSchema() {
+            return ImmutableAttributesSchema.EMPTY;
+        }
+
+        @Override
+        public boolean isMissing() {
+            return false;
+        }
+
+        @Override
+        public boolean isChanging() {
+            return false;
+        }
+
+        @Override
+        public @Nullable String getStatus() {
+            return null;
+        }
+
+        @Override
+        public @Nullable List<String> getStatusScheme() {
+            return null;
+        }
+
+        @Override
+        public ImmutableList<? extends VirtualComponentIdentifier> getPlatformOwners() {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public ImmutableAttributes getAttributes() {
+            return ImmutableAttributes.EMPTY;
+        }
+
+        @Override
+        public List<? extends ExternalModuleVariantGraphResolveMetadata> getVariantsForGraphTraversal() {
+            return ImmutableList.of(getRuntimeVariant());
+        }
+
+        private DefaultConfigurationMetadata getRuntimeVariant() {
+            List<File> classpath = module.getImplementationClasspath().getAsFiles();
+            ImmutableList.Builder<ModuleComponentArtifactMetadata> artifacts = ImmutableList.builderWithExpectedSize(classpath.size());
+            for (File file : classpath) {
+                IvyArtifactName ivyArtifactName = new DefaultIvyArtifactName(module.getId().getModule(), "jar", "jar");
+                artifacts.add(new DefaultModuleComponentArtifactMetadata(new DistributionFileArtifactIdentifier(getId(), ivyArtifactName, module.getName(), file)));
+            }
+
+            List<AvailableDistributionModules.AvailableModule> dependencyModules = module.getDependencies();
+            ImmutableList.Builder<ModuleDependencyMetadata> dependencies = ImmutableList.builderWithExpectedSize(dependencyModules.size());
+            for (AvailableDistributionModules.AvailableModule dependency : dependencyModules) {
+                ModuleComponentIdentifier dependencyId = dependency.getId();
+                dependencies.add(new GradleDependencyMetadata(
+                    DefaultModuleComponentSelector.newSelector(dependencyId.getModuleIdentifier(), dependencyId.getVersion()),
+                    ImmutableList.of(),
+                    false,
+                    false,
+                    null,
+                    false,
+                    null
+                ));
+            }
+
+            String name = "runtime";
+            DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(
+                name,
+                new NamedVariantIdentifier(getId(), name),
+                getId(),
+                true,
+                false,
+                ImmutableSet.of(),
+                artifacts.build(),
+                getVariantMetadataRules(),
+                ImmutableList.of(),
+                mavenAttributesFactory.runtimeScope(ImmutableAttributes.EMPTY),
+                false
+            );
+            configuration.setDependencies(dependencies.build());
+            return configuration;
+        }
+
+        @Override
+        public Set<String> getConfigurationNames() {
+            return ImmutableSet.of();
+        }
+
+    }
+
+    /**
+     * Metadata for an artifact belonging to a distribution module.
+     */
+    private static class DistributionFileArtifactIdentifier extends DefaultModuleComponentArtifactIdentifier {
+
+        private final String moduleName;
+        private final File file;
+
+        public DistributionFileArtifactIdentifier(ModuleComponentIdentifier componentId, IvyArtifactName ivyArtifactName, String moduleName, File file) {
+            super(componentId, ivyArtifactName);
+            this.moduleName = moduleName;
+            this.file = file;
+        }
+
+        public File getFile() {
+            return file;
+        }
+
+        @Override
+        public String getFileName() {
+            return file.getName();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return moduleName + " " + file.getName();
+        }
+
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/GradleDistributionRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/GradleDistributionRepository.java
@@ -74,6 +74,7 @@ import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveRe
 import org.gradle.util.GradleVersion;
 import org.jspecify.annotations.Nullable;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -90,6 +91,7 @@ public class GradleDistributionRepository extends AbstractResolutionAwareArtifac
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final MavenVariantAttributesFactory mavenAttributesFactory;
 
+    @Inject
     public GradleDistributionRepository(
         ObjectFactory objectFactory,
         VersionParser versionParser,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/package-info.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/distribution/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Defines a repository that loads components from modules in a Gradle distribution.
+ */
+@NullMarked
+package org.gradle.api.internal.artifacts.repositories.distribution;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -25,11 +25,8 @@ import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.immutable.ImmutableAttributesSchema;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.ImmutableModuleSources;
-import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleSources;
-import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -163,18 +160,6 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     @Override
     public ImmutableList<? extends ComponentVariant> getVariants() {
         return variants;
-    }
-
-    @Override
-    public ModuleComponentArtifactMetadata artifact(String type, @Nullable String extension, @Nullable String classifier) {
-        IvyArtifactName ivyArtifactName = new DefaultIvyArtifactName(getModuleVersionId().getName(), type, extension, classifier);
-        return new DefaultModuleComponentArtifactMetadata(getId(), ivyArtifactName);
-    }
-
-    @Override
-    public ModuleComponentArtifactMetadata optionalArtifact(String type, @Nullable String extension, @Nullable String classifier) {
-        IvyArtifactName ivyArtifactName = new DefaultIvyArtifactName(getModuleVersionId().getName(), type, extension, classifier);
-        return new ModuleComponentOptionalArtifactMetadata(getId(), ivyArtifactName);
     }
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentGraphResolveStateFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentGraphResolveStateFactory.java
@@ -19,7 +19,6 @@ package org.gradle.internal.component.external.model;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.internal.component.external.model.ivy.DefaultIvyComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
-import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata;
 import org.gradle.internal.component.model.ComponentIdGenerator;
 import org.gradle.internal.component.model.DefaultExternalModuleComponentGraphResolveState;
 import org.gradle.internal.service.scopes.Scope;
@@ -39,11 +38,9 @@ public class ModuleComponentGraphResolveStateFactory {
         if (metadata instanceof IvyModuleResolveMetadata) {
             IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metadata;
             return new DefaultIvyComponentGraphResolveState(idGenerator.nextComponentId(), ivyMetadata, attributeDesugaring, idGenerator);
-        } else if (metadata instanceof MavenModuleResolveMetadata) {
-            return new DefaultExternalModuleComponentGraphResolveState<>(idGenerator.nextComponentId(), metadata, metadata, attributeDesugaring, idGenerator);
         }
 
-        throw new IllegalArgumentException("Unsupported module component metadata type: " + metadata);
+        return new DefaultExternalModuleComponentGraphResolveState<>(idGenerator.nextComponentId(), metadata, metadata, attributeDesugaring, idGenerator);
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetadata.java
@@ -20,6 +20,8 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
+import org.gradle.internal.component.model.DefaultIvyArtifactName;
+import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSources;
 import org.jspecify.annotations.Nullable;
@@ -65,9 +67,15 @@ public interface ModuleComponentResolveMetadata extends ExternalComponentResolve
     /**
      * Creates an artifact for this module. Does not mutate this metadata.
      */
-    ModuleComponentArtifactMetadata artifact(String type, @Nullable String extension, @Nullable String classifier);
+    default ModuleComponentArtifactMetadata artifact(String type, @Nullable String extension, @Nullable String classifier)  {
+        IvyArtifactName ivyArtifactName = new DefaultIvyArtifactName(getModuleVersionId().getName(), type, extension, classifier);
+        return new DefaultModuleComponentArtifactMetadata(getId(), ivyArtifactName);
+    }
 
-    ModuleComponentArtifactMetadata optionalArtifact(String type, @Nullable String extension, @Nullable String classifier);
+    default ModuleComponentArtifactMetadata optionalArtifact(String type, @Nullable String extension, @Nullable String classifier) {
+        IvyArtifactName ivyArtifactName = new DefaultIvyArtifactName(getModuleVersionId().getName(), type, extension, classifier);
+        return new ModuleComponentOptionalArtifactMetadata(getId(), ivyArtifactName);
+    }
 
     /**
      * Returns the variants of this component

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -26,8 +26,11 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModu
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator
+import org.gradle.api.internal.artifacts.repositories.distribution.AvailableDistributionModules
+import org.gradle.api.internal.artifacts.repositories.distribution.GradleDistributionRepository
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenVariantAttributesFactory
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileResolver
@@ -43,6 +46,7 @@ import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class DefaultBaseRepositoryFactoryTest extends Specification {
+
     final LocalMavenRepositoryLocator localMavenRepoLocator = Mock()
     final FileResolver fileResolver = Mock()
     final FileCollectionFactory fileCollectionFactory = Mock()
@@ -61,13 +65,31 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
     final ProviderFactory providerFactory = Mock()
 
     final DefaultBaseRepositoryFactory factory = new DefaultBaseRepositoryFactory(
-            localMavenRepoLocator, fileResolver, fileCollectionFactory, transportFactory, locallyAvailableResourceFinder,
-            artifactIdentifierFileStore, externalResourceFileStore, pomParser, metadataParser, authenticationSchemeRegistry, ivyContextManager, moduleIdentifierFactory,
-            TestUtil.instantiatorFactory(), Mock(FileResourceRepository), mavenMetadataFactory, ivyMetadataFactory, SnapshotTestUtil.isolatableFactory(), TestUtil.objectFactory(),
-            CollectionCallbackActionDecorator.NOOP,
-            urlArtifactRepositoryFactory,
-            TestUtil.checksumService,
-            providerFactory, new VersionParser()
+        localMavenRepoLocator,
+        fileResolver,
+        fileCollectionFactory,
+        transportFactory,
+        locallyAvailableResourceFinder,
+        artifactIdentifierFileStore,
+        externalResourceFileStore,
+        pomParser,
+        metadataParser,
+        authenticationSchemeRegistry,
+        ivyContextManager,
+        moduleIdentifierFactory,
+        TestUtil.instantiatorFactory(),
+        Mock(FileResourceRepository),
+        mavenMetadataFactory,
+        ivyMetadataFactory,
+        SnapshotTestUtil.isolatableFactory(),
+        TestUtil.objectFactory(),
+        CollectionCallbackActionDecorator.NOOP,
+        urlArtifactRepositoryFactory,
+        TestUtil.checksumService,
+        providerFactory,
+        new VersionParser(),
+        Stub(AvailableDistributionModules),
+        Stub(MavenVariantAttributesFactory)
     )
 
     def testCreateFlatDirResolver() {
@@ -141,4 +163,13 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
         def repo = factory.createMavenRepository()
         repo instanceof DefaultMavenArtifactRepository
     }
+
+    def "creates distribution repository"() {
+        when:
+        def repo = factory.createGradleDistributionRepository()
+
+        then:
+        repo instanceof GradleDistributionRepository
+    }
+
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -20,6 +20,7 @@ import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
 import groovy.transform.stc.SimpleType;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ArtifactRepositoryContainer;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.ExclusiveContentRepository;
@@ -94,6 +95,16 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      */
     @HiddenInDefinition
     FlatDirectoryArtifactRepository flatDir(Action<? super FlatDirectoryArtifactRepository> action);
+
+    /**
+     * Adds a repository that resolves dependencies from the Gradle distribution.
+     *
+     * @return The Gradle distribution repository.
+     *
+     * @since 9.4.0
+     */
+    @Incubating
+    ArtifactRepository gradleDistribution();
 
     /**
      * Adds a repository which looks in Gradle Central Plugin Repository for dependencies.


### PR DESCRIPTION
This repository allows users to resolve select dependencies from the gradle distribution. This is intended as a replacement for the existing localGroovy dependency, and will eventually be used to provide a local copy of the new gradle public api jar

Related: https://github.com/gradle/gradle/issues/29049

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
