### PR TITLE
Run `IsolatedProjectsAndroidProjectSyncTest` on Linux machines

### DIFF
--- a/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/IsolatedProjectsAndroidProjectSyncTest.groovy
+++ b/testing/smoke-ide-test/src/smokeIdeTest/groovy/org/gradle/ide/sync/IsolatedProjectsAndroidProjectSyncTest.groovy
@@ -18,14 +18,7 @@ package org.gradle.ide.sync
 
 import org.gradle.ide.starter.IdeScenarioBuilder
 import org.gradle.integtests.fixtures.versions.AndroidGradlePluginVersions
-import org.gradle.test.precondition.Requires
-import org.gradle.test.preconditions.UnitTestPreconditions
-import spock.lang.Issue
 
-// `intellij-ide-starter` can't kill the AS process properly on Linux,
-// what is leading to failing these tests by a timeout
-@Issue("https://youtrack.jetbrains.com/issue/AT-3405/Starter-com.intellij.ide.starter.process.ProcessUtilsKtgetJavaProcessId-fails-to-find-Ide-process-for-Android-Studio")
-@Requires(UnitTestPreconditions.MacOs)
 class IsolatedProjectsAndroidProjectSyncTest extends AbstractIdeSyncTest {
 
     // https://developer.android.com/build/releases/gradle-plugin


### PR DESCRIPTION
Assuming the original issue https://youtrack.jetbrains.com/issue/AT-3405/Starter-com.intellij.ide.starter.process.ProcessUtilsKtgetJavaProcessId-fails-to-find-Ide-process-for-Android-Studio on the starter side was fixed in 253.x timeline, and we have updated starter version by https://github.com/gradle/gradle/pull/36587, we can try to run AndroidStudio sync tests on Linux again.

Note: Current precondition(running on MacOs) effectively disables this test.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
