### PR TITLE
Add baseline, sortable, JSON, and GitLab report formats to CodeNarc p…

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -97,6 +97,36 @@ Tooling API clients can now directly access Gradle help and version information 
 This allows IDEs and other tools to provide a more consistent user experience when interacting with Gradle.
 For example, In IntelliJ IDEA users will be able to run `--help` and `--version` via the `Execute Gradle task` toolbar action.
 
+### CodeNarc plugin improvements
+
+#### Additional report formats
+
+The [CodeNarc plugin](userguide/codenarc_plugin.html) now supports `baseline`, `sortable`, `json`, and `gitlab` report formats, in addition to the existing `xml`, `html`, `text`, and `console` formats.
+
+The `baseline` format generates a [baseline XML report](https://codenarc.org/codenarc-baseline-xml-report-writer.html) that can be used to suppress existing violations.
+The `sortable` format generates a [sortable HTML report](https://codenarc.org/codenarc-sortable-html-report-writer.html) with sortable columns.
+The `json` format generates a [JSON report](https://codenarc.org/codenarc-json-report-writer.html) with structured violation data.
+The `gitlab` format generates a [GitLab Code Quality JSON report](https://codenarc.org/codenarc-gitlab-report-writer.html) suitable for consumption by GitLab CI/CD.
+
+These can be enabled via the extension:
+
+```groovy
+codenarc {
+    reportFormat = "json"
+}
+```
+
+Or configured directly on tasks:
+
+```groovy
+codenarcMain.reports {
+    baseline.required = true
+    sortable.required = true
+    json.required = true
+    gitlab.required = true
+}
+```
+
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ==========================================================

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -91,15 +91,11 @@ plugins {
 }
 ```
 
-## Tooling integration improvements
+### Core plugin and plugin authoring enhancements
 
-Tooling API clients can now directly access Gradle help and version information the same way as the Gradle CLI.
-This allows IDEs and other tools to provide a more consistent user experience when interacting with Gradle.
-For example, In IntelliJ IDEA users will be able to run `--help` and `--version` via the `Execute Gradle task` toolbar action.
+Gradle provides a comprehensive plugin system, including built-in [Core Plugins](userguide/plugin_reference.html) for standard tasks and powerful APIs for creating custom plugins.
 
-### CodeNarc plugin improvements
-
-#### Additional report formats
+#### Additional report formats for the CodeNarc plugin
 
 The [CodeNarc plugin](userguide/codenarc_plugin.html) now supports `baseline`, `sortable`, `json`, and `gitlab` report formats, in addition to the existing `xml`, `html`, `text`, and `console` formats.
 
@@ -126,6 +122,8 @@ codenarcMain.reports {
     gitlab.required = true
 }
 ```
+
+See the [CodeNarc plugin report](userguide/codenarc_plugin.html#sec:codenarc_reports) section in the Gradle User Manual for more information.
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -125,6 +125,12 @@ codenarcMain.reports {
 
 See the [CodeNarc plugin report](userguide/codenarc_plugin.html#sec:codenarc_reports) section in the Gradle User Manual for more information.
 
+## Tooling integration improvements
+
+Tooling API clients can now directly access Gradle help and version information the same way as the Gradle CLI.
+This allows IDEs and other tools to provide a more consistent user experience when interacting with Gradle.
+For example, In IntelliJ IDEA users will be able to run `--help` and `--version` via the `Execute Gradle task` toolbar action.
+
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ==========================================================

--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/codenarc_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/codenarc_plugin.adoc
@@ -98,6 +98,42 @@ include::sample[dir="snippets/codeQuality/codeQuality/groovy",files="build.gradl
 ====
 
 
+[[sec:codenarc_reports]]
+== Reports
+
+The CodeNarc plugin generates results in several formats.
+
+The following report types are available on every CodeNarc task via the link:{groovyDslPath}/org.gradle.api.plugins.quality.CodeNarc.html#org.gradle.api.plugins.quality.CodeNarc:reports[`reports`] container:
+
+`xml`:: Standard CodeNarc XML report.
+`html`:: Standard CodeNarc HTML report. Enabled by default.
+`text`:: Plain text report.
+`console`:: Writes violations directly to the console.
+`baseline`:: _(Incubating)_ Generates a https://codenarc.org/codenarc-baseline-xml-report-writer.html[baseline XML report] that can be used to suppress existing violations.
+`sortable`:: _(Incubating)_ Generates a https://codenarc.org/codenarc-sortable-html-report-writer.html[sortable HTML report] with sortable columns.
+`json`:: _(Incubating)_ Generates a https://codenarc.org/codenarc-json-report-writer.html[JSON report] with structured violation data.
+`gitlab`:: _(Incubating)_ Generates a https://codenarc.org/codenarc-gitlab-report-writer.html[GitLab Code Quality JSON report] suitable for GitLab CI/CD.
+
+By default, only the `html` report is enabled.
+You can change the default report format for all tasks via the extension:
+
+[source,groovy]
+----
+codenarc {
+    reportFormat = "json"
+}
+----
+
+Or enable multiple reports on individual tasks:
+
+[source,groovy]
+----
+codenarcMain.reports {
+    json.required = true
+    gitlab.required = true
+}
+----
+
 [[sec:codenarc_configuration]]
 == Configuration
 

--- a/platforms/jvm/code-quality-workers/src/main/java/org/gradle/api/plugins/quality/internal/CodeNarcInvoker.java
+++ b/platforms/jvm/code-quality-workers/src/main/java/org/gradle/api/plugins/quality/internal/CodeNarcInvoker.java
@@ -106,6 +106,11 @@ class CodeNarcInvoker implements Action<AntBuilderDelegate> {
                         .findFirst()
                         .orElse(null);
                     if (humanReadableReport == null) {
+                        humanReadableReport = reportsWithFiles.stream().filter(it -> it.getName().get().equals("sortable"))
+                            .findFirst()
+                            .orElse(null);
+                    }
+                    if (humanReadableReport == null) {
                         humanReadableReport = reportsWithFiles.stream().filter(it -> it.getName().get().equals("text"))
                             .findFirst()
                             .orElse(null);
@@ -115,7 +120,7 @@ class CodeNarcInvoker implements Action<AntBuilderDelegate> {
                             .findFirst()
                             .orElse(null);
                     }
-                    // Prefer HTML > text > XML and don't include a link if we don't recognize the report format
+                    // Prefer HTML > sortable > text > XML and don't include a link if we don't recognize the report format
                     if (humanReadableReport != null) {
                         String reportUrl = new ConsoleRenderer().asClickableFileUrl(humanReadableReport.getOutputLocation().getAsFile().get());
                         message += " See the report at: " + reportUrl;

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginVersionIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginVersionIntegrationTest.groovy
@@ -155,6 +155,95 @@ class CodeNarcPluginVersionIntegrationTest extends MultiVersionIntegrationSpec i
         failure.assertThatCause(both(startsWith("CodeNarc rule violations were found. See the report at:")).and(endsWith("xml")))
     }
 
+    def "reports sortable report over text or XML report in failure message"() {
+        badCode()
+        buildFile << """
+            codenarcTest.reports {
+                html.required = false
+                sortable.required = true
+                xml.required = true
+                text.required = true
+            }
+        """
+
+        expect:
+        fails("check")
+        failure.assertThatCause(both(startsWith("CodeNarc rule violations were found. See the report at:")).and(endsWith("sortable.html")))
+    }
+
+    def "can generate baseline report"() {
+        given:
+        buildFile << """
+            codenarcMain.reports {
+                html.required = false
+                baseline.required = true
+            }
+        """
+
+        and:
+        goodCode()
+
+        expect:
+        succeeds("check")
+        executedAndNotSkipped(":codenarcMain")
+        report("main", "baseline.xml").exists()
+    }
+
+    def "can generate sortable report"() {
+        given:
+        buildFile << """
+            codenarcMain.reports {
+                html.required = false
+                sortable.required = true
+            }
+        """
+
+        and:
+        goodCode()
+
+        expect:
+        succeeds("check")
+        executedAndNotSkipped(":codenarcMain")
+        report("main", "sortable.html").exists()
+        report("main", "sortable.html").text.contains("Sort by")
+    }
+
+    def "can generate json report"() {
+        given:
+        buildFile << """
+            codenarcMain.reports {
+                html.required = false
+                json.required = true
+            }
+        """
+
+        and:
+        goodCode()
+
+        expect:
+        succeeds("check")
+        executedAndNotSkipped(":codenarcMain")
+        report("main", "json").exists()
+    }
+
+    def "can generate gitlab report"() {
+        given:
+        buildFile << """
+            codenarcMain.reports {
+                html.required = false
+                gitlab.required = true
+            }
+        """
+
+        and:
+        goodCode()
+
+        expect:
+        succeeds("check")
+        executedAndNotSkipped(":codenarcMain")
+        report("main", "gitlab.json").exists()
+    }
+
     def "analyze bad code"() {
         badCode()
 

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeNarcExtension.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeNarcExtension.java
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public abstract class CodeNarcExtension extends CodeQualityExtension {
 
-    private static final Set<String> REPORT_FORMATS = Sets.newHashSet("xml", "html", "console", "text");
+    private static final Set<String> REPORT_FORMATS = Sets.newHashSet("xml", "html", "console", "text", "baseline", "sortable", "json", "gitlab");
 
     private final Project project;
 
@@ -125,7 +125,7 @@ public abstract class CodeNarcExtension extends CodeQualityExtension {
     }
 
     /**
-     * The format type of the CodeNarc report. One of <code>html</code>, <code>xml</code>, <code>text</code>, <code>console</code>.
+     * The format type of the CodeNarc report. One of <code>html</code>, <code>xml</code>, <code>text</code>, <code>console</code>, <code>baseline</code>, <code>sortable</code>, <code>json</code>, <code>gitlab</code>.
      */
     @ToBeReplacedByLazyProperty
     public String getReportFormat() {
@@ -133,7 +133,7 @@ public abstract class CodeNarcExtension extends CodeQualityExtension {
     }
 
     /**
-     * The format type of the CodeNarc report. One of <code>html</code>, <code>xml</code>, <code>text</code>, <code>console</code>.
+     * The format type of the CodeNarc report. One of <code>html</code>, <code>xml</code>, <code>text</code>, <code>console</code>, <code>baseline</code>, <code>sortable</code>, <code>json</code>, <code>gitlab</code>.
      */
     public void setReportFormat(String reportFormat) {
         if (REPORT_FORMATS.contains(reportFormat)) {

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeNarcPlugin.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeNarcPlugin.java
@@ -83,6 +83,9 @@ public abstract class CodeNarcPlugin extends AbstractCodeQualityPlugin<CodeNarc>
     @Override
     protected void configureConfiguration(Configuration configuration) {
         configureDefaultDependencies(configuration);
+        configuration.getDependencyConstraints().add(
+            project.getDependencies().getConstraints().create("org.apache.groovy:groovy-json:4.0.30")
+        );
     }
 
     @Override
@@ -123,7 +126,19 @@ public abstract class CodeNarcPlugin extends AbstractCodeQualityPlugin<CodeNarc>
         task.getReports().all(action(report -> {
             report.getRequired().convention(providers.provider(() -> report.getName().equals(reportFormat.get())));
             report.getOutputLocation().convention(layout.getProjectDirectory().file(providers.provider(() -> {
-                String fileSuffix = report.getName().equals("text") ? "txt" : report.getName();
+                String reportName = report.getName();
+                String fileSuffix;
+                if (reportName.equals("text")) {
+                    fileSuffix = "txt";
+                } else if (reportName.equals("sortable")) {
+                    fileSuffix = "sortable.html";
+                } else if (reportName.equals("baseline")) {
+                    fileSuffix = "baseline.xml";
+                } else if (reportName.equals("gitlab")) {
+                    fileSuffix = "gitlab.json";
+                } else {
+                    fileSuffix = reportName;
+                }
                 return new File(reportsDir.get().getAsFile(), baseName + "." + fileSuffix).getAbsolutePath();
             })));
         }));

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeNarcReports.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeNarcReports.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.plugins.quality;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.reporting.ReportContainer;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.tasks.Internal;
@@ -48,4 +49,44 @@ public interface CodeNarcReports extends ReportContainer<SingleFileReport> {
      */
     @Internal
     SingleFileReport getText();
+
+    /**
+     * The codenarc baseline XML report
+     *
+     * @return The codenarc baseline XML report
+     * @since 9.5.0
+     */
+    @Incubating
+    @Internal
+    SingleFileReport getBaseline();
+
+    /**
+     * The codenarc sortable HTML report
+     *
+     * @return The codenarc sortable HTML report
+     * @since 9.5.0
+     */
+    @Incubating
+    @Internal
+    SingleFileReport getSortable();
+
+    /**
+     * The codenarc JSON report
+     *
+     * @return The codenarc JSON report
+     * @since 9.5.0
+     */
+    @Incubating
+    @Internal
+    SingleFileReport getJson();
+
+    /**
+     * The codenarc GitLab Code Quality JSON report
+     *
+     * @return The codenarc GitLab Code Quality JSON report
+     * @since 9.5.0
+     */
+    @Incubating
+    @Internal
+    SingleFileReport getGitlab();
 }

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/internal/CodeNarcReportsImpl.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/internal/CodeNarcReportsImpl.java
@@ -35,7 +35,11 @@ public class CodeNarcReportsImpl extends DelegatingReportContainer<SingleFileRep
             factory.instantiateReport(DefaultSingleFileReport.class, "xml", owner),
             factory.instantiateReport(DefaultSingleFileReport.class, "html", owner),
             factory.instantiateReport(DefaultSingleFileReport.class, "text", owner),
-            factory.instantiateReport(DefaultSingleFileReport.class, "console", owner)
+            factory.instantiateReport(DefaultSingleFileReport.class, "console", owner),
+            factory.instantiateReport(DefaultSingleFileReport.class, "baseline", owner),
+            factory.instantiateReport(DefaultSingleFileReport.class, "sortable", owner),
+            factory.instantiateReport(DefaultSingleFileReport.class, "json", owner),
+            factory.instantiateReport(DefaultSingleFileReport.class, "gitlab", owner)
         )));
     }
 
@@ -52,5 +56,25 @@ public class CodeNarcReportsImpl extends DelegatingReportContainer<SingleFileRep
     @Override
     public SingleFileReport getText() {
         return getByName("text");
+    }
+
+    @Override
+    public SingleFileReport getBaseline() {
+        return getByName("baseline");
+    }
+
+    @Override
+    public SingleFileReport getSortable() {
+        return getByName("sortable");
+    }
+
+    @Override
+    public SingleFileReport getJson() {
+        return getByName("json");
+    }
+
+    @Override
+    public SingleFileReport getGitlab() {
+        return getByName("gitlab");
     }
 }

--- a/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodeNarcPluginTest.groovy
+++ b/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodeNarcPluginTest.groovy
@@ -116,6 +116,90 @@ class CodeNarcPluginTest extends AbstractProjectBuilderSpec {
         }
     }
 
+    def "can enable baseline report via extension"() {
+        def task = project.tasks.create("codenarcCustom", CodeNarc)
+
+        project.codenarc {
+            reportFormat = "baseline"
+        }
+
+        expect:
+        task.reports.enabled*.name == ["baseline"]
+        task.reports.baseline.outputLocation.asFile.get() == project.file("build/reports/codenarc/custom.baseline.xml")
+    }
+
+    def "can enable sortable report via extension"() {
+        def task = project.tasks.create("codenarcCustom", CodeNarc)
+
+        project.codenarc {
+            reportFormat = "sortable"
+        }
+
+        expect:
+        task.reports.enabled*.name == ["sortable"]
+        task.reports.sortable.outputLocation.asFile.get() == project.file("build/reports/codenarc/custom.sortable.html")
+    }
+
+    def "can enable baseline and sortable reports directly"() {
+        CodeNarc task = project.tasks.create("codenarcCustom", CodeNarc)
+
+        task.reports.baseline {
+            required = true
+        }
+        task.reports.sortable {
+            required = true
+        }
+
+        expect:
+        task.reports {
+            assert enabled == [html, baseline, sortable] as Set
+            assert baseline.outputLocation.asFile.get() == project.file("build/reports/codenarc/custom.baseline.xml")
+            assert sortable.outputLocation.asFile.get() == project.file("build/reports/codenarc/custom.sortable.html")
+        }
+    }
+
+    def "can enable json report via extension"() {
+        def task = project.tasks.create("codenarcCustom", CodeNarc)
+
+        project.codenarc {
+            reportFormat = "json"
+        }
+
+        expect:
+        task.reports.enabled*.name == ["json"]
+        task.reports.json.outputLocation.asFile.get() == project.file("build/reports/codenarc/custom.json")
+    }
+
+    def "can enable gitlab report via extension"() {
+        def task = project.tasks.create("codenarcCustom", CodeNarc)
+
+        project.codenarc {
+            reportFormat = "gitlab"
+        }
+
+        expect:
+        task.reports.enabled*.name == ["gitlab"]
+        task.reports.gitlab.outputLocation.asFile.get() == project.file("build/reports/codenarc/custom.gitlab.json")
+    }
+
+    def "can enable json and gitlab reports directly"() {
+        CodeNarc task = project.tasks.create("codenarcCustom", CodeNarc)
+
+        task.reports.json {
+            required = true
+        }
+        task.reports.gitlab {
+            required = true
+        }
+
+        expect:
+        task.reports {
+            assert enabled == [html, json, gitlab] as Set
+            assert json.outputLocation.asFile.get() == project.file("build/reports/codenarc/custom.json")
+            assert gitlab.outputLocation.asFile.get() == project.file("build/reports/codenarc/custom.gitlab.json")
+        }
+    }
+
     def "tool configuration has correct attributes"() {
         expect:
         with(project.configurations.codenarc.attributes) {

--- a/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodenarcTest.groovy
+++ b/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodenarcTest.groovy
@@ -31,8 +31,8 @@ class CodenarcTest extends Specification {
         codenarc.config.inputFiles.singleFile == project.file("config/file.txt")
     }
 
-    def "has html/xml/text/console"() {
+    def "has html/xml/text/console/baseline/sortable/json/gitlab"() {
         expect:
-        codenarc.reports.names == ['console', 'html', 'text', 'xml'] as Set
+        codenarc.reports.names == ['baseline', 'console', 'gitlab', 'html', 'json', 'sortable', 'text', 'xml'] as Set
     }
 }


### PR DESCRIPTION
…lugin

groovy-json 4.0.30 is required for JSON/GitLab reports, more details in GROOVY-11578

Resolves: #36270

<!--- The issue this PR addresses -->
https://github.com/gradle/gradle/issues/36270
<!-- Fixes #? -->

### Context
The creator of the issue also requested SARIF support. Unfortunately, SARIF reports are part of the CodeNarc 4.0 release, which has not yet materialized.
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
