### PR TITLE
Substitute unversioned capability selectors with attributes and capabilities

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -17,6 +17,13 @@
 
 package org.gradle.integtests.resolve
 
+import org.gradle.api.JavaVersion
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.java.TargetJvmVersion
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
@@ -1696,6 +1703,7 @@ Required by:
                 }
             }
         }
+
     }
 
     @Issue("https://github.com/gradle/gradle/issues/36331")
@@ -1780,4 +1788,202 @@ Required by:
             }
         }
     }
+
+    def "can substitute unversioned selector using attributes"() {
+        mavenRepo.module("org", "foo", "1").publish()
+
+        mavenRepo.module("org", "bar", "1")
+            .withModuleMetadata()
+            .variant("bar", [(Category.CATEGORY_ATTRIBUTE.name): "bat"])
+            .publish()
+
+        settingsFile << """
+            include(":other")
+        """
+
+        buildFile("other/build.gradle", """
+            configurations.consumable("bar") {
+                attributes {
+                    attribute(Category.CATEGORY_ATTRIBUTE, named(Category, "bat"))
+                }
+            }
+
+            version = "1"
+        """)
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${mavenTestRepository()}
+
+            ${resolve.configureProject("runtimeClasspath")}
+
+            dependencies {
+                implementation("org:foo:1")
+                implementation("org:foo:1") {
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, named(Category, "cat"))
+                    }
+                }
+            }
+
+            configurations.runtimeClasspath {
+                resolutionStrategy.dependencySubstitution {
+                    def from = variant(module('org:foo')) {
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, named(Category, "cat"))
+                        }
+                    }
+
+                    if ($toProject) {
+                        substitute(from).using(variant(project(':other')) {
+                            attributes {
+                                attribute(Category.CATEGORY_ATTRIBUTE, named(Category, "bat"))
+                            }
+                        })
+                    } else {
+                        substitute(from).using(variant(module("org:bar:1")) {
+                            attributes {
+                                attribute(Category.CATEGORY_ATTRIBUTE, named(Category, "bat"))
+                            }
+                        })
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds(":checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":depsub:") {
+                module("org:foo:1")
+                if (toProject) {
+                    edge("org:foo:1", ":other", "depsub:other:1") {
+                        byReason("selected by rule")
+                        variant("bar", [
+                            (Category.CATEGORY_ATTRIBUTE.name): "bat"
+                        ])
+                        noArtifacts()
+                    }
+                } else {
+                    edge("org:foo:1", "org:bar:1") {
+                        byReason("selected by rule")
+                        variant("bar", [
+                            (Category.CATEGORY_ATTRIBUTE.name): "bat",
+                            (ProjectInternal.STATUS_ATTRIBUTE.name): "release"
+                        ])
+                    }
+                }
+            }
+        }
+
+        where:
+        toProject << [true, false]
+    }
+
+    def "can substitute unversioned selector using capabilities"() {
+        mavenRepo.module("org", "foo", "1").publish()
+
+        mavenRepo.module("org", "bar", "1")
+            .withModuleMetadata()
+            .variant("testFixtures", [(Category.CATEGORY_ATTRIBUTE.name): Category.LIBRARY]) {
+                capability("org", "bar-test-fixtures", "1")
+            }
+            .publish()
+
+        settingsFile << """
+            include(":other")
+        """
+
+        buildFile("other/build.gradle", """
+            plugins {
+                id("java-library")
+                id("java-test-fixtures")
+            }
+
+            version = "1"
+        """)
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${mavenTestRepository()}
+
+            ${resolve.configureProject("runtimeClasspath")}
+
+            dependencies {
+                implementation("org:foo:1")
+                implementation(testFixtures("org:foo:1"))
+            }
+
+            configurations.runtimeClasspath {
+                resolutionStrategy.dependencySubstitution {
+                    def from = variant(module('org:foo')) {
+                        capabilities {
+                            requireFeature("test-fixtures")
+                        }
+                    }
+
+                    if ($toProject) {
+                        substitute(from).using(variant(project(':other')) {
+                            capabilities {
+                                requireFeature("test-fixtures")
+                            }
+                        })
+                    } else {
+                        substitute(from).using(variant(module("org:bar:1")) {
+                            capabilities {
+                                requireFeature("test-fixtures")
+                            }
+                        })
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds(":checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":depsub:") {
+                module("org:foo:1")
+                if (toProject) {
+                    edge("org:foo:1", ":other", "depsub:other:1") {
+                        project(":other", "depsub:other:1") {
+                            artifact(name: "other")
+                        }
+
+                        byReason("selected by rule")
+                        variant("testFixturesRuntimeElements", [
+                            (Category.CATEGORY_ATTRIBUTE.name): Category.LIBRARY,
+                            (Bundling.BUNDLING_ATTRIBUTE.name): Bundling.EXTERNAL,
+                            (TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE.name): JavaVersion.current().majorVersion,
+                            (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR,
+                            (Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME
+                        ])
+                        artifact(classifier: "test-fixtures")
+                    }
+                } else {
+                    edge("org:foo:1", "org:bar:1") {
+                        byReason("selected by rule")
+                        variant("testFixtures", [
+                            (Category.CATEGORY_ATTRIBUTE.name): Category.LIBRARY,
+                            (ProjectInternal.STATUS_ATTRIBUTE.name): "release"
+                        ])
+                    }
+                }
+            }
+        }
+
+        where:
+        toProject << [true, false]
+    }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
@@ -265,14 +265,15 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
                 boolean projectInvolved = substituted instanceof ProjectComponentSelector || notation instanceof ProjectComponentSelector;
 
                 if (substituted instanceof UnversionedModuleComponentSelector) {
-                    final ModuleIdentifier moduleId = ((UnversionedModuleComponentSelector) substituted).getModuleIdentifier();
+                    UnversionedModuleComponentSelector unversioned = (UnversionedModuleComponentSelector) substituted;
+                    final ModuleIdentifier moduleId = unversioned.getModuleIdentifier();
                     if (notation instanceof ModuleComponentSelector) {
                         if (((ModuleComponentSelector) notation).getModuleIdentifier().equals(moduleId)) {
                             // This substitution is effectively a force
                             substitutionReason = substitutionReason.markAsEquivalentToForce();
                         }
                     }
-                    addSubstitution(new ModuleMatchDependencySubstitutionAction(substitutionReason, moduleId, notation, () -> artifactAction), projectInvolved);
+                    addSubstitution(new ModuleMatchDependencySubstitutionAction(substitutionReason, unversioned, notation, () -> artifactAction), projectInvolved);
                 } else {
                     addSubstitution(new ExactMatchDependencySubstitutionAction(substitutionReason, substituted, notation, () -> artifactAction), projectInvolved);
                 }
@@ -395,8 +396,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
             this.artifactSelectionAction = artifactSelectionAction;
         }
 
-        @Override
-        public void execute(DependencySubstitution dependencySubstitution) {
+        protected void applyArtifactSelectionAction(DependencySubstitution dependencySubstitution) {
             dependencySubstitution.artifactSelection(artifactSelectionAction.get());
         }
     }
@@ -416,7 +416,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
         @Override
         public void execute(DependencySubstitution dependencySubstitution) {
             if (substituted.equals(dependencySubstitution.getRequested())) {
-                super.execute(dependencySubstitution);
+                applyArtifactSelectionAction(dependencySubstitution);
                 ((DependencySubstitutionInternal) dependencySubstitution).useTarget(substitute, selectionReason);
             }
         }
@@ -425,13 +425,13 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
 
     private static class ModuleMatchDependencySubstitutionAction extends AbstractDependencySubstitutionAction {
         private final ComponentSelectionDescriptorInternal selectionReason;
-        private final ModuleIdentifier moduleId;
+        private final UnversionedModuleComponentSelector unversioned;
         private final ComponentSelector substitute;
 
-        public ModuleMatchDependencySubstitutionAction(ComponentSelectionDescriptorInternal selectionReason, ModuleIdentifier moduleId, ComponentSelector substitute, Supplier<Action<? super ArtifactSelectionDetails>> artifactSelectionAction) {
+        public ModuleMatchDependencySubstitutionAction(ComponentSelectionDescriptorInternal selectionReason, UnversionedModuleComponentSelector unversioned, ComponentSelector substitute, Supplier<Action<? super ArtifactSelectionDetails>> artifactSelectionAction) {
             super(artifactSelectionAction);
             this.selectionReason = selectionReason;
-            this.moduleId = moduleId;
+            this.unversioned = unversioned;
             this.substitute = substitute;
         }
 
@@ -439,8 +439,11 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
         public void execute(DependencySubstitution dependencySubstitution) {
             if (dependencySubstitution.getRequested() instanceof ModuleComponentSelector) {
                 ModuleComponentSelector requested = (ModuleComponentSelector) dependencySubstitution.getRequested();
-                if (moduleId.equals(requested.getModuleIdentifier())) {
-                    super.execute(dependencySubstitution);
+                if (unversioned.getModuleIdentifier().equals(requested.getModuleIdentifier()) &&
+                    unversioned.getAttributes().equals(requested.getAttributes()) &&
+                    unversioned.getCapabilitySelectors().equals(requested.getCapabilitySelectors())
+                ) {
+                    applyArtifactSelectionAction(dependencySubstitution);
                     ((DependencySubstitutionInternal) dependencySubstitution).useTarget(substitute, selectionReason);
                 }
             }
@@ -461,7 +464,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
 
         @Override
         public void execute(DependencySubstitution substitution) {
-            super.execute(substitution);
+            applyArtifactSelectionAction(substitution);
             ModuleVersionIdentifier requested = componentSelectorConverter.getModuleVersionId(substitution.getRequested());
             DefaultDependencyResolveDetails details = instantiator.newInstance(DefaultDependencyResolveDetails.class, substitution, requested);
             delegate.execute(details);
@@ -518,35 +521,25 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
             this.selector = selector;
         }
 
-        private void createComponentOfCategory(String category) {
-            if (selector instanceof ProjectComponentSelector) {
-                AttributeContainerInternal container = createCategory(category);
-                selector = DefaultProjectComponentSelector.withAttributes((ProjectComponentSelector) selector, container.asImmutable());
-            } else if (selector instanceof ModuleComponentSelector) {
-                AttributeContainerInternal container = createCategory(category);
-                selector = DefaultModuleComponentSelector.withAttributes((ModuleComponentSelector) selector, container.asImmutable());
-            }
-        }
-
-        private AttributeContainerInternal createCategory(String category) {
-            AttributeContainer attributeContainer = attributesFactory.mutable();
-            return (AttributeContainerInternal) attributeContainer
-                .attribute(Category.CATEGORY_ATTRIBUTE, attributeContainer.named(Category.class, category));
+        private void withCategoryAttribute(String category) {
+            attributes(attrs ->
+                attrs.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, category))
+            );
         }
 
         @Override
         public void platform() {
-            createComponentOfCategory(Category.REGULAR_PLATFORM);
+            withCategoryAttribute(Category.REGULAR_PLATFORM);
         }
 
         @Override
         public void enforcedPlatform() {
-            createComponentOfCategory(Category.ENFORCED_PLATFORM);
+            withCategoryAttribute(Category.ENFORCED_PLATFORM);
         }
 
         @Override
         public void library() {
-            createComponentOfCategory(Category.LIBRARY);
+            withCategoryAttribute(Category.LIBRARY);
         }
 
         @Override
@@ -557,6 +550,10 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
                 selector = DefaultProjectComponentSelector.withAttributes((ProjectComponentSelector) selector, container.asImmutable());
             } else if (selector instanceof ModuleComponentSelector) {
                 selector = DefaultModuleComponentSelector.withAttributes((ModuleComponentSelector) selector, container.asImmutable());
+            } else if (selector instanceof UnversionedModuleComponentSelector) {
+                selector = ((UnversionedModuleComponentSelector) selector).withAttributes(container.asImmutable());
+            } else {
+                throw new IllegalArgumentException("Unknown selector type: " + selector.getClass());
             }
         }
 
@@ -570,6 +567,10 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
                 selector = DefaultProjectComponentSelector.withCapabilities((ProjectComponentSelector) selector, ImmutableSet.copyOf(handler.getCapabilitySelectors().get()));
             } else if (selector instanceof ModuleComponentSelector) {
                 selector = DefaultModuleComponentSelector.withCapabilities((ModuleComponentSelector) selector, ImmutableSet.copyOf(handler.getCapabilitySelectors().get()));
+            } else if (selector instanceof UnversionedModuleComponentSelector) {
+                selector = ((UnversionedModuleComponentSelector) selector).withCapabilities(ImmutableSet.copyOf(handler.getCapabilitySelectors().get()));
+            } else {
+                throw new IllegalArgumentException("Unknown selector type: " + selector.getClass());
             }
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverter.java
@@ -16,9 +16,11 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.TypedNotationConverter;
@@ -50,7 +52,7 @@ public class ModuleSelectorStringNotationConverter extends TypedNotationConverte
         String name = validate(split[1].trim(), notation);
 
         if (split.length == 2) {
-            return new UnversionedModuleComponentSelector(moduleIdentifierFactory.module(group, name));
+            return new UnversionedModuleComponentSelector(moduleIdentifierFactory.module(group, name), ImmutableAttributes.EMPTY, ImmutableSet.of());
         }
         String version = split[2].trim();
         if (!GUtil.isTrue(version)) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/ModuleSelectorStringNotationConverterTest.groovy
@@ -16,10 +16,13 @@
 
 
 package org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution
+
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.typeconversion.NotationParserBuilder
 import org.gradle.internal.typeconversion.UnsupportedNotationException
@@ -37,8 +40,8 @@ class ModuleSelectorStringNotationConverterTest extends Specification {
 
     def "parses module identifier notation"() {
         expect:
-        parser.parseNotation("org.gradle:gradle-core") == new UnversionedModuleComponentSelector(moduleIdentifierFactory.module("org.gradle", "gradle-core"))
-        parser.parseNotation(" foo:bar ") == new UnversionedModuleComponentSelector(moduleIdentifierFactory.module("foo", "bar"))
+        parser.parseNotation("org.gradle:gradle-core") == new UnversionedModuleComponentSelector(moduleIdentifierFactory.module("org.gradle", "gradle-core"), ImmutableAttributes.EMPTY, ImmutableSet.of())
+        parser.parseNotation(" foo:bar ") == new UnversionedModuleComponentSelector(moduleIdentifierFactory.module("foo", "bar"), ImmutableAttributes.EMPTY, ImmutableSet.of())
     }
 
     def "parses module component identifier notation"() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDeclaredSubstitutionsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDeclaredSubstitutionsIntegrationTest.groovy
@@ -264,6 +264,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
 
     }
 
+    // TODO: The behavior in this test has changed
     def "preserves the requested attributes when performing a composite substitution using mapping"() {
         platformDependency 'org.test:platform:1.0'
 
@@ -332,6 +333,7 @@ class CompositeBuildDeclaredSubstitutionsIntegrationTest extends AbstractComposi
 
     }
 
+    // TODO: The behavior in this test has changed
     def "preserves the requested capabilities when performing a composite substitution using mapping"() {
         buildA.buildFile << """
             dependencies {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitutions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitutions.java
@@ -62,7 +62,8 @@ public interface DependencySubstitutions {
     DependencySubstitutions all(Action<? super DependencySubstitution> rule);
 
     /**
-     * Create a ModuleComponentSelector from the provided input string. Strings must be in the format "{group}:{module}:{version}".
+     * Create a ModuleComponentSelector from the provided input string.
+     * Strings must be in the format "{group}:{module}" or "{group}:{module}:{version}".
      */
     ComponentSelector module(String notation);
 


### PR DESCRIPTION
Previously we would silently ignore requests to attach attributes and capability selectors to these component selectors, leading to APIs which should work in theory to silently do something you don't expect

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
