### PR TITLE
Fix handling of circular Property references

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheLambdaIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheLambdaIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.cc.impl
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
+import spock.lang.Issue
 
 class ConfigurationCacheLambdaIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
@@ -328,5 +329,57 @@ class ConfigurationCacheLambdaIntegrationTest extends AbstractConfigurationCache
 
         then:
         succeeds("a", "b")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/32607")
+    def "can serialize property with circular reference in a lambda"() {
+        javaFile("buildSrc/src/main/java/com/example/MyTask.java", """
+            package com.example;
+
+            import org.gradle.api.DefaultTask;
+            import org.gradle.api.provider.Property;
+            import org.gradle.api.tasks.Internal;
+            import org.gradle.api.tasks.TaskAction;
+
+            public abstract class MyTask extends DefaultTask {
+                @Internal
+                abstract Property<String> getValue();
+
+                @TaskAction
+                public void action() {
+                    System.out.println("value = " + getValue().getOrNull());
+                }
+            }
+        """)
+
+        javaFile("buildSrc/src/main/java/com/example/MyPlugin.java", """
+            package com.example;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+
+            import java.io.File;
+
+            public class MyPlugin implements Plugin<Project> {
+                @Override
+                public void apply(Project p) {
+                    var environment = p.getProviders().systemProperty("some.property");
+                    p.getTasks().register("run", MyTask.class, task -> {
+                        var value = task.getValue();
+                        value.set(environment.map(v -> v + System.identityHashCode(value)));
+                    });
+                }
+            }
+        """)
+
+        buildFile """
+            apply plugin: com.example.MyPlugin
+        """
+
+        when:
+        configurationCacheRun("run", "-Dsome.property=some value")
+
+        then:
+        outputContains("some value")
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassLoaderScopes.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/ClassLoaderScopes.kt
@@ -19,12 +19,12 @@ package org.gradle.internal.cc.impl.serialize
 import org.gradle.initialization.ClassLoaderScopeOrigin
 import org.gradle.internal.Describables
 import org.gradle.internal.classpath.ClassPath
+import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.graph.ReadIdentities
 import org.gradle.internal.serialize.graph.WriteIdentities
-import org.gradle.internal.serialize.graph.decodePreservingIdentity
 
 
 internal
@@ -147,26 +147,33 @@ open class InlineClassLoaderScopeSpecDecoder : ClassLoaderScopeSpecDecoder {
     private
     val scopes = ReadIdentities()
 
-    override fun Decoder.decodeScope(): ClassLoaderScopeSpec = decodePreservingIdentity(scopes) { id ->
-        val parent = if (readBoolean()) {
-            decodeScope()
-        } else {
-            null
-        }
+    override fun Decoder.decodeScope(): ClassLoaderScopeSpec {
+        val id = readSmallInt()
+        val previousValue = scopes.getInstance(id)
+        return when {
+            previousValue != null -> previousValue.uncheckedCast()
+            else -> {
+                val parent = if (readBoolean()) {
+                    decodeScope()
+                } else {
+                    null
+                }
 
-        val name = readString()
-        val origin = readOrigin()
-        val localImplementationHash = readNullableHashCode()
-        val localClassPath = decodeClassPath()
-        val exportClassPath = decodeClassPath()
+                val name = readString()
+                val origin = readOrigin()
+                val localImplementationHash = readNullableHashCode()
+                val localClassPath = decodeClassPath()
+                val exportClassPath = decodeClassPath()
 
-        val newScope = ClassLoaderScopeSpec(parent, name, origin).apply {
-            this.localClassPath = localClassPath
-            this.localImplementationHash = localImplementationHash
-            this.exportClassPath = exportClassPath
+                val newScope = ClassLoaderScopeSpec(parent, name, origin).apply {
+                    this.localClassPath = localClassPath
+                    this.localImplementationHash = localImplementationHash
+                    this.exportClassPath = exportClassPath
+                }
+                scopes.putInstance(id, newScope)
+                newScope
+            }
         }
-        scopes.putInstance(id, newScope)
-        newScope
     }
 
     protected open fun Decoder.decodeClassPath(): ClassPath =

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassDecoder.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/serialize/DefaultClassDecoder.kt
@@ -20,6 +20,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.internal.instantiation.DeserializationInstantiator
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.graph.ClassDecoder
+import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.ReadIdentities
 import org.gradle.internal.serialize.graph.decodePreservingIdentity
 import java.util.IdentityHashMap
@@ -45,7 +46,7 @@ class DefaultClassDecoder(
     private
     val scopeBySpec = IdentityHashMap<ClassLoaderScopeSpec, ClassLoaderScope>()
 
-    override fun Decoder.decodeClass(): Class<*> = decodePreservingIdentity(classes) { id ->
+    override fun ReadContext.decodeClass(): Class<*> = decodePreservingIdentity(classes) { id ->
         val isGenerated = readBoolean()
         val name = readString()
         val classLoader = decodeClassLoader()
@@ -55,7 +56,7 @@ class DefaultClassDecoder(
         actualType
     }
 
-    override fun Decoder.decodeClassLoader(): ClassLoader? =
+    override fun ReadContext.decodeClassLoader(): ClassLoader? =
         if (readBoolean()) {
             val scope = readScope()
             val classLoader = if (readBoolean()) {

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -80,9 +80,13 @@ abstract class AbstractUserTypeCodecTest {
         }
 
     protected
-    fun <T : Any> configurationCacheRoundtripOf(graph: T, codec: Codec<Any?> = userTypesCodec()): T =
-        writeToByteArray(graph, codec)
-            .let { readFromByteArray(it, codec)!! }
+    fun <T : Any> configurationCacheRoundtripOf(
+        graph: T,
+        codec: Codec<Any?> = userTypesCodec(),
+        integrityCheck: Boolean = false
+    ): T =
+        writeToByteArray(graph, codec, integrityCheck)
+            .let { readFromByteArray(it, codec, integrityCheck)!! }
             .uncheckedCast()
 
     internal
@@ -92,11 +96,12 @@ abstract class AbstractUserTypeCodecTest {
     }
 
     internal
-    fun writeToByteArray(graph: Any, codec: Codec<Any?>): ByteArray {
+    fun writeToByteArray(graph: Any, codec: Codec<Any?>, integrityCheck: Boolean = false): ByteArray {
         val outputStream = ByteArrayOutputStream()
         writeTo(
             outputStream, graph, codec,
-            loggingProblemsListener()
+            loggingProblemsListener(),
+            integrityCheck
         )
         return outputStream.toByteArray()
     }
@@ -106,9 +111,10 @@ abstract class AbstractUserTypeCodecTest {
         outputStream: OutputStream,
         graph: Any,
         codec: Codec<Any?>,
-        problemsListener: ProblemsListener = mock()
+        problemsListener: ProblemsListener = mock(),
+        integrityCheck: Boolean = false
     ) {
-        writeContextFor(KryoBackedEncoder(outputStream), codec, problemsListener).useToRun {
+        writeContextFor(KryoBackedEncoder(outputStream), codec, problemsListener, integrityCheck).useToRun {
             withIsolateMock(codec) {
                 runWriteOperation {
                     write(graph)
@@ -118,12 +124,17 @@ abstract class AbstractUserTypeCodecTest {
     }
 
     internal
-    fun readFromByteArray(bytes: ByteArray, codec: Codec<Any?>) =
-        readFrom(ByteArrayInputStream(bytes), codec, loggingProblemsListener())
+    fun readFromByteArray(bytes: ByteArray, codec: Codec<Any?>, integrityCheck: Boolean = false) =
+        readFrom(ByteArrayInputStream(bytes), codec, loggingProblemsListener(), integrityCheck)
 
     private
-    fun readFrom(inputStream: ByteArrayInputStream, codec: Codec<Any?>, problemsListener: ProblemsListener) =
-        readContextFor(inputStream, codec, problemsListener).run {
+    fun readFrom(
+        inputStream: ByteArrayInputStream,
+        codec: Codec<Any?>,
+        problemsListener: ProblemsListener,
+        integrityCheck: Boolean = false
+    ) =
+        readContextFor(inputStream, codec, problemsListener, integrityCheck).run {
             withIsolateMock(codec) {
                 runReadOperation {
                     read()
@@ -138,25 +149,35 @@ abstract class AbstractUserTypeCodecTest {
         }
 
     private
-    fun writeContextFor(encoder: FlushableEncoder, codec: Codec<Any?>, problemHandler: ProblemsListener) =
+    fun writeContextFor(
+        encoder: FlushableEncoder,
+        codec: Codec<Any?>,
+        problemHandler: ProblemsListener,
+        integrityCheck: Boolean = false
+    ) =
         DefaultWriteContext(
             codec = codec,
             encoder = encoder,
             classEncoder = DefaultClassEncoder(mock()),
             beanStateWriterLookup = DefaultBeanStateWriterLookup(),
-            isIntegrityCheckEnabled = false,
+            isIntegrityCheckEnabled = integrityCheck,
             logger = mock(),
             tracer = null,
             problemsListener = problemHandler
         )
 
     private
-    fun readContextFor(inputStream: ByteArrayInputStream, codec: Codec<Any?>, problemsListener: ProblemsListener) =
+    fun readContextFor(
+        inputStream: ByteArrayInputStream,
+        codec: Codec<Any?>,
+        problemsListener: ProblemsListener,
+        integrityCheck: Boolean = false
+    ) =
         DefaultReadContext(
             codec = codec,
             decoder = KryoBackedDecoder(inputStream),
             beanStateReaderLookup = beanStateReaderLookupForTesting(),
-            isIntegrityCheckEnabled = false,
+            isIntegrityCheckEnabled = integrityCheck,
             logger = mock(),
             problemsListener = problemsListener,
             classDecoder = DefaultClassDecoder(mock(), mock())

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/UserTypesCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/UserTypesCodecTest.kt
@@ -17,9 +17,17 @@
 package org.gradle.internal.cc.impl.serialization.codecs
 
 import org.gradle.internal.configuration.problems.PropertyTrace
+import org.gradle.internal.serialize.graph.Codec
+import org.gradle.internal.serialize.graph.ReadContext
+import org.gradle.internal.serialize.graph.WriteContext
+import org.gradle.internal.serialize.graph.codecs.Bindings
+import org.gradle.internal.serialize.graph.decodePreservingIdentity
+import org.gradle.internal.serialize.graph.encodePreservingIdentityOf
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.junit.Assert.fail
 import org.junit.Test
 
 
@@ -58,6 +66,91 @@ class UserTypesCodecTest : AbstractUserTypeCodecTest() {
         assertThat(readFoo.fooString, equalTo("fooString"))
         assertThat(readFoo.bar!!.barString, equalTo("barString"))
         assertThat(readFoo.bar!!.foo, sameInstance(readFoo))
+    }
+
+    class SelfRef {
+        var inner: SelfRef? = null
+    }
+
+    @Test
+    fun `integrity check detects circular reference from a buggy codec`() {
+        // Codec that intentionally reads its inner state before calling putInstance,
+        // simulating the kind of bug the integrity check is meant to catch.
+        val brokenCodec: Codec<SelfRef> = object : Codec<SelfRef> {
+            override suspend fun WriteContext.encode(value: SelfRef) {
+                encodePreservingIdentityOf(value) {
+                    write(value.inner)
+                }
+            }
+
+            override suspend fun ReadContext.decode(): SelfRef =
+                decodePreservingIdentity { id ->
+                    val inner = read() as SelfRef?
+                    val ref = SelfRef()
+                    ref.inner = inner
+                    isolate.identities.putInstance(id, ref)
+                    ref
+                }
+        }
+        val codec = Bindings.of { bind(brokenCodec) }.build()
+
+        val self = SelfRef().also { it.inner = it }
+
+        try {
+            configurationCacheRoundtripOf(self, codec, integrityCheck = true)
+            fail("Expected exception to be thrown")
+        } catch (e: IllegalStateException) {
+            assertThat(e.message, containsString("Unresolvable circular reference detected when decoding id="))
+        }
+    }
+
+    class Item(val payload: String)
+    class TwoItems(val a: Item, val b: Item)
+
+    @Test
+    fun `integrity check detects unexpected reuse of an id from a buggy codec`() {
+        // Codec that during decode registers itself correctly but also pollutes the NEXT id slot.
+        // The next decode call will see that slot already occupied and the integrity check should fire.
+        val pollutingItemCodec: Codec<Item> = object : Codec<Item> {
+            override suspend fun WriteContext.encode(value: Item) {
+                encodePreservingIdentityOf(value) {
+                    writeString(value.payload)
+                }
+            }
+
+            override suspend fun ReadContext.decode(): Item =
+                decodePreservingIdentity { id ->
+                    val item = Item(readString())
+                    isolate.identities.putInstance(id, item)
+                    // Buggy: pollute the next id slot. A correct codec only writes its own id.
+                    isolate.identities.putInstance(id + 1, "stale")
+                    item
+                }
+        }
+
+        // Plain wrapper codec that just forwards to its children without consuming an identity slot,
+        // so the two children get assigned consecutive ids in the isolate's identities map.
+        val twoItemsCodec: Codec<TwoItems> = object : Codec<TwoItems> {
+            override suspend fun WriteContext.encode(value: TwoItems) {
+                write(value.a)
+                write(value.b)
+            }
+
+            override suspend fun ReadContext.decode(): TwoItems =
+                TwoItems(read() as Item, read() as Item)
+        }
+
+        val codec = Bindings.of {
+            bind(twoItemsCodec)
+            bind(pollutingItemCodec)
+        }.build()
+
+        try {
+            configurationCacheRoundtripOf(TwoItems(Item("a"), Item("b")), codec, integrityCheck = true)
+            fail("Expected exception to be thrown")
+        } catch (e: IllegalStateException) {
+            assertThat(e.message, containsString("Unexpected reuse of id="))
+        }
     }
 
     @Test

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/UserTypesCodecTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/internal/cc/impl/serialization/codecs/UserTypesCodecTest.kt
@@ -38,6 +38,28 @@ class UserTypesCodecTest : AbstractUserTypeCodecTest() {
         )
     }
 
+    class Bar(val barString: String) {
+        var foo: Foo? = null
+    }
+
+    class Foo(val fooString: String) {
+        var bar: Bar? = null
+    }
+
+    @Test
+    fun `can handle circular bean references`() {
+        val foo = Foo("fooString")
+        val bar = Bar("barString")
+        foo.bar = bar
+        bar.foo = foo
+
+        val readFoo = configurationCacheRoundtripOf(foo)
+
+        assertThat(readFoo.fooString, equalTo("fooString"))
+        assertThat(readFoo.bar!!.barString, equalTo("barString"))
+        assertThat(readFoo.bar!!.foo, sameInstance(readFoo))
+    }
+
     @Test
     fun `internal types codec leaves not implemented trace for unsupported types`() {
 

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
@@ -400,9 +400,11 @@ class PropertyCodec(
     override suspend fun ReadContext.decodeThis(): DefaultProperty<*> {
         return decodePreservingIdentity { id ->
             val type: Class<Any> = readClass().uncheckedCast()
-            val provider = providerCodec.run { decodeProvider() }
-            val property = propertyFactory.property(type).provider(provider)
+            val property = propertyFactory.property(type)
             isolate.identities.putInstance(id, property)
+
+            val provider = providerCodec.run { decodeProvider() }
+            property.provider(provider)
             property
         }
     }

--- a/platforms/core-configuration/graph-isolation/src/main/kotlin/org/gradle/internal/isolate/graph/IsolatedActionSerializer.kt
+++ b/platforms/core-configuration/graph-isolation/src/main/kotlin/org/gradle/internal/isolate/graph/IsolatedActionSerializer.kt
@@ -28,7 +28,6 @@ import org.gradle.internal.extensions.stdlib.invert
 import org.gradle.internal.extensions.stdlib.maybeUnwrapInvocationTargetException
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.extensions.stdlib.useToRun
-import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.graph.BeanStateReaderLookup
 import org.gradle.internal.serialize.graph.BeanStateWriterLookup
 import org.gradle.internal.serialize.graph.ClassDecoder
@@ -38,6 +37,7 @@ import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.DefaultReadContext
 import org.gradle.internal.serialize.graph.DefaultWriteContext
 import org.gradle.internal.serialize.graph.IsolateOwner
+import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.readNonNull
 import org.gradle.internal.serialize.graph.runReadOperation
@@ -172,7 +172,7 @@ private
 class EnvironmentDecoder(
     val environment: Map<Int, Any>
 ) : ClassDecoder {
-    override fun Decoder.decodeClass(): Class<*> =
+    override fun ReadContext.decodeClass(): Class<*> =
         environment[readSmallInt()]!!.uncheckedCast()
 }
 

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -296,7 +296,7 @@ inline fun <T : MutableIsolateContext, R> T.withPropertyTrace(trace: PropertyTra
  * invoked; otherwise a fresh id is assigned and [encode] is called to write the value's contents.
  * The matching read side is [ReadContext.decodePreservingIdentity].
  *
- * @see encodePreservingIdentityOf for the underlying form and proper-usage notes.
+ * See the explicit-identities overload of [encodePreservingIdentityOf] for proper-usage notes.
  */
 inline fun <T : Any> WriteContext.encodePreservingIdentityOf(reference: T, encode: WriteContext.(T) -> Unit) =
     encodePreservingIdentityOf(isolate.identities, reference, encode)
@@ -312,17 +312,6 @@ inline fun <T : Any> WriteContext.encodePreservingSharedIdentityOf(reference: T,
 
 
 /**
- * Like [WriteContext.encodePreservingIdentityOf] but uses the provided [WriteIdentities] to keep track of visited identities.
- */
-inline fun <T : Any> WriteContext.encodePreservingIdentityOf(
-    identities: WriteIdentities,
-    reference: T,
-    encode: WriteContext.(T) -> Unit
-) =
-    encodePreservingIdentityOf(identities, circularReferences, isIntegrityCheckEnabled, reference, encode)
-
-
-/**
  * Encodes [reference] preserving its identity in the given [identities] map.
  *
  * On first encounter a new id is assigned, [reference] is registered immediately (so a cycle
@@ -332,28 +321,26 @@ inline fun <T : Any> WriteContext.encodePreservingIdentityOf(
  * **Proper usage:** the matching decoder must call [ReadIdentities.putInstance] *before* reading
  * any sub-graph that could transitively reference the value being decoded. Decoders that read
  * non-trivial state before registering the partial instance break under self-references and
- * produce corrupted streams. See [Decoder.decodePreservingIdentity] for the read-side contract.
+ * produce corrupted streams. See [ReadContext.decodePreservingIdentity] for the read-side contract.
  *
- * When [integrityCheckEnabled] is `true`, an extra boolean is written after the id indicating
- * whether this encounter is a back-reference (`true`) or a fresh write (`false`). The matching
- * decoder verifies the flag and fails fast with a clear message if a back-reference is
- * encountered before the partial instance has been registered.
+ * When the receiving context has [WriteContext.isIntegrityCheckEnabled] set, an extra boolean is
+ * written after the id indicating whether this encounter is a back-reference (`true`) or a fresh
+ * write (`false`). The matching decoder verifies the flag and fails fast with a clear message if
+ * the writer's view of the identity state disagrees with the reader's.
  */
-inline fun <T : Any, C: Encoder> C.encodePreservingIdentityOf(
+inline fun <T : Any> WriteContext.encodePreservingIdentityOf(
     identities: WriteIdentities,
-    circularReferences: CircularReferences,
-    integrityCheckEnabled: Boolean = false,
     reference: T,
-    encode: C.(T) -> Unit
+    encode: WriteContext.(T) -> Unit
 ) {
     val id = identities.getId(reference)
     if (id >= 0) {
         writeSmallInt(id)
-        if (integrityCheckEnabled) writeBoolean(true)
+        if (isIntegrityCheckEnabled) writeBoolean(true)
     } else {
         val newId = identities.putInstance(reference)
         writeSmallInt(newId)
-        if (integrityCheckEnabled) writeBoolean(false)
+        if (isIntegrityCheckEnabled) writeBoolean(false)
         circularReferences.enter(reference)
         try {
             encode(reference)
@@ -368,10 +355,10 @@ inline fun <T : Any, C: Encoder> C.encodePreservingIdentityOf(
  * Decodes a value previously written with [encodePreservingIdentityOf] within the current
  * isolate's identities.
  *
- * See [Decoder.decodePreservingIdentity] for the proper-usage contract.
+ * See the explicit-identities overload of [decodePreservingIdentity] for the proper-usage contract.
  */
 inline fun <T> ReadContext.decodePreservingIdentity(decode: ReadContext.(Int) -> T): T =
-    decodePreservingIdentity(isolate.identities, isIntegrityCheckEnabled, decode)
+    decodePreservingIdentity(isolate.identities, decode)
 
 
 /**
@@ -381,12 +368,11 @@ inline fun <T> ReadContext.decodePreservingIdentity(decode: ReadContext.(Int) ->
  *
  * **Limitation:** registration happens *after* [decode] returns, so this helper cannot handle
  * self-cycles — a sub-read inside [decode] that back-references the value being decoded will
- * trip the circular-reference detection under the integrity check. Use [Decoder.decodePreservingIdentity]
+ * trip the circular-reference detection under the integrity check. Use [decodePreservingIdentity]
  * with manual `putInstance` if the decoded graph may reference itself.
- *
  */
 inline fun <T : Any> ReadContext.decodePreservingSharedIdentity(decode: ReadContext.(Int) -> T): T =
-    decodePreservingIdentity(sharedIdentities, isIntegrityCheckEnabled) { id ->
+    decodePreservingIdentity(sharedIdentities) { id ->
         decode(id).also {
             sharedIdentities.putInstance(id, it)
         }
@@ -415,22 +401,25 @@ inline fun <T : Any> ReadContext.decodePreservingSharedIdentity(decode: ReadCont
  *
  * Reading children before `putInstance` corrupts the stream when a self-reference is encountered.
  *
- * When [integrityCheckEnabled] is `true`, the encoder has written a boolean flag indicating
- * whether the id is a back-reference. If the flag says "back-reference" but the id has not yet
- * been registered, the function fails fast with [IllegalStateException] pointing at the buggy
- * codec — instead of letting a stream-corruption error surface later.
+ * When the receiving context has [ReadContext.isIntegrityCheckEnabled] set, the encoder has
+ * written a boolean flag indicating whether the id is a back-reference. The decoder verifies that
+ * the flag matches the current identity state and fails fast with [IllegalStateException]
+ * pointing at the buggy codec — instead of letting a stream-corruption error surface later.
+ * Note that the writer side must have been running with the integrity check enabled too;
+ * mismatched modes corrupt the stream.
  *
  * @throws IllegalArgumentException if [decode] hasn't called `putInstance`
- *      or if the [integrityCheckEnabled] is true and the expected back-reference cannot be fulfilled
+ * @throws IllegalStateException if integrity checks are enabled and the writer's view of the
+ *      identity state disagrees with the reader's (back-reference to a not-yet-registered id, or
+ *      fresh write to an already-bound id)
  */
-inline fun <T, C : Decoder> C.decodePreservingIdentity(
+inline fun <T> ReadContext.decodePreservingIdentity(
     identities: ReadIdentities,
-    integrityCheckEnabled: Boolean = false,
-    decode: C.(Int) -> T
+    decode: ReadContext.(Int) -> T
 ): T {
     val id = readSmallInt()
     val previousValue = identities.getInstance(id)
-    if (integrityCheckEnabled) {
+    if (isIntegrityCheckEnabled) {
         val reusedExpected = readBoolean()
         if (reusedExpected) {
             // Let's check if the current state of the identities is valid according to what is written in the stream.

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -289,22 +289,33 @@ inline fun <T : MutableIsolateContext, R> T.withPropertyTrace(trace: PropertyTra
 }
 
 
-inline fun <T : Any> WriteContext.encodePreservingIdentityOf(reference: T, encode: WriteContext.(T) -> Unit) {
+inline fun <T : Any> WriteContext.encodePreservingIdentityOf(reference: T, encode: WriteContext.(T) -> Unit) =
     encodePreservingIdentityOf(isolate.identities, reference, encode)
-}
 
 
 inline fun <T : Any> WriteContext.encodePreservingSharedIdentityOf(reference: T, encode: WriteContext.(T) -> Unit) =
     encodePreservingIdentityOf(sharedIdentities, reference, encode)
 
 
-inline fun <T : Any> WriteContext.encodePreservingIdentityOf(identities: WriteIdentities, reference: T, encode: WriteContext.(T) -> Unit) {
+inline fun <T : Any> WriteContext.encodePreservingIdentityOf(identities: WriteIdentities, reference: T, encode: WriteContext.(T) -> Unit) =
+    encodePreservingIdentityOf(identities, circularReferences, isIntegrityCheckEnabled, reference, encode)
+
+
+inline fun <T : Any, C: Encoder> C.encodePreservingIdentityOf(
+    identities: WriteIdentities,
+    circularReferences: CircularReferences,
+    integrityCheckEnabled: Boolean = false,
+    reference: T,
+    encode: C.(T) -> Unit
+) {
     val id = identities.getId(reference)
     if (id >= 0) {
         writeSmallInt(id)
+        if (integrityCheckEnabled) writeBoolean(true)
     } else {
         val newId = identities.putInstance(reference)
         writeSmallInt(newId)
+        if (integrityCheckEnabled) writeBoolean(false)
         circularReferences.enter(reference)
         try {
             encode(reference)
@@ -316,20 +327,46 @@ inline fun <T : Any> WriteContext.encodePreservingIdentityOf(identities: WriteId
 
 
 inline fun <T> ReadContext.decodePreservingIdentity(decode: ReadContext.(Int) -> T): T =
-    decodePreservingIdentity(isolate.identities, decode)
+    decodePreservingIdentity(isolate.identities, isIntegrityCheckEnabled, decode)
 
 
 inline fun <T : Any> ReadContext.decodePreservingSharedIdentity(decode: ReadContext.(Int) -> T): T =
-    decodePreservingIdentity(sharedIdentities) { id ->
+    decodePreservingIdentity(sharedIdentities, isIntegrityCheckEnabled) { id ->
         decode(id).also {
             sharedIdentities.putInstance(id, it)
         }
     }
 
 
-inline fun <T, C : Decoder> C.decodePreservingIdentity(identities: ReadIdentities, decode: C.(Int) -> T): T {
+inline fun <T, C : Decoder> C.decodePreservingIdentity(
+    identities: ReadIdentities,
+    integrityCheckEnabled: Boolean = false,
+    decode: C.(Int) -> T
+): T {
     val id = readSmallInt()
     val previousValue = identities.getInstance(id)
+    if (integrityCheckEnabled) {
+        val reusedExpected = readBoolean()
+        if (reusedExpected) {
+            // Let's check if the current state of the identities is valid according to what is written in the stream.
+            // Our codecs should handle everything users throw at them properly. Invalid identity state is our fault.
+            // Let's point the user in a right direction.
+            check(previousValue != null) {
+                // We have a circular reference and must backfill it, but the reference is not available.
+                "Unresolvable circular reference detected when decoding id=$id. An existing instance is expected but none available. " +
+                    "This is likely a bug in a Gradle codec. " +
+                    "Please report the issue to Gradle's bug tracker."
+            }
+        } else {
+            check(previousValue == null) {
+                // We have a fresh id that is followed by a definition, but the id is already used for something.
+                "Unexpected reuse of id=$id. The id is already bound to `${previousValue!!.javaClass.name}`. " +
+                    "This is likely a bug in a Gradle codec. " +
+                    "Please report the issue to Gradle's bug tracker."
+            }
+        }
+    }
+
     return when {
         previousValue != null -> previousValue.uncheckedCast()
         else -> {

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Codec.kt
@@ -289,18 +289,56 @@ inline fun <T : MutableIsolateContext, R> T.withPropertyTrace(trace: PropertyTra
 }
 
 
+/**
+ * Encodes [reference] preserving its identity within the current isolate.
+ *
+ * If [reference] has been seen before in this isolate, only its id is written and [encode] is NOT
+ * invoked; otherwise a fresh id is assigned and [encode] is called to write the value's contents.
+ * The matching read side is [ReadContext.decodePreservingIdentity].
+ *
+ * @see encodePreservingIdentityOf for the underlying form and proper-usage notes.
+ */
 inline fun <T : Any> WriteContext.encodePreservingIdentityOf(reference: T, encode: WriteContext.(T) -> Unit) =
     encodePreservingIdentityOf(isolate.identities, reference, encode)
 
 
+/**
+ * Like [WriteContext.encodePreservingIdentityOf] but uses [WriteContext.sharedIdentities] — identity is
+ * preserved across all isolates.
+ * Use for values that may legitimately appear in multiple isolates (e.g. classes, classloader scopes).
+ */
 inline fun <T : Any> WriteContext.encodePreservingSharedIdentityOf(reference: T, encode: WriteContext.(T) -> Unit) =
     encodePreservingIdentityOf(sharedIdentities, reference, encode)
 
 
-inline fun <T : Any> WriteContext.encodePreservingIdentityOf(identities: WriteIdentities, reference: T, encode: WriteContext.(T) -> Unit) =
+/**
+ * Like [WriteContext.encodePreservingIdentityOf] but uses the provided [WriteIdentities] to keep track of visited identities.
+ */
+inline fun <T : Any> WriteContext.encodePreservingIdentityOf(
+    identities: WriteIdentities,
+    reference: T,
+    encode: WriteContext.(T) -> Unit
+) =
     encodePreservingIdentityOf(identities, circularReferences, isIntegrityCheckEnabled, reference, encode)
 
 
+/**
+ * Encodes [reference] preserving its identity in the given [identities] map.
+ *
+ * On first encounter a new id is assigned, [reference] is registered immediately (so a cycle
+ * inside [encode] resolves to the same id rather than a duplicate), and [encode] writes the
+ * contents. On subsequent encounters only the id is written.
+ *
+ * **Proper usage:** the matching decoder must call [ReadIdentities.putInstance] *before* reading
+ * any sub-graph that could transitively reference the value being decoded. Decoders that read
+ * non-trivial state before registering the partial instance break under self-references and
+ * produce corrupted streams. See [Decoder.decodePreservingIdentity] for the read-side contract.
+ *
+ * When [integrityCheckEnabled] is `true`, an extra boolean is written after the id indicating
+ * whether this encounter is a back-reference (`true`) or a fresh write (`false`). The matching
+ * decoder verifies the flag and fails fast with a clear message if a back-reference is
+ * encountered before the partial instance has been registered.
+ */
 inline fun <T : Any, C: Encoder> C.encodePreservingIdentityOf(
     identities: WriteIdentities,
     circularReferences: CircularReferences,
@@ -326,10 +364,27 @@ inline fun <T : Any, C: Encoder> C.encodePreservingIdentityOf(
 }
 
 
+/**
+ * Decodes a value previously written with [encodePreservingIdentityOf] within the current
+ * isolate's identities.
+ *
+ * See [Decoder.decodePreservingIdentity] for the proper-usage contract.
+ */
 inline fun <T> ReadContext.decodePreservingIdentity(decode: ReadContext.(Int) -> T): T =
     decodePreservingIdentity(isolate.identities, isIntegrityCheckEnabled, decode)
 
 
+/**
+ * Decodes a value previously written with [WriteContext.encodePreservingSharedIdentityOf]. The decoded
+ * instance is registered with [ReadContext.sharedIdentities] automatically, so callers do not
+ * need to call `putInstance` themselves.
+ *
+ * **Limitation:** registration happens *after* [decode] returns, so this helper cannot handle
+ * self-cycles — a sub-read inside [decode] that back-references the value being decoded will
+ * trip the circular-reference detection under the integrity check. Use [Decoder.decodePreservingIdentity]
+ * with manual `putInstance` if the decoded graph may reference itself.
+ *
+ */
 inline fun <T : Any> ReadContext.decodePreservingSharedIdentity(decode: ReadContext.(Int) -> T): T =
     decodePreservingIdentity(sharedIdentities, isIntegrityCheckEnabled) { id ->
         decode(id).also {
@@ -338,6 +393,36 @@ inline fun <T : Any> ReadContext.decodePreservingSharedIdentity(decode: ReadCont
     }
 
 
+/**
+ * Decodes a value previously written with [encodePreservingIdentityOf], looking up identities in
+ * the given [identities] map.
+ *
+ * If the id has already been decoded, the previously-registered instance is returned and [decode]
+ * is NOT invoked. Otherwise [decode] is called with the id; it must produce the value AND register
+ * it via `identities.putInstance(id, instance)` — the registration is asserted on return.
+ *
+ * **Proper usage of [decode]:** call `putInstance(id, partialInstance)` *before* reading any
+ * sub-graph that could transitively reference the value being decoded. The typical pattern is:
+ *
+ * ```
+ * decodePreservingIdentity { id ->
+ *     val partial = createEmptyInstance()
+ *     identities.putInstance(id, partial)   // register first
+ *     populate(partial)                     // then read children that may reference `partial`
+ *     partial
+ * }
+ * ```
+ *
+ * Reading children before `putInstance` corrupts the stream when a self-reference is encountered.
+ *
+ * When [integrityCheckEnabled] is `true`, the encoder has written a boolean flag indicating
+ * whether the id is a back-reference. If the flag says "back-reference" but the id has not yet
+ * been registered, the function fails fast with [IllegalStateException] pointing at the buggy
+ * codec — instead of letting a stream-corruption error surface later.
+ *
+ * @throws IllegalArgumentException if [decode] hasn't called `putInstance`
+ *      or if the [integrityCheckEnabled] is true and the expected back-reference cannot be fulfilled
+ */
 inline fun <T, C : Decoder> C.decodePreservingIdentity(
     identities: ReadIdentities,
     integrityCheckEnabled: Boolean = false,

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -151,20 +151,20 @@ object NullClassEncoder : ClassEncoder {
 
 
 object NullClassDecoder : ClassDecoder {
-    override fun Decoder.decodeClass(): Class<*> =
+    override fun ReadContext.decodeClass(): Class<*> =
         error("Cannot decode class in this context.")
 }
 
 
 interface ClassDecoder {
-    fun Decoder.decodeClass(): Class<*>
+    fun ReadContext.decodeClass(): Class<*>
 
     /**
      * Decodes a [ClassLoader] previously encoded via [ClassEncoder.encodeClassLoader].
      *
      * @return the previously encoded [ClassLoader] or `null` when [ClassEncoder.encodeClassLoader] returns `false`
      */
-    fun Decoder.decodeClassLoader(): ClassLoader? = null
+    fun ReadContext.decodeClassLoader(): ClassLoader? = null
 }
 
 


### PR DESCRIPTION
Fixes #32607

* Expose semi-prepared Property instance earlier, so a circular reference can be resolved
* Add a check that prevents trying to read a back reference as a full instance
### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
