### PR TITLE
master: Fix leaf-into-non-leaf merging in TestTreeModel.finalizePath() to prevent crash when a test group is re-emitted without children

### DIFF
--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModel.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModel.java
@@ -185,7 +185,16 @@ public class TestTreeModel {
                 // multiple test workers.  These results must be recombined in the model to get the correct counts and report structure.
                 boolean isLeaf = rootInfo.isLeaf();
                 if (isLeaf) {
-                    existingRootInfos.add(rootInfo);
+                    // Merge into an existing non-leaf if possible, otherwise add as a new entry for retries.
+                    PerRootInfo.Builder existingNonLeaf = existingRootInfos.stream()
+                        .filter(info -> !info.isLeaf())
+                        .findFirst()
+                        .orElse(null);
+                    if (existingNonLeaf != null) {
+                        existingNonLeaf.merge(rootInfo);
+                    } else {
+                        existingRootInfos.add(rootInfo);
+                    }
                 } else {
                     // Merge into the one that is also not a leaf if possible, otherwise just merge into the first one.
                     PerRootInfo.Builder toMerge = existingRootInfos.stream()

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModelTest.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModelTest.groovy
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.report.generic
+
+import org.gradle.api.internal.tasks.testing.TestCompleteEvent
+import org.gradle.api.internal.tasks.testing.TestDescriptorInternal
+import org.gradle.api.internal.tasks.testing.TestStartEvent
+import org.gradle.api.internal.tasks.testing.results.serializable.SerializableTestResultStore
+import org.gradle.api.tasks.testing.TestResult
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
+
+/**
+ * Tests for {@link TestTreeModel}, specifically the merging behavior in finalizePath().
+ *
+ * <p>When a test group (e.g. a test class) is emitted multiple times within the same root,
+ * some executions may have no children (e.g. when all methods are skipped). These childless
+ * executions appear as leaves and must be merged into any existing non-leaf entry for the same
+ * node, rather than being added as separate entries. True leaf retries (where all entries are
+ * leaves) should still be preserved as separate entries.</p>
+ */
+class TestTreeModelTest extends Specification {
+
+    @TempDir
+    Path tempDir
+
+    private int nextDescriptorId = 1
+
+    def "merges leaf entry into existing non-leaf within same store"() {
+        given:
+        def store = writeStore { writer ->
+            def root = descriptor("root", null)
+            def suite1 = descriptor("MySuite", root, "com.example.MySuite")
+            def testA = descriptor("testA", suite1, "com.example.MySuite")
+
+            writer.started(root, new TestStartEvent(100))
+            writer.started(suite1, new TestStartEvent(100))
+            writer.started(testA, new TestStartEvent(100))
+            writer.completed(testA, successResult(100, 200), new TestCompleteEvent(200))
+            writer.completed(suite1, successResult(100, 200), new TestCompleteEvent(200))
+
+            def suite2 = descriptor("MySuite", root, "com.example.MySuite")
+            writer.started(suite2, new TestStartEvent(300))
+            writer.completed(suite2, successResult(300, 400), new TestCompleteEvent(400))
+
+            writer.completed(root, successResult(100, 400), new TestCompleteEvent(400))
+        }
+
+        when:
+        def model = TestTreeModel.loadModelFromStores([store])
+
+        then:
+        model.children.size() == 1
+        def suiteNode = model.children[0]
+        suiteNode.path.name == "MySuite"
+        suiteNode.perRootInfo[0].size() == 1
+        !suiteNode.perRootInfo[0][0].isLeaf()
+        suiteNode.children.size() == 1
+        suiteNode.children[0].path.name == "testA"
+    }
+
+    def "report generation does not crash when childless execution follows execution with children"() {
+        given:
+        def storeDir = writeStoreDir { writer ->
+            def root = descriptor("root", null)
+            def suite1 = descriptor("MySuite", root, "com.example.MySuite")
+            def testA = descriptor("testA", suite1, "com.example.MySuite")
+
+            writer.started(root, new TestStartEvent(100))
+            writer.started(suite1, new TestStartEvent(100))
+            writer.started(testA, new TestStartEvent(100))
+            writer.completed(testA, successResult(100, 200), new TestCompleteEvent(200))
+            writer.completed(suite1, successResult(100, 200), new TestCompleteEvent(200))
+
+            def suite2 = descriptor("MySuite", root, "com.example.MySuite")
+            writer.started(suite2, new TestStartEvent(300))
+            writer.completed(suite2, successResult(300, 400), new TestCompleteEvent(400))
+
+            writer.completed(root, successResult(100, 400), new TestCompleteEvent(400))
+        }
+
+        when:
+        TestTreeModelResultsProvider.useResultsFrom(storeDir) { provider ->
+            provider.visitClasses { }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "true leaf retries are preserved as separate entries"() {
+        given:
+        def store = writeStore { writer ->
+            def root = descriptor("root", null)
+
+            writer.started(root, new TestStartEvent(100))
+
+            def testA1 = descriptor("testA", root, "com.example.MySuite")
+            writer.started(testA1, new TestStartEvent(100))
+            writer.completed(testA1, successResult(100, 200), new TestCompleteEvent(200))
+
+            def testA2 = descriptor("testA", root, "com.example.MySuite")
+            writer.started(testA2, new TestStartEvent(300))
+            writer.completed(testA2, successResult(300, 400), new TestCompleteEvent(400))
+
+            writer.completed(root, successResult(100, 400), new TestCompleteEvent(400))
+        }
+
+        when:
+        def model = TestTreeModel.loadModelFromStores([store])
+
+        then:
+        model.children.size() == 1
+        def testNode = model.children[0]
+        testNode.path.name == "testA"
+        testNode.perRootInfo[0].size() == 2
+        testNode.perRootInfo[0][0].isLeaf()
+        testNode.perRootInfo[0][1].isLeaf()
+    }
+
+    private Path writeStoreDir(String name = "store", Closure writeAction) {
+        def storeDir = tempDir.resolve(name)
+        def store = new SerializableTestResultStore(storeDir)
+        def writer = store.openWriter(0)
+        try {
+            writeAction(writer)
+        } finally {
+            writer.close()
+        }
+        return storeDir
+    }
+
+    private SerializableTestResultStore writeStore(String name = "store", Closure writeAction) {
+        def storeDir = tempDir.resolve(name)
+        def store = new SerializableTestResultStore(storeDir)
+        def writer = store.openWriter(0)
+        try {
+            writeAction(writer)
+        } finally {
+            writer.close()
+        }
+        return store
+    }
+
+    private TestDescriptorInternal descriptor(String name, TestDescriptorInternal parent, String className = null) {
+        def uniqueId = nextDescriptorId++
+        return Mock(TestDescriptorInternal) {
+            getId() >> uniqueId
+            getName() >> name
+            getDisplayName() >> name
+            getClassName() >> className
+            getParent() >> parent
+        }
+    }
+
+    private TestResult successResult(long startTime, long endTime) {
+        return Mock(TestResult) {
+            getStartTime() >> startTime
+            getEndTime() >> endTime
+            getResultType() >> TestResult.ResultType.SUCCESS
+            getAssumptionFailure() >> null
+            getFailures() >> []
+        }
+    }
+}


### PR DESCRIPTION
### Context
When a test group (e.g. a test class) is executed multiple times within a single build where some executions have children and others don't, the HTML and XML report generation crashes with:

```
IllegalStateException: Expected exactly one run for grouping node :com.example.MyTest but found: 2
```

This happens because `finalizePath()` in `TestTreeModel` treats a childless re-execution as a leaf and adds it as a separate `PerRootInfo entry`, instead of merging it into the existing non-leaf entry. The downstream report generator then fails its single-entry assertion.

This is commonly triggered by [Develocity Test Distribution](https://gradle.com/develocity/product/test-distribution/), which can reschedule a test class to a different agent after a remote executor disconnects. When the rescheduled execution skips all methods, the test framework emits the test group without any children. The build then fails at report generation despite all tests having valid results.

This proposes fixing by merging childless re-executions into existing non-leaf entries in the model, while preserving true leaf retries as separate entries.

Fixes #36808

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
