### PR TITLE
Show stacktrace to fix the failed assertion

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
@@ -103,7 +103,7 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
                 "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
         }
-        fails taskName
+        fails(taskName, "-s")
 
         then:
         failure.assertThatCause(containsText("could not be started because the command line exceed operating system limits."))


### PR DESCRIPTION
With [JDK 21 patch version upgrade](https://github.com/gradle/gradle/pull/36450), the test [starts failing with error](https://builds.gradle.org/buildConfiguration/Gradle_Release8x_Check_Parallel_7_bucket4/108453133):

```
Condition failed with Exception:
  
  failure.assertThatCause(containsText("could not be started because the command line exceed operating system limits."))
  |       |               |
  |       |               a CharSequence that contains text "could not be started because the command line exceed operating system limits."
  |       java.lang.AssertionError: No matching cause found
  |       Expected: A cause which is a CharSequence that contains text "could not be started because the command line exceed operating system limits."
  |            but: causes were [A problem occurred starting process 'command '/mnt/tcagent1/jdks/linux-amd64-temurin-jdk-21.0.10_7/bin/java'']
  |       Output:
  |       =======
  |       Starting a Gradle Daemon (subsequent builds will be faster)
  |       > Task :compileJava
  |       > Task :processResources NO-SOURCE
  |       > Task :classes
  |       > Task :runWithExecOperations FAILED
  |       2 actionable tasks: 2 executed
  |        
  |       Error:
  |       ======
  |        
  |       FAILURE: Build failed with an exception.
  |        
  |       * What went wrong:
  |       Execution failed for task ':runWithExecOperations'.
  |       > A problem occurred starting process 'command '/mnt/tcagent1/jdks/linux-amd64-temurin-jdk-21.0.10_7/bin/java''
  |        
  |       * Try:
  |       > Run with --stacktrace option to get the stack trace.
  |       > Run with --info or --debug option to get more log output.
  |       > Run with --scan to get full insights.
  |       > Get more help at https://help.gradle.org/.
```

Adding `-s` to the tests would show deeper stacktrace, thus fixed the assertion. [Validation](https://builds.gradle.org/buildConfiguration/Gradle_Release8x_Check_Parallel_7_bucket4/108471744)