### PR TITLE
Adds RFC9457 problem details to dependency management

### DIFF
--- a/platforms/software/resources-http/build.gradle.kts
+++ b/platforms/software/resources-http/build.gradle.kts
@@ -21,18 +21,17 @@ dependencies {
     implementation(projects.hashing)
     implementation(projects.loggingApi)
 
-    // Jackson for RFC9457 JSON parsing
-    implementation(libs.jacksonCore)
-    implementation(libs.jacksonDatabind)
-
     implementation(libs.commonsIo)
     implementation(libs.commonsLang)
+    implementation(libs.jacksonDatabind)
     implementation(libs.jcifs)
     implementation(libs.jsoup)
     implementation(libs.slf4jApi)
 
     runtimeOnly(projects.core)
     runtimeOnly(projects.coreApi)
+
+    runtimeOnly(libs.jacksonCore)
 
     testImplementation(projects.internalIntegTesting)
     testImplementation(testFixtures(projects.core))

--- a/platforms/software/resources-http/build.gradle.kts
+++ b/platforms/software/resources-http/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
     implementation(projects.hashing)
     implementation(projects.loggingApi)
 
+    // Jackson for RFC9457 JSON parsing
+    implementation(libs.jacksonCore)
+    implementation(libs.jacksonDatabind)
+
     implementation(libs.commonsIo)
     implementation(libs.commonsLang)
     implementation(libs.jcifs)

--- a/platforms/software/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/Rfc9457ErrorDetailIntegrationTest.groovy
+++ b/platforms/software/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/Rfc9457ErrorDetailIntegrationTest.groovy
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http
+
+import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.test.fixtures.server.http.HttpServer
+import org.junit.Rule
+import spock.lang.Specification
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Integration tests for RFC 9457 Problem Details support in HTTP error handling.
+ * Tests that HttpClientHelper correctly extracts and uses detailed error messages
+ * from repositories that support RFC 9457 (e.g., Nexus Repository Manager 3.75+).
+ */
+class Rfc9457ErrorDetailIntegrationTest extends Specification {
+
+    @Rule
+    HttpServer httpServer = new HttpServer()
+    SslContextFactory sslContextFactory = new DefaultSslContextFactory()
+    HttpSettings settings = DefaultHttpSettings.builder()
+        .withAuthenticationSettings([])
+        .withSslContextFactory(sslContextFactory)
+        .withRedirectVerifier({})
+        .build()
+    HttpClientHelper client = new HttpClientHelper(new DocumentationRegistry(), settings)
+
+    def "uses title field when detail is missing from RFC 9457 response"() {
+        given:
+        httpServer.start()
+        def rfc9457Json = '''
+        {
+            "type": "about:blank",
+            "title": "Artifact Quarantined",
+            "status": 403
+        }
+        '''
+        httpServer.expect("/artifact.jar", ['GET'],
+            new Rfc9457ErrorAction(403, rfc9457Json))
+
+        when:
+        client.performGet("${httpServer.address}/artifact.jar", false)
+
+        then:
+        HttpErrorStatusCodeException e = thrown()
+        e.statusCode == 403
+        e.message.contains("Artifact Quarantined")
+    }
+
+    def "handles RFC 9457 response with charset in content-type"() {
+        given:
+        httpServer.start()
+        def rfc9457Json = '''
+        {
+            "detail": "Repository policy violation: artifact contains known vulnerabilities"
+        }
+        '''
+        httpServer.expect("/artifact.jar", ['GET'],
+            new Rfc9457ErrorAction(403, rfc9457Json, "application/problem+json; charset=utf-8"))
+
+        when:
+        client.performGet("${httpServer.address}/artifact.jar", false)
+
+        then:
+        HttpErrorStatusCodeException e = thrown()
+        e.statusCode == 403
+        e.message.contains("Repository policy violation: artifact contains known vulnerabilities")
+    }
+
+    def "handles RFC 9457 response with all standard fields"() {
+        given:
+        httpServer.start()
+        def rfc9457Json = '''
+        {
+            "type": "https://example.com/problems/license-violation",
+            "title": "License Policy Violation",
+            "status": 451,
+            "detail": "The artifact com.example:my-library:1.0.0 violates the organization's license policy (GPL license not allowed)",
+            "instance": "/repository/maven-central/com/example/my-library/1.0.0/my-library-1.0.0.jar"
+        }
+        '''
+        httpServer.expect("/artifact.jar", ['GET'],
+            new Rfc9457ErrorAction(451, rfc9457Json))
+
+        when:
+        client.performGet("${httpServer.address}/artifact.jar", false)
+
+        then:
+        HttpErrorStatusCodeException e = thrown()
+        e.statusCode == 451
+        e.message.contains("The artifact com.example:my-library:1.0.0 violates the organization's license policy (GPL license not allowed)")
+    }
+
+    def "falls back to reason phrase for non-RFC 9457 responses"() {
+        given:
+        httpServer.start()
+        httpServer.expect("/artifact.jar", ['GET'],
+            new NonRfc9457ErrorAction(403))
+
+        when:
+        client.performGet("${httpServer.address}/artifact.jar", false)
+
+        then:
+        HttpErrorStatusCodeException e = thrown()
+        e.statusCode == 403
+        e.message.contains("Forbidden")
+    }
+
+    def "handles RFC 9457 response with invalid JSON gracefully"() {
+        given:
+        httpServer.start()
+        def invalidJson = '{"detail": "Missing closing brace"'
+        httpServer.expect("/artifact.jar", ['GET'],
+            new Rfc9457ErrorAction(500, invalidJson))
+
+        when:
+        client.performGet("${httpServer.address}/artifact.jar", false)
+
+        then:
+        HttpErrorStatusCodeException e = thrown()
+        e.statusCode == 500
+        // Should fall back to reason phrase or empty string
+        e.message.contains("Could not GET")
+    }
+
+    def "test built-in broken response"() {
+        given:
+        httpServer.start()
+        httpServer.expectGetBroken("/test.jar")
+
+        when:
+        client.performGet("${httpServer.address}/test.jar", false)
+
+        then:
+        HttpErrorStatusCodeException e = thrown()
+        e.statusCode == 500
+    }
+
+    def "handles RFC 9457 response with empty JSON object"() {
+        given:
+        httpServer.start()
+        def emptyJson = '{}'
+        httpServer.expect("/artifact.jar", ['GET'],
+            new Rfc9457ErrorAction(403, emptyJson))
+
+        when:
+        client.performGet("${httpServer.address}/artifact.jar", false)
+
+        then:
+        HttpErrorStatusCodeException e = thrown()
+        e.statusCode == 403
+        // Should fall back to reason phrase or empty string
+        e.message.contains("Could not GET")
+    }
+}
+
+/**
+ * Action that returns an RFC 9457 Problem Details JSON response.
+ */
+class Rfc9457ErrorAction extends HttpServer.ActionSupport {
+    private final int statusCode
+    private final String jsonBody
+    private final String contentType
+
+    Rfc9457ErrorAction(int statusCode, String jsonBody, String contentType = "application/problem+json") {
+        super("Return RFC 9457 error with status ${statusCode}")
+        this.statusCode = statusCode
+        this.jsonBody = jsonBody
+        this.contentType = contentType
+    }
+
+    @Override
+    void handle(HttpServletRequest request, HttpServletResponse response) {
+        response.setStatus(statusCode)
+        response.setContentType(contentType)
+        response.setCharacterEncoding("utf-8")
+        byte[] bodyBytes = jsonBody.getBytes("UTF-8")
+        response.setContentLength(bodyBytes.length)
+        response.outputStream.write(bodyBytes)
+        response.outputStream.flush()
+    }
+}
+
+/**
+ * Action that returns a non-RFC 9457 error response (traditional HTML error).
+ */
+class NonRfc9457ErrorAction extends HttpServer.ActionSupport {
+    private final int statusCode
+
+    NonRfc9457ErrorAction(int statusCode) {
+        super("Return non-RFC 9457 error with status ${statusCode}")
+        this.statusCode = statusCode
+    }
+
+    @Override
+    void handle(HttpServletRequest request, HttpServletResponse response) {
+        response.setStatus(statusCode)
+    }
+}

--- a/platforms/software/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/Rfc9457ErrorDetailIntegrationTest.groovy
+++ b/platforms/software/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/Rfc9457ErrorDetailIntegrationTest.groovy
@@ -16,46 +16,48 @@
 
 package org.gradle.internal.resource.transport.http
 
+import com.google.common.collect.ImmutableMap
+import org.apache.http.impl.client.HttpClientBuilder
 import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.test.fixtures.server.http.HttpRequest
+import org.gradle.test.fixtures.server.http.HttpResponse
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.junit.Rule
 import spock.lang.Specification
 
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
-
 /**
  * Integration tests for RFC 9457 Problem Details support in HTTP error handling.
- * Tests that HttpClientHelper correctly extracts and uses detailed error messages
+ * Tests that ApacheCommonsHttpClient correctly extracts and uses detailed error messages
  * from repositories that support RFC 9457 (e.g., Nexus Repository Manager 3.75+).
  */
 class Rfc9457ErrorDetailIntegrationTest extends Specification {
-
     @Rule
-    HttpServer httpServer = new HttpServer()
-    SslContextFactory sslContextFactory = new DefaultSslContextFactory()
-    HttpSettings settings = DefaultHttpSettings.builder()
+    private HttpServer httpServer = new HttpServer()
+    private sslContextFactory = new DefaultSslContextFactory()
+    private settings = DefaultHttpSettings.builder()
         .withAuthenticationSettings([])
         .withSslContextFactory(sslContextFactory)
         .withRedirectVerifier({})
         .build()
-    HttpClientHelper client = new HttpClientHelper(new DocumentationRegistry(), settings)
+    private client = new ApacheCommonsHttpClient(new DocumentationRegistry(), settings, () -> HttpClientBuilder.create())
+
+    def setup() {
+        httpServer.start()
+    }
 
     def "uses title field when detail is missing from RFC 9457 response"() {
         given:
-        httpServer.start()
         def rfc9457Json = '''
-        {
-            "type": "about:blank",
-            "title": "Artifact Quarantined",
-            "status": 403
-        }
+            {
+                "type": "about:blank",
+                "title": "Artifact Quarantined",
+                "status": 403
+            }
         '''
-        httpServer.expect("/artifact.jar", ['GET'],
-            new Rfc9457ErrorAction(403, rfc9457Json))
+        httpServer.expect("/artifact.jar", ['GET'], new Rfc9457ErrorAction(403, rfc9457Json))
 
         when:
-        client.performGet("${httpServer.address}/artifact.jar", false)
+        client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
         HttpErrorStatusCodeException e = thrown()
@@ -65,17 +67,15 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
 
     def "handles RFC 9457 response with charset in content-type"() {
         given:
-        httpServer.start()
         def rfc9457Json = '''
-        {
-            "detail": "Repository policy violation: artifact contains known vulnerabilities"
-        }
+            {
+                "detail": "Repository policy violation: artifact contains known vulnerabilities"
+            }
         '''
-        httpServer.expect("/artifact.jar", ['GET'],
-            new Rfc9457ErrorAction(403, rfc9457Json, "application/problem+json; charset=utf-8"))
+        httpServer.expect("/artifact.jar", ['GET'], new Rfc9457ErrorAction(403, rfc9457Json, "application/problem+json; charset=utf-8"))
 
         when:
-        client.performGet("${httpServer.address}/artifact.jar", false)
+        client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
         HttpErrorStatusCodeException e = thrown()
@@ -85,21 +85,19 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
 
     def "handles RFC 9457 response with all standard fields"() {
         given:
-        httpServer.start()
         def rfc9457Json = '''
-        {
-            "type": "https://example.com/problems/license-violation",
-            "title": "License Policy Violation",
-            "status": 451,
-            "detail": "The artifact com.example:my-library:1.0.0 violates the organization's license policy (GPL license not allowed)",
-            "instance": "/repository/maven-central/com/example/my-library/1.0.0/my-library-1.0.0.jar"
-        }
+            {
+                "type": "https://example.com/problems/license-violation",
+                "title": "License Policy Violation",
+                "status": 451,
+                "detail": "The artifact com.example:my-library:1.0.0 violates the organization's license policy (GPL license not allowed)",
+                "instance": "/repository/maven-central/com/example/my-library/1.0.0/my-library-1.0.0.jar"
+            }
         '''
-        httpServer.expect("/artifact.jar", ['GET'],
-            new Rfc9457ErrorAction(451, rfc9457Json))
+        httpServer.expect("/artifact.jar", ['GET'], new Rfc9457ErrorAction(451, rfc9457Json))
 
         when:
-        client.performGet("${httpServer.address}/artifact.jar", false)
+        client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
         HttpErrorStatusCodeException e = thrown()
@@ -109,12 +107,10 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
 
     def "falls back to reason phrase for non-RFC 9457 responses"() {
         given:
-        httpServer.start()
-        httpServer.expect("/artifact.jar", ['GET'],
-            new NonRfc9457ErrorAction(403))
+        httpServer.expect("/artifact.jar", ['GET'], new NonRfc9457ErrorAction(403))
 
         when:
-        client.performGet("${httpServer.address}/artifact.jar", false)
+        client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
         HttpErrorStatusCodeException e = thrown()
@@ -124,92 +120,93 @@ class Rfc9457ErrorDetailIntegrationTest extends Specification {
 
     def "handles RFC 9457 response with invalid JSON gracefully"() {
         given:
-        httpServer.start()
         def invalidJson = '{"detail": "Missing closing brace"'
-        httpServer.expect("/artifact.jar", ['GET'],
-            new Rfc9457ErrorAction(500, invalidJson))
+        httpServer.expect("/artifact.jar", ['GET'], new Rfc9457ErrorAction(500, invalidJson))
 
         when:
-        client.performGet("${httpServer.address}/artifact.jar", false)
+        client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
         HttpErrorStatusCodeException e = thrown()
         e.statusCode == 500
-        // Should fall back to reason phrase or empty string
+
+        and: "should fall back to reason phrase or empty string"
         e.message.contains("Could not GET")
     }
 
-    def "test built-in broken response"() {
+    def "5xx responses without RFC9457 body still produce a server-error exception"() {
         given:
-        httpServer.start()
-        httpServer.expectGetBroken("/test.jar")
+        httpServer.expect("/broken.jar", ['GET'], new NonRfc9457ErrorAction(500))
 
         when:
-        client.performGet("${httpServer.address}/test.jar", false)
+        client.performGet(URI.create("${httpServer.address}/broken.jar"), ImmutableMap.of())
 
         then:
         HttpErrorStatusCodeException e = thrown()
         e.statusCode == 500
+        e.serverError
+        e.message.contains("Could not GET")
+        e.message.contains("500")
     }
 
     def "handles RFC 9457 response with empty JSON object"() {
         given:
-        httpServer.start()
         def emptyJson = '{}'
-        httpServer.expect("/artifact.jar", ['GET'],
-            new Rfc9457ErrorAction(403, emptyJson))
+        httpServer.expect("/artifact.jar", ['GET'], new Rfc9457ErrorAction(403, emptyJson))
 
         when:
-        client.performGet("${httpServer.address}/artifact.jar", false)
+        client.performGet(URI.create("${httpServer.address}/artifact.jar"), ImmutableMap.of())
 
         then:
         HttpErrorStatusCodeException e = thrown()
         e.statusCode == 403
-        // Should fall back to reason phrase or empty string
+
+        and: "should fall back to reason phrase or empty string"
         e.message.contains("Could not GET")
     }
-}
 
-/**
- * Action that returns an RFC 9457 Problem Details JSON response.
- */
-class Rfc9457ErrorAction extends HttpServer.ActionSupport {
-    private final int statusCode
-    private final String jsonBody
-    private final String contentType
+    /**
+     * Action that returns an RFC 9457 Problem Details JSON response.
+     */
+    @SuppressWarnings('GroovyAccessibility')
+    private static class Rfc9457ErrorAction extends HttpServer.ActionSupport {
+        private final int statusCode
+        private final String jsonBody
+        private final String contentType
 
-    Rfc9457ErrorAction(int statusCode, String jsonBody, String contentType = "application/problem+json") {
-        super("Return RFC 9457 error with status ${statusCode}")
-        this.statusCode = statusCode
-        this.jsonBody = jsonBody
-        this.contentType = contentType
+        Rfc9457ErrorAction(int statusCode, String jsonBody, String contentType = "application/problem+json") {
+            super("Return RFC 9457 error with status ${statusCode}")
+            this.statusCode = statusCode
+            this.jsonBody = jsonBody
+            this.contentType = contentType
+        }
+
+        @Override
+        void handle(HttpRequest request, HttpResponse response) {
+            response.setStatus(statusCode)
+            response.setContentType(contentType)
+            byte[] bodyBytes = jsonBody.getBytes("UTF-8")
+            response.setContentLength(bodyBytes.length)
+            response.outputStream.write(bodyBytes)
+            response.outputStream.flush()
+        }
     }
 
-    @Override
-    void handle(HttpServletRequest request, HttpServletResponse response) {
-        response.setStatus(statusCode)
-        response.setContentType(contentType)
-        response.setCharacterEncoding("utf-8")
-        byte[] bodyBytes = jsonBody.getBytes("UTF-8")
-        response.setContentLength(bodyBytes.length)
-        response.outputStream.write(bodyBytes)
-        response.outputStream.flush()
-    }
-}
+    /**
+     * Action that returns a non-RFC 9457 error response (traditional HTML error).
+     */
+    @SuppressWarnings('GroovyAccessibility')
+    private static class NonRfc9457ErrorAction extends HttpServer.ActionSupport {
+        private final int statusCode
 
-/**
- * Action that returns a non-RFC 9457 error response (traditional HTML error).
- */
-class NonRfc9457ErrorAction extends HttpServer.ActionSupport {
-    private final int statusCode
+        NonRfc9457ErrorAction(int statusCode) {
+            super("Return non-RFC 9457 error with status ${statusCode}")
+            this.statusCode = statusCode
+        }
 
-    NonRfc9457ErrorAction(int statusCode) {
-        super("Return non-RFC 9457 error with status ${statusCode}")
-        this.statusCode = statusCode
-    }
-
-    @Override
-    void handle(HttpServletRequest request, HttpServletResponse response) {
-        response.setStatus(statusCode)
+        @Override
+        void handle(HttpRequest request, HttpResponse response) {
+            response.setStatus(statusCode)
+        }
     }
 }

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
@@ -331,17 +331,17 @@ public class ApacheCommonsHttpClient implements HttpClient {
             Rfc9457Problem problem = OBJECT_MAPPER.readValue(content, Rfc9457Problem.class);
 
             LOGGER.trace("RFC9457 parsed successfully - type: {}, title: {}, status: {}, detail: {}, instance: {}",
-                problem.getType(), problem.getTitle(), problem.getStatus(), problem.getDetail(), problem.getInstance());
+                problem.type(), problem.title(), problem.status(), problem.detail(), problem.instance());
 
             // Prefer "detail" field as it contains the specific explanation
-            String detail = problem.getDetail();
+            String detail = problem.detail();
             if (detail != null && !detail.isEmpty()) {
                 LOGGER.trace("Using RFC9457 'detail' field: {}", detail);
                 return detail;
             }
 
             // Fallback to "title" field if "detail" is not present
-            String title = problem.getTitle();
+            String title = problem.title();
             if (title != null && !title.isEmpty()) {
                 LOGGER.trace("RFC9457 'detail' field empty, using 'title' field: {}", title);
                 return title;
@@ -402,6 +402,38 @@ public class ApacheCommonsHttpClient implements HttpClient {
 
         private URI getLastRedirectLocation() {
             return lastRedirectLocation;
+        }
+    }
+
+    /**
+     * Record representing RFC9457 Problem Details for HTTP APIs.
+     * See: https://www.rfc-editor.org/rfc/rfc9457.html
+     */
+    @NullMarked
+    @VisibleForTesting
+    record Rfc9457Problem(
+        @Nullable String type,
+        @Nullable String title,
+        @Nullable Integer status,
+        @Nullable String detail,
+        @Nullable String instance
+    ) {
+    }
+
+    /**
+     * Factory for creating the {@link HttpClientHelper}
+     */
+    @FunctionalInterface
+    @ServiceScope(Scope.Global.class)
+    public interface Factory {
+        HttpClientHelper create(HttpSettings settings);
+
+        /**
+         * Method should only be used for DI registry and testing.
+         * For other uses of {@link HttpClientHelper}, inject an instance of {@link Factory} to create one.
+         */
+        static Factory createFactory(DocumentationRegistry documentationRegistry) {
+            return settings -> new HttpClientHelper(documentationRegistry, settings);
         }
     }
 

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
@@ -44,13 +44,16 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
 
@@ -64,6 +67,18 @@ import static org.apache.http.client.protocol.HttpClientContext.REDIRECT_LOCATIO
 public class ApacheCommonsHttpClient implements HttpClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApacheCommonsHttpClient.class);
+
+    /**
+     * Shared ObjectMapper instance for parsing RFC9457 Problem Details responses.
+     * Thread-safe after configuration.
+     */
+    private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
+
+    private static ObjectMapper createObjectMapper() {
+        return new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
+    }
 
     private final DocumentationRegistry documentationRegistry;
     private final HttpSettings settings;
@@ -259,51 +274,50 @@ public class ApacheCommonsHttpClient implements HttpClient {
         return redirectLocations.isEmpty() ? null : Iterables.getLast(redirectLocations);
     }
 
-    private static Response processResponse(Response response) {
+    private Response processResponse(Response response) {
         if (response.isSuccessful()) {
             return response;
-        }
-
-        // Consume content for non-successful responses. This avoids the connection being left open.
-        response.close();
-
-        if (response.isMissing()) {
+        } else if (response.isMissing()) {
+            // Consume content to avoid leaving the connection open.
+            response.close();
             LOGGER.info("Resource missing. [HTTP {}: {}]", response.getMethod(), stripUserCredentials(response.getEffectiveUri()));
             return response;
-        }
+        } else {
+            URI effectiveUri = stripUserCredentials(response.getEffectiveUri());
+            LOGGER.info("Failed to get resource: {}. [HTTP {}: {})]", response.getMethod(), response.getStatusCode(), effectiveUri);
 
-        URI effectiveUri = stripUserCredentials(response.getEffectiveUri());
-        LOGGER.info("Failed to get resource: {}. [HTTP {}: {})]", response.getMethod(), response.getStatusCode(), effectiveUri);
-        throw new HttpErrorStatusCodeException(response.getMethod(), effectiveUri.toString(), response.getStatusCode(), response.getStatusReason());
+            // Extract detailed error message (must be done before closing response)
+            String errorDetail = extractErrorDetail(response).orElse("");
+
+            // Close the response to avoid leaving connections open
+            response.close();
+
+            throw new HttpErrorStatusCodeException(response.getMethod(), effectiveUri.toString(), response.getStatusCode(), errorDetail);
+        }
     }
 
     /**
      * Extracts error detail from the HTTP response.
      * Supports RFC9457 (Problem Details for HTTP APIs) format.
-     * Falls back to reason phrase if RFC9457 is not available.
+     * Falls back to the HTTP reason phrase when RFC9457 is not available.
      *
      * @param response the HTTP response
-     * @return the error detail message
+     * @return the error detail message, or empty if none is available
      */
     @VisibleForTesting
-    String extractErrorDetail(HttpClientResponse response) {
-        // Try RFC9457 first
+    Optional<String> extractErrorDetail(HttpClient.Response response) {
         String contentType = response.getHeader("Content-Type");
-        if (contentType != null && contentType.contains("application/problem+json")) {
+        if (contentType != null && contentType.toLowerCase(Locale.ROOT).contains("application/problem+json")) {
             LOGGER.debug("RFC9457 content type detected: {}", contentType);
-            String rfc9457Detail = parseRFC9457Response(response);
-            if (rfc9457Detail != null) {
-                LOGGER.debug("RFC9457 error detail extracted: {}", rfc9457Detail);
+            Optional<String> rfc9457Detail = parseRFC9457Response(response);
+            if (rfc9457Detail.isPresent()) {
                 return rfc9457Detail;
             }
-            LOGGER.debug("RFC9457 parsing failed or returned null, falling back to reason phrase");
+            LOGGER.debug("RFC9457 parsing failed or produced no detail, falling back to reason phrase");
         }
 
         // Fallback to reason phrase (empty in HTTP/2)
-        String reasonPhrase = response.getStatusLine().getReasonPhrase();
-        String result = reasonPhrase != null ? reasonPhrase : "";
-        LOGGER.debug("Using fallback error detail: '{}'", result);
-        return result;
+        return Optional.ofNullable(response.getStatusReason()).filter(s -> !s.isEmpty());
     }
 
     /**
@@ -316,42 +330,30 @@ public class ApacheCommonsHttpClient implements HttpClient {
      * - instance: URI reference identifying the specific occurrence
      *
      * @param response the HTTP response
-     * @return the detail field from the RFC9457 response, or null if parsing fails
+     * @return the detail field (or title as fallback) from the RFC9457 response, or empty if parsing fails or yields no usable field
      */
     @VisibleForTesting
-    @Nullable
-    String parseRFC9457Response(HttpClientResponse response) {
+    Optional<String> parseRFC9457Response(HttpClient.Response response) {
         try {
-            java.io.InputStream content = response.getContent();
-            if (content == null) {
-                LOGGER.debug("RFC9457 response has no content");
-                return null;
-            }
-
+            InputStream content = response.getContent();
             Rfc9457Problem problem = OBJECT_MAPPER.readValue(content, Rfc9457Problem.class);
 
             LOGGER.trace("RFC9457 parsed successfully - type: {}, title: {}, status: {}, detail: {}, instance: {}",
-                problem.type(), problem.title(), problem.status(), problem.detail(), problem.instance());
+                problem.getType(), problem.getTitle(), problem.getStatus(), problem.getDetail(), problem.getInstance());
 
-            // Prefer "detail" field as it contains the specific explanation
-            String detail = problem.detail();
+            // Prefer "detail" field, fall back to "title" if detail is absent or empty
+            String detail = problem.getDetail();
             if (detail != null && !detail.isEmpty()) {
-                LOGGER.trace("Using RFC9457 'detail' field: {}", detail);
-                return detail;
+                return Optional.of(detail);
             }
-
-            // Fallback to "title" field if "detail" is not present
-            String title = problem.title();
+            String title = problem.getTitle();
             if (title != null && !title.isEmpty()) {
-                LOGGER.trace("RFC9457 'detail' field empty, using 'title' field: {}", title);
-                return title;
+                return Optional.of(title);
             }
-
-            LOGGER.trace("RFC9457 response has neither 'detail' nor 'title' fields");
-            return null;
+            return Optional.empty();
         } catch (Exception e) {
             LOGGER.warn("Failed to parse RFC9457 response", e);
-            return null;
+            return Optional.empty();
         }
     }
 
@@ -406,34 +408,60 @@ public class ApacheCommonsHttpClient implements HttpClient {
     }
 
     /**
-     * Record representing RFC9457 Problem Details for HTTP APIs.
+     * Represents RFC9457 Problem Details for HTTP APIs.
      * See: https://www.rfc-editor.org/rfc/rfc9457.html
      */
-    @NullMarked
     @VisibleForTesting
-    record Rfc9457Problem(
-        @Nullable String type,
-        @Nullable String title,
-        @Nullable Integer status,
-        @Nullable String detail,
-        @Nullable String instance
-    ) {
-    }
+    static class Rfc9457Problem {
+        @Nullable private String type;
+        @Nullable private String title;
+        @Nullable private Integer status;
+        @Nullable private String detail;
+        @Nullable private String instance;
 
-    /**
-     * Factory for creating the {@link HttpClientHelper}
-     */
-    @FunctionalInterface
-    @ServiceScope(Scope.Global.class)
-    public interface Factory {
-        HttpClientHelper create(HttpSettings settings);
+        @Nullable
+        public String getType() {
+            return type;
+        }
 
-        /**
-         * Method should only be used for DI registry and testing.
-         * For other uses of {@link HttpClientHelper}, inject an instance of {@link Factory} to create one.
-         */
-        static Factory createFactory(DocumentationRegistry documentationRegistry) {
-            return settings -> new HttpClientHelper(documentationRegistry, settings);
+        public void setType(@Nullable String type) {
+            this.type = type;
+        }
+
+        @Nullable
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(@Nullable String title) {
+            this.title = title;
+        }
+
+        @Nullable
+        public Integer getStatus() {
+            return status;
+        }
+
+        public void setStatus(@Nullable Integer status) {
+            this.status = status;
+        }
+
+        @Nullable
+        public String getDetail() {
+            return detail;
+        }
+
+        public void setDetail(@Nullable String detail) {
+            this.detail = detail;
+        }
+
+        @Nullable
+        public String getInstance() {
+            return instance;
+        }
+
+        public void setInstance(@Nullable String instance) {
+            this.instance = instance;
         }
     }
 

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
@@ -75,8 +75,7 @@ public class ApacheCommonsHttpClient implements HttpClient {
 
     private static ObjectMapper createObjectMapper() {
         return new ObjectMapper()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            .configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     private final DocumentationRegistry documentationRegistry;

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.resource.transport.http;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -272,6 +275,84 @@ public class ApacheCommonsHttpClient implements HttpClient {
         URI effectiveUri = stripUserCredentials(response.getEffectiveUri());
         LOGGER.info("Failed to get resource: {}. [HTTP {}: {})]", response.getMethod(), response.getStatusCode(), effectiveUri);
         throw new HttpErrorStatusCodeException(response.getMethod(), effectiveUri.toString(), response.getStatusCode(), response.getStatusReason());
+    }
+
+    /**
+     * Extracts error detail from the HTTP response.
+     * Supports RFC9457 (Problem Details for HTTP APIs) format.
+     * Falls back to reason phrase if RFC9457 is not available.
+     *
+     * @param response the HTTP response
+     * @return the error detail message
+     */
+    @VisibleForTesting
+    String extractErrorDetail(HttpClientResponse response) {
+        // Try RFC9457 first
+        String contentType = response.getHeader("Content-Type");
+        if (contentType != null && contentType.contains("application/problem+json")) {
+            LOGGER.debug("RFC9457 content type detected: {}", contentType);
+            String rfc9457Detail = parseRFC9457Response(response);
+            if (rfc9457Detail != null) {
+                LOGGER.debug("RFC9457 error detail extracted: {}", rfc9457Detail);
+                return rfc9457Detail;
+            }
+            LOGGER.debug("RFC9457 parsing failed or returned null, falling back to reason phrase");
+        }
+
+        // Fallback to reason phrase (empty in HTTP/2)
+        String reasonPhrase = response.getStatusLine().getReasonPhrase();
+        String result = reasonPhrase != null ? reasonPhrase : "";
+        LOGGER.debug("Using fallback error detail: '{}'", result);
+        return result;
+    }
+
+    /**
+     * Parses RFC9457 (Problem Details for HTTP APIs) response.
+     * RFC9457 defines a JSON format for error responses with fields like:
+     * - type: URI reference for the problem type
+     * - title: Short, human-readable summary
+     * - status: HTTP status code
+     * - detail: Human-readable explanation specific to this occurrence
+     * - instance: URI reference identifying the specific occurrence
+     *
+     * @param response the HTTP response
+     * @return the detail field from the RFC9457 response, or null if parsing fails
+     */
+    @VisibleForTesting
+    @Nullable
+    String parseRFC9457Response(HttpClientResponse response) {
+        try {
+            java.io.InputStream content = response.getContent();
+            if (content == null) {
+                LOGGER.debug("RFC9457 response has no content");
+                return null;
+            }
+
+            Rfc9457Problem problem = OBJECT_MAPPER.readValue(content, Rfc9457Problem.class);
+
+            LOGGER.trace("RFC9457 parsed successfully - type: {}, title: {}, status: {}, detail: {}, instance: {}",
+                problem.getType(), problem.getTitle(), problem.getStatus(), problem.getDetail(), problem.getInstance());
+
+            // Prefer "detail" field as it contains the specific explanation
+            String detail = problem.getDetail();
+            if (detail != null && !detail.isEmpty()) {
+                LOGGER.trace("Using RFC9457 'detail' field: {}", detail);
+                return detail;
+            }
+
+            // Fallback to "title" field if "detail" is not present
+            String title = problem.getTitle();
+            if (title != null && !title.isEmpty()) {
+                LOGGER.trace("RFC9457 'detail' field empty, using 'title' field: {}", title);
+                return title;
+            }
+
+            LOGGER.trace("RFC9457 response has neither 'detail' nor 'title' fields");
+            return null;
+        } catch (Exception e) {
+            LOGGER.warn("Failed to parse RFC9457 response", e);
+            return null;
+        }
     }
 
     private synchronized CloseableHttpClient getClient() {

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClient.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.resource.transport.http;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -289,10 +288,14 @@ public class ApacheCommonsHttpClient implements HttpClient {
             // Extract detailed error message (must be done before closing response)
             String errorDetail = extractErrorDetail(response).orElse("");
 
+            // Capture response state before closing, as reading a closed response is fragile
+            String method = response.getMethod();
+            int statusCode = response.getStatusCode();
+
             // Close the response to avoid leaving connections open
             response.close();
 
-            throw new HttpErrorStatusCodeException(response.getMethod(), effectiveUri.toString(), response.getStatusCode(), errorDetail);
+            throw new HttpErrorStatusCodeException(method, effectiveUri.toString(), statusCode, errorDetail);
         }
     }
 

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClientTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClientTest.groovy
@@ -34,6 +34,12 @@ class ApacheCommonsHttpClientTest extends Specification {
 
     @Rule SetSystemProperties sysProp = new SetSystemProperties()
 
+    private ApacheCommonsHttpClient client
+
+    def setup() {
+        client = new ApacheCommonsHttpClient(new DocumentationRegistry(), httpSettings, () -> HttpClientBuilder.create())
+    }
+
     def "throws HttpRequestException if an IO error occurs during a request"() {
         def client = new ApacheCommonsHttpClient(new DocumentationRegistry(), httpSettings, () -> {
             Stub(HttpClientBuilder) {
@@ -62,6 +68,8 @@ class ApacheCommonsHttpClientTest extends Specification {
                 isStreaming() >> true
                 getContent() >> Mock(InputStream)
             }
+            // extractErrorDetail() checks Content-Type before attempting RFC9457 parsing
+            getFirstHeader("Content-Type") >> null
         }
 
         def client = new ApacheCommonsHttpClient(new DocumentationRegistry(), httpSettings, () -> {
@@ -98,7 +106,6 @@ class ApacheCommonsHttpClientTest extends Specification {
 
     def "parseRFC9457Response extracts detail field"() {
         given:
-        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
         def responseBody = '{"type": "about:blank", "title": "Not Found", "status": 404, "detail": "The requested artifact was not found in the repository"}'
         def response = createMockResponse("application/problem+json", responseBody)
 
@@ -106,12 +113,11 @@ class ApacheCommonsHttpClientTest extends Specification {
         def result = client.parseRFC9457Response(response)
 
         then:
-        result == "The requested artifact was not found in the repository"
+        result == Optional.of("The requested artifact was not found in the repository")
     }
 
     def "parseRFC9457Response falls back to title if detail is missing"() {
         given:
-        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
         def responseBody = '{"type": "about:blank", "title": "Not Found", "status": 404}'
         def response = createMockResponse("application/problem+json", responseBody)
 
@@ -119,12 +125,23 @@ class ApacheCommonsHttpClientTest extends Specification {
         def result = client.parseRFC9457Response(response)
 
         then:
-        result == "Not Found"
+        result == Optional.of("Not Found")
     }
 
-    def "parseRFC9457Response returns null for invalid JSON"() {
+    def "parseRFC9457Response falls back to title if detail is empty string"() {
         given:
-        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def responseBody = '{"title": "Server Overloaded", "detail": ""}'
+        def response = createMockResponse("application/problem+json", responseBody)
+
+        when:
+        def result = client.parseRFC9457Response(response)
+
+        then:
+        result == Optional.of("Server Overloaded")
+    }
+
+    def "parseRFC9457Response returns empty for invalid JSON"() {
+        given:
         def responseBody = 'not a json'
         def response = createMockResponse("application/problem+json", responseBody)
 
@@ -132,26 +149,24 @@ class ApacheCommonsHttpClientTest extends Specification {
         def result = client.parseRFC9457Response(response)
 
         then:
-        result == null
+        result == Optional.empty()
     }
 
-    def "parseRFC9457Response returns null when content is null"() {
+    def "parseRFC9457Response returns empty when content is missing"() {
         given:
-        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
-        def response = Mock(HttpClientResponse) {
-            getContent() >> null
+        def response = Mock(HttpClient.Response) {
+            getContent() >> { throw new IOException("no content") }
         }
 
         when:
         def result = client.parseRFC9457Response(response)
 
         then:
-        result == null
+        result == Optional.empty()
     }
 
     def "extractErrorDetail uses RFC9457 when content-type is application/problem+json"() {
         given:
-        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
         def responseBody = '{"detail": "Custom error message from registry"}'
         def response = createMockResponse("application/problem+json", responseBody)
 
@@ -159,42 +174,76 @@ class ApacheCommonsHttpClientTest extends Specification {
         def result = client.extractErrorDetail(response)
 
         then:
-        result == "Custom error message from registry"
+        result == Optional.of("Custom error message from registry")
+    }
+
+    def "extractErrorDetail matches content-type case-insensitively"() {
+        given:
+        def responseBody = '{"detail": "Weird casing but still problem+json"}'
+        def response = createMockResponse("Application/Problem+JSON; charset=UTF-8", responseBody)
+
+        when:
+        def result = client.extractErrorDetail(response)
+
+        then:
+        result == Optional.of("Weird casing but still problem+json")
     }
 
     def "extractErrorDetail falls back to reason phrase for non-RFC9457 responses"() {
         given:
-        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
-        def response = Mock(HttpClientResponse) {
+        def response = Mock(HttpClient.Response) {
             getHeader("Content-Type") >> "text/html"
-            getStatusLine() >> new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 404, "Not Found")
+            getStatusReason() >> "Not Found"
         }
 
         when:
         def result = client.extractErrorDetail(response)
 
         then:
-        result == "Not Found"
+        result == Optional.of("Not Found")
     }
 
-    def "extractErrorDetail returns empty string when reason phrase is null"() {
+    def "extractErrorDetail returns empty when reason phrase is null"() {
         given:
-        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
-        def response = Mock(HttpClientResponse) {
+        def response = Mock(HttpClient.Response) {
             getHeader("Content-Type") >> "text/html"
-            getStatusLine() >> new BasicStatusLine(new ProtocolVersion("HTTP", 2, 0), 404, null)
+            getStatusReason() >> null
         }
 
         when:
         def result = client.extractErrorDetail(response)
 
         then:
-        result == ""
+        result == Optional.empty()
+    }
+
+    def "extractErrorDetail returns empty when reason phrase is empty string"() {
+        given:
+        def response = Mock(HttpClient.Response) {
+            getHeader("Content-Type") >> null
+            getStatusReason() >> ""
+        }
+
+        when:
+        def result = client.extractErrorDetail(response)
+
+        then:
+        result == Optional.empty()
+    }
+
+    def "extractErrorDetail falls back to reason phrase when RFC9457 body has no usable fields"() {
+        given:
+        def response = createMockResponse("application/problem+json", '{"type": "about:blank"}')
+
+        when:
+        def result = client.extractErrorDetail(response)
+
+        then: "type-only responses fall through to reason phrase via createMockResponse"
+        result == Optional.of("Bad Request")
     }
 
     def "extractErrorDetail handles RFC9457 with charset in content-type"() {
         given:
-        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
         def responseBody = '{"detail": "Error with charset"}'
         def response = createMockResponse("application/problem+json; charset=utf-8", responseBody)
 
@@ -202,12 +251,11 @@ class ApacheCommonsHttpClientTest extends Specification {
         def result = client.extractErrorDetail(response)
 
         then:
-        result == "Error with charset"
+        result == Optional.of("Error with charset")
     }
 
-    def "parseRFC9457Response handles empty JSON object"() {
+    def "parseRFC9457Response returns empty for empty JSON object"() {
         given:
-        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
         def responseBody = '{}'
         def response = createMockResponse("application/problem+json", responseBody)
 
@@ -215,12 +263,11 @@ class ApacheCommonsHttpClientTest extends Specification {
         def result = client.parseRFC9457Response(response)
 
         then:
-        result == null
+        result == Optional.empty()
     }
 
     def "parseRFC9457Response handles all RFC9457 fields"() {
         given:
-        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
         def responseBody = '{"type": "https://example.com/error", "title": "Not Found", "status": 404, "detail": "The requested resource was not found", "instance": "/resource/123"}'
         def response = createMockResponse("application/problem+json", responseBody)
 
@@ -228,15 +275,27 @@ class ApacheCommonsHttpClientTest extends Specification {
         def result = client.parseRFC9457Response(response)
 
         then:
-        result == "The requested resource was not found"
+        result == Optional.of("The requested resource was not found")
     }
 
-    private HttpClientResponse createMockResponse(String contentType, String responseBody) {
+    def "parseRFC9457Response ignores unknown fields (vendor extensions)"() {
+        given:
+        def responseBody = '{"detail": "Rate limited", "retryAfter": 60, "quotaRemaining": 0}'
+        def response = createMockResponse("application/problem+json", responseBody)
+
+        when:
+        def result = client.parseRFC9457Response(response)
+
+        then:
+        result == Optional.of("Rate limited")
+    }
+
+    private HttpClient.Response createMockResponse(String contentType, String responseBody) {
         def inputStream = new ByteArrayInputStream(responseBody.getBytes("UTF-8"))
-        return Mock(HttpClientResponse) {
+        return Mock(HttpClient.Response) {
             getHeader("Content-Type") >> contentType
             getContent() >> inputStream
-            getStatusLine() >> new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 400, "Bad Request")
+            getStatusReason() >> "Bad Request"
         }
     }
 

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClientTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/ApacheCommonsHttpClientTest.groovy
@@ -96,6 +96,150 @@ class ApacheCommonsHttpClientTest extends Specification {
         strippedUri.host == "foo.example"
     }
 
+    def "parseRFC9457Response extracts detail field"() {
+        given:
+        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def responseBody = '{"type": "about:blank", "title": "Not Found", "status": 404, "detail": "The requested artifact was not found in the repository"}'
+        def response = createMockResponse("application/problem+json", responseBody)
+
+        when:
+        def result = client.parseRFC9457Response(response)
+
+        then:
+        result == "The requested artifact was not found in the repository"
+    }
+
+    def "parseRFC9457Response falls back to title if detail is missing"() {
+        given:
+        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def responseBody = '{"type": "about:blank", "title": "Not Found", "status": 404}'
+        def response = createMockResponse("application/problem+json", responseBody)
+
+        when:
+        def result = client.parseRFC9457Response(response)
+
+        then:
+        result == "Not Found"
+    }
+
+    def "parseRFC9457Response returns null for invalid JSON"() {
+        given:
+        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def responseBody = 'not a json'
+        def response = createMockResponse("application/problem+json", responseBody)
+
+        when:
+        def result = client.parseRFC9457Response(response)
+
+        then:
+        result == null
+    }
+
+    def "parseRFC9457Response returns null when content is null"() {
+        given:
+        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def response = Mock(HttpClientResponse) {
+            getContent() >> null
+        }
+
+        when:
+        def result = client.parseRFC9457Response(response)
+
+        then:
+        result == null
+    }
+
+    def "extractErrorDetail uses RFC9457 when content-type is application/problem+json"() {
+        given:
+        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def responseBody = '{"detail": "Custom error message from registry"}'
+        def response = createMockResponse("application/problem+json", responseBody)
+
+        when:
+        def result = client.extractErrorDetail(response)
+
+        then:
+        result == "Custom error message from registry"
+    }
+
+    def "extractErrorDetail falls back to reason phrase for non-RFC9457 responses"() {
+        given:
+        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def response = Mock(HttpClientResponse) {
+            getHeader("Content-Type") >> "text/html"
+            getStatusLine() >> new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 404, "Not Found")
+        }
+
+        when:
+        def result = client.extractErrorDetail(response)
+
+        then:
+        result == "Not Found"
+    }
+
+    def "extractErrorDetail returns empty string when reason phrase is null"() {
+        given:
+        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def response = Mock(HttpClientResponse) {
+            getHeader("Content-Type") >> "text/html"
+            getStatusLine() >> new BasicStatusLine(new ProtocolVersion("HTTP", 2, 0), 404, null)
+        }
+
+        when:
+        def result = client.extractErrorDetail(response)
+
+        then:
+        result == ""
+    }
+
+    def "extractErrorDetail handles RFC9457 with charset in content-type"() {
+        given:
+        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def responseBody = '{"detail": "Error with charset"}'
+        def response = createMockResponse("application/problem+json; charset=utf-8", responseBody)
+
+        when:
+        def result = client.extractErrorDetail(response)
+
+        then:
+        result == "Error with charset"
+    }
+
+    def "parseRFC9457Response handles empty JSON object"() {
+        given:
+        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def responseBody = '{}'
+        def response = createMockResponse("application/problem+json", responseBody)
+
+        when:
+        def result = client.parseRFC9457Response(response)
+
+        then:
+        result == null
+    }
+
+    def "parseRFC9457Response handles all RFC9457 fields"() {
+        given:
+        def client = new HttpClientHelper(new DocumentationRegistry(), httpSettings)
+        def responseBody = '{"type": "https://example.com/error", "title": "Not Found", "status": 404, "detail": "The requested resource was not found", "instance": "/resource/123"}'
+        def response = createMockResponse("application/problem+json", responseBody)
+
+        when:
+        def result = client.parseRFC9457Response(response)
+
+        then:
+        result == "The requested resource was not found"
+    }
+
+    private HttpClientResponse createMockResponse(String contentType, String responseBody) {
+        def inputStream = new ByteArrayInputStream(responseBody.getBytes("UTF-8"))
+        return Mock(HttpClientResponse) {
+            getHeader("Content-Type") >> contentType
+            getContent() >> inputStream
+            getStatusLine() >> new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 400, "Bad Request")
+        }
+    }
+
     private HttpSettings getHttpSettings() {
         return Stub(HttpSettings) {
             getProxySettings() >> Mock(HttpProxySettings)


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #36203

### Context
  - Detailed, actionable error messages from modern repositories
  - HTTP/2 compatible (addresses empty reason phrase limitation)
  - Graceful fallback for non-RFC 9457 responses
 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
