### PR TITLE
Remove handling of derived names for Named definition objects

### DIFF
--- a/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/antlr/AntlrConfiguration.java
+++ b/platforms/core-configuration/project-features-demos/src/main/java/org/gradle/api/plugins/antlr/AntlrConfiguration.java
@@ -16,10 +16,9 @@
 
 package org.gradle.api.plugins.antlr;
 
-import org.gradle.api.Named;
 import org.gradle.api.provider.Property;
 
-public interface AntlrConfiguration extends Named, HasAntlrGrammars {
+public interface AntlrConfiguration extends HasAntlrGrammars {
     Property<Boolean> getTrace();
     Property<Boolean> getTraceLexer();
     Property<Boolean> getTraceParser();

--- a/platforms/core-configuration/project-features-demos/src/main/kotlin/org/gradle/api/plugins/antlr/AntlrProjectFeaturePlugin.kt
+++ b/platforms/core-configuration/project-features-demos/src/main/kotlin/org/gradle/api/plugins/antlr/AntlrProjectFeaturePlugin.kt
@@ -49,13 +49,13 @@ class AntlrProjectFeaturePlugin : Plugin<Project> {
             ) { definition, buildModel, target ->
                 val parentModel = getBuildModel(target)
 
-                definition.grammarSources = createAntlrSourceDirectorySet(definition.name, project.objects)
+                definition.grammarSources = createAntlrSourceDirectorySet(parentModel.name, project.objects)
                 val outputDirectory = projectLayout.buildDirectory.dir("/generated-src/antlr/" + definition.grammarSources.getName())
 
                 // Add the generated antlr sources to the java sources
                 parentModel.inputSources.srcDir(outputDirectory)
 
-                project.tasks.register("generate" + StringUtils.capitalize(definition.name) + "AntlrSources", AntlrTask::class.java) { antlrTask ->
+                project.tasks.register("generate" + StringUtils.capitalize(parentModel.name) + "AntlrSources", AntlrTask::class.java) { antlrTask ->
                     antlrTask.group = LifecycleBasePlugin.BUILD_GROUP
                     antlrTask.description = "Generates sources from the " + definition.grammarSources.name + " Antlr grammars."
                     antlrTask.source = definition.grammarSources

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultProjectFeatureApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/software/internal/DefaultProjectFeatureApplicator.java
@@ -16,7 +16,6 @@
 
 package org.gradle.plugin.software.internal;
 
-import org.gradle.api.Named;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.internal.DynamicObjectAware;
@@ -87,7 +86,7 @@ public class DefaultProjectFeatureApplicator implements ProjectFeatureApplicator
     }
 
     private <T extends Definition<V>, V extends BuildModel> T instantiateBoundFeatureObjectsAndApply(Object parentDefinition, ProjectFeatureImplementation<T, V> projectFeature) {
-        T definition = instantiateDefinitionObject(parentDefinition, projectFeature);
+        T definition = instantiateDefinitionObject(projectFeature);
         V buildModelInstance = ProjectFeatureSupportInternal.createBuildModelInstance(objectFactory, projectFeature);
         ProjectFeatureSupportInternal.attachDefinitionContext(definition, buildModelInstance, this, projectFeatureDeclarations, objectFactory);
 
@@ -99,19 +98,8 @@ public class DefaultProjectFeatureApplicator implements ProjectFeatureApplicator
         return definition;
     }
 
-    private <T extends Definition<V>, V extends BuildModel> T instantiateDefinitionObject(Object target, ProjectFeatureImplementation<T, V> projectFeature) {
-        Class<? extends T> dslType = projectFeature.getDefinitionImplementationType();
-
-        if (Named.class.isAssignableFrom(dslType)) {
-            if (target instanceof Named) {
-                return objectFactory.newInstance(projectFeature.getDefinitionPublicType(), ((Named) target).getName());
-            } else {
-                throw new IllegalArgumentException("Cannot infer a name for definition " + dslType.getSimpleName() +
-                    " because the parent definition of type " + target.getClass().getSimpleName() + " does not implement Named.");
-            }
-        } else {
-            return objectFactory.newInstance(dslType);
-        }
+    private <T extends Definition<V>, V extends BuildModel> T instantiateDefinitionObject(ProjectFeatureImplementation<T, V> projectFeature) {
+        return objectFactory.newInstance(projectFeature.getDefinitionImplementationType());
     }
 
     private static class ClassLoaderContextFromScope implements ModelDefaultsApplicator.ClassLoaderContext {


### PR DESCRIPTION
This changes the instantiation of definition objects so that we no longer potentially derive a name from the parent object.  If a feature author wants a `Named` definition object, they need to handle deriving/setting the name themselves (via an unsafe abstract class).

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
