### PR TITLE
Add Groovy to build catalog for constraints

### DIFF
--- a/gradle/dependency-management/build.versions.toml
+++ b/gradle/dependency-management/build.versions.toml
@@ -3,6 +3,7 @@
 asciidoctor = "2.5.13"
 checkstyle = "10.25.0"
 develocity = "4.3.2"
+groovy = "4.0.29"
 javaparser = "3.18.0"
 kotlin = "kotlin-stub" # will be replaced by platfrom
 
@@ -27,6 +28,7 @@ foojayConventions = { module = "org.gradle.toolchains.foojay-resolver-convention
 gradleGuidesPlugin = { group = "org.gradle.guides", name = "gradle-guides-plugin", version = "0.24.0" }
 gson = { module = "com.google.code.gson:gson", version = "2.13.1" }
 guava = { module = "com.google.guava:guava", version = "33.4.6-jre" }
+groovy = { module = "org.apache.groovy:groovy", version.ref = "groovy" }
 ideaExtPlugin = { module = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext", version = "1.3" }
 jacksonBom = { module = "com.fasterxml.jackson:jackson-bom", version = "2.16.1" } # CVE-2025-52999 on lower versions
 jakartaXml = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version = "4.0.2" }


### PR DESCRIPTION
We were using Spock which would pull in Groovy 4.0.4, but we generally want to use a consistent known version. Currently, this matches with shared-versions.properties, but keeping it separate may be better to avoid issues when upgrading to Groovy 5 later.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
