### PR TITLE
Use larger blocking server backlog

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsOnAuthenticatedRepoIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsOnAuthenticatedRepoIntegrationTest.groovy
@@ -16,9 +16,6 @@
 
 package org.gradle.integtests.resolve
 
-import org.gradle.test.fixtures.Flaky
-
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/5047")
 class ParallelDownloadsOnAuthenticatedRepoIntegrationTest extends ParallelDownloadsIntegrationTest {
     private final static String USERNAME = 'username'
     private final static String PASSWORD = 'password'

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.java
@@ -75,7 +75,7 @@ public class BlockingHttpServer extends ExternalResource implements ResettableEx
 
     public BlockingHttpServer(int timeoutMs) throws IOException {
         // Use an OS selected port
-        this(HttpServer.create(new InetSocketAddress(0), 10), timeoutMs, Scheme.HTTP);
+        this(HttpServer.create(new InetSocketAddress(0), 100), timeoutMs, Scheme.HTTP);
     }
 
     public void setHostAlias(String hostAlias) {


### PR DESCRIPTION
Before we would previously only open a limited number of concurrent connections to the blocking server Now, we open 20 concurrent connections, which can overwhelm the backlog and cause connections to be refused on windows. Now, we increase the backlog to avoid failures during testing

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
