### PR TITLE
Clean up perf test split dir

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -38,6 +38,7 @@ import model.CIBuildModel
 import model.PerformanceTestBuildSpec
 import model.PerformanceTestType
 import model.Stage
+import model.cleanupPerformanceTestSplits
 
 class PerformanceTest(
     model: CIBuildModel,
@@ -119,6 +120,7 @@ class PerformanceTest(
                     removeSubstDirOnWindows(os)
                     killProcessStep(buildTypeThis, KILL_PROCESSES_STARTED_BY_GRADLE, os, executionMode = BuildStep.ExecutionMode.ALWAYS)
                     checkCleanM2AndAndroidUserHome(os)
+                    cleanupPerformanceTestSplits(os)()
                 }
             }
 

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -69,6 +69,7 @@ class PerformanceTestBuildTypeTest {
                 "GRADLE_RUNNER",
                 "KILL_PROCESSES_STARTED_BY_GRADLE",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME",
+                "CLEANUP_PERFORMANCE_TEST_SPLITS",
             ),
             performanceTest.steps.items.map(BuildStep::name),
         )
@@ -147,6 +148,7 @@ class PerformanceTestBuildTypeTest {
                 "REMOVE_VIRTUAL_DISK_FOR_PERF_TEST",
                 "KILL_PROCESSES_STARTED_BY_GRADLE",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME",
+                "CLEANUP_PERFORMANCE_TEST_SPLITS",
             ),
             performanceTest.steps.items.map(BuildStep::name),
         )


### PR DESCRIPTION
In performance test, there is a step setting up `performance-test-splits` directory, but it never gets cleaned up. Discussed in https://gradle.slack.com/archives/CBSJ2GUTV/p1769510709157649

