### PR TITLE
Support --help and --version on the Tooling API for older Gradle versions

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r950/HelpConsumerCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r950/HelpConsumerCrossVersionSpec.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.tooling.r950
 
-import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.BuildAction
@@ -25,24 +24,7 @@ import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.GradleProject
 
 @ToolingApiVersion(">=9.5.0")
-@TargetGradleVersion(">=9.4.0") // the required provider-side features were added in 9.4.0
 class HelpConsumerCrossVersionSpec extends ToolingApiSpecification {
-
-    @TargetGradleVersion(">=4.0 <9.4.0")
-    def "help request is ignored for old Gradle version"() {
-        when:
-        withConnection { connection ->
-            connection.newBuild()
-                .forTasks("projects")
-                .withArguments("--help")
-                .run()
-        }
-
-        then:
-        assertSuccessful()
-        result.assertHasErrorOutput('The Tooling API does not support --help, --version or --show-version arguments for this operation. These arguments have been ignored.')
-        result.assertTaskExecuted(":projects")
-    }
 
     def "prints help and ignores tasks when --help is present"() {
         when:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r950/VersionConsumerCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r950/VersionConsumerCrossVersionSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.tooling.r950
 
 import org.gradle.integtests.fixtures.executer.ExecutionResult
-import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.BuildAction
@@ -26,24 +25,7 @@ import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.GradleProject
 
 @ToolingApiVersion(">=9.5.0")
-@TargetGradleVersion(">=9.4.0") // the required provider-side features were added in 9.4.0
 class VersionConsumerCrossVersionSpec extends ToolingApiSpecification {
-
-    @TargetGradleVersion(">=4.0 <9.4.0")
-    def "version request is ignored for old Gradle version"() {
-        when:
-        withConnection { connection ->
-            connection.newBuild()
-                .forTasks("projects")
-                .withArguments("--version")
-                .run()
-        }
-
-        then:
-        assertSuccessful()
-        result.assertHasErrorOutput('The Tooling API does not support --help, --version or --show-version arguments for this operation. These arguments have been ignored.')
-        result.assertTaskExecuted(":projects")
-    }
 
     def "prints version and ignores tasks when --version is present"() {
         when:
@@ -114,9 +96,8 @@ class VersionConsumerCrossVersionSpec extends ToolingApiSpecification {
         arg << ['--show-version', '-V']
     }
 
-    private static void assertVersionInfoRendered(ExecutionResult result) {
-        result.assertOutputContains('Gradle')
-        result.assertOutputContains('Build time:')
-        result.assertOutputContains('Revision:')
+    private void assertVersionInfoRendered(ExecutionResult result) {
+        result.assertOutputContains('------------------------------------------------------------')
+        result.assertOutputContains("Gradle " + targetDist.version.version)
     }
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/AbstractConsumerConnection.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/AbstractConsumerConnection.java
@@ -32,6 +32,7 @@ public abstract class AbstractConsumerConnection extends HasCompatibilityMapping
     private final VersionDetails providerMetaData;
 
     public AbstractConsumerConnection(ConnectionVersion4 delegate, VersionDetails providerMetaData) {
+        super(providerMetaData);
         this.delegate = delegate;
         this.providerMetaData = providerMetaData;
     }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/CancellableModelBuilderBackedModelProducer.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/CancellableModelBuilderBackedModelProducer.java
@@ -35,6 +35,7 @@ public class CancellableModelBuilderBackedModelProducer extends HasCompatibility
     protected final CancellationExceptionTransformer exceptionTransformer;
 
     public CancellableModelBuilderBackedModelProducer(ProtocolToModelAdapter adapter, VersionDetails versionDetails, ModelMapping modelMapping, InternalCancellableConnection builder, CancellationExceptionTransformer exceptionTransformer) {
+        super(versionDetails);
         this.adapter = adapter;
         this.versionDetails = versionDetails;
         this.modelMapping = modelMapping;

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/HasCompatibilityMapping.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/HasCompatibilityMapping.java
@@ -18,6 +18,7 @@ package org.gradle.tooling.internal.consumer.connection;
 
 import org.gradle.tooling.internal.adapter.ViewBuilder;
 import org.gradle.tooling.internal.consumer.converters.BasicGradleProjectIdentifierMixin;
+import org.gradle.tooling.internal.consumer.converters.BuildEnvironmentVersionInfoMixin;
 import org.gradle.tooling.internal.consumer.converters.EclipseExternalDependencyUnresolvedMixin;
 import org.gradle.tooling.internal.consumer.converters.EclipseProjectHasAutoBuildMixin;
 import org.gradle.tooling.internal.consumer.converters.FixedBuildIdentifierProvider;
@@ -26,8 +27,10 @@ import org.gradle.tooling.internal.consumer.converters.IdeaModuleDependencyTarge
 import org.gradle.tooling.internal.consumer.converters.IdeaProjectJavaLanguageSettingsMixin;
 import org.gradle.tooling.internal.consumer.converters.IncludedBuildsMixin;
 import org.gradle.tooling.internal.consumer.parameters.ConsumerOperationParameters;
+import org.gradle.tooling.internal.consumer.versioning.VersionDetails;
 import org.gradle.tooling.internal.gradle.DefaultProjectIdentifier;
 import org.gradle.tooling.model.GradleProject;
+import org.gradle.tooling.model.build.BuildEnvironment;
 import org.gradle.tooling.model.eclipse.EclipseExternalDependency;
 import org.gradle.tooling.model.eclipse.EclipseProject;
 import org.gradle.tooling.model.gradle.BasicGradleProject;
@@ -36,6 +39,12 @@ import org.gradle.tooling.model.idea.IdeaDependency;
 import org.gradle.tooling.model.idea.IdeaProject;
 
 public class HasCompatibilityMapping {
+
+    private final VersionDetails versionDetails;
+
+    public HasCompatibilityMapping(VersionDetails versionDetails) {
+        this.versionDetails = versionDetails;
+    }
 
     public <T> ViewBuilder<T> applyCompatibilityMapping(ViewBuilder<T> viewBuilder, ConsumerOperationParameters parameters) {
         DefaultProjectIdentifier projectIdentifier = new DefaultProjectIdentifier(parameters.getProjectDir(), ":");
@@ -52,6 +61,7 @@ public class HasCompatibilityMapping {
         viewBuilder.mixInTo(GradleBuild.class, IncludedBuildsMixin.class);
         viewBuilder.mixInTo(EclipseProject.class, EclipseProjectHasAutoBuildMixin.class);
         viewBuilder.mixInTo(EclipseExternalDependency.class, EclipseExternalDependencyUnresolvedMixin.class);
+        viewBuilder.mixInTo(BuildEnvironment.class, new BuildEnvironmentVersionInfoMixin(versionDetails.getVersion()));
         return viewBuilder;
     }
 }

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/HelpAndVersionHandlingConsumerConnection.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/HelpAndVersionHandlingConsumerConnection.java
@@ -38,7 +38,7 @@ public abstract class HelpAndVersionHandlingConsumerConnection extends AbstractC
 
     @Override
     public <T> T run(Class<T> type, ConsumerOperationParameters operationParameters) {
-        if (operationParameters.containsHelpOrVersionArgs() && type == Void.class && getVersionDetails().supportsHelpToolingModel()) {
+        if (operationParameters.containsHelpOrVersionArgs() && type == Void.class) {
             // For task execution, handle --help/--version and skip task execution
             return handleHelpOrVersion(type, operationParameters);
         }
@@ -103,8 +103,13 @@ public abstract class HelpAndVersionHandlingConsumerConnection extends AbstractC
 
     private void queryAndPrintHelp(ConsumerOperationParameters operationParameters, ConsumerOperationParameters modelParams){
         OutputStream standardOutput = operationParameters.getStandardOutput();
-        Help helpModel = getModelProducer().produceModel(Help.class, modelParams);
-        print(standardOutput, helpModel.getRenderedText());
+        if (getVersionDetails().supportsHelpToolingModel()) {
+            Help helpModel = getModelProducer().produceModel(Help.class, modelParams);
+            print(standardOutput, helpModel.getRenderedText());
+        } else {
+            String renderedText = HelpModelCompatibilityHelper.getRenderedText(getVersionDetails().getVersion());
+            print(standardOutput, renderedText);
+        }
     }
 
     private void queryAndPrintVersion(ConsumerOperationParameters operationParameters, ConsumerOperationParameters modelParams) {

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/HelpModelCompatibilityHelper.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/HelpModelCompatibilityHelper.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.consumer.connection;
+
+import org.gradle.util.GradleVersion;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class to load the expected {@link org.gradle.tooling.model.build.Help} model output for Gradle versions &lt; 9.4.
+ */
+class HelpModelCompatibilityHelper {
+
+    private HelpModelCompatibilityHelper() {
+    }
+
+    static String getRenderedText(String version) {
+        GradleVersion gradleVersion = GradleVersion.version(version);
+        String templateVersion = templateVersion(gradleVersion);
+        String resourceName = "help-output/gradle-" + templateVersion + ".txt";
+
+        InputStream resourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName);
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(resourceStream, StandardCharsets.UTF_8))) {
+            return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+        } catch (IOException e) {
+            throw new RuntimeException("cannot load " + resourceName + " from classloader resource for " + version,  e);
+        }
+    }
+
+    private static String templateVersion(GradleVersion gradleVersion) {
+        // The classpath resources contain the unique help outputs for a range of Gradle versions.
+        // For each range, the lowest version is used as the resource identifier.
+        String[] helpOutputResourceVersion = {
+            "9.2.0", "9.1.0", "9.0.0",
+            "8.11", "8.3", "8.2", "8.1", "8.0.1", "8.0",
+            "7.6", "7.5", "7.3", "7.1", "7.0",
+            "6.8.1", "6.6", "6.5", "6.2", "6.1", "6.0",
+            "5.0",
+            "4.8", "4.6", "4.5", "4.4", "4.3", "4.0"
+        };
+        for (String resourceVersion : helpOutputResourceVersion) {
+            if (gradleVersion.compareTo(GradleVersion.version(resourceVersion)) >= 0) {
+                return resourceVersion;
+            }
+        }
+        // We fall back to the lowest supported version for very old Gradle versions
+        return "4.0";
+    }
+}

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/UnparameterizedBuildController.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/UnparameterizedBuildController.java
@@ -55,6 +55,7 @@ abstract class UnparameterizedBuildController extends HasCompatibilityMapping im
     private final File rootDir;
 
     public UnparameterizedBuildController(ProtocolToModelAdapter adapter, ModelMapping modelMapping, VersionDetails gradleVersion, File rootDir) {
+        super(gradleVersion);
         this.adapter = adapter;
         // Treat all models returned to the action as part of the same object graph
         this.resultAdapter = adapter.newGraph();

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/BuildEnvironmentVersionInfoMixin.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/BuildEnvironmentVersionInfoMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.consumer.converters;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.io.Serializable;
+
+@NullMarked
+public class BuildEnvironmentVersionInfoMixin implements Serializable {
+    private final String version;
+
+    public BuildEnvironmentVersionInfoMixin(String version) {
+        this.version = version;
+    }
+
+    @SuppressWarnings("unused")// Used by reflection
+    public String getVersionInfo() {
+        return String.join(System.lineSeparator(),
+            "",
+            "------------------------------------------------------------",
+            "Gradle " + version,
+            "------------------------------------------------------------",
+            "");
+    }
+}

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.0.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.0.txt
@@ -1,0 +1,45 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help          Shows this help message.
+-a, --no-rebuild        Do not rebuild project dependencies.
+-b, --build-file        Specify the build file.
+--build-cache           Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds. [incubating]
+-c, --settings-file     Specify the settings file.
+--configure-on-demand   Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console               Specifies which type of console output to generate. Values are 'plain', 'auto' (default) or 'rich'.
+--continue              Continue task execution after a task failure.
+-D, --system-prop       Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug             Log in debug mode (includes normal stacktrace).
+--daemon                Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--foreground            Starts the Gradle Daemon in the foreground. [incubating]
+-g, --gradle-user-home  Specifies the gradle user home directory.
+-I, --init-script       Specify an initialization script.
+-i, --info              Set log level to info.
+--include-build         Include the specified build in the composite. [incubating]
+-m, --dry-run           Run the builds with all task actions disabled.
+--max-workers           Configure the number of concurrent workers Gradle is allowed to use. [incubating]
+--no-build-cache        Disables the Gradle build cache. [incubating]
+--no-daemon             Do not use the Gradle Daemon to run the build.
+--no-scan               Disables the creation of a build scan. (https://gradle.com/build-scans) [incubating]
+--offline               Execute the build without accessing network resources.
+-P, --project-prop      Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir       Specifies the start directory for Gradle. Defaults to current directory.
+--parallel              Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use. [incubating]
+--profile               Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir     Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet             Log errors only.
+--recompile-scripts     Force build script recompiling.
+--refresh-dependencies  Refresh the state of dependencies.
+--rerun-tasks           Ignore previously cached task results.
+-S, --full-stacktrace   Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace        Print out the stacktrace for all exceptions.
+--scan                  Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans) [incubating]
+--status                Shows status of running and recently stopped Gradle Daemon(s).
+--stop                  Stops the Gradle Daemon if it is running.
+-t, --continuous        Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change. [incubating]
+-u, --no-search-upward  Don't search in parent folders for a settings.gradle file.
+-v, --version           Print version info.
+-w, --warn              Set log level to warn.
+-x, --exclude-task      Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.3.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.3.txt
@@ -1,0 +1,47 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help            Shows this help message.
+-a, --no-rebuild          Do not rebuild project dependencies.
+-b, --build-file          Specify the build file.
+--build-cache             Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds. [incubating]
+-c, --settings-file       Specify the settings file.
+--configure-on-demand     Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                 Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                Continue task execution after a task failure.
+-D, --system-prop         Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug               Log in debug mode (includes normal stacktrace).
+--daemon                  Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--foreground              Starts the Gradle Daemon in the foreground. [incubating]
+-g, --gradle-user-home    Specifies the gradle user home directory.
+-I, --init-script         Specify an initialization script.
+-i, --info                Set log level to info.
+--include-build           Include the specified build in the composite. [incubating]
+-m, --dry-run             Run the builds with all task actions disabled.
+--max-workers             Configure the number of concurrent workers Gradle is allowed to use. [incubating]
+--no-build-cache          Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds. [incubating]
+--no-configure-on-demand  Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--no-daemon               Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--no-parallel             Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use. [incubating]
+--no-scan                 Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans) [incubating]
+--offline                 Execute the build without accessing network resources.
+-P, --project-prop        Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir         Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use. [incubating]
+--profile                 Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir       Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet               Log errors only.
+--recompile-scripts       Force build script recompiling. [deprecated - Support for --recompile-scripts was deprecated and is scheduled to be removed in Gradle 5.0.]
+--refresh-dependencies    Refresh the state of dependencies.
+--rerun-tasks             Ignore previously cached task results.
+-S, --full-stacktrace     Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace          Print out the stacktrace for all exceptions.
+--scan                    Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans) [incubating]
+--status                  Shows status of running and recently stopped Gradle Daemon(s).
+--stop                    Stops the Gradle Daemon if it is running.
+-t, --continuous          Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change. [incubating]
+-u, --no-search-upward    Don't search in parent folders for a settings.gradle file.
+-v, --version             Print version info.
+-w, --warn                Set log level to warn.
+-x, --exclude-task        Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.4.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.4.txt
@@ -1,0 +1,47 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help            Shows this help message.
+-a, --no-rebuild          Do not rebuild project dependencies. [deprecated]
+-b, --build-file          Specify the build file.
+--build-cache             Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds. [incubating]
+-c, --settings-file       Specify the settings file.
+--configure-on-demand     Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                 Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                Continue task execution after a task failure.
+-D, --system-prop         Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug               Log in debug mode (includes normal stacktrace).
+--daemon                  Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--foreground              Starts the Gradle Daemon in the foreground. [incubating]
+-g, --gradle-user-home    Specifies the gradle user home directory.
+-I, --init-script         Specify an initialization script.
+-i, --info                Set log level to info.
+--include-build           Include the specified build in the composite. [incubating]
+-m, --dry-run             Run the builds with all task actions disabled.
+--max-workers             Configure the number of concurrent workers Gradle is allowed to use. [incubating]
+--no-build-cache          Disables the Gradle build cache. [incubating]
+--no-configure-on-demand  Disables the use of configuration on demand. [incubating]
+--no-daemon               Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel             Disables parallel execution to build projects. [incubating]
+--no-scan                 Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans. [incubating]
+--offline                 Execute the build without accessing network resources.
+-P, --project-prop        Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir         Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use. [incubating]
+--profile                 Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir       Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet               Log errors only.
+--recompile-scripts       Force build script recompiling. [deprecated]
+--refresh-dependencies    Refresh the state of dependencies.
+--rerun-tasks             Ignore previously cached task results.
+-S, --full-stacktrace     Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace          Print out the stacktrace for all exceptions.
+--scan                    Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans) [incubating]
+--status                  Shows status of running and recently stopped Gradle Daemon(s).
+--stop                    Stops the Gradle Daemon if it is running.
+-t, --continuous          Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change. [incubating]
+-u, --no-search-upward    Don't search in parent folders for a settings file.
+-v, --version             Print version info.
+-w, --warn                Set log level to warn.
+-x, --exclude-task        Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.5.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.5.txt
@@ -1,0 +1,48 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help            Shows this help message.
+-a, --no-rebuild          Do not rebuild project dependencies. [deprecated]
+-b, --build-file          Specify the build file.
+--build-cache             Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds. [incubating]
+-c, --settings-file       Specify the settings file.
+--configure-on-demand     Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                 Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                Continue task execution after a task failure.
+-D, --system-prop         Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug               Log in debug mode (includes normal stacktrace).
+--daemon                  Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--foreground              Starts the Gradle Daemon in the foreground. [incubating]
+-g, --gradle-user-home    Specifies the gradle user home directory.
+-I, --init-script         Specify an initialization script.
+-i, --info                Set log level to info.
+--include-build           Include the specified build in the composite. [incubating]
+-m, --dry-run             Run the builds with all task actions disabled.
+--max-workers             Configure the number of concurrent workers Gradle is allowed to use. [incubating]
+--no-build-cache          Disables the Gradle build cache. [incubating]
+--no-configure-on-demand  Disables the use of configuration on demand. [incubating]
+--no-daemon               Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel             Disables parallel execution to build projects. [incubating]
+--no-scan                 Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans. [incubating]
+--offline                 Execute the build without accessing network resources.
+-P, --project-prop        Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir         Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use. [incubating]
+--profile                 Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir       Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet               Log errors only.
+--recompile-scripts       Force build script recompiling. [deprecated]
+--refresh-dependencies    Refresh the state of dependencies.
+--rerun-tasks             Ignore previously cached task results.
+-S, --full-stacktrace     Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace          Print out the stacktrace for all exceptions.
+--scan                    Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans) [incubating]
+--status                  Shows status of running and recently stopped Gradle Daemon(s).
+--stop                    Stops the Gradle Daemon if it is running.
+-t, --continuous          Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change. [incubating]
+-u, --no-search-upward    Don't search in parent folders for a settings file.
+-v, --version             Print version info.
+-w, --warn                Set log level to warn.
+--warning-mode            Specifies which mode of warnings to generate. Values are 'all', 'summary'(default) or 'no'
+-x, --exclude-task        Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.6.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.6.txt
@@ -1,0 +1,48 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help            Shows this help message.
+-a, --no-rebuild          Do not rebuild project dependencies. [deprecated]
+-b, --build-file          Specify the build file.
+--build-cache             Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file       Specify the settings file.
+--configure-on-demand     Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                 Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                Continue task execution after a task failure.
+-D, --system-prop         Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug               Log in debug mode (includes normal stacktrace).
+--daemon                  Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--foreground              Starts the Gradle Daemon in the foreground. [incubating]
+-g, --gradle-user-home    Specifies the gradle user home directory.
+-I, --init-script         Specify an initialization script.
+-i, --info                Set log level to info.
+--include-build           Include the specified build in the composite. [incubating]
+-m, --dry-run             Run the builds with all task actions disabled.
+--max-workers             Configure the number of concurrent workers Gradle is allowed to use. [incubating]
+--no-build-cache          Disables the Gradle build cache.
+--no-configure-on-demand  Disables the use of configuration on demand. [incubating]
+--no-daemon               Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel             Disables parallel execution to build projects. [incubating]
+--no-scan                 Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans. [incubating]
+--offline                 Execute the build without accessing network resources.
+-P, --project-prop        Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir         Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use. [incubating]
+--profile                 Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir       Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet               Log errors only.
+--recompile-scripts       Force build script recompiling. [deprecated]
+--refresh-dependencies    Refresh the state of dependencies.
+--rerun-tasks             Ignore previously cached task results.
+-S, --full-stacktrace     Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace          Print out the stacktrace for all exceptions.
+--scan                    Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans) [incubating]
+--status                  Shows status of running and recently stopped Gradle Daemon(s).
+--stop                    Stops the Gradle Daemon if it is running.
+-t, --continuous          Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change. [incubating]
+-u, --no-search-upward    Don't search in parent folders for a settings file.
+-v, --version             Print version info.
+-w, --warn                Set log level to warn.
+--warning-mode            Specifies which mode of warnings to generate. Values are 'all', 'summary'(default) or 'none'
+-x, --exclude-task        Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.8.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-4.8.txt
@@ -1,0 +1,50 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help            Shows this help message.
+-a, --no-rebuild          Do not rebuild project dependencies. [deprecated]
+-b, --build-file          Specify the build file.
+--build-cache             Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file       Specify the settings file.
+--configure-on-demand     Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                 Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                Continue task execution after a task failure.
+-D, --system-prop         Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug               Log in debug mode (includes normal stacktrace).
+--daemon                  Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--foreground              Starts the Gradle Daemon in the foreground. [incubating]
+-g, --gradle-user-home    Specifies the gradle user home directory.
+-I, --init-script         Specify an initialization script.
+-i, --info                Set log level to info.
+--include-build           Include the specified build in the composite. [incubating]
+-m, --dry-run             Run the builds with all task actions disabled.
+--max-workers             Configure the number of concurrent workers Gradle is allowed to use. [incubating]
+--no-build-cache          Disables the Gradle build cache.
+--no-configure-on-demand  Disables the use of configuration on demand. [incubating]
+--no-daemon               Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel             Disables parallel execution to build projects. [incubating]
+--no-scan                 Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans. [incubating]
+--offline                 Execute the build without accessing network resources.
+-P, --project-prop        Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir         Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use. [incubating]
+--profile                 Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir       Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet               Log errors only.
+--recompile-scripts       Force build script recompiling. [deprecated]
+--refresh-dependencies    Refresh the state of dependencies.
+--rerun-tasks             Ignore previously cached task results.
+-S, --full-stacktrace     Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace          Print out the stacktrace for all exceptions.
+--scan                    Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans) [incubating]
+--status                  Shows status of running and recently stopped Gradle Daemon(s).
+--stop                    Stops the Gradle Daemon if it is running.
+-t, --continuous          Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change. [incubating]
+-u, --no-search-upward    Don't search in parent folders for a settings file.
+--update-locks            Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version             Print version info.
+-w, --warn                Set log level to warn.
+--warning-mode            Specifies which mode of warnings to generate. Values are 'all', 'summary'(default) or 'none'
+--write-locks             Persists dependency resolution for locked configurations, ignoring existing locking information if it exists [incubating]
+-x, --exclude-task        Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-5.0.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-5.0.txt
@@ -1,0 +1,49 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help            Shows this help message.
+-a, --no-rebuild          Do not rebuild project dependencies.
+-b, --build-file          Specify the build file.
+--build-cache             Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file       Specify the settings file.
+--configure-on-demand     Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                 Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                Continue task execution after a task failure.
+-D, --system-prop         Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug               Log in debug mode (includes normal stacktrace).
+--daemon                  Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--foreground              Starts the Gradle Daemon in the foreground.
+-g, --gradle-user-home    Specifies the gradle user home directory.
+-I, --init-script         Specify an initialization script.
+-i, --info                Set log level to info.
+--include-build           Include the specified build in the composite.
+-m, --dry-run             Run the builds with all task actions disabled.
+--max-workers             Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache          Disables the Gradle build cache.
+--no-configure-on-demand  Disables the use of configuration on demand. [incubating]
+--no-daemon               Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel             Disables parallel execution to build projects.
+--no-scan                 Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--offline                 Execute the build without accessing network resources.
+-P, --project-prop        Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir         Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low' [incubating]
+--profile                 Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir       Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet               Log errors only.
+--refresh-dependencies    Refresh the state of dependencies.
+--rerun-tasks             Ignore previously cached task results.
+-S, --full-stacktrace     Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace          Print out the stacktrace for all exceptions.
+--scan                    Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                  Shows status of running and recently stopped Gradle Daemon(s).
+--stop                    Stops the Gradle Daemon if it is running.
+-t, --continuous          Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks            Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version             Print version info.
+-w, --warn                Set log level to warn.
+--warning-mode            Specifies which mode of warnings to generate. Values are 'all', 'summary'(default) or 'none'
+--write-locks             Persists dependency resolution for locked configurations, ignoring existing locking information if it exists [incubating]
+-x, --exclude-task        Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.0.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.0.txt
@@ -1,0 +1,49 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help            Shows this help message.
+-a, --no-rebuild          Do not rebuild project dependencies.
+-b, --build-file          Specify the build file.
+--build-cache             Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file       Specify the settings file.
+--configure-on-demand     Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                 Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                Continue task execution after a task failure.
+-D, --system-prop         Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug               Log in debug mode (includes normal stacktrace).
+--daemon                  Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--foreground              Starts the Gradle Daemon in the foreground.
+-g, --gradle-user-home    Specifies the gradle user home directory.
+-I, --init-script         Specify an initialization script.
+-i, --info                Set log level to info.
+--include-build           Include the specified build in the composite.
+-m, --dry-run             Run the builds with all task actions disabled.
+--max-workers             Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache          Disables the Gradle build cache.
+--no-configure-on-demand  Disables the use of configuration on demand. [incubating]
+--no-daemon               Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel             Disables parallel execution to build projects.
+--no-scan                 Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--offline                 Execute the build without accessing network resources.
+-P, --project-prop        Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir         Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low' [incubating]
+--profile                 Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir       Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet               Log errors only.
+--refresh-dependencies    Refresh the state of dependencies.
+--rerun-tasks             Ignore previously cached task results.
+-S, --full-stacktrace     Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace          Print out the stacktrace for all exceptions.
+--scan                    Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                  Shows status of running and recently stopped Gradle Daemon(s).
+--stop                    Stops the Gradle Daemon if it is running.
+-t, --continuous          Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks            Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version             Print version info.
+-w, --warn                Set log level to warn.
+--warning-mode            Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--write-locks             Persists dependency resolution for locked configurations, ignoring existing locking information if it exists [incubating]
+-x, --exclude-task        Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.1.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.1.txt
@@ -1,0 +1,50 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                 Shows this help message.
+-a, --no-rebuild               Do not rebuild project dependencies.
+-b, --build-file               Specify the build file.
+--build-cache                  Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file            Specify the settings file.
+--configure-on-demand          Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                      Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                     Continue task execution after a task failure.
+-D, --system-prop              Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                    Log in debug mode (includes normal stacktrace).
+--daemon                       Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--foreground                   Starts the Gradle Daemon in the foreground.
+-g, --gradle-user-home         Specifies the gradle user home directory.
+-I, --init-script              Specify an initialization script.
+-i, --info                     Set log level to info.
+--include-build                Include the specified build in the composite.
+-m, --dry-run                  Run the builds with all task actions disabled.
+--max-workers                  Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache               Disables the Gradle build cache.
+--no-configure-on-demand       Disables the use of configuration on demand. [incubating]
+--no-daemon                    Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                  Disables parallel execution to build projects.
+--no-scan                      Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--offline                      Execute the build without accessing network resources.
+-P, --project-prop             Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir              Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                     Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                     Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low' [incubating]
+--profile                      Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir            Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                    Log errors only.
+--refresh-dependencies         Refresh the state of dependencies.
+--rerun-tasks                  Ignore previously cached task results.
+-S, --full-stacktrace          Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace               Print out the stacktrace for all exceptions.
+--scan                         Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                       Shows status of running and recently stopped Gradle Daemon(s).
+--stop                         Stops the Gradle Daemon if it is running.
+-t, --continuous               Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks                 Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version                  Print version info.
+-w, --warn                     Set log level to warn.
+--warning-mode                 Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--write-locks                  Persists dependency resolution for locked configurations, ignoring existing locking information if it exists [incubating]
+--write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list) [incubating]
+-x, --exclude-task             Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.2.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.2.txt
@@ -1,0 +1,53 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file.
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file.
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification. [incubating]
+-F, --dependency-verification      Configures the dependency verification mode (strict, lenient or off) [incubating]
+--foreground                       Starts the Gradle Daemon in the foreground.
+-g, --gradle-user-home             Specifies the gradle user home directory.
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list) [incubating]
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low' [incubating]
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-dependencies             Refresh the state of dependencies.
+--refresh-keys                     Refresh the public keys used for dependency verification. [incubating]
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle Daemon(s).
+--stop                             Stops the Gradle Daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version                      Print version info.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists [incubating]
+-x, --exclude-task                 Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.5.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.5.txt
@@ -1,0 +1,56 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file.
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file.
+--configuration-cache              Enables the configuration cache (off, on, or warn). Gradle will try to reuse the build configuration from previous builds. [incubating]
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification. [incubating]
+-F, --dependency-verification      Configures the dependency verification mode (strict, lenient or off) [incubating]
+--foreground                       Starts the Gradle Daemon in the foreground.
+-g, --gradle-user-home             Specifies the gradle user home directory.
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list) [incubating]
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system. [incubating]
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low' [incubating]
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-dependencies             Refresh the state of dependencies.
+--refresh-keys                     Refresh the public keys used for dependency verification. [incubating]
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle Daemon(s).
+--stop                             Stops the Gradle Daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version                      Print version info.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build. [incubating]
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists [incubating]
+-x, --exclude-task                 Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.6.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.6.txt
@@ -1,0 +1,58 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file.
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file.
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds. [incubating]
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail. [incubating]
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification. [incubating]
+-F, --dependency-verification      Configures the dependency verification mode (strict, lenient or off) [incubating]
+--foreground                       Starts the Gradle Daemon in the foreground.
+-g, --gradle-user-home             Specifies the gradle user home directory.
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list) [incubating]
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system. [incubating]
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low' [incubating]
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-dependencies             Refresh the state of dependencies.
+--refresh-keys                     Refresh the public keys used for dependency verification. [incubating]
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle Daemon(s).
+--stop                             Stops the Gradle Daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version                      Print version info.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build. [incubating]
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists [incubating]
+-x, --exclude-task                 Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.8.1.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-6.8.1.txt
@@ -1,0 +1,58 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file.
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file.
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds. [incubating]
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail. [incubating]
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification. [incubating]
+-F, --dependency-verification      Configures the dependency verification mode (strict, lenient or off) [incubating]
+--foreground                       Starts the Gradle Daemon in the foreground.
+-g, --gradle-user-home             Specifies the gradle user home directory.
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list) [incubating]
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low' [incubating]
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-dependencies             Refresh the state of dependencies.
+--refresh-keys                     Refresh the public keys used for dependency verification. [incubating]
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle Daemon(s).
+--stop                             Stops the Gradle Daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version                      Print version info.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists [incubating]
+-x, --exclude-task                 Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-7.0.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-7.0.txt
@@ -1,0 +1,58 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file.
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file.
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds. [incubating]
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail. [incubating]
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode (strict, lenient or off)
+--foreground                       Starts the Gradle Daemon in the foreground.
+-g, --gradle-user-home             Specifies the gradle user home directory.
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-dependencies             Refresh the state of dependencies.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle Daemon(s).
+--stop                             Stops the Gradle Daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version                      Print version info.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-7.1.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-7.1.txt
@@ -1,0 +1,58 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file. (deprecated)
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file. (deprecated)
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds. [incubating]
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail. [incubating]
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode (strict, lenient or off)
+--foreground                       Starts the Gradle Daemon in the foreground.
+-g, --gradle-user-home             Specifies the gradle user home directory.
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-dependencies             Refresh the state of dependencies.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle Daemon(s).
+--stop                             Stops the Gradle Daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version                      Print version info.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-7.3.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-7.3.txt
@@ -1,0 +1,58 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file. [deprecated]
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file. [deprecated]
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds. [incubating]
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail. [incubating]
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-dependencies             Refresh the state of dependencies.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-v, --version                      Print version info.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-7.5.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-7.5.txt
@@ -1,0 +1,59 @@
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file. [deprecated]
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file. [deprecated]
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds. [incubating]
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail. [incubating]
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-dependencies             Refresh the state of dependencies.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-7.6.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-7.6.txt
@@ -1,0 +1,62 @@
+
+To see help contextual to the project, use gradle help
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file. [deprecated]
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file. [deprecated]
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds. [incubating]
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail. [incubating]
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-dependencies             Refresh the state of dependencies.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.0.1.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.0.1.txt
@@ -1,0 +1,62 @@
+
+To see help contextual to the project, use gradle help
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file. [deprecated]
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file. [deprecated]
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds. [incubating]
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail. [incubating]
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+-U, --refresh-dependencies         Refresh the state of dependencies.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.0.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.0.txt
@@ -1,0 +1,61 @@
+
+To see help contextual to the project, use gradle help
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-b, --build-file                   Specify the build file. [deprecated]
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file. [deprecated]
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds. [incubating]
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail. [incubating]
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+-U, --refresh-dependencies         Refresh the state of dependencies.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.1.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.1.txt
@@ -1,0 +1,62 @@
+
+To see help contextual to the project, use gradle help
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file. [deprecated]
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file. [deprecated]
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds.
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail.
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache.
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+-U, --refresh-dependencies         Refresh the state of dependencies.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.11.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.11.txt
@@ -1,0 +1,70 @@
+
+To see help contextual to the project, use gradle help
+
+To see more detail about a task, run gradle help --task <task>
+
+To see a list of available tasks, run gradle tasks
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file. [deprecated]
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+--no-build-cache                   Disables the Gradle build cache.
+-c, --settings-file                Specify the settings file. [deprecated]
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds.
+--no-configuration-cache           Disables the configuration cache.
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail.
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+--no-continue                      Stop task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--no-parallel                      Disables parallel execution to build projects.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--problems-report                  (Experimental) enables HTML problems report
+--no-problems-report               (Experimental) disables HTML problems report
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+--property-upgrade-report          (Experimental) Runs build with experimental property upgrade report.
+-q, --quiet                        Log errors only.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+-U, --refresh-dependencies         Refresh the state of dependencies.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--no-watch-fs                      Disables watching the file system.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.2.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.2.txt
@@ -1,0 +1,63 @@
+
+To see help contextual to the project, use gradle help
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file. [deprecated]
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+-c, --settings-file                Specify the settings file. [deprecated]
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds.
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail.
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--no-build-cache                   Disables the Gradle build cache.
+--no-configuration-cache           Disables the configuration cache.
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--no-continue                      Stop task execution after a task failure.
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--no-parallel                      Disables parallel execution to build projects.
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--no-watch-fs                      Disables watching the file system.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+-U, --refresh-dependencies         Refresh the state of dependencies.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.3.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-8.3.txt
@@ -1,0 +1,63 @@
+
+To see help contextual to the project, use gradle help
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+-b, --build-file                   Specify the build file. [deprecated]
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+--no-build-cache                   Disables the Gradle build cache.
+-c, --settings-file                Specify the settings file. [deprecated]
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds.
+--no-configuration-cache           Disables the configuration cache.
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail.
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+--no-continue                      Stop task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--no-parallel                      Disables parallel execution to build projects.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+-q, --quiet                        Log errors only.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans)
+--no-scan                          Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans.
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+-U, --refresh-dependencies         Refresh the state of dependencies.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--no-watch-fs                      Disables watching the file system.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-9.0.0.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-9.0.0.txt
@@ -1,0 +1,70 @@
+
+To see help contextual to the project, use gradle help
+
+To see more detail about a task, run gradle help --task <task>
+
+To see a list of available tasks, run gradle tasks
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+--no-build-cache                   Disables the Gradle build cache.
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds.
+--no-configuration-cache           Disables the configuration cache.
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail.
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+--no-continue                      Stop task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--no-parallel                      Disables parallel execution to build projects.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--problems-report                  (Experimental) enables HTML problems report
+--no-problems-report               (Experimental) disables HTML problems report
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+--property-upgrade-report          (Experimental) Runs build with experimental property upgrade report.
+-q, --quiet                        Log errors only.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Generate a Build Scan (Powered by Develocity).
+                                   Build Scan and Develocity are registered trademarks of Gradle, Inc.
+                                   For more information, please visit https://gradle.com/develocity/product/build-scan/.
+--no-scan                          Disables the creation of a Build Scan.
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+-U, --refresh-dependencies         Refresh the state of dependencies.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--no-watch-fs                      Disables watching the file system.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-9.1.0.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-9.1.0.txt
@@ -1,0 +1,71 @@
+
+To see help contextual to the project, use gradle help
+
+To see more detail about a task, run gradle help --task <task>
+
+To see a list of available tasks, run gradle tasks
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+--no-build-cache                   Disables the Gradle build cache.
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds.
+--no-configuration-cache           Disables the configuration cache.
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail.
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'colored', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+--no-continue                      Stop task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--no-parallel                      Disables parallel execution to build projects.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--problems-report                  (Experimental) enables HTML problems report
+--no-problems-report               (Experimental) disables HTML problems report
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+--property-upgrade-report          (Experimental) Runs build with experimental property upgrade report.
+-q, --quiet                        Log errors only.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Generate a Build Scan (Powered by Develocity).
+                                   Build Scan and Develocity are registered trademarks of Gradle, Inc.
+                                   For more information, please visit https://gradle.com/develocity/product/build-scan/.
+--no-scan                          Disables the creation of a Build Scan.
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--task-graph                       (Experimental) Print task graph instead of executing tasks.
+-U, --refresh-dependencies         Refresh the state of dependencies.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--no-watch-fs                      Disables watching the file system.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+

--- a/platforms/ide/tooling-api/src/main/resources/help-output/gradle-9.2.0.txt
+++ b/platforms/ide/tooling-api/src/main/resources/help-output/gradle-9.2.0.txt
@@ -1,0 +1,71 @@
+
+To see help contextual to the project, use gradle help
+
+To see more detail about a task, run gradle help --task <task>
+
+To see a list of available tasks, run gradle tasks
+
+USAGE: gradle [option...] [task...]
+
+-?, -h, --help                     Shows this help message.
+-a, --no-rebuild                   Do not rebuild project dependencies.
+--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
+--no-build-cache                   Disables the Gradle build cache.
+--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds.
+--no-configuration-cache           Disables the configuration cache.
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail.
+--configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
+--console                          Specifies which type of console output to generate. Values are 'plain', 'colored', 'auto' (default), 'rich' or 'verbose'.
+--continue                         Continue task execution after a task failure.
+--no-continue                      Stop task execution after a task failure.
+-D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
+-d, --debug                        Log in debug mode (includes normal stacktrace).
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
+--no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--export-keys                      Exports the public keys used for dependency verification.
+-F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+--foreground                       Starts the Gradle daemon in the foreground.
+-g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
+-I, --init-script                  Specify an initialization script.
+-i, --info                         Set log level to info.
+--include-build                    Include the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
+-m, --dry-run                      Run the builds with all task actions disabled.
+--max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
+--offline                          Execute the build without accessing network resources.
+-P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
+--parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--no-parallel                      Disables parallel execution to build projects.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
+--problems-report                  (Experimental) enables HTML problems report
+--no-problems-report               (Experimental) disables HTML problems report
+--profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
+--property-upgrade-report          (Experimental) Runs build with experimental property upgrade report.
+-q, --quiet                        Log errors only.
+--refresh-keys                     Refresh the public keys used for dependency verification.
+--rerun-tasks                      Ignore previously cached task results.
+-S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Print out the stacktrace for all exceptions.
+--scan                             Generate a Build Scan (powered by Develocity).
+                                   Build Scan and Develocity are registered trademarks of Gradle, Inc.
+                                   For more information, please visit https://gradle.com/develocity/product/build-scan/.
+--no-scan                          Disables the creation of a Build Scan.
+--status                           Shows status of running and recently stopped Gradle daemon(s).
+--stop                             Stops the Gradle daemon if it is running.
+-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
+--task-graph                       (Experimental) Print task graph instead of executing tasks.
+-U, --refresh-dependencies         Refresh the state of dependencies.
+--update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
+-V, --show-version                 Print version info and continue.
+-v, --version                      Print version info and exit.
+-w, --warn                         Set log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
+--watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
+--no-watch-fs                      Disables watching the file system.
+--write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
+-x, --exclude-task                 Specify a task to be excluded from execution.
+--                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/BuildControllerWithoutParameterSupportTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/BuildControllerWithoutParameterSupportTest.groovy
@@ -32,11 +32,13 @@ class BuildControllerWithoutParameterSupportTest extends Specification {
     def controller = new BuildControllerWithoutParameterSupport(delegate, new ProtocolToModelAdapter(), modelMapping, new File("root dir"), version)
 
     def "delegates when no parameter is given"() {
+        setup:
         def model = new Object()
         def modelType = Object
         def buildResult = Stub(BuildResult) {
             getModel() >> model
         }
+        _ * version.getVersion() >> "4.1"
 
         when:
         def result = controller.getModel(null, modelType, null, null)
@@ -50,11 +52,10 @@ class BuildControllerWithoutParameterSupportTest extends Specification {
     }
 
     def "throws exception when parameter is given"() {
+        setup:
         def modelType = Object.class
         def parameterType = Object.class
         def parameterInitializer = Mock(Action)
-
-        given:
         _ * version.getVersion() >> "4.1"
 
         when:

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ParameterAwareBuildControllerAdapterTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ParameterAwareBuildControllerAdapterTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.tooling.internal.protocol.InternalUnsupportedModelException
 import org.gradle.tooling.internal.protocol.ModelIdentifier
 import org.gradle.tooling.model.Element
 import org.gradle.tooling.model.gradle.GradleBuild
+import org.gradle.util.GradleVersion
 import spock.lang.Specification
 
 class ParameterAwareBuildControllerAdapterTest extends Specification {
@@ -45,7 +46,7 @@ class ParameterAwareBuildControllerAdapterTest extends Specification {
         }
     }
     def delegate = Mock(InternalBuildControllerVersion2)
-    def controller = new ParameterAwareBuildControllerAdapter(delegate, adapter, mapping, Stub(VersionDetails), new File("root"))
+    def controller = new ParameterAwareBuildControllerAdapter(delegate, adapter, mapping, VersionDetails.from(GradleVersion.current()), new File("root"))
 
     def "unpacks unsupported model exception"() {
         def failure = new RuntimeException()

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -353,7 +353,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
         def toolingApiJar = contentsDir.file("lib/gradle-tooling-api-${baseVersion}.jar")
         toolingApiJar.assertIsFile()
-        assert toolingApiJar.length() < 550 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
+        assert toolingApiJar.length() < 600 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
 
         // Kotlin DSL
         assertIsGradleJar(contentsDir.file("lib/gradle-kotlin-dsl-${baseVersion}.jar"))


### PR DESCRIPTION
Follow-up for https://github.com/gradle/gradle/pull/35987

This PR makes the Tooling API return meaningful data when the client runs the build with `--version`, `--help` or `--show-version` and targets a Gradle version < 9.3.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
