### PR TITLE
[Investigation] Implement parallel task dependency resolution

### DIFF
--- a/PARALLEL-RESOLUTION.md
+++ b/PARALLEL-RESOLUTION.md
@@ -1,0 +1,155 @@
+# Parallel Task Dependency Resolution for Isolated Projects
+
+## How Task Scheduling Works
+
+```
+./gradlew compileJava
+        │
+        ▼
+┌─────────────────────────┐
+│  Task Selection         │  "compileJava" → [:app:compileJava, :lib:compileJava]
+│                         │  (triggers project configuration in IP mode)
+└─────────┬───────────────┘
+          │  addEntryTasks([:app:compileJava, :lib:compileJava])
+          ▼
+┌─────────────────────────┐
+│  Discover Relationships │  Sequential DFS — resolves dependencies
+│                         │  one node at a time, walks the full graph
+└─────────┬───────────────┘
+          ▼
+┌─────────────────────────┐
+│  Determine Plan         │  Topological sort → ordered execution list
+└─────────┬───────────────┘
+          ▼
+┌─────────────────────────┐
+│  CC Store/Load          │  Serialize the work graph to cache
+└─────────┬───────────────┘  (on CC hit, everything above is skipped)
+          ▼
+┌─────────────────────────┐ʔ„
+│  Execute                │  Worker threads pick up tasks
+└─────────────────────────┘
+```
+
+### The bottleneck
+
+**Discover Relationships** is single-threaded. Each node is resolved sequentially,
+acquiring one project lock at a time. In large builds (1000+ projects),
+this phase dominates CC-miss builds where configuration is already done.
+
+### How dependencies are discovered
+
+Task dependencies are discovered by walking dependency containers (`TaskDependency`,
+`FileCollection`, `Provider` chains). The walker returns leaf nodes:
+
+- **String task paths** (`dependsOn ':foo:compile'`) — resolved via `TaskResolver`
+- **Artifact dependencies** (`implementation project(':lib')`) — resolved through the
+  dependency engine: `compileClasspath` → `ProjectArtifactResolver` → `DefaultResolvableArtifact`
+  → `ResolveAction` (a `WorkNodeAction`) → `ActionNode`
+- **Reverse dependency searches** (`buildDependents`) — search all projects for dependents
+
+## Parallel Task Dependency Resolution (BFS Waves)
+
+We replace the sequential DFS with a parallel BFS for `LocalTaskNode` resolution:
+
+```
+Entry tasks: [:app:compileJava, :lib:compileJava]
+                    │
+                    ▼
+┌──────────────────────────────────────────────────────┐
+│  Wave 1 — resolve in parallel, grouped by project    │
+│                                                      │
+│   :app lock          :lib lock                       │
+│  ┌────────────┐    ┌────────────────┐                │
+│  │:app:compile│    │:lib:compileJava│                │
+│  │  Java      │    │  → (done)      │                │
+│  │  → Action  │    └────────────────┘                │
+│  │    Node    │                                      │
+│  │  → :lib    │ ← cross-project dep deferred         │
+│  │    :jar    │    as placeholder                     │
+│  └────────────┘                                      │
+└──────────────────┬───────────────────────────────────┘
+                   │  resolve placeholders:
+                   │  :lib:jar found under :lib lock
+                   ▼
+┌──────────────────────────────────────────────────────┐
+│  Wave 2 — newly discovered LocalTaskNodes            │
+│                                                      │
+│   :lib lock                                          │
+│  ┌────────────┐                                      │
+│  │ :lib:jar   │                                      │
+│  │  → :lib:   │                                      │
+│  │  compile   │                                      │
+│  │  Java      │  ← already resolved in wave 1        │
+│  └────────────┘                                      │
+└──────────────────┬───────────────────────────────────┘
+                   │  no more LocalTaskNodes
+                   ▼
+┌──────────────────────────────────────────────────────┐
+│  Sequential DFS — handles remaining non-task nodes   │
+│  (ActionNodes, TaskInAnotherBuild, etc.)             │
+│  Pre-resolved tasks use cached results → fast        │
+└──────────────────────────────────────────────────────┘
+```
+
+### Key ideas
+
+- **BFS waves** resolve `LocalTaskNode`s in parallel, one project lock at a time
+- **Cross-project dependencies** → deferred as placeholders, resolved between waves under the correct project lock
+- **Non-task nodes** (ActionNode, etc.) → sequential DFS fallback, but pre-resolved tasks use cached results
+- **Same result** as sequential, just faster discovery
+
+### What's parallelized vs sequential
+
+| Phase | Before | After |
+|---|---|---|
+| Task dependency resolution | Sequential DFS, one node at a time | Parallel BFS waves by project |
+| Cross-project task lookup | Inline under single lock | Deferred placeholder → resolved under correct lock |
+| ActionNode / transforms | Sequential | Sequential (TODO: resolve between waves to discover more tasks for parallel waves) |
+| Execution plan ordering | Sequential | Sequential (unchanged) |
+| Task execution | Parallel (unchanged) | Parallel (unchanged) |
+
+## Future: IP Cache (Per-project CC Store)
+
+The parallel BFS creates a natural per-project serialization boundary. Each project's
+`Map<LocalTaskNode, ResolvedNodeRelationships>` is self-contained, with cross-project
+edges stored as symbolic references (`DeferredCrossProjectDependency`: identity path + task name).
+
+This enables **per-project configuration cache**: change one project's build script and
+only that project needs re-resolution. The rest load from cache.
+
+```
+CC hit (whole graph)  →  skip straight to Execute
+
+CC miss (whole graph), but per-project hits:
+
+  ┌─────────────────────────┐
+  │  Task Selection         │
+  └─────────┬───────────────┘
+            ▼
+  ┌─────────────────────────────────────────┐
+  │  BFS                                    │
+  │  :app → per-project CC hit, load chunk  │
+  │  :lib → per-project CC miss, resolve    │
+  └─────────┬───────────────────────────────┘
+            ▼
+  ┌───────────────────────────────────┐
+  │  IP cache (Per-project CC store)  │  store :lib's chunk
+  └─────────┬─────────────────────────┘
+            ▼
+  ┌──────────────────────────┐
+  │  Stitch + Determine Plan │  resolve cross-project placeholders, topological sort
+  └─────────┬────────────────┘  
+            ▼
+  ┌─────────────────────────┐
+  │  CC Load/Store          │  store everything (existing behavior)
+  └─────────┬───────────────┘
+            ▼
+  ┌─────────────────────────┐
+  │  Execute                │
+  └─────────────────────────┘
+```
+
+The whole-graph CC is the fast path — when it hits, nothing else runs.
+Per-project CC is the fallback that makes the miss path faster: only
+cache-miss projects need re-resolution, the rest load from per-project cache.
+Both stored, cheapest one wins on the next run.

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -541,6 +541,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         then:
         dependencies.toList() == [task]
         1 * taskResolver.resolveTask(Path.path("c")) >> task
+        _ * taskResolver.resolveTargetProjectIdentityPath(_)
         0 * _
     }
 
@@ -560,6 +561,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         dependencies.toList() == [taskA, taskB]
         1 * fileCollectionMock.visitDependencies(_) >> { TaskDependencyResolveContext context -> context.add(taskA) }
         1 * taskResolver.resolveTask(Path.path("b")) >> taskB
+        _ * taskResolver.resolveTargetProjectIdentityPath(_)
         0 * _
     }
 
@@ -578,6 +580,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         fileTreeDependencies.toList() == [task]
         filteredFileTreeDependencies.toList() == [task]
         3 * taskResolver.resolveTask(Path.path("task")) >> task
+        _ * taskResolver.resolveTargetProjectIdentityPath(_)
         0 * _
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/AbstractTaskDependencyContainerVisitingContext.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/AbstractTaskDependencyContainerVisitingContext.java
@@ -63,11 +63,6 @@ public abstract class AbstractTaskDependencyContainerVisitingContext extends Abs
     }
 
     @Override
-    public boolean deferCrossProjectResolution(Path taskPath) {
-        return delegate.deferCrossProjectResolution(taskPath);
-    }
-
-    @Override
     public boolean deferAllProjectsSearch(Consumer<TaskDependencyResolveContext> resolutionAction) {
         return delegate.deferAllProjectsSearch(resolutionAction);
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/AbstractTaskDependencyContainerVisitingContext.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/AbstractTaskDependencyContainerVisitingContext.java
@@ -20,10 +20,12 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.AbstractTaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * A {@link TaskDependencyResolveContext} which visits incoming dependencies if they are {@link TaskDependencyContainer} instances.
@@ -53,5 +55,20 @@ public abstract class AbstractTaskDependencyContainerVisitingContext extends Abs
     @Override
     public Task getTask() {
         return delegate.getTask();
+    }
+
+    @Override
+    public boolean deferCrossProjectResolution(Path targetProjectIdentityPath, String taskName) {
+        return delegate.deferCrossProjectResolution(targetProjectIdentityPath, taskName);
+    }
+
+    @Override
+    public boolean deferCrossProjectResolution(Path taskPath) {
+        return delegate.deferCrossProjectResolution(taskPath);
+    }
+
+    @Override
+    public boolean deferAllProjectsSearch(Consumer<TaskDependencyResolveContext> resolutionAction) {
+        return delegate.deferAllProjectsSearch(resolutionAction);
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -147,7 +147,9 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 }
             } else if (resolver != null && dependency instanceof CharSequence) {
                 org.gradle.util.Path taskPath = org.gradle.util.Path.path(dependency.toString());
-                context.add(resolver.resolveTask(taskPath));
+                if (!context.deferCrossProjectResolution(taskPath)) {
+                    context.add(resolver.resolveTask(taskPath));
+                }
             } else if (dependency instanceof VisitBehavior) {
                 ((VisitBehavior) dependency).onVisit.accept(context);
             } else {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -147,7 +147,8 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 }
             } else if (resolver != null && dependency instanceof CharSequence) {
                 org.gradle.util.Path taskPath = org.gradle.util.Path.path(dependency.toString());
-                if (!context.deferCrossProjectResolution(taskPath)) {
+                org.gradle.util.Path targetIdentityPath = resolver.resolveTargetProjectIdentityPath(taskPath);
+                if (!context.deferCrossProjectResolution(targetIdentityPath, taskPath.getName())) {
                     context.add(resolver.resolveTask(taskPath));
                 }
             } else if (dependency instanceof VisitBehavior) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DeferredCrossProjectDependency.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DeferredCrossProjectDependency.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks;
+
+import org.gradle.api.Task;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+/**
+ * Marker type passed to {@link TaskDependencyResolveContext#add} during parallel task
+ * dependency resolution to defer cross-project dependency lookups. Intercepted by
+ * {@link ProjectScopedCachingTaskDependencyResolveContext#add} before reaching the graph walker.
+ */
+@NullMarked
+public abstract class DeferredCrossProjectDependency {
+
+    private DeferredCrossProjectDependency() {
+    }
+
+    /**
+     * Find a task by name in a specific project, identified by its build-tree identity path.
+     */
+    public static class ByProjectTask extends DeferredCrossProjectDependency {
+        private final Path targetProjectIdentityPath;
+        private final String taskName;
+
+        public ByProjectTask(Path targetProjectIdentityPath, String taskName) {
+            this.targetProjectIdentityPath = targetProjectIdentityPath;
+            this.taskName = taskName;
+        }
+
+        public Path getTargetProjectIdentityPath() {
+            return targetProjectIdentityPath;
+        }
+
+        public String getTaskName() {
+            return taskName;
+        }
+    }
+
+    /**
+     * Deferred resolution that needs access to multiple projects.
+     * Carries the original resolution logic as a {@link Consumer} so it can be
+     * re-executed later under proper locking without duplicating implementation details.
+     */
+    public static class AllProjectsSearch extends DeferredCrossProjectDependency {
+        private final Consumer<TaskDependencyResolveContext> resolutionAction;
+        private final @Nullable Task sourceTask;
+
+        public AllProjectsSearch(Consumer<TaskDependencyResolveContext> resolutionAction, @Nullable Task sourceTask) {
+            this.resolutionAction = resolutionAction;
+            this.sourceTask = sourceTask;
+        }
+
+        public Consumer<TaskDependencyResolveContext> getResolutionAction() {
+            return resolutionAction;
+        }
+
+        public @Nullable Task getSourceTask() {
+            return sourceTask;
+        }
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/ProjectScopedCachingTaskDependencyResolveContext.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/ProjectScopedCachingTaskDependencyResolveContext.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * A project-scoped variant of {@link CachingTaskDependencyResolveContext} used during
+ * parallel task dependency resolution. Intercepts {@link DeferredCrossProjectDependency}
+ * markers in {@link #add} and converts them to placeholder nodes using the provided
+ * {@link PlaceholderHandler}.
+ *
+ * <p>Placeholders are injected into the underlying graph walker via {@link #add} so they
+ * participate in the walker's cache. When cached placeholders appear in subsequent results,
+ * the source task is registered via the handler so that placeholder substitution knows
+ * which tasks need post-processing.</p>
+ */
+@NullMarked
+public class ProjectScopedCachingTaskDependencyResolveContext<T> extends CachingTaskDependencyResolveContext<T> {
+
+    private final Path currentProjectIdentityPath;
+    private final PlaceholderHandler<T> placeholderHandler;
+
+    /**
+     * All placeholders ever created via the handler, used to detect whether a
+     * result set contains placeholders that require source task registration.
+     */
+    private final Set<T> createdPlaceholders = Collections.newSetFromMap(new IdentityHashMap<>());
+
+    public ProjectScopedCachingTaskDependencyResolveContext(
+        Collection<? extends WorkDependencyResolver<T>> workResolvers,
+        Path currentProjectIdentityPath,
+        PlaceholderHandler<T> placeholderHandler
+    ) {
+        super(prependPlaceholderResolver(workResolvers));
+        this.currentProjectIdentityPath = currentProjectIdentityPath;
+        this.placeholderHandler = placeholderHandler;
+    }
+
+    private static <T> List<WorkDependencyResolver<T>> prependPlaceholderResolver(Collection<? extends WorkDependencyResolver<T>> workResolvers) {
+        return ImmutableList.<WorkDependencyResolver<T>>builderWithExpectedSize(workResolvers.size() + 1)
+            .add(new PlaceholderResolver<>())
+            .addAll(workResolvers)
+            .build();
+    }
+
+    @Override
+    public boolean deferCrossProjectResolution(Path targetProjectIdentityPath, String taskName) {
+        if (currentProjectIdentityPath.equals(targetProjectIdentityPath)) {
+            return false;
+        }
+        add(new DeferredCrossProjectDependency.ByProjectTask(targetProjectIdentityPath, taskName));
+        return true;
+    }
+
+
+    @Override
+    public boolean deferAllProjectsSearch(Consumer<TaskDependencyResolveContext> resolutionAction) {
+        add(new DeferredCrossProjectDependency.AllProjectsSearch(resolutionAction, getTask()));
+        return true;
+    }
+
+    @Override
+    public void add(Object dependency) {
+        if (dependency instanceof DeferredCrossProjectDependency) {
+            T placeholder = placeholderHandler.createPlaceholder((DeferredCrossProjectDependency) dependency);
+            createdPlaceholders.add(placeholder);
+            // Wrap in a PlaceholderMarker and feed into the walker so the placeholder
+            // becomes a cached value of the parent container node.
+            super.add(new PlaceholderMarker<>(placeholder));
+        } else {
+            super.add(dependency);
+        }
+    }
+
+    @Override
+    public Set<T> getDependencies(@Nullable Task task, Object dependencies) {
+        Set<T> result = super.getDependencies(task, dependencies);
+        if (task != null && resultContainsPlaceholder(result)) {
+            placeholderHandler.registerSourceTaskWithPlaceholder(task);
+        }
+        return result;
+    }
+
+    private boolean resultContainsPlaceholder(Set<T> result) {
+        if (createdPlaceholders.isEmpty()) {
+            return false;
+        }
+        for (T value : result) {
+            if (createdPlaceholders.contains(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Thin wrapper that carries a placeholder value through the graph walker.
+     * The walker visits it as a node, and {@link PlaceholderResolver} unwraps it
+     * into a resolved value that gets cached alongside same-project dependencies.
+     */
+    private static class PlaceholderMarker<T> {
+        final T placeholder;
+
+        PlaceholderMarker(T placeholder) {
+            this.placeholder = placeholder;
+        }
+    }
+
+    /**
+     * {@link WorkDependencyResolver} that handles {@link PlaceholderMarker} nodes
+     * by unwrapping and emitting the placeholder as a resolved value.
+     */
+    private static class PlaceholderResolver<T> implements WorkDependencyResolver<T> {
+        @Override
+        @SuppressWarnings("unchecked")
+        public boolean resolve(Task task, Object node, Action<? super T> resolveAction) {
+            if (node instanceof PlaceholderMarker) {
+                resolveAction.execute(((PlaceholderMarker<T>) node).placeholder);
+                return true;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Handles cross-project dependency placeholders during parallel task dependency resolution.
+     *
+     * @param <T> the dependency node type
+     */
+    public interface PlaceholderHandler<T> {
+
+        /**
+         * Creates a placeholder node for a deferred cross-project dependency and
+         * registers it for later resolution.
+         */
+        T createPlaceholder(DeferredCrossProjectDependency dep);
+
+        /**
+         * Registers the given task as having placeholder nodes in its resolved dependencies,
+         * so that placeholder substitution knows to process it.
+         */
+        void registerSourceTaskWithPlaceholder(Task task);
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/TaskDependencyResolveContext.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/TaskDependencyResolveContext.java
@@ -19,7 +19,10 @@ package org.gradle.api.internal.tasks;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.internal.artifacts.transform.TransformNodeDependency;
+import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
+
+import java.util.function.Consumer;
 
 public interface TaskDependencyResolveContext extends Action<Task> {
     @Override
@@ -58,4 +61,44 @@ public interface TaskDependencyResolveContext extends Action<Task> {
      */
     @Nullable
     Task getTask();
+
+    /**
+     * Defers the resolution of a task from another project during parallel dependency resolution.
+     *
+     * <p><b>Important:</b> Implementations that delegate to another context must forward this method
+     * to the delegate. Returning {@code false} when the delegate would return {@code true} causes
+     * cross-project state to be accessed without proper locking, losing dependency information.</p>
+     *
+     * @return {@code true} if the resolution was deferred; {@code false} if the caller should proceed with immediate resolution.
+     */
+    default boolean deferCrossProjectResolution(Path targetProjectIdentityPath, String taskName) {
+        return false;
+    }
+
+    /**
+     * Defers the resolution of a task from another project during parallel dependency resolution.
+     *
+     * <p><b>Important:</b> Implementations that delegate to another context must forward this method
+     * to the delegate. Returning {@code false} when the delegate would return {@code true} causes
+     * cross-project state to be accessed without proper locking, losing dependency information.</p>
+     *
+     * @return {@code true} if the resolution was deferred; {@code false} if the caller should proceed with immediate resolution.
+     */
+    default boolean deferCrossProjectResolution(Path taskPath) {
+        return false;
+    }
+
+    /**
+     * Defers a global task search (e.g., by name) to avoid cross-project contention during parallel dependency resolution.
+     *
+     * <p><b>Important:</b> Implementations that delegate to another context must forward this method
+     * to the delegate. Returning {@code false} when the delegate would return {@code true} causes
+     * cross-project state to be accessed without proper locking, losing dependency information.</p>
+     *
+     * @param resolutionAction the logic to be re-executed later under proper locks.
+     * @return {@code true} if the search was deferred; {@code false} if the caller should execute it now.
+     */
+    default boolean deferAllProjectsSearch(Consumer<TaskDependencyResolveContext> resolutionAction) {
+        return false;
+    }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/TaskDependencyResolveContext.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/TaskDependencyResolveContext.java
@@ -76,19 +76,6 @@ public interface TaskDependencyResolveContext extends Action<Task> {
     }
 
     /**
-     * Defers the resolution of a task from another project during parallel dependency resolution.
-     *
-     * <p><b>Important:</b> Implementations that delegate to another context must forward this method
-     * to the delegate. Returning {@code false} when the delegate would return {@code true} causes
-     * cross-project state to be accessed without proper locking, losing dependency information.</p>
-     *
-     * @return {@code true} if the resolution was deferred; {@code false} if the caller should proceed with immediate resolution.
-     */
-    default boolean deferCrossProjectResolution(Path taskPath) {
-        return false;
-    }
-
-    /**
      * Defers a global task search (e.g., by name) to avoid cross-project contention during parallel dependency resolution.
      *
      * <p><b>Important:</b> Implementations that delegate to another context must forward this method

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/TaskResolver.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/TaskResolver.java
@@ -39,4 +39,11 @@ public interface TaskResolver {
      */
     Task resolveTask(Path path);
 
+    /**
+     * Computes the build-tree identity path of the project that owns the given task path,
+     * without actually resolving the task.
+     *
+     * <p>Used during parallel dependency resolution to defer cross-project task lookups.</p>
+     */
+    Path resolveTargetProjectIdentityPath(Path taskPath);
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/tasks/ProjectScopedCachingTaskDependencyResolveContextTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/tasks/ProjectScopedCachingTaskDependencyResolveContextTest.groovy
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks
+
+import org.gradle.api.Task
+import org.gradle.util.Path
+import spock.lang.Specification
+
+class ProjectScopedCachingTaskDependencyResolveContextTest extends Specification {
+
+    // Build path ":" (root build), current project ":projectA", identity path ":projectA"
+    def currentProjectIdentityPath = Path.path(":projectA")
+
+    List<DeferredCrossProjectDependency> capturedDeps = []
+    ProjectScopedCachingTaskDependencyResolveContext<Task> context
+
+    def setup() {
+        def handler = new TestPlaceholderHandler(capturedDeps)
+        context = new ProjectScopedCachingTaskDependencyResolveContext<Task>(
+            [WorkDependencyResolver.TASK_AS_TASK],
+            currentProjectIdentityPath,
+            handler
+        )
+    }
+
+    static class TestPlaceholderHandler implements ProjectScopedCachingTaskDependencyResolveContext.PlaceholderHandler<Task> {
+        private final List<DeferredCrossProjectDependency> capturedDeps
+
+        TestPlaceholderHandler(List<DeferredCrossProjectDependency> capturedDeps) {
+            this.capturedDeps = capturedDeps
+        }
+
+        @Override
+        Task createPlaceholder(DeferredCrossProjectDependency dep) {
+            capturedDeps.add(dep)
+            return [:] as Task
+        }
+
+        @Override
+        void registerSourceTaskWithPlaceholder(Task task) {}
+    }
+
+    def "deferCrossProjectResolution defers when target project differs from current"() {
+        when:
+        def deferred = context.deferCrossProjectResolution(Path.path(":projectB"), "compile")
+
+        then:
+        deferred
+        capturedDeps.size() == 1
+        def capturedDependency = capturedDeps[0] as DeferredCrossProjectDependency.ByProjectTask
+        capturedDependency.targetProjectIdentityPath == Path.path(":projectB")
+        capturedDependency.taskName == "compile"
+    }
+
+    def "deferCrossProjectResolution does not defer when target is current project"() {
+        when:
+        def deferred = context.deferCrossProjectResolution(Path.path(":projectA"), "compile")
+
+        then:
+        !deferred
+        capturedDeps.isEmpty()
+    }
+
+    def 'deferAllProjectsSearch always defers'() {
+        given:
+        def action = { TaskDependencyResolveContext ctx -> } as java.util.function.Consumer
+
+        when:
+        def deferred = context.deferAllProjectsSearch(action)
+
+        then:
+        deferred
+        capturedDeps.size() == 1
+        capturedDeps[0] instanceof DeferredCrossProjectDependency.AllProjectsSearch
+    }
+
+    def "getDependencies merges placeholders into result set"() {
+        given:
+        def realTask = Mock(Task)
+        def dependency = Mock(TaskDependencyContainerInternal) {
+            visitDependencies(_) >> { TaskDependencyResolveContext ctx ->
+                // Add a real task dependency
+                ctx.add(realTask)
+                // Add a deferred cross-project dependency (will become a placeholder)
+                ctx.add(new DeferredCrossProjectDependency.ByProjectTask(Path.path(":projectB"), "compile"))
+            }
+        }
+
+        when:
+        def result = context.getDependencies(null, dependency)
+
+        then:
+        result.size() == 2
+        result.contains(realTask)
+        capturedDeps.size() == 1
+    }
+
+    def "getDependencies returns unmodified result when no placeholders are created"() {
+        given:
+        def realTask = Mock(Task)
+        def dependency = Mock(TaskDependencyContainerInternal) {
+            visitDependencies(_) >> { TaskDependencyResolveContext ctx ->
+                ctx.add(realTask)
+            }
+        }
+
+        when:
+        def result = context.getDependencies(null, dependency)
+
+        then:
+        result.size() == 1
+        result.contains(realTask)
+        capturedDeps.isEmpty()
+    }
+
+    def "getDependencies returns cross-project placeholder on second call with same shared dependency container"() {
+        given:
+        def realTask = Mock(Task)
+        // A shared container that produces both a same-project task and a cross-project deferred dep
+        def sharedContainer = Mock(TaskDependencyContainerInternal) {
+            visitDependencies(_) >> { TaskDependencyResolveContext ctx ->
+                ctx.add(realTask)
+                ctx.add(new DeferredCrossProjectDependency.ByProjectTask(Path.path(":projectB"), "compile"))
+            }
+        }
+
+        when: "first resolution — walker traverses the container"
+        def result1 = context.getDependencies(null, sharedContainer)
+
+        then: "returns both the real task and the placeholder"
+        result1.size() == 2
+        result1.contains(realTask)
+        capturedDeps.size() == 1
+
+        when: "second resolution with the same container — walker cache hit"
+        def result2 = context.getDependencies(null, sharedContainer)
+
+        then: "should still return both the real task and the cached placeholder"
+        result2.size() == 2
+        result2.contains(realTask)
+    }
+
+}

--- a/platforms/jvm/platform-jvm/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
+++ b/platforms/jvm/platform-jvm/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
@@ -36,7 +36,10 @@ import static org.hamcrest.MatcherAssert.assertThat
 
 class DefaultSourceSetTest extends Specification {
     public @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
-    private final TaskResolver taskResolver = path -> { Mock(Task) { getName() >> path.getName() }}
+    private final TaskResolver taskResolver = Mock(TaskResolver) {
+        resolveTask(_) >> { args -> Mock(Task) { getName() >> args[0].getName() } }
+        resolveTargetProjectIdentityPath(_) >> null
+    }
     private final TaskDependencyFactory taskDependencyFactory = new DefaultTaskDependencyFactory(taskResolver, Mock(TaskDependencyUsageTracker))
     private final FileResolver fileResolver = TestFiles.resolver(tmpDir.testDirectory)
     private final FileCollectionFactory fileCollectionFactory = TestFiles.fileCollectionFactory(tmpDir.testDirectory, taskDependencyFactory)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvableArtifact.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvableArtifact.java
@@ -181,5 +181,21 @@ public class DefaultResolvableArtifact implements ResolvableArtifact {
         public void run(NodeExecutionContext context) {
             artifact.fileSource.finalizeIfNotAlready();
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ResolveAction)) {
+                return false;
+            }
+            return artifact.artifactId.equals(((ResolveAction) o).artifact.artifactId);
+        }
+
+        @Override
+        public int hashCode() {
+            return artifact.artifactId.hashCode();
+        }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjects.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjects.java
@@ -34,6 +34,7 @@ class TasksFromDependentProjects implements TaskDependencyContainerInternal {
 
     private final String taskName;
     private final String configurationName;
+    private final TaskDependencyChecker checker;
     private final TaskDependencyContainerInternal taskDependencyDelegate;
 
     public TasksFromDependentProjects(String taskName, String configurationName, TaskDependencyFactory taskDependencyFactory) {
@@ -43,18 +44,25 @@ class TasksFromDependentProjects implements TaskDependencyContainerInternal {
     public TasksFromDependentProjects(String taskName, String configurationName, TaskDependencyChecker checker, TaskDependencyFactory taskDependencyFactory) {
         this.taskName = taskName;
         this.configurationName = configurationName;
+        this.checker = checker;
         this.taskDependencyDelegate = taskDependencyFactory.visitingDependencies(context -> {
-            Project thisProject = context.getTask().getProject();
-            Set<Task> tasksWithName = thisProject.getRootProject().getTasksByName(taskName, true);
-            for (Task nextTask : tasksWithName) {
-                if (context.getTask() != nextTask) {
-                    boolean isDependency = checker.isDependent(thisProject, configurationName, nextTask.getProject());
-                    if (isDependency) {
-                        context.add(nextTask);
-                    }
-                }
+            if (!context.deferAllProjectsSearch(this::searchAllProjectsForTasks)) {
+                searchAllProjectsForTasks(context);
             }
         });
+    }
+
+    private void searchAllProjectsForTasks(TaskDependencyResolveContext context) {
+        Project thisProject = context.getTask().getProject();
+        Set<Task> tasksWithName = thisProject.getRootProject().getTasksByName(taskName, true);
+        for (Task nextTask : tasksWithName) {
+            if (context.getTask() != nextTask) {
+                boolean isDependency = checker.isDependent(thisProject, configurationName, nextTask.getProject());
+                if (isDependency) {
+                    context.add(nextTask);
+                }
+            }
+        }
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependencies.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependencies.java
@@ -57,6 +57,11 @@ class TasksFromProjectDependencies implements TaskDependencyContainerInternal {
     ) {
         for (ProjectDependency projectDependency : projectDependencies) {
             Path identityPath = ((ProjectDependencyInternal) projectDependency).getTargetProjectIdentity().getBuildTreePath();
+
+            if (context.deferCrossProjectResolution(identityPath, taskName)) {
+                continue;
+            }
+
             ProjectState projectState = projectStateRegistry.stateFor(identityPath);
             projectState.ensureTasksDiscovered();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactResolver.java
@@ -61,12 +61,11 @@ public class ProjectArtifactResolver implements ArtifactResolver, HoldsProjectSt
 
     @Override
     public void resolveArtifact(ComponentArtifactResolveMetadata component, ComponentArtifactMetadata artifact, BuildableArtifactResolveResult result) {
-        // NOTE: This isn't thread-safe because we're not locking around allResolvedArtifacts to ensure we're not inserting multiple resolvableArtifacts for
-        // the same artifact id.
-        //
-        // This should be replaced by a computeIfAbsent(...) to be thread-safe and ensure there's only ever one DefaultResolvableArtifact created for a single id.
-        // This is not thread-safe because of lock juggling that happens for project state. When calculating the dependencies for an IDEA model, we can easily
-        // deadlock when there are multiple projects that need to be locked at the same time.
+        // We cannot use computeIfAbsent() here because the creation involves projectState.fromMutableState()
+        // which acquires a project lock. Holding ConcurrentHashMap's compute lock while acquiring a project lock
+        // can deadlock when multiple projects are locked concurrently (e.g., IDEA model dependency calculation).
+        // Instead, we use putIfAbsent() after pre-computing the candidate. Two threads may both create a candidate,
+        // but only one is stored and returned — the loser's candidate is discarded.
         ResolvableArtifact resolvableArtifact = allResolvedArtifacts.get(artifact.getId());
         if (resolvableArtifact == null) {
             LocalComponentArtifactMetadata projectArtifact = (LocalComponentArtifactMetadata) artifact;
@@ -74,8 +73,9 @@ public class ProjectArtifactResolver implements ArtifactResolver, HoldsProjectSt
             File localArtifactFile = projectStateRegistry.stateFor(projectId).fromMutableState(p -> projectArtifact.getFile());
             if (localArtifactFile != null) {
                 CalculatedValue<File> artifactSource = calculatedValueContainerFactory.create(Describables.of(artifact.getId()), resolveArtifactLater(artifact));
-                resolvableArtifact = new DefaultResolvableArtifact(component.getModuleVersionId(), artifact.getName(), artifact.getId(), context -> context.add(artifact.getBuildDependencies()), artifactSource, calculatedValueContainerFactory);
-                allResolvedArtifacts.put(artifact.getId(), resolvableArtifact);
+                ResolvableArtifact candidate = new DefaultResolvableArtifact(component.getModuleVersionId(), artifact.getName(), artifact.getId(), context -> context.add(artifact.getBuildDependencies()), artifactSource, calculatedValueContainerFactory);
+                ResolvableArtifact existing = allResolvedArtifacts.putIfAbsent(artifact.getId(), candidate);
+                resolvableArtifact = existing != null ? existing : candidate;
             }
         }
         if (resolvableArtifact != null) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjectsTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjectsTest.groovy
@@ -47,6 +47,7 @@ class TasksFromDependentProjectsTest extends AbstractProjectBuilderSpec {
         when: dep.visitDependencies(context)
 
         then:
+        _ * context.deferAllProjectsSearch(_) >> false
         4 * context.getTask() >> child1.tasks["buildDependents"]
         1 * checker.isDependent(child1, "testRuntime", child2) >> false
         1 * checker.isDependent(child1, "testRuntime", child3) >> true

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependenciesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependenciesTest.groovy
@@ -68,6 +68,7 @@ class TasksFromProjectDependenciesTest extends AbstractProjectBuilderSpec {
         tasks.visitDependencies(context)
 
         then:
+        _ * context.deferCrossProjectResolution(_, _) >> false
         1 * project1State.ensureTasksDiscovered()
         1 * tasks1.findByName("buildNeeded") >> task
         1 * project2State.ensureTasksDiscovered()

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -48,6 +48,7 @@ import org.gradle.execution.plan.SelfExecutingNode
 import org.gradle.execution.plan.TaskDependencyResolver
 import org.gradle.execution.plan.TaskNodeFactory
 import org.gradle.initialization.DefaultBuildCancellationToken
+import org.gradle.internal.Factory
 import org.gradle.internal.build.BuildLifecycleController
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildToolingModelController
@@ -61,6 +62,8 @@ import org.gradle.internal.concurrent.CompositeStoppable
 import org.gradle.internal.concurrent.DefaultExecutorFactory
 import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.file.Stat
+import org.gradle.api.internal.project.ProjectStateRegistry
+import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.internal.properties.bean.PropertyWalker
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
@@ -295,6 +298,7 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
         _ * project.pluginManager >> Stub(PluginManagerInternal)
         def lock = Stub(ResourceLock)
         _ * projectState.taskExecutionLock >> lock
+        _ * projectState.fromMutableState(_) >> { args -> args[0].apply(project) }
         _ * lock.tryLock() >> true
         return task
     }
@@ -311,7 +315,10 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
                 []
             }
         }
-        def plan = new DefaultExecutionPlan(displayName, nodeFactory, new OrdinalGroupFactory(), dependencyResolver, hierarchies.outputHierarchy, hierarchies.destroyableHierarchy, services.services.coordinationService)
+        def planWorkerLeaseService = Stub(WorkerLeaseService) {
+            runAsIsolatedTask(_ as Factory) >> { Factory factory -> factory.create() }
+        }
+        def plan = new DefaultExecutionPlan(displayName, nodeFactory, new OrdinalGroupFactory(), dependencyResolver, hierarchies.outputHierarchy, hierarchies.destroyableHierarchy, services.services.coordinationService, planWorkerLeaseService, new TestBuildOperationExecutor(), Stub(ProjectStateRegistry), false)
         def workPlan = Stub(BuildWorkPlan) {
             _ * stop() >> { plan.close() }
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -943,6 +943,13 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
             }
         }
 
+        /**
+         * Returns {@code true} if the domain object has already been created.
+         */
+        protected boolean wasObjectCreated() {
+            return object != null;
+        }
+
         @Override
         public boolean calculatePresence(ValueConsumer consumer) {
             return findDomainObject(getName()) != null;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/BuildScopedTaskResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/BuildScopedTaskResolver.java
@@ -33,24 +33,30 @@ public class BuildScopedTaskResolver implements TaskResolver {
     }
 
     @Override
-    @SuppressWarnings("ReferenceEquality") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
-    public Task resolveTask(Path path) {
-        String targetTaskName = path.getName();
-        if (targetTaskName == null) {
-            assert path == Path.ROOT;
-            throw new IllegalArgumentException("The root path is not a valid task path");
-        }
+    public Path resolveTargetProjectIdentityPath(Path taskPath) {
+        Path targetProjectPath = validateAndGetTargetProjectPath(taskPath);
+        return build.getIdentityPath().append(targetProjectPath);
+    }
 
-        if (!path.isAbsolute()) {
-            throw new IllegalArgumentException(String.format("Cannot resolve task at path '%s' since the path is not absolute.", path));
-        }
+    @Override
+    public Task resolveTask(Path path) {
+        Path targetProjectPath = validateAndGetTargetProjectPath(path);
+        String targetTaskName = path.getName();
 
         build.ensureProjectsConfigured();
 
-        Path targetProjectPath = path.getParent() == null ? Path.ROOT : path.getParent();
         ProjectState projectState = build.getProjects().getProject(targetProjectPath);
         projectState.ensureTasksDiscovered();
         return projectState.getMutableModel().getTasks().getByName(targetTaskName);
     }
 
+    private static Path validateAndGetTargetProjectPath(Path taskPath) {
+        if (taskPath.getName() == null) {
+            throw new IllegalArgumentException("The root path is not a valid task path");
+        }
+        if (!taskPath.isAbsolute()) {
+            throw new IllegalArgumentException(String.format("Cannot resolve task at path '%s' since the path is not absolute.", taskPath));
+        }
+        return taskPath.getParent() == null ? Path.ROOT : taskPath.getParent();
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectScopedTaskResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectScopedTaskResolver.java
@@ -41,6 +41,21 @@ public class ProjectScopedTaskResolver implements TaskResolver {
     }
 
     @Override
+    public Path resolveTargetProjectIdentityPath(Path taskPath) {
+        if (!taskPath.isAbsolute() && taskPath.segmentCount() <= 1) {
+            return currentProject.getBuildTreePath();
+        }
+        Path taskParent = taskPath.getParent();
+        Path targetProjectPath = taskParent != null
+            ? currentProject.getProjectPath().absolutePath(taskParent)
+            : Path.ROOT;
+        if (targetProjectPath.equals(currentProject.getProjectPath())) {
+            return currentProject.getBuildTreePath();
+        }
+        return ProjectIdentity.computeProjectIdentityPath(currentProject.getBuildPath(), targetProjectPath);
+    }
+
+    @Override
     @SuppressWarnings("ReferenceEquality") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
     public Task resolveTask(Path path) {
         String targetTaskName = path.getName();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -735,6 +735,20 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         }
 
         @Override
+        protected Value<? extends I> calculateOwnValue(ValueConsumer consumer) {
+            // During parallel task dependency resolution, concurrent worker threads can
+            // independently trigger the same TaskProvider, racing on the unsynchronized
+            // object == null check in the parent class and creating duplicate Task instances.
+            // Use double-checked locking: skip synchronization when the task is already realized.
+            if (wasObjectCreated()) {
+                return super.calculateOwnValue(consumer);
+            }
+            synchronized (this) {
+                return super.calculateOwnValue(consumer);
+            }
+        }
+
+        @Override
         protected void tryCreate() {
             buildOperationRunner.run(new RunnableBuildOperation() {
                 @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -21,8 +21,12 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
+import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
+import org.gradle.internal.work.WorkerLeaseService;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.AbstractCollection;
 import java.util.Collection;
@@ -61,8 +65,11 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
     private final Set<Node> filteredNodes = newIdentityHashSet();
     private final Set<Node> finalizers = new LinkedHashSet<>();
     private final OrdinalNodeAccess ordinalNodeAccess;
+    @Nullable
+    private final ParallelNodeRelationshipsResolver parallelNodeRelationshipsResolver;
     private Consumer<LocalTaskNode> completionHandler = localTaskNode -> {
     };
+
 
     private DefaultFinalizedExecutionPlan finalizedPlan;
     // An immutable copy of the final plan
@@ -75,7 +82,11 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
         TaskDependencyResolver dependencyResolver,
         ExecutionNodeAccessHierarchy outputHierarchy,
         ExecutionNodeAccessHierarchy destroyableHierarchy,
-        ResourceLockCoordinationService lockCoordinator
+        ResourceLockCoordinationService lockCoordinator,
+        WorkerLeaseService workerLeaseService,
+        BuildOperationExecutor buildOperationExecutor,
+        ProjectStateRegistry projectStateRegistry,
+        boolean parallelTaskDependencyResolution
     ) {
         this.displayName = displayName;
         this.taskNodeFactory = taskNodeFactory;
@@ -84,6 +95,9 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
         this.destroyableHierarchy = destroyableHierarchy;
         this.lockCoordinator = lockCoordinator;
         this.ordinalNodeAccess = new OrdinalNodeAccess(ordinalGroupFactory);
+        this.parallelNodeRelationshipsResolver = parallelTaskDependencyResolution
+            ? new ParallelNodeRelationshipsResolver(dependencyResolver, workerLeaseService, buildOperationExecutor, projectStateRegistry, taskNodeFactory)
+            : null;
     }
 
     @Override
@@ -156,6 +170,16 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
 
     @SuppressWarnings("NonApiType") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)
     private void discoverNodeRelationships(LinkedList<Node> queue) {
+        if (parallelNodeRelationshipsResolver != null) {
+            Map<LocalTaskNode, ResolvedNodeRelationships> preResolved = parallelNodeRelationshipsResolver.resolve(queue);
+            discoverNodeRelationshipsSequential(queue, preResolved);
+        } else {
+            discoverNodeRelationshipsSequential(queue, null);
+        }
+    }
+
+    @SuppressWarnings("NonApiType")
+    private void discoverNodeRelationshipsSequential(LinkedList<Node> queue, @Nullable Map<LocalTaskNode, ResolvedNodeRelationships> preResolved) {
         Set<Node> visiting = new HashSet<>();
         while (!queue.isEmpty()) {
             Node node = queue.getFirst();
@@ -180,7 +204,19 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
             if (visiting.add(node)) {
                 // Have not seen this node before - add its dependencies to the head of the queue and leave this
                 // node in the queue
-                node.resolveDependencies(dependencyResolver);
+                if (preResolved != null && node instanceof LocalTaskNode) {
+                    LocalTaskNode localNode = (LocalTaskNode) node;
+                    ResolvedNodeRelationships resolved = preResolved.remove(localNode);
+                    if (resolved == null) {
+                        // We preresolve only LocalTaskNodes, but not other nodes,
+                        // so if a task comes in the graph as an artifact transform dependency, we may not have preresolved dependencies for that task
+                        localNode.resolveDependencies(dependencyResolver);
+                    } else {
+                            localNode.applyRelationships(resolved);
+                    }
+                } else {
+                    node.resolveDependencies(dependencyResolver);
+                }
                 for (Node successor : node.getHardSuccessors()) {
                     successor.maybeInheritOrdinalAsDependency(node.getGroup().asOrdinal());
                 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DeferredCrossProjectNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DeferredCrossProjectNode.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import org.gradle.api.internal.tasks.DeferredCrossProjectDependency;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A placeholder {@link Node} representing an unresolved cross-project dependency.
+ * Created during parallel task dependency resolution when a cross-project lookup
+ * cannot be performed under the current project lock.
+ *
+ * <p>These nodes are injected into {@link ResolvedNodeRelationships} dependency sets
+ * during parallel resolution and substituted with the real resolved nodes before
+ * the results are passed to the sequential phase. They never appear in the final
+ * execution graph.</p>
+ */
+@NullMarked
+class DeferredCrossProjectNode extends Node {
+
+    private final DeferredCrossProjectDependency deferredDependency;
+    private List<Node> resolvedNodes = Collections.emptyList();
+
+    DeferredCrossProjectNode(DeferredCrossProjectDependency deferredDependency) {
+        this.deferredDependency = deferredDependency;
+    }
+
+    DeferredCrossProjectDependency getDeferredDependency() {
+        return deferredDependency;
+    }
+
+    /**
+     * Sets the real nodes that this placeholder resolves to.
+     * For {@link DeferredCrossProjectDependency.ByProjectTask}, this is 0 or 1 node.
+     * For {@link DeferredCrossProjectDependency.AllProjectsSearch}, this can be multiple nodes.
+     */
+    void resolve(List<Node> nodes) {
+        this.resolvedNodes = nodes;
+    }
+
+    List<Node> getResolvedNodes() {
+        return resolvedNodes;
+    }
+
+    @Override
+    @Nullable
+    public Throwable getNodeFailure() {
+        return null;
+    }
+
+    @Override
+    public void resolveDependencies(TaskDependencyResolver dependencyResolver) {
+        throw new IllegalStateException(
+            "DeferredCrossProjectNode should be substituted before sequential resolution: " + this
+        );
+    }
+
+    @Override
+    public String toString() {
+        if (deferredDependency instanceof DeferredCrossProjectDependency.ByProjectTask) {
+            DeferredCrossProjectDependency.ByProjectTask byProject = (DeferredCrossProjectDependency.ByProjectTask) deferredDependency;
+            return "deferred cross-project node " + byProject.getTargetProjectIdentityPath() + ":" + byProject.getTaskName();
+        }
+        return "deferred cross-project node (all-projects search)";
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlanFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlanFactory.java
@@ -16,9 +16,13 @@
 
 package org.gradle.execution.plan;
 
+import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.internal.buildtree.BuildModelParameters;
+import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.internal.work.WorkerLeaseService;
 
 @ServiceScope(Scope.Build.class)
 public class ExecutionPlanFactory {
@@ -29,6 +33,10 @@ public class ExecutionPlanFactory {
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy destroyableHierarchy;
     private final ResourceLockCoordinationService lockCoordinationService;
+    private final WorkerLeaseService workerLeaseService;
+    private final BuildOperationExecutor buildOperationExecutor;
+    private final ProjectStateRegistry projectStateRegistry;
+    private final boolean parallelTaskDependencyResolution;
 
     public ExecutionPlanFactory(
         String displayName,
@@ -37,7 +45,11 @@ public class ExecutionPlanFactory {
         TaskDependencyResolver dependencyResolver,
         ExecutionNodeAccessHierarchy outputHierarchy,
         ExecutionNodeAccessHierarchy destroyableHierarchy,
-        ResourceLockCoordinationService lockCoordinationService
+        ResourceLockCoordinationService lockCoordinationService,
+        WorkerLeaseService workerLeaseService,
+        BuildOperationExecutor buildOperationExecutor,
+        ProjectStateRegistry projectStateRegistry,
+        BuildModelParameters buildModelParameters
     ) {
         this.displayName = displayName;
         this.taskNodeFactory = taskNodeFactory;
@@ -46,9 +58,13 @@ public class ExecutionPlanFactory {
         this.outputHierarchy = outputHierarchy;
         this.destroyableHierarchy = destroyableHierarchy;
         this.lockCoordinationService = lockCoordinationService;
+        this.workerLeaseService = workerLeaseService;
+        this.buildOperationExecutor = buildOperationExecutor;
+        this.projectStateRegistry = projectStateRegistry;
+        this.parallelTaskDependencyResolution = buildModelParameters.isParallelProjectConfiguration();
     }
 
     public ExecutionPlan createPlan() {
-        return new DefaultExecutionPlan(displayName, taskNodeFactory, ordinalGroupFactory, dependencyResolver, outputHierarchy, destroyableHierarchy, lockCoordinationService);
+        return new DefaultExecutionPlan(displayName, taskNodeFactory, ordinalGroupFactory, dependencyResolver, outputHierarchy, destroyableHierarchy, lockCoordinationService, workerLeaseService, buildOperationExecutor, projectStateRegistry, parallelTaskDependencyResolution);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -119,25 +119,47 @@ public class LocalTaskNode extends TaskNode {
 
     @Override
     public void resolveDependencies(TaskDependencyResolver dependencyResolver) {
+        applyRelationships(resolveRelationships(dependencyResolver));
+    }
+
+    /**
+     * Resolves all dependency relationships for this node without mutating the graph.
+     * This is the expensive phase that can be safely run in parallel across projects,
+     * as long as each parallel worker uses its own {@link TaskDependencyResolver}.
+     */
+    public ResolvedNodeRelationships resolveRelationships(TaskDependencyResolver dependencyResolver) {
         // Make sure it has been configured
         taskProject.getTasks().prepareForExecution(task);
 
-        for (Node targetNode : getDependencies(dependencyResolver)) {
+        Set<Node> dependencies = getDependencies(dependencyResolver);
+        Set<Node> lifecycle = dependencyResolver.resolveDependenciesFor(task, task.getLifecycleDependencies());
+        Set<Node> finalizedBy = getFinalizedBy(dependencyResolver);
+        Set<Node> mustRunAfter = getMustRunAfter(dependencyResolver);
+        Set<Node> shouldRunAfter = getShouldRunAfter(dependencyResolver);
+
+        return new ResolvedNodeRelationships(this, dependencies, lifecycle, finalizedBy, mustRunAfter, shouldRunAfter);
+    }
+
+    /**
+     * Applies previously resolved relationships to the graph. Must be called from a single thread.
+     */
+    public void applyRelationships(ResolvedNodeRelationships resolved) {
+        for (Node targetNode : resolved.getDependencies()) {
             addDependencySuccessor(targetNode);
         }
 
-        lifecycleSuccessors = dependencyResolver.resolveDependenciesFor(task, task.getLifecycleDependencies());
+        lifecycleSuccessors = resolved.getLifecycleDependencies();
 
-        for (Node targetNode : getFinalizedBy(dependencyResolver)) {
+        for (Node targetNode : resolved.getFinalizedBy()) {
             if (!(targetNode instanceof TaskNode)) {
                 throw new IllegalStateException("Only tasks can be finalizers: " + targetNode);
             }
             addFinalizerNode((TaskNode) targetNode);
         }
-        for (Node targetNode : getMustRunAfter(dependencyResolver)) {
+        for (Node targetNode : resolved.getMustRunAfter()) {
             addMustSuccessor(targetNode);
         }
-        for (Node targetNode : getShouldRunAfter(dependencyResolver)) {
+        for (Node targetNode : resolved.getShouldRunAfter()) {
             addShouldSuccessor(targetNode);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ParallelNodeRelationshipsResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ParallelNodeRelationshipsResolver.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
+import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.internal.tasks.AbstractTaskDependencyResolveContext;
+import org.gradle.api.internal.tasks.DeferredCrossProjectDependency;
+import org.gradle.api.internal.tasks.ProjectScopedCachingTaskDependencyResolveContext.PlaceholderHandler;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.BuildOperationQueue;
+import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.internal.work.WorkerLeaseService;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Pre-resolves {@link LocalTaskNode} dependency relationships in parallel using BFS waves,
+ * without mutating the task graph. The result is consumed by the sequential DFS phase in
+ * {@link DefaultExecutionPlan}.
+ *
+ * <p>Node dependencies are resolved wave-by-wave: each wave is grouped by owning project and resolved in
+ * parallel under that project's lock. Cross-project dependency lookups that cannot be performed
+ * under a single project lock are represented as {@link DeferredCrossProjectNode} placeholders
+ * in the dependency sets, resolved after the wave, and then substituted with the real nodes.</p>
+ */
+@NullMarked
+class ParallelNodeRelationshipsResolver {
+
+    private final TaskDependencyResolver dependencyResolver;
+    private final WorkerLeaseService workerLeaseService;
+    private final BuildOperationExecutor buildOperationExecutor;
+    private final ProjectStateRegistry projectStateRegistry;
+    private final TaskNodeFactory taskNodeFactory;
+
+    ParallelNodeRelationshipsResolver(
+        TaskDependencyResolver dependencyResolver,
+        WorkerLeaseService workerLeaseService,
+        BuildOperationExecutor buildOperationExecutor,
+        ProjectStateRegistry projectStateRegistry,
+        TaskNodeFactory taskNodeFactory
+    ) {
+        this.dependencyResolver = dependencyResolver;
+        this.workerLeaseService = workerLeaseService;
+        this.buildOperationExecutor = buildOperationExecutor;
+        this.projectStateRegistry = projectStateRegistry;
+        this.taskNodeFactory = taskNodeFactory;
+    }
+
+    /**
+     * Pre-resolves relationships for all {@link LocalTaskNode}s reachable from {@code initialQueue}
+     * in parallel. Cross-project dependencies are represented as placeholder nodes during resolution,
+     * then resolved and substituted with real nodes before returning.
+     */
+    @SuppressWarnings("NonApiType")
+    Map<LocalTaskNode, ResolvedNodeRelationships> resolve(LinkedList<Node> initialQueue) {
+        Map<LocalTaskNode, ResolvedNodeRelationships> results = new HashMap<>();
+        BfsWaveQueue waves = new BfsWaveQueue(initialQueue);
+        CrossProjectPlaceholderRegistry placeholderRegistry = new CrossProjectPlaceholderRegistry(taskNodeFactory);
+        Map<ProjectInternal, ProjectScopedTaskDependencyResolver> resolverCache = new HashMap<>();
+
+        while (waves.hasNextWave()) {
+            List<LocalTaskNode> currentWave = waves.takeNextWave();
+
+            List<NodeResolutionResult> waveResults = resolveDependenciesInParallel(currentWave, placeholderRegistry, resolverCache);
+
+            for (NodeResolutionResult result : waveResults) {
+                results.put(result.node, result.resolved);
+                waves.enqueue(result.resolved.getDependencies());
+                waves.enqueue(result.resolved.getFinalizedBy());
+            }
+
+            List<DeferredCrossProjectNode> placeholders = placeholderRegistry.takePending();
+            if (!placeholders.isEmpty()) {
+                resolvePlaceholderNodes(placeholders);
+                for (DeferredCrossProjectNode deferred : placeholders) {
+                    waves.enqueue(deferred.getResolvedNodes());
+                }
+            }
+        }
+
+        return placeholderRegistry.substitutePlaceholders(results);
+    }
+
+    /**
+     * Resolves dependencies of a wave of {@link LocalTaskNode}s in parallel, grouped by owning project.
+     */
+    @SuppressWarnings("MixedMutabilityReturnType")
+    private List<NodeResolutionResult> resolveDependenciesInParallel(
+        List<LocalTaskNode> nodes,
+        CrossProjectPlaceholderRegistry placeholders,
+        Map<ProjectInternal, ProjectScopedTaskDependencyResolver> resolverCache
+    ) {
+        if (nodes.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<ProjectInternal, List<LocalTaskNode>> byProject = new LinkedHashMap<>();
+        for (LocalTaskNode node : nodes) {
+            byProject.computeIfAbsent(node.getOwningProject(), k -> new ArrayList<>()).add(node);
+        }
+
+        if (byProject.size() == 1) {
+            ProjectInternal project = nodes.get(0).getOwningProject();
+            ProjectScopedTaskDependencyResolver resolver = resolverCache.computeIfAbsent(project, p -> createProjectScopedResolver(p, placeholders));
+            List<NodeResolutionResult> results = new ArrayList<>();
+            for (LocalTaskNode node : nodes) {
+                results.add(new NodeResolutionResult(node, node.resolveRelationships(resolver)));
+            }
+            return results;
+        }
+
+        // Multiple projects: resolve each project group in parallel under its own lock.
+        List<List<LocalTaskNode>> projectGroups = new ArrayList<>(byProject.values());
+        ConcurrentLinkedQueue<NodeResolutionResult> results = new ConcurrentLinkedQueue<>();
+        runInParallelWithProjectAccess(queue -> {
+            for (List<LocalTaskNode> group : projectGroups) {
+                ProjectInternal project = group.get(0).getOwningProject();
+                ProjectScopedTaskDependencyResolver resolver = resolverCache.computeIfAbsent(project, p -> createProjectScopedResolver(p, placeholders));
+                queue.add(buildOp("Resolve task dependencies for project " + project, () -> {
+                    project.getOwner().fromMutableState(p -> {
+                        for (LocalTaskNode node : group) {
+                            ResolvedNodeRelationships resolved = node.resolveRelationships(resolver);
+                            results.add(new NodeResolutionResult(node, resolved));
+                        }
+                        return null;
+                    });
+                }));
+            }
+        });
+
+        return new ArrayList<>(results);
+    }
+
+    private ProjectScopedTaskDependencyResolver createProjectScopedResolver(ProjectInternal project, CrossProjectPlaceholderRegistry placeholders) {
+        return dependencyResolver.newProjectScopedResolver(project, placeholders);
+    }
+
+    /**
+     * Resolves all {@link DeferredCrossProjectNode} placeholders by looking up their target tasks.
+     */
+    private void resolvePlaceholderNodes(List<DeferredCrossProjectNode> deferredNodes) {
+        Map<Path, List<DeferredCrossProjectNode>> byTarget = new LinkedHashMap<>();
+        List<DeferredCrossProjectNode> allProjectsSearchNodes = new ArrayList<>();
+
+        for (DeferredCrossProjectNode node : deferredNodes) {
+            DeferredCrossProjectDependency dep = node.getDeferredDependency();
+            if (dep instanceof DeferredCrossProjectDependency.ByProjectTask) {
+                Path targetPath = ((DeferredCrossProjectDependency.ByProjectTask) dep).getTargetProjectIdentityPath();
+                byTarget.computeIfAbsent(targetPath, k -> new ArrayList<>()).add(node);
+            } else if (dep instanceof DeferredCrossProjectDependency.AllProjectsSearch) {
+                allProjectsSearchNodes.add(node);
+            }
+        }
+
+        // For ByTarget placeholder node find a task
+        resolveByTargetPlaceholderNodesToLocalTaskNodes(byTarget);
+
+        // Resolve AllProjectsSearch items sequentially (needs all-projects access)
+        for (DeferredCrossProjectNode node : allProjectsSearchNodes) {
+            DeferredCrossProjectDependency.AllProjectsSearch search =
+                (DeferredCrossProjectDependency.AllProjectsSearch) node.getDeferredDependency();
+            node.resolve(resolveAllProjectsSearch(search));
+        }
+    }
+
+    /**
+     * Discovers tasks and resolves {@link DeferredCrossProjectDependency.ByProjectTask} placeholders
+     * in parallel, one build operation per target project.
+     */
+    private void resolveByTargetPlaceholderNodesToLocalTaskNodes(Map<Path, List<DeferredCrossProjectNode>> byTarget) {
+        if (byTarget.isEmpty()) {
+            return;
+        }
+
+        runInParallelWithProjectAccess(queue -> {
+            for (Map.Entry<Path, List<DeferredCrossProjectNode>> entry : byTarget.entrySet()) {
+                Path projectPath = entry.getKey();
+                queue.add(buildOp("Resolve cross-project tasks for " + projectPath, () -> {
+                    ProjectState projectState = projectStateRegistry.stateFor(projectPath);
+                    projectState.fromMutableState(project -> {
+                        projectState.ensureTasksDiscovered();
+                        for (DeferredCrossProjectNode node : entry.getValue()) {
+                            DeferredCrossProjectDependency.ByProjectTask byProject = (DeferredCrossProjectDependency.ByProjectTask) node.getDeferredDependency();
+                            Task task = project.getTasks().findByName(byProject.getTaskName());
+                            // Task may not exist — skip silently, consistent with how the sequential resolution path handles missing tasks
+                            if (task != null) {
+                                node.resolve(Collections.singletonList(taskNodeFactory.getOrCreateNode(task)));
+                            }
+                        }
+                        return null;
+                    });
+                }));
+            }
+        });
+    }
+
+    private List<Node> resolveAllProjectsSearch(DeferredCrossProjectDependency.AllProjectsSearch search) {
+        TaskCollectingContext collectingContext = new TaskCollectingContext(search.getSourceTask());
+        search.getResolutionAction().accept(collectingContext);
+        List<Node> result = new ArrayList<>();
+        for (Task task : collectingContext.collectedTasks) {
+            result.add(taskNodeFactory.getOrCreateNode(task));
+        }
+        return result;
+    }
+
+
+    private void runInParallelWithProjectAccess(Action<BuildOperationQueue<RunnableBuildOperation>> scheduler) {
+        workerLeaseService.runAsIsolatedTask(() -> buildOperationExecutor.runAllWithAccessToProjectState(scheduler));
+    }
+
+    private static RunnableBuildOperation buildOp(String displayName, Runnable action) {
+        return new RunnableBuildOperation() {
+            @Override
+            public void run(BuildOperationContext context) {
+                action.run();
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                return BuildOperationDescriptor.displayName(displayName);
+            }
+        };
+    }
+
+    /**
+     * Manages BFS wave traversal: deduplication via a seen-set and a pending queue
+     * that becomes the next wave on {@link #takeNextWave()}.
+     */
+    private static class BfsWaveQueue {
+        private final Set<LocalTaskNode> seen = new HashSet<>();
+        private List<LocalTaskNode> pending = new ArrayList<>();
+
+        BfsWaveQueue(Iterable<? extends Node> seed) {
+            enqueue(seed);
+        }
+
+        boolean hasNextWave() {
+            return !pending.isEmpty();
+        }
+
+        List<LocalTaskNode> takeNextWave() {
+            List<LocalTaskNode> wave = pending;
+            pending = new ArrayList<>();
+            return wave;
+        }
+
+        void enqueue(Iterable<? extends Node> nodes) {
+            for (Node node : nodes) {
+                if (node instanceof LocalTaskNode) {
+                    LocalTaskNode localNode = (LocalTaskNode) node;
+                    if (!localNode.getDependenciesProcessed() && !localNode.isCannotRunInAnyPlan() && seen.add(localNode)) {
+                        pending.add(localNode);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Thread-safe registry that tracks {@link DeferredCrossProjectNode} placeholders
+     * created during parallel resolution. Worker threads call {@link #createPlaceholder} to
+     * create placeholders; the main thread calls {@link #takePending} and
+     * {@link #substitutePlaceholders} to drain and replace them.
+     */
+    private static class CrossProjectPlaceholderRegistry implements PlaceholderHandler<Node> {
+        private final TaskNodeFactory taskNodeFactory;
+        private final ConcurrentLinkedQueue<DeferredCrossProjectNode> pendingQueue = new ConcurrentLinkedQueue<>();
+        private final Set<LocalTaskNode> nodesWithPlaceholders = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+        CrossProjectPlaceholderRegistry(TaskNodeFactory taskNodeFactory) {
+            this.taskNodeFactory = taskNodeFactory;
+        }
+
+        @Override
+        public Node createPlaceholder(DeferredCrossProjectDependency dep) {
+            DeferredCrossProjectNode placeholder = new DeferredCrossProjectNode(dep);
+            pendingQueue.add(placeholder);
+            return placeholder;
+        }
+
+        @Override
+        public void registerSourceTaskWithPlaceholder(Task task) {
+            nodesWithPlaceholders.add((LocalTaskNode) taskNodeFactory.getOrCreateNode(task));
+        }
+
+        List<DeferredCrossProjectNode> takePending() {
+            List<DeferredCrossProjectNode> result = new ArrayList<>();
+            DeferredCrossProjectNode item;
+            while ((item = pendingQueue.poll()) != null) {
+                result.add(item);
+            }
+            return result;
+        }
+
+        Map<LocalTaskNode, ResolvedNodeRelationships> substitutePlaceholders(Map<LocalTaskNode, ResolvedNodeRelationships> results) {
+            for (LocalTaskNode sourceNode : nodesWithPlaceholders) {
+                ResolvedNodeRelationships relationships = results.get(sourceNode);
+                checkNotNull(relationships, "Node %s was marked as having placeholders but has no resolved relationships", sourceNode);
+                results.put(sourceNode, substituteInRelationships(relationships));
+            }
+            return results;
+        }
+
+        private static ResolvedNodeRelationships substituteInRelationships(ResolvedNodeRelationships relationships) {
+            Set<Node> newDeps = substitutePlaceholders(relationships.getDependencies());
+            Set<Node> newLifecycle = substitutePlaceholders(relationships.getLifecycleDependencies());
+            Set<Node> newFinalizedBy = substitutePlaceholders(relationships.getFinalizedBy());
+            Set<Node> newMustRunAfter = substitutePlaceholders(relationships.getMustRunAfter());
+            Set<Node> newShouldRunAfter = substitutePlaceholders(relationships.getShouldRunAfter());
+            if (newDeps == relationships.getDependencies()
+                && newLifecycle == relationships.getLifecycleDependencies()
+                && newFinalizedBy == relationships.getFinalizedBy()
+                && newMustRunAfter == relationships.getMustRunAfter()
+                && newShouldRunAfter == relationships.getShouldRunAfter()) {
+                return relationships;
+            }
+            return new ResolvedNodeRelationships(relationships.getNode(), newDeps, newLifecycle, newFinalizedBy, newMustRunAfter, newShouldRunAfter);
+        }
+
+        private static Set<Node> substitutePlaceholders(Set<Node> original) {
+            if (!hasAnyPlaceholder(original)) {
+                return original;
+            }
+            Set<Node> result = new HashSet<>();
+            for (Node n : original) {
+                if (n instanceof DeferredCrossProjectNode) {
+                    result.addAll(((DeferredCrossProjectNode) n).getResolvedNodes());
+                } else {
+                    result.add(n);
+                }
+            }
+            return result;
+        }
+
+        private static boolean hasAnyPlaceholder(Set<Node> nodes) {
+            for (Node n : nodes) {
+                if (n instanceof DeferredCrossProjectNode) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Minimal context that collects Task objects added via {@link #add}.
+     * Used to re-execute deferred {@link DeferredCrossProjectDependency.AllProjectsSearch} actions.
+     */
+    private static class TaskCollectingContext extends AbstractTaskDependencyResolveContext {
+        private final @Nullable Task sourceTask;
+        final List<Task> collectedTasks = new ArrayList<>();
+
+        TaskCollectingContext(@Nullable Task sourceTask) {
+            this.sourceTask = sourceTask;
+        }
+
+        @Override
+        public @Nullable Task getTask() {
+            return sourceTask;
+        }
+
+        @Override
+        public void add(Object dependency) {
+            if (dependency instanceof Task) {
+                collectedTasks.add((Task) dependency);
+            }
+        }
+    }
+
+    static class NodeResolutionResult {
+        final LocalTaskNode node;
+        final ResolvedNodeRelationships resolved;
+
+        NodeResolutionResult(LocalTaskNode node, ResolvedNodeRelationships resolved) {
+            this.node = node;
+            this.resolved = resolved;
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ProjectScopedTaskDependencyResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ProjectScopedTaskDependencyResolver.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.tasks.ProjectScopedCachingTaskDependencyResolveContext;
+import org.gradle.api.internal.tasks.ProjectScopedCachingTaskDependencyResolveContext.PlaceholderHandler;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A project-scoped resolver used during parallel task dependency resolution.
+ * Extends {@link TaskDependencyResolver} so it can be passed to
+ * {@link LocalTaskNode#resolveRelationships}, but uses a
+ * {@link ProjectScopedCachingTaskDependencyResolveContext} that converts cross-project
+ * dependencies into placeholder nodes via the provided factory.
+ */
+@NullMarked
+class ProjectScopedTaskDependencyResolver extends TaskDependencyResolver {
+
+    private final ProjectScopedCachingTaskDependencyResolveContext<Node> cachingContext;
+
+    ProjectScopedTaskDependencyResolver(
+        List<DependencyResolver> dependencyResolvers,
+        ProjectInternal project,
+        PlaceholderHandler<Node> placeholderHandler
+    ) {
+        super(dependencyResolvers);
+        this.cachingContext = new ProjectScopedCachingTaskDependencyResolveContext<>(
+            dependencyResolvers,
+            project.getGradle().getIdentityPath(),
+            project.getProjectPath(),
+            project.getIdentityPath(),
+            placeholderHandler
+        );
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("ParallelTaskDependencyResolver should not be cleared");
+    }
+
+    @Override
+    public Set<Node> resolveDependenciesFor(@Nullable TaskInternal task, Object dependencies) {
+        return cachingContext.getDependencies(task, dependencies);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ProjectScopedTaskDependencyResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ProjectScopedTaskDependencyResolver.java
@@ -46,8 +46,6 @@ class ProjectScopedTaskDependencyResolver extends TaskDependencyResolver {
         super(dependencyResolvers);
         this.cachingContext = new ProjectScopedCachingTaskDependencyResolveContext<>(
             dependencyResolvers,
-            project.getGradle().getIdentityPath(),
-            project.getProjectPath(),
             project.getIdentityPath(),
             placeholderHandler
         );

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ResolvedNodeRelationships.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ResolvedNodeRelationships.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Set;
+
+/**
+ * Holds the resolved dependency relationships for a {@link LocalTaskNode}, without mutating the graph.
+ * Used to separate the expensive resolution phase from the cheap graph mutation phase
+ * during parallel discovery.
+ */
+@NullMarked
+public class ResolvedNodeRelationships {
+
+    private final LocalTaskNode node;
+    private final Set<Node> dependencies;
+    private final Set<Node> lifecycleDependencies;
+    private final Set<Node> finalizedBy;
+    private final Set<Node> mustRunAfter;
+    private final Set<Node> shouldRunAfter;
+
+    public ResolvedNodeRelationships(
+        LocalTaskNode node,
+        Set<Node> dependencies,
+        Set<Node> lifecycleDependencies,
+        Set<Node> finalizedBy,
+        Set<Node> mustRunAfter,
+        Set<Node> shouldRunAfter
+    ) {
+        this.node = node;
+        this.dependencies = dependencies;
+        this.lifecycleDependencies = lifecycleDependencies;
+        this.finalizedBy = finalizedBy;
+        this.mustRunAfter = mustRunAfter;
+        this.shouldRunAfter = shouldRunAfter;
+    }
+
+    public LocalTaskNode getNode() {
+        return node;
+    }
+
+    public Set<Node> getDependencies() {
+        return dependencies;
+    }
+
+    public Set<Node> getLifecycleDependencies() {
+        return lifecycleDependencies;
+    }
+
+    public Set<Node> getFinalizedBy() {
+        return finalizedBy;
+    }
+
+    public Set<Node> getMustRunAfter() {
+        return mustRunAfter;
+    }
+
+    public Set<Node> getShouldRunAfter() {
+        return shouldRunAfter;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskDependencyResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskDependencyResolver.java
@@ -17,7 +17,9 @@
 package org.gradle.execution.plan;
 
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext;
+import org.gradle.api.internal.tasks.ProjectScopedCachingTaskDependencyResolveContext.PlaceholderHandler;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.jspecify.annotations.NullMarked;
@@ -34,18 +36,26 @@ public class TaskDependencyResolver {
 
     public TaskDependencyResolver(List<DependencyResolver> dependencyResolvers) {
         this.dependencyResolvers = dependencyResolvers;
-        this.context = createTaskDependencyResolverContext(dependencyResolvers);
+        this.context = new CachingTaskDependencyResolveContext<Node>(dependencyResolvers);
     }
 
     public void clear() {
-        context = createTaskDependencyResolverContext(dependencyResolvers);
-    }
-
-    private static CachingTaskDependencyResolveContext<Node> createTaskDependencyResolverContext(List<DependencyResolver> workResolvers) {
-        return new CachingTaskDependencyResolveContext<Node>(workResolvers);
+        context = new CachingTaskDependencyResolveContext<Node>(dependencyResolvers);
     }
 
     public Set<Node> resolveDependenciesFor(@Nullable TaskInternal task, Object dependencies) {
         return context.getDependencies(task, dependencies);
+    }
+
+    /**
+     * Creates a new {@link ProjectScopedTaskDependencyResolver} scoped to a specific project.
+     * Used for parallel resolution where each worker thread needs its own context and
+     * cross-project access is deferred via placeholder nodes created by the factory.
+     */
+    ProjectScopedTaskDependencyResolver newProjectScopedResolver(
+        ProjectInternal project,
+        PlaceholderHandler<Node> placeholderHandler
+    ) {
+        return new ProjectScopedTaskDependencyResolver(dependencyResolvers, project, placeholderHandler);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -50,6 +50,32 @@ public abstract class TaskInAnotherBuild extends TaskNode implements SelfExecuti
     }
 
     /**
+     * Creates a lazy reference to a task in another build from a task instance.
+     *
+     * This is needed for parallel task relations resolution, where we do not want
+     * to access the work graph immediately on the worker thread, but rather defer
+     * it until the main thread accesses the task resource.
+     *
+     * @param task the task
+     * @param taskGraph the task graph where the task should be located
+     * @return a lazy reference to the given task.
+     */
+    public static TaskInAnotherBuild lazy(
+        TaskInternal task,
+        BuildTreeWorkGraphController taskGraph
+    ) {
+        BuildIdentifier targetBuild = buildIdentifierOf(task);
+        TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, task);
+        Lazy<IncludedBuildTaskResource> taskResource = Lazy.unsafe().of(() -> taskGraph.locateTask(taskIdentifier));
+        return new TaskInAnotherBuild(task.getIdentityPath(), task.getPath(), targetBuild) {
+            @Override
+            protected IncludedBuildTaskResource getTarget() {
+                return taskResource.get();
+            }
+        };
+    }
+
+    /**
      * Creates a lazy reference to a task in another build.
      *
      * The task will be located on-demand to allow for cycles between builds stored to

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -89,7 +89,7 @@ public class TaskNodeFactory {
         if (sameBuild) {
             return new LocalTaskNode(task, new DefaultWorkValidationContext(typeOriginInspectorFactory.forTask(task), problems), resolveMutationsNodeFactory);
         }
-        return TaskInAnotherBuild.of(task, workGraphController);
+        return TaskInAnotherBuild.lazy(task, workGraphController);
     }
 
     public void resetState() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/WorkNodeDependencyResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/WorkNodeDependencyResolver.java
@@ -23,11 +23,11 @@ import org.gradle.api.internal.tasks.WorkNodeAction;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-import java.util.IdentityHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 @ServiceScope(Scope.Build.class)
 public class WorkNodeDependencyResolver implements DependencyResolver, HoldsProjectState {
-    private final IdentityHashMap<WorkNodeAction, ActionNode> nodesForAction = new IdentityHashMap<>();
+    private final ConcurrentHashMap<WorkNodeAction, ActionNode> nodesForAction = new ConcurrentHashMap<>();
 
     @Override
     public boolean resolve(Task task, final Object node, Action<? super Node> resolveAction) {
@@ -47,11 +47,6 @@ public class WorkNodeDependencyResolver implements DependencyResolver, HoldsProj
     }
 
     private ActionNode actionNodeFor(WorkNodeAction action) {
-        ActionNode actionNode = nodesForAction.get(action);
-        if (actionNode == null) {
-            actionNode = new ActionNode(action);
-            nodesForAction.put(action, actionNode);
-        }
-        return actionNode;
+        return nodesForAction.computeIfAbsent(action, ActionNode::new);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -241,6 +241,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.DefaultTextFileResourceLoader;
 import org.gradle.internal.resource.TextFileResourceLoader;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
+import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.internal.resources.SharedResourceLeaseRegistry;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.scripts.ScriptExecutionListener;
@@ -335,7 +336,11 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
         OrdinalGroupFactory ordinalGroupFactory,
         TaskDependencyResolver dependencyResolver,
         ExecutionNodeAccessHierarchies executionNodeAccessHierarchies,
-        ResourceLockCoordinationService lockCoordinationService
+        ResourceLockCoordinationService lockCoordinationService,
+        WorkerLeaseService workerLeaseService,
+        BuildOperationExecutor buildOperationExecutor,
+        ProjectStateRegistry projectStateRegistry,
+        BuildModelParameters buildModelParameters
     ) {
         return new ExecutionPlanFactory(
             build.getDisplayName().getDisplayName(),
@@ -344,7 +349,11 @@ public class BuildScopeServices implements ServiceRegistrationProvider {
             dependencyResolver,
             executionNodeAccessHierarchies.getOutputHierarchy(),
             executionNodeAccessHierarchies.getDestroyableHierarchy(),
-            lockCoordinationService
+            lockCoordinationService,
+            workerLeaseService,
+            buildOperationExecutor,
+            projectStateRegistry,
+            buildModelParameters
         );
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
@@ -86,6 +86,9 @@ abstract class AbstractExecutionPlanSpec extends Specification {
         _ * project.services >> backing.services
         _ * project.tasks >> Stub(TaskContainerInternal)
 
+        _ * projectState.fromMutableState(_) >> { args -> args[0].apply(project) }
+        _ * projectState.getMutableModel() >> project
+
         def lock = new MockLock(project, acquired)
         locks.add(lock)
         _ * projectState.taskExecutionLock >> lock

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.execution.plan
 
+import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
@@ -34,7 +35,10 @@ import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.file.Stat
+import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.operations.TestBuildOperationRunner
+import org.gradle.internal.Factory
+import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.FileSystemTestPreconditions
@@ -58,7 +62,10 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
     def setup() {
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
-        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, accessHierarchies.outputHierarchy, accessHierarchies.destroyableHierarchy, coordinator)
+        def workerLeaseService = Stub(WorkerLeaseService) {
+            runAsIsolatedTask(_ as Factory) >> { Factory factory -> factory.create() }
+        }
+        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, accessHierarchies.outputHierarchy, accessHierarchies.destroyableHierarchy, coordinator, workerLeaseService, new TestBuildOperationExecutor(), Stub(ProjectStateRegistry), false)
     }
 
     Node priorityNode(Map<String, ?> options = [:]) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.execution.plan
 
+import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.CircularReferenceException
 import org.gradle.api.Task
@@ -25,7 +26,10 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.file.Stat
+import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.operations.TestBuildOperationRunner
+import org.gradle.internal.Factory
+import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.util.Path
 import org.gradle.util.TestUtil
 import org.gradle.util.internal.TextUtil
@@ -51,7 +55,10 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
 
     private DefaultExecutionPlan newExecutionPlan() {
         executionPlan?.close()
-        new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, accessHierarchies.outputHierarchy, accessHierarchies.destroyableHierarchy, coordinator)
+        def workerLeaseService = Stub(WorkerLeaseService) {
+            runAsIsolatedTask(_ as Factory) >> { Factory factory -> factory.create() }
+        }
+        new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, accessHierarchies.outputHierarchy, accessHierarchies.destroyableHierarchy, coordinator, workerLeaseService, new TestBuildOperationExecutor(), Stub(ProjectStateRegistry), false)
     }
 
     def "schedules tasks in dependency order"() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/ParallelNodeRelationshipsResolverTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/ParallelNodeRelationshipsResolverTest.groovy
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectStateRegistry
+import org.gradle.api.internal.project.taskfactory.TestTaskIdentities
+import org.gradle.api.internal.tasks.DeferredCrossProjectDependency
+import org.gradle.api.internal.tasks.TaskDependencyContainerInternal
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
+import org.gradle.api.internal.tasks.TaskStateInternal
+import org.gradle.composite.internal.BuildTreeWorkGraphController
+import org.gradle.internal.Factory
+import org.gradle.internal.file.Stat
+import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.operations.TestBuildOperationRunner
+import org.gradle.internal.work.WorkerLeaseService
+
+import org.gradle.util.TestUtil
+
+import static org.gradle.internal.snapshot.CaseSensitivity.CASE_SENSITIVE
+
+class ParallelNodeRelationshipsResolverTest extends AbstractExecutionPlanSpec {
+
+    def accessHierarchies = new ExecutionNodeAccessHierarchies(CASE_SENSITIVE, Stub(Stat))
+    def taskNodeFactory = new TaskNodeFactory(project.gradle, Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationRunner(), accessHierarchies, TestUtil.problemsService())
+    def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
+    def workerLeaseService = Stub(WorkerLeaseService) {
+        runAsIsolatedTask(_ as Factory) >> { Factory f -> f.create() }
+        runAsIsolatedTask(_ as Runnable) >> { Runnable r -> r.run() }
+    }
+    def buildOperationExecutor = new TestBuildOperationExecutor()
+    def projectStateRegistry = Stub(ProjectStateRegistry)
+
+    def resolver = new ParallelNodeRelationshipsResolver(dependencyResolver, workerLeaseService, buildOperationExecutor, projectStateRegistry, taskNodeFactory)
+
+    TaskInternal task(Map<String, ?> options = [:], String name) {
+        def proj = (options.project ?: this.project) as ProjectInternal
+        def task = createTask(name, proj, options.type ?: TaskInternal)
+        _ * task.taskDependencies >> taskDependencyResolvingTo(task, options.dependsOn ?: [])
+        _ * task.lifecycleDependencies >> taskDependencyResolvingTo(task, options.dependsOn ?: [])
+        _ * task.finalizedBy >> taskDependencyResolvingTo(task, options.finalizedBy ?: [])
+        _ * task.shouldRunAfter >> taskDependencyResolvingTo(task, options.shouldRunAfter ?: [])
+        _ * task.mustRunAfter >> taskDependencyResolvingTo(task, options.mustRunAfter ?: [])
+        _ * task.sharedResources >> (options.resources ?: [])
+        _ * task.taskIdentity >> TestTaskIdentities.create(name, DefaultTask, proj)
+        TaskStateInternal state = Mock()
+        _ * task.state >> state
+        return task
+    }
+
+    LocalTaskNode nodeFor(TaskInternal task) {
+        return taskNodeFactory.getOrCreateNode(task) as LocalTaskNode
+    }
+
+    LinkedList<Node> queueOf(LocalTaskNode... nodes) {
+        return new LinkedList<Node>(Arrays.asList(nodes))
+    }
+
+    def "resolve returns empty map for empty initial queue"() {
+        expect:
+        resolver.resolve(new LinkedList<Node>()).isEmpty()
+    }
+
+    def "resolve ignores non-LocalTaskNode entries in initial queue"() {
+        given:
+        def nonLocalNode = Mock(Node)
+
+        when:
+        def result = resolver.resolve(new LinkedList<Node>([nonLocalNode]))
+
+        then:
+        result.isEmpty()
+    }
+
+    def "resolves single task with no dependencies"() {
+        given:
+        def taskA = task("a")
+        def nodeA = nodeFor(taskA)
+
+        when:
+        def result = resolver.resolve(queueOf(nodeA))
+
+        then:
+        result.size() == 1
+        result[nodeA].dependencies.isEmpty()
+        result[nodeA].lifecycleDependencies.isEmpty()
+        result[nodeA].finalizedBy.isEmpty()
+        result[nodeA].mustRunAfter.isEmpty()
+        result[nodeA].shouldRunAfter.isEmpty()
+    }
+
+    def "resolves task chain via BFS waves"() {
+        given:
+        def taskC = task("c")
+        def taskB = task("b", dependsOn: [taskC])
+        def taskA = task("a", dependsOn: [taskB])
+        def nodeA = nodeFor(taskA)
+        def nodeB = nodeFor(taskB)
+        def nodeC = nodeFor(taskC)
+
+        when:
+        def result = resolver.resolve(queueOf(nodeA))
+
+        then:
+        result.size() == 3
+        result.containsKey(nodeA)
+        result.containsKey(nodeB)
+        result.containsKey(nodeC)
+        result[nodeA].dependencies.contains(nodeB)
+        result[nodeB].dependencies.contains(nodeC)
+        result[nodeC].dependencies.isEmpty()
+    }
+
+    def "resolves task with finalizedBy relationship"() {
+        given:
+        def taskB = task("b")
+        def taskA = task("a", finalizedBy: [taskB])
+        def nodeA = nodeFor(taskA)
+        def nodeB = nodeFor(taskB)
+
+        when:
+        def result = resolver.resolve(queueOf(nodeA))
+
+        then:
+        result.size() == 2
+        result.containsKey(nodeA)
+        result.containsKey(nodeB)
+        result[nodeA].finalizedBy.contains(nodeB)
+        result[nodeA].dependencies.isEmpty()
+    }
+
+    def "resolves task with mustRunAfter and shouldRunAfter ordering"() {
+        given:
+        def taskB = task("b")
+        def taskC = task("c")
+        def taskA = task("a", mustRunAfter: [taskB], shouldRunAfter: [taskC])
+        def nodeA = nodeFor(taskA)
+        def nodeB = nodeFor(taskB)
+        def nodeC = nodeFor(taskC)
+
+        when:
+        def result = resolver.resolve(queueOf(nodeA))
+
+        then:
+        // mustRunAfter/shouldRunAfter are resolved but do not trigger BFS discovery
+        result.size() == 1
+        result[nodeA].mustRunAfter.contains(nodeB)
+        result[nodeA].shouldRunAfter.contains(nodeC)
+    }
+
+    def "resolves tasks from multiple projects in parallel wave"() {
+        given:
+        def projectA = project(project, "a")
+        _ * projectA.projectPath >> projectA.projectIdentity.projectPath
+
+        def projectB = project(project, "b")
+        _ * projectB.projectPath >> projectB.projectIdentity.projectPath
+
+        def taskA = task("taskA", project: projectA)
+        def taskB = task("taskB", project: projectB)
+        def nodeA = nodeFor(taskA)
+        def nodeB = nodeFor(taskB)
+
+        when:
+        def result = resolver.resolve(queueOf(nodeA, nodeB))
+
+        then:
+        result.size() == 2
+        result.containsKey(nodeA)
+        result.containsKey(nodeB)
+        result[nodeA].dependencies.isEmpty()
+        result[nodeB].dependencies.isEmpty()
+    }
+
+    def "skips nodes where dependenciesProcessed is true"() {
+        given:
+        def taskA = task("a")
+        def nodeA = nodeFor(taskA)
+        nodeA.dependenciesProcessed()
+
+        when:
+        def result = resolver.resolve(queueOf(nodeA))
+
+        then:
+        result.isEmpty()
+    }
+
+    def "resolves deferred cross-project dependencies with placeholder substitution"() {
+        given:
+        def projectA = project(project, "a")
+        _ * projectA.projectPath >> projectA.projectIdentity.projectPath
+
+        def projectB = project(project, "b")
+        _ * projectB.projectPath >> projectB.projectIdentity.projectPath
+
+        def taskB = task("taskB", project: projectB)
+        def nodeB = nodeFor(taskB)
+
+        // Stub project state registry so placeholder resolution can discover project B's tasks
+        def projectBIdentityPath = projectB.identityPath
+        _ * projectStateRegistry.stateFor(projectBIdentityPath) >> projectB.owner
+        _ * projectB.owner.ensureTasksDiscovered() >> {}
+        _ * projectB.tasks.findByName("taskB") >> taskB
+
+        // Task A has a deferred cross-project dependency on projectB:taskB.
+        // We use separate mock instances for taskDependencies and lifecycleDependencies
+        // to avoid CachingDirectedGraphWalker returning cached results.
+        def taskA = createTask("taskA", projectA)
+        _ * taskA.taskDependencies >> deferredDependencyOn(projectBIdentityPath, "taskB")
+        _ * taskA.lifecycleDependencies >> deferredDependencyOn(projectBIdentityPath, "taskB")
+        _ * taskA.finalizedBy >> taskDependencyResolvingTo(taskA, [])
+        _ * taskA.shouldRunAfter >> taskDependencyResolvingTo(taskA, [])
+        _ * taskA.mustRunAfter >> taskDependencyResolvingTo(taskA, [])
+        _ * taskA.sharedResources >> []
+        _ * taskA.taskIdentity >> TestTaskIdentities.create("taskA", DefaultTask, projectA)
+        _ * taskA.state >> Mock(TaskStateInternal)
+        def nodeA = nodeFor(taskA)
+
+        // A second task in project B so the initial wave has multiple projects (triggers multi-project path)
+        def taskDummy = task("dummy", project: projectB)
+        def nodeDummy = nodeFor(taskDummy)
+
+        when:
+        def result = resolver.resolve(queueOf(nodeA, nodeDummy))
+
+        then:
+        result.containsKey(nodeA)
+        result.containsKey(nodeDummy)
+        // Placeholders were resolved and substituted with the real nodeB
+        result[nodeA].dependencies.contains(nodeB)
+        result[nodeA].lifecycleDependencies.contains(nodeB)
+    }
+
+    def "resolves shared dependency only once across BFS waves"() {
+        given:
+        def taskC = task("c")
+        def taskA = task("a", dependsOn: [taskC])
+        def taskB = task("b", dependsOn: [taskC])
+        def nodeA = nodeFor(taskA)
+        def nodeB = nodeFor(taskB)
+        def nodeC = nodeFor(taskC)
+
+        when:
+        def result = resolver.resolve(queueOf(nodeA, nodeB))
+
+        then:
+        result.size() == 3
+        result[nodeA].dependencies.contains(nodeC)
+        result[nodeB].dependencies.contains(nodeC)
+        result.containsKey(nodeC)
+    }
+
+    def "BFS discovers dependencies of finalized tasks"() {
+        given:
+        def taskC = task("c")
+        def taskB = task("b", dependsOn: [taskC])
+        def taskA = task("a", finalizedBy: [taskB])
+        def nodeA = nodeFor(taskA)
+        def nodeB = nodeFor(taskB)
+        def nodeC = nodeFor(taskC)
+
+        when:
+        def result = resolver.resolve(queueOf(nodeA))
+
+        then:
+        result.size() == 3
+        result[nodeA].finalizedBy.contains(nodeB)
+        result[nodeB].dependencies.contains(nodeC)
+        result[nodeC].dependencies.isEmpty()
+    }
+
+    /**
+     * Creates a mock TaskDependencyContainer that adds a deferred cross-project dependency
+     * when visited. Each call creates a new mock to avoid CachingDirectedGraphWalker cache hits.
+     */
+    private TaskDependencyContainerInternal deferredDependencyOn(org.gradle.util.Path targetProjectIdentityPath, String taskName) {
+        return Mock(TaskDependencyContainerInternal) {
+            visitDependencies(_) >> { TaskDependencyResolveContext context ->
+                context.add(new DeferredCrossProjectDependency.ByProjectTask(targetProjectIdentityPath, taskName))
+            }
+        }
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.execution.taskgraph
 
+import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.api.Action
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.CircularReferenceException
@@ -62,6 +63,8 @@ import org.gradle.internal.concurrent.ManagedExecutor
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.file.Stat
 import org.gradle.internal.operations.TestBuildOperationRunner
+import org.gradle.internal.Factory
+import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.work.DefaultWorkerLeaseService
@@ -624,7 +627,10 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
     }
 
     private DefaultExecutionPlan newExecutionPlan() {
-        return new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), coordinator)
+        def workerLeaseService = Stub(WorkerLeaseService) {
+            runAsIsolatedTask(_ as Factory) >> { Factory factory -> factory.create() }
+        }
+        return new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), coordinator, workerLeaseService, new TestBuildOperationExecutor(), Stub(ProjectStateRegistry), false)
     }
 
     def task(String name, Task... dependsOn = []) {


### PR DESCRIPTION
This PR introduces parallel task dependency resolution during execution plan construction. When "isolated projects" is enabled, ParallelNodeRelationshipsResolver pre-resolves LocalTaskNode dependency
relationships in parallel before the sequential DFS phase in DefaultExecutionPlan.

#### How it works

Main logic is in ParallelNodeRelationshipsResolver so it's separated from DefaultExecutionPlan.

BFS wave resolution: Task nodes are processed in breadth-first waves. Each wave groups nodes by owning project and resolves their dependencies in parallel — each project group runs under its own project lock. Discovered dependency nodes feed the next wave.

Cross-project dependency handling: During parallel resolution, each project group can only safely access its own project state. Cross-project dependencies (e.g., :app:compileJava → :lib:jar) are intercepted by
ProjectScopedCachingTaskDependencyResolveContext and converted into DeferredCrossProjectNode placeholder objects that are injected directly into the dependency sets. After each wave, placeholders are resolved
in parallel (task lookup) and added to next wave for dependency resolution. And at the end, a substitution pass replaces all placeholders with the real task nodes. The sequential DFS phase receives clean results with no
placeholders.
