### PR TITLE
Fix no-daemon tests spawning a single-use daemon process

### DIFF
--- a/testing/internal-integ-testing/src/integTest/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuterIntegrationTest.groovy
+++ b/testing/internal-integ-testing/src/integTest/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuterIntegrationTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.launcher.daemon.client.SingleUseDaemonClient
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
+
+@Requires(IntegTestPreconditions.IsNoDaemonExecutor)
+class NoDaemonGradleExecuterIntegrationTest extends AbstractIntegrationSpec {
+    def "no daemon executer does not spawn daemon"() {
+        given:
+        buildFile """
+            tasks.register("hello") {
+                doLast {
+                    println("Hello")
+                }
+            }
+        """
+
+        when:
+        run "hello"
+
+        then:
+        outputContains("Hello")
+        assertWasNotForked()
+    }
+
+    private void assertWasNotForked() {
+        outputDoesNotContain(SingleUseDaemonClient.MESSAGE)
+    }
+}

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -595,18 +595,6 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
             gradleInvocation.implicitLauncherJvmArgs.add(debugLauncher.toDebugArgument());
         }
         gradleInvocation.implicitLauncherJvmArgs.add("-ea");
-
-        // Note: it's possible we shouldn't calculate _any_ implicit JVM args when requested to use only the specified ones, but to preserve behavior I only excluded the new flag here
-        if (useOnlyRequestedJvmOpts) {
-            return;
-        }
-
-        JavaVersion javaVersion = getJavaVersionFromJavaHome();
-        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_24)) {
-            // Remove known warning that occurs in the launcher. This can be fixed by refactoring the bin/gradle start script to pass the flag or by adding the flag to the launcher JAR
-            // and refactoring the start script to use that JAR instead of a main class.
-            gradleInvocation.implicitLauncherJvmArgs.add("--enable-native-access=ALL-UNNAMED");
-        }
     }
 
     protected static String joinAndQuoteJvmArgs(List<String> buildJvmArgs) {


### PR DESCRIPTION
We missed that because it only happens on Java 24+, and we were running no-daemon tests on Java 21 until recently. Additionally, there were no specific tests covering no-daemon executor not spawning the single-use process.

This commit doesn't clean up all the places that add `--enable-native-access` and equivalents, but it eliminates at least one duplicate.

Having duplicate switches is breaking process compatibility checks but this commit doesn't address that either.

Fixes gradle/gradle-private#5031.
