### PR TITLE
Polish lightweight checks

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/LightweightChecks.kt
+++ b/.teamcity/src/main/kotlin/configurations/LightweightChecks.kt
@@ -57,6 +57,10 @@ class LightweightChecks(
                         "$defaultJavaBinary" .teamcity/scripts/FindCommits.java ${model.branch.branchName} | \
                         "$defaultJavaBinary" .teamcity/scripts/CheckWrapper.java
                         """.trimIndent()
+
+                    conditions {
+                        doesNotEqual("teamcity.build.branch", BOT_DAILY_UPGRADLE_WRAPPER_BRANCH)
+                    }
                 }
                 if (model.branch.isMaster) {
                     script {
@@ -69,14 +73,14 @@ class LightweightChecks(
                             "$defaultJavaBinary" .teamcity/scripts/CheckBadMerge.java
                             """.trimIndent()
                     }
-                    script {
-                        name = "CHECK_REMOTE_PROJECT_REF"
-                        scriptContent =
-                            """
-                            set -eu
-                            "$defaultJavaBinary" .teamcity/scripts/CheckRemoteProjectRef.java ${remoteProjectRefs.joinToString(" ")}
-                            """.trimIndent()
-                    }
+                }
+                script {
+                    name = "CHECK_REMOTE_PROJECT_REF"
+                    scriptContent =
+                        """
+                        set -eu
+                        "$defaultJavaBinary" .teamcity/scripts/CheckRemoteProjectRef.java ${remoteProjectRefs.joinToString(" ")}
+                        """.trimIndent()
                 }
                 script {
                     name = "RUN_MAVEN_CLEAN_VERIFY"


### PR DESCRIPTION
This PR makes the following changes:

- Disable CheckWrapper with `devprod/upgrade-to-latest-wrapper` branch because it obviously won't work.
- Run `CHECK_REMOTE_PROJECT_REF` unconditionally. In the past, it was only available on `master`. 