### PR TITLE
Disable AWS SDK v1 deprecation warnings

### DIFF
--- a/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyPublishS3IntegrationTest.groovy
+++ b/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyPublishS3IntegrationTest.groovy
@@ -28,7 +28,10 @@ class IvyPublishS3IntegrationTest extends AbstractIvyPublishIntegTest {
     public S3Server server = new S3Server(temporaryFolder)
 
     def setup() {
-        executer.withArgument("-Dorg.gradle.s3.endpoint=${server.getUri()}")
+        executer.beforeExecute {
+            executer.withArgument("-Dorg.gradle.s3.endpoint=${server.getUri()}")
+            executer.withArgument("-Daws.java.v1.disableDeprecationAnnouncement=true")
+        }
     }
 
     def "can publish to an S3 Ivy repository"() {

--- a/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyS3RepoResolveIntegrationTest.groovy
+++ b/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyS3RepoResolveIntegrationTest.groovy
@@ -35,6 +35,7 @@ class IvyS3RepoResolveIntegrationTest extends AbstractIvyRemoteRepoResolveIntegr
     protected ExecutionResult succeeds(String... tasks) {
         executer.withArgument("-Dorg.gradle.s3.endpoint=${server.uri}")
         executer.withArgument("-Dorg.gradle.s3.maxErrorRetry=0")
+        executer.withArgument("-Daws.java.v1.disableDeprecationAnnouncement=true")
         result = executer.withTasks(*tasks).run()
     }
 

--- a/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3ProxiedRepoIntegrationTest.groovy
+++ b/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3ProxiedRepoIntegrationTest.groovy
@@ -37,6 +37,9 @@ class MavenS3ProxiedRepoIntegrationTest extends AbstractS3DependencyResolutionTe
     def setup() {
         proxyServer.start()
         module = getMavenS3Repo().module("org.gradle", "test", artifactVersion)
+        executer.beforeExecute {
+            executer.withArgument("-Daws.java.v1.disableDeprecationAnnouncement=true")
+        }
     }
 
     def "should proxy requests using HTTP system proxy settings"() {

--- a/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
+++ b/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
@@ -51,6 +51,9 @@ task retrieve(type: Sync) {
     into 'libs'
 }
 """
+        executer.beforeExecute {
+            executer.withArgument("-Daws.java.v1.disableDeprecationAnnouncement=true")
+        }
     }
 
     @ToBeFixedForConfigurationCache

--- a/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoResolveIntegrationTest.groovy
+++ b/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoResolveIntegrationTest.groovy
@@ -31,6 +31,9 @@ class MavenS3RepoResolveIntegrationTest extends AbstractS3DependencyResolutionTe
 
     def setup(){
         module = getMavenS3Repo().module("org.gradle", "test", artifactVersion)
+        executer.beforeExecute {
+            executer.withArgument("-Daws.java.v1.disableDeprecationAnnouncement=true")
+        }
     }
 
     def "should not download artifacts when already present in maven home"() {

--- a/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3SnapshotRepoIntegrationTest.groovy
+++ b/platforms/software/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3SnapshotRepoIntegrationTest.groovy
@@ -26,6 +26,9 @@ class MavenS3SnapshotRepoIntegrationTest extends AbstractS3DependencyResolutionT
 
     def setup() {
         module = getMavenS3Repo().module("org.gradle", "test", artifactVersion)
+        executer.beforeExecute {
+            executer.withArgument("-Daws.java.v1.disableDeprecationAnnouncement=true")
+        }
     }
 
     def "resolves a maven snapshot module stored in S3"() {


### PR DESCRIPTION
There are [quite some deprecation warnings](https://ge.gradle.org/scans/tests?search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.integtests.resource.s3.ivy.IvyS3RepoResolveIntegrationTest) like this:

```
The AWS SDK for Java 1.x entered maintenance mode starting July 31, 2024 and will reach end of support on December 31, 2025. For more information, see https://aws.amazon.com/blogs/developer/the-aws-sdk-for-java-1-x-is-in-maintenance-mode-effective-july-31-2024/	
You can print where on the file system the AWS SDK for Java 1.x core runtime is located by setting the AWS_JAVA_V1_PRINT_LOCATION environment variable or aws.java.v1.printLocation system property to 'true'.	
This message can be disabled by setting the AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT environment variable or aws.java.v1.disableDeprecationAnnouncement system property to 'true'.	
The AWS SDK for Java 1.x is being used here:	
at java.base/java.lang.Thread.getStackTrace(Thread.java:2193)	
at com.amazonaws.util.VersionInfoUtils.printDeprecationAnnouncement(VersionInfoUtils.java:81)	
at com.amazonaws.util.VersionInfoUtils.<clinit>(VersionInfoUtils.java:59)	
at com.amazonaws.ClientConfiguration.<clinit>(ClientConfiguration.java:95)
```

This unblocks ReadyForRelease while we are working on AWS SDK upgrade.