### PR TITLE
Do not use kotlin-stub

### DIFF
--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
         val distributionDependencies = versionCatalogs.named("buildLibs")
         distributionDependencies.libraryAliases.forEach { alias ->
             api(distributionDependencies.findLibrary(alias).get().map { module ->
-                if (module.version == "kotlin-stub") {
+                if (module.group == "org.jetbrains.kotlin") {
                     module.copy().apply {
                         version {
                             strictly(kotlinVersion)

--- a/gradle/dependency-management/build.versions.toml
+++ b/gradle/dependency-management/build.versions.toml
@@ -4,7 +4,6 @@ asciidoctor = "2.5.13"
 checkstyle = "10.25.0"
 develocity = "4.3.2"
 javaparser = "3.18.0"
-kotlin = "kotlin-stub" # will be replaced by platfrom
 
 [libraries]
 ant = { module = "org.apache.ant:ant", version = "1.10.15" } # Bump the version brought in transitively by gradle-guides-plugin
@@ -39,10 +38,10 @@ jhighlight = { module = "com.uwyn:jhighlight", version = "1.0" }
 jmhPlugin = { module = "me.champeau.jmh:jmh-gradle-plugin", version = "0.7.2" }
 jsoup = { module = "org.jsoup:jsoup", version = "1.15.3" }
 jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
-kgp = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-kotlinMetadata = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
-kotlinSamWithReceiver = { group = "org.jetbrains.kotlin", name = "kotlin-sam-with-receiver", version.ref = "kotlin" }
+kgp = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin"}
+kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable"}
+kotlinMetadata = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm"}
+kotlinSamWithReceiver = { group = "org.jetbrains.kotlin", name = "kotlin-sam-with-receiver"}
 nullaway = { module = "com.uber.nullaway:nullaway", version = "0.12.10" }
 nullawayPlugin = { module = "net.ltgt.gradle:gradle-nullaway-plugin", version = "2.2.0" }
 pdfbox = { module = "org.apache.pdfbox:pdfbox", version = "2.0.24" } # Flexmark 0.34.60 brings in a vulnerable version of pdfbox


### PR DESCRIPTION
Dependency resolution sees this version before it sees the platform, so it tries to resolve it. It does this every time we execute the build logic and wastes about 500ms on each cc miss. We instead do not include a version at all. Unlike the stub version, dependency resolution will not attempt to resolve a non-present version.

Before:
<img width="736" height="193" alt="image" src="https://github.com/user-attachments/assets/5d86d1cd-b3ed-4250-8ed9-a75f133fcdf8" />

After:
<img width="752" height="171" alt="image" src="https://github.com/user-attachments/assets/ad4e502d-bd7c-4323-8c88-49022ff132ff" />


Notice all the downloads in the before trace were from fake kotlin-stub dependencies:
<img width="841" height="104" alt="image" src="https://github.com/user-attachments/assets/26b0dee2-e78a-41d4-a053-457857b47779" />


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
