### PR TITLE
Increase timeout for Linux DocsTest

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/DocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/DocsTest.kt
@@ -91,7 +91,7 @@ class DocsTest(
             "docs:docsTest docs:checkSamples",
             os = os,
             arch = os.defaultArch,
-            timeout = if (os == Os.WINDOWS) 90 else 60,
+            timeout = if (os == Os.WINDOWS || os == Os.LINUX) 90 else 60,
             extraParameters =
                 listOf(
                     buildScanTagParam(docsTestType.docsTestName),


### PR DESCRIPTION
While we are investigating https://github.com/gradle/gradle-private/issues/4994, increase timeout to 90m to unblock merge.