### PR TITLE
Add progress display name for building task graph

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
@@ -121,9 +121,9 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
 
         private static String buildingTaskGraphDisplayName(GradleInternal gradle) {
             if (gradle.isRootBuild()) {
-                return "Building root build task graph";
+                return "Building task graph of root build";
             } else {
-                return "Building build '" + gradle.getIdentityPath().asString() + "' task graph";
+                return "Building task graph of build '" + gradle.getIdentityPath().asString() + "'";
             }
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparerTest.groovy
@@ -100,7 +100,7 @@ class BuildOperationFiringBuildWorkPreparerTest extends Specification {
 
         then:
         def record = buildOperationRunner.log.mostRecent(CalculateTaskGraphBuildOperationType)
-        record.descriptor.progressDisplayName == "Building root build task graph"
+        record.descriptor.progressDisplayName == "Building task graph of root build"
     }
 
     def "build operation has good progress display name for included build"() {
@@ -125,6 +125,6 @@ class BuildOperationFiringBuildWorkPreparerTest extends Specification {
 
         then:
         def record = buildOperationRunner.log.mostRecent(CalculateTaskGraphBuildOperationType)
-        record.descriptor.progressDisplayName == "Building build ':buildB' task graph"
+        record.descriptor.progressDisplayName == "Building task graph of build ':buildB'"
     }
 }


### PR DESCRIPTION
This can take a lot of time in builds and it's not clear to users what's happening sometimes, as the command-line will just say "100% CONFIGURING" and "Resolving [...]" during task graph dependency resolution, or just the "CONFIGURING" if it's doing CPU-bound work.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
