### PR TITLE
Don't require setting explicit problem id for deprecation logging

### DIFF
--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -162,6 +162,10 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
             setProblemIdDisplayName(createDefaultDeprecationIdDisplayName());
         }
 
+        if (problemId == null) {
+            setProblemId(DeprecationMessageBuilder.createDefaultDeprecationId(createDefaultDeprecationIdDisplayName()));
+        }
+
         return new DeprecationMessage(summary, deprecationTimeline.toString(), advice, context, documentation, usageType, problemIdDisplayName, problemId);
     }
 

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -528,6 +528,26 @@ Problem found: Project is a prototype (id: sample-problems:prototype-project)
         errorOutput.count(docLink) == 1
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/36719")
+    def "minimal DeprecationLogger nagging can emit problems"() {
+        setup:
+        ignoreCleanupAssertions()
+        buildFile << """
+            org.gradle.internal.deprecation.DeprecationLogger
+                .deprecate("Feature")
+                .willBeRemovedInGradle10()
+                .undocumented()
+                .nagUser()
+        """
+        executer.expectDocumentedDeprecationWarning("Feature has been deprecated. This is scheduled to be removed in Gradle 10.")
+
+        expect:
+        succeeds("help")
+        verifyAll(receivedProblem) {
+            it.definition.id.group.name == 'deprecation'
+        }
+    }
+
     static String problemIdScript() {
         """${ProblemGroup.name} problemGroup = ${ProblemGroup.name}.create("generic", "group label");
            ${ProblemId.name} problemId = ${ProblemId.name}.create("type", "label", problemGroup)"""


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Fixes https://github.com/gradle/gradle/issues/36719

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

When introducing Problems API integration for DeprecationLogger, we missed adding default values for the deprecation entries not providing `WithReplacement`. This did not cause any problems, until we [introduced stricter validation for problem ids and groups](https://github.com/gradle/gradle/pull/35483). This PR adds the missing default value to the message builder.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
