### PR TITLE
Improve error message for service lookup failure on closed registry

### DIFF
--- a/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
+++ b/platforms/core-runtime/service-registry-impl/src/main/java/org/gradle/internal/service/DefaultServiceRegistry.java
@@ -301,10 +301,12 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
         }
     }
 
-    private void serviceRequested() {
+    private void serviceRequested(Type serviceType) {
         noLongerMutable();
         if (state.get() == State.CLOSED) {
-            throw new IllegalStateException(String.format("%s has been closed.", getDisplayName()));
+            throw new IllegalStateException(String.format(
+                "Failed to obtain service '%s', because %s has been closed.", format(serviceType), getDisplayName()
+            ));
         }
     }
 
@@ -344,7 +346,7 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
 
     @Nullable
     private Service getService(Type serviceType) {
-        serviceRequested();
+        serviceRequested(serviceType);
         return find(serviceType, null, allServices);
     }
 
@@ -352,7 +354,7 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
     public <T> List<T> getAll(Class<T> serviceType) throws ServiceLookupException {
         assertValidServiceType(serviceType);
         List<T> services = new ArrayList<T>();
-        serviceRequested();
+        serviceRequested(serviceType);
         allServices.getAll(serviceType, null, new InstanceUnpackingVisitor<T>(serviceType, services));
         return services;
     }
@@ -547,7 +549,7 @@ public class DefaultServiceRegistry implements CloseableServiceRegistry, Contain
 
         @Override
         public Object getInstance() {
-            serviceRequested();
+            serviceRequested(serviceProvider.serviceTypes.get(0));
             return serviceProvider.getPreparedInstance();
         }
     }

--- a/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/platforms/core-runtime/service-registry-impl/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -1275,14 +1275,14 @@ class DefaultServiceRegistryTest extends Specification {
 
         then:
         IllegalStateException e = thrown()
-        e.message == "test registry has been closed."
+        e.message == "Failed to obtain service 'String', because test registry has been closed."
 
         when:
         registry.getAll(String)
 
         then:
         e = thrown()
-        e.message == "test registry has been closed."
+        e.message == "Failed to obtain service 'String', because test registry has been closed."
     }
 
     /**


### PR DESCRIPTION
Such errors can happen when project-scoped providers aren't realized until a shared build service is closed, and then try to use project services.