### PR TITLE
Fix issue with declarative Gradle not auto-applying develocity plugin

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/settings/PluginsInterpretationSequenceStep.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/settings/PluginsInterpretationSequenceStep.kt
@@ -41,6 +41,7 @@ import org.gradle.internal.declarativedsl.evaluator.conversion.InterpretationSeq
 import org.gradle.internal.declarativedsl.plugins.PluginsTopLevelReceiver
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.plugin.management.internal.DefaultPluginRequest
+import org.gradle.plugin.management.internal.PluginHandler
 import org.gradle.plugin.management.internal.PluginRequestInternal
 import org.gradle.plugin.management.internal.PluginRequests
 import org.gradle.plugin.use.internal.DefaultPluginId
@@ -109,7 +110,9 @@ class PluginsInterpretationSequenceStep(
                 val scriptHandler = get(ScriptHandlerFactory::class.java).create(scriptSource, targetScope, StandaloneDomainObjectContext.forScript(scriptSource))
                 val pluginManager = get(PluginManagerInternal::class.java)
                 val pluginApplicator = get(PluginRequestApplicator::class.java)
-                pluginApplicator.applyPlugins(PluginRequests.of(pluginRequests), scriptHandler, pluginManager, targetScope)
+                val pluginHandler = get(PluginHandler::class.java)
+                val allPluginRequests = pluginHandler.getAllPluginRequests(PluginRequests.of(pluginRequests), target)
+                pluginApplicator.applyPlugins(allPluginRequests, scriptHandler, pluginManager, targetScope)
             }
             targetScope.lock()
         }

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/BaseBuildScanPluginCheckInFixture.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/BaseBuildScanPluginCheckInFixture.groovy
@@ -76,7 +76,7 @@ abstract class BaseBuildScanPluginCheckInFixture {
         """
             pluginManagement {
                 repositories {
-                    maven { url = '${mavenRepo.uri}' }
+                    maven { url = uri("${mavenRepo.uri}") }
                 }
             }
         """
@@ -84,7 +84,7 @@ abstract class BaseBuildScanPluginCheckInFixture {
 
     String plugins() {
         """
-            plugins { id "$id" version "$runtimeVersion" }
+            plugins { id("$id").version("$runtimeVersion") }
         """
     }
 


### PR DESCRIPTION
Previously, the plugin interprator for Settings scripts would only extract the plugins referenced in the script and did not include auto-applied plugins like the Develocity plugin.  This PR adds this support and adds test coverage to the auto-applied plugin integration test for all three supported DSLs (previously it only tested groovy scripts).

* Fixes #36102 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
