### PR TITLE
Use 100% instead of 40px to position submenus

### DIFF
--- a/platforms/documentation/docs/src/docs/css/base.css
+++ b/platforms/documentation/docs/src/docs/css/base.css
@@ -541,7 +541,7 @@ h3.releaseinfo {
     display: none;
     width: 170px;
     background-color: white;
-    top: 40px;
+    top: 100%;
     left: 7px; /* NOTE: This must match the padding of .site-header__navigation-link */
     padding: 3px 10px 6px 10px;
     z-index: 100;

--- a/platforms/documentation/docs/src/docs/css/manual.css
+++ b/platforms/documentation/docs/src/docs/css/manual.css
@@ -801,7 +801,7 @@ select { width: 100%; }
     display: none;
     width: 170px;
     background-color: var(--menu-burger-color);
-    top: 40px;
+    top: 100%;
     left: 7px;
     padding: 3px 10px 6px 10px;
     z-index: 100;


### PR DESCRIPTION
This prevents the menu from closing when moving from the main menu to the submenu, as seen in https://github.com/gradle/gradle/issues/24864#issuecomment-1841126425

I didn't test this locally exactly, because `serveDocs` doesn't have the version selector. I manually edited the CSS on the live site to match.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
