### PR TITLE
Modify example to demonstrate confusion

### DIFF
--- a/platforms/documentation/docs/src/snippets/performance/resolveAtBuildTime/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/performance/resolveAtBuildTime/groovy/build.gradle
@@ -10,6 +10,12 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.11'
 }
 
+configurations.all {
+    incoming.beforeResolve {
+        println ">> Resolving configuration: ${name}"
+    }
+}
+
 // tag::copy[]
 tasks.register('copyFiles', Copy) {
     into(layout.buildDirectory.dir('output'))

--- a/platforms/documentation/docs/src/snippets/performance/resolveAtBuildTime/tests/copyFiles.sample.conf
+++ b/platforms/documentation/docs/src/snippets/performance/resolveAtBuildTime/tests/copyFiles.sample.conf
@@ -1,4 +1,4 @@
 executable: gradle
-args: copyFiles -q
+args: "copyFiles -q --console=plain --info"
 expected-output-file: copyFiles.out
 allow-additional-output: true


### PR DESCRIPTION
Run with `:docs:docsTest --tests "*snippet-performance-resolve-at-build-time*groovy*"`.  

Compare results to [documentation here](https://docs.gradle.org/current/userguide/performance.html#avoid_dependency_resolution_during_configuration).