### PR TITLE
No Java 25 test on release8x

### DIFF
--- a/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompileToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompileToolchainIntegrationTest.groovy
@@ -234,7 +234,7 @@ class GroovyCompileToolchainIntegrationTest extends MultiVersionIntegrationSpec 
         JavaVersion.forClass(classFile("groovy", "test", "GroovySpec.class").bytes) == groovyTarget
 
         where:
-        javaVersion << JavaVersion.values().findAll { JavaVersion.VERSION_1_8 <= it && GroovyCoverage.supportsJavaVersion("$versionNumber", it) }
+        javaVersion << JavaVersion.values().findAll { JavaVersion.VERSION_1_8 <= it && it < JavaVersion.VERSION_25 && GroovyCoverage.supportsJavaVersion("$versionNumber", it) }
     }
 
     private TestFile configureTool(Jvm jdk) {


### PR DESCRIPTION
If the env includes Java 25 (e.g. TestDistribution), it will be detected and used, causing test failures like [this](https://ge.gradle.org/s/afqy74mwrurbk/tests/task/:language-groovy:integMultiVersionTest/details/org.gradle.groovy.compile.GroovyCompileToolchainIntegrationTest/can%20compile%20source%20and%20run%20tests%20using%20Java%2025%20for%20Groovy%20%204.0.26?top-execution=2)