### PR TITLE
Benchmark `PersistentSet` against `CopyOnWriteArraySet`

### DIFF
--- a/platforms/core-runtime/collections/build.gradle.kts
+++ b/platforms/core-runtime/collections/build.gradle.kts
@@ -63,6 +63,7 @@ jmh {
 //        "PersistentArrayBenchmark.randomUpdate",
 //        "PersistentSetBenchmark",
 //        "PersistentSetBenchmark.iteration",
+//        "PersistentSetBenchmark.randomLookup",
 //        "PersistentSetBenchmark.contains(Absent|Present)",
 //        "PersistentSetBenchmark.remove",
 //        "PersistentSetBenchmark.removeAbsent",


### PR DESCRIPTION
Conclusion: faster and more scalable mutations and lookups, slower iterations.

Charts for multiple insertions, random lookups (50/50) and iteration in logarithmic scale below.

### Multiple insertions in a row
<img width="1078" height="394" alt="CopyOnWriteArraySet-insertion" src="https://github.com/user-attachments/assets/bd958efa-d168-48d4-8574-49186ee196da" />

### Random lookups
<img width="1084" height="393" alt="CopyOnWriteArraySet-randomLookup" src="https://github.com/user-attachments/assets/a94feed1-ce7a-4709-9460-17d33a44eacc" />

### Iteration
<img width="1061" height="386" alt="CopyOnWriteArraySet-iteration" src="https://github.com/user-attachments/assets/facd5cb4-75ad-4cae-8bf5-223e7b844a01" />

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
