### PR TITLE
Restore line info for compile errors with Java 8 + annotation processors

### DIFF
--- a/platforms/jvm/java-compiler-worker/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/java-compiler-worker/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -266,7 +266,7 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
             return formatter.format((JCDiagnostic) diagnostic, JavacMessages.instance(context).getCurrentLocale());
         } catch (Exception ex) {
             LOGGER.info(FORMATTER_FALLBACK_MESSAGE);
-            return diagnostic.getMessage(Locale.getDefault());
+            return diagnostic.toString();
         }
     }
 

--- a/platforms/jvm/java-compiler-worker/src/test/groovy/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListenerTest.groovy
+++ b/platforms/jvm/java-compiler-worker/src/test/groovy/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListenerTest.groovy
@@ -28,6 +28,7 @@ import static javax.tools.Diagnostic.NOPOS
 class DiagnosticToProblemListenerTest extends Specification {
 
     private static final String DIAGNOSTIC_DETAIL = "Error detail line 1${System.lineSeparator()}error detail line 2"
+    private static final String DIAGNOSTIC_DETAIL_WITH_LINE_INFO = "Main.java:6: " + DIAGNOSTIC_DETAIL;
 
     def spec = Mock(InternalProblemSpec)
 
@@ -197,13 +198,14 @@ class DiagnosticToProblemListenerTest extends Specification {
         then:
         // Only the first line of the message is used as the contextual message
         1 * spec.contextualLabel("Error detail line 1")
-        1 * spec.details(DIAGNOSTIC_DETAIL)
+        1 * spec.details(DIAGNOSTIC_DETAIL_WITH_LINE_INFO)
     }
 
     Diagnostic<?> getMockDiagnostics() {
         return Mock(Diagnostic) {
             code >> "dummy.code"
             getMessage(_) >> DIAGNOSTIC_DETAIL
+            toString() >> DIAGNOSTIC_DETAIL_WITH_LINE_INFO
             kind >> Diagnostic.Kind.ERROR
         }
     }


### PR DESCRIPTION
Fixes a regression originally introduced in Gradle 8.9. The problem was reported in [#31160](https://github.com/gradle/gradle/issues/31160) and [#32199](https://github.com/gradle/gradle/issues/32199).

Details about the proposed fix are described in https://github.com/gradle/gradle/issues/32199#issuecomment-3828813059.

### Context

Java 8 is still supported by all major JDK providers. Annotation processors like [Immutables](https://immutables.github.io/) are quite popular.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
