### PR TITLE
Fix process for disconnecting incoming edges

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -473,7 +473,7 @@ class EdgeState implements DependencyGraphEdge {
         this.unattached = true;
     }
 
-    public void markAttached() {
+    public void markNotUnattached() {
         this.unattached = false;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -289,7 +289,7 @@ public class ModuleResolveState implements CandidateModule {
 
     public void removeUnattachedEdge(EdgeState edge) {
         if (unattachedEdges.remove(edge)) {
-            edge.markAttached();
+            edge.markNotUnattached();
         }
     }
 
@@ -377,8 +377,9 @@ public class ModuleResolveState implements CandidateModule {
     }
 
     void disconnectIncomingEdge(NodeState removalSource, EdgeState incomingEdge) {
-        incomingEdge.clearSelector();
+        // Remove the unattached edge first, as clearing the selector may trigger re-selection and mutate the unattached edge
         removeUnattachedEdge(incomingEdge);
+        incomingEdge.clearSelector();
         if (!incomingEdge.isConstraint()) {
             pendingDependencies.decreaseHardEdgeCount();
             if (pendingDependencies.isPending()) {


### PR DESCRIPTION
When disconnecting an incoming edge that might be unattached, we remove it first before updating it.
This prevents re-selection on selector removal to apply to stale state.

Backport from #36212

 Issue #35228