### PR TITLE
Add clickable links to files in console output upon failure

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -19,8 +19,10 @@ package org.gradle.kotlin.dsl.integration
 import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okio.Path.Companion.toPath
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
+import org.gradle.internal.buildevents.BuildExceptionReporter
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DeepThought
@@ -616,6 +618,7 @@ class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
 
                 * Where:
                 Build file '${buildFile.canonicalPath}' line: 1
+                  ${BuildExceptionReporter.formatClickableLink(buildFile.canonicalPath, 1)}
 
                 * What went wrong:
                 Script compilation error:
@@ -664,6 +667,7 @@ class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
 
                     * Where:
                     Build file '${buildFile.canonicalPath}' line: 1
+                      ${BuildExceptionReporter.formatClickableLink(buildFile.canonicalPath, 1)}
 
                     * What went wrong:
                     Script compilation errors:

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -22,7 +22,7 @@ import okhttp3.mockwebserver.MockWebServer
 import okio.Path.Companion.toPath
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
-import org.gradle.internal.buildevents.BuildExceptionReporter
+import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DeepThought
@@ -46,6 +46,9 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import spock.lang.Issue
 
+
+private fun formatClickableLink(file: java.io.File, lineNumber: Int = 1): String =
+    "(Clickable link: ${ConsoleRenderer().asClickableFileUrl(file, lineNumber)})"
 
 class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
 
@@ -618,7 +621,7 @@ class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
 
                 * Where:
                 Build file '${buildFile.canonicalPath}' line: 1
-                  ${BuildExceptionReporter.formatClickableLink(buildFile.canonicalPath, 1)}
+                  ${formatClickableLink(buildFile)}
 
                 * What went wrong:
                 Script compilation error:
@@ -667,7 +670,7 @@ class GradleKotlinDslIntegrationTest : AbstractKotlinIntegrationTest() {
 
                     * Where:
                     Build file '${buildFile.canonicalPath}' line: 1
-                      ${BuildExceptionReporter.formatClickableLink(buildFile.canonicalPath, 1)}
+                      ${formatClickableLink(buildFile)}
 
                     * What went wrong:
                     Script compilation errors:

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptException.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptException.kt
@@ -34,6 +34,6 @@ private
 fun reduceCause(cause: Throwable?): Throwable? =
     when (cause) {
         is InvocationTargetException -> reduceCause(cause.targetException)
-        is LocationAwareException -> if (cause.location == null && cause.cause != null) reduceCause(cause.cause!!) else cause
+        is LocationAwareException -> if (cause.describeLocation() == null && cause.cause != null) reduceCause(cause.cause!!) else cause
         else -> cause
     }

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -293,6 +293,7 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
             throw LocationAwareException(
                 IllegalArgumentException(validationErrors.joinToString("\n")),
                 plugin.scriptFile.path,
+                plugin.scriptFile.path,
                 requests.first().lineNumber
             )
         }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
@@ -40,7 +40,7 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
 
         val reports = buildEditorReportsFor(
             script,
-            listOf(LocationAwareException(Exception("BOOM"), script.canonicalPath, 3)),
+            listOf(LocationAwareException(Exception("BOOM"), script.canonicalPath, script.canonicalPath, 3)),
             true
         )
 
@@ -59,7 +59,7 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
 
         val reports = buildEditorReportsFor(
             script,
-            listOf(LocationAwareException(Exception("BOOM"), script.canonicalPath, 3)),
+            listOf(LocationAwareException(Exception("BOOM"), script.canonicalPath, script.canonicalPath, 3)),
             true
         )
 
@@ -80,8 +80,8 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
         val reports = buildEditorReportsFor(
             script,
             listOf(
-                LocationAwareException(java.lang.Exception(null as String?), script.canonicalPath, 1),
-                LocationAwareException(java.lang.Exception(""), script.canonicalPath, 2)
+                LocationAwareException(java.lang.Exception(null as String?), script.canonicalPath, script.canonicalPath, 1),
+                LocationAwareException(java.lang.Exception(""), script.canonicalPath, script.canonicalPath, 2)
             ),
             true
         )

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
@@ -1,5 +1,6 @@
 package org.gradle.kotlin.dsl.integration
 
+import org.gradle.internal.buildevents.BuildExceptionReporter
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 
@@ -116,6 +117,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractKotlinIntegrationTe
             """
             * Where:
             Script '${present.canonicalPath}' line: 1
+              ${BuildExceptionReporter.formatClickableLink(present.canonicalPath, 1)}
 
             * What went wrong:
             Could not read script '${existing("absent.gradle.kts").canonicalPath}' as it does not exist.

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
@@ -1,12 +1,15 @@
 package org.gradle.kotlin.dsl.integration
 
-import org.gradle.internal.buildevents.BuildExceptionReporter
+import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 
+
+private fun formatClickableLink(file: java.io.File, lineNumber: Int = 1): String =
+    "(Clickable link: ${ConsoleRenderer().asClickableFileUrl(file, lineNumber)})"
 
 class LocationAwareScriptEvaluationIntegrationTest : AbstractKotlinIntegrationTest() {
 
@@ -117,7 +120,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractKotlinIntegrationTe
             """
             * Where:
             Script '${present.canonicalPath}' line: 1
-              ${BuildExceptionReporter.formatClickableLink(present.canonicalPath, 1)}
+              ${formatClickableLink(present)}
 
             * What went wrong:
             Could not read script '${existing("absent.gradle.kts").canonicalPath}' as it does not exist.

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/ConsoleRenderer.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/ConsoleRenderer.java
@@ -18,7 +18,7 @@ package org.gradle.internal.logging;
 
 import org.gradle.internal.UncheckedException;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/ConsoleRenderer.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/ConsoleRenderer.java
@@ -18,6 +18,7 @@ package org.gradle.internal.logging;
 
 import org.gradle.internal.UncheckedException;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -38,5 +39,20 @@ public class ConsoleRenderer {
         } catch (URISyntaxException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
+    }
+
+    /**
+     * Renders a path name as a file URL that is likely recognized by consoles,
+     * optionally including a line number suffix.
+     *
+     * @param path the file path to render
+     * @param lineNumber the optional line number to append
+     */
+    public String asClickableFileUrl(File path, @Nullable Integer lineNumber) {
+        String url = asClickableFileUrl(path);
+        if (lineNumber != null) {
+            url = url + ":" + lineNumber;
+        }
+        return url;
     }
 }

--- a/platforms/core-runtime/logging/src/test/groovy/org/gradle/logging/ConsoleRendererTest.groovy
+++ b/platforms/core-runtime/logging/src/test/groovy/org/gradle/logging/ConsoleRendererTest.groovy
@@ -35,4 +35,18 @@ class ConsoleRendererTest extends Specification {
         expect:
         renderer.asClickableFileUrl(new File("C:\\foo\\teŝt files\\bar")) == "file:///C:/foo/te%C5%9Dt%20files/bar"
     }
+
+    @Requires(UnitTestPreconditions.NotWindows)
+    def "appends line number to file URL when provided"() {
+        expect:
+        renderer.asClickableFileUrl(new File("/foo/bar"), 42) == "file:///foo/bar:42"
+    }
+
+    @Requires(UnitTestPreconditions.NotWindows)
+    def "returns same URL when line number is null"() {
+        def file = new File("/foo/bar")
+
+        expect:
+        renderer.asClickableFileUrl(file, null) == renderer.asClickableFileUrl(file)
+    }
 }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/exceptions/ExceptionMetadataHelper.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/exceptions/ExceptionMetadataHelper.java
@@ -61,7 +61,7 @@ public final class ExceptionMetadataHelper {
             if (laeLineNumber != null) {
                 metadata.put(METADATA_KEY_LINE_NUMBER, laeLineNumber.toString());
             }
-            metadata.put(METADATA_KEY_LOCATION, lae.getLocation());
+            metadata.put(METADATA_KEY_LOCATION, lae.describeLocation());
         }
 
         if (t instanceof MultiCauseException) {

--- a/platforms/enterprise/enterprise/src/test/groovy/org/gradle/internal/enterprise/exceptions/ExceptionMetadataHelperTest.groovy
+++ b/platforms/enterprise/enterprise/src/test/groovy/org/gradle/internal/enterprise/exceptions/ExceptionMetadataHelperTest.groovy
@@ -54,7 +54,7 @@ class ExceptionMetadataHelperTest extends Specification {
         def l = 57
         def c = new RuntimeException("!")
         def s = "source"
-        def e = new LocationAwareException(c, s, l)
+        def e = new LocationAwareException(c, null, s, l)
 
         expect:
         with(ExceptionMetadataHelper.getMetadata(e)) {
@@ -67,7 +67,7 @@ class ExceptionMetadataHelperTest extends Specification {
     def "can deal with LAE when everything is null"() {
         given:
         def c = new RuntimeException("!")
-        def e = new LocationAwareException(c, null as String, null)
+        def e = new LocationAwareException(c, null, null as String, null)
 
         expect:
         with(ExceptionMetadataHelper.getMetadata(e)) {

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/GeneratePluginAdaptersTask.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/GeneratePluginAdaptersTask.java
@@ -147,6 +147,7 @@ public abstract class GeneratePluginAdaptersTask extends DefaultTask {
         }
         if (!validationErrors.isEmpty()) {
             throw new LocationAwareException(new IllegalArgumentException(String.join("\n", validationErrors)),
+                scriptPlugin.getBodySource().getFileName(),
                 scriptPlugin.getBodySource().getResource().getLocation().getDisplayName(),
                 pluginRequests.iterator().next().getLineNumber());
         }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
@@ -165,7 +165,7 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
                     throw exceptionOccurred(request, e);
                 }
             } catch (Exception e) {
-                throw new LocationAwareException(e, request.getScriptDisplayName(), request.getLineNumber());
+                throw new LocationAwareException(e, null, request.getScriptDisplayName(), request.getLineNumber());
             }
         }
     }
@@ -192,7 +192,7 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
         } catch (Exception e) {
             throw new LocationAwareException(
                 new GradleException(String.format("Error resolving plugin %s", request.getDisplayName()), e),
-                request.getScriptDisplayName(), request.getLineNumber());
+                null, request.getScriptDisplayName(), request.getLineNumber());
         }
 
         return result.getFound(request);

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/PluginResolutionResult.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/PluginResolutionResult.java
@@ -110,7 +110,7 @@ public class PluginResolutionResult {
 
         String message = sb.toString();
         Exception exception = new UnknownPluginException(message);
-        throw new LocationAwareException(exception, request.getScriptDisplayName(), request.getLineNumber());
+        throw new LocationAwareException(exception, null, request.getScriptDisplayName(), request.getLineNumber());
     }
 
     public List<NotFound> getNotFound() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/buildevents/BuildFailureIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/buildevents/BuildFailureIntegrationTest.groovy
@@ -58,4 +58,26 @@ throw new BadException()
         failureCauseContains("BOOM self")
         result.assertHasErrorOutput("Caused by: java.lang.Throwable: [CIRCULAR REFERENCE: java.lang.Exception: BOOM self]")
     }
+
+    def "build file path with spaces produces clickable file URI in failure output"() {
+        given:
+        def projectDir = file("project with spaces")
+        def settings = projectDir.file("settings.gradle")
+        settings.text = ""
+        def buildScript = projectDir.file("build.gradle")
+        buildScript.text = """
+            // line 1
+            this is not valid groovy
+        """
+
+        when:
+        inDirectory(projectDir)
+        fails("help")
+
+        then:
+        failure.assertHasFileName("Build file '${buildScript}'")
+        failure.assertHasLineNumber(3)
+        def expectedLink = BuildExceptionReporter.formatClickableLink(buildScript.absolutePath, 3)
+        result.assertHasErrorOutput(expectedLink)
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/buildevents/BuildFailureIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/buildevents/BuildFailureIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.buildevents
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 
@@ -77,7 +78,7 @@ throw new BadException()
         then:
         failure.assertHasFileName("Build file '${buildScript}'")
         failure.assertHasLineNumber(3)
-        def expectedLink = BuildExceptionReporter.formatClickableLink(buildScript.absolutePath, 3)
-        result.assertHasErrorOutput(expectedLink)
+        def expectedUrl = new ConsoleRenderer().asClickableFileUrl(buildScript, 3)
+        result.assertHasErrorOutput("(Clickable link: " + expectedUrl + ")")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/exception/DefaultExceptionAnalyser.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/exception/DefaultExceptionAnalyser.java
@@ -70,12 +70,14 @@ public class DefaultExceptionAnalyser implements ExceptionCollector {
             return actualException;
         }
 
+        String sourcePath = null;
         String source = null;
         Integer lineNumber = null;
 
         // TODO: remove these special cases
         if (actualException instanceof ScriptCompilationException) {
             ScriptCompilationException scriptCompilationException = (ScriptCompilationException) actualException;
+            sourcePath = scriptCompilationException.getScriptSource().getFileName();
             source = scriptCompilationException.getScriptSource().getLongDisplayName().getCapitalizedDisplayName();
             lineNumber = scriptCompilationException.getLineNumber();
         }
@@ -88,13 +90,14 @@ public class DefaultExceptionAnalyser implements ExceptionCollector {
             ) {
                 Location location = diagnosticsFactory.forException(currentException).getLocation();
                 if (location != null) {
+                    sourcePath = location.getFilePath();
                     source = location.getSourceLongDisplayName().getCapitalizedDisplayName();
                     lineNumber = location.getLineNumber();
                 }
             }
         }
 
-        return new LocationAwareException(actualException, source, lineNumber);
+        return new LocationAwareException(actualException, sourcePath, source, lineNumber);
     }
 
     private static Throwable findDeepestRootException(Throwable exception) {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -47,7 +47,6 @@ import org.gradle.util.internal.GUtil;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-import java.io.File;
 import java.io.StringWriter;
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -544,31 +543,6 @@ public class BuildExceptionReporter implements Action<Throwable> {
             ((StyledException) failure.getOriginal()).render(details);
         } else {
             details.text(getMessage(failure));
-        }
-    }
-
-    /**
-     * Formats a clickable file URI link for IDE console output.
-     * <p>
-     * Creates a properly formatted clickable link that IDEs can recognize in console output.
-     * The file path is converted to a {@code file:} URI with proper percent-encoding.
-     * When a line number is provided, it is appended using the {@code :lineNumber} format.
-     *
-     * @param filePath the absolute file path to format as a clickable link
-     * @param lineNumber the optional line number to append to the URI
-     * @return the formatted clickable link text
-     * @throws IllegalArgumentException if the file path cannot be converted to a URI
-     */
-    public static String formatClickableLink(String filePath, @Nullable Integer lineNumber) {
-        try {
-            File f = new File(filePath);
-            String uri = f.toURI().toASCIIString();
-            if (lineNumber != null) {
-                uri = uri + ":" + lineNumber;
-            }
-            return "(Clickable link: " + uri + ")";
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to format clickable link for path: " + filePath, e);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/ContextAwareExceptionHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/ContextAwareExceptionHandler.java
@@ -46,10 +46,8 @@ public class ContextAwareExceptionHandler {
         }
         visitor.endVisiting();
         if (contextAwareException.getOriginal() instanceof LocationAwareException) {
-            String location = ((LocationAwareException) contextAwareException.getOriginal()).getLocation();
-            if (location != null) {
-                visitor.visitLocation(location);
-            }
+            LocationAwareException original = (LocationAwareException) contextAwareException.getOriginal();
+            visitor.visitLocationException(original);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/ExceptionContextVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/ExceptionContextVisitor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.buildevents;
 
+import org.gradle.internal.exceptions.LocationAwareException;
 import org.gradle.internal.problems.failure.Failure;
 import org.gradle.util.internal.TreeVisitor;
 
@@ -23,7 +24,7 @@ public abstract class ExceptionContextVisitor extends TreeVisitor<Failure> {
 
     protected abstract void visitCause(Failure cause);
 
-    protected abstract void visitLocation(String location);
+    protected abstract void visitLocationException(LocationAwareException location);
 
     /**
      * Should be called after each time this visitor has finished visiting.

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/LocationAwareException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/LocationAwareException.java
@@ -17,25 +17,39 @@ package org.gradle.internal.exceptions;
 
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.groovy.scripts.ScriptSource;
+import org.gradle.internal.buildevents.BuildExceptionReporter;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.jspecify.annotations.Nullable;
+
 
 /**
  * A {@code LocationAwareException} is an exception which can be annotated with a location in a script.
  */
 @UsedByScanPlugin
 public class LocationAwareException extends ContextAwareException implements FailureResolutionAware {
+    private final String sourcePath;
     private final String sourceDisplayName;
     private final Integer lineNumber;
 
     public LocationAwareException(Throwable cause, ScriptSource source, Integer lineNumber) {
-        this(cause, source != null ? source.getDisplayName() : null, lineNumber);
+        this(cause, source != null ? source.getFileName() : null, source != null ? source.getDisplayName() : null, lineNumber);
     }
 
-    public LocationAwareException(Throwable cause, @Nullable String sourceDisplayName, @Nullable Integer lineNumber) {
+    public LocationAwareException(Throwable cause, @Nullable String sourcePath, @Nullable String sourceDisplayName, @Nullable Integer lineNumber) {
         super(cause);
+        this.sourcePath = sourcePath;
         this.sourceDisplayName = sourceDisplayName;
         this.lineNumber = lineNumber;
+    }
+
+    /**
+     * Returns the file path of the script where this exception occurred.
+     *
+     * @return The source file path, or null if not known.
+     */
+    @Nullable
+    public String getSourcePath() {
+        return sourcePath;
     }
 
     /**
@@ -54,7 +68,7 @@ public class LocationAwareException extends ContextAwareException implements Fai
      * @return The location description.
      */
     @Nullable
-    public String getLocation() {
+    public String describeLocation() {
         if (sourceDisplayName == null) {
             return null;
         }
@@ -63,6 +77,30 @@ public class LocationAwareException extends ContextAwareException implements Fai
             return sourceMsg;
         }
         return String.format("%s line: %d", sourceMsg, lineNumber);
+    }
+
+    /**
+     * Returns a location string that may be enhanced with a clickable file URI.
+     * <p>
+     * If the source path contains special characters (whitespace, non-ASCII, etc.) that
+     * would prevent IDEs from recognizing it as a clickable link, this method appends
+     * a properly encoded file: URI to make the location clickable in IDE consoles.
+     * <p>
+     * When a line number is available, it is appended to the URI using the {@code :lineNumber}
+     * format that IDEs recognize for opening files at specific lines.
+     *
+     * @return the location string, potentially with a clickable URI appended. Returns the same
+     *         as {@link #describeLocation()} if no source path is available.
+     * @see #describeLocation()
+     * @see BuildExceptionReporter#formatClickableLink(String, Integer)
+     */
+    @Nullable
+    public String describeClickableLocation() {
+        if (sourcePath == null) {
+            return describeLocation();
+        } else {
+            return maybeAddClickableLocation(describeLocation());
+        }
     }
 
     /**
@@ -83,7 +121,7 @@ public class LocationAwareException extends ContextAwareException implements Fai
     @Nullable
     @Override
     public String getMessage() {
-        String location = getLocation();
+        String location = describeLocation();
         String message = getCause().getMessage();
         if (location == null && message == null) {
             return null;
@@ -103,5 +141,90 @@ public class LocationAwareException extends ContextAwareException implements Fai
             FailureResolutionAware resolutionAware = (FailureResolutionAware) getCause();
             resolutionAware.appendResolutions(context);
         }
+    }
+
+    /**
+     * Enhances the location string with a clickable file URI if needed.
+     * <p>
+     * IDEs typically tokenize console output by whitespace to detect clickable file paths.
+     * When the source path contains characters that break tokenization (whitespace, non-ASCII, etc.),
+     * this method appends a properly encoded file: URI on a new line to ensure the location
+     * remains clickable in IDE consoles.
+     * <p>
+     * If URI conversion fails for any reason, the original location is returned to ensure
+     * error reporting is not disrupted.
+     *
+     * @param location the base location string to potentially enhance
+     * @return the location string, with a clickable URI appended if the source path needs encoding
+     * @see #needsUriEncoding(String)
+     * @see BuildExceptionReporter#formatClickableLink(String, Integer)
+     */
+    private String maybeAddClickableLocation(String location) {
+        if (needsUriEncoding(sourcePath)) {
+            try {
+                return location + "\n  " + BuildExceptionReporter.formatClickableLink(sourcePath, lineNumber);
+            } catch (Exception e) {
+                // Don't let URI conversion break error reporting
+            }
+        }
+        return location;
+    }
+
+    /**
+     * Determines if a file path needs URI encoding to be clickable in IDEs.
+     * <p>
+     * IDEs typically tokenize console output by whitespace to detect clickable file paths.
+     * Paths containing certain characters will not be recognized as clickable links and need
+     * to be converted to file: URIs with proper percent-encoding.
+     * <p>
+     * This method detects:
+     * <ul>
+     * <li>Whitespace characters (space, tab, newline, etc.) - break tokenization</li>
+     * <li>Non-ASCII/Unicode characters - may not be recognized by pattern matchers</li>
+     * <li>Special characters that could break URI parsing (#, ?, %, etc.)</li>
+     * </ul>
+     *
+     * @param path the file path to check
+     * @return true if the path needs URI encoding to be clickable
+     */
+    private static boolean needsUriEncoding(String path) {
+        if (path == null || path.isEmpty()) {
+            return false;
+        }
+
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+
+            // Whitespace breaks IDE tokenization
+            if (Character.isWhitespace(c)) {
+                return true;
+            }
+
+            // Non-ASCII characters may not be recognized by simple pattern matchers
+            if (c > '~') {
+                return true;
+            }
+
+            // Special characters that could break URI parsing or IDE link detection
+            // Note: Forward slash (/) and colon (:) are allowed as they're used in paths
+            // Note: Backslash (\) is allowed as it's used in Windows paths
+            switch (c) {
+                case '#':  // Fragment identifier
+                case '?':  // Query separator
+                case '%':  // Percent encoding
+                case '[':  // Square brackets
+                case ']':
+                case '{':  // Curly braces
+                case '}':
+                case '|':  // Pipe
+                case '^':  // Caret
+                case '`':  // Backtick
+                case '<':  // Angle brackets (invalid in some file systems)
+                case '>':
+                case '"':  // Quote (invalid in some file systems)
+                    return true;
+            }
+        }
+        return false;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/exceptions/LocationAwareException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/exceptions/LocationAwareException.java
@@ -17,9 +17,11 @@ package org.gradle.internal.exceptions;
 
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.groovy.scripts.ScriptSource;
-import org.gradle.internal.buildevents.BuildExceptionReporter;
+import org.gradle.internal.logging.ConsoleRenderer;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.jspecify.annotations.Nullable;
+
+import java.io.File;
 
 
 /**
@@ -92,7 +94,7 @@ public class LocationAwareException extends ContextAwareException implements Fai
      * @return the location string, potentially with a clickable URI appended. Returns the same
      *         as {@link #describeLocation()} if no source path is available.
      * @see #describeLocation()
-     * @see BuildExceptionReporter#formatClickableLink(String, Integer)
+     * @see ConsoleRenderer#asClickableFileUrl(File, Integer)
      */
     @Nullable
     public String describeClickableLocation() {
@@ -157,12 +159,13 @@ public class LocationAwareException extends ContextAwareException implements Fai
      * @param location the base location string to potentially enhance
      * @return the location string, with a clickable URI appended if the source path needs encoding
      * @see #needsUriEncoding(String)
-     * @see BuildExceptionReporter#formatClickableLink(String, Integer)
+     * @see ConsoleRenderer#asClickableFileUrl(File, Integer)
      */
     private String maybeAddClickableLocation(String location) {
         if (needsUriEncoding(sourcePath)) {
             try {
-                return location + "\n  " + BuildExceptionReporter.formatClickableLink(sourcePath, lineNumber);
+                String url = new ConsoleRenderer().asClickableFileUrl(new File(sourcePath), lineNumber);
+                return location + "\n  (Clickable link: " + url + ")";
             } catch (Exception e) {
                 // Don't let URI conversion break error reporting
             }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
@@ -85,7 +85,7 @@ public class PluginRequestCollector {
                 PluginRequestInternal second = iterator.next();
 
                 InvalidPluginRequestException exception = new InvalidPluginRequestException(second, "Plugin with id '" + key + "' was already requested at line " + first.getLineNumber());
-                throw new LocationAwareException(exception, second.getScriptDisplayName(), second.getLineNumber());
+                throw new LocationAwareException(exception, scriptSource.getFileName(), second.getScriptDisplayName(), second.getLineNumber());
             }
         }
         return pluginRequests;

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -31,6 +31,7 @@ import org.gradle.internal.exceptions.ContextAwareException
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.exceptions.FailureResolutionAware
 import org.gradle.internal.exceptions.LocationAwareException
+import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.internal.logging.DefaultLoggingConfiguration
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutput
@@ -606,7 +607,7 @@ $GET_HELP
         reporter.buildFinished(failure(exception))
         output.value.contains("* Where:")
         output.value.contains("Build file '${path.absolutePath}' line: 42")
-        output.value.contains("  " + BuildExceptionReporter.formatClickableLink(path.absolutePath, 42))
+        output.value.contains("  " + formatClickableLink(path.absolutePath, 42))
 
         where:
         description        | pathSegment
@@ -684,7 +685,7 @@ $GET_HELP
         expect:
         reporter.buildFinished(failure(exception))
         output.value.contains("Build file '${path.absolutePath}' line: 100")
-        output.value.contains("  " + BuildExceptionReporter.formatClickableLink(path.absolutePath, 100))
+        output.value.contains("  " + formatClickableLink(path.absolutePath, 100))
 
         where:
         description        | pathSegment
@@ -703,13 +704,18 @@ $GET_HELP
         expect:
         reporter.buildFinished(failure(exception))
         output.value.contains("Build file '${pathWithSpaces.absolutePath}'")
-        def expectedLink = BuildExceptionReporter.formatClickableLink(pathWithSpaces.absolutePath, null)
+        def expectedLink = formatClickableLink(pathWithSpaces.absolutePath, null)
         output.value.contains("  " + expectedLink)
         !output.value.contains(":null")
     }
 
     def failure(Throwable failure) {
         failureFactory.create(failure)
+    }
+
+    private static String formatClickableLink(String filePath, Integer lineNumber) {
+        String url = new ConsoleRenderer().asClickableFileUrl(new File(filePath), lineNumber)
+        return "(Clickable link: " + url + ")"
     }
 
     abstract class TestException extends GradleException implements FailureResolutionAware {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/ContextAwareExceptionHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/ContextAwareExceptionHandlerTest.groovy
@@ -228,7 +228,7 @@ class ContextAwareExceptionHandlerTest extends Specification {
     def "visitor visits location"() {
         ExceptionContextVisitor visitor = Mock()
         def cause = new RuntimeException()
-        def e = new LocationAwareException(cause, "location", 42)
+        def e = new LocationAwareException(cause, null, "location", 42)
 
         when:
         visit(e, visitor)
@@ -236,7 +236,7 @@ class ContextAwareExceptionHandlerTest extends Specification {
         then:
         1 * visitor.visitCause(isFailureFor(cause))
         1 * visitor.endVisiting()
-        1 * visitor.visitLocation("Location line: 42")
+        1 * visitor.visitLocationException(e)
         0 * visitor._
 
         and:


### PR DESCRIPTION
Enhance failure output with robust clickable links.

IDEs often fails to recognize file paths containing special characters (e.g., spaces, unicode, or symbols) as clickable links in build failure output. This makes navigating to the source of an error more cumbersome.

This update enhances error reporting by:
- Modifying the exception handling to explicitly store the absolute file path where an error occurs.
- Introducing a mechanism to detect if a file path needs URI encoding to be clickable by IDEs.
- Automatically appending a properly encoded `file:` URI with the line number to the console output when necessary.

This ensures that all failure locations, even those in complex paths, provide a direct and clickable link in IDEs, significantly improving the developer experience.
