### PR TITLE
Update Documentation: remove outdated plugin

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/publishing_gradle_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/plugin-development/publishing_gradle_plugins.adoc
@@ -38,8 +38,6 @@ image::plugin-portal-registration-page.png[]
 
 Provide the credentials as Gradle properties (`gradle.publish.key` and `gradle.publish.secret`), usually in <<build_environment.adoc#sec:gradle_configuration_properties,`$HOME/.gradle/gradle.properties`>>, or supply them via environment variables (`GRADLE_PUBLISH_KEY` and `GRADLE_PUBLISH_SECRET`), which is convenient for CI/CD.
 
-If you are concerned about placing your credentials in gradle.properties, check out the link:https://plugins.gradle.org/plugin/de.qaware.seu.as.code.credentials[Seauc Credentials plugin].
-
 [[plugin-publishing-plugin]]
 == Adding the {publishplugin}
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- Remove outdated plugin from publishing plugin page

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [X] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [X] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description