### PR TITLE
Store Assessed attribute values as Strings to avoid potential for ClassNotFoundExceptions on CC deserialization

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionCandidateAssessor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionCandidateAssessor.java
@@ -36,6 +36,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -213,14 +214,14 @@ public final class ResolutionCandidateAssessor {
         private final Attribute<T> attribute;
 
         @Nullable
-        private final T requested;
+        private final String requested;
         @Nullable
-        private final T provided;
+        private final String provided;
 
         private AssessedAttribute(Attribute<T> attribute, @Nullable T requested, @Nullable T provided) {
             this.attribute = attribute;
-            this.requested = requested;
-            this.provided = provided;
+            this.requested = Objects.toString(requested);
+            this.provided = Objects.toString(provided);
         }
 
         public Attribute<T> getAttribute() {
@@ -228,12 +229,12 @@ public final class ResolutionCandidateAssessor {
         }
 
         @Nullable
-        public T getRequested() {
+        public String getRequested() {
             return requested;
         }
 
         @Nullable
-        public T getProvided() {
+        public String getProvided() {
             return provided;
         }
 


### PR DESCRIPTION
There is no need to store Attribute values at strongly typed instances when a failure has occurred - we can just get their String value.  This is all that is needed by the failure handling machinery, and it avoids a potential failure case where the value's class is not available for CC deserialization.

Fixes:
- https://github.com/gradle/gradle/issues/35318