### PR TITLE
Use consistent wording in help output

### DIFF
--- a/platforms/core-runtime/cli/src/main/java/org/gradle/cli/CommandLineParser.java
+++ b/platforms/core-runtime/cli/src/main/java/org/gradle/cli/CommandLineParser.java
@@ -208,7 +208,7 @@ public class CommandLineParser {
             lines.put(key, value);
         }
         // The "--" delimiter isn't an option, but it's useful to print it in the usage message anyway.
-        lines.put("--", "Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.");
+        lines.put("--", "Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.");
 
         int max = 0;
         for (String optionStr : lines.keySet()) {

--- a/platforms/core-runtime/cli/src/main/java/org/gradle/cli/ProjectPropertiesCommandLineConverter.java
+++ b/platforms/core-runtime/cli/src/main/java/org/gradle/cli/ProjectPropertiesCommandLineConverter.java
@@ -30,6 +30,6 @@ public class ProjectPropertiesCommandLineConverter extends AbstractPropertiesCom
 
     @Override
     protected String getPropertyOptionDescription() {
-        return "Set project property for the build script (e.g. -Pmyprop=myvalue).";
+        return "Sets a project property for the build script (for example, -Pmyprop=myvalue).";
     }
 }

--- a/platforms/core-runtime/cli/src/main/java/org/gradle/cli/SystemPropertiesCommandLineConverter.java
+++ b/platforms/core-runtime/cli/src/main/java/org/gradle/cli/SystemPropertiesCommandLineConverter.java
@@ -29,6 +29,6 @@ public class SystemPropertiesCommandLineConverter extends AbstractPropertiesComm
 
     @Override
     protected String getPropertyOptionDescription() {
-        return "Set system property of the JVM (e.g. -Dmyprop=myvalue).";
+        return "Sets a JVM system property (for example, -Dmyprop=myvalue).";
     }
 }

--- a/platforms/core-runtime/cli/src/test/groovy/org/gradle/cli/CommandLineParserTest.groovy
+++ b/platforms/core-runtime/cli/src/test/groovy/org/gradle/cli/CommandLineParserTest.groovy
@@ -380,7 +380,7 @@ class CommandLineParserTest extends Specification {
             '-B',
             '-b',
             '-y, -z, --end-option, --last-option  this is the last option',
-            '--                                   Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.'
+            '--                                   Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.'
         ]
     }
 
@@ -398,7 +398,7 @@ class CommandLineParserTest extends Specification {
             '-b                 [deprecated]',
             '-c                 option c [incubating]',
             '-d                 [incubating]',
-            '--                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.'
+            '--                 Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.'
         ]
     }
 
@@ -706,7 +706,7 @@ class CommandLineParserTest extends Specification {
             '--a-option-other  this is option --a-option-other',
             '--c-option',
             '--no-c-option',
-            '--                Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.'
+            '--                Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.'
         ]
     }
 }

--- a/platforms/core-runtime/gradle-cli/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
+++ b/platforms/core-runtime/gradle-cli/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
@@ -124,8 +124,8 @@ public class DefaultCommandLineActionFactory implements CommandLineActionFactory
         @Override
         public void configureCommandLineParser(CommandLineParser parser) {
             parser.option(HELP, "?", "help").hasDescription("Shows this help message.");
-            parser.option(VERSION, "version").hasDescription("Print version info and exit.");
-            parser.option(VERSION_CONTINUE, "show-version").hasDescription("Print version info and continue.");
+            parser.option(VERSION, "version").hasDescription("Prints version information and exits.");
+            parser.option(VERSION_CONTINUE, "show-version").hasDescription("Prints version information and continues.");
         }
 
         @Override

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/internal/HelpRenderer.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/internal/HelpRenderer.java
@@ -93,8 +93,8 @@ public final class HelpRenderer {
         new BuildOptionBackedConverter<>(new DaemonBuildOptions()).configure(parser);
         // Built-in options: -h/--help/-?, -v/--version, -V/--show-version
         parser.option("h", "?", "help").hasDescription("Shows this help message.");
-        parser.option("v", "version").hasDescription("Print version info and exit.");
-        parser.option("V", "show-version").hasDescription("Print version info and continue.");
+        parser.option("v", "version").hasDescription("Prints version information and exits.");
+        parser.option("V", "show-version").hasDescription("Prints version information and continues.");
         return parser;
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -253,7 +253,7 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         public static final String GRADLE_PROPERTY = "org.gradle.daemon";
 
         public DaemonOption() {
-            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("daemon", "Uses the Gradle daemon to run the build. Starts the daemon if not running.", "Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default."));
+            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("daemon", "Uses the Gradle daemon to run the build. Starts the daemon if it is not running.", "Runs the build without the Gradle daemon. Useful occasionally if you have configured Gradle to always run with the daemon by default."));
         }
 
         @Override
@@ -286,7 +286,7 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
 
     public static class StatusOption extends EnabledOnlyBooleanBuildOption<DaemonParameters> {
         public StatusOption() {
-            super(null, CommandLineOptionConfiguration.create("status", "Shows status of running and recently stopped Gradle daemon(s)."));
+            super(null, CommandLineOptionConfiguration.create("status", "Shows the status of running and recently stopped Gradle daemons."));
         }
 
         @Override
@@ -299,7 +299,7 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         public static final String GRADLE_PROPERTY = "org.gradle.priority";
 
         public PriorityOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create("priority", "Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'"));
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create("priority", "Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Supported values are 'normal' (default) or 'low'."));
         }
 
         @Override

--- a/platforms/core-runtime/launcher/src/testFixtures/groovy/org/gradle/launcher/cli/HelpFixture.groovy
+++ b/platforms/core-runtime/launcher/src/testFixtures/groovy/org/gradle/launcher/cli/HelpFixture.groovy
@@ -28,67 +28,67 @@ To see a list of available tasks, run gradle tasks
 USAGE: gradle [option...] [task...]
 
 -?, -h, --help                     Shows this help message.
--a, --no-rebuild                   Do not rebuild project dependencies.
+-a, --no-rebuild                   Disables rebuilding of project dependencies.
 --build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
 --no-build-cache                   Disables the Gradle build cache.
 --configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds.
 --no-configuration-cache           Disables the configuration cache.
---configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Defaults to fail.
---configure-on-demand              Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
+--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Supported values are 'warn', or 'fail' (default).
+--configure-on-demand              Configures necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
 --no-configure-on-demand           Disables the use of configuration on demand. [incubating]
---console                          Specifies which type of console output to generate. Values are 'plain', 'colored', 'auto' (default), 'rich' or 'verbose'.
---console-unicode                  Specifies which character types are allowed in console output to generate. Values are 'auto' (default), 'disable' or 'enable'.
---continue                         Continue task execution after a task failure.
---no-continue                      Stop task execution after a task failure.
--D, --system-prop                  Set system property of the JVM (e.g. -Dmyprop=myvalue).
--d, --debug                        Log in debug mode (includes normal stacktrace).
---daemon                           Uses the Gradle daemon to run the build. Starts the daemon if not running.
---no-daemon                        Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
+--console                          Specifies which type of console output to generate. Supported values are 'plain', 'colored', 'auto' (default), 'rich', or 'verbose'.
+--console-unicode                  Specifies which character types are allowed in the console output. Supported values are 'auto' (default), 'disable', or 'enable'.
+--continue                         Continues task execution after a task failure.
+--no-continue                      Stops task execution after a task failure.
+-D, --system-prop                  Sets a JVM system property (for example, -Dmyprop=myvalue).
+-d, --debug                        Sets log level to debug. Includes the normal stacktrace.
+--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if it is not running.
+--no-daemon                        Runs the build without the Gradle daemon. Useful occasionally if you have configured Gradle to always run with the daemon by default.
 --export-keys                      Exports the public keys used for dependency verification.
--F, --dependency-verification      Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.
+-F, --dependency-verification      Configures the dependency verification mode. Supported values are 'strict', 'lenient', or 'off'.
 --foreground                       Starts the Gradle daemon in the foreground.
--g, --gradle-user-home             Specifies the Gradle user home directory. Defaults to ~/.gradle
--I, --init-script                  Specify an initialization script.
--i, --info                         Set log level to info.
---include-build                    Include the specified build in the composite.
--M, --write-verification-metadata  Generates checksums for dependencies used in the project (comma-separated list)
--m, --dry-run                      Run the builds with all task actions disabled.
---max-workers                      Configure the number of concurrent workers Gradle is allowed to use.
---offline                          Execute the build without accessing network resources.
--P, --project-prop                 Set project property for the build script (e.g. -Pmyprop=myvalue).
--p, --project-dir                  Specifies the start directory for Gradle. Defaults to current directory.
---parallel                         Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
---no-parallel                      Disables parallel execution to build projects.
---priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are 'normal' (default) or 'low'
---problems-report                  (Experimental) enables HTML problems report
---no-problems-report               (Experimental) disables HTML problems report
---profile                          Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
---project-cache-dir                Specify the project-specific cache directory. Defaults to .gradle in the root project directory.
---property-upgrade-report          (Experimental) Runs build with experimental property upgrade report.
--q, --quiet                        Log errors only.
---refresh-keys                     Refresh the public keys used for dependency verification.
---rerun-tasks                      Ignore previously cached task results.
--S, --full-stacktrace              Print out the full (very verbose) stacktrace for all exceptions.
--s, --stacktrace                   Print out the stacktrace for all exceptions.
---scan                             Generate a Build Scan (powered by Develocity).
+-g, --gradle-user-home             Specifies the Gradle user home directory. Default is ~/.gradle.
+-I, --init-script                  Specifies an initialization script.
+-i, --info                         Sets the log level to info.
+--include-build                    Includes the specified build in the composite.
+-M, --write-verification-metadata  Generates checksums for dependencies used in the project. Accepts a comma-separated list.
+-m, --dry-run                      Runs the build with all task actions disabled.
+--max-workers                      Configures the maximum number of concurrent workers Gradle is allowed to use.
+--offline                          Runs the build without accessing network resources.
+-P, --project-prop                 Sets a project property for the build script (for example, -Pmyprop=myvalue).
+-p, --project-dir                  Specifies the start directory for Gradle. Default is the current directory.
+--parallel                         Builds projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
+--no-parallel                      Disables parallel project execution.
+--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Supported values are 'normal' (default) or 'low'.
+--problems-report                  Enables the HTML problems report. [incubating]
+--no-problems-report               Disables the HTML problems report. [incubating]
+--profile                          Profiles build execution time. Generates a report in the <build_dir>/reports/profile directory.
+--project-cache-dir                Specifies the project-specific cache directory. Default is .gradle in the root project directory.
+--property-upgrade-report          Runs the build with the experimental property upgrade report. [incubating]
+-q, --quiet                        Logs errors only.
+--refresh-keys                     Refreshes the public keys used for dependency verification.
+--rerun-tasks                      Ignores previously cached task results.
+-S, --full-stacktrace              Prints the full (very verbose) stacktrace for all exceptions.
+-s, --stacktrace                   Prints the stacktrace for all exceptions.
+--scan                             Generates a Build Scan (powered by Develocity).
                                    Build Scan and Develocity are registered trademarks of Gradle, Inc.
                                    For more information, please visit https://gradle.com/develocity/product/build-scan/.
 --no-scan                          Disables the creation of a Build Scan.
---status                           Shows status of running and recently stopped Gradle daemon(s).
+--status                           Shows the status of running and recently stopped Gradle daemons.
 --stop                             Stops the Gradle daemon if it is running.
 -t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
---task-graph                       Print task graph instead of executing tasks.
--U, --refresh-dependencies         Refresh the state of dependencies.
---update-locks                     Perform a partial update of the dependency lock, letting passed in module notations change version. [incubating]
--V, --show-version                 Print version info and continue.
--v, --version                      Print version info and exit.
--w, --warn                         Set log level to warn.
---warning-mode                     Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'
---watch-fs                         Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.
---no-watch-fs                      Disables watching the file system.
---write-locks                      Persists dependency resolution for locked configurations, ignoring existing locking information if it exists
--x, --exclude-task                 Specify a task to be excluded from execution.
---                                 Signals the end of built-in options. Gradle parses subsequent parameters as only tasks or task options.
+--task-graph                       Prints the task graph instead of executing tasks.
+-U, --refresh-dependencies         Refreshes the state of dependencies.
+--update-locks                     Performs a partial update of the dependency lock. Allows passed-in module notations to change version. [incubating]
+-V, --show-version                 Prints version information and continues.
+-v, --version                      Prints version information and exits.
+-w, --warn                         Sets the log level to warn.
+--warning-mode                     Specifies which mode of warnings to generate. Supported values are 'all', 'fail', 'summary' (default), or 'none'.
+--watch-fs                         Enables file system watching. Reuses file system data for subsequent builds.
+--no-watch-fs                      Disables file system watching.
+--write-locks                      Persists dependency resolution for locked configurations. Ignores existing locking information if it exists.
+-x, --exclude-task                 Specifies a task to exclude from execution.
+--                                 Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.
 
 '''
 }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -78,10 +78,10 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
         public LogLevelOption() {
             super(
                 GRADLE_PROPERTY,
-                CommandLineOptionConfiguration.create(QUIET_LONG_OPTION, QUIET_SHORT_OPTION, "Log errors only."),
-                CommandLineOptionConfiguration.create(WARN_LONG_OPTION, WARN_SHORT_OPTION, "Set log level to warn."),
-                CommandLineOptionConfiguration.create(INFO_LONG_OPTION, INFO_SHORT_OPTION, "Set log level to info."),
-                CommandLineOptionConfiguration.create(DEBUG_LONG_OPTION, DEBUG_SHORT_OPTION, "Log in debug mode (includes normal stacktrace).")
+                CommandLineOptionConfiguration.create(QUIET_LONG_OPTION, QUIET_SHORT_OPTION, "Logs errors only."),
+                CommandLineOptionConfiguration.create(WARN_LONG_OPTION, WARN_SHORT_OPTION, "Sets the log level to warn."),
+                CommandLineOptionConfiguration.create(INFO_LONG_OPTION, INFO_SHORT_OPTION, "Sets the log level to info."),
+                CommandLineOptionConfiguration.create(DEBUG_LONG_OPTION, DEBUG_SHORT_OPTION, "Sets log level to debug. Includes the normal stacktrace.")
             );
         }
 
@@ -140,7 +140,7 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
         private static final String[] ALL_SHORT_OPTIONS = new String[]{STACKTRACE_SHORT_OPTION, FULL_STACKTRACE_SHORT_OPTION};
 
         public StacktraceOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(STACKTRACE_LONG_OPTION, STACKTRACE_SHORT_OPTION, "Print out the stacktrace for all exceptions."), CommandLineOptionConfiguration.create(FULL_STACKTRACE_LONG_OPTION, FULL_STACKTRACE_SHORT_OPTION, "Print out the full (very verbose) stacktrace for all exceptions."));
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(STACKTRACE_LONG_OPTION, STACKTRACE_SHORT_OPTION, "Prints the stacktrace for all exceptions."), CommandLineOptionConfiguration.create(FULL_STACKTRACE_LONG_OPTION, FULL_STACKTRACE_SHORT_OPTION, "Prints the full (very verbose) stacktrace for all exceptions."));
         }
 
         @Override
@@ -184,7 +184,7 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
         public static final String GRADLE_PROPERTY = "org.gradle.console";
 
         public ConsoleOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which type of console output to generate. Values are 'plain', 'colored', 'auto' (default), 'rich' or 'verbose'."));
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which type of console output to generate. Supported values are 'plain', 'colored', 'auto' (default), 'rich', or 'verbose'."));
         }
 
         @Override
@@ -206,7 +206,7 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
         public static final String GRADLE_PROPERTY = "org.gradle.console.unicode";
 
         public ConsoleUnicodeOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which character types are allowed in console output to generate. Values are 'auto' (default), 'disable' or 'enable'."));
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which character types are allowed in the console output. Supported values are 'auto' (default), 'disable', or 'enable'."));
         }
 
         @Override
@@ -227,7 +227,7 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
         public static final String GRADLE_PROPERTY = "org.gradle.warning.mode";
 
         public WarningsOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'"));
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which mode of warnings to generate. Supported values are 'all', 'fail', 'summary' (default), or 'none'."));
         }
 
         @Override

--- a/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper-main/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -35,7 +35,7 @@ import java.util.jar.Manifest
 import static org.hamcrest.CoreMatchers.containsString
 
 class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
-    private static final HashCode EXPECTED_WRAPPER_JAR_HASH = HashCode.fromString("55243ef57851f12b070ad14f7f5bb8302daceeebc5bce5ece5fa6edb23e1145c")
+    private static final HashCode EXPECTED_WRAPPER_JAR_HASH = HashCode.fromString("7ef3d73bd95c047814d76ec8324f72deefb96593eb9ce87aa06ecdcdaba7ffe8")
 
     def "generated wrapper scripts use correct line separators"() {
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildLayoutParametersBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildLayoutParametersBuildOptions.java
@@ -47,7 +47,7 @@ public class BuildLayoutParametersBuildOptions extends BuildOptionSet<BuildLayou
 
     public static class GradleUserHomeOption extends StringBuildOption<BuildLayoutParameters> {
         public GradleUserHomeOption() {
-            super(BuildLayoutParameters.GRADLE_USER_HOME_PROPERTY_KEY, CommandLineOptionConfiguration.create("gradle-user-home", "g", "Specifies the Gradle user home directory. Defaults to ~/.gradle"));
+            super(BuildLayoutParameters.GRADLE_USER_HOME_PROPERTY_KEY, CommandLineOptionConfiguration.create("gradle-user-home", "g", "Specifies the Gradle user home directory. Default is ~/.gradle."));
         }
 
         @Override
@@ -59,7 +59,7 @@ public class BuildLayoutParametersBuildOptions extends BuildOptionSet<BuildLayou
 
     public static class ProjectDirOption extends StringBuildOption<BuildLayoutParameters> {
         public ProjectDirOption() {
-            super(null, CommandLineOptionConfiguration.create("project-dir", "p", "Specifies the start directory for Gradle. Defaults to current directory."));
+            super(null, CommandLineOptionConfiguration.create("project-dir", "p", "Specifies the start directory for Gradle. Default is the current directory."));
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/ParallelismBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ParallelismBuildOptions.java
@@ -43,7 +43,7 @@ public class ParallelismBuildOptions extends BuildOptionSet<ParallelismConfigura
         public static final String GRADLE_PROPERTY = "org.gradle.parallel";
 
         public ParallelOption() {
-            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("parallel", "Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.", "Disables parallel execution to build projects."));
+            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("parallel", "Builds projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.", "Disables parallel project execution."));
         }
 
         @Override
@@ -58,7 +58,7 @@ public class ParallelismBuildOptions extends BuildOptionSet<ParallelismConfigura
         public static final String HINT = "must be a positive, non-zero, integer";
 
         public MaxWorkersOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Configure the number of concurrent workers Gradle is allowed to use."));
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Configures the maximum number of concurrent workers Gradle is allowed to use."));
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -101,7 +101,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         public static final String PROPERTY_NAME = "org.gradle.projectcachedir";
 
         public ProjectCacheDirOption() {
-            super(PROPERTY_NAME, CommandLineOptionConfiguration.create("project-cache-dir", "Specify the project-specific cache directory. Defaults to .gradle in the root project directory."));
+            super(PROPERTY_NAME, CommandLineOptionConfiguration.create("project-cache-dir", "Specifies the project-specific cache directory. Default is .gradle in the root project directory."));
         }
 
         @Override
@@ -113,7 +113,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class RerunTasksOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
         public RerunTasksOption() {
-            super(null, CommandLineOptionConfiguration.create("rerun-tasks", "Ignore previously cached task results."));
+            super(null, CommandLineOptionConfiguration.create("rerun-tasks", "Ignores previously cached task results."));
         }
 
         @Override
@@ -124,7 +124,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class ProfileOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
         public ProfileOption() {
-            super(null, CommandLineOptionConfiguration.create("profile", "Profile build execution time and generates a report in the <build_dir>/reports/profile directory."));
+            super(null, CommandLineOptionConfiguration.create("profile", "Profiles build execution time. Generates a report in the <build_dir>/reports/profile directory."));
         }
 
         @Override
@@ -143,8 +143,8 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
                 PROPERTY_NAME,
                 BooleanCommandLineOptionConfiguration.create(
                     LONG_OPTION,
-                    "Continue task execution after a task failure.",
-                    "Stop task execution after a task failure."
+                    "Continues task execution after a task failure.",
+                    "Stops task execution after a task failure."
                 )
             );
         }
@@ -157,7 +157,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class OfflineOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
         public OfflineOption() {
-            super(null, CommandLineOptionConfiguration.create("offline", "Execute the build without accessing network resources."));
+            super(null, CommandLineOptionConfiguration.create("offline", "Runs the build without accessing network resources."));
         }
 
         @Override
@@ -168,7 +168,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class RefreshDependenciesOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
         public RefreshDependenciesOption() {
-            super(null, CommandLineOptionConfiguration.create("refresh-dependencies", "U", "Refresh the state of dependencies."));
+            super(null, CommandLineOptionConfiguration.create("refresh-dependencies", "U", "Refreshes the state of dependencies."));
         }
 
         @Override
@@ -179,7 +179,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class DryRunOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
         public DryRunOption() {
-            super(null, CommandLineOptionConfiguration.create("dry-run", "m", "Run the builds with all task actions disabled."));
+            super(null, CommandLineOptionConfiguration.create("dry-run", "m", "Runs the build with all task actions disabled."));
         }
 
         @Override
@@ -218,7 +218,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         private static final String SHORT_OPTION = "a";
 
         public NoProjectDependenciesRebuildOption() {
-            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, SHORT_OPTION, "Do not rebuild project dependencies."));
+            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, SHORT_OPTION, "Disables rebuilding of project dependencies."));
         }
 
         @Override
@@ -229,7 +229,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class InitScriptOption extends ListBuildOption<StartParameterInternal> {
         public InitScriptOption() {
-            super(null, CommandLineOptionConfiguration.create("init-script", "I", "Specify an initialization script."));
+            super(null, CommandLineOptionConfiguration.create("init-script", "I", "Specifies an initialization script."));
         }
 
         @Override
@@ -244,7 +244,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class ExcludeTaskOption extends ListBuildOption<StartParameterInternal> {
         public ExcludeTaskOption() {
-            super(null, CommandLineOptionConfiguration.create("exclude-task", "x", "Specify a task to be excluded from execution."));
+            super(null, CommandLineOptionConfiguration.create("exclude-task", "x", "Specifies a task to exclude from execution."));
         }
 
         @Override
@@ -255,7 +255,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class IncludeBuildOption extends ListBuildOption<StartParameterInternal> {
         public IncludeBuildOption() {
-            super(null, CommandLineOptionConfiguration.create("include-build", "Include the specified build in the composite."));
+            super(null, CommandLineOptionConfiguration.create("include-build", "Includes the specified build in the composite."));
         }
 
         @Override
@@ -272,7 +272,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         public static final String GRADLE_PROPERTY = "org.gradle.configureondemand";
 
         public ConfigureOnDemandOption() {
-            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("configure-on-demand", "Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds.", "Disables the use of configuration on demand.").incubating());
+            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create("configure-on-demand", "Configures necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds.", "Disables the use of configuration on demand.").incubating());
         }
 
         @Override
@@ -314,8 +314,8 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         public WatchFileSystemOption() {
             super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create(
                 LONG_OPTION,
-                "Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.",
-                "Disables watching the file system."
+                "Enables file system watching. Reuses file system data for subsequent builds.",
+                "Disables file system watching."
             ));
         }
 
@@ -346,7 +346,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
         public BuildScanOption() {
             super(null, BooleanCommandLineOptionConfiguration.create(LONG_OPTION,
-                "Generate a Build Scan (powered by Develocity).\n" +
+                "Generates a Build Scan (powered by Develocity).\n" +
                     "                                   Build Scan and Develocity are registered trademarks of Gradle, Inc.\n" +
                     "                                   For more information, please visit https://gradle.com/develocity/product/build-scan/.",
                 "Disables the creation of a Build Scan."));
@@ -366,7 +366,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         public static final String LONG_OPTION = "write-locks";
 
         public DependencyLockingWriteOption() {
-            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "Persists dependency resolution for locked configurations, ignoring existing locking information if it exists"));
+            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "Persists dependency resolution for locked configurations. Ignores existing locking information if it exists."));
         }
 
         @Override
@@ -381,7 +381,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
         DependencyVerificationWriteOption() {
             super(null, CommandLineOptionConfiguration.create(LONG_OPTION, SHORT_OPTION,
-                "Generates checksums for dependencies used in the project (comma-separated list)"));
+                "Generates checksums for dependencies used in the project. Accepts a comma-separated list."));
         }
 
         @Override
@@ -409,7 +409,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
                 DependencyVerificationMode.values(),
                 GRADLE_PROPERTY,
                 CommandLineOptionConfiguration.create(
-                    LONG_OPTION, SHORT_OPTION, "Configures the dependency verification mode. Values are 'strict', 'lenient' or 'off'.")
+                    LONG_OPTION, SHORT_OPTION, "Configures the dependency verification mode. Supported values are 'strict', 'lenient', or 'off'.")
             );
         }
 
@@ -422,7 +422,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
     public static class DependencyLockingUpdateOption extends ListBuildOption<StartParameterInternal> {
 
         public DependencyLockingUpdateOption() {
-            super(null, CommandLineOptionConfiguration.create("update-locks", "Perform a partial update of the dependency lock, letting passed in module notations change version.").incubating());
+            super(null, CommandLineOptionConfiguration.create("update-locks", "Performs a partial update of the dependency lock. Allows passed-in module notations to change version.").incubating());
         }
 
         @Override
@@ -437,7 +437,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
         public RefreshKeysOption() {
             super(null,
-                CommandLineOptionConfiguration.create(LONG_OPTION, "Refresh the public keys used for dependency verification."));
+                CommandLineOptionConfiguration.create(LONG_OPTION, "Refreshes the public keys used for dependency verification."));
         }
 
         @Override
@@ -516,7 +516,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
                 DEPRECATED_PROPERTY_NAME,
                 CommandLineOptionConfiguration.create(
                     LONG_OPTION,
-                    "Configures how the configuration cache handles problems (fail or warn). Defaults to fail."
+                    "Configures how the configuration cache handles problems (fail or warn). Supported values are 'warn', or 'fail' (default)."
                 )
             );
         }
@@ -741,7 +741,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         public static final String LONG_OPTION = "property-upgrade-report";
 
         public PropertyUpgradeReportOption() {
-            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "(Experimental) Runs build with experimental property upgrade report."));
+            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "Runs the build with the experimental property upgrade report.").incubating());
         }
 
         @Override
@@ -756,7 +756,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         public static final String GRADLE_PROPERTY = "org.gradle.problems.report";
 
         public ProblemReportGenerationOption() {
-            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create(LONG_OPTION, "(Experimental) enables HTML problems report", "(Experimental) disables HTML problems report"));
+            super(GRADLE_PROPERTY, BooleanCommandLineOptionConfiguration.create(LONG_OPTION, "Enables the HTML problems report.", "Disables the HTML problems report.").incubating());
         }
 
         @Override
@@ -770,7 +770,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         public static final String LONG_OPTION = "task-graph";
 
         public TaskGraphOption() {
-            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "Print task graph instead of executing tasks."));
+            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "Prints the task graph instead of executing tasks."));
         }
 
         @Override

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ParallelismConfigurationCommandLineConverterTest.groovy
@@ -73,7 +73,7 @@ class ParallelismConfigurationCommandLineConverterTest extends Specification {
 
         then:
         Throwable t = thrown(CommandLineArgumentException)
-        t.message == "No argument was provided for command-line option '--max-workers' with description: 'Configure the number of concurrent workers Gradle is allowed to use.'"
+        t.message == "No argument was provided for command-line option '--max-workers' with description: 'Configures the maximum number of concurrent workers Gradle is allowed to use.'"
     }
 
     ParallelismConfiguration convert(String... args) {


### PR DESCRIPTION
The updated output is below. The diff is available [here](https://github.com/gradle/gradle/pull/36890/changes#diff-e9ebc85b79b4b9daec03cbf86f4990daa9d5d817359c33998525ffdb871b8505).

```
-?, -h, --help                     Shows this help message.
-a, --no-rebuild                   Does not rebuild project dependencies.
--build-cache                      Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
--no-build-cache                   Disables the Gradle build cache.
--configuration-cache              Enables the configuration cache. Gradle will try to reuse the build configuration from previous builds.
--no-configuration-cache           Disables the configuration cache.
--configuration-cache-problems     Configures how the configuration cache handles problems (fail or warn). Supported values are 'warn', or 'fail' (default).
--configure-on-demand              Configures necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
--no-configure-on-demand           Disables the use of configuration on demand. [incubating]
--console                          Specifies which type of console output to generate. Supported values are 'plain', 'colored', 'auto' (default), 'rich', or 'verbose'.
--console-unicode                  Specifies which character types are allowed in the console output. Supported values are 'auto' (default), 'disable', or 'enable'.
--continue                         Continues task execution after a task failure.
--no-continue                      Stops task execution after a task failure.
-D, --system-prop                  Sets a JVM system property (fo example, -Dmyprop=myvalue).
-d, --debug                        Sets log level to debug. Includes the normal stacktrace.
--daemon                           Uses the Gradle daemon to run the build. Starts the daemon if it is not running.
--no-daemon                        Does not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
--export-keys                      Exports the public keys used for dependency verification.
-F, --dependency-verification      Configures the dependency verification mode. Supported values are 'strict', 'lenient', or 'off'.
--foreground                       Starts the Gradle daemon in the foreground.
-g, --gradle-user-home             Specifies the Gradle user home directory. Default is ~/.gradle.
-I, --init-script                  Specifies an initialization script.
-i, --info                         Sets the log level to info.
--include-build                    Includes the specified build in the composite.
-M, --write-verification-metadata  Generates checksums for dependencies used in the project. Accepts a comma-separated list.
-m, --dry-run                      Runs the build with all task actions disabled.
--max-workers                      Configures the maximum number of concurrent workers Gradle is allowed to use.
--offline                          Invokes the build without accessing network resources.
-P, --project-prop                 Sets a project property for the build script (for example, -Pmyprop=myvalue).
-p, --project-dir                  Specifies the start directory for Gradle. Default is the current directory.
--parallel                         Builds projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use.
--no-parallel                      Disables parallel project execution.
--priority                         Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Supported values are 'normal' (default) or 'low'.
--problems-report                  Enables the HTML problems report. [incubating]
--no-problems-report               Disables the HTML problems report. [incubating]
--profile                          Profiles build execution time. Generates a report in the <build_dir>/reports/profile directory.
--project-cache-dir                Specifies the project-specific cache directory. Default is .gradle in the root project directory.
--property-upgrade-report          Runs the build with the experimental property upgrade report. [incubating]
-q, --quiet                        Logs errors only.
--refresh-keys                     Refreshes the public keys used for dependency verification.
--rerun-tasks                      Ignores previously cached task results.
-S, --full-stacktrace              Prints the full (very verbose) stacktrace for all exceptions.
-s, --stacktrace                   Prints the stacktrace for all exceptions.
--scan                             Generates a Build Scan (powered by Develocity).
                                   Build Scan and Develocity are registered trademarks of Gradle, Inc.
                                   For more information, please visit https://gradle.com/develocity/product/build-scan/.
--no-scan                          Disables the creation of a Build Scan.
--status                           Shows the status of running and recently stopped Gradle daemons.
--stop                             Stops the Gradle daemon if it is running.
-t, --continuous                   Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change.
--task-graph                       Prints the task graph instead of executing tasks.
-U, --refresh-dependencies         Refreshes the state of dependencies.
--update-locks                     Performs a partial update of the dependency lock. Allows passed-in module notations to change version. [incubating]
-V, --show-version                 Prints version information and continues.
-v, --version                      Prints version information and exits.
-w, --warn                         Sets the log level to warn.
--warning-mode                     Specifies which mode of warnings to generate. Supported values are 'all', 'fail', 'summary' (default), or 'none'.
--watch-fs                         Enables file system watching. Reuses file system data for subsequent builds.
--no-watch-fs                      Disables file system watching.
--write-locks                      Persists dependency resolution for locked configurations. Ignores existing locking information if it exists.
-x, --exclude-task                 Specifies a task to exclude from execution.
--                                 Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.
```

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
