### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,9 +25,9 @@ systemProp.develocity.internal.testacceleration.enableCustomValues=true
 # If enabled, the build logs whenever a WorkerReadyMessage is received. This should help analyzing the problem of remote executors being in wrong state.
 systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 # Default ReadyForNightly performance baseline
-defaultRfnPerformanceBaselines=9.4.0-commit-1fbb3b1261c
+defaultRfnPerformanceBaselines=9.5.0-commit-8fbe0e2275e
 # Default ReadyForRelease performance baseline
-defaultRfrPerformanceBaselines=9.4.0-commit-1fbb3b1261c
+defaultRfrPerformanceBaselines=9.5.0-commit-8fbe0e2275e
 systemProp.dependency.analysis.test.analysis=false
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
Because DeclarativeDslFirstUsePerformanceTest requires minimum 9.5 base version.