### PR TITLE
Maintain compatibility with plugins using custom TestDescriptor implementations

### DIFF
--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/tasks/testing/TestDescriptor.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/tasks/testing/TestDescriptor.java
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.testing;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.internal.tasks.testing.source.DefaultNoSource;
 import org.gradle.api.tasks.testing.source.TestSource;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -71,7 +72,6 @@ public interface TestDescriptor {
     @Nullable
     TestDescriptor getParent();
 
-
     /**
      * Returns the source of the test descriptor.
      *
@@ -79,5 +79,7 @@ public interface TestDescriptor {
      * @since 9.4.0
      */
     @Incubating
-    TestSource getSource();
+    default TestSource getSource() {
+        return DefaultNoSource.getInstance();
+    }
 }


### PR DESCRIPTION
Multiple plugins that contribute to testing implement their own `TestDescriptor` types. For example, `test-retry-plugin` has [TestDescriptorImpl](https://github.com/gradle/test-retry-gradle-plugin/blob/main/plugin/src/main/java/org/gradle/testretry/internal/executer/TestDescriptorImpl.java).

Gradle 9.4 introduces a new `TestDescriptor.getSource()` method. To ensure compatibility,  this PR introduces a default implementation for that method.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
