### PR TITLE
Fix typo in documentation anchor

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/unused/implementing_gradle_plugins.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/unused/implementing_gradle_plugins.adoc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-[[implemention_plugins]]
+[[implementing_plugins]]
 = Implementation Options for Plugins
 
 The choice between script, precompiled script, or binary plugins depends on your specific requirements and preferences.


### PR DESCRIPTION
Fixes typo in documentation anchor from 'implemention_plugins' to 'implementing_plugins'.