### PR TITLE
No PTS with release7x

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -325,10 +325,7 @@ val Project.predictiveTestSelectionEnabled: Provider<Boolean>
         .map { it.toBoolean() }
         .orElse(
             buildBranch.zip(buildRunningOnCi) { branch, ci ->
-                val protectedBranches = listOf("master", "release")
-                ci && !protectedBranches.contains(branch)
-                    && !branch.startsWith("pre-test/")
-                    && !branch.startsWith("gh-readonly-queue/")
+                ci && !listOf("master", "release", "gh-readonly-queue/").any { branch.startsWith(it) }
             }
         ).zip(project.rerunAllTests) { enabled, rerunAllTests ->
             enabled && !rerunAllTests


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/4961#issue-3693593217

This PR copies the same logic on `release` and `release8x` to `release7x`.