### PR TITLE
Source files can have platform-dependent encoding.

### DIFF
--- a/platforms/native/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/sourceparser/RegexBackedCSourceParser.java
+++ b/platforms/native/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/sourceparser/RegexBackedCSourceParser.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
@@ -38,17 +39,16 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.Files.newBufferedReader;
-
 /**
  * Parses a subset of the C preprocessor language, to extract details of {@code #include}, {@code #import} and {@code #define} directives. Only handles a subset of the possible expressions that can be
  * used as the body of these directives.
  */
 public class RegexBackedCSourceParser implements CSourceParser {
     @Override
+    @SuppressWarnings("DefaultCharset")
     public IncludeDirectives parseSource(File sourceFile) {
-        try (Reader fileReader = newBufferedReader(sourceFile.toPath(), UTF_8)) {
+        // Note: source files can have non-UTF8 encoding. FileReader uses default Charset and also handles invalid characters.
+        try (Reader fileReader = new FileReader(sourceFile)) {
             return parseSource(fileReader);
         } catch (Exception e) {
             throw new GradleException(String.format("Could not extract includes from source file %s.", sourceFile), e);

--- a/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/antlr2/MetadataExtracter.java
+++ b/platforms/software/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/antlr2/MetadataExtracter.java
@@ -21,15 +21,13 @@ import org.jspecify.annotations.Nullable;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.Files.newBufferedReader;
 
 /**
  * Preprocess an Antlr grammar file so that dependencies between grammars can be properly determined such that they can
@@ -73,9 +71,11 @@ public class MetadataExtracter {
     }
 
     @Nullable
-    private String getPackageName(File grammarFileFile) {
+    @SuppressWarnings("DefaultCharset")
+    private String getPackageName(File grammarFile) {
         try {
-            return getPackageName(newBufferedReader(grammarFileFile.toPath(), UTF_8));
+            // Note: source files can have non-UTF8 encoding. FileReader uses default Charset and also handles invalid characters.
+            return getPackageName(new FileReader(grammarFile));
         } catch (IOException e) {
             throw new UncheckedIOException("Cannot read antlr grammar file", e);
         }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisher.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisher.java
@@ -28,13 +28,10 @@ import org.gradle.api.publish.maven.MavenArtifact;
 import org.gradle.internal.UncheckedException;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
-import java.io.Reader;
 import java.util.HashSet;
 import java.util.Set;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.Files.newBufferedReader;
 
 public class ValidatingMavenPublisher implements MavenPublisher {
     private static final java.lang.String ID_REGEX = "[A-Za-z0-9_\\-.]+";
@@ -88,8 +85,10 @@ public class ValidatingMavenPublisher implements MavenPublisher {
         }
     }
 
+    @SuppressWarnings("DefaultCharset")
     private Model readModelFromPom(File pomFile) throws IOException, XmlPullParserException {
-        try (Reader reader = newBufferedReader(pomFile.toPath(), UTF_8)) {
+        // Note: source files can have non-UTF8 encoding. FileReader uses default Charset and also handles invalid characters.
+        try (FileReader reader = new FileReader(pomFile)) {
             return new MavenXpp3Reader().read(reader);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/declarations/NioFileInterceptors.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/declarations/NioFileInterceptors.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.newBufferedReader;
 import static org.gradle.internal.classpath.FileUtils.optionsAllowReading;
 import static org.gradle.internal.classpath.FileUtils.tryReportDirectoryContentObserved;
@@ -136,7 +135,7 @@ public class NioFileInterceptors {
         @CallerClassName String consumer
     ) throws IOException {
         tryReportFileOpened(path, consumer);
-        return newBufferedReader(path, UTF_8);
+        return newBufferedReader(path);
     }
 
     @InterceptCalls


### PR DESCRIPTION
Fixes #36399

Same as 
* https://github.com/gradle/gradle/pull/36407
but for 9.3.1 branch

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
