### PR TITLE
Enable IP in the build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.configuration-cache.entries-per-key=2
+org.gradle.unsafe.isolated-projects=true
 systemProp.org.gradle.classloaderscope.strict=true
 systemProp.gradle.publish.skip.namespace.check=true
 # Kotlin DSL settings


### PR DESCRIPTION
Enables Isolated Project in the gradle/gradle build itself to allow for frictionless dogfooding on developer machines

Fixes https://github.com/gradle/gradle-private/issues/5057