### PR TITLE
Use Lazy.locking() in ResolveConfigurationResolutionBuildOperationResult

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
@@ -50,7 +50,7 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
         AttributesFactory attributesFactory
     ) {
         this.graphSource = graphSource;
-        this.lazyDesugaredAttributes = Lazy.unsafe().of(() -> desugarAttributes(attributesFactory, requestedAttributes));
+        this.lazyDesugaredAttributes = Lazy.locking().of(() -> desugarAttributes(attributesFactory, requestedAttributes));
     }
 
     @Override


### PR DESCRIPTION
The value might be read from two threads concurrently, causing NPEs in case we don't use locking.

We saw this happening when consuming these build operations in multiple Develocity plugins (something we do internally).