### PR TITLE
Reenable dcl build init test with new plugin version

### DIFF
--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/specs/internal/BuildInitSpecsIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/specs/internal/BuildInitSpecsIntegrationTest.groovy
@@ -26,12 +26,11 @@ import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.test.preconditions.UnitTestPreconditions
-import spock.lang.Ignore
 
 @Requires(UnitTestPreconditions.Jdk17OrLater)
 class BuildInitSpecsIntegrationTest extends AbstractInitIntegrationSpec implements TestsBuildInitSpecsViaPlugin, JavaToolchainFixture {
     private static final String DECLARATIVE_JVM_PLUGIN_ID = "org.gradle.experimental.jvm-ecosystem-init"
-    private static final String DECLARATIVE_PLUGIN_VERSION = "0.1.50"
+    private static final String DECLARATIVE_PLUGIN_VERSION = "0.1.54"
     private static final String DECLARATIVE_PLUGIN_SPEC = "$DECLARATIVE_JVM_PLUGIN_ID:$DECLARATIVE_PLUGIN_VERSION"
 
     // Just need an arbitrary Plugin<Settings> here, so use the Declarative Prototype.  Note that we can't use JVM, because
@@ -252,7 +251,6 @@ class BuildInitSpecsIntegrationTest extends AbstractInitIntegrationSpec implemen
         assertWrapperGenerated()
     }
 
-    @Ignore("Fails due to breaking changes to ProjectFeatureApplicationContext.  Temporarily disabling until we can publish a new declarative build init plugin.")
     @LeaksFileHandles
     @Requires(value = [
         IntegTestPreconditions.Java17HomeAvailable,
@@ -277,7 +275,7 @@ class BuildInitSpecsIntegrationTest extends AbstractInitIntegrationSpec implemen
 }
 
 plugins {
-    id("org.gradle.experimental.jvm-ecosystem").version("0.1.49")
+    id("org.gradle.experimental.jvm-ecosystem").version("0.1.53")
 }
 
 rootProject.name = "example-java-app"


### PR DESCRIPTION
New versions of the prototype plugins are available that are compatible with 9.5.0.  Reenabling the build init custom spec test.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
