### PR TITLE
Prevent two resolutions from using same binary store

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
@@ -94,11 +94,11 @@ public class ResolutionResultsStoreFactory implements Closeable {
     public StoreSet createStoreSet() {
         return new StoreSet() {
             final int storeSetId = storeSetBaseId.getAndIncrement();
-            int binaryStoreId;
+            final AtomicInteger binaryStoreId = new AtomicInteger(0);
             @Override
             public DefaultBinaryStore nextBinaryStore() {
                 //one binary store per id+threadId
-                String storeKey = Thread.currentThread().getId() + "-" + binaryStoreId++;
+                String storeKey = Thread.currentThread().getId() + "-" + binaryStoreId.getAndIncrement();
                 return createBinaryStore(storeKey);
             }
 


### PR DESCRIPTION
When resolving configurations in parallel, it is possible that two separate configuration resolutions may use the binary store.

Fixes https://github.com/gradle/gradle/issues/36543

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
