### PR TITLE
Fix DCL dependency collectors appearances in the schema

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/ClassMembersForSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/ClassMembersForSchema.kt
@@ -414,3 +414,8 @@ data class SupportedKParameter(
     val isVararg: Boolean,
     val isOptional: Boolean
 )
+
+val SupportedCallable.isJavaBeanGetter get() =
+    kind == MemberKind.FUNCTION &&
+        name.substringAfter("get", "").firstOrNull()?.isUpperCase() == true &&
+        parameters.isEmpty()

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/FunctionExtractor.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/FunctionExtractor.kt
@@ -108,7 +108,7 @@ class DefaultFunctionExtractor(
 ) : FunctionExtractor {
     override fun memberFunctions(host: SchemaBuildingHost, kClass: KClass<*>, preIndex: DataSchemaBuilder.PreIndex): List<FunctionExtractionResult> =
         host.classMembers(kClass).declarativeMembers
-            .filter { it.kind == MemberKind.FUNCTION && host.isUnusedMember(kClass, it) }
+            .filter { it.kind == MemberKind.FUNCTION && !it.isJavaBeanGetter }
             .map { ExtractionResult.of(memberFunction(host, kClass, it, preIndex, configureLambdas), FunctionExtractionMetadata(listOf(it))) }
 
     override fun topLevelFunction(host: SchemaBuildingHost, function: KFunction<*>, preIndex: DataSchemaBuilder.PreIndex): SchemaResult<DataTopLevelFunction> =

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/PropertyExtractor.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/PropertyExtractor.kt
@@ -66,17 +66,21 @@ operator fun PropertyExtractor.plus(other: PropertyExtractor): CompositeProperty
     include(other)
 })
 
-class DefaultPropertyExtractor(val propertyTypePredicate: (SupportedTypeProjection.SupportedType) -> Boolean = { true }) : PropertyExtractor {
+class DefaultPropertyExtractor(
+    val includePredicate: (owner: KClass<*>, callable: SupportedCallable) -> Boolean = { _, _ -> true }
+) : PropertyExtractor {
     override fun extractProperties(host: SchemaBuildingHost, kClass: KClass<*>, propertyNamePredicate: (String) -> Boolean): Iterable<PropertyExtractionResult> =
         propertiesFromAccessorsOf(host, kClass, propertyNamePredicate) + memberPropertiesOf(host, kClass, propertyNamePredicate)
 
     private
     fun propertiesFromAccessorsOf(host: SchemaBuildingHost, kClass: KClass<*>, propertyNamePredicate: (String) -> Boolean): List<PropertyExtractionResult> {
-        val functions = host.classMembers(kClass).declarativeMembers.filter { it.kind == MemberKind.FUNCTION && propertyTypePredicate(it.returnType) }
+        val functions = host.classMembers(kClass).declarativeMembers.filter { it.kind == MemberKind.FUNCTION && includePredicate(kClass, it) }
+
         val functionsByName = functions.groupBy { it.name }
 
-        val getters = functionsByName
-            .filterKeys { it.startsWith("get") && it.substringAfter("get").firstOrNull()?.isUpperCase() == true }
+        val getters = functions
+            .filter { it.isJavaBeanGetter }
+            .groupBy { it.name }
             .mapValues { (_, functions) -> functions.singleOrNull { fn -> fn.parameters.isEmpty() } }
             .filterValues { it != null && it.returnType.classifier.isValidPropertyType }
         return getters.mapNotNull { (name, getter) ->
@@ -124,7 +128,7 @@ class DefaultPropertyExtractor(val propertyTypePredicate: (SupportedTypeProjecti
     private
     fun memberPropertiesOf(host: SchemaBuildingHost, kClass: KClass<*>, propertyNamePredicate: (String) -> Boolean): List<PropertyExtractionResult> =
         host.classMembers(kClass).declarativeMembers.filter { it.kind.isProperty }.filter { property ->
-            propertyNamePredicate(property.name) && propertyTypePredicate(property.returnType) && property.returnType.classifier.isValidPropertyType
+            propertyNamePredicate(property.name) && includePredicate(kClass, property) && property.returnType.classifier.isValidPropertyType
         }.map { property ->
             host.inContextOfModelMember(property.kCallable) { kPropertyInformation(host, property) }
         }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/GradleCustomizationSchemaBuildingComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/GradleCustomizationSchemaBuildingComponent.kt
@@ -17,7 +17,6 @@
 package org.gradle.internal.declarativedsl.common
 
 import org.gradle.internal.declarativedsl.evaluationSchema.EvaluationSchemaBuilder
-import org.gradle.internal.declarativedsl.evaluationSchema.MinimalSchemaBuildingComponent
 import org.gradle.internal.declarativedsl.evaluationSchema.ObjectConversionComponent
 import org.gradle.internal.declarativedsl.evaluationSchema.gradleConfigureLambdas
 import org.gradle.internal.declarativedsl.evaluationSchema.ifConversionSupported

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/MinimalSchemaBuildingComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/MinimalSchemaBuildingComponent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.declarativedsl.evaluationSchema
+package org.gradle.internal.declarativedsl.common
 
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.artifacts.dsl.DependencyCollector
 import org.gradle.api.provider.Provider
+import org.gradle.internal.declarativedsl.dependencycollectors.DependencyCollectorFunctionExtractorAndRuntimeResolver
+import org.gradle.internal.declarativedsl.evaluationSchema.AnalysisSchemaComponent
+import org.gradle.internal.declarativedsl.evaluationSchema.gradleConfigureLambdas
 import org.gradle.internal.declarativedsl.schemaBuilder.DefaultFunctionExtractor
 import org.gradle.internal.declarativedsl.schemaBuilder.DefaultPropertyExtractor
 import org.gradle.internal.declarativedsl.schemaBuilder.FunctionExtractor
 import org.gradle.internal.declarativedsl.schemaBuilder.GetterBasedConfiguringFunctionExtractor
 import org.gradle.internal.declarativedsl.schemaBuilder.PropertyExtractor
+import org.gradle.internal.declarativedsl.schemaBuilder.SupportedCallable
 import org.gradle.internal.declarativedsl.schemaBuilder.SupportedTypeProjection
 import org.gradle.internal.declarativedsl.schemaBuilder.isValidNestedModelType
 import kotlin.reflect.KClass
@@ -36,7 +40,7 @@ import kotlin.reflect.full.isSubclassOf
  */
 class MinimalSchemaBuildingComponent : AnalysisSchemaComponent {
     override fun propertyExtractors(): List<PropertyExtractor> =
-        listOf(DefaultPropertyExtractor(propertyTypePredicate = ::isValidBasicPropertyType))
+        listOf(DefaultPropertyExtractor(includePredicate = ::isValidBasicProperty))
     override fun functionExtractors(): List<FunctionExtractor> = listOf(
         DefaultFunctionExtractor(configureLambdas = gradleConfigureLambdas),
         GetterBasedConfiguringFunctionExtractor(::isValidNestedGradleModelType)
@@ -54,7 +58,9 @@ private fun isValidNestedGradleModelType(type: SupportedTypeProjection.Supported
             !it.isSubclassOf(DependencyCollector::class)
     } == true
 
-private fun isValidBasicPropertyType(type: SupportedTypeProjection.SupportedType): Boolean =
-    (type.classifier as? KClass<*>)?.let {
-        !it.isSubclassOf(DependencyCollector::class)
-    } ?: true
+/**
+ * Exclude properties imported as dependency collectors.
+ * TODO: find a better communication mechanism for the schema builder components to coordinate importing a member
+ */
+private fun isValidBasicProperty(owner: KClass<*>, callable: SupportedCallable): Boolean =
+    !DependencyCollectorFunctionExtractorAndRuntimeResolver.Companion.isDependencyCollectorPropertyOrGetter(owner, callable)

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/defaults/modelDefaultsSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/defaults/modelDefaultsSchema.kt
@@ -25,7 +25,7 @@ import org.gradle.internal.declarativedsl.analysis.DefaultOperationGenerationId
 import org.gradle.internal.declarativedsl.analysis.and
 import org.gradle.internal.declarativedsl.analysis.implies
 import org.gradle.internal.declarativedsl.common.UnsupportedSyntaxFeatureCheck
-import org.gradle.internal.declarativedsl.common.dependencyCollectors
+import org.gradle.internal.declarativedsl.dependencycollectors.dependencyCollectors
 import org.gradle.internal.declarativedsl.common.gradleDslGeneralSchema
 import org.gradle.internal.declarativedsl.evaluationSchema.SimpleInterpretationSequenceStep
 import org.gradle.internal.declarativedsl.evaluationSchema.buildEvaluationSchema

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/dependencycollectors/dependencyConfigurationSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/dependencycollectors/dependencyConfigurationSchema.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.declarativedsl.common
+package org.gradle.internal.declarativedsl.dependencycollectors
 
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalDependency
-import org.gradle.api.artifacts.dsl.DependencyCollector
 import org.gradle.api.plugins.jvm.PlatformDependencyModifiers
 import org.gradle.internal.declarativedsl.analysis.DefaultDataParameter
-import org.gradle.internal.declarativedsl.analysis.ParameterSemanticsInternal.DefaultUnknown
+import org.gradle.internal.declarativedsl.analysis.ParameterSemanticsInternal
 import org.gradle.internal.declarativedsl.evaluationSchema.AnalysisSchemaComponent
 import org.gradle.internal.declarativedsl.evaluationSchema.EvaluationSchemaBuilder
 import org.gradle.internal.declarativedsl.evaluationSchema.FixedTypeDiscovery
@@ -31,10 +30,8 @@ import org.gradle.internal.declarativedsl.mappingToJvm.RuntimeFunctionResolver
 import org.gradle.internal.declarativedsl.schemaBuilder.FunctionExtractor
 import org.gradle.internal.declarativedsl.schemaBuilder.LossySchemaBuildingOperation
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery
-import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass.DiscoveryTag.Special
 import org.gradle.internal.declarativedsl.schemaBuilder.orError
 import kotlin.reflect.typeOf
-
 
 internal
 fun EvaluationSchemaBuilder.dependencyCollectors() {
@@ -49,15 +46,15 @@ fun EvaluationSchemaBuilder.dependencyCollectors() {
 
 /**
  * Introduces functions for registering dependencies, such as `implementation(...)`, as member functions of
- * types with getters returning [DependencyCollector] in the schema.
+ * types with getters returning [org.gradle.api.artifacts.dsl.DependencyCollector] in the schema.
  * Resolves such functions at runtime, if used with object conversion.
  */
 private
 class DependencyCollectorsComponent : AnalysisSchemaComponent, ObjectConversionComponent {
     @OptIn(LossySchemaBuildingOperation::class) // referencing a predefined type is safe
     private val dependencyCollectorFunctionExtractorAndRuntimeResolver = DependencyCollectorFunctionExtractorAndRuntimeResolver(
-        gavDependencyParam = { host -> DefaultDataParameter("dependency", host.modelTypeRef(typeOf<String>()).orError(), false, DefaultUnknown) },
-        dependencyParam = { host -> DefaultDataParameter("dependency", host.modelTypeRef(typeOf<Dependency>()).orError(), false, DefaultUnknown) },
+        gavDependencyParam = { host -> DefaultDataParameter("dependency", host.modelTypeRef(typeOf<String>()).orError(), false, ParameterSemanticsInternal.DefaultUnknown) },
+        dependencyParam = { host -> DefaultDataParameter("dependency", host.modelTypeRef(typeOf<Dependency>()).orError(), false, ParameterSemanticsInternal.DefaultUnknown) },
     )
 
     override fun functionExtractors(): List<FunctionExtractor> = listOf(
@@ -74,7 +71,7 @@ class DependencyCollectorsComponent : AnalysisSchemaComponent, ObjectConversionC
             FixedTypeDiscovery(
                 PlatformDependencyModifiers::class,
                 listOf(
-                    TypeDiscovery.DiscoveredClass(ExternalDependency::class, listOf(Special("needed for dependencies DSL")))
+                    TypeDiscovery.DiscoveredClass(ExternalDependency::class, listOf(TypeDiscovery.DiscoveredClass.DiscoveryTag.Special("needed for dependencies DSL")))
                 )
             )
         )

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/ProjectSchema.kt
@@ -17,7 +17,7 @@
 package org.gradle.internal.declarativedsl.project
 
 import org.gradle.internal.declarativedsl.analysis.analyzeEverything
-import org.gradle.internal.declarativedsl.common.dependencyCollectors
+import org.gradle.internal.declarativedsl.dependencycollectors.dependencyCollectors
 import org.gradle.internal.declarativedsl.common.gradleDslGeneralSchema
 import org.gradle.internal.declarativedsl.evaluationSchema.DefaultInterpretationSequence
 import org.gradle.internal.declarativedsl.evaluationSchema.buildEvaluationAndConversionSchema

--- a/platforms/core-configuration/declarative-dsl-provider/src/test/java/org/gradle/internal/declarativedsl/DependencyCollectorsComponentTestJava.java
+++ b/platforms/core-configuration/declarative-dsl-provider/src/test/java/org/gradle/internal/declarativedsl/DependencyCollectorsComponentTestJava.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.declarativedsl;
+
+import org.gradle.api.artifacts.dsl.Dependencies;
+import org.gradle.api.artifacts.dsl.DependencyCollector;
+
+public class DependencyCollectorsComponentTestJava {
+
+    @SuppressWarnings("unused")
+    interface TestReceiver extends Dependencies {
+        DependencyCollector getApi();
+        DependencyCollector getImplementation();
+    }
+}

--- a/platforms/core-configuration/declarative-dsl-provider/src/test/kotlin/org/gradle/internal/declarativedsl/DependencyCollectorsComponentTest.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/test/kotlin/org/gradle/internal/declarativedsl/DependencyCollectorsComponentTest.kt
@@ -20,7 +20,7 @@ import org.gradle.api.artifacts.dsl.Dependencies
 import org.gradle.api.artifacts.dsl.DependencyCollector
 import org.gradle.declarative.dsl.schema.FunctionSemantics
 import org.gradle.internal.declarativedsl.analysis.analyzeEverything
-import org.gradle.internal.declarativedsl.common.dependencyCollectors
+import org.gradle.internal.declarativedsl.dependencycollectors.dependencyCollectors
 import org.gradle.internal.declarativedsl.common.gradleDslGeneralSchema
 import org.gradle.internal.declarativedsl.evaluationSchema.buildEvaluationSchema
 import org.gradle.internal.declarativedsl.schemaUtils.typeFor
@@ -31,24 +31,32 @@ import kotlin.reflect.KClass
 class DependencyCollectorsComponentTest {
     @Test
     fun `dependency collectors are imported only as adding functions`() {
-        schemaFrom(TestReceiver::class).analysisSchema.run {
-            val type = typeFor<TestReceiver>()
-            val functions = type.memberFunctions
+        listOf( // the same definition in Java and Kotlin
+            TestReceiver::class,
+            DependencyCollectorsComponentTestJava.TestReceiver::class,
+        ).forEach { receiverClass ->
+            schemaFrom(receiverClass).analysisSchema.run {
+                val type = typeFor(receiverClass.java)
+                val functions = type.memberFunctions
 
-            Assert.assertTrue(
-                "no DCL properties are imported from the dependency collector properties",
-                type.properties.isEmpty()
-            )
-            Assert.assertEquals(
-                "only project value factory and the two dependency collectors are imported from the class",
-                setOf("project", "api", "implementation"),
-                functions.map { it.simpleName }.toSet()
-            )
-            Assert.assertTrue(
-                "all dependency collector-produced functions have the adding semantics",
-                functions.filter { it.simpleName == "api" || it.simpleName == "implementation" }.all { it.semantics is FunctionSemantics.AddAndConfigure }
-            )
-
+                Assert.assertTrue(
+                    "getters like getApi, getImplementation are not imported from the class",
+                    functions.map { it.simpleName }.intersect(setOf("getApi", "getImplementation")).isEmpty(),
+                )
+                Assert.assertTrue(
+                    "no DCL properties are imported from the dependency collector properties",
+                    type.properties.isEmpty()
+                )
+                Assert.assertEquals(
+                    "only project value factory and the two dependency collectors are imported from the class",
+                    setOf("project", "api", "implementation"),
+                    functions.map { it.simpleName }.toSet()
+                )
+                Assert.assertTrue(
+                    "all dependency collector-produced functions have the adding semantics",
+                    functions.filter { it.simpleName == "api" || it.simpleName == "implementation" }.all { it.semantics is FunctionSemantics.AddAndConfigure }
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Fix dependency collectors in DCL appearing as nested models or properties

The DCL schema should not have configuring functions produced from the
`DependencyCollector` getters. They should not be visible as DCL properties
(even read-only ones) either.

<details>
<summary>Before</summary>

<img width="1358" height="609" alt="image" src="https://github.com/user-attachments/assets/709a2087-5848-4aa7-a1db-794ffe22c9ed" />

<img width="443" height="922" alt="image" src="https://github.com/user-attachments/assets/44e55c63-2016-43a0-bf77-df22004c445c" />


</details>


<details>
<summary>After</summary>

<img width="1364" height="340" alt="image" src="https://github.com/user-attachments/assets/162832cf-a312-4489-aa2f-bf70fd836856" />

<img width="423" height="635" alt="image" src="https://github.com/user-attachments/assets/84ec6212-872d-4330-a261-77e715793e4c" />

</details>