### PR TITLE
Increase memory for IDE sync test

### DIFF
--- a/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/IsolatedProjectsGradleceptionSyncTest.groovy
+++ b/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/IsolatedProjectsGradleceptionSyncTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.test.fixtures.file.TestFile
 class IsolatedProjectsGradleceptionSyncTest extends AbstractIdeSyncTest {
 
     def setup() {
-        ideXmxMb = 4096
+        ideXmxMb = 4096 + 512
     }
 
     def "can sync gradle/gradle build without problems"() {


### PR DESCRIPTION
since it's a recent source of flakiness for the `IsolatedProjectsGradleceptionSyncTest`

https://ge.gradle.org/s/4cmna7ss7stn6/tests/task/:smoke-ide-test:smokeIdeTest/details/org.gradle.ide.sync.IsolatedProjectsGradleceptionSyncTest/can%20sync%20gradle%2Fgradle%20build%20without%20problems?focused-execution=1&page=eyJvdXRwdXQiOnsiMCI6M319&top-execution=1#L441

---

Fixes https://github.com/gradle/gradle-private/issues/5028