### PR TITLE
Modify log messages to make IDEA sync work again

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
@@ -51,7 +51,7 @@ class SourceDistributionResolver(private val project: Project) : SourceDistribut
             sourceDirs
         } catch (ex: Exception) {
             project.logger.warn("Could not resolve Gradle distribution sources. See debug logs for details.")
-            project.logger.debug("Root cause for failure to resolve Gradle distribution sources", ex)
+            project.logger.debug("Gradle distribution source resolution failure", ex)
             emptyList()
         }
 


### PR DESCRIPTION
Fixes #36797

This PR is solving symptoms rather than the root cause: IDEA seems to pick up the warning log, which contains a stacktrace. This will result in IDEA—incorrectly—marking the sync as failed, even if it is successful with a `BUILD SUCCESS` message.

This PR pushes the stacktrace behind `--debug`, and keeps an informative + breadcrumb logline only.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
