### PR TITLE
Remove unnecessary areChangesAllowed() method 

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -94,8 +94,7 @@ plugins {
 
 ### Domain Object Collections can be made immutable
 
-Plugin and build authors can now lock domain object collections to prevent further modifications using the new `disallowChanges()` method. 
-You can also verify the status of a collection using `areChangesAllowed()`.
+Plugin and build authors can now lock domain object collections to prevent further modifications using the new `disallowChanges()` method.
 - Once `disallowChanges()` is called, elements can no longer be added to or removed from the collection.
 - Invoking this method does not force the realization of lazy items previously added to the collection. 
 - This lock applies only to the collection itself. Individual objects within the collection can still be modified.
@@ -104,12 +103,10 @@ You can also verify the status of a collection using `areChangesAllowed()`.
 val myCollection = objects.domainObjectContainer(MyType::class)
 val main = MyType("main")
 
-myCollection.areChangesAllowed()  // returns true
 myCollection.add(main)
 myCollection.add(MyType("test"))
 
 myCollection.disallowChanges()    // the collection is now immutable
-myCollection.areChangesAllowed()  // returns false
 main.setFoo("bar")                // individual elements can still be modified
 myCollection.add(MyType("other")) // this will fail
 myCollection.remove(main)         // this will fail

--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
@@ -227,14 +227,4 @@ public interface DomainObjectCollection<T> extends Collection<T> {
     default void disallowChanges() {
         throw new UnsupportedOperationException("disallowChanges() is not supported by this collection");
     }
-
-    /**
-     * Returns {@code false} if {@link DomainObjectCollection#disallowChanges()} has been called on this collection.
-     *
-     * @since 9.5.0
-     */
-    @Incubating
-    default boolean areChangesAllowed() {
-        return true;
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -499,11 +499,6 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         });
     }
 
-    @Override
-    public boolean areChangesAllowed() {
-        return !changesDisallowed;
-    }
-
     protected class IteratorImpl implements Iterator<T> {
         private final Iterator<T> iterator;
         private T currentElement;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DelegatingDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DelegatingDomainObjectSet.java
@@ -196,11 +196,6 @@ public class DelegatingDomainObjectSet<T> implements DomainObjectSet<T>, DomainO
         ((DomainObjectCollectionInternal<T>) delegate).disallowChanges();
     }
 
-    @Override
-    public boolean areChangesAllowed() {
-        return ((DomainObjectCollectionInternal<T>) delegate).areChangesAllowed();
-    }
-
     @Internal
     @Override
     public String getDisplayName() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
@@ -757,17 +757,6 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
         thrown(IllegalStateException)
     }
 
-    def "areChangesAllowed reflects state correctly"() {
-        expect:
-        container.areChangesAllowed()
-
-        when:
-        container.disallowChanges()
-
-        then:
-        !container.areChangesAllowed()
-    }
-
     interface Subtype extends CharSequence {}
 
     static <T> Collection<T> collect(Iterable<T> iterable) {


### PR DESCRIPTION
This method was added by #36891.  

After some internal discussion, we've decided that:
1) Querying state is not an existing general capability of lazy things (e.g. `Property` has a `disallowChanges()` method but no way to query that state).
2) Exposing this could lead to some anti-patterns that we would rather not enable (e.g. working around the fact that a container has been locked against further changes).

This is not necessary for anything internal to Gradle, so we're reverting this for now.  We can add it back if sound use cases emerge that require it.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
