### PR TITLE
Fix non-ASCII characters in exported ascii armored keyring UIDs

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractSignatureVerificationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractSignatureVerificationIntegrationTest.groovy
@@ -63,6 +63,10 @@ abstract class AbstractSignatureVerificationIntegrationTest extends AbstractDepe
         createSimpleKeyRing(temporaryFolder.createDir("keys-${UUID.randomUUID()}"))
     }
 
+    protected SimpleKeyRing newKeyRingWithUserId(String userId) {
+        createSimpleKeyRing(temporaryFolder.createDir("keys-${UUID.randomUUID()}"), "gradle", userId)
+    }
+
     protected SimpleKeyRing newKeyRingFromResource(String publicKeyResource, String secretKeyResource) {
         createSimpleKeyRingFromResource(publicKeyResource, secretKeyResource)
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -539,6 +539,42 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         outputContains("Exported 1 keys to")
     }
 
+    def "exported ascii armored keyring preserves non-ascii characters in user ids"() {
+        def userId = "Björk Guðmundsdóttir <bjork@example.com>"
+        def keyring = newKeyRingWithUserId(userId)
+        keyServerFixture.registerPublicKey(keyring.publicKey)
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+        }
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature {
+                keyring.sign(it)
+            }
+        }
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        when:
+        writeVerificationMetadata()
+        succeeds ":help", "--export-keys"
+
+        then:
+        def exportedKeyRingAscii = file("gradle/verification-keyring.keys")
+        exportedKeyRingAscii.exists()
+        exportedKeyRingAscii.getText("UTF-8").contains("uid    $userId")
+
+        then:
+        // We can read the armored keyring back, the non-ASCII character is not an issue
+        succeeds "compileJava"
+
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/18567")
     def "--export-keys can export keys even with without --write-verification-metadata"() {
         def keyring = newKeyRing()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -603,7 +603,9 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
                     List<String> userIDs = PGPUtils.getUserIDs(pk);
                     for(String uid : userIDs) {
                         hasUid = true;
-                        out.write(("uid    " + uid + "\n").getBytes(StandardCharsets.US_ASCII));
+                        // We can store UTF-8 text despite being an ASCII-armored file,
+                        // as ArmoredInputStream only cares about finding armor headers and does not otherwise care about encoding
+                        out.write(("uid    " + uid + "\n").getBytes(StandardCharsets.UTF_8));
                     }
                     if (hasUid) {
                         out.write('\n');


### PR DESCRIPTION
Use UTF-8 instead of US_ASCII when writing user IDs in the ascii armored keyring file, so that characters like ö are preserved instead of being replaced with ?.

Fixes #21612