### PR TITLE
Fix misleading dependency locking warning when all changing modules are ignored 

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -223,6 +223,37 @@ dependencies {
         succeeds 'dependencies'
     }
 
+    def 'does not warn about changing modules when all are ignored'() {
+        mavenRepo.module('org', 'bar', '1.0-SNAPSHOT').publish()
+
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+    ignoredDependencies.add('org:bar')
+}
+
+repositories {
+    maven {
+        name = 'repo'
+        url = "${mavenRepo.uri}"
+    }
+}
+configurations {
+    lockedConf
+}
+
+dependencies {
+    lockedConf 'org:bar:1.0-SNAPSHOT'
+}
+"""
+
+        when:
+        succeeds 'dependencies', '--write-locks'
+
+        then:
+        outputDoesNotContain('contains changing modules')
+    }
+
     def "can update a single lock entry when using #version"() {
         ['bar', 'baz', 'foo'].each { artifactId ->
             mavenRepo.module('org', artifactId, '1.0').publish()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -198,9 +198,10 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     ) {
         if (writeLocks) {
             List<String> modulesOrdered = getModulesOrdered(resolvedModules);
-            if (!changingResolvedModules.isEmpty()) {
+            List<String> changingModulesOrdered = getModulesOrdered(changingResolvedModules);
+            if (!changingModulesOrdered.isEmpty()) {
                 LOGGER.warn("Dependency lock state for {} contains changing modules: {}. This means that dependencies content may still change over time. {}",
-                    lockOwner, getModulesOrdered(changingResolvedModules), DOC_REG.getDocumentationRecommendationFor("details", "dependency_locking"));
+                    lockOwner, changingModulesOrdered, DOC_REG.getDocumentationRecommendationFor("details", "dependency_locking"));
             }
             allLockState.put(lockId, modulesOrdered);
         }


### PR DESCRIPTION
fixes #35627


### Context
When using dependency locking with `ignoredDependencies` and `--write-locks`, Gradle emits a misleading warning: `Dependency lock state for configuration ':foo' contains changing modules: []. This means that dependencies content may still change over time.`

The warning fires even when all changing modules (e.g. SNAPSHOTs) have been explicitly added to `ignoredDependencies`, resulting in an empty list `[]` in the message. This is confusing  because the user has already acknowledged these dependencies should be ignored.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
