### PR TITLE
Remove unused cache

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -91,8 +91,11 @@ class ProjectAccessorsClassPathGenerator @Inject internal constructor(
 ) {
 
     fun projectAccessorsClassPath(scriptTarget: ExtensionAware, classPath: ClassPath): AccessorsClassPath {
-        val classLoaderScope = classLoaderScopeOf(scriptTarget) ?: return AccessorsClassPath.empty
-        val configuredProjectSchemaOf = configuredProjectSchemaOf(scriptTarget, classLoaderScope) ?: return AccessorsClassPath.empty
+        val classLoaderScope = classLoaderScopeOf(scriptTarget)
+            ?: return AccessorsClassPath.empty
+        val configuredProjectSchemaOf = configuredProjectSchemaOf(scriptTarget, classLoaderScope)
+            ?: return AccessorsClassPath.empty
+
         val work = GenerateProjectAccessors(
             scriptTarget,
             configuredProjectSchemaOf,


### PR DESCRIPTION
This cache was causing thread contention when performing configuration in parallel. We determined the cache was never hit by running all tests and throwing an exception if we saw a cache hit. We never observed an exception. This makes sense, as this cache caches the result of project accessor generation, which should only happen once per per project per build.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
