### PR TITLE
JavaToolchainService: Lenient fetch toolchains

### DIFF
--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/JavaToolchainNotFoundMode.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/JavaToolchainNotFoundMode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Describes how to handle missing {@link JavaToolchainSpec}.
+ *
+ * @see JavaToolchainSpec#getOnNoMatchFound
+ * @since 9.5.0
+ */
+@Incubating
+public enum JavaToolchainNotFoundMode {
+    /**
+     * If no toolchain matching a given {@link JavaToolchainSpec} is found, failures will be ignored.
+     *
+     * @since 9.5.0
+     */
+    IGNORE,
+
+    /**
+     * If no toolchain matching a given {@link JavaToolchainSpec} can be found, a failure will be thrown.
+     *
+     * @since 9.5.0
+     */
+    THROW_EXCEPTION,
+}

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/JavaToolchainSpec.java
@@ -26,11 +26,11 @@ import org.gradle.internal.HasInternalProtocol;
  * Requirements for selecting a Java toolchain.
  * <p>
  * A toolchain is a JRE/JDK used by the tasks of a build.
- * Tasks may require one or more of the tools (javac, java, or javadoc) of a toolchain.
+ * Tasks may require one or more of the tools ({@code javac}, {@code java}, or {@code javadoc}) of a toolchain.
  * Depending on the needs of a build, only toolchains matching specific characteristics can be used to run a build or a specific task of a build.
  * <p>
  * Even though specification properties can be configured independently,
- * the configuration must follow certain rules in order to form a  specification.
+ * the configuration must follow certain rules to form a specification.
  * <p>
  * A {@code JavaToolchainSpec} is considered <em>valid</em> in two cases:
  * <ul>
@@ -83,6 +83,15 @@ public interface JavaToolchainSpec extends Describable {
     @Incubating
     Property<Boolean> getNativeImageCapable();
 
+    /**
+     * Controls how to handle the outcome when a matching toolchain cannot be found.
+     *
+     * @since 9.5.0
+     */
+    @Incubating
+    Property<JavaToolchainNotFoundMode> getOnNoMatchFound();
+
+
     @Override
     default String getDisplayName() {
         final MoreObjects.ToStringHelper builder = MoreObjects.toStringHelper("");
@@ -91,6 +100,7 @@ public interface JavaToolchainSpec extends Describable {
         builder.add("vendor", getVendor().map(JvmVendorSpec::toString).getOrNull());
         builder.add("implementation", getImplementation().map(JvmImplementation::toString).getOrNull());
         builder.add("nativeImageCapable", getNativeImageCapable().getOrElse(false));
+        builder.add("onNoMatchFound", getOnNoMatchFound().getOrNull());
         return builder.toString();
     }
 

--- a/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/platforms/jvm/toolchains-jvm-shared/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -19,8 +19,10 @@ package org.gradle.jvm.toolchain.internal;
 import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaToolchainNotFoundMode;
 import org.gradle.jvm.toolchain.JvmImplementation;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
@@ -32,6 +34,7 @@ public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
     private final Property<JvmVendorSpec> vendor;
     private final Property<JvmImplementation> implementation;
     private final Property<Boolean> nativeImageCapable;
+    private final Property<JavaToolchainNotFoundMode> missingToolchainMode;
 
     public static class Key implements JavaToolchainSpecInternal.Key {
         private final JavaLanguageVersion languageVersion;
@@ -83,6 +86,7 @@ public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
         vendor = propertyFactory.property(JvmVendorSpec.class);
         implementation = propertyFactory.property(JvmImplementation.class);
         nativeImageCapable = propertyFactory.property(Boolean.class);
+        missingToolchainMode = propertyFactory.property(JavaToolchainNotFoundMode.class);
 
         getVendor().convention(getConventionVendor());
         getImplementation().convention(getConventionImplementation());
@@ -106,6 +110,12 @@ public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
     @Override
     public Property<Boolean> getNativeImageCapable() {
         return nativeImageCapable;
+    }
+
+    @Override
+    @NonNull
+    public Property<JavaToolchainNotFoundMode> getOnNoMatchFound() {
+        return missingToolchainMode;
     }
 
     @Override

--- a/platforms/jvm/toolchains-jvm/src/test/groovy/org/gradle/api/plugins/JvmToolchainsPluginTest.groovy
+++ b/platforms/jvm/toolchains-jvm/src/test/groovy/org/gradle/api/plugins/JvmToolchainsPluginTest.groovy
@@ -16,9 +16,24 @@
 
 package org.gradle.api.plugins
 
+import org.gradle.api.Action
+import org.gradle.api.provider.Provider
 import org.gradle.internal.Actions
+import org.gradle.internal.jvm.Jvm
+import org.gradle.jvm.toolchain.JavaCompiler
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.jvm.toolchain.JavaToolchainNotFoundMode
 import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.jvm.toolchain.JavaToolchainSpec
+import org.gradle.jvm.toolchain.JavadocTool
+import org.gradle.jvm.toolchain.JvmImplementation
+import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.gradle.jvm.toolchain.internal.JavaToolchainSpecInternal
+import org.gradle.jvm.toolchain.internal.install.exceptions.ToolchainProvisioningException
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+import org.gradle.util.TestUtil
+import org.jspecify.annotations.Nullable
 
 class JvmToolchainsPluginTest extends AbstractProjectBuilderSpec {
 
@@ -39,5 +54,189 @@ class JvmToolchainsPluginTest extends AbstractProjectBuilderSpec {
     def "toolchain service dependencies are satisfied"() {
         expect:
         project.extensions.getByType(JavaToolchainService).launcherFor(Actions.doNothing()).get().executablePath.asFile.isFile()
+    }
+
+    def "compilerFor - when toolchain is unavailable - expect provider throws"() {
+        given:
+        def javaToolchains = project.extensions.getByType(JavaToolchainService)
+
+        when:
+        Provider<JavaCompiler> compiler = javaToolchains.compilerFor(javaToolchainSpec(999, optional))
+        compiler.getOrNull()
+
+        then:
+        thrown ToolchainProvisioningException
+
+        where:
+        optional << [false, null]
+    }
+
+    def "compilerFor - when optional toolchain is unavailable - expect provider returns null"() {
+        given:
+        def javaToolchains = project.extensions.getByType(JavaToolchainService)
+
+        when:
+        Provider<JavaCompiler> compiler = javaToolchains.compilerFor(toolchainSpec)
+
+        then:
+        compiler.getOrNull() == null
+
+        where:
+        toolchainSpec << [
+            javaToolchainSpecAction(999, true),
+            javaToolchainSpec(999, true),
+        ]
+    }
+
+    def "compilerFor - chained providers"() {
+        given:
+        def javaToolchains = project.extensions.getByType(JavaToolchainService)
+
+        when:
+        Provider<JavaCompiler> compiler = javaToolchains.compilerFor(javaToolchainSpec(999, true))
+            .orElse(javaToolchains.compilerFor(javaToolchainSpec(998, true)))
+            .orElse(javaToolchains.compilerFor(javaToolchainSpec(997, true)))
+            .orElse(javaToolchains.compilerFor(Actions.doNothing()))
+
+        then:
+        compiler.get().metadata.languageVersion.asInt() == Jvm.current().javaVersionMajor
+        compiler.get().executablePath.asFile.isFile()
+    }
+
+    def "launcherFor - when toolchain is unavailable - expect provider throws"() {
+        given:
+        def javaToolchains = project.extensions.getByType(JavaToolchainService)
+
+        when:
+        Provider<JavaLauncher> launcher = javaToolchains.launcherFor(javaToolchainSpec(999, optional))
+        launcher.getOrNull()
+
+        then:
+        thrown ToolchainProvisioningException
+
+        where:
+        optional << [false, null]
+    }
+
+    def "launcherFor - when optional toolchain is unavailable - expect provider returns null"() {
+        given:
+        def javaToolchains = project.extensions.getByType(JavaToolchainService)
+
+        when:
+        Provider<JavaLauncher> launcher = javaToolchains.launcherFor(toolchainSpec)
+
+        then:
+        launcher.getOrNull() == null
+
+        where:
+        toolchainSpec << [
+            javaToolchainSpecAction(999, true),
+            javaToolchainSpec(999, true),
+        ]
+    }
+
+    def "launcherFor - chained providers"() {
+        given:
+        def javaToolchains = project.extensions.getByType(JavaToolchainService)
+
+        when:
+        Provider<JavaLauncher> launcher = javaToolchains.launcherFor(javaToolchainSpec(999, true))
+            .orElse(javaToolchains.launcherFor(javaToolchainSpec(998, true)))
+            .orElse(javaToolchains.launcherFor(javaToolchainSpec(997, true)))
+            .orElse(javaToolchains.launcherFor(Actions.doNothing()))
+
+        then:
+        launcher.get().metadata.languageVersion.asInt() == Jvm.current().javaVersionMajor
+        launcher.get().executablePath.asFile.isFile()
+    }
+
+    def "javadocTool - when toolchain is unavailable - expect provider throws"() {
+        given:
+        def javaToolchains = project.extensions.getByType(JavaToolchainService)
+
+        when:
+        Provider<JavadocTool> javadoc = javaToolchains.javadocToolFor(javaToolchainSpec(999, optional))
+        javadoc.getOrNull()
+
+        then:
+        thrown ToolchainProvisioningException
+
+        where:
+        optional << [false, null]
+    }
+
+    def "javadocTool - when optional toolchain is unavailable - expect provider returns null"() {
+        given:
+        def javaToolchains = project.extensions.getByType(JavaToolchainService)
+
+        when:
+        Provider<JavadocTool> javadoc = javaToolchains.javadocToolFor(toolchainSpec)
+
+        then:
+        javadoc.getOrNull() == null
+
+        where:
+        toolchainSpec << [
+            javaToolchainSpecAction(999, true),
+            javaToolchainSpec(999, true),
+        ]
+    }
+
+    def "javadocTool - chained providers"() {
+        given:
+        def javaToolchains = project.extensions.getByType(JavaToolchainService)
+
+        when:
+        Provider<JavadocTool> javadoc = javaToolchains.javadocToolFor(javaToolchainSpec(999, true))
+            .orElse(javaToolchains.javadocToolFor(javaToolchainSpec(998, true)))
+            .orElse(javaToolchains.javadocToolFor(javaToolchainSpec(997, true)))
+            .orElse(javaToolchains.javadocToolFor(Actions.doNothing()))
+
+        then:
+        javadoc.get().metadata.languageVersion.asInt() == Jvm.current().javaVersionMajor
+        javadoc.get().executablePath.asFile.isFile()
+    }
+
+    private static Action<JavaToolchainSpec> javaToolchainSpecAction(
+        int languageVersion,
+        Boolean optional
+    ) {
+        return new Action<JavaToolchainSpec>() {
+            @Override
+            void execute(JavaToolchainSpec spec) {
+                spec.languageVersion.set(JavaLanguageVersion.of(languageVersion))
+                if (optional == true) {
+                    spec.onNoMatchFound.set(JavaToolchainNotFoundMode.IGNORE)
+                } else if (optional == false) {
+                    spec.onNoMatchFound.set(JavaToolchainNotFoundMode.THROW_EXCEPTION)
+                }
+            }
+        }
+    }
+
+    private JavaToolchainSpec javaToolchainSpec(int languageVersion, @Nullable Boolean optional) {
+        return Mock(JavaToolchainSpecInternal) { spec ->
+            spec.getLanguageVersion() >> TestUtil.propertyFactory().property(JavaLanguageVersion).value(JavaLanguageVersion.of(languageVersion))
+            spec.isValid() >> true
+            spec.isConfigured() >> true
+            spec.getNativeImageCapable() >>
+                TestUtil.propertyFactory().property(Boolean)
+            spec.getVendor() >>
+                TestUtil.propertyFactory().property(JvmVendorSpec).value(JvmVendorSpec.ADOPTOPENJDK)
+            spec.getImplementation() >>
+                TestUtil.propertyFactory().property(JvmImplementation).value(JvmImplementation.VENDOR_SPECIFIC)
+
+            def onMissingToolchain = TestUtil.propertyFactory().property(JavaToolchainNotFoundMode)
+            if (optional == true) {
+                spec.getOnNoMatchFound() >>
+                    onMissingToolchain.value(JavaToolchainNotFoundMode.IGNORE)
+            } else if (optional == false) {
+                spec.getOnNoMatchFound() >>
+                    onMissingToolchain.value(JavaToolchainNotFoundMode.THROW_EXCEPTION)
+            } else {
+                spec.getOnNoMatchFound() >>
+                    onMissingToolchain
+            }
+        }
     }
 }


### PR DESCRIPTION
Add new method to JavaToolchainSpec, `getOnNoMatchFound()`, that can be configured to ignore failures when resolving toolchains.

- `JavaToolchainNotFoundMode.IGNORE` - failures will be ignored, the provider returned by `JavaToolchainService` can be safely evaluated using `getOrNull()`.
- `JavaToolchainNotFoundMode.THROW_EXCEPTION` - The current behaviour. The provider returned by `JavaToolchainService` will throw when it is evaluated, even if using `getOrNull()`.

Lenient fetching of toolchains permits using them as optional task inputs, or multiple toolchains can be chained together.

fix #29758

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
