### PR TITLE
Update Kotlin embedded compiler docs to reflect supported architectures

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
@@ -29,7 +29,7 @@ TIP: If you are interested in migrating an existing Gradle build to the Kotlin D
 [[kotdsl:prerequisites]]
 == Prerequisites
 
-* The embedded Kotlin compiler works on Linux, macOS, Windows, Cygwin, FreeBSD, and Solaris on x86-64 architectures.
+* The embedded Kotlin compiler works on Linux, macOS, Windows, Cygwin, FreeBSD, and Solaris on x86-64 and aarch64 (ARM64) architectures.
 * Familiarity with Kotlin syntax and basic language features is recommended.
 Refer to the link:{kotlin-reference}[Kotlin documentation] and link:https://kotlinlang.org/docs/tutorials/koans.html[Kotlin Koans] to learn the basics.
 * Using the <<plugins_intermediate.adoc#sec:plugins_block,`plugins {}`>> block to declare Gradle plugins is highly recommended as it significantly improves the editing experience.


### PR DESCRIPTION
Fixes #37017

Updates the Kotlin DSL documentation to reflect that the embedded Kotlin compiler now supports both x86-64 and aarch64 (ARM64) architectures, not just x86-64 as previously documented.

The documentation was last edited 8 years ago when only x86-64 was supported. The Kotlin compiler embeddable and Gradle now support aarch64 on Linux, macOS (Apple Silicon), and Windows ARM.
