### PR TITLE
Fix `PersistentMap#modify` when there are partial hash collisions

### DIFF
--- a/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/PersistentMapTrie.java
+++ b/platforms/core-runtime/collections/src/main/java/org/gradle/internal/collect/PersistentMapTrie.java
@@ -356,10 +356,10 @@ final class PersistentMapTrie<K, V> implements PersistentMap<K, V> {
                 }
             } else {
                 // Entry does not exist
-                int curKeyHash = curKey.hashCode();
-                Object curVal = content[keyIndex + 1];
-                V newVal = f.apply(key, (V) curVal);
+                V newVal = f.apply(key, null);
                 if (newVal != null) {
+                    Object curVal = content[keyIndex + 1];
+                    int curKeyHash = curKey.hashCode();
                     Object newNode = curKeyHash == hash
                         ? new HashCollisionNode(hash, new Object[]{curKey, curVal, key, newVal})
                         : branchOnKeys(key, hash, newVal, curKey, curKeyHash, curVal, shift + BITS, modification);


### PR DESCRIPTION
The previous version was wrongly passing the value associated with the collided key to the modification function.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
