### PR TITLE
fix(wrapper): set read timeout for HEAD requests

### DIFF
--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/Download.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/Download.java
@@ -95,6 +95,7 @@ public class Download implements IDownload {
             addAuthentication(uri, conn);
             conn.setRequestProperty("User-Agent", calculateUserAgent());
             conn.setConnectTimeout(networkTimeout);
+            conn.setReadTimeout(networkTimeout);
             conn.connect();
             responseCode = conn.getResponseCode();
             if (responseCode != 200) {


### PR DESCRIPTION
Previously only the actual wrapper download request used networkTimeout
for both connect timeout and read timeout. The HEAD request did not set
read timeout which could result in the wrapper task hanging
indefinitely.

This change adds a read timeout configured to networkTimeout to the HEAD
request as well, making it symetric to how the download request is
configured.
