### PR TITLE
Apply excludes to originally requested dependency

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -1692,6 +1692,88 @@ Required by:
                 }
             }
         }
+    }
 
+    @Issue("https://github.com/gradle/gradle/issues/36331")
+    def "exclusions are applied to originally requested dependency"() {
+        mavenRepo.module("org", "foo")
+            .dependsOn(mavenRepo.module("org", "bar").publish())
+            .publish()
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${mavenTestRepository()}
+
+            dependencies {
+                implementation("org:foo:1.0") {
+                    exclude(group: "org", module: "bar")
+                }
+                implementation("org:baz:1.0")
+            }
+
+            ${resolve.configureProject("runtimeClasspath")}
+
+            configurations.runtimeClasspath {
+                exclude(group: "org", module: "baz")
+                resolutionStrategy.dependencySubstitution {
+                    substitute(module("org:bar")).using(module("org:a:1.0"))
+                    substitute(module("org:baz")).using(module("org:b:1.0"))
+               }
+            }
+        """
+
+        when:
+        succeeds(":checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":depsub:") {
+                module("org:foo:1.0")
+            }
+        }
+    }
+
+    def "exclusions are applied to substituted dependency"() {
+        mavenRepo.module("org", "foo")
+            .dependsOn(mavenRepo.module("org", "bar").publish())
+            .publish()
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${mavenTestRepository()}
+
+            dependencies {
+                implementation("org:foo:1.0") {
+                    exclude(group: "org", module: "a")
+                }
+                implementation("org:baz:1.0")
+            }
+
+            ${resolve.configureProject("runtimeClasspath")}
+
+            configurations.runtimeClasspath {
+                exclude(group: "org", module: "b")
+                resolutionStrategy.dependencySubstitution {
+                    substitute(module("org:bar")).using(module("org:a:1.0"))
+                    substitute(module("org:baz")).using(module("org:b:1.0"))
+               }
+            }
+        """
+
+        when:
+        succeeds(":checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":depsub:") {
+                module("org:foo:1.0")
+            }
+        }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
@@ -637,10 +638,17 @@ public class NodeState implements DependencyGraphNode {
         if (excludeSpec == moduleExclusions.nothing()) {
             return false;
         }
-        ModuleIdentifier targetModuleId = dependencyState.getModuleIdentifier(resolveState.getComponentSelectorConverter());
+        ComponentSelectorConverter componentSelectorConverter = resolveState.getComponentSelectorConverter();
+        ModuleIdentifier targetModuleId = dependencyState.getModuleIdentifier(componentSelectorConverter);
         if (excludeSpec.excludes(targetModuleId)) {
             LOGGER.debug("{} is excluded from {} by {}.", targetModuleId, this, excludeSpec);
             return true;
+        }
+
+        // If we were substituted, apply the exclusion to the original selector as well.
+        ComponentSelector requestedSelector = dependencyState.getRequested();
+        if (requestedSelector != dependencyState.getDependency().getSelector()) {
+            return excludeSpec.excludes(componentSelectorConverter.getModuleVersionId(requestedSelector).getModule());
         }
 
         return false;


### PR DESCRIPTION
This was originally introduced in https://github.com/gradle/gradle/pull/34927 , but there was no test to verify this behavior. Now, we add a test to verify that exclusions are applied to dependencies before and after substitution

Fixes https://github.com/gradle/gradle/issues/36331

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
