### PR TITLE
Add BuildPlatform overload to tryInstall to allow for foreign platforms

### DIFF
--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
@@ -150,7 +150,7 @@ public class DaemonClientToolchainServices implements ServiceRegistrationProvide
             buildProgressListener
         );
         SecureFileDownloader secureFileDownloader = new SecureFileDownloader(externalResourceFactory);
-        DaemonJavaToolchainProvisioningService javaToolchainProvisioningService = new DaemonJavaToolchainProvisioningService(secureFileDownloader, jdkCacheDirectory, currentBuildPlatform, toolchainDownloadUrlProvider, toolchainConfiguration.isDownloadEnabled(), progressLoggerFactory);
+        DaemonJavaToolchainProvisioningService javaToolchainProvisioningService = new DaemonJavaToolchainProvisioningService(secureFileDownloader, jdkCacheDirectory, currentBuildPlatform.toBuildPlatform(), toolchainDownloadUrlProvider, toolchainConfiguration.isDownloadEnabled(), progressLoggerFactory);
         return new JavaToolchainQueryService(jvmMetadataDetector, filePropertyFactory, javaToolchainProvisioningService, javaInstallationRegistry, null);
     }
 }

--- a/platforms/core-runtime/client-services/src/test/groovy/org/gradle/launcher/daemon/toolchain/DaemonJavaToolchainProvisioningServiceTest.groovy
+++ b/platforms/core-runtime/client-services/src/test/groovy/org/gradle/launcher/daemon/toolchain/DaemonJavaToolchainProvisioningServiceTest.groovy
@@ -29,8 +29,8 @@ import org.gradle.jvm.toolchain.internal.install.SecureFileDownloader
 import org.gradle.jvm.toolchain.internal.install.exceptions.ToolchainDownloadException
 import org.gradle.jvm.toolchain.internal.install.exceptions.ToolchainProvisioningException
 import org.gradle.platform.Architecture
+import org.gradle.platform.BuildPlatformFactory
 import org.gradle.platform.OperatingSystem
-import org.gradle.platform.internal.CurrentBuildPlatform
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 import spock.lang.TempDir
@@ -47,7 +47,7 @@ class DaemonJavaToolchainProvisioningServiceTest extends Specification {
     def downloader = Mock(SecureFileDownloader)
     def cache = Mock(DefaultJdkCacheDirectory)
     def archiveFileLock = Mock(FileLock)
-    def buildPlatform = Mock(CurrentBuildPlatform)
+    def buildPlatform = BuildPlatformFactory.of(Architecture.AARCH64, OperatingSystem.LINUX)
     def spec = Mock(JavaToolchainSpec) {
         getLanguageVersion() >> TestUtil.propertyFactory().property(JavaLanguageVersion).value(JavaLanguageVersion.of(11))
         getVendor() >> TestUtil.propertyFactory().property(JvmVendorSpec).value(JvmVendorSpec.ADOPTIUM)
@@ -77,7 +77,7 @@ class DaemonJavaToolchainProvisioningServiceTest extends Specification {
 
     def "cache is properly locked around provisioning a jdk"() {
         given:
-        def toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider([(buildPlatform.toBuildPlatform()) : DOWNLOAD_URL.toString()])
+        def toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider([(buildPlatform) : DOWNLOAD_URL.toString()])
         def provisioningService = new DaemonJavaToolchainProvisioningService(downloader, cache, buildPlatform, toolchainDownloadUrlProvider, true, progressLoggerFactory)
 
         when:
@@ -91,7 +91,7 @@ class DaemonJavaToolchainProvisioningServiceTest extends Specification {
 
     def "skips downloading if already downloaded"() {
         given:
-        def toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider([(buildPlatform.toBuildPlatform()) : DOWNLOAD_URL.toString()])
+        def toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider([(buildPlatform) : DOWNLOAD_URL.toString()])
         def provisioningService = new DaemonJavaToolchainProvisioningService(downloader, cache, buildPlatform, toolchainDownloadUrlProvider, true, progressLoggerFactory)
         new File(temporaryFolder, UPDATED_ARCHIVE_NAME).createNewFile()
 
@@ -108,7 +108,7 @@ class DaemonJavaToolchainProvisioningServiceTest extends Specification {
 
     def "auto download can be disabled"() {
         given:
-        def toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider([(buildPlatform.toBuildPlatform()) : DOWNLOAD_URL.toString()])
+        def toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider([(buildPlatform) : DOWNLOAD_URL.toString()])
         def provisioningService = new DaemonJavaToolchainProvisioningService(downloader, cache, buildPlatform, toolchainDownloadUrlProvider, false, progressLoggerFactory)
 
         when:
@@ -134,7 +134,7 @@ class DaemonJavaToolchainProvisioningServiceTest extends Specification {
 
     def "fails downloading from invalid provided platform toolchain url"() {
         given:
-        def toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider([(buildPlatform.toBuildPlatform()) : "invalid url"])
+        def toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider([(buildPlatform) : "invalid url"])
         def provisioningService = new DaemonJavaToolchainProvisioningService(downloader, cache, buildPlatform, toolchainDownloadUrlProvider, true, progressLoggerFactory)
 
         when:
@@ -147,7 +147,7 @@ class DaemonJavaToolchainProvisioningServiceTest extends Specification {
 
     def "downloads from url"() {
         given:
-        def toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider([(buildPlatform.toBuildPlatform()) : DOWNLOAD_URL.toString()])
+        def toolchainDownloadUrlProvider = new ToolchainDownloadUrlProvider([(buildPlatform) : DOWNLOAD_URL.toString()])
         def provisioningService = new DaemonJavaToolchainProvisioningService(downloader, cache, buildPlatform, toolchainDownloadUrlProvider, true, progressLoggerFactory)
 
         when:

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/install/JavaToolchainProvisioningService.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/install/JavaToolchainProvisioningService.java
@@ -28,6 +28,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.internal.install.exceptions.ToolchainDownloadException;
 import org.gradle.jvm.toolchain.internal.install.exceptions.ToolchainProvisioningException;
+import org.gradle.platform.BuildPlatform;
 
 import java.io.File;
 import java.net.URI;
@@ -36,6 +37,8 @@ import java.net.URI;
 public interface JavaToolchainProvisioningService {
 
     File tryInstall(JavaToolchainSpec spec) throws ToolchainDownloadException, ToolchainProvisioningException;
+
+    File tryInstall(JavaToolchainSpec spec, BuildPlatform buildPlatform) throws ToolchainDownloadException, ToolchainProvisioningException;
 
     default boolean isAutoDownloadEnabled() {
         return true;

--- a/platforms/jvm/toolchains-jvm-shared/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/platforms/jvm/toolchains-jvm-shared/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.jvm.toolchain.JvmImplementation
 import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.jvm.toolchain.internal.install.JavaToolchainProvisioningService
 import org.gradle.jvm.toolchain.internal.install.exceptions.ToolchainProvisioningException
+import org.gradle.platform.BuildPlatform
 import org.gradle.util.TestUtil
 import spock.lang.Issue
 import spock.lang.Specification
@@ -356,6 +357,10 @@ class JavaToolchainQueryServiceTest extends Specification {
                 installed = true
                 new File("/path/12")
             }
+
+            File tryInstall(JavaToolchainSpec spec, BuildPlatform buildPlatform) {
+                throw new UnsupportedOperationException()
+            }
         }
         def queryService = createQueryService(registry, newJvmMetadataDetector(), provisionService)
 
@@ -377,6 +382,10 @@ class JavaToolchainQueryServiceTest extends Specification {
             File tryInstall(JavaToolchainSpec spec) {
                 installed = true
                 new File("/path/12.broken")
+            }
+
+            File tryInstall(JavaToolchainSpec spec, BuildPlatform buildPlatform) {
+                throw new UnsupportedOperationException()
             }
         }
         def queryService = createQueryService(registry, newJvmMetadataDetector(), provisionService)
@@ -400,6 +409,10 @@ class JavaToolchainQueryServiceTest extends Specification {
             File tryInstall(JavaToolchainSpec spec) {
                 installed++
                 new File("/path/12")
+            }
+
+            File tryInstall(JavaToolchainSpec spec, BuildPlatform buildPlatform) {
+                throw new UnsupportedOperationException()
             }
         }
         def queryService = createQueryService(registry, newJvmMetadataDetector(), provisionService)


### PR DESCRIPTION
In lieu of public interfaces for #18817, this adds an overload to the existing build service for `tryInstall` so the `BuildPlatform` can be specified.

### Context
It's currently not possible to have Gradle provision a toolchain on your behalf for foreign platform, which means the simple task of resolving a toochain for use with `jlink` manual, difficult and error prone.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
