### PR TITLE
No Java 26 tests

### DIFF
--- a/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompileToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompileToolchainIntegrationTest.groovy
@@ -251,7 +251,7 @@ class GroovyCompileToolchainIntegrationTest extends MultiVersionIntegrationSpec 
         JavaVersion.forClass(classFile("groovy", "test", "GroovySpec.class").bytes) == groovyTarget
 
         where:
-        javaVersion << JavaVersion.values().findAll { it >= JavaVersion.VERSION_1_8 }
+        javaVersion << JavaVersion.values().findAll { JavaVersion.VERSION_1_8 <= it && it < JavaVersion.VERSION_26 && GroovyCoverage.supportsJavaVersion("$versionNumber", it) }
     }
 
     private TestFile configureTool(Jvm jdk) {


### PR DESCRIPTION
Cherry-picked https://github.com/gradle/gradle/pull/36339 to `release9x`.