### PR TITLE
Add build operation around Develocity build finished callback

### DIFF
--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -242,6 +242,7 @@ public class LauncherServices extends AbstractGradleModuleServices {
                 new BuildCompletionNotifyingBuildActionRunner(
                     gradleEnterprisePluginManager,
                     failureFactory,
+                    buildOperationRunner,
                     new FileSystemWatchingBuildActionRunner(
                         eventEmitter,
                         virtualFileSystem,


### PR DESCRIPTION
for making the Develocity build finished callback visible in build operation traces. Note that currently you cannot measure this build operation in Gradle profiler, since the BuildService responsible for measuring it has already been closed when the build operation fires. Though you can use `--build-ops-trace` to capture it.