### PR TITLE
Do not copy variant capabilities on each call

### DIFF
--- a/platforms/core-runtime/serialization/src/test/groovy/org/gradle/internal/serialize/ListSerializerTest.groovy
+++ b/platforms/core-runtime/serialization/src/test/groovy/org/gradle/internal/serialize/ListSerializerTest.groovy
@@ -35,11 +35,4 @@ class ListSerializerTest extends SerializerSpec {
         serialize([10L, 5L, 99L], serializer) == [10L, 5L, 99L]
     }
 
-    def "serialize null entry"() {
-        when:
-        def serializer = new ListSerializer(stringSerializer)
-
-        then:
-        serialize(["one", null, "three"], serializer) == ["one", null, "three"]
-    }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
@@ -1114,4 +1114,31 @@ testRuntimeClasspath
         expect:
         succeeds("resolve")
     }
+
+    def "capabilities on variant always return same instance"() {
+        mavenRepo.module("org", "foo", "1.0").publish()
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${mavenTestRepository()}
+
+            dependencies {
+                implementation("org:foo:1.0")
+            }
+
+            tasks.register("resolve") {
+                def rootComponent = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
+                doLast {
+                    def variant = rootComponent.get().dependencies.first().resolvedVariant
+                    assert variant.capabilities.is(variant.capabilities)
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
@@ -16,10 +16,10 @@
 
 package org.gradle.api.internal.artifacts.ivyservice;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.component.Artifact;
-import org.gradle.internal.component.model.VariantIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult;
@@ -27,6 +27,7 @@ import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.gradle.internal.component.model.VariantIdentifier;
 
 import java.io.File;
 import java.util.HashSet;
@@ -53,7 +54,7 @@ public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
         try {
             if (seenArtifacts.add(artifact.getId())) {
                 File file = artifact.getFile();
-                this.artifacts.add(new DefaultResolvedArtifactResult(artifact.getId(), attributeDesugaring.desugar(attributes), capabilities, artifactSetName, Artifact.class, file));
+                this.artifacts.add(new DefaultResolvedArtifactResult(artifact.getId(), attributeDesugaring.desugar(attributes), ImmutableList.copyOf(capabilities.asSet()), artifactSetName, Artifact.class, file));
             }
         } catch (Exception t) {
             failures.add(t);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CompleteComponentResultSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CompleteComponentResultSerializer.java
@@ -30,7 +30,6 @@ import org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.Describables;
-import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.resolve.caching.DesugaringAttributeContainerSerializer;
 import org.gradle.internal.serialize.Decoder;
@@ -54,7 +53,7 @@ public class CompleteComponentResultSerializer implements ComponentResultSeriali
     private final Serializer<ModuleVersionIdentifier> moduleVersionIdSerializer;
     private final Serializer<AttributeContainer> attributeContainerSerializer;
     private final Serializer<ComponentIdentifier> componentIdSerializer;
-    private final Serializer<List<Capability>> capabilitySerializer;
+    private final ListSerializer<Capability> capabilitySerializer;
 
     @Inject
     public CompleteComponentResultSerializer(
@@ -128,11 +127,11 @@ public class CompleteComponentResultSerializer implements ComponentResultSeriali
         ComponentIdentifier ownerId = componentIdSerializer.read(decoder);
         String displayName = decoder.readString();
         AttributeContainer attributes = attributeContainerSerializer.read(decoder);
-        List<Capability> capabilities = capabilitySerializer.read(decoder);
+        ImmutableList<Capability> capabilities = capabilitySerializer.read(decoder);
 
         // TODO: Read the external variant, like we do with the variant reference.
 
-        visitor.visitSelectedVariant(nodeId, new DefaultResolvedVariantResult(ownerId, Describables.of(displayName), attributes, ImmutableCapabilities.of(capabilities), null));
+        visitor.visitSelectedVariant(nodeId, new DefaultResolvedVariantResult(ownerId, Describables.of(displayName), attributes, capabilities, null));
     }
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolutionResultGraphBuilder.java
@@ -76,7 +76,7 @@ public class ResolutionResultGraphBuilder implements ResolvedComponentVisitor {
             componentIdentifier,
             Describables.of(rootVariantName),
             attributeDesugaring.desugar(attributes),
-            capabilities,
+            ImmutableList.copyOf(capabilities.asSet()),
             null
         );
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.query;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
@@ -45,7 +46,6 @@ import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.internal.Describables;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
-import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
@@ -215,7 +215,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
             BuildableArtifactResolveResult resolveResult = new DefaultBuildableArtifactResolveResult();
             artifactResolver.resolveArtifact(component, artifactMetaData, resolveResult);
             try {
-                artifacts.addArtifact(externalResolverFactory.verifiedArtifact(new DefaultResolvedArtifactResult(artifactMetaData.getId(), ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, Describables.of(component.getId().getDisplayName()), type, resolveResult.getResult().getFile())));
+                artifacts.addArtifact(externalResolverFactory.verifiedArtifact(new DefaultResolvedArtifactResult(artifactMetaData.getId(), ImmutableAttributes.EMPTY, ImmutableList.of(), Describables.of(component.getId().getDisplayName()), type, resolveResult.getResult().getFile())));
             } catch (Exception e) {
                 artifacts.addArtifact(new DefaultUnresolvedArtifactResult(artifactMetaData.getId(), type, e));
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
@@ -15,13 +15,14 @@
  */
 package org.gradle.api.internal.artifacts.result;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.Artifact;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.component.external.model.ImmutableCapabilities;
 
 import java.io.File;
 
@@ -33,7 +34,7 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
 
     public DefaultResolvedArtifactResult(ComponentArtifactIdentifier identifier,
                                          AttributeContainer variantAttributes,
-                                         ImmutableCapabilities capabilities,
+                                         ImmutableList<Capability> capabilities,
                                          DisplayName variantDisplayName,
                                          Class<? extends Artifact> type,
                                          File file) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedVariantResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedVariantResult.java
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
@@ -33,14 +32,14 @@ public class DefaultResolvedVariantResult implements ResolvedVariantResult {
     private final ComponentIdentifier owner;
     private final DisplayName displayName;
     private final AttributeContainer attributes;
-    private final ImmutableCapabilities capabilities;
+    private final ImmutableList<Capability> capabilities;
     private final ResolvedVariantResult externalVariant;
     private final int hashCode;
 
     public DefaultResolvedVariantResult(ComponentIdentifier owner,
                                         DisplayName displayName,
                                         AttributeContainer attributes,
-                                        ImmutableCapabilities capabilities,
+                                        ImmutableList<Capability> capabilities,
                                         @Nullable ResolvedVariantResult externalVariant) {
         this.owner = owner;
         this.displayName = displayName;
@@ -67,7 +66,7 @@ public class DefaultResolvedVariantResult implements ResolvedVariantResult {
 
     @Override
     public List<Capability> getCapabilities() {
-        return ImmutableList.copyOf(capabilities.asSet());
+        return capabilities;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
@@ -16,8 +16,10 @@
 
 package org.gradle.internal.component.model;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.capabilities.ImmutableCapability;
@@ -97,11 +99,11 @@ public abstract class AbstractComponentGraphResolveState<T extends ComponentGrap
             .collect(Collectors.toList());
     }
 
-    private ImmutableCapabilities capabilitiesFor(ImmutableCapabilities capabilities) {
+    private ImmutableList<Capability> capabilitiesFor(ImmutableCapabilities capabilities) {
         if (capabilities.asSet().isEmpty()) {
-            return ImmutableCapabilities.of(DefaultImmutableCapability.defaultCapabilityForComponent(getMetadata().getModuleVersionId()));
+            return ImmutableList.of(DefaultImmutableCapability.defaultCapabilityForComponent(getMetadata().getModuleVersionId()));
         } else {
-            return capabilities;
+            return ImmutableList.copyOf(capabilities.asSet());
         }
     }
 

--- a/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
+++ b/platforms/software/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
@@ -28,7 +28,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 import org.gradle.internal.Describables
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
-import org.gradle.internal.component.external.model.ImmutableCapabilities
 import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.util.AttributeTestUtil
 
@@ -62,7 +61,7 @@ class ResolutionResultDataBuilder {
         def ownerId = DefaultModuleComponentIdentifier.newId(
             newId(ownerGroup, ownerModule, ownerVersion)
         )
-        return new DefaultResolvedVariantResult(ownerId, Describables.of(name), mutableAttributes, ImmutableCapabilities.EMPTY, null)
+        return new DefaultResolvedVariantResult(ownerId, Describables.of(name), mutableAttributes, ImmutableList.of(), null)
     }
 
     static ModuleComponentSelector newSelector(String group, String module, String version) {

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -34,7 +34,6 @@ import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependenc
 import org.gradle.internal.Describables
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
-import org.gradle.internal.component.external.model.ImmutableCapabilities
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -210,7 +209,7 @@ class DependencyInsightReporterSpec extends Specification {
         def ownerId = DefaultModuleComponentIdentifier.newId(
             DefaultModuleVersionIdentifier.newId(ownerGroup, ownerModule, ownerVersion)
         )
-        new DefaultResolvedVariantResult(ownerId, Describables.of("default"), ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, null)
+        new DefaultResolvedVariantResult(ownerId, Describables.of("default"), ImmutableAttributes.EMPTY, ImmutableList.of(), null)
     }
 
     private static DefaultResolvedDependencyResult path(String path) {


### PR DESCRIPTION
This can be inefficient for consumers. So, we make sure the value we return is stable and don't copy unnecessarily


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
