### PR TITLE
In SourceDistributionProvider use root build dir to lookup wrapper properties

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(projects.baseAsm)
     implementation(projects.instrumentationReporting)
     implementation(projects.buildOperations)
+    implementation(projects.buildDiscoveryImpl)
     implementation(projects.buildOption)
     implementation(projects.coreKotlinExtensions)
     implementation(projects.declarativeDslEvaluator)


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Instead of trying to guess where the `gradle-wrapper.properties` could be, let's be precise. The file should be located in root of the build tree under the `gradle/wrapper` directory. `SourceDistributionProvider` has access to the configured project and consequently to build tree representation via `project.gradle.parent` properties.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

This is an alternative approach to fixing the issue explained in https://github.com/gradle/gradle/pull/36723.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
