### PR TITLE
Print detailed message when there is performance test failures

### DIFF
--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
@@ -51,17 +51,17 @@ public class DefaultReportGenerator extends AbstractReportGenerator<AllResultsSt
         executionDataProvider.getReportScenarios()
             .forEach(scenario -> {
                 if (scenario.isBuildFailed()) {
-                    failureCollector.scenarioFailed();
+                    failureCollector.scenarioFailed(scenario);
                 } else if (scenario.isRegressed()) {
                     Set<PerformanceFlakinessDataProvider.ScenarioRegressionResult> regressionResults = scenario.getCurrentExecutions().stream()
                         .map(execution -> flakinessDataProvider.getScenarioRegressionResult(scenario.getPerformanceExperiment(), execution))
                         .collect(Collectors.toSet());
                     if (regressionResults.contains(STABLE_REGRESSION)) {
-                        failureCollector.scenarioRegressed();
+                        failureCollector.scenarioRegressed(scenario);
                     } else if (regressionResults.stream().allMatch(BIG_FLAKY_REGRESSION::equals)) {
-                        failureCollector.flakyScenarioWithBigRegression();
+                        failureCollector.flakyScenarioWithBigRegression(scenario);
                     } else {
-                        failureCollector.flakyScenarioWithSmallRegression();
+                        failureCollector.flakyScenarioWithSmallRegression(scenario);
                     }
                 }
             });


### PR DESCRIPTION
Sometimes we see very confusing TeamCity performance test failure like [this](https://builds.gradle.org/buildConfiguration/Gradle_Release8x_Check_PerformanceTestTestLinux_Trigger/108418604), the report generator fails with "X scenarios failed", but we can't find any in performance report. 

This PR prints more detailed error message, which includes the TC build id of failed scenarios.