### PR TITLE
Remove accessing the `ProjectFeaturesDynamicObject` of a parent project

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
@@ -41,13 +41,18 @@ import java.util.Map;
 public class ExtensibleDynamicObject extends MixInClosurePropertiesAsMethodsDynamicObject {
 
     public enum Location {
-        BeforeConvention, AfterConvention
+        BeforeConventionNotInherited, BeforeConvention, AfterConvention
     }
 
     private final AbstractDynamicObject dynamicDelegate;
+    @Nullable
     private DynamicObject parent;
     private final DefaultExtensionContainer extensionContainer;
+    @Nullable
+    private DynamicObject beforeConventionNotInherited;
+    @Nullable
     private DynamicObject beforeConvention;
+    @Nullable
     private DynamicObject afterConvention;
     private final DynamicObject extraPropertiesDynamicObject;
 
@@ -72,16 +77,17 @@ public class ExtensibleDynamicObject extends MixInClosurePropertiesAsMethodsDyna
     }
 
     private void updateDelegates() {
-        DynamicObject[] delegates = new DynamicObject[6];
+        DynamicObject[] delegates = new DynamicObject[7];
         delegates[0] = dynamicDelegate;
         delegates[1] = extraPropertiesDynamicObject;
         int idx = 2;
+        if (beforeConventionNotInherited != null) {
+            delegates[idx++] = beforeConventionNotInherited;
+        }
         if (beforeConvention != null) {
             delegates[idx++] = beforeConvention;
         }
-        if (extensionContainer != null) {
-            delegates[idx++] = extensionContainer.getExtensionsAsDynamicObject();
-        }
+        delegates[idx++] = extensionContainer.getExtensionsAsDynamicObject();
         if (afterConvention != null) {
             delegates[idx++] = afterConvention;
         }
@@ -122,11 +128,12 @@ public class ExtensibleDynamicObject extends MixInClosurePropertiesAsMethodsDyna
         return extensionContainer.getExtraProperties();
     }
 
+    @Nullable
     public DynamicObject getParent() {
         return parent;
     }
 
-    public void setParent(DynamicObject parent) {
+    public void setParent(@Nullable DynamicObject parent) {
         this.parent = parent;
         updateDelegates();
     }
@@ -137,6 +144,9 @@ public class ExtensibleDynamicObject extends MixInClosurePropertiesAsMethodsDyna
 
     public void addObject(DynamicObject object, Location location) {
         switch (location) {
+            case BeforeConventionNotInherited:
+                beforeConventionNotInherited = object;
+                break;
             case BeforeConvention:
                 beforeConvention = object;
                 break;
@@ -217,6 +227,7 @@ public class ExtensibleDynamicObject extends MixInClosurePropertiesAsMethodsDyna
         }
 
         @Override
+        @Nullable
         public Object getProperty(String name) {
             return snapshotInheritable().getProperty(name);
         }
@@ -242,6 +253,7 @@ public class ExtensibleDynamicObject extends MixInClosurePropertiesAsMethodsDyna
         }
 
         @Override
+        @Nullable
         public Object invokeMethod(String name, @Nullable Object... arguments) {
             return snapshotInheritable().invokeMethod(name, arguments);
         }

--- a/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/ProjectFeatureSupportInternal.java
+++ b/platforms/core-configuration/project-features/src/main/java/org/gradle/plugin/software/internal/ProjectFeatureSupportInternal.java
@@ -199,7 +199,7 @@ public class ProjectFeatureSupportInternal {
     ) {
         ((ExtensibleDynamicObject) dslObjectToInitialize.getAsDynamicObject()).addObject(
             objectFactory.newInstance(ProjectFeaturesDynamicObject.class, dslObjectToInitialize, context),
-            ExtensibleDynamicObject.Location.BeforeConvention
+            ExtensibleDynamicObject.Location.BeforeConventionNotInherited
         );
     }
 }


### PR DESCRIPTION
This was allowed because `beforeConvention` objects are inherited in `ExtensibleDynamicObject#snapshotInheritable`. We need to keep that behavior for `ProjectInternal#setScript`, but we stop using it for `ProjectFeaturesDynamicObject` as it's not intended and could cause further issues with IP.

Also, looking up `ProjectFeaturesDynamicObject` in parent projects would cause issues with declarative.

The added `Location`, `BeforeConventionNotInherited`, is not inherited.

* Fixes https://github.com/gradle/gradle/issues/34498

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
