### PR TITLE
Migrate DefaultBuildEventsListenerRegistry to MultiProducerSingleConsumerProcessor

### DIFF
--- a/platforms/core-runtime/concurrent/build.gradle.kts
+++ b/platforms/core-runtime/concurrent/build.gradle.kts
@@ -40,6 +40,14 @@ gradleModule {
     }
 }
 
+jvmCompile {
+    compilations {
+        named("main") {
+            usesFutureStdlib = true
+        }
+    }
+}
+
 errorprone {
     nullawayEnabled = true
 }

--- a/platforms/core-runtime/concurrent/src/main/java/org/gradle/internal/concurrent/MultiProducerSingleConsumerProcessor.java
+++ b/platforms/core-runtime/concurrent/src/main/java/org/gradle/internal/concurrent/MultiProducerSingleConsumerProcessor.java
@@ -131,6 +131,32 @@ public class MultiProducerSingleConsumerProcessor<T> {
             }
         }
 
+        doSubmit(value);
+    }
+
+    /**
+     * Submit a value to be processed, discarding the value if the processor is
+     * shutdown or in a failure state.
+     */
+    public void maybeSubmit(T value) {
+        if (failure != null) {
+            return;
+        }
+
+        if (!running) {
+            if (worker.getState() == Thread.State.NEW) {
+                throw new IllegalStateException("Cannot submit values before processor has been started.");
+            }
+            return;
+        }
+
+        doSubmit(value);
+    }
+
+    /**
+     * Submit the value to the queue, waking up the worker thread if necessary.
+     */
+    private void doSubmit(T value) {
         if (!queue.offer(value)) {
             throw new IllegalStateException("Failed to offer value to queue");
         }

--- a/platforms/core-runtime/concurrent/src/main/java/org/gradle/internal/concurrent/MultiProducerSingleConsumerProcessor.java
+++ b/platforms/core-runtime/concurrent/src/main/java/org/gradle/internal/concurrent/MultiProducerSingleConsumerProcessor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.concurrent;
 
+import org.gradle.api.JavaVersion;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
 import org.jspecify.annotations.Nullable;
@@ -45,6 +46,23 @@ public class MultiProducerSingleConsumerProcessor<T> {
      * before checking failure status or thread interruption.
      */
     static final int BATCH_SIZE = 1024;
+
+    /**
+     * Allows us to use {@link Thread#onSpinWait()}, while remaining compatible with JDK8.
+     */
+    private static final boolean AT_LEAST_JDK9 = JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_9);
+
+    /**
+     * Number of hardware spins before we yield to the OS scheduler, allowing us to
+     * avoid the overhead of a syscall before waiting for more values.
+     */
+    private static final int SPIN_TRIES = 100;
+
+    /**
+     * Number of yields to execute before parking, allowing us to keep the {@link #awake}
+     * flag true for as long as possible, preventing producers from needing to unpark.
+     */
+    private static final int YIELD_TRIES = 5;
 
     /**
      * Processes submitted values on a separate thread.
@@ -197,7 +215,11 @@ public class MultiProducerSingleConsumerProcessor<T> {
         }
     }
 
+    @SuppressWarnings("ThreadPriorityCheck")
     private void workerLoop() {
+        int idleSpins = 0;
+        int idleYields = 0;
+
         try {
             while (running || !queue.isEmpty()) {
                 if (Thread.interrupted()) {
@@ -210,11 +232,45 @@ public class MultiProducerSingleConsumerProcessor<T> {
                 if (failure != null) {
                     break;
                 }
+
                 if (processed > 0) {
+                    idleSpins = 0;
+                    idleYields = 0;
                     continue;
                 }
 
-                // Signal that we are going to sleep.
+                // While a producer is submitting a value, the JCTools queue may report
+                // non-empty even if `drain` does not process any items. Wait for the item
+                // to be submitted before looping.
+                if (!queue.isEmpty()) {
+                    if (AT_LEAST_JDK9) {
+                        Thread.onSpinWait();
+                    } else {
+                        Thread.yield();
+                    }
+                    continue;
+                }
+
+                // A quick spin wait buffer, before we proceed with the overhead of yielding.
+                if (idleSpins < SPIN_TRIES) {
+                    idleSpins++;
+                    if (AT_LEAST_JDK9) {
+                        Thread.onSpinWait();
+                    }
+                    continue;
+                }
+
+                // Yield the worker thread to the CPU, queueing us up for later execution, allowing
+                // us to keep the `awake` flag enabled. This reduces the number of times producer
+                // threads need to unpark this thread.
+                if (idleYields < YIELD_TRIES) {
+                    idleYields++;
+                    Thread.yield();
+                    continue;
+                }
+
+                // The queue is truly idle. Go to sleep. After this moment, producer threads will
+                // face the overhead of unparking the worker thread.
                 awake.set(false);
 
                 // Double-check: It is possible that a new value was submitted after we drained the
@@ -230,6 +286,8 @@ public class MultiProducerSingleConsumerProcessor<T> {
                 // (spurious wakeup). Therefore, we must always set the `awake` flag to true
                 // unconditionally to maintain the invariant that awake=true when the worker is active.
                 awake.set(true);
+                idleSpins = 0;
+                idleYields = 0;
             }
         } catch (Throwable e) {
             // `processor` should never throw, but this catch ensures we do not miss any fatal JVM Errors.

--- a/platforms/core-runtime/concurrent/src/test/groovy/org/gradle/internal/concurrent/MultiProducerSingleConsumerProcessorTest.groovy
+++ b/platforms/core-runtime/concurrent/src/test/groovy/org/gradle/internal/concurrent/MultiProducerSingleConsumerProcessorTest.groovy
@@ -386,6 +386,79 @@ class MultiProducerSingleConsumerProcessorTest extends ConcurrentSpec {
         stopQuietly(processor)
     }
 
+    def "maybeSubmit processes values when running"() {
+        given:
+        def processed = new CopyOnWriteArrayList<Integer>()
+        def processor = newProcessor { Integer value ->
+            processed.add(value)
+            instant.processed
+        }
+        processor.start()
+
+        when:
+        processor.maybeSubmit(123)
+        waitFor.processed
+
+        then:
+        processed == [123]
+
+        cleanup:
+        stopQuietly(processor)
+    }
+
+    def "maybeSubmit throws exception when called before start"() {
+        given:
+        def processor = newProcessor {}
+
+        when:
+        processor.maybeSubmit(123)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == "Cannot submit values before processor has been started."
+    }
+
+    def "maybeSubmit discards values after stop"() {
+        given:
+        def processed = new CopyOnWriteArrayList<Integer>()
+        def processor = newProcessor { processed.add(it) }
+        processor.start()
+        processor.stop(TIMEOUT)
+
+        when:
+        processor.maybeSubmit(123)
+
+        then:
+        processed.isEmpty()
+    }
+
+    def "maybeSubmit discards values after failure"() {
+        given:
+        def processed = new CopyOnWriteArrayList<Integer>()
+        def processor = newProcessor { Integer value ->
+            if (value == 1) {
+                throw new RuntimeException("failed")
+            }
+            processed.add(value)
+        }
+        processor.start()
+
+        when:
+        processor.submit(1)
+
+        then:
+        waitForFailure { processor.submit(2) }
+
+        when:
+        processor.maybeSubmit(3)
+
+        then:
+        processed.isEmpty()
+
+        cleanup:
+        stopQuietly(processor)
+    }
+
     /**
      * A failure in the processor may not be immediately visible in the producing thread,
      * so we retry a given action we expect to emit a failure util that failure is emitted.

--- a/subprojects/build-events/build.gradle.kts
+++ b/subprojects/build-events/build.gradle.kts
@@ -7,7 +7,6 @@ description = "Implementation of build event services and build event types (wor
 dependencies {
     api(projects.baseServices)
     api(projects.buildOperations)
-    api(projects.concurrent)
     api(projects.core)
     api(projects.coreApi)
     api(projects.messaging)
@@ -17,6 +16,7 @@ dependencies {
     api(projects.stdlibJavaExtensions)
     api(projects.toolingApi)
 
+    implementation(projects.concurrent)
     implementation(projects.logging)
     implementation(projects.modelCore)
 

--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
@@ -269,7 +269,7 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec implements Veri
 
         then:
         // TODO - add some context to the failure
-        failure.assertHasDescription("broken")
+        failure.assertHasCause("broken")
 
         output.count("BROKEN:") == 1
 
@@ -282,7 +282,7 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec implements Veri
 
         then:
         // TODO - add some context to the failure
-        failure.assertHasDescription("broken")
+        failure.assertHasCause("broken")
 
         output.count("BROKEN:") == 1
 

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -29,13 +29,11 @@ import org.gradle.build.event.BuildEventsListenerRegistry;
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Pair;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.build.event.types.DefaultTaskFinishedProgressEvent;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.code.UserCodeSource;
 import org.gradle.internal.concurrent.CompositeStoppable;
-import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.concurrent.ManagedExecutor;
+import org.gradle.internal.concurrent.MultiProducerSingleConsumerProcessor;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationListener;
@@ -55,16 +53,12 @@ import org.gradle.tooling.internal.protocol.events.InternalTaskResult;
 import org.jspecify.annotations.Nullable;
 
 import java.io.Closeable;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedTransferQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TransferQueue;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -76,20 +70,17 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
     private final BuildOperationListenerManager buildOperationListenerManager;
     @GuardedBy("subscriptions")
     private final Map<Provider<?>, AbstractListener<?>> subscriptions = new LinkedHashMap<>();
-    private final ExecutorFactory executorFactory;
 
     public DefaultBuildEventsListenerRegistry(
         UserCodeApplicationContext applicationContext,
         BuildEventListenerFactory factory,
         ListenerManager listenerManager,
-        BuildOperationListenerManager buildOperationListenerManager,
-        ExecutorFactory executorFactory
+        BuildOperationListenerManager buildOperationListenerManager
     ) {
         this.applicationContext = applicationContext;
         this.factory = factory;
         this.listenerManager = listenerManager;
         this.buildOperationListenerManager = buildOperationListenerManager;
-        this.executorFactory = executorFactory;
         listenerManager.addListener(new ListenerCleanup());
     }
 
@@ -118,7 +109,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
     }
 
     private ForwardingBuildOperationListener makeBuildOperationSubscription(Provider<? extends BuildOperationListener> listenerProvider) {
-        ForwardingBuildOperationListener subscription = new ForwardingBuildOperationListener(getCurrentContext(), listenerProvider, executorFactory);
+        ForwardingBuildOperationListener subscription = new ForwardingBuildOperationListener(getCurrentContext(), listenerProvider);
         processIfBuildService(listenerProvider);
         buildOperationListenerManager.addListener(subscription);
         return subscription;
@@ -130,7 +121,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
     }
 
     private ForwardingBuildEventConsumer makeTaskCompletionSubscription(Provider<? extends OperationCompletionListener> listenerProvider) {
-        ForwardingBuildEventConsumer subscription = new ForwardingBuildEventConsumer(getCurrentContext(), listenerProvider, executorFactory);
+        ForwardingBuildEventConsumer subscription = new ForwardingBuildEventConsumer(getCurrentContext(), listenerProvider);
         processIfBuildService(listenerProvider);
 
         for (Object listener : subscription.getListeners()) {
@@ -195,17 +186,15 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
     }
 
     private static abstract class AbstractListener<T> implements Closeable {
-        private static final Object END = new Object();
+
         @Nullable
         private final UserCodeSource registrationPoint;
-        private final ManagedExecutor executor;
-        private final TransferQueue<Object> events = new LinkedTransferQueue<>();
-        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+        private final MultiProducerSingleConsumerProcessor<T> processor;
 
-        public AbstractListener(@Nullable UserCodeSource registrationPoint, ExecutorFactory executorFactory) {
+        public AbstractListener(@Nullable UserCodeSource registrationPoint) {
             this.registrationPoint = registrationPoint;
-            this.executor = executorFactory.create("build event listener");
-            Future<?> ignored = executor.submit(this::run);
+            this.processor =  new MultiProducerSingleConsumerProcessor<>("build event listener", this::handle);
+            this.processor.start();
         }
 
         @Nullable
@@ -213,48 +202,17 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
             return registrationPoint;
         }
 
-        private void run() {
-            while (true) {
-                Object next;
-                try {
-                    next = events.take();
-                } catch (InterruptedException e) {
-                    throw UncheckedException.throwAsUncheckedException(e);
-                }
-                if (next == END) {
-                    return;
-                }
-                try {
-                    handle(Cast.uncheckedNonnullCast(next));
-                } catch (Throwable t) {
-                    failure.set(t);
-                    break;
-                }
-            }
-            // A failure has happened. Drain the queue and complete without waiting. There should no more messages added to the queue
-            // as the dispatch method will see the failure
-            events.clear();
-        }
-
         protected abstract void handle(T message);
 
         public abstract List<Object> getListeners();
 
         protected void queue(T message) {
-            if (failure.get() == null) {
-                events.add(message);
-            }
-            // else, the handler thread is no longer handling messages so discard it
+            processor.maybeSubmit(message);
         }
 
         @Override
         public void close() {
-            events.add(END);
-            executor.stop(60, TimeUnit.SECONDS);
-            Throwable failure = this.failure.get();
-            if (failure != null) {
-                throw UncheckedException.throwAsUncheckedException(failure);
-            }
+            processor.stop(Duration.ofMinutes(1));
         }
     }
 
@@ -263,10 +221,9 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
 
         public ForwardingBuildOperationListener(
             @Nullable UserCodeSource registrationPoint,
-            Provider<? extends BuildOperationListener> listenerProvider,
-            ExecutorFactory executorFactory
+            Provider<? extends BuildOperationListener> listenerProvider
         ) {
-            super(registrationPoint, executorFactory);
+            super(registrationPoint);
             this.listenerProvider = listenerProvider;
         }
 
@@ -300,10 +257,9 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
 
         public ForwardingBuildEventConsumer(
             @Nullable UserCodeSource registrationPoint,
-            Provider<? extends OperationCompletionListener> listenerProvider,
-            ExecutorFactory executorFactory
+            Provider<? extends OperationCompletionListener> listenerProvider
         ) {
-            super(registrationPoint, executorFactory);
+            super(registrationPoint);
             this.listenerProvider = listenerProvider;
             BuildEventSubscriptions eventSubscriptions = new BuildEventSubscriptions(Collections.singleton(OperationType.TASK));
             // TODO - share these listeners here and with the tooling api client, where possible

--- a/subprojects/build-events/src/test/groovy/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistryTest.groovy
+++ b/subprojects/build-events/src/test/groovy/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistryTest.groovy
@@ -28,7 +28,6 @@ import org.gradle.internal.build.event.types.DefaultTaskSkippedResult
 import org.gradle.internal.build.event.types.DefaultTaskSuccessResult
 import org.gradle.internal.code.DefaultUserCodeApplicationContext
 import org.gradle.internal.event.DefaultListenerManager
-import org.gradle.internal.event.ListenerNotificationException
 import org.gradle.internal.operations.BuildOperationDescriptor
 import org.gradle.internal.operations.BuildOperationListener
 import org.gradle.internal.operations.DefaultBuildOperationListenerManager
@@ -44,8 +43,6 @@ import org.gradle.tooling.events.task.TaskFinishEvent
 import org.gradle.tooling.events.task.TaskSkippedResult
 import org.gradle.tooling.events.task.TaskSuccessResult
 
-import java.lang.reflect.UndeclaredThrowableException
-
 class DefaultBuildEventsListenerRegistryTest extends ConcurrentSpec {
     def factory = new MockBuildEventListenerFactory()
     def listenerManager = new DefaultListenerManager(Scope.Build)
@@ -54,7 +51,7 @@ class DefaultBuildEventsListenerRegistryTest extends ConcurrentSpec {
         isRootBuild() >> true
     }
     def buildResult = new BuildResult(gradle, null)
-    def registry = new DefaultBuildEventsListenerRegistry(new DefaultUserCodeApplicationContext(), factory, listenerManager, buildOperationListenerManager, executorFactory)
+    def registry = new DefaultBuildEventsListenerRegistry(new DefaultUserCodeApplicationContext(), factory, listenerManager, buildOperationListenerManager)
 
     def cleanup() {
         // Signal the end of the build, to stop everything
@@ -179,14 +176,14 @@ class DefaultBuildEventsListenerRegistryTest extends ConcurrentSpec {
         0 * okListener._
 
         and:
-        def e = thrown(exceptionType)
-        exceptionCheck.call(e)
+        def e = thrown(IllegalStateException)
+        exceptionCheck.call(e.cause)
 
         where:
-        failure                 | exceptionType                     | exceptionCheck
-        new RuntimeException()  | RuntimeException                  | { t -> t.is(failure) }
-        new Error()             | ListenerNotificationException     | { t -> t.getCauses().get(0).is(failure) }
-        new Throwable()         | UndeclaredThrowableException      | { t -> t.getCause().is(failure) }
+        failure                | exceptionCheck
+        new RuntimeException() | { t -> t.is(failure) }
+        new Error()            | { t -> t.is(failure) }
+        new Throwable()        | { t -> t.cause.is(failure) }
     }
 
     private signalBuildFinished() {


### PR DESCRIPTION
Previously we relied on a LinkedTransferQueue and a hand-written event processing thread. MPSCP implements this behind a reusable abstraction.
    
Along the way, we determined that our existing MPSCP is not as performant as LTQ. We add strategic spin waits and yields to the worker loop, and now we beat LTQ's performance. For reference, LTQ performs a single yield in its 'take' implementation. Updating our MPSCP to use a single yield produces slightly better performanec than LTQ, as it can avoid linking and allocation overhead of LTQ. Increasing to 5 yields improves performance by ~35%.
    
In a series of local benchmarks executed against gradle/gradle, different approaches producer threads spent varying amount of times submitting work to the queue:
- existing LTQ: 3.3k samples
- MPSCP without optimization: 5.3k samples
- MPSCP with optimizations: 2.1k samples

MPSCP without optimization:
<img width="1579" height="330" alt="image" src="https://github.com/user-attachments/assets/dead204d-4cb2-4a7d-9784-4cbb14c0c512" />

LTQ: 
<img width="1583" height="386" alt="image" src="https://github.com/user-attachments/assets/15a65443-b3d2-4566-8964-4c552d65c79b" />

MPSCP with single yield:
<img width="1580" height="336" alt="image" src="https://github.com/user-attachments/assets/90a1b8e3-fd71-422b-aadc-aa403d09707f" />

MPSCP with spin loop & multiple yields:
<img width="1582" height="342" alt="image" src="https://github.com/user-attachments/assets/cfe3d5f2-57e4-4e3b-88f8-88b09b2bbed4" />

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
