### PR TITLE
Detach AS app if it's already attached

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/ExtractAndroidStudioTask.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/ExtractAndroidStudioTask.kt
@@ -79,8 +79,12 @@ abstract class ExtractAndroidStudioTask @Inject constructor(
     fun extractDmg(androidStudioDistribution: File) {
         val volumeDir = "/Volumes/$VOLUME_NAME"
         val srcDir = "/Volumes/$VOLUME_NAME/Android Studio.app"
-        require(!File(srcDir).exists()) {
-            "The directory $srcDir already exists. Please unmount it via `hdiutil detach $volumeDir`."
+        // A previous build may have been interrupted before the finally block could detach the volume.
+        // Detach it automatically so the task can proceed without requiring manual intervention.
+        if (File(srcDir).exists()) {
+            execOps.exec {
+                commandLine("hdiutil", "detach", volumeDir)
+            }
         }
 
         try {


### PR DESCRIPTION
Sometimes, if a build didn't clean up AS mounting properly (e.g. build is cancelled), the next build will fail with error:

```
org.gradle.tooling.internal.consumer.DefaultFailure: The directory /Volumes/AndroidStudioForGradle/Android Studio.app already exists. Please unmount it via `hdiutil detach /Volumes/AndroidStudioForGradle`.
```

Let's run `detach` automatically if it's attached.