### PR TITLE
Consider console width when rendering help

### DIFF
--- a/platforms/core-runtime/cli/src/main/java/org/gradle/cli/CommandLineParser.java
+++ b/platforms/core-runtime/cli/src/main/java/org/gradle/cli/CommandLineParser.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * <p>A command-line parser which supports a command/sub-command style command-line interface. Supports the following
@@ -185,7 +186,7 @@ public class CommandLineParser {
      * @param out The output stream to write to.
      */
     @SuppressWarnings("NullAway")
-    public void printUsage(Appendable out) {
+    public void printUsage(Appendable out, int widthHint) {
         // sort options before grouping
         Set<CommandLineOption> commandLineOptions = new TreeSet<>(new OptionComparator());
         commandLineOptions.addAll(optionsByString.values());
@@ -199,18 +200,17 @@ public class CommandLineParser {
             categoryToOptions.get(option.getCategory()).add(RenderedCommandLineOption.from(option));
         }
 
-        // calculate padding for option names
-        int padding = 0;
-        for (List<RenderedCommandLineOption> renderedOptions : categoryToOptions.values()) {
-            for (RenderedCommandLineOption renderedOption : renderedOptions) {
-                padding = Math.max(padding, renderedOption.getName().length());
-            }
-        }
-        padding += 3; // two extra spaces before each option + two spaces between the longest option and its description
+        // calculate column widths for option name and description
+        int nameColumnWidth = categoryToOptions.values().stream()
+            .flatMap(List::stream)
+            .mapToInt(o -> o.getName().length())
+            .max()
+            .orElse(0) + 3; // account for two extra spaces before each option plus an extra space between the longest option and its description
+        int descriptionColumnWidth = Math.max(30, widthHint - nameColumnWidth);
 
         // print hint about end signal
         Formatter formatter = new Formatter(out);
-        printOption(formatter, padding, "--", "Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.");
+        printRenderedOption(formatter, "--", nameColumnWidth, "Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.", descriptionColumnWidth);
 
         // print each category and its options
         for (OptionCategory category : OptionCategory.values()) {
@@ -229,31 +229,57 @@ public class CommandLineParser {
             for (RenderedCommandLineOption option : options) {
                 String name = option.getName();
                 String description = option.getDescription();
-                // handle multi-line descriptions
-                List<String> lines = Arrays.asList(description.split("\\r?\\n"));
-                for (int i = 0; i < lines.size(); i++) {
-                    if (description == null || description.isEmpty()) {
-                        printOptionName(formatter, "  " + name);
-                    } else {
-                        printOption(formatter, padding, i == 0 ? "  " + name : "", lines.get(i));
-                    }
-                }
-
+                printRenderedOption(formatter, "  " + name, nameColumnWidth, description, descriptionColumnWidth);
             }
         }
         formatter.flush();
     }
 
-    private static void printCategory(Formatter formatter, String categoryName) {
-        formatter.format("%n%s:%n", categoryName);
+    private static void printRenderedOption(Formatter formatter, String name, int nameColumnWidth, String description, int descriptionColumnWidth) {
+        if (description == null || description.isEmpty()) {
+            printOption(formatter, name);
+        } else {
+            // handle multi-line descriptions and split lines that are too long for the console
+            List<String> descriptionLines = Arrays.stream(description.split("\\r?\\n"))
+                .flatMap(n -> splitToLength(n, descriptionColumnWidth).stream())
+                .collect(Collectors.toList());
+            for (int i = 0; i < descriptionLines.size(); i++) {
+                printOption(formatter, i == 0 ? name : "", nameColumnWidth, descriptionLines.get(i));
+            }
+        }
     }
 
-    private static void printOptionName(Formatter formatter, String name) {
+    public static List<String> splitToLength(String input, int n) {
+        List<String> lines = new ArrayList<>();
+        int start = 0;
+        while (start < input.length()) {
+            int end = Math.min(start + n, input.length());
+            if (end < input.length()) {
+                int lastSpace = input.lastIndexOf(' ', end);
+                if (lastSpace > start) {
+                    end = lastSpace;
+                }
+            }
+            lines.add(input.substring(start, end));
+            start = end;
+            // skip whitespace at beginning of next line
+            while (start < input.length() && Character.isWhitespace(input.charAt(start))) {
+                start++;
+            }
+        }
+        return lines;
+    }
+
+    private static void printCategory(Formatter formatter, String name) {
+        formatter.format("%n%s:%n", name);
+    }
+
+    private static void printOption(Formatter formatter, String name) {
         formatter.format("%s%n", name);
     }
 
-    private static void printOption(Formatter formatter, int padding, String name, String description) {
-        formatter.format("%-" + padding + "s %s%n", name, description);
+    private static void printOption(Formatter formatter, String name, int nameColumnWidth, String description) {
+        formatter.format("%-" + nameColumnWidth + "s %s%n", name, description);
     }
 
     @NullMarked

--- a/platforms/core-runtime/cli/src/test/groovy/org/gradle/cli/CommandLineParserTest.groovy
+++ b/platforms/core-runtime/cli/src/test/groovy/org/gradle/cli/CommandLineParserTest.groovy
@@ -373,7 +373,7 @@ class CommandLineParserTest extends Specification {
         def outstr = new StringWriter()
 
         expect:
-        parser.printUsage(outstr)
+        parser.printUsage(outstr, 160)
         outstr.toString().readLines() == [
             '--                                     Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.',
             '  --another-long-option                this is a long option',
@@ -392,7 +392,7 @@ class CommandLineParserTest extends Specification {
         def outstr = new StringWriter()
 
         expect:
-        parser.printUsage(outstr)
+        parser.printUsage(outstr, 160)
         outstr.toString().readLines() == [
             '--                   Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.',
             '  -b                 [deprecated]',
@@ -699,7 +699,7 @@ class CommandLineParserTest extends Specification {
         def outstr = new StringWriter()
 
         expect:
-        parser.printUsage(outstr)
+        parser.printUsage(outstr, 160)
         outstr.toString().readLines() == [
             '--                  Signals the end of built-in options. Parses subsequent parameters as tasks or task options only.',
             '  --a-option        this is option --a-option',
@@ -719,7 +719,7 @@ class CommandLineParserTest extends Specification {
         def outstr = new StringWriter()
 
         expect:
-        parser.printUsage(outstr)
+        parser.printUsage(outstr, 160)
         def usage = outstr.toString()
         usage.contains('--long-option, -a')
         usage.contains('--another-long-option')
@@ -735,7 +735,7 @@ class CommandLineParserTest extends Specification {
         def outstr = new StringWriter()
 
         expect:
-        parser.printUsage(outstr)
+        parser.printUsage(outstr, 160)
         def usage = outstr.toString()
         usage.contains('Execution')
         usage.contains('Logging')
@@ -753,7 +753,7 @@ class CommandLineParserTest extends Specification {
         def outstr = new StringWriter()
 
         expect:
-        parser.printUsage(outstr)
+        parser.printUsage(outstr, 160)
         def lines = outstr.toString().readLines()
         int idxA = lines.findIndexOf { it.contains('--a-option') }
         int idxB = lines.findIndexOf { it.contains('--b-option') }
@@ -770,7 +770,7 @@ class CommandLineParserTest extends Specification {
         def outstr = new StringWriter()
 
         expect:
-        parser.printUsage(outstr)
+        parser.printUsage(outstr, 160)
         def lines = outstr.toString().readLines()
         int idxOn = lines.findIndexOf { it.contains('--a-option') }
         int idxOff = lines.findIndexOf { it.contains('--no-a-option') }
@@ -779,5 +779,24 @@ class CommandLineParserTest extends Specification {
         // ensure they are adjacent (no other option between them)
         idxOff == idxOn + 1
     }
+
+    def "Can print long description to narrow console"() {
+        parser.option('a-option').hasDescription('Option A has a very long description that should be wrapped when printed to a narrow console.')
+        def outstr = new StringWriter()
+
+        expect:
+        parser.printUsage(outstr, 20)
+        outstr.toString().readLines() == [
+           '--            Signals the end of built-in',
+           '              options. Parses subsequent',
+           '              parameters as tasks or task',
+           '              options only.',
+           '  --a-option  Option A has a very long',
+           '              description that should be',
+           '              wrapped when printed to a',
+           '              narrow console.',
+        ]
+    }
+
 }
 

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/internal/HelpRenderer.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/cli/internal/HelpRenderer.java
@@ -21,6 +21,9 @@ import org.gradle.cli.OptionCategory;
 import org.gradle.configuration.DefaultBuildClientMetaData;
 import org.gradle.configuration.GradleLauncherMetaData;
 import org.gradle.initialization.BuildClientMetaData;
+import org.gradle.internal.nativeintegration.console.ConsoleDetector;
+import org.gradle.internal.nativeintegration.console.ConsoleMetaData;
+import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.launcher.cli.converter.BuildLayoutConverter;
 import org.gradle.launcher.cli.converter.BuildOptionBackedConverter;
 import org.gradle.launcher.cli.converter.InitialPropertiesConverter;
@@ -77,7 +80,7 @@ public final class HelpRenderer {
         metaData.describeCommand(out, "[option...]", "[task...]");
         out.println();
         out.println();
-        parser.printUsage(out);
+        parser.printUsage(out, consoleWidth() - 1);
         out.println();
 
         out.flush();
@@ -97,5 +100,10 @@ public final class HelpRenderer {
         parser.option("v", "version").hasDescription("Prints version information and exits.").hasCategory(OptionCategory.HELP);
         parser.option("V", "show-version").hasDescription("Prints version information and continues.").hasCategory(OptionCategory.HELP);
         return parser;
+    }
+
+    private static int consoleWidth() {
+        ConsoleMetaData console = NativeServices.getInstance().get(ConsoleDetector.class).getConsole();
+        return console != null ? console.getCols() : Integer.MAX_VALUE;
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

The output of `--help` outputs long strings, which may not be easily readable on the console. To fix that, this PR breaks up those long strings and prints them as multi-line strings. The PR leaves the output untouched if Gradle is not attached to a console.

Example output with 80 columns:

```
To see help contextual to the project, use gradle help

To see more detail about a task, run gradle help --task <task>

To see a list of available tasks, run gradle tasks

USAGE: gradle [option...] [task...]

--                                   Signals the end of built-in options. Parses
                                     subsequent parameters as tasks or task
                                     options only.

Help:
  --help, -?, -h                     Shows this help message.
  --show-version, -V                 Prints version information and continues.
  --version, -v                      Prints version information and exits.

Logging:
  --console                          Specifies which type of console output to
                                     generate. Supported values are 'plain',
                                     'colored', 'auto' (default), 'rich', or
                                     'verbose'.
  --console-unicode                  Specifies which character types are allowed
                                     in the console output. Supported values are
                                     'auto' (default), 'disable', or 'enable'.
  --debug, -d                        Sets log level to debug. Includes the normal
                                     stacktrace.
  --full-stacktrace, -S              Prints the full (very verbose) stacktrace
                                     for all exceptions.
  --info, -i                         Sets the log level to info.
  --quiet, -q                        Logs errors only.
  --stacktrace, -s                   Prints the stacktrace for all exceptions.
  --warn, -w                         Sets the log level to warn.

Configuration:
  --gradle-user-home, -g             Specifies the Gradle user home directory.
                                     Default is ~/.gradle.
  --include-build                    Includes the specified build in the
                                     composite.
  --init-script, -I                  Specifies an initialization script.
  --offline                          Runs the build without accessing network
                                     resources.
  --project-cache-dir                Specifies the project-specific cache
                                     directory. Default is .gradle in the root
                                     project directory.
  --project-dir, -p                  Specifies the start directory for Gradle.
                                     Default is the current directory.
  --project-prop, -P                 Sets a project property for the build script
                                     (for example, -Pmyprop=myvalue).
  --refresh-dependencies, -U         Refreshes the state of dependencies.
  --system-prop, -D                  Sets a JVM system property (for example,
                                     -Dmyprop=myvalue).

Execution:
  --continue                         Continues task execution after a task
                                     failure.
  --no-continue                      Stops task execution after a task failure.
  --continuous, -t                   Enables continuous build. Gradle does not
                                     exit and will re-execute tasks when task
                                     file inputs change.
  --dry-run, -m                      Runs the build with all task actions
                                     disabled.
  --exclude-task, -x                 Specifies a task to exclude from execution.
  --no-rebuild, -a                   Disables rebuilding of project dependencies.
  --rerun-tasks                      Ignores previously cached task results.

Performance:
  --build-cache                      Enables the Gradle build cache. Gradle will
                                     try to reuse outputs from previous builds.
  --no-build-cache                   Disables the Gradle build cache.
  --configuration-cache              Enables the configuration cache. Gradle will
                                     try to reuse the build configuration from
                                     previous builds.
  --no-configuration-cache           Disables the configuration cache.
  --configure-on-demand              Configures necessary projects only. Gradle
                                     will attempt to reduce configuration time
                                     for large multi-project builds. [incubating]
  --no-configure-on-demand           Disables the use of configuration on demand.
                                     [incubating]
  --max-workers                      Configures the maximum number of concurrent
                                     workers Gradle is allowed to use.
  --parallel                         Builds projects in parallel. Gradle will
                                     attempt to determine the optimal number of
                                     executor threads to use.
  --no-parallel                      Disables parallel project execution.
  --priority                         Specifies the scheduling priority for the
                                     Gradle daemon and all processes launched by
                                     it. Supported values are 'normal' (default)
                                     or 'low'.
  --watch-fs                         Enables file system watching. Reuses file
                                     system data for subsequent builds.
  --no-watch-fs                      Disables file system watching.

Security:
  --dependency-verification, -F      Configures the dependency verification mode.
                                     Supported values are 'strict', 'lenient', or
                                     'off'.
  --export-keys                      Exports the public keys used for dependency
                                     verification.
  --refresh-keys                     Refreshes the public keys used for
                                     dependency verification.
  --update-locks                     Performs a partial update of the dependency
                                     lock. Allows passed-in module notations to
                                     change version. [incubating]
  --write-locks                      Persists dependency resolution for locked
                                     configurations. Ignores existing locking
                                     information if it exists.
  --write-verification-metadata, -M  Generates checksums for dependencies used in
                                     the project. Accepts a comma-separated list.

Diagnostics:
  --configuration-cache-problems     Configures how the configuration cache
                                     handles problems (fail or warn). Supported
                                     values are 'warn', or 'fail' (default).
  --problems-report                  Enables the HTML problems report.
                                     [incubating]
  --no-problems-report               Disables the HTML problems report.
                                     [incubating]
  --profile                          Profiles build execution time. Generates a
                                     report in the <build_dir>/reports/profile
                                     directory.
  --property-upgrade-report          Runs the build with the experimental
                                     property upgrade report. [incubating]
  --task-graph                       Prints the task graph instead of executing
                                     tasks.
  --warning-mode                     Specifies which mode of warnings to
                                     generate. Supported values are 'all',
                                     'fail', 'summary' (default), or 'none'.

Daemon:
  --daemon                           Uses the Gradle daemon to run the build.
                                     Starts the daemon if it is not running.
  --no-daemon                        Runs the build without the Gradle daemon.
                                     Useful occasionally if you have configured
                                     Gradle to always run with the daemon by
                                     default.
  --foreground                       Starts the Gradle daemon in the foreground.
  --status                           Shows the status of running and recently
                                     stopped Gradle daemons.
  --stop                             Stops the Gradle daemon if it is running.

Develocity:
  --scan                             Generates a Build Scan (powered by
                                     Develocity).
  --no-scan                          Disables the creation of a Build Scan.
```

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
