### PR TITLE
Fix broken test where we now erroneously find the properties file instead of the jar

### DIFF
--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegrationTest.groovy
@@ -60,7 +60,8 @@ class GradleRunnerMiscEndUserIntegrationTest extends BaseTestKitEndUserIntegrati
         def jarsDir = file('jars').createDir()
 
         new File(distribution.gradleHomeDir, 'lib').eachFileRecurse(FileType.FILES) { f ->
-            if (f.name.contains("gradle-test-kit")
+            if (f.name.endsWith(".jar") && (
+                f.name.contains("gradle-test-kit")
                 || f.name.contains("commons-io")
                 || f.name.contains("guava")
                 || f.name.contains("gradle-base-services")
@@ -70,12 +71,12 @@ class GradleRunnerMiscEndUserIntegrationTest extends BaseTestKitEndUserIntegrati
                 || f.name.contains("gradle-tooling-api")
                 || f.name.contains("gradle-core")
                 || f.name.contains("gradle-build-process-services")
-            ) {
+            )) {
                 GFileUtils.copyFile(f, new File(jarsDir, f.name))
             }
         }
 
-        def testKitJar = jarsDir.listFiles().find { it.name.contains("test-kit") && it.name.endsWith(".jar") }
+        def testKitJar = jarsDir.listFiles().find { it.name.contains "test-kit" }
         buildFile << """
             dependencies {
                 testImplementation fileTree(dir: 'jars', include: '*.jar')


### PR DESCRIPTION
Caused by changes from https://github.com/gradle/gradle/pull/36169

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
