### PR TITLE
Fix ip gradleception test brittleness

### DIFF
--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -426,14 +426,14 @@ class HasConfigurationCacheProblemsSpec {
     Integer problemsWithStackTraceCount
 
     /**
-     * Whether total problem count should not be strictly verified, only a number greater or equal to
+     * Whether total problem count should be strictly verified, otherwise only a number greater or equal to
      * the number of unique problems should be expected
-     * (useful when there are a large, frequently changing number of duplicates - such as in smoke/Gradleception tests
+     * (disabling this is useful when there is a large, frequently changing number of duplicates - such as in smoke/Gradleception tests
      * - but only unique problems actually matter).
      *
-     * When `true`, `totalProblemsCount` should not be specified.
+     * When `false`, `totalProblemsCount` should not be specified.
      */
-    boolean ignoreDuplicateProblemCount = false
+    boolean enforceTotalProblemCount = true
 
     /**
      * Whether to check for problem messages in the report.
@@ -458,9 +458,9 @@ class HasConfigurationCacheProblemsSpec {
                 throw new IllegalArgumentException("Count of problems with stacktrace can't be greater that count of total problems.")
             }
         }
-        if (ignoreDuplicateProblemCount && totalProblemsCount != null) {
+        if (!enforceTotalProblemCount && totalProblemsCount != null) {
             throw new IllegalArgumentException(
-                "Must not expect a specific `totalProblemsCount` if duplicate problem count should be ignored"
+                "Must not expect a specific `totalProblemsCount` if `enforceTotalProblemCount` is false"
             )
         }
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheReportFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheReportFixture.groovy
@@ -221,17 +221,17 @@ abstract class ConfigurationCacheReportFixture {
                 spec.inputs instanceof ItemSpec.ExpectingSome):
                 "The spec suggests the report shouldn't be generated but it was"
 
-            if (spec.ignoreDuplicateProblemCount) {
-                assertThat(
-                    "HTML report JS model does not have the minimum number of total problem(s)",
-                    jsModel.totalProblemCount,
-                    greaterThanOrEqualTo(uniqueProblemCount)
-                )
-            } else {
+            if (spec.enforceTotalProblemCount) {
                 assertThat(
                     "HTML report JS model has wrong number of total problem(s)",
                     jsModel.totalProblemCount,
                     equalTo(totalProblemCount)
+                )
+            } else {
+                assertThat(
+                    "HTML report JS model does not have the minimum number of total problem(s)",
+                    jsModel.totalProblemCount,
+                    greaterThanOrEqualTo(uniqueProblemCount)
                 )
             }
             assertThat(

--- a/testing/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixtureTest.groovy
+++ b/testing/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixtureTest.groovy
@@ -301,7 +301,7 @@ class ConfigurationCacheProblemsFixtureTest extends Specification {
                 "Some problem 1",
                 "Some problem 2"
             )
-            ignoreDuplicateProblemCount = true
+            enforceTotalProblemCount = false
             problemsWithStackTraceCount = 0
         }
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildIsolatedProjectsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildIsolatedProjectsSmokeTest.groovy
@@ -91,7 +91,7 @@ class GradleBuildIsolatedProjectsSmokeTest extends AbstractGradleBuildIsolatedPr
                 "Project ':' cannot access 'Project.extensions' functionality on subprojects via 'allprojects'",
             )
             // checking total problem count is too brittle, as that number changes whenever projects are added or removed
-            ignoreDuplicateProblemCount = true
+            enforceTotalProblemCount = false
         }
         result.assertNoConfigurationCache()
     }


### PR DESCRIPTION
Asserting on a specific number of total problems is too brittle for Gradleception tests. This PR allows to weaken that assertion so at least the number of unique problems are expected. 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
