### PR TITLE
Expose failOnNoMatchingTests (or equivalent) on AbstractTestTask

### DIFF
--- a/platforms/documentation/docs/src/docs/dsl/org.gradle.api.tasks.testing.AbstractTestTask.xml
+++ b/platforms/documentation/docs/src/docs/dsl/org.gradle.api.tasks.testing.AbstractTestTask.xml
@@ -37,6 +37,10 @@
                 <td/>
             </tr>
             <tr>
+                <td>allowNoMatchingTests</td>
+                <td/>
+            </tr>
+            <tr>
                 <td>reports</td>
                 <td/>
             </tr>

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -83,6 +83,17 @@ This is useful for running Gradle in automated environments such as CI pipelines
 
 See the [Non-interactive mode](userguide/command_line_interface.html#sec:non_interactive) section in the Gradle User Manual for more information.
 
+### More control over test filtering on the command line
+
+When running `--tests` filters on a task like `test` that spans multiple subprojects, Gradle previously failed the build if the task found no matching tests.
+You can now pass `--allow-no-matches` alongside `--tests` to allow the build to succeed when a filter matches no tests on a given `Test` task:
+
+`./gradlew test --tests "*FooTest*" --allow-no-matches`
+
+This is especially useful in multi-project builds where a filter is only expected to match tests in some subprojects.
+
+The default behavior (fail when no tests match) is unchanged.
+
 ### Build authoring improvements
 Gradle provides [rich APIs](userguide/getting_started_dev.html) for build engineers and plugin authors, enabling the creation of custom, reusable build logic and better maintainability.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/platforms/jvm/java_testing.adoc
@@ -123,6 +123,15 @@ For more details and examples of declaring filters in the build script, please s
 
 The command-line option is especially useful to execute a single test method. When you use `--tests`, be aware that the inclusions declared in the build script are still honored. It is also possible to supply multiple `--tests` options, all of whose patterns will take effect. The following sections have several examples of using the command-line option.
 
+[WARNING]
+====
+When filtering tests, Gradle will fail the build if the filter does not match any test by default.
+
+When running multiple `Test` tasks with a top-level task selector like `test` in a multi-project build, there is a high chance of causing the build to fail if you supply a `--tests` filter that does not match at least one test in every `Test` task.
+
+To change this behavior, pass the additional command-line option `--allow-no-matches` which will allow the build to succeed even if the filter does not match any test on any `Test` task.
+====
+
 NOTE: Not all test frameworks play well with filtering. Some advanced, synthetic tests may not be fully compatible.
 However, the vast majority of tests and use cases work perfectly well with Gradle's filtering mechanism.
 

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -65,6 +65,7 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.VerificationTask;
+import org.gradle.api.tasks.options.NoDisable;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.api.tasks.testing.logging.TestLogging;
 import org.gradle.api.tasks.testing.logging.TestLoggingContainer;
@@ -692,7 +693,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
     }
 
     private boolean shouldFailOnNoMatchingTests() {
-        return patternFiltersSpecified() && getFailOnNoMatchingTests().getOrElse(filter.isFailOnNoMatchingTests());
+        return patternFiltersSpecified() && getAllowNoMatchingTests().map(allow -> !allow).getOrElse(filter.isFailOnNoMatchingTests());
     }
 
     boolean testsAreNotFiltered() {
@@ -795,23 +796,27 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
     }
 
     /**
-     * Whether the task should fail when a filter was configured but no test matched the filter.
-     * Defaults to true.
+     * Whether to allow the task to succeed when a filter was configured but no tests matched.
+     * When not set, falls back to {@link TestFilter#isFailOnNoMatchingTests()} (default: fail).
      *
      * <p>
      * If configured this takes precedence over {@link TestFilter#isFailOnNoMatchingTests()}.
      * <p>
-     * The main use case for this property is the CLI and being able to invoke a generic test task with a filter that may or may not match tests depending on the project,
-     * and being able to not fail when it doesn't match any tests.
+     * The main use case for this property is the CLI: when running a generic test task with a
+     * filter (e.g. {@code --tests "*FooTest*"}) across a multi-project build, only some subprojects
+     * may have matching tests. Pass {@code --allow-no-matches} to avoid failing in those that don't.
+     * <p>
+     * The exposed CLI option is {@code --allow-no-matches}.
      *
      * @since 9.6.0
      * @see TestFilter#isFailOnNoMatchingTests()
      */
     @Incubating
-    @Option(option = "fail-on-no-matching-tests", description = "Fail the task if a filter was specified but no tests matched.")
+    @Option(option = "allow-no-matches", description = "Allow the task to succeed when a filter was specified but no tests matched.")
+    @NoDisable
     @Optional
     @Input
-    public abstract Property<Boolean> getFailOnNoMatchingTests();
+    public abstract Property<Boolean> getAllowNoMatchingTests();
 
     /**
      * Whether the task should fail if test sources are present, but no tests are discovered during test execution.  Defaults to true.

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -61,6 +61,7 @@ import org.gradle.api.reporting.Reporting;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.VerificationTask;
@@ -691,7 +692,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
     }
 
     private boolean shouldFailOnNoMatchingTests() {
-        return patternFiltersSpecified() && filter.isFailOnNoMatchingTests();
+        return patternFiltersSpecified() && getFailOnNoMatchingTests().getOrElse(filter.isFailOnNoMatchingTests());
     }
 
     boolean testsAreNotFiltered() {
@@ -792,6 +793,25 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
     public TestFilter getFilter() {
         return filter;
     }
+
+    /**
+     * Whether the task should fail when a filter was configured but no test matched the filter.
+     * Defaults to true.
+     *
+     * <p>
+     * If configured this takes precedence over {@link TestFilter#isFailOnNoMatchingTests()}.
+     * <p>
+     * The main use case for this property is the CLI and being able to invoke a generic test task with a filter that may or may not match tests depending on the project,
+     * and being able to not fail when it doesn't match any tests.
+     *
+     * @since 9.6.0
+     * @see TestFilter#isFailOnNoMatchingTests()
+     */
+    @Incubating
+    @Option(option = "fail-on-no-matching-tests", description = "Fail the task if a filter was specified but no tests matched.")
+    @Optional
+    @Input
+    public abstract Property<Boolean> getFailOnNoMatchingTests();
 
     /**
      * Whether the task should fail if test sources are present, but no tests are discovered during test execution.  Defaults to true.

--- a/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -243,12 +243,12 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         failure.assertHasCause("No tests found for given includes: [${testSuite('SomeTest')}.missingMethod](filter.includeTestsMatching)")
     }
 
-    def "can disable fail on no matching tests via task property"() {
+    def "can allow no matching tests via task property"() {
         given:
         createPassingFailingTest()
         buildFile << """
             tasks.withType(AbstractTestTask) {
-                failOnNoMatchingTests = false
+                allowNoMatchingTests = true
             }
         """
 
@@ -259,18 +259,39 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         noExceptionThrown()
     }
 
-    def "can disable fail on no matching tests via CLI"() {
+    def "can allow no matching tests via CLI"() {
         given:
         createPassingFailingTest()
 
         when:
-        run(testTaskName, "--tests", "${testSuite('SomeTest')}.missingMethod", "--no-fail-on-no-matching-tests")
+        run(testTaskName, "--tests", "${testSuite('SomeTest')}.missingMethod", "--allow-no-matches")
 
         then:
         noExceptionThrown()
     }
 
-    def "task property takes precedence over filter property for failOnNoMatchingTests: #scenario"() {
+    def "task property and filter property for allowNoMatchingTests - combinations that do not fail when no match: #scenario"() {
+        given:
+        createPassingFailingTest()
+        buildFile << """
+            tasks.withType(AbstractTestTask) {
+                ${taskPropertyConfig}
+                ${filterPropertyConfig}
+            }
+        """
+
+        expect:
+        succeeds(testTaskName, "--tests", "${testSuite('SomeTest')}.missingMethod")
+
+        where:
+        scenario                    | taskPropertyConfig                | filterPropertyConfig
+        "task=true, filter=true"    | "allowNoMatchingTests = true"     | "filter.failOnNoMatchingTests = true"
+        "task=true, filter=false"   | "allowNoMatchingTests = true"     | "filter.failOnNoMatchingTests = false"
+        "task=true, filter unset"   | "allowNoMatchingTests = true"     | "// filter not configured"
+        "task unset, filter=false"  | "// task property not configured" | "filter.failOnNoMatchingTests = false"
+    }
+
+    def "task property and filter property for allowNoMatchingTests - combinations that do fail when no match: #scenario"() {
         given:
         createPassingFailingTest()
         buildFile << """
@@ -281,30 +302,18 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         """
 
         when:
-        if (shouldFail) {
-            fails(testTaskName, "--tests", "${testSuite('SomeTest')}.missingMethod")
-        } else {
-            run(testTaskName, "--tests", "${testSuite('SomeTest')}.missingMethod")
-        }
+        fails(testTaskName, "--tests", "${testSuite('SomeTest')}.missingMethod")
 
         then:
-        if (shouldFail) {
-            failure.assertHasCause("No tests found for given includes:")
-        } else {
-            // All good
-        }
+        failure.assertHasCause("No tests found for given includes:")
 
         where:
-        scenario                    | taskPropertyConfig                | filterPropertyConfig                     | shouldFail
-        "task=false, filter=true"   | "failOnNoMatchingTests = false"   | "filter.failOnNoMatchingTests = true"    | false
-        "task=true, filter=false"   | "failOnNoMatchingTests = true"    | "filter.failOnNoMatchingTests = false"   | true
-        "task=false, filter=false"  | "failOnNoMatchingTests = false"   | "filter.failOnNoMatchingTests = false"   | false
-        "task=true, filter=true"    | "failOnNoMatchingTests = true"    | "filter.failOnNoMatchingTests = true"    | true
-        "task=false, filter unset"  | "failOnNoMatchingTests = false"   | "// filter not configured"               | false
-        "task=true, filter unset"   | "failOnNoMatchingTests = true"    | "// filter not configured"               | true
-        "task unset, filter=false"  | "// task property not configured" | "filter.failOnNoMatchingTests = false"   | false
-        "task unset, filter=true"   | "// task property not configured" | "filter.failOnNoMatchingTests = true"    | true
-        "task unset, filter unset"  | "// task property not configured" | "// filter not configured"               | true
+        scenario                    | taskPropertyConfig                | filterPropertyConfig
+        "task=false, filter=true"   | "allowNoMatchingTests = false"    | "filter.failOnNoMatchingTests = true"
+        "task=false, filter=false"  | "allowNoMatchingTests = false"    | "filter.failOnNoMatchingTests = false"
+        "task=false, filter unset"  | "allowNoMatchingTests = false"    | "// filter not configured"
+        "task unset, filter=true"   | "// task property not configured" | "filter.failOnNoMatchingTests = true"
+        "task unset, filter unset"  | "// task property not configured" | "// filter not configured"
     }
 
     def "task is out of date when --tests argument changes"() {

--- a/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -243,6 +243,70 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         failure.assertHasCause("No tests found for given includes: [${testSuite('SomeTest')}.missingMethod](filter.includeTestsMatching)")
     }
 
+    def "can disable fail on no matching tests via task property"() {
+        given:
+        createPassingFailingTest()
+        buildFile << """
+            tasks.withType(AbstractTestTask) {
+                failOnNoMatchingTests = false
+            }
+        """
+
+        when:
+        run(testTaskName, "--tests", "${testSuite('SomeTest')}.missingMethod")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "can disable fail on no matching tests via CLI"() {
+        given:
+        createPassingFailingTest()
+
+        when:
+        run(testTaskName, "--tests", "${testSuite('SomeTest')}.missingMethod", "--no-fail-on-no-matching-tests")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "task property takes precedence over filter property for failOnNoMatchingTests: #scenario"() {
+        given:
+        createPassingFailingTest()
+        buildFile << """
+            tasks.withType(AbstractTestTask) {
+                ${taskPropertyConfig}
+                ${filterPropertyConfig}
+            }
+        """
+
+        when:
+        if (shouldFail) {
+            fails(testTaskName, "--tests", "${testSuite('SomeTest')}.missingMethod")
+        } else {
+            run(testTaskName, "--tests", "${testSuite('SomeTest')}.missingMethod")
+        }
+
+        then:
+        if (shouldFail) {
+            failure.assertHasCause("No tests found for given includes:")
+        } else {
+            // All good
+        }
+
+        where:
+        scenario                    | taskPropertyConfig                | filterPropertyConfig                     | shouldFail
+        "task=false, filter=true"   | "failOnNoMatchingTests = false"   | "filter.failOnNoMatchingTests = true"    | false
+        "task=true, filter=false"   | "failOnNoMatchingTests = true"    | "filter.failOnNoMatchingTests = false"   | true
+        "task=false, filter=false"  | "failOnNoMatchingTests = false"   | "filter.failOnNoMatchingTests = false"   | false
+        "task=true, filter=true"    | "failOnNoMatchingTests = true"    | "filter.failOnNoMatchingTests = true"    | true
+        "task=false, filter unset"  | "failOnNoMatchingTests = false"   | "// filter not configured"               | false
+        "task=true, filter unset"   | "failOnNoMatchingTests = true"    | "// filter not configured"               | true
+        "task unset, filter=false"  | "// task property not configured" | "filter.failOnNoMatchingTests = false"   | false
+        "task unset, filter=true"   | "// task property not configured" | "filter.failOnNoMatchingTests = true"    | true
+        "task unset, filter unset"  | "// task property not configured" | "// filter not configured"               | true
+    }
+
     def "task is out of date when --tests argument changes"() {
         given:
         createPassingFailingTest()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOptionsGenerator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOptionsGenerator.java
@@ -84,7 +84,11 @@ public class TaskOptionsGenerator {
             if (option instanceof InstanceOptionDescriptor) {
                 OptionElement optionElement = ((InstanceOptionDescriptor) option).getOptionElement();
                 if (optionElement instanceof BooleanOptionElement) {
-                    BooleanOptionElement oppositeOptionElement = BooleanOptionElement.oppositeOf((BooleanOptionElement) optionElement);
+                    BooleanOptionElement booleanOptionElement = (BooleanOptionElement) optionElement;
+                    if (!booleanOptionElement.isGenerateDisabledOption()) {
+                        continue;
+                    }
+                    BooleanOptionElement oppositeOptionElement = BooleanOptionElement.oppositeOf(booleanOptionElement);
                     String oppositeOptionName = oppositeOptionElement.getOptionName();
                     if (options.containsKey(oppositeOptionName)) {
                         LOGGER.warn("Opposite option '{}' in task {} was disabled for clashing with another option of same name", oppositeOptionName, target);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/BooleanOptionElement.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/BooleanOptionElement.java
@@ -39,17 +39,39 @@ public class BooleanOptionElement extends AbstractOptionElement {
     private static final String DISABLE_NAME_PREFIX = "no-";
     private final PropertySetter setter;
     private final boolean newOptionValue;
+    private final boolean generateDisabledOption;
 
     public BooleanOptionElement(String optionName, Option option, PropertySetter setter) {
         super(optionName, option, Void.TYPE, setter.getDeclaringClass());
         this.setter = setter;
         this.newOptionValue = true;
+        this.generateDisabledOption = true;
     }
 
     private BooleanOptionElement(String optionName, String optionDescription, PropertySetter setter, boolean newOptionValue) {
         super(optionDescription, optionName, Void.TYPE);
         this.setter = setter;
         this.newOptionValue = newOptionValue;
+        this.generateDisabledOption = true;
+    }
+
+    private BooleanOptionElement(String optionName, String optionDescription, PropertySetter setter, boolean newOptionValue, boolean generateDisabledOption) {
+        super(optionDescription, optionName, Void.TYPE);
+        this.setter = setter;
+        this.newOptionValue = newOptionValue;
+        this.generateDisabledOption = generateDisabledOption;
+    }
+
+    /**
+     * Returns a copy of this option element with disabled-option generation suppressed.
+     * Used when the element is annotated with {@code @NoDisable}.
+     */
+    public BooleanOptionElement withoutDisabledOption() {
+        return new BooleanOptionElement(getOptionName(), getDescription(), setter, newOptionValue, false);
+    }
+
+    public boolean isGenerateDisabledOption() {
+        return generateDisabledOption;
     }
 
     public static BooleanOptionElement oppositeOf(BooleanOptionElement optionElement) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/OptionReader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/OptionReader.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.reflect.TypeToken;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.options.NoDisable;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.api.tasks.options.OptionValues;
 import org.gradle.internal.reflect.JavaMethod;
@@ -157,7 +158,9 @@ public class OptionReader {
         for (Field field : type.getDeclaredFields()) {
             Option option = findOption(field);
             if (option != null) {
-                fieldOptionElements.add(FieldOptionElement.create(option, field, optionValueNotationParserFactory));
+                OptionElement element = FieldOptionElement.create(option, field, optionValueNotationParserFactory);
+                element = applyNoDisable(element, field.getAnnotation(NoDisable.class), field.getName(), type);
+                fieldOptionElements.add(element);
             }
         }
         return fieldOptionElements;
@@ -179,12 +182,24 @@ public class OptionReader {
         for (Method method : type.getDeclaredMethods()) {
             Option option = findOption(method);
             if (option != null) {
-                OptionElement methodOptionDescriptor = MethodOptionElement.create(option, method,
-                    optionValueNotationParserFactory);
-                methodOptionElements.add(new OptionElementAndSignature(methodOptionDescriptor, MethodSignature.from(method)));
+                OptionElement element = MethodOptionElement.create(option, method, optionValueNotationParserFactory);
+                element = applyNoDisable(element, method.getAnnotation(NoDisable.class), method.getName(), type);
+                methodOptionElements.add(new OptionElementAndSignature(element, MethodSignature.from(method)));
             }
         }
         return methodOptionElements;
+    }
+
+    private static OptionElement applyNoDisable(OptionElement element, @Nullable NoDisable noDisable, String elementName, Class<?> type) {
+        if (noDisable == null) {
+            return element;
+        }
+        if (!(element instanceof BooleanOptionElement)) {
+            throw new OptionValidationException(String.format(
+                "@NoDisable on '%s' in class '%s' is only supported on boolean options.",
+                elementName, type.getName()));
+        }
+        return ((BooleanOptionElement) element).withoutDisabledOption();
     }
 
     private Option findOption(Method method) {

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/options/NoDisable.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/options/NoDisable.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.options;
+
+import org.gradle.api.Incubating;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Modifier for {@link Option} that suppresses the automatic generation of the negative
+ * counterpart option.
+ *
+ * <p>By default, every boolean {@link Option} gets an opposite option generated automatically.
+ * For example, an option {@code --foo} gets a {@code --no-foo} counterpart that sets the value to false.
+ * Annotating the same element with {@code @NoDisable} prevents that counterpart from being generated,
+ * so only the positive flag ({@code --foo}) is available on the command line.</p>
+ *
+ * <p>This annotation must be used alongside {@link Option} on a boolean option (i.e. a {@code boolean},
+ * {@code Boolean}, or {@code Property<Boolean>} type). Using it on a non-boolean option is an error.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * {@literal @}Option(option = "allow-no-matches", description = "Allow the task to succeed when no tests match the filter.")
+ * {@literal @}NoDisable
+ * public abstract Property&lt;Boolean&gt; getAllowNoMatchingTests();
+ * </pre>
+ *
+ * @since 9.6.0
+ * @see Option
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Inherited
+@Incubating
+public @interface NoDisable {
+}

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/options/package-info.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/options/package-info.java
@@ -19,4 +19,7 @@
  *
  * @since 4.6
  */
+@NullMarked
 package org.gradle.api.tasks.options;
+
+import org.jspecify.annotations.NullMarked;

--- a/testing/architecture-test/src/changes/archunit-store/public-api-nullability.txt
+++ b/testing/architecture-test/src/changes/archunit-store/public-api-nullability.txt
@@ -126,8 +126,6 @@ Class <org.gradle.api.tasks.compile.GroovyForkOptions> is not annotated (directl
 Class <org.gradle.api.tasks.compile.JavaCompile> is not annotated (directly or via an enclosing element) with @org.jspecify.annotations.NullMarked in (JavaCompile.java:0)
 Class <org.gradle.api.tasks.compile.ProviderAwareCompilerDaemonForkOptions> is not annotated (directly or via an enclosing element) with @org.jspecify.annotations.NullMarked in (ProviderAwareCompilerDaemonForkOptions.java:0)
 Class <org.gradle.api.tasks.diagnostics.artifact.transforms.ArtifactTransformReports> is not annotated (directly or via an enclosing element) with @org.jspecify.annotations.NullMarked in (ArtifactTransformReports.java:0)
-Class <org.gradle.api.tasks.options.Option> is not annotated (directly or via an enclosing element) with @org.jspecify.annotations.NullMarked in (Option.java:0)
-Class <org.gradle.api.tasks.options.OptionValues> is not annotated (directly or via an enclosing element) with @org.jspecify.annotations.NullMarked in (OptionValues.java:0)
 Class <org.gradle.api.tasks.scala.IncrementalCompileOptions> is not annotated (directly or via an enclosing element) with @org.jspecify.annotations.NullMarked in (IncrementalCompileOptions.java:0)
 Class <org.gradle.api.tasks.scala.ScalaCompile> is not annotated (directly or via an enclosing element) with @org.jspecify.annotations.NullMarked in (ScalaCompile.java:0)
 Class <org.gradle.api.tasks.scala.ScalaCompileOptions> is not annotated (directly or via an enclosing element) with @org.jspecify.annotations.NullMarked in (ScalaCompileOptions.java:0)


### PR DESCRIPTION
Add top-level `Property<Boolean>` on `AbstractTestTask` that
shadows `filter.failOnNoMatchingTests`. It is annotated with `@Option` to
expose `--fail-on-no-matching-tests` and `--no-fail-on-no-matching-tests`
CLI flags.

Add integration tests verifying the property can be set via the build
script DSL and via the CLI option. Tests also encode that the task
property has precedence of the filter property.