### PR TITLE
Use LinkedTransferQueue instead of LinkedBlockingQueue

### DIFF
--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -60,10 +60,10 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TransferQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -199,7 +199,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         @Nullable
         private final UserCodeSource registrationPoint;
         private final ManagedExecutor executor;
-        private final BlockingQueue<Object> events = new LinkedBlockingQueue<>();
+        private final TransferQueue<Object> events = new LinkedTransferQueue<>();
         private final AtomicReference<Throwable> failure = new AtomicReference<>();
 
         public AbstractListener(@Nullable UserCodeSource registrationPoint, ExecutorFactory executorFactory) {


### PR DESCRIPTION
This increases performance

After the switch to `LinkedTransferQueue` the number of occurences in the stacktraces shrinked to 51
<img width="1263" height="231" alt="image" src="https://github.com/user-attachments/assets/90733b12-47c2-441a-a39f-8a322a8ebfed" />

compared to 264 occurences of `LinkedBlockingQueue`
<img width="1149" height="371" alt="image" src="https://github.com/user-attachments/assets/855429d0-153e-431a-b10c-ea3b5518b65c" />

both where recording with `rebuild_bl_abi_change_pip_warm`

also execution time went down

Now
<img width="971" height="157" alt="image" src="https://github.com/user-attachments/assets/0e34345e-6ccd-4f83-8f5c-352b8c6214a7" />
before
<img width="988" height="146" alt="image" src="https://github.com/user-attachments/assets/761bfb00-6764-419b-89e6-4eaf008cd5aa" />


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
