### PR TITLE
Use CAS to try to avoid unpark

### DIFF
--- a/platforms/core-runtime/concurrent/src/main/java/org/gradle/internal/concurrent/MultiProducerSingleConsumerProcessor.java
+++ b/platforms/core-runtime/concurrent/src/main/java/org/gradle/internal/concurrent/MultiProducerSingleConsumerProcessor.java
@@ -135,13 +135,14 @@ public class MultiProducerSingleConsumerProcessor<T> {
             throw new IllegalStateException("Failed to offer value to queue");
         }
 
+        // Check if the worker is already active, using an inexpensive volatile read.
         if (awake.get()) {
             return;
         }
 
-        if (!awake.getAndSet(true)) {
+        if (awake.compareAndSet(false, true)) {
             // Only pay the cost to notify the worker if it is not already
-            // processing values.
+            // processing values. We use a CAS so only one thread has to pay this cost.
             LockSupport.unpark(worker);
         }
     }


### PR DESCRIPTION
By using CAS, we can potentially avoid calling LockSupport.unpark from multiple threads. Only one thread needs to call unpark, which is an expensive operation involving a syscall.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
