### PR TITLE
Increase duration for GradleImplDepsPerformanceIntegrationTest

### DIFF
--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsPerformanceIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsPerformanceIntegrationTest.groovy
@@ -50,7 +50,7 @@ class GradleImplDepsPerformanceIntegrationTest extends BaseGradleImplDepsIntegra
         then:
         def generation = operations.only("Generate $dependency jar")
         def durationMs = generation.endTime - generation.startTime
-        durationMs < 8000
+        durationMs < 10000
 
         where:
         dependency       | declaration


### PR DESCRIPTION
It's [very flaky](https://ge.gradle.org/scans/tests?search.timeZoneId=Asia%2FShanghai&tests.container=org.gradle.plugin.devel.impldeps.GradleImplDepsPerformanceIntegrationTest) since https://github.com/gradle/gradle/pull/36661