### PR TITLE
[8.x] Upgrade ASM to 9.8 for increased Java 25 compatibility

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -15,7 +15,7 @@ val groovyVersion = GroovySystem.getVersion()
 val isGroovy4 = VersionNumber.parse(groovyVersion).major >= 4
 val codenarcVersion = if (isGroovy4) "3.1.0-groovy-4.0" else "3.1.0"
 val spockVersion = if (isGroovy4) "2.2-groovy-4.0" else "2.2-groovy-3.0"
-val asmVersion = "9.7.1"
+val asmVersion = "9.8"
 // To try out better kotlin compilation avoidance and incremental compilation
 // with -Pkotlin.incremental.useClasspathSnapshot=true
 val kotlinVersion = providers.gradleProperty("buildKotlinVersion")

--- a/build-logic/java-api-extractor/build.gradle.kts
+++ b/build-logic/java-api-extractor/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     //      but then we have an incompatibility between kotlinx-metadata versions.
     //      The error can be reproduced in production code by running an integration test
     //      that uses Kotlin DSL, like ManagedPropertyJavaInterOpIntegrationTest.
-    implementation("org.ow2.asm:asm:9.7.1")
+    implementation("org.ow2.asm:asm:9.8")
     implementation("com.google.guava:guava:33.4.6-jre") {
         isTransitive = false
     }

--- a/packaging/distributions-dependencies/build.gradle.kts
+++ b/packaging/distributions-dependencies/build.gradle.kts
@@ -17,9 +17,11 @@ description = "Provides a platform dependency to align all distribution versions
 
 val antVersion = "1.10.15"
 // Don't forget to bump versions in
-// subprojects/base-services/src/main/java/org/gradle/internal/classanalysis/AsmConstants.java
+// build-logic-commons/build-platform/build.gradle.kts
+// and in the comment at
+// platforms/core-runtime/base-asm/src/main/java/org/gradle/model/internal/asm/AsmConstants.java
 // when upgrading ASM.
-val asmVersion = "9.7.1"
+val asmVersion = "9.8"
 val awsS3Version = "1.12.780"
 val bouncycastleVersion = "1.78.1"
 val jacksonVersion = "2.16.1"

--- a/platforms/core-runtime/base-asm/src/main/java/org/gradle/model/internal/asm/AsmConstants.java
+++ b/platforms/core-runtime/base-asm/src/main/java/org/gradle/model/internal/asm/AsmConstants.java
@@ -29,12 +29,12 @@ public class AsmConstants {
     /**
      * The latest version of Java for which ASM understands the bytecodes.
      *
-     * Updated for ASM 9.7.1.
+     * Updated for ASM 9.8.
      *
      * @see <a href="https://asm.ow2.io/versions.html">ASM release notes</a>
      * Note that this does not mean that this version of Java is supported, just that ASM can handle the bytecode.
      */
-    public static final int MAX_SUPPORTED_JAVA_VERSION = 24;
+    public static final int MAX_SUPPORTED_JAVA_VERSION = 25;
 
     public static boolean isSupportedVersion(int javaMajorVersion) {
         return javaMajorVersion <= MAX_SUPPORTED_JAVA_VERSION;

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -69,9 +69,15 @@ It has now been correctly updated to a `DirectoryProperty` to reflect the intend
 
 Groovy has been updated to https://groovy-lang.org/changelogs/changelog-3.0.25.html[Groovy 3.0.25].
 
+Since the previous version was 3.0.22, this includes changes for https://groovy-lang.org/changelogs/changelog-3.0.24.html[Groovy 3.0.24] and https://groovy-lang.org/changelogs/changelog-3.0.23.html[Groovy 3.0.23] as well.
+
 ==== Upgrade to JaCoCo 0.8.13
 
 JaCoCo has been updated to https://www.jacoco.org/jacoco/trunk/doc/changes.html[0.8.13].
+
+==== Upgrade to ASM 9.8
+
+ASM was upgraded from 9.7.1 to https://asm.ow2.io/versions.html[9.8].
 
 === Deprecations
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -47,9 +47,9 @@ import spock.lang.Subject
 import java.util.zip.ZipEntry
 
 class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
-    private static final String HASH_JAR = "2237539028494c023ca6ba0154b1b63b"
-    private static final String HASH_JAR_WITH_STORED_RESOURCE = "e592d5efeff1967dd9ef2120b20d9b0f"
-    private static final String HASH_DIR = "dbc7c1d348c743c06d46137f2fdd25e2"
+    private static final String HASH_JAR = "86136c96d17f4ca1bf07830e4e158287"
+    private static final String HASH_JAR_WITH_STORED_RESOURCE = "70bf4e479c9956f05e0a8d7adb791962"
+    private static final String HASH_DIR = "4e60705c7f9b68cb25dca49369dddd32"
     private static final String HASH_COPYING_TRANSFORM_ON_JAR = "o_e161f24809571a55f09d3f820c8e5942"
 
     @Rule
@@ -406,7 +406,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/447b2b801d9cc27cc9539f0cd2c94692/thing.jar")
+        def cachedFile = testDir.file("cached/53b67959b2360eadf3518ee172cac1a4/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, transform)


### PR DESCRIPTION
Upgrading ASM to 9.8 gives additional Java 25 compatibility to 8.x.

See #35111.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
This is a follow-up to #35218.
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
