### PR TITLE
packaging: GenerateClasspathModuleProperties: skip generating aliases for distribution modules that refer to projects for now

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/GenerateClasspathModuleProperties.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/tasks/GenerateClasspathModuleProperties.kt
@@ -35,6 +35,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -152,10 +153,7 @@ abstract class GenerateClasspathModuleProperties : DefaultTask() {
             }
             is ProjectComponentIdentifier -> {
                 val moduleName: String = "gradle-" + id.projectName
-                val alias: ModuleAlias? = component.moduleVersion?.let {
-                    ModuleAlias(it.group, it.name, it.version)
-                }
-                return moduleName to alias
+                return moduleName to null
             }
             else -> throw AssertionError("Unknown component type ${component.id}")
         }
@@ -163,7 +161,7 @@ abstract class GenerateClasspathModuleProperties : DefaultTask() {
 
     data class GraphNode(
         @get:Input val moduleName: String,
-        @get:Nested val alias: ModuleAlias?,
+        @get:Nested @get:Optional val alias: ModuleAlias?,
         @get:Internal val dependencyComponentIds: Set<ComponentIdentifier> // Can be declared input after https://github.com/gradle/gradle/pull/36174
     )
 


### PR DESCRIPTION
* gradle/gradle#36169

Introduced it and in CI builds the `alias.version` of every property file related to any Gradle distribution module contains a timestamp in addition to the base version.

As that timestamp differs between builds we experience cache misses and as a result spend more time executing tests that could be avoided.