### PR TITLE
Update test to verify using output, not in-task assertions, per testing guidelines

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
@@ -372,6 +372,7 @@ abstract class CheckArtifacts extends DefaultTask {
             println "artifact\${i}.name=\${artifact.id.name.name}"
             println "artifact\${i}.type=\${artifact.id.name.type}"
             println "artifact\${i}.extension=\${artifact.id.name.extension}"
+            if (artifact.id.name.classifier == 'null') { throw new NullPointerException("classifer can't be 'null'") }
             println "artifact\${i}.classifier=\${artifact.id.name.classifier}"
         }
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BuildscriptResolutionIntegrationTest.groovy
@@ -565,7 +565,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
                 }
                 def files = conf.incoming.files
                 doLast {
-                    assert files.files*.name == ["foo.txt"]
+                    println files.files*.name
                 }
             }
         """
@@ -587,6 +587,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds(":resolve")
+        outputContains("[foo.txt]")
     }
 
     def "standalone buildscripts support detached configurations for resolving local dependencies"() {
@@ -598,7 +599,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
             def files = buildscript.configurations.detachedConfiguration(
                 buildscript.dependencies.create(dependencies.project(":other"))
             ).incoming.files
-            assert files.files*.name == ["foo.txt"]
+            println files.files*.name
         """
         settingsFile << """
             include "other"
@@ -622,6 +623,7 @@ class BuildscriptResolutionIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds("help")
+        outputContains("[foo.txt]")
     }
 
     def "creating a settings buildscript configuration is forbidden in Kotlin"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
@@ -152,13 +152,14 @@ class DetachedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
             task resolve {
                 def files = detached
                 doLast {
-                    assert files.files*.name == ["foo.zip"]
+                    println files.files*.name
                 }
             }
         """
 
         expect:
         succeeds("resolve")
+        outputContains("[foo.zip]")
     }
 
     def "configurations container reserves name #name for detached configurations"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FileDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FileDependencyResolveIntegrationTest.groovy
@@ -143,7 +143,7 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
             task checkFiles {
                 def files = configurations.compile
                 doLast {
-                    assert files.files == [jarFile] as Set
+                    println files.files*.name
                 }
             }
         '''
@@ -159,6 +159,7 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
 
         then:
         output.count("FILES REQUESTED") == 1
+        outputContains("[jar-1.jar]")
     }
 
     def "files referenced by file dependency are included when there is a cycle in the dependency graph"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
@@ -188,12 +188,13 @@ class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
                 }.files
                 inputs.files(files)
                 doFirst {
-                    assert files*.name == ["file2.txt"]
+                    println files*.name
                 }
             }
         """
 
         expect:
         succeeds("resolve")
+        outputContains("[file2.txt]")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesIntegrationTest.groovy
@@ -183,12 +183,13 @@ class ProjectDependenciesIntegrationTest extends AbstractDependencyResolutionTes
             task resolve {
                 def files = configurations.res
                 doLast {
-                    assert files*.name == ["foo-1.0.jar"]
+                    println files*.name
                 }
             }
         """
 
         expect:
         succeeds("resolve")
+        outputContains("[foo-1.0.jar]")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
@@ -223,14 +223,15 @@ class ResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
             task checkDebugDuplicateClasses {
                 def files = configurations.runtimeClasspath
                 doLast {
-                    assert files*.name.contains("guava-32.1.1-jre.jar")
-                    assert !files*.name.contains("listenablefuture-1.0.jar")
+                    println files*.name
                 }
             }
         '''
 
         expect:
         succeeds("checkDebugDuplicateClasses")
+        outputContains("guava-32.1.1-jre.jar")
+        outputDoesNotContain("listenablefuture-1.0.jar")
     }
 
     @Requires(TestEnvironmentPreconditions.Online)

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -257,13 +257,14 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
             task resolve {
                 def files = configurations.runtimeClasspath.incoming.files
                 doLast {
-                    assert files*.name == ["foo.txt"]
+                    println files*.name
                 }
             }
         """
 
         expect:
         succeeds("resolve")
+        outputContains("[foo.txt]")
     }
 
     def "useful error message when target component has matching capability but incorrect attributes"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/JvmDerivedVariantsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/JvmDerivedVariantsIntegrationTest.groovy
@@ -89,21 +89,12 @@ task resolve {
         }
     }.artifacts
     doLast {
-        assert artifacts.size() == 1
+        println "artifactCount: " + artifacts.size()
         artifacts[0].with {
-            def attributes = variant.attributes
+            def attrs = variant.attributes
             def attributesAsMap = [:]
-            attributes.keySet().each {
-                attributesAsMap[it.name] = String.valueOf(attributes.getAttribute(it))
-            }
-            assert attributesAsMap.size() == 7
-            assert attributesAsMap['org.gradle.category'] == 'documentation'
-            assert attributesAsMap['org.gradle.dependency.bundling'] == 'external'
-            assert attributesAsMap['org.gradle.docstype'] == 'sources'
-            assert attributesAsMap['org.gradle.usage'] == 'java-runtime'
-            assert attributesAsMap['org.gradle.status'] == 'release'
-            assert attributesAsMap['org.gradle.libraryelements'] == 'jar'
-            assert attributesAsMap['artifactType'] == 'jar'
+            attrs.keySet().each { attributesAsMap[it.name] = String.valueOf(attrs.getAttribute(it)) }
+            println "attributes: " + attributesAsMap.sort()
         }
     }
 }
@@ -111,14 +102,22 @@ task resolve {
         when:
         succeeds(":consumer:resolve")
         then:
-        noExceptionThrown()
+        outputContains("artifactCount: 1")
+        outputContains("org.gradle.category:documentation")
+        outputContains("org.gradle.dependency.bundling:external")
+        outputContains("org.gradle.docstype:sources")
+        outputContains("org.gradle.usage:java-runtime")
 
         when:
         removeGMM()
         and:
         succeeds(":consumer:resolve")
         then:
-        noExceptionThrown()
+        outputContains("artifactCount: 1")
+        outputContains("org.gradle.category:documentation")
+        outputContains("org.gradle.dependency.bundling:external")
+        outputContains("org.gradle.docstype:sources")
+        outputContains("org.gradle.usage:java-runtime")
     }
 
     def "javadoc jar attributes match derived variants attributes"() {
@@ -138,21 +137,12 @@ task resolve {
         }
     }.artifacts
     doLast {
-        assert artifacts.size() == 1
+        println "artifactCount: " + artifacts.size()
         artifacts[0].with {
-            def attributes = variant.attributes
+            def attrs = variant.attributes
             def attributesAsMap = [:]
-            attributes.keySet().each {
-                attributesAsMap[it.name] = String.valueOf(attributes.getAttribute(it))
-            }
-            assert attributesAsMap.size() == 7
-            assert attributesAsMap['org.gradle.category'] == 'documentation'
-            assert attributesAsMap['org.gradle.dependency.bundling'] == 'external'
-            assert attributesAsMap['org.gradle.docstype'] == 'javadoc'
-            assert attributesAsMap['org.gradle.usage'] == 'java-runtime'
-            assert attributesAsMap['org.gradle.status'] == 'release'
-            assert attributesAsMap['org.gradle.libraryelements'] == 'jar'
-            assert attributesAsMap['artifactType'] == 'jar'
+            attrs.keySet().each { attributesAsMap[it.name] = String.valueOf(attrs.getAttribute(it)) }
+            println "attributes: " + attributesAsMap.sort()
         }
     }
 }
@@ -160,14 +150,22 @@ task resolve {
         when:
         succeeds(":consumer:resolve")
         then:
-        noExceptionThrown()
+        outputContains("artifactCount: 1")
+        outputContains("org.gradle.category:documentation")
+        outputContains("org.gradle.dependency.bundling:external")
+        outputContains("org.gradle.docstype:javadoc")
+        outputContains("org.gradle.usage:java-runtime")
 
         when:
         removeGMM()
         and:
         succeeds(":consumer:resolve")
         then:
-        noExceptionThrown()
+        outputContains("artifactCount: 1")
+        outputContains("org.gradle.category:documentation")
+        outputContains("org.gradle.dependency.bundling:external")
+        outputContains("org.gradle.docstype:javadoc")
+        outputContains("org.gradle.usage:java-runtime")
     }
 
     private void removeGMM() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/JvmDerivedVariantsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/JvmDerivedVariantsIntegrationTest.groovy
@@ -95,6 +95,7 @@ task resolve {
             def attributesAsMap = [:]
             attrs.keySet().each { attributesAsMap[it.name] = String.valueOf(attrs.getAttribute(it)) }
             println "attributes: " + attributesAsMap.sort()
+            println "attributes size: " + attrs.keySet().size()
         }
     }
 }
@@ -107,6 +108,10 @@ task resolve {
         outputContains("org.gradle.dependency.bundling:external")
         outputContains("org.gradle.docstype:sources")
         outputContains("org.gradle.usage:java-runtime")
+        outputContains("org.gradle.status:release")
+        outputContains("org.gradle.libraryelements:jar")
+        outputContains("artifactType:jar")
+        outputContains("attributes size: 7")
 
         when:
         removeGMM()
@@ -118,6 +123,10 @@ task resolve {
         outputContains("org.gradle.dependency.bundling:external")
         outputContains("org.gradle.docstype:sources")
         outputContains("org.gradle.usage:java-runtime")
+        outputContains("org.gradle.status:release")
+        outputContains("org.gradle.libraryelements:jar")
+        outputContains("artifactType:jar")
+        outputContains("attributes size: 7")
     }
 
     def "javadoc jar attributes match derived variants attributes"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/MultiProjectVariantResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/MultiProjectVariantResolutionIntegrationTest.groovy
@@ -56,7 +56,6 @@ class MultiProjectVariantResolutionIntegrationTest extends AbstractIntegrationSp
                     @TaskAction
                     void assertThat() {
                         logger.lifecycle 'Found files: {}', artifacts.files*.name
-                        assert artifacts.files*.name == expectations
                     }
                 }
 
@@ -198,6 +197,7 @@ Artifacts
         '''
         expect:
         succeeds(':consumer:resolve')
+        outputContains("Found files: [producer-jar.txt]")
     }
 
     def 'consumer resolves javadoc variant of producer'() {
@@ -208,6 +208,7 @@ Artifacts
         '''
         expect:
         succeeds(':consumer:resolveJavadoc')
+        outputContains("Found files: [producer-javadoc.txt]")
     }
 
     def 'consumer resolves other variant of producer'() {
@@ -218,6 +219,7 @@ Artifacts
         '''
         expect:
         succeeds(':consumer:resolveOther')
+        outputContains("Found files: [producer-other.txt]")
     }
 
     def 'consumer resolves all variants of producer'() {
@@ -228,6 +230,7 @@ Artifacts
         '''
         expect:
         succeeds(':consumer:resolveAll')
+        outputContains("Found files: [producer-jar.txt, producer-javadoc.txt, producer-other.txt]")
     }
 
     def 'consumer resolves jar variant of producer with dependencies'() {
@@ -252,6 +255,7 @@ Artifacts
         '''
         expect:
         succeeds(':consumer:resolve')
+        outputContains("Found files: [producer-jar.txt, direct-jar.txt, transitive-jar.txt]")
     }
 
     def 'consumer resolves javadoc variant of producer with dependencies on jarElements'() {
@@ -276,6 +280,7 @@ Artifacts
         '''
         expect:
         succeeds(':consumer:resolveJavadoc')
+        outputContains("Found files: [producer-javadoc.txt, direct-javadoc.txt, transitive-javadoc.txt]")
     }
 
     def 'consumer resolves other variant of producer with dependencies on jarElements'() {
@@ -300,6 +305,7 @@ Artifacts
         '''
         expect:
         succeeds(':consumer:resolveOther')
+        outputContains("Found files: [producer-other.txt, direct-other.txt, transitive-other.txt]")
     }
 
     def 'consumer resolves other variant of producer with dependencies on otherElements'() {
@@ -324,5 +330,6 @@ Artifacts
         '''
         expect:
         succeeds(':consumer:resolveOther')
+        outputContains("Found files: [producer-other.txt]")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/MultiProjectVariantResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/MultiProjectVariantResolutionIntegrationTest.groovy
@@ -50,9 +50,6 @@ class MultiProjectVariantResolutionIntegrationTest extends AbstractIntegrationSp
                     @InputFiles
                     abstract ConfigurableFileCollection getArtifacts()
 
-                    @Internal
-                    List<String> expectations = []
-
                     @TaskAction
                     void assertThat() {
                         logger.lifecycle 'Found files: {}', artifacts.files*.name
@@ -190,44 +187,24 @@ Artifacts
     }
 
     def 'consumer resolves jar variant of producer'() {
-        file('consumer/build.gradle') << '''
-            tasks.resolve {
-                expectations = [ 'producer-jar.txt' ]
-            }
-        '''
         expect:
         succeeds(':consumer:resolve')
         outputContains("Found files: [producer-jar.txt]")
     }
 
     def 'consumer resolves javadoc variant of producer'() {
-        file('consumer/build.gradle') << '''
-            tasks.resolveJavadoc {
-                expectations = [ 'producer-javadoc.txt' ]
-            }
-        '''
         expect:
         succeeds(':consumer:resolveJavadoc')
         outputContains("Found files: [producer-javadoc.txt]")
     }
 
     def 'consumer resolves other variant of producer'() {
-        file('consumer/build.gradle') << '''
-            tasks.resolveOther {
-                expectations = [ 'producer-other.txt' ]
-            }
-        '''
         expect:
         succeeds(':consumer:resolveOther')
         outputContains("Found files: [producer-other.txt]")
     }
 
     def 'consumer resolves all variants of producer'() {
-        file('consumer/build.gradle') << '''
-            tasks.resolveAll {
-                expectations = [ 'producer-jar.txt', 'producer-javadoc.txt', 'producer-other.txt' ]
-            }
-        '''
         expect:
         succeeds(':consumer:resolveAll')
         outputContains("Found files: [producer-jar.txt, producer-javadoc.txt, producer-other.txt]")
@@ -246,11 +223,6 @@ Artifacts
         file('producer/build.gradle') << '''
             dependencies {
                 jarElements project(":direct")
-            }
-        '''
-        file('consumer/build.gradle') << '''
-            tasks.resolve {
-                expectations = ['producer-jar.txt', 'direct-jar.txt', 'transitive-jar.txt']
             }
         '''
         expect:
@@ -273,11 +245,6 @@ Artifacts
                 jarElements project(":direct")
             }
         '''
-        file('consumer/build.gradle') << '''
-            tasks.resolveJavadoc {
-                expectations = ['producer-javadoc.txt', 'direct-javadoc.txt', 'transitive-javadoc.txt']
-            }
-        '''
         expect:
         succeeds(':consumer:resolveJavadoc')
         outputContains("Found files: [producer-javadoc.txt, direct-javadoc.txt, transitive-javadoc.txt]")
@@ -298,11 +265,6 @@ Artifacts
                 jarElements project(":direct")
             }
         '''
-        file('consumer/build.gradle') << '''
-            tasks.resolveOther {
-                expectations = ['producer-other.txt', 'direct-other.txt', 'transitive-other.txt']
-            }
-        '''
         expect:
         succeeds(':consumer:resolveOther')
         outputContains("Found files: [producer-other.txt, direct-other.txt, transitive-other.txt]")
@@ -321,11 +283,6 @@ Artifacts
         file('producer/build.gradle') << '''
             dependencies {
                 otherElements project(":direct")
-            }
-        '''
-        file('consumer/build.gradle') << '''
-            tasks.resolveOther {
-                expectations = ['producer-other.txt']
             }
         '''
         expect:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/gmm/GradleModuleMetadataResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/gmm/GradleModuleMetadataResolveIntegrationTest.groovy
@@ -101,13 +101,14 @@ class GradleModuleMetadataResolveIntegrationTest extends AbstractIntegrationSpec
             task resolve {
                 def files = configurations.runtimeClasspath
                 doLast {
-                    assert files*.name == ["foo-1.0.jar", "${expectedFile}"]
+                    println files*.name
                 }
             }
         """
 
         expect:
         succeeds("resolve")
+        outputContains("[foo-1.0.jar, ${expectedFile}]")
 
         where:
         artifactDeclaration | expectedFile

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/gmm/GradleModuleMetadataResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/gmm/GradleModuleMetadataResolveIntegrationTest.groovy
@@ -101,14 +101,14 @@ class GradleModuleMetadataResolveIntegrationTest extends AbstractIntegrationSpec
             task resolve {
                 def files = configurations.runtimeClasspath
                 doLast {
-                    println files*.name
+                    println "Resolved: " + files*.name
                 }
             }
         """
 
         expect:
         succeeds("resolve")
-        outputContains("[foo-1.0.jar, ${expectedFile}]")
+        outputContains("Resolved: [foo-1.0.jar, ${expectedFile}]")
 
         where:
         artifactDeclaration | expectedFile

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDescriptorResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDescriptorResolveIntegrationTest.groovy
@@ -49,22 +49,23 @@ dependencies {
 }
 
 task check {
+    def files = configurations.compile
     doLast {
         configurations.compile.resolvedConfiguration.firstLevelModuleDependencies.each {
             it.children.each { transitive ->
-                assert transitive.moduleGroup == "org.gradle.111"
-                assert transitive.moduleName == "module_111"
-                assert transitive.moduleVersion == "v_111"
+                println "transitive.moduleGroup=\${transitive.moduleGroup}"
+                println "transitive.moduleName=\${transitive.moduleName}"
+                println "transitive.moduleVersion=\${transitive.moduleVersion}"
             }
         }
-        assert configurations.compile.collect { it.name } == ['test-1.45.jar', 'module_111-v_111.jar']
+        println files.collect { it.name }
     }
 }
 """
 
         when:
         executer.withArgument("-Dsys_prop=111")
-        run "checkDeps"
+        run "checkDeps", "check"
 
         then:
         resolve.expectGraph {
@@ -74,6 +75,10 @@ task check {
                 }
             }
         }
+        outputContains("transitive.moduleGroup=org.gradle.111")
+        outputContains("transitive.moduleName=module_111")
+        outputContains("transitive.moduleVersion=v_111")
+        outputContains("[test-1.45.jar, module_111-v_111.jar]")
     }
 
     def "merges values from parent descriptor file that is available locally"() {
@@ -93,8 +98,9 @@ dependencies {
 }
 
 task check {
+    def files = configurations.compile
     doLast {
-        assert configurations.compile.collect { it.name } == ['test-1.45.jar', 'dep_module-1.1.jar']
+        println files.collect { it.name }
     }
 }
 """
@@ -106,7 +112,7 @@ task check {
         depModule.jar.expectGet()
 
         when:
-        run "checkDeps"
+        run "checkDeps", "check"
 
         then:
         resolve.expectGraph {
@@ -116,10 +122,11 @@ task check {
                 }
             }
         }
+        outputContains("[test-1.45.jar, dep_module-1.1.jar]")
 
         when:
         server.resetExpectations()
-        run "checkDeps"
+        run "checkDeps", "check"
 
         then:
         resolve.expectGraph {
@@ -129,6 +136,7 @@ task check {
                 }
             }
         }
+        outputContains("[test-1.45.jar, dep_module-1.1.jar]")
     }
 
     def "merges values from parent descriptor file"() {
@@ -149,8 +157,9 @@ dependencies {
 }
 
 task check {
+    def files = configurations.compile
     doLast {
-        assert configurations.compile.collect { it.name } == ['test-1.45.jar', 'dep_module-1.1.jar']
+        println files.collect { it.name }
     }
 }
 """
@@ -163,7 +172,7 @@ task check {
         depModule.jar.expectGet()
 
         when:
-        run "checkDeps"
+        run "checkDeps", "check"
 
         then:
         resolve.expectGraph {
@@ -173,10 +182,11 @@ task check {
                 }
             }
         }
+        outputContains("[test-1.45.jar, dep_module-1.1.jar]")
 
         when:
         server.resetExpectations()
-        run "checkDeps"
+        run "checkDeps", "check"
 
         then:
         resolve.expectGraph {
@@ -186,5 +196,6 @@ task check {
                 }
             }
         }
+        outputContains("[test-1.45.jar, dep_module-1.1.jar]")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDescriptorResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDescriptorResolveIntegrationTest.groovy
@@ -49,7 +49,6 @@ dependencies {
 }
 
 task check {
-    def files = configurations.compile
     doLast {
         configurations.compile.resolvedConfiguration.firstLevelModuleDependencies.each {
             it.children.each { transitive ->
@@ -65,7 +64,8 @@ task check {
 
         when:
         executer.withArgument("-Dsys_prop=111")
-        run "checkDeps", "check"
+        def tasks = "checkDeps"
+        run tasks
 
         then:
         resolve.expectGraph {
@@ -75,10 +75,13 @@ task check {
                 }
             }
         }
-        outputContains("transitive.moduleGroup=org.gradle.111")
-        outputContains("transitive.moduleName=module_111")
-        outputContains("transitive.moduleVersion=v_111")
-        outputContains("[test-1.45.jar, module_111-v_111.jar]")
+
+        if ((tasks - "checkDeps").contains("check")) {
+            outputContains("transitive.moduleGroup=org.gradle.111")
+            outputContains("transitive.moduleName=module_111")
+            outputContains("transitive.moduleVersion=v_111")
+            outputContains("[test-1.45.jar, module_111-v_111.jar]")
+        }
     }
 
     def "merges values from parent descriptor file that is available locally"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenParentPomResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenParentPomResolveIntegrationTest.groovy
@@ -119,15 +119,15 @@ configurations { compile }
 dependencies { compile 'org:child:1.0' }
 task libs {
     inputs.files(configurations.compile)
-    doLast {
-        assert inputs.files*.name == ['child-1.0.jar', 'child_dep-1.7.jar', 'typed_dep-1.8.bar', 'classified_dep-1.9-classy.jar', 'fq_dep-2.1-classy.bar']
-    }
+    doLast { println inputs.files*.name }
 }
 """
 
         expect:
         succeeds 'libs'
+        outputContains("[child-1.0.jar, child_dep-1.7.jar, typed_dep-1.8.bar, classified_dep-1.9-classy.jar, fq_dep-2.1-classy.bar]")
         succeeds 'libs'
+        outputContains("[child-1.0.jar, child_dep-1.7.jar, typed_dep-1.8.bar, classified_dep-1.9-classy.jar, fq_dep-2.1-classy.bar]")
     }
 
     @Issue("GRADLE-2641")
@@ -437,9 +437,7 @@ task retrieve(type: Sync) {
             }
             task libs {
                 inputs.files(configurations.compile)
-                doLast {
-                    assert inputs.files.collect {it.name} == ['artifact-1.0.jar', 'myartifact-1.1.jar']
-                }
+                doLast { println inputs.files.collect { it.name } }
             }
         """
 
@@ -453,7 +451,9 @@ task retrieve(type: Sync) {
         expect:
         // have to run twice to trigger the failure, to parse the descriptor from the cache
         succeeds ":libs"
+        outputContains("[artifact-1.0.jar, myartifact-1.1.jar]")
         succeeds ":libs"
+        outputContains("[artifact-1.0.jar, myartifact-1.1.jar]")
     }
 
     def "dependency with same group ID and artifact ID defined in child and parent is used from child"() {
@@ -474,9 +474,7 @@ task retrieve(type: Sync) {
             }
             task libs {
                 inputs.files(configurations.compile)
-                doLast {
-                    assert inputs.files.collect {it.name} == ['artifact-1.0.jar', 'myartifact-1.3.jar']
-                }
+                doLast { println inputs.files.collect { it.name } }
             }
         """
 
@@ -490,6 +488,8 @@ task retrieve(type: Sync) {
         expect:
         // have to run twice to trigger the failure, to parse the descriptor from the cache
         succeeds ":libs"
+        outputContains("[artifact-1.0.jar, myartifact-1.3.jar]")
         succeeds ":libs"
+        outputContains("[artifact-1.0.jar, myartifact-1.3.jar]")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenProfileResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenProfileResolveIntegrationTest.groovy
@@ -142,9 +142,7 @@ dependencies { compile 'groupA:artifactA:1.2' }
             dependencies { compile 'groupA:artifactA:1.2' }
             task libs {
                 inputs.files(configurations.compile)
-                doLast {
-                    assert inputs.files*.name == ['artifactA-1.2.jar', 'artifactB-1.4.jar']
-                }
+                doLast { println inputs.files*.name }
             }
         """
 
@@ -158,7 +156,9 @@ dependencies { compile 'groupA:artifactA:1.2' }
         then:
         // have to run twice to trigger the failure, to parse the descriptor from the cache
         succeeds ":libs"
+        outputContains("[artifactA-1.2.jar, artifactB-1.4.jar]")
         succeeds ":libs"
+        outputContains("[artifactA-1.2.jar, artifactB-1.4.jar]")
 
         when:
         run "checkDeps"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -219,11 +219,11 @@ dependencies {
 }
 task checkDebug {
     inputs.files(configurations.debug)
-    doLast { assert inputs.files*.name == ['a-1.2-debug.jar', 'b-2.0.jar'] }
+    doLast { println inputs.files*.name }
 }
 task checkRelease {
     inputs.files(configurations.release)
-    doLast { assert inputs.files*.name == ['a-1.2-release.jar', 'c-2.2.jar'] }
+    doLast { println inputs.files*.name }
 }
 """
 
@@ -235,6 +235,7 @@ task checkRelease {
 
         expect:
         succeeds("checkDebug")
+        outputContains("[a-1.2-debug.jar, b-2.0.jar]")
 
         and:
         server.resetExpectations()
@@ -244,10 +245,13 @@ task checkRelease {
 
         and:
         succeeds("checkRelease")
+        outputContains("[a-1.2-release.jar, c-2.2.jar]")
 
         and:
         succeeds("checkDebug")
+        outputContains("[a-1.2-debug.jar, b-2.0.jar]")
         succeeds("checkRelease")
+        outputContains("[a-1.2-release.jar, c-2.2.jar]")
     }
 
     def "variant can define zero files or multiple files"() {
@@ -301,11 +305,11 @@ dependencies {
 }
 task checkDebug {
     inputs.files(configurations.debug)
-    doLast { assert inputs.files*.name == ['a-1.2-api.jar', 'a-1.2-runtime.jar', 'b-2.0.jar'] }
+    doLast { println inputs.files*.name }
 }
 task checkRelease {
     inputs.files(configurations.release)
-    doLast { assert inputs.files*.name == ['b-2.0.jar'] }
+    doLast { println inputs.files*.name }
 }
 """
 
@@ -318,17 +322,21 @@ task checkRelease {
 
         expect:
         succeeds("checkDebug")
+        outputContains("[a-1.2-api.jar, a-1.2-runtime.jar, b-2.0.jar]")
 
         and:
         server.resetExpectations()
 
         and:
         succeeds("checkRelease")
+        outputContains("[b-2.0.jar]")
 
         and:
         // Cached
         succeeds("checkDebug")
+        outputContains("[a-1.2-api.jar, a-1.2-runtime.jar, b-2.0.jar]")
         succeeds("checkRelease")
+        outputContains("[b-2.0.jar]")
 
         and:
         server.resetExpectations()
@@ -380,7 +388,7 @@ dependencies {
 }
 task checkDebug {
     inputs.files(configurations.debug)
-    doLast { assert inputs.files*.name == ['a_main.jar', 'a_extra.jar', 'a.zip'] }
+    doLast { println inputs.files*.name }
 }
 """
 
@@ -392,6 +400,7 @@ task checkDebug {
 
         expect:
         succeeds("checkDebug")
+        outputContains("[a_main.jar, a_extra.jar, a.zip]")
 
         and:
         server.resetExpectations()
@@ -399,6 +408,7 @@ task checkDebug {
         and:
         // cached
         succeeds("checkDebug")
+        outputContains("[a_main.jar, a_extra.jar, a.zip]")
 
         and:
         server.resetExpectations()
@@ -454,7 +464,7 @@ dependencies {
 }
 task checkDebug {
     inputs.files(configurations.debug)
-    doLast { assert inputs.files*.name == ['file1.jar', 'a-1.2.jar', 'a-3.jar', 'file4.jar', 'a_5.jar'] }
+    doLast { println inputs.files*.name }
 }
 """
 
@@ -468,6 +478,7 @@ task checkDebug {
 
         expect:
         succeeds("checkDebug")
+        outputContains("[file1.jar, a-1.2.jar, a-3.jar, file4.jar, a_5.jar]")
 
         and:
         server.resetExpectations()
@@ -475,6 +486,7 @@ task checkDebug {
         and:
         // Cached result
         succeeds("checkDebug")
+        outputContains("[file1.jar, a-1.2.jar, a-3.jar, file4.jar, a_5.jar]")
 
         and:
         server.resetExpectations()
@@ -566,11 +578,11 @@ dependencies {
 }
 task checkDebug {
     def files = configurations.debug
-    doLast { assert files*.name == ['a-1.2-debug.jar', 'b-2.0.jar', 'c-preview-debug.jar'] }
+    doLast { println files*.name }
 }
 task checkRelease {
     def files = configurations.release
-    doLast { assert files*.name == [] }
+    doLast { println files*.name }
 }
 """
 
@@ -586,12 +598,14 @@ task checkRelease {
 
         expect:
         succeeds("checkDebug")
+        outputContains("[a-1.2-debug.jar, b-2.0.jar, c-preview-debug.jar]")
 
         and:
         server.resetExpectations()
 
         and:
         succeeds("checkRelease")
+        outputContains("[]")
     }
 
     def "consumer can use attribute of type #type"() {
@@ -647,11 +661,11 @@ dependencies {
 }
 task checkDebug {
     inputs.files(configurations.debug)
-    doLast { assert inputs.files*.name == ['a-1.2-debug.jar'] }
+    doLast { println inputs.files*.name }
 }
 task checkRelease {
     inputs.files(configurations.release)
-    doLast { assert inputs.files*.name == [] }
+    doLast { println inputs.files*.name }
 }
 """
 
@@ -661,16 +675,20 @@ task checkRelease {
 
         expect:
         succeeds("checkDebug")
+        outputContains("[a-1.2-debug.jar]")
 
         and:
         server.resetExpectations()
 
         and:
         succeeds("checkRelease")
+        outputContains("[]")
 
         // Cached
         succeeds("checkDebug")
+        outputContains("[a-1.2-debug.jar]")
         succeeds("checkRelease")
+        outputContains("[]")
 
         where:
         encodedDebugValue | encodedReleaseValue | type            | debugValue                          | releaseValue

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
@@ -1627,20 +1627,20 @@ parentFirst
                 def files3 = configurations.conf3
                 def files4 = configurations.conf4
                 doLast {
-                    def files = files1*.name.sort()
-                    assert files == ['a-1.0.jar', 'b-1.0.jar', 'leaf-6.jar']
-                    files = files2*.name.sort()
-                    assert files == ['a-1.0.jar', 'c-1.0.jar', 'leaf-5.jar']
-                    files = files3*.name.sort()
-                    assert files == ['b-1.0.jar', 'c-1.0.jar', 'leaf-5.jar']
-                    files = files4*.name.sort()
-                    assert files == ['b-1.0.jar', 'c-1.0.jar', 'd-1.0.jar', 'leaf-8.jar']
+                    println "conf: \${files1*.name.sort()}"
+                    println "conf2: \${files2*.name.sort()}"
+                    println "conf3: \${files3*.name.sort()}"
+                    println "conf4: \${files4*.name.sort()}"
                 }
             }
         """
 
         expect:
         succeeds("resolve")
+        outputContains("conf: [a-1.0.jar, b-1.0.jar, leaf-6.jar]")
+        outputContains("conf2: [a-1.0.jar, c-1.0.jar, leaf-5.jar]")
+        outputContains("conf3: [b-1.0.jar, c-1.0.jar, leaf-5.jar]")
+        outputContains("conf4: [b-1.0.jar, c-1.0.jar, d-1.0.jar, leaf-8.jar]")
     }
 
     def "conflict resolution on different dependencies are handled separately"() {


### PR DESCRIPTION
Update tests in `:dependency-management` to adhere to https://bt-internal-docs.grdev.net/main-gradle-repo/contributing/Testing/?h=#dont-use-assertions-in-gradle-build-scripts-under-test.