### PR TITLE
Fixes #36364. Hostnames are no longer case-sensitive in wrapper properties

### DIFF
--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -35,7 +35,7 @@ import java.util.jar.Manifest
 import static org.hamcrest.CoreMatchers.containsString
 
 class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
-    private static final HashCode EXPECTED_WRAPPER_JAR_HASH = HashCode.fromString("05f861840524c805e30c138be22139b8b89a134dbe89f571372633718b30f873")
+    private static final HashCode EXPECTED_WRAPPER_JAR_HASH = HashCode.fromString("55243ef57851f12b070ad14f7f5bb8302daceeebc5bce5ece5fa6edb23e1145c")
 
     def "generated wrapper scripts use correct line separators"() {
         buildFile << """

--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
@@ -42,7 +42,11 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     private static final String DEFAULT_TOKEN = "token"
 
     private String getDefaultBaseUrl() {
-        "http://$HOST:${server.port}"
+        return getDefaultBaseUrl(false);
+    }
+
+    private String getDefaultBaseUrl(boolean uppercaseHost) {
+        "http://${uppercaseHost ? HOST.toUpperCase(Locale.ROOT) : HOST}:${server.port}"
     }
 
     private String getDefaultAuthenticatedBaseUrl(String user = USER, String password = PASSWORD) {
@@ -57,7 +61,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
                     println 'hello'
                 }
             }
-        
+
             task echoProperty {
                 doLast {
                     println "fooD=" + project.findProperty("fooD")
@@ -76,7 +80,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         if (!userHomeDists.exists() || !userHomeDists.isDirectory()) {
             return false
         }
-        
+
         // Check if there's an actual distribution file (zip or extracted directory with marker)
         def foundDistribution = false
         userHomeDists.eachFileRecurse { file ->
@@ -382,7 +386,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         """.stripIndent()
         server.withBearerAuthentication(DEFAULT_TOKEN)
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        prepareWrapper(getDefaultBaseUrl()).run()
+        prepareWrapper(getDefaultBaseUrl(uppercaseHost)).run()
         server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
@@ -390,6 +394,9 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         then:
         assertThat(result.output, containsString('hello'))
+
+        where:
+        uppercaseHost << [false, true]
     }
 
     def "downloads wrapper from basic authenticated server using credentials from gradle.properties"() {

--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/util/internal/WrapperCredentials.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/util/internal/WrapperCredentials.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -92,7 +93,7 @@ public final class WrapperCredentials {
         Function<? super String, ? extends @Nullable String> propertyProvider
     ) {
         if (host != null) {
-            String hostEscaped = host.replace('.', '_');
+            String hostEscaped = host.replace('.', '_').toLowerCase(Locale.ROOT);
             String hostProperty = propertyProvider.apply("gradle." + hostEscaped + '.' + key);
             if (hostProperty != null) {
                 return hostProperty;

--- a/platforms/core-runtime/wrapper-shared/src/test/groovy/org/gradle/util/internal/WrapperCredentialsTest.groovy
+++ b/platforms/core-runtime/wrapper-shared/src/test/groovy/org/gradle/util/internal/WrapperCredentialsTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.util.internal
+
+import spock.lang.Specification
+
+class WrapperCredentialsTest extends Specification {
+    private static WrapperCredentials testBasicUserInfo(int index) {
+        return WrapperCredentials.fromBasicUserInfo("TestUser$index:TestPassword$index")
+    }
+
+    private static WrapperCredentials testTokenInfo(int index) {
+        return WrapperCredentials.fromToken("TestToken$index")
+    }
+
+    private static String sysPropertyKey(String hostname, String key) {
+        return hostname != null ? "gradle.$hostname.$key" : "gradle.$key"
+    }
+
+    private static Map<String, String> wrapperUserAndPassKeys(int index, String hostname = null) {
+        return [
+            (sysPropertyKey(hostname, "wrapperUser")): "TestUser$index".toString(),
+            (sysPropertyKey(hostname, "wrapperPassword")): "TestPassword$index".toString(),
+        ]
+    }
+
+    private static Map<String, String> wrapperTokenKeys(int index, String hostname = null) {
+        return [(sysPropertyKey(hostname, "wrapperToken")): "TestToken$index".toString()]
+    }
+
+    def "test findCredentials"() {
+        expect:
+        WrapperCredentials.findCredentials(new URI("https://${hostname}/dists/gradle-x.zip")) { sysProperties[it] } == expectation
+
+        where:
+        hostname           | sysProperties                                                                          || expectation
+        "my.company1.com"  | wrapperUserAndPassKeys(1)                                                              || testBasicUserInfo(1)
+        "my.company1.com"  | wrapperTokenKeys(1)                                                                    || testTokenInfo(1)
+        "my.company1.com"  | wrapperUserAndPassKeys(1, "my_company1_com")                                           || testBasicUserInfo(1)
+        "my.company1.com"  | wrapperTokenKeys(1, "my_company1_com")                                                 || testTokenInfo(1)
+        "MY.Company1.com"  | wrapperUserAndPassKeys(1, "my_company1_com")                                           || testBasicUserInfo(1)
+        "MY.Company1.com"  | wrapperTokenKeys(1, "my_company1_com")                                                 || testTokenInfo(1)
+        "my.company1.com"  | wrapperUserAndPassKeys(1) + wrapperUserAndPassKeys(2, "my_company1_com")               || testBasicUserInfo(2)
+        "my.company1.com"  | wrapperTokenKeys(1) + wrapperTokenKeys(2, "my_company1_com")                           || testTokenInfo(2)
+        "my.company1.com"  | wrapperUserAndPassKeys(1) + wrapperTokenKeys(2)                                        || testTokenInfo(2)
+        "my.company1.com"  | wrapperUserAndPassKeys(1, "my_company1_com") + wrapperTokenKeys(2)                     || testTokenInfo(2)
+        "my.company1.com"  | wrapperUserAndPassKeys(1) + wrapperTokenKeys(2, "my_company1_com")                     || testTokenInfo(2)
+        "my.company1.com"  | wrapperUserAndPassKeys(1, "my_company1_com") + wrapperTokenKeys(2, "my_company1_com")  || testTokenInfo(2)
+        "TestUser1:TestPassword1@my.company1.com"  | [:]                                                            || testBasicUserInfo(1)
+        "TestUser1:TestPassword1@my.company1.com"  | wrapperTokenKeys(2)                                            || testTokenInfo(2)
+    }
+}

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/gradle_wrapper.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/gradle_wrapper.adoc
@@ -359,6 +359,10 @@ WARNING: Using `systemProp.gradle.wrapperUser` and `systemProp.gradle.wrapperPas
 
 To safeguard your credentials, prefix these system properties with your private server's hostname, replacing all dots (`.`) with underscores (`_`).
 
+NOTE: Hostnames are not case-sensitive thus Gradle converts the hostname in the property name into lowercase.
+ That is, if you wrote `MYCOMPANY.COM` in your wrapper configuration, then you have to use the string
+ `mycompany_com` in the system property key.
+
 For example, if your private server hostname is `your.private-server.com`, use the following system properties:
 
 [source,properties]


### PR DESCRIPTION
The hostname in `distributionUrl` is (potentially) used as a key to find the credentials for downloading the Gradle distribution. This PR makes sure that the hostname is not case-sensitive. It is done by always expecting the hostname in the system properties in lowercase.

I have also added some unit test cases for credential finding not completely relevant for the case-sensitivity. I assume that is not a problem. I just felt that the logic is sufficiently complex now to warrant some unit tests (alongside the integration test).

* Fixes #36364.

> [!NOTE]
> I think this should be backported to `9.4.0`, because otherwise it will be a backward incompatible change.
> Also, the change is relatively trivial (just a single `.toLowerCase(Locale.ROOT)` was added), so shouldn't be much of a concern.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
