### PR TITLE
TeamCity: delete obsolete configuration for the TeamCity Artifactory Plug-in

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/SanityCheck.kt
+++ b/.teamcity/src/main/kotlin/promotion/SanityCheck.kt
@@ -20,7 +20,6 @@ object SanityCheck : BuildType({
         gradleWrapper {
             tasks = "tasks"
             gradleParams = ""
-            param("org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration", "GLOBAL")
         }
     }
 

--- a/.teamcity/src/main/kotlin/promotion/StartReleaseCycle.kt
+++ b/.teamcity/src/main/kotlin/promotion/StartReleaseCycle.kt
@@ -66,7 +66,6 @@ object StartReleaseCycle : BasePromotionBuildType() {
                         "%gitUserName%",
                         "%gitUserEmail%",
                     )
-                param("org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration", "GLOBAL")
             }
         }
 


### PR DESCRIPTION
It's probably unused for years.
maybe introduced in https://github.com/gradle/gradle/commit/2e0b03f7204cc3d82292b40d2942bdb093ddab30
https://github.com/gradle/gradle/blob/2e0b03f7204cc3d82292b40d2942bdb093ddab30/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_MasterSanityCheck.xml#L15

It's not clear when it stopped being useful, but the TeamCity Artifactory Plug-in is not installed currently.

https://github.com/search?q=repo%3Ajfrog%2Fteamcity-artifactory-plugin%20defaultModuleVersionConfiguration&type=code

