### PR TITLE
Allow address resolver properties for Gradle Daemon

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
@@ -62,11 +62,22 @@ public class JvmOptions {
     public static final String SSL_TRUSTPASSWORD_KEY = "javax.net.ssl.trustStorePassword";
     public static final String SSL_TRUSTSTORETYPE_KEY = "javax.net.ssl.trustStoreType";
 
+    // The following three properties are used in java.net.InetAddress.initializePlatformLookupPolicy
+    // (static initialization).
+
+    // Useful fallback when using IPv6 causes issues.
+    public static final String JAVA_NET_PREFER_IPV4_STACK_KEY = "java.net.preferIPv4Stack";
+    // Note: InetAddress.get*() yield IPv4 addresses before IPv6 addresses (Hyrum's law).
+    // To comply with https://datatracker.ietf.org/doc/html/rfc6724, users have to set
+    // java.net.preferIPv6Addresses=true.
+    public static final String JAVA_NET_PREFER_IPV6_ADDRESSES_KEY = "java.net.preferIPv6Addresses";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(JvmOptions.class);
 
     public static final Collection<String> IMMUTABLE_SYSTEM_PROPERTIES = Arrays.asList(
         FILE_ENCODING_KEY, USER_LANGUAGE_KEY, USER_COUNTRY_KEY, USER_VARIANT_KEY, JMX_REMOTE_KEY, JAVA_IO_TMPDIR_KEY, JAVA_SECURITY_PROPERTIES_KEY, JDK_ENABLE_ADS_KEY,
         SSL_KEYSTORE_KEY, SSL_KEYSTOREPASSWORD_KEY, SSL_KEYSTORETYPE_KEY, SSL_TRUSTPASSWORD_KEY, SSL_TRUSTSTORE_KEY, SSL_TRUSTSTORETYPE_KEY,
+        JAVA_NET_PREFER_IPV4_STACK_KEY, JAVA_NET_PREFER_IPV6_ADDRESSES_KEY,
         // Gradle specific
         HeapProportionalCacheSizer.CACHE_RESERVED_SYSTEM_PROPERTY
     );

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
@@ -27,6 +27,8 @@ import java.nio.charset.Charset
 
 import static org.gradle.process.internal.JvmOptions.FILE_ENCODING_KEY
 import static org.gradle.process.internal.JvmOptions.JAVA_IO_TMPDIR_KEY
+import static org.gradle.process.internal.JvmOptions.JAVA_NET_PREFER_IPV4_STACK_KEY
+import static org.gradle.process.internal.JvmOptions.JAVA_NET_PREFER_IPV6_ADDRESSES_KEY
 import static org.gradle.process.internal.JvmOptions.JAVA_SECURITY_PROPERTIES_KEY
 import static org.gradle.process.internal.JvmOptions.JMX_REMOTE_KEY
 import static org.gradle.process.internal.JvmOptions.SSL_KEYSTOREPASSWORD_KEY
@@ -179,20 +181,22 @@ class JvmOptionsTest extends Specification {
         opts.immutableSystemProperties.containsKey(propKey)
 
         where:
-        propDescr                 | propKey                         | propAsArg
-        "file encoding"           | FILE_ENCODING_KEY               | "-D${FILE_ENCODING_KEY}=UTF-8"
-        "user variant"            | USER_VARIANT_KEY                | "-D${USER_VARIANT_KEY}"
-        "user language"           | USER_LANGUAGE_KEY               | "-D${USER_LANGUAGE_KEY}=en"
-        "user country"            | USER_COUNTRY_KEY                | "-D${USER_COUNTRY_KEY}=US"
-        "jmx remote"              | JMX_REMOTE_KEY                  | "-D${JMX_REMOTE_KEY}"
-        "temp directory"          | JAVA_IO_TMPDIR_KEY              | "-D${JAVA_IO_TMPDIR_KEY}=/some/tmp/folder"
-        "security properties"     | JAVA_SECURITY_PROPERTIES_KEY    | "-D${JAVA_SECURITY_PROPERTIES_KEY}=/some/tmp/security.properties"
-        "ssl keystore path"       | SSL_KEYSTORE_KEY                | "-D${SSL_KEYSTORE_KEY}=/keystore/path"
-        "ssl keystore password"   | SSL_KEYSTOREPASSWORD_KEY        | "-D${SSL_KEYSTOREPASSWORD_KEY}=secret"
-        "ssl keystore type"       | SSL_KEYSTORETYPE_KEY            | "-D${SSL_KEYSTORETYPE_KEY}=jks"
-        "ssl truststore path"     | SSL_TRUSTSTORE_KEY              | "-D${SSL_TRUSTSTORE_KEY}=truststore/path"
-        "ssl truststore password" | SSL_TRUSTPASSWORD_KEY           | "-D${SSL_TRUSTPASSWORD_KEY}=secret"
-        "ssl truststore type"     | SSL_TRUSTSTORETYPE_KEY          | "-D${SSL_TRUSTSTORETYPE_KEY}=jks"
+        propDescr                 | propKey                            | propAsArg
+        "file encoding"           | FILE_ENCODING_KEY                  | "-D${FILE_ENCODING_KEY}=UTF-8"
+        "user variant"            | USER_VARIANT_KEY                   | "-D${USER_VARIANT_KEY}"
+        "user language"           | USER_LANGUAGE_KEY                  | "-D${USER_LANGUAGE_KEY}=en"
+        "user country"            | USER_COUNTRY_KEY                   | "-D${USER_COUNTRY_KEY}=US"
+        "jmx remote"              | JMX_REMOTE_KEY                     | "-D${JMX_REMOTE_KEY}"
+        "temp directory"          | JAVA_IO_TMPDIR_KEY                 | "-D${JAVA_IO_TMPDIR_KEY}=/some/tmp/folder"
+        "security properties"     | JAVA_SECURITY_PROPERTIES_KEY       | "-D${JAVA_SECURITY_PROPERTIES_KEY}=/some/tmp/security.properties"
+        "ssl keystore path"       | SSL_KEYSTORE_KEY                   | "-D${SSL_KEYSTORE_KEY}=/keystore/path"
+        "ssl keystore password"   | SSL_KEYSTOREPASSWORD_KEY           | "-D${SSL_KEYSTOREPASSWORD_KEY}=secret"
+        "ssl keystore type"       | SSL_KEYSTORETYPE_KEY               | "-D${SSL_KEYSTORETYPE_KEY}=jks"
+        "ssl truststore path"     | SSL_TRUSTSTORE_KEY                 | "-D${SSL_TRUSTSTORE_KEY}=truststore/path"
+        "ssl truststore password" | SSL_TRUSTPASSWORD_KEY              | "-D${SSL_TRUSTPASSWORD_KEY}=secret"
+        "ssl truststore type"     | SSL_TRUSTSTORETYPE_KEY             | "-D${SSL_TRUSTSTORETYPE_KEY}=jks"
+        "prefer IPv4 stack"       | JAVA_NET_PREFER_IPV4_STACK_KEY     | "-D${JAVA_NET_PREFER_IPV4_STACK_KEY}=true"
+        "prefer IPv6 addresses"   | JAVA_NET_PREFER_IPV6_ADDRESSES_KEY | "-D${JAVA_NET_PREFER_IPV6_ADDRESSES_KEY}=true"
     }
 
     def "#propDescr can be set as systemproperty"() {
@@ -200,20 +204,58 @@ class JvmOptionsTest extends Specification {
         when:
         opts.systemProperty(propKey, propValue)
         then:
-        opts.allJvmArgs.contains("-D${propKey}=${propValue}".toString());
+        opts.allJvmArgs.contains("-D${propKey}=${propValue}".toString())
         where:
-        propDescr                 | propKey                         | propValue
-        "file encoding"           | FILE_ENCODING_KEY               | "ISO-8859-1"
-        "user country"            | USER_COUNTRY_KEY                | "en"
-        "user language"           | USER_LANGUAGE_KEY               | "US"
-        "temp directory"          | JAVA_IO_TMPDIR_KEY              | "/some/tmp/folder"
-        "security properties"     | JAVA_SECURITY_PROPERTIES_KEY    | "/some/folder/security.properties"
-        "ssl keystore path"       | SSL_KEYSTORE_KEY                | "/keystore/path"
-        "ssl keystore password"   | SSL_KEYSTOREPASSWORD_KEY        | "secret"
-        "ssl keystore type"       | SSL_KEYSTORETYPE_KEY            | "jks"
-        "ssl truststore path"     | SSL_TRUSTSTORE_KEY              | "truststore/path"
-        "ssl truststore password" | SSL_TRUSTPASSWORD_KEY           | "secret"
-        "ssl truststore type"     | SSL_TRUSTSTORETYPE_KEY          | "jks"
+        propDescr                 | propKey                            | propValue
+        "file encoding"           | FILE_ENCODING_KEY                  | "ISO-8859-1"
+        "user country"            | USER_COUNTRY_KEY                   | "en"
+        "user language"           | USER_LANGUAGE_KEY                  | "US"
+        "temp directory"          | JAVA_IO_TMPDIR_KEY                 | "/some/tmp/folder"
+        "security properties"     | JAVA_SECURITY_PROPERTIES_KEY       | "/some/folder/security.properties"
+        "ssl keystore path"       | SSL_KEYSTORE_KEY                   | "/keystore/path"
+        "ssl keystore password"   | SSL_KEYSTOREPASSWORD_KEY           | "secret"
+        "ssl keystore type"       | SSL_KEYSTORETYPE_KEY               | "jks"
+        "ssl truststore path"     | SSL_TRUSTSTORE_KEY                 | "truststore/path"
+        "ssl truststore password" | SSL_TRUSTPASSWORD_KEY              | "secret"
+        "ssl truststore type"     | SSL_TRUSTSTORETYPE_KEY             | "jks"
+        "prefer IPv4 stack"       | JAVA_NET_PREFER_IPV4_STACK_KEY     | "true"
+        "prefer IPv6 addresses"   | JAVA_NET_PREFER_IPV6_ADDRESSES_KEY | "true"
+    }
+
+    def "#propDescr can be set as an immutable systemproperty"() {
+        JvmOptions opts = createOpts()
+        when:
+        opts.systemProperty(propKey, propValue)
+        then:
+        opts.immutableSystemProperties.containsKey(propKey)
+        opts.immutableSystemProperties.get(propKey) == propValue
+        where:
+        propDescr                 | propKey                            | propValue
+        "file encoding"           | FILE_ENCODING_KEY                  | "ISO-8859-1"
+        "user country"            | USER_COUNTRY_KEY                   | "en"
+        "user language"           | USER_LANGUAGE_KEY                  | "US"
+        "temp directory"          | JAVA_IO_TMPDIR_KEY                 | "/some/tmp/folder"
+        "security properties"     | JAVA_SECURITY_PROPERTIES_KEY       | "/some/folder/security.properties"
+        "ssl keystore path"       | SSL_KEYSTORE_KEY                   | "/keystore/path"
+        "ssl keystore password"   | SSL_KEYSTOREPASSWORD_KEY           | "secret"
+        "ssl keystore type"       | SSL_KEYSTORETYPE_KEY               | "jks"
+        "ssl truststore path"     | SSL_TRUSTSTORE_KEY                 | "truststore/path"
+        "ssl truststore password" | SSL_TRUSTPASSWORD_KEY              | "secret"
+        "ssl truststore type"     | SSL_TRUSTSTORETYPE_KEY             | "jks"
+        "prefer IPv4 stack"       | JAVA_NET_PREFER_IPV4_STACK_KEY     | "true"
+        "prefer IPv6 addresses"   | JAVA_NET_PREFER_IPV6_ADDRESSES_KEY | "true"
+    }
+
+    def "#propKey cannot be set as an immutable systemproperty"() {
+        JvmOptions opts = createOpts()
+        when:
+        opts.systemProperty(propKey, propValue)
+        then:
+        !opts.immutableSystemProperties.containsKey(propKey)
+        where:
+        propKey           | propValue
+        "foo"             | "ISO-8859-1"
+        "stdout.encoding" | "US_ASCII"
     }
 
     def "can enter debug mode"() {


### PR DESCRIPTION
Currently it is not possible to set the system properties `java.net.preferIPv6Addresses` and `java.net.preferIPv4Stack` for the Gradle Daemon. As for example artifact resolution depends on Java's name resolution, downloads almost always happen via IPv4.

As Java complies with "Hyrum's law", the IP addresses returned by `InetAddress.get*()` yield IPv4 _before_ IPv6 addresses, even if it ignores the system settings and [RFC 6724](https://datatracker.ietf.org/doc/html/rfc6724). To comply with RFC 6724, users have to set `java.net.preferIPv6Addresses=true`. `java.net.preferIPv4Stack` is generally useful when IPv6 issues arise.

Background for this issue: `org.gradle.launcher.daemon.configuration.DaemonParameters#getEffectiveJvmArgs` yields only the _immutable_ system properties for the Gradle daemon JVM arguments, not all JVM arguments configured for example via `org.gradle.jvmargs` in `gradle.properties` or `gradlew`'s `-D` argument.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
