### PR TITLE
Use JDK API for reading a link instead of readlink

### DIFF
--- a/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
+++ b/testing/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
@@ -161,13 +161,7 @@ class TestFileHelper {
     }
 
     String readLink() {
-        def process = ["readlink", file.absolutePath].execute()
-        def error = process.errorStream.text
-        def retval = process.waitFor()
-        if (retval != 0) {
-            throw new RuntimeException("Could not read link '$file': $error")
-        }
-        return process.inputStream.text.trim()
+        Files.readSymbolicLink(file.toPath()).toFile().absolutePath
     }
 
     ExecOutput exec(List args) {


### PR DESCRIPTION
This avoids having to fork an executable and parse command-line output


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
