### PR TITLE
Fix overflow for long code block in test report

### DIFF
--- a/platforms/software/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/generic/style.css
+++ b/platforms/software/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/generic/style.css
@@ -121,10 +121,6 @@ div.metadata td {
     color: darkred;
 }
 
-.code {
-    position: relative;
-}
-
 .clipboard-copy-btn {
     position: absolute;
     top: 8px;

--- a/platforms/software/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
+++ b/platforms/software/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
@@ -83,10 +83,6 @@ ul.linkList li {
     margin-bottom: 5px;
 }
 
-.code {
-    position: relative;
-}
-
 .clipboard-copy-btn {
     position: absolute;
     top: 8px;

--- a/subprojects/core/src/main/resources/org/gradle/reporting/base-style.css
+++ b/subprojects/core/src/main/resources/org/gradle/reporting/base-style.css
@@ -149,9 +149,10 @@ div.tab td.numeric, div.tab th.numeric {
 }
 
 span.code {
-    display: inline-block;
+    display: block;
     margin-top: 0;
     margin-bottom: 1em;
+    position: relative;
 }
 
 span.code pre {
@@ -162,6 +163,7 @@ span.code pre {
     border: solid 1px #d0d0d0;
     min-width: 700px;
     width: auto;
+    overflow: auto;
 }
 
 span.wrapped pre {


### PR DESCRIPTION
### Context

Fixes https://github.com/gradle/gradle/issues/36434.

Set the `overflow` property of the code block to `auto` so that a scroll bar is displayed if the content is overflowing.

![](https://github.com/user-attachments/assets/0da2148a-3ee7-44d7-8b06-08fcd0a78438)

> [!NOTE]
> This change does not affect the "Wrap lines" option
>
> https://github.com/user-attachments/assets/f515c199-ecf6-4846-bc48-93ca708a2e32


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
