### PR TITLE
Write performance DB profiling output to file instead of stdout

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/reporter/PerformanceReporter.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/reporter/PerformanceReporter.groovy
@@ -41,32 +41,6 @@ class PerformanceReporter {
         this.fileOperations = fileOperations
     }
 
-    static class PerformanceReportExecOutputStream extends OutputStream {
-        private File profilingOutput;
-        private StringBuilder buffer = new StringBuilder()
-
-        PerformanceReportExecOutputStream(File profilingOutput) {
-            this.profilingOutput = profilingOutput
-        }
-
-        @Override
-        void write(int b) throws IOException {
-            char c = (char) b
-            if (c == ('\n' as char)) {
-                String line = buffer.toString()
-                String prefix = "[Profiling] "
-                if (line.startsWith(prefix)) {
-                    profilingOutput << line.substring(prefix.length()) << "\n"
-                }
-                println(line)
-
-                buffer.setLength(0) // Clear for next line
-            } else {
-                buffer.append(c)
-            }
-        }
-    }
-
     void report(
         String reportGeneratorClass,
         File reportDir,
@@ -85,7 +59,6 @@ class PerformanceReporter {
             it.delete(reportDir)
         }
         reportDir.mkdirs()
-        OutputStream output = new PerformanceReportExecOutputStream(new File(reportDir, "profiling.txt"))
 
         ExecResult result = execOperations.javaexec(new Action<JavaExecSpec>() {
             void execute(JavaExecSpec spec) {
@@ -98,6 +71,7 @@ class PerformanceReporter {
                 spec.systemProperty("org.gradle.performance.execution.channel.patterns", channelPatterns.join(","))
                 spec.systemProperty("org.gradle.performance.execution.branch", branchName)
                 spec.systemProperty("org.gradle.performance.dependencyBuildIds", dependencyBuildIds)
+                spec.systemProperty("org.gradle.performance.db.profiling.output", new File(reportDir, "profiling.txt").absolutePath)
 
                 // For org.gradle.performance.util.Git
                 spec.systemProperty("gradleBuildBranch", branchName)
@@ -106,8 +80,6 @@ class PerformanceReporter {
                 spec.setClasspath(classpath)
 
                 spec.ignoreExitValue = true
-                spec.setErrorOutput(output)
-                spec.setStandardOutput(output)
             }
         })
 

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -326,6 +326,7 @@ abstract class PerformanceTest extends DistributionTest {
             addSystemPropertyIfExist(result, "org.gradle.performance.regression.checks", checks)
             addSystemPropertyIfExist(result, "org.gradle.performance.execution.channel", channel.get())
             addSystemPropertyIfExist(result, "org.gradle.performance.debugArtifactsDirectory", getDebugArtifactsDirectory())
+            addSystemPropertyIfExist(result, "org.gradle.performance.db.profiling.output", new File(debugArtifactsDirectory, "db-profiling.txt").absolutePath)
             addSystemPropertyIfExist(result, "gradleBuildBranch", branchName)
 
             if (profiler.isPresent() && profiler.get() != "none") {

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -70,7 +70,7 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
             }
             batchResult = statement.executeBatch();
         } finally {
-            System.out.println("[Profiling] " + SQLProfilingData.create("batchInsertOperation", sql, results.getBuilds().stream().toList(), batchResult, startTime).toJson());
+            PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("batchInsertOperation", sql, results.getBuilds().stream().toList(), batchResult, startTime).toJson());
         }
     }
 
@@ -100,7 +100,7 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
                 return keys.getLong(1);
             }
         } finally {
-            System.out.println("[Profiling] " + SQLProfilingData.create("insertExecution", sql, List.of(results.getTeamCityBuildId()), executeResult, startTime).toJson());
+            PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("insertExecution", sql, List.of(results.getTeamCityBuildId()), executeResult, startTime).toJson());
         }
     }
 
@@ -117,7 +117,7 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
         } catch (SQLIntegrityConstraintViolationException ignore) {
             // This is expected, ignore.
         } finally {
-            System.out.println("[Profiling] " + SQLProfilingData.create("insertExecutionExperiment", sql, List.of(results.getTestId(), results.getTestProject(), results.getTestClass()), executeResult, startTime).toJson());
+            PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("insertExecutionExperiment", sql, List.of(results.getTestId(), results.getTestProject(), results.getTestClass()), executeResult, startTime).toJson());
         }
     }
 
@@ -158,7 +158,7 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
                     return Lists.newArrayList(testNames);
                 }
             } finally {
-                System.out.println("[Profiling] " + SQLProfilingData.create("getPerformanceExperiments", sql, List.of(resultType), rs, startTime).toJson());
+                PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("getPerformanceExperiments", sql, List.of(resultType), rs, startTime).toJson());
             }
         });
     }
@@ -237,12 +237,12 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
                                 builds.add(displayInfo);
                             }
                         } finally {
-                            System.out.println("[Profiling] " + SQLProfilingData.create("operationsForExecution", operationsForExecutionSql, List.of(id), operationsForExecutionRs, operationsForExecutionStartTime).toJson());
+                            PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("operationsForExecution", operationsForExecutionSql, List.of(id), operationsForExecutionRs, operationsForExecutionStartTime).toJson());
                         }
                     }
                     return new CrossBuildPerformanceTestHistory(experiment, ImmutableList.copyOf(builds), results);
                 } finally {
-                    System.out.println("[Profiling] " + SQLProfilingData.create("executionsForName", executionsForNameSql, List.of(experiment.getScenario().getClassName(),  experiment.getScenario().getTestName(), experiment.getTestProject(), minDate), executionsForNameRs, executionsForNameStartTime).toJson());
+                    PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("executionsForName", executionsForNameSql, List.of(experiment.getScenario().getClassName(),  experiment.getScenario().getTestName(), experiment.getTestProject(), minDate), executionsForNameRs, executionsForNameStartTime).toJson());
                 }
             }
         });

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -102,7 +102,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
         } catch (SQLIntegrityConstraintViolationException ignore) {
             // This is expected, ignore.
         } finally {
-            System.out.println("[Profiling] " + SQLProfilingData.create("insertExecutionExperiment", sql, List.of(results.getTestId(), results.getTestProject(), results.getTestClass()), result, startTime).toJson());
+            PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("insertExecutionExperiment", sql, List.of(results.getTestId(), results.getTestProject(), results.getTestClass()), result, startTime).toJson());
         }
     }
 
@@ -118,7 +118,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                 statement.setString(4, results.getTestClass());
                 result = statement.execute();
             } finally {
-                System.out.println("[Profiling] " + SQLProfilingData.create("updatePreviousTestId", sql, List.of(results.getTestId(), previousId, results.getTestProject(), results.getTestClass()), result, startTime).toJson());
+                PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("updatePreviousTestId", sql, List.of(results.getTestId(), previousId, results.getTestProject(), results.getTestClass()), result, startTime).toJson());
             }
         }
     }
@@ -134,7 +134,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
             }
             result = statement.executeBatch();
         } finally {
-            System.out.println("[Profiling] " + SQLProfilingData.create("batchInsertOperation", sql, List.of(String.valueOf(results.getTeamCityBuildId())), result, startTime).toJson());
+            PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("batchInsertOperation", sql, List.of(String.valueOf(results.getTeamCityBuildId())), result, startTime).toJson());
         }
     }
 
@@ -188,7 +188,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                 return keys.getLong(1);
             }
         } finally {
-            System.out.println("[Profiling] " + SQLProfilingData.create("insertExecution", insertStatement, List.of(results.getTeamCityBuildId()), result, startTime).toJson());
+            PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("insertExecution", insertStatement, List.of(results.getTeamCityBuildId()), result, startTime).toJson());
         }
     }
 
@@ -226,7 +226,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                 }
                 return testNames;
             } finally {
-                System.out.println("[Profiling] " + SQLProfilingData.create("getPerformanceExperiments", sql, List.of(), rs, startTime).toJson());
+                PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("getPerformanceExperiments", sql, List.of(), rs, startTime).toJson());
             }
         });
     }
@@ -299,7 +299,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                         allBranches.add(performanceResults.getVcsBranch());
                     }
                 } finally {
-                    System.out.println("[Profiling] " + SQLProfilingData.create("executionsForName", executionsForNameSql, List.of(experiment.getScenario().getClassName(), experiment.getScenario().getTestName(), experiment.getTestProject(), minDate), executionsForNameRs, executionsForNameStartTime).toJson());
+                    PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("executionsForName", executionsForNameSql, List.of(experiment.getScenario().getClassName(), experiment.getScenario().getTestName(), experiment.getTestProject(), minDate), executionsForNameRs, executionsForNameStartTime).toJson());
                 }
 
                 operationsForExecution.setFetchSize(10 * results.size());
@@ -338,7 +338,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                         }
                     }
                 } finally {
-                    System.out.println("[Profiling] " + SQLProfilingData.create("operationsForExecution", operationsForExecutionSql, List.of(experiment.getScenario().getClassName(), experiment.getScenario().getTestName(), experiment.getTestProject(), minDate), operationsForExecutionRs, operationsForExecutionStartTime).toJson());
+                    PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("operationsForExecution", operationsForExecutionSql, List.of(experiment.getScenario().getClassName(), experiment.getScenario().getTestName(), experiment.getTestProject(), minDate), operationsForExecutionRs, operationsForExecutionStartTime).toJson());
                 }
                 return new CrossVersionPerformanceTestHistory(experiment, new ArrayList<>(allVersions), new ArrayList<>(allBranches), Lists.newArrayList(results.values()));
             }

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceDatabase.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceDatabase.java
@@ -20,6 +20,9 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 import javax.sql.DataSource;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
@@ -32,17 +35,25 @@ public class PerformanceDatabase {
     private static final int MAX_LIFETIME_MS = 30 * 1000;
     private static final String PERFORMANCE_DB_URL_PROPERTY_NAME = "org.gradle.performance.db.url";
     private static final DateTimeFormatter PROFILING_TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    private static final String PROFILING_OUTPUT_PROPERTY = "org.gradle.performance.db.profiling.output";
     private final String databaseName;
     private final List<ConnectionAction<Void>> databaseInitializers;
     private HikariDataSource dataSource;
 
-    private static void logProfilingWithCallStack(String jsonPayload) {
+    static void logProfilingWithCallStack(String jsonPayload) {
         // Capture stack at call site. We'll still include this method in the trace, but skip it when printing.
         StackTraceElement[] stackTrace = new Exception("Call stack for profiling log").getStackTrace();
         String ts = LocalDateTime.now().format(PROFILING_TIMESTAMP_FORMATTER);
-        System.out.println("[Profiling] " + ts + " " + jsonPayload);
-        for (int i = 1; i < stackTrace.length; i++) {
-            System.out.println("[Profiling] \tat " + stackTrace[i]);
+        String profilingOutputPath = System.getProperty(PROFILING_OUTPUT_PROPERTY);
+        if (profilingOutputPath != null) {
+            try (PrintWriter pw = new PrintWriter(new FileWriter(profilingOutputPath, true))) {
+                pw.println(ts + " " + jsonPayload);
+                for (int i = 1; i < stackTrace.length; i++) {
+                    pw.println("\tat " + stackTrace[i]);
+                }
+            } catch (IOException e) {
+                System.err.println("Failed to write profiling output to " + profilingOutputPath + ": " + e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/5105

In the past we wrote performance DB profiling log output to stdout directly, which messed up the test output. This PR changes it to write to a profiling file instead of stdout.

Verified in https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_PerformanceTestTestLinuxbucket7/109795024