### PR TITLE
Rename internal CC properties

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/AbstractConfigurationCacheIntegrationTest.groovy
@@ -32,7 +32,7 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractConfigu
     static final String DISABLE_GRADLE_PROP = "${ConfigurationCacheOption.PROPERTY_NAME}=false"
     static final String DISABLE_SYS_PROP = "-D$DISABLE_GRADLE_PROP"
     // Should be provided if a link to the report is expected even if no errors were found
-    static final String LOG_REPORT_LINK_AS_WARNING = "-Dorg.gradle.configuration-cache.internal.report-link-as-warning=true"
+    static final String LOG_REPORT_LINK_AS_WARNING = "-Dorg.gradle.internal.configuration-cache.report-link-as-warning=true"
     static final String ENABLE_READ_ONLY_CACHE = "-D${ConfigurationCacheReadOnlyOption.PROPERTY_NAME}=true"
 
     static final String MAX_PROBLEMS_GRADLE_PROP = "${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}"

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEnablementIntegrationTest.groovy
@@ -126,9 +126,9 @@ class ConfigurationCacheEnablementIntegrationTest extends AbstractConfigurationC
         task    | ccOn  | problemsAs| maxProblems   | quiet | recreate  | debug | options
         "check" | false | WARN      | _             | _     | _         | _     | ["-Dorg.gradle.configuration-cache.problems=warn"]
         "check" | false | _         | 100           | _     | _         | _     | ["-Dorg.gradle.configuration-cache.max-problems=100"]
-        "check" | false | _         | _             | true  | _         | _     | ["-Dorg.gradle.configuration-cache.internal.quiet=true"]
-        "check" | false | _         | _             | _     | true      | _     | ["-Dorg.gradle.configuration-cache.internal.recreate-cache=true"]
-        "check" | false | _         | _             | _     | _         | true  | ["-Dorg.gradle.configuration-cache.internal.debug=true"]
+        "check" | false | _         | _             | true  | _         | _     | ["-Dorg.gradle.internal.configuration-cache.quiet=true"]
+        "check" | false | _         | _             | _     | true      | _     | ["-Dorg.gradle.internal.configuration-cache.recreate-cache=true"]
+        "check" | false | _         | _             | _     | _         | true  | ["-Dorg.gradle.internal.configuration-cache.debug=true"]
         "check" | false | WARN      | _             | _     | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache-problems=warn"]
         "check" | false | _         | 100           | _     | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache.max-problems=100"]
         "check" | false | _         | _             | true  | _         | _     | ["-Dorg.gradle.unsafe.configuration-cache.quiet=true"]

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -57,7 +57,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
     def "configuration cache can be loaded without errors from #source using #encryptionTransformation"() {
         given:
         def additionalOpts = [
-            "-Dorg.gradle.configuration-cache.internal.encryption-alg=${encryptionTransformation}"
+            "-Dorg.gradle.internal.configuration-cache.encryption-alg=${encryptionTransformation}"
         ]
         def configurationCache = newConfigurationCacheFixture()
         runWithEncryption(source, ["help"], additionalOpts)
@@ -127,7 +127,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
             kind,
             ["useSensitive"],
             ["-Psensitive_property_name=sensitive_property_value",
-             "-Dorg.gradle.configuration-cache.internal.deduplicate-strings=false"],
+             "-Dorg.gradle.internal.configuration-cache.deduplicate-strings=false"],
             [(ENV_PROJECT_PROPERTIES_PREFIX + 'sensitive_property_name2'): 'sensitive_property_value2',
              "SENSITIVE_ENV_VAR_NAME": 'sensitive_env_var_value']
         )
@@ -342,7 +342,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         switch (kind) {
             case EncryptionKind.KEYSTORE:
                 return [
-                    "-Dorg.gradle.configuration-cache.internal.key-store-dir=${keyStoreDir}",
+                    "-Dorg.gradle.internal.configuration-cache.key-store-dir=${keyStoreDir}",
                 ]
             case EncryptionKind.ENV_VAR:
                 // the env var is all that is required
@@ -350,7 +350,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
             default:
                 // NONE
                 return [
-                    "-Dorg.gradle.configuration-cache.internal.encryption=false"
+                    "-Dorg.gradle.internal.configuration-cache.encryption=false"
                 ]
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheParallelStoreIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheParallelStoreIntegrationTest.groovy
@@ -86,7 +86,7 @@ class ConfigurationCacheParallelStoreIntegrationTest extends AbstractConfigurati
         settingsFile.createFile()
 
         when:
-        configurationCacheRun("help", "-d", "-Dorg.gradle.configuration-cache.internal.parallel-store=false")
+        configurationCacheRun("help", "-d", "-Dorg.gradle.internal.configuration-cache.parallel-store=false")
 
         then:
         output.contains("[org.gradle.configurationcache] saving task graph sequentially")
@@ -98,7 +98,7 @@ class ConfigurationCacheParallelStoreIntegrationTest extends AbstractConfigurati
         settingsFile.createFile()
 
         when:
-        configurationCacheRun("help", "-d", "-Dorg.gradle.configuration-cache.internal.parallel-load=false")
+        configurationCacheRun("help", "-d", "-Dorg.gradle.internal.configuration-cache.parallel-load=false")
 
         then:
         output.contains("[org.gradle.configurationcache] saving task graph in parallel")
@@ -124,7 +124,7 @@ class ConfigurationCacheParallelStoreIntegrationTest extends AbstractConfigurati
 
         when:
         run("-D${StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME}=true", "help", "-d",
-            "-Dorg.gradle.configuration-cache.internal.parallel-store=false")
+            "-Dorg.gradle.internal.configuration-cache.parallel-store=false")
 
         then:
         outputDoesNotContain("Parallel Configuration Cache is an incubating feature.")

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
@@ -39,10 +39,10 @@ object BuildModelParametersProvider {
     val logger = Logging.getLogger(BuildModelParametersProvider::class.java)
 
     private
-    val configurationCacheParallelStore = InternalFlag("org.gradle.configuration-cache.internal.parallel-store", true)
+    val configurationCacheParallelStore = InternalFlag("org.gradle.internal.configuration-cache.parallel-store", true)
 
     private
-    val configurationCacheParallelLoad = InternalFlag("org.gradle.configuration-cache.internal.parallel-load", true)
+    val configurationCacheParallelLoad = InternalFlag("org.gradle.internal.configuration-cache.parallel-load", true)
 
     private
     val invalidateCoupledProjects = InternalFlag("org.gradle.internal.invalidate-coupled-projects", true)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheStartParameter.kt
@@ -47,16 +47,16 @@ class ConfigurationCacheStartParameter internal constructor(
         /**
          * See [org.gradle.internal.cc.impl.initialization.ConfigurationCacheStartParameter.customReportOutputDirectory].
          */
-        const val REPORT_OUTPUT_DIR = "org.gradle.configuration-cache.internal.report-output-directory"
+        const val REPORT_OUTPUT_DIR = "org.gradle.internal.configuration-cache.report-output-directory"
     }
 
-    val taskExecutionAccessPreStable: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.task-execution-access-pre-stable")
+    val taskExecutionAccessPreStable: Boolean = options.getInternalFlag("org.gradle.internal.configuration-cache.task-execution-access-pre-stable")
 
     /**
      * Should be provided if a link to the report is expected even if no errors were found.
      * Useful in testing.
      */
-    val alwaysLogReportLinkAsWarning: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.report-link-as-warning", false)
+    val alwaysLogReportLinkAsWarning: Boolean = options.getInternalFlag("org.gradle.internal.configuration-cache.report-link-as-warning", false)
 
     /**
      * Custom output directory for the Configuration Cache report relative to the build tree root directory.
@@ -76,7 +76,7 @@ class ConfigurationCacheStartParameter internal constructor(
      *
      * The default is `true`.
      */
-    val isDeduplicatingStrings: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.deduplicate-strings", true)
+    val isDeduplicatingStrings: Boolean = options.getInternalFlag("org.gradle.internal.configuration-cache.deduplicate-strings", true)
 
     /**
      * Whether shareable objects in the configuration cache should be shared
@@ -84,7 +84,7 @@ class ConfigurationCacheStartParameter internal constructor(
      *
      * The default is `true`.
      */
-    val isSharingObjects: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.share-objects", true)
+    val isSharingObjects: Boolean = options.getInternalFlag("org.gradle.internal.configuration-cache.share-objects", true)
 
     /**
      * See [org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheFineGrainedPropertyTracking].

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/CommonReport.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/CommonReport.kt
@@ -64,7 +64,7 @@ class CommonReport(
 
     companion object {
         private
-        val stacktraceHashes = InternalFlag("org.gradle.configuration-cache.internal.report.stacktrace-hashes", false)
+        val stacktraceHashes = InternalFlag("org.gradle.internal.configuration-cache.report.stacktrace-hashes", false)
     }
 
     private

--- a/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
+++ b/platforms/core-configuration/encryption-services/src/main/kotlin/org/gradle/internal/encryption/impl/DefaultEncryptionService.kt
@@ -44,13 +44,13 @@ class DefaultEncryptionService(
 ) : EncryptionService {
 
     private
-    val encryptionRequestedOption: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.encryption", true)
+    val encryptionRequestedOption: Boolean = options.getInternalFlag("org.gradle.internal.configuration-cache.encryption", true)
 
     private
-    val keystoreDirOption: String? = options.getStringOrNull("org.gradle.configuration-cache.internal.key-store-dir")
+    val keystoreDirOption: String? = options.getStringOrNull("org.gradle.internal.configuration-cache.key-store-dir")
 
     private
-    val encryptionAlgorithmOption: String = options.getString("org.gradle.configuration-cache.internal.encryption-alg", SupportedEncryptionAlgorithm.getDefault().transformation)
+    val encryptionAlgorithmOption: String = options.getString("org.gradle.internal.configuration-cache.encryption-alg", SupportedEncryptionAlgorithm.getDefault().transformation)
 
     private
     val secretKey: SecretKey? by lazy {

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginTasksIntegrationTest.kt
@@ -130,7 +130,7 @@ class PrecompiledScriptPluginTasksIntegrationTest : AbstractKotlinIntegrationTes
 
         // TODO: the Kotlin compile tasks check for cacheability using Task.getProject
         executer.beforeExecute {
-            it.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+            it.withBuildJvmOpts("-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true")
         }
 
         build(firstDir, "classes", "--build-cache").apply {

--- a/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/InternalOption.java
+++ b/platforms/core-runtime/build-option/src/main/java/org/gradle/internal/buildoption/InternalOption.java
@@ -52,7 +52,6 @@ public abstract class InternalOption<T extends @Nullable Object> implements Opti
 
     public static boolean isInternalOption(String name) {
         return name.startsWith(INTERNAL_PROPERTY_PREFIX) ||
-            name.startsWith("org.gradle.unsafe.") || // TODO: avoid reading public 'unsafe' properties via internal options
-            name.startsWith("org.gradle.configuration-cache.internal."); // TODO:configuration-cache - https://github.com/gradle/gradle/issues/35489
+            name.startsWith("org.gradle.unsafe."); // TODO: avoid reading public 'unsafe' properties via internal options
     }
 }

--- a/platforms/documentation/docs/src/samples/android-application/tests/buildTask.sample.conf
+++ b/platforms/documentation/docs/src/samples/android-application/tests/buildTask.sample.conf
@@ -1,6 +1,6 @@
 commands: [{
     executable: gradle
-    args: "build -x lint -x lintVitalRelease -Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true"
+    args: "build -x lint -x lintVitalRelease -Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true"
     # The following deprecation is coming from the Android plugin
     #> Task :app:javaPreCompileDebug
     #The Substitution.with(ComponentSelector) method has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the using(ComponentSelector) method instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.1-20210406210000+0000/userguide/upgrading_version_7.html#dependency_substitutions_with

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/dependencyLocking-lockingAllConfigurations/tests/locking-all.sample.conf
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/dependencyLocking-lockingAllConfigurations/tests/locking-all.sample.conf
@@ -1,2 +1,2 @@
 executable: gradle
-args: "resolveAndLockAll --write-locks -Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true"
+args: "resolveAndLockAll --write-locks -Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedConfigurationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedConfigurationIntegrationTest.groovy
@@ -78,7 +78,7 @@ class ResolvedConfigurationIntegrationTest extends AbstractHttpDependencyResolut
 
         expect:
         //TODO: fix dependency resolution results usage in this test and remove this flag
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+        executer.withBuildJvmOpts("-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true")
 
         fails "validate"
         outputContains("evaluating:") // ensure the failure happens when querying the resolved configuration
@@ -140,7 +140,7 @@ class ResolvedConfigurationIntegrationTest extends AbstractHttpDependencyResolut
 
         expect:
         //TODO: fix dependency resolution results usage in this test and remove this flag
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+        executer.withBuildJvmOpts("-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true")
 
         fails "validate"
         outputContains("evaluating:") // ensure the failure happens when querying the resolved configuration
@@ -208,7 +208,7 @@ class ResolvedConfigurationIntegrationTest extends AbstractHttpDependencyResolut
 
         expect:
         //TODO: fix dependency resolution results usage in this test and remove this flag
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+        executer.withBuildJvmOpts("-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true")
         succeeds "validate"
     }
 
@@ -281,7 +281,7 @@ class ResolvedConfigurationIntegrationTest extends AbstractHttpDependencyResolut
 
         expect:
         //TODO: fix dependency resolution results usage in this test and remove this flag
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+        executer.withBuildJvmOpts("-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true")
         succeeds "validate"
     }
 
@@ -343,7 +343,7 @@ class ResolvedConfigurationIntegrationTest extends AbstractHttpDependencyResolut
 
         expect:
         //TODO: fix dependency resolution results usage in this test and remove this flag
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+        executer.withBuildJvmOpts("-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true")
         succeeds "validate"
     }
 
@@ -394,7 +394,7 @@ class ResolvedConfigurationIntegrationTest extends AbstractHttpDependencyResolut
 
         expect:
         //TODO: fix dependency resolution results usage in this test and remove this flag
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+        executer.withBuildJvmOpts("-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true")
         succeeds "validate"
     }
 
@@ -441,7 +441,7 @@ class ResolvedConfigurationIntegrationTest extends AbstractHttpDependencyResolut
 
         expect:
         //TODO: fix dependency resolution results usage in this test and remove this flag
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+        executer.withBuildJvmOpts("-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true")
         succeeds "validate"
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
@@ -353,7 +353,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
 
         when:
         //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+        executer.withBuildJvmOpts("-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true")
         fails "resolve"
 
         then:

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -593,7 +593,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class ConfigurationCacheDebugOption extends BooleanBuildOption<StartParameterInternal> {
 
-        public static final String PROPERTY_NAME = "org.gradle.configuration-cache.internal.debug";
+        public static final String PROPERTY_NAME = "org.gradle.internal.configuration-cache.debug";
         public static final String DEPRECATED_PROPERTY_NAME = "org.gradle.unsafe.configuration-cache.debug";
 
         public ConfigurationCacheDebugOption() {
@@ -650,7 +650,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class ConfigurationCacheRecreateOption extends BooleanBuildOption<StartParameterInternal> {
 
-        public static final String PROPERTY_NAME = "org.gradle.configuration-cache.internal.recreate-cache";
+        public static final String PROPERTY_NAME = "org.gradle.internal.configuration-cache.recreate-cache";
         public static final String DEPRECATED_PROPERTY_NAME = "org.gradle.unsafe.configuration-cache.recreate-cache";
 
         public ConfigurationCacheRecreateOption() {
@@ -666,7 +666,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class ConfigurationCacheQuietOption extends BooleanBuildOption<StartParameterInternal> {
 
-        public static final String PROPERTY_NAME = "org.gradle.configuration-cache.internal.quiet";
+        public static final String PROPERTY_NAME = "org.gradle.internal.configuration-cache.quiet";
         public static final String DEPRECATED_PROPERTY_NAME = "org.gradle.unsafe.configuration-cache.quiet";
 
         public ConfigurationCacheQuietOption() {

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ConfigurationCacheGradleExecuter.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ConfigurationCacheGradleExecuter.groovy
@@ -30,7 +30,7 @@ class ConfigurationCacheGradleExecuter extends DaemonGradleExecuter {
         "-D${ConfigurationCacheQuietOption.PROPERTY_NAME}=true",
         "-D${ConfigurationCacheParallelOption.PROPERTY_NAME}=true",
         "-D${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}=0",
-        "-Dorg.gradle.configuration-cache.internal.report-output-directory=.gradle/configuration-cache/reports"
+        "-Dorg.gradle.internal.configuration-cache.report-output-directory=.gradle/configuration-cache/reports"
     ].collect { it.toString() }
 
     ConfigurationCacheGradleExecuter(

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IsolatedProjectsGradleExecuter.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IsolatedProjectsGradleExecuter.groovy
@@ -25,7 +25,7 @@ class IsolatedProjectsGradleExecuter extends DaemonGradleExecuter {
     static final List<String> ISOLATED_PROJECTS_ARGS = [
         "-D${StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME}=true",
         "-D${StartParameterBuildOptions.ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}=0",
-        "-Dorg.gradle.configuration-cache.internal.report-output-directory=.gradle/isolated-projects/reports",
+        "-Dorg.gradle.internal.configuration-cache.report-output-directory=.gradle/isolated-projects/reports",
     ].collect { it.toString() }
 
     IsolatedProjectsGradleExecuter(

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -49,7 +49,7 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         return runner.withJvmArguments(runner.jvmArguments + [
             // A workaround for this has been added to TaskExecutionAccessCheckers;
             // TODO once we remove it, uncomment the flag below or upgrade AGP
-            // "-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true"
+            // "-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true"
         ])
     }
 

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
@@ -53,7 +53,7 @@ class GradleVersionsPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         when:
         def runner = runner('dependencyUpdates', '-DoutputFormatter=txt')
             // TODO: com.github.benmanes.gradle.versions.updates.DependencyUpdates plugin triggers dependency resolution at execution time
-            .withJvmArguments("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+            .withJvmArguments("-Dorg.gradle.internal.configuration-cache.task-execution-access-pre-stable=true")
 
         runner
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/35489

Renames CC properties:
```
org.gradle.configuration-cache.internal.*     ==>
org.gradle.internal.configuration-cache.*
```