### PR TITLE
Pass CI env env down to subprocesses

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleKotlinDslReferencePlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleKotlinDslReferencePlugin.java
@@ -16,7 +16,6 @@
 
 package gradlebuild.docs;
 
-import gradlebuild.basics.BuildEnvironmentKt;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -36,6 +35,8 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Locale;
+
+import static gradlebuild.basics.BuildParamsKt.getBuildCommitId;
 
 public class GradleKotlinDslReferencePlugin implements Plugin<Project> {
 
@@ -117,7 +118,7 @@ public class GradleKotlinDslReferencePlugin implements Plugin<Project> {
     }
 
     private static void configureSourceLinks(Project project, GradleDocumentationExtension extension, DokkaSourceSetSpec spec) {
-        String commitId = BuildEnvironmentKt.getBuildEnvironmentExtension(project).getGitCommitId().get();
+        String commitId = getBuildCommitId(project).get();
         if (commitId.isBlank() || commitId.toLowerCase(Locale.ROOT).contains("unknown")) {
             // we can't figure out the commit ID (probably this is a source distribution build), let's skip adding source links
             return;

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -274,7 +274,10 @@ fun Test.isUnitTest() = listOf("test", "writePerformanceScenarioDefinitions", "w
  * If enabled, test JVM will inherit the DEVELOCITY_ACCESS_TOKEN
  * environment variable. This allows build scans to be published for integration tests.
  */
-fun Test.inheritDevelocityAccessTokenEnv() = setOf("smoke-test").contains(project.name)
+fun Test.inheritedEnvVars(): List<String> = when {
+    project.name == "smoke-test" -> listOf("DEVELOCITY_ACCESS_KEY", "CI")
+    else -> emptyList()
+}
 
 fun Test.usesEmbeddedExecuter() = systemProperties["org.gradle.integtest.executer"]?.equals("embedded") ?: false
 
@@ -305,7 +308,7 @@ fun configureTests() {
     tasks.withType<Test>().configureEach {
 
         configureAndroidUserHome()
-        filterEnvironmentVariables(inheritDevelocityAccessTokenEnv())
+        filterEnvironmentVariables(inheritedEnvVars())
 
         maxParallelForks = project.maxParallelForks
 

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -108,15 +108,15 @@ val credentialsKeywords = listOf(
 )
 
 
-fun Test.filterEnvironmentVariables(inheritDevelocityAccessToken: Boolean) {
+fun Test.filterEnvironmentVariables(inheritedEnvVars: List<String>) {
     environment = makePropagatedEnvironment()
     environment.forEach { (key, _) ->
         require(credentialsKeywords.none { key.contains(it, true) }) { "Found sensitive data in filtered environment variables: $key" }
     }
 
-    if (inheritDevelocityAccessToken) {
-        System.getenv("DEVELOCITY_ACCESS_KEY")?.let {
-            environment["DEVELOCITY_ACCESS_KEY"] = it
+    inheritedEnvVars.forEach { envVar ->
+        System.getenv(envVar)?.let {
+            environment[envVar] = it
         }
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectSmokeTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.smoketests
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
 
 abstract class AndroidProjectSmokeTest extends AbstractAndroidProjectSmokeTest {
 }
@@ -63,7 +64,7 @@ class AndroidProjectIncrementalCompilationSmokeTest extends AndroidProjectSmokeT
         def result = buildLocation(checkoutDir, agpVersion)
 
         then:
-        result.task(":core:ui:compileProdDebugKotlin").outcome == SUCCESS
+        result.task(":core:ui:compileProdDebugKotlin").outcome in [SUCCESS, FROM_CACHE]
         if (GradleContextualExecuter.isConfigCache()) {
             result.assertConfigurationCacheStateStored()
         }
@@ -73,7 +74,7 @@ class AndroidProjectIncrementalCompilationSmokeTest extends AndroidProjectSmokeT
         result = buildCachedLocation(checkoutDir, agpVersion)
 
         then:
-        result.task(":core:ui:compileProdDebugKotlin").outcome == SUCCESS
+        result.task(":core:ui:compileProdDebugKotlin").outcome in [SUCCESS, FROM_CACHE]
         if (GradleContextualExecuter.isConfigCache()) {
             result.assertConfigurationCacheStateLoaded()
         }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildIsolatedProjectsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildIsolatedProjectsSmokeTest.groovy
@@ -60,10 +60,13 @@ class GradleBuildIsolatedProjectsSmokeTest extends AbstractGradleBuildIsolatedPr
             "-Pgradle_installPath=/dev/null",
             "-PartifactoryUserName=foo",
             "-PartifactoryUserPassword=bar",
-            "-PtoolingApiShadedJarInstallPath=/tmp"
+            "-PtoolingApiShadedJarInstallPath=/tmp",
+            "-PpromotionCommitId=1234567"
         ]
         def requiredEnvironmentVars = [
             "GRADLE_INTERNAL_REPO_URL": "file:///bogus-repository",
+            "BUILD_COMMIT_ID": "1234567",
+            "BUILD_BRANCH": "master",
         ]
         def tasks = [
             "--init-script",
@@ -77,7 +80,7 @@ class GradleBuildIsolatedProjectsSmokeTest extends AbstractGradleBuildIsolatedPr
 
         when:
         maxIsolatedProjectProblems = 200000
-        run(isolatedProjectsRunner(tasks).withEnvironment(requiredEnvironmentVars))
+        run(isolatedProjectsRunner(tasks, 1).withEnvironment(requiredEnvironmentVars))
 
         then:
         fixture.htmlReport(result.output).assertContents {


### PR DESCRIPTION
Because we publish many build scans in some tests (like smoke tests, Gradleception, etc), we need to pass down the `CI` env variable, otherwise they will show as local builds.