### PR TITLE
Cache plugin entries extracted from JAR files

### DIFF
--- a/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/PluginEntry.kt
+++ b/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/PluginEntry.kt
@@ -23,9 +23,17 @@ import java.util.jar.JarEntry
 import java.util.jar.JarFile
 
 
+interface PluginEntryCache {
+    fun computeIfAbsent(jar: File, producer: (File) -> List<PluginEntry>): List<PluginEntry>
+}
+
 data class PluginEntry(val pluginId: String, val implementationClass: String)
 
 
+fun pluginEntriesFrom(jar: File, pluginEntryCache: PluginEntryCache): List<PluginEntry> =
+    pluginEntryCache.computeIfAbsent(jar, ::pluginEntriesFrom)
+
+private
 fun pluginEntriesFrom(jar: File): List<PluginEntry> = try {
     JarFile(jar, false).use { jarFile ->
         jarFile.entries().asSequence().filter {

--- a/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/PluginIdExtensionsFacade.kt
+++ b/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/PluginIdExtensionsFacade.kt
@@ -87,12 +87,24 @@ data class PluginExtension(
 
 private
 fun pluginExtensionsFrom(jars: Iterable<File>): Sequence<PluginExtension> =
-    jars.asSequence().flatMap(::pluginExtensionsFrom)
-
+    LocalPluginEntryCache().let { cache ->
+        jars.asSequence().flatMap { pluginExtensionsFrom(it, cache) }
+    }
 
 private
-fun pluginExtensionsFrom(file: File): Sequence<PluginExtension> =
-    pluginEntriesFrom(file)
+class LocalPluginEntryCache : PluginEntryCache {
+    private val cache: MutableMap<String, List<PluginEntry>> = HashMap()
+    override fun computeIfAbsent(
+        jar: File,
+        producer: (File) -> List<PluginEntry>
+    ): List<PluginEntry> = cache.computeIfAbsent(jar.canonicalPath) {
+        producer(jar)
+    }
+}
+
+private
+fun pluginExtensionsFrom(file: File, pluginEntryCache: PluginEntryCache): Sequence<PluginExtension> =
+    pluginEntriesFrom(file, pluginEntryCache)
         .asSequence()
         .map { (id, implementationClass) ->
             val simpleId = id.substringAfter("org.gradle.")

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
 
     implementation(libs.kotlinCompilerEmbeddable)
 
+    implementation("org.gradle:kotlin-dsl-shared-runtime")
+
     compileOnly(libs.kotlinReflect)
 
     testImplementation(testFixtures(projects.kotlinDsl))

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -39,6 +39,7 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.deprecation.Documentation
 import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.PluginEntryCache
 import org.gradle.kotlin.dsl.precompile.v1.PrecompiledInitScript
 import org.gradle.kotlin.dsl.precompile.v1.PrecompiledProjectScript
 import org.gradle.kotlin.dsl.precompile.v1.PrecompiledSettingsScript
@@ -257,6 +258,7 @@ fun Project.enableScriptCompilationOf(
         configureKotlinCompilerArguments(
             objects,
             serviceOf(),
+            serviceOf(),
             compileClasspath,
             generatePrecompiledScriptPluginAccessors.flatMap { it.metadataOutputDir }
         )
@@ -302,6 +304,7 @@ private fun Project.registerCompilePluginsBlocksTask(
         task.configureKotlinCompilerArgumentsLazily(
             resolverEnvironmentStringFor(
                 project.serviceOf(),
+                project.serviceOf(),
                 compileClasspath,
                 externalPluginSpecBuildersTask.flatMap { it.metadataOutputDir },
             )
@@ -316,6 +319,7 @@ private
 fun configureKotlinCompilerArguments(
     objects: ObjectFactory,
     implicitImports: ImplicitImports,
+    pluginEntryCache: PluginEntryCache,
     compileClasspath: FileCollection,
     accessorsMetadata: Provider<Directory>
 ) {
@@ -323,6 +327,7 @@ fun configureKotlinCompilerArguments(
         objects,
         resolverEnvironmentStringFor(
             implicitImports,
+            pluginEntryCache,
             compileClasspath,
             accessorsMetadata
         )

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ClassPathAware.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ClassPathAware.kt
@@ -24,6 +24,7 @@ import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
 import org.gradle.kotlin.dsl.accessors.PluginTree
 import org.gradle.kotlin.dsl.accessors.pluginTreesFrom
+import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.PluginEntryCache
 import org.gradle.kotlin.dsl.support.ImplicitImports
 
 
@@ -38,9 +39,10 @@ interface ClassPathAware {
 internal
 fun implicitImportsForPrecompiledScriptPlugins(
     implicitImports: ImplicitImports,
+    pluginEntryCache: PluginEntryCache,
     classPathFiles: FileCollection
 ): List<String> {
-    return implicitImports.list + "${sharedAccessorsPackageFor(pluginTreesFrom(classPathFiles))}.*"
+    return implicitImports.list + "${sharedAccessorsPackageFor(pluginTreesFrom(classPathFiles, pluginEntryCache))}.*"
 }
 
 

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
@@ -23,12 +23,11 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-
+import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.PluginEntryCache
 import org.gradle.kotlin.dsl.provider.PrecompiledScriptsEnvironment.EnvironmentProperties.kotlinDslImplicitImports
 import org.gradle.kotlin.dsl.support.ImplicitImports
 import org.gradle.kotlin.dsl.support.listFilesOrdered
 import org.gradle.work.DisableCachingByDefault
-
 import java.io.File
 import javax.inject.Inject
 
@@ -44,6 +43,9 @@ abstract class ConfigurePrecompiledScriptDependenciesResolver @Inject constructo
     @get:Internal
     abstract val metadataDir: DirectoryProperty
 
+    @get:Inject
+    internal abstract val pluginEntryCache: PluginEntryCache
+
     private
     lateinit var onConfigure: (Provider<String>) -> Unit
 
@@ -55,6 +57,7 @@ abstract class ConfigurePrecompiledScriptDependenciesResolver @Inject constructo
     fun configureImports() {
         val resolverEnvironment = resolverEnvironmentStringFor(
             implicitImports,
+            pluginEntryCache,
             classPathFiles,
             metadataDir
         )
@@ -66,12 +69,13 @@ abstract class ConfigurePrecompiledScriptDependenciesResolver @Inject constructo
 internal
 fun resolverEnvironmentStringFor(
     implicitImports: ImplicitImports,
+    pluginEntryCache: PluginEntryCache,
     classPathFiles: FileCollection,
     accessorsMetadataDir: Provider<Directory>
 ): Provider<String> = accessorsMetadataDir.map { metadataDir ->
     resolverEnvironmentStringFor(
         listOf(
-            kotlinDslImplicitImports to implicitImportsForPrecompiledScriptPlugins(implicitImports, classPathFiles)
+            kotlinDslImplicitImports to implicitImportsForPrecompiledScriptPlugins(implicitImports, pluginEntryCache, classPathFiles)
         ) + precompiledScriptPluginImportsFrom(metadataDir.asFile)
     )
 }

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GenerateExternalPluginSpecBuilders.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GenerateExternalPluginSpecBuilders.kt
@@ -27,8 +27,10 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.accessors.pluginEntriesFrom
 import org.gradle.kotlin.dsl.accessors.pluginTreesFrom
 import org.gradle.kotlin.dsl.accessors.writeSourceCodeForPluginSpecBuildersFor
+import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.PluginEntryCache
 import org.gradle.kotlin.dsl.provider.PrecompiledScriptsEnvironment.EnvironmentProperties.kotlinDslPluginSpecBuildersImplicitImports
 import java.io.File
+import javax.inject.Inject
 
 
 @CacheableTask
@@ -37,9 +39,14 @@ abstract class GenerateExternalPluginSpecBuilders : DefaultTask() {
     @get:Internal
     abstract val classPathFiles: ConfigurableFileCollection
 
+    @get:Inject
+    internal abstract val pluginEntryCache: PluginEntryCache
+
     @Suppress("LeakingThis")
     @get:Input
-    val pluginEntries = classPathFiles.elements.map { elements -> pluginEntriesFrom(elements.map { it.asFile }) }
+    val pluginEntries = classPathFiles.elements.map { elements ->
+        pluginEntriesFrom(elements.map { it.asFile }, pluginEntryCache)
+    }
 
     @get:OutputDirectory
     abstract val sourceCodeOutputDir: DirectoryProperty

--- a/platforms/core-configuration/kotlin-dsl/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl/build.gradle.kts
@@ -30,6 +30,10 @@ dependencies {
     api(projects.stdlibJavaExtensions)
     api(projects.toolingApi)
 
+    api("org.gradle:kotlin-dsl-shared-runtime") {
+        because("Internal KotlinDslPluginEntriesCache exposes PluginEntriesCache")
+    }
+
     api(libs.groovy)
     api(libs.guava)
     api(libs.kotlinCompilerEmbeddable)
@@ -66,7 +70,6 @@ dependencies {
     implementation(projects.wrapperShared)
 
     implementation(projects.javaApiExtractor)
-    implementation("org.gradle:kotlin-dsl-shared-runtime")
 
     implementation(libs.asm)
     implementation(libs.jetbrainsAnnotations)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/BuildTreeServices.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/BuildTreeServices.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.accessors
+
+import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory
+import org.gradle.internal.hash.ChecksumService
+import org.gradle.internal.service.Provides
+import org.gradle.internal.service.ServiceRegistrationProvider
+
+internal object BuildTreeServices : ServiceRegistrationProvider {
+
+    @Provides
+    fun createKotlinDslPluginEntryCache(
+        cacheBuilderFactory: BuildTreeScopedCacheBuilderFactory,
+        inMemoryCacheDecoratorFactory: InMemoryCacheDecoratorFactory,
+        checksums: ChecksumService,
+    ): KotlinDslPluginEntryCache =
+        KotlinDslPluginEntryCache(
+            cacheBuilderFactory,
+            inMemoryCacheDecoratorFactory,
+            checksums,
+        )
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/GeneratePluginSpecBuilderAccessors.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/GeneratePluginSpecBuilderAccessors.kt
@@ -32,6 +32,7 @@ import org.gradle.kotlin.dsl.concurrent.withAsynchronousIO
 import org.gradle.kotlin.dsl.concurrent.withSynchronousIO
 import org.gradle.kotlin.dsl.concurrent.writeFile
 import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.KOTLIN_DSL_PACKAGE_PATH
+import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.PluginEntryCache
 import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.fileHeader
 import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.fileHeaderFor
 import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.pluginEntriesFrom
@@ -60,6 +61,7 @@ import org.gradle.kotlin.dsl.support.bytecode.publicKotlinClass
 import org.gradle.kotlin.dsl.support.bytecode.publicMethod
 import org.gradle.kotlin.dsl.support.bytecode.publicStaticMethod
 import org.gradle.kotlin.dsl.support.bytecode.writeFileFacadeClassHeader
+import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.kotlin.dsl.support.uppercaseFirstChar
 import org.gradle.kotlin.dsl.support.useToRun
 import org.gradle.plugin.use.PluginDependenciesSpec
@@ -118,6 +120,7 @@ class GeneratePluginSpecBuilderAccessors(
         kotlinScriptClassPathProviderOf(rootProject).run {
             withAsynchronousIO(rootProject) {
                 buildPluginDependencySpecAccessorsFor(
+                    pluginEntryCache = rootProject.serviceOf(),
                     pluginDescriptorsClassPath = exportClassPathFromHierarchyOf(buildSrcClassLoaderScope),
                     srcDir = getSourcesOutputDir(workspace),
                     binDir = getClassesOutputDir(workspace),
@@ -153,13 +156,14 @@ sealed class PluginDependencySpecAccessor {
 
 internal
 fun IO.buildPluginDependencySpecAccessorsFor(
+    pluginEntryCache: PluginEntryCache,
     pluginDescriptorsClassPath: ClassPath,
     srcDir: File,
     binDir: File
 ) {
     makeAccessorOutputDirs(srcDir, binDir, KOTLIN_DSL_PACKAGE_PATH)
 
-    val pluginTrees = pluginTreesFrom(pluginDescriptorsClassPath.asFiles)
+    val pluginTrees = pluginTreesFrom(pluginDescriptorsClassPath.asFiles, pluginEntryCache)
 
     val baseFileName = "$KOTLIN_DSL_PACKAGE_PATH/PluginDependencySpecAccessors"
     val sourceFile = srcDir.resolve("$baseFileName.kt")
@@ -364,19 +368,19 @@ fun typeSpecForPluginGroupType(groupType: String) =
     TypeSpec(groupType, InternalName("$KOTLIN_DSL_PACKAGE_PATH/$groupType"))
 
 
-fun pluginTreesFrom(classPathFiles: Iterable<File>): Map<String, PluginTree> =
-    pluginTreesFrom(pluginEntriesFrom(classPathFiles))
+fun pluginTreesFrom(classPathFiles: Iterable<File>, pluginEntryCache: PluginEntryCache): Map<String, PluginTree> =
+    pluginTreesFrom(pluginEntriesFrom(classPathFiles, pluginEntryCache))
 
 
 fun pluginTreesFrom(pluginEntries: List<Pair<String, String>>): Map<String, PluginTree> =
     PluginTree.of(pluginEntries.map { PluginTree.PluginSpec(it.first, it.second) }.asSequence())
 
 
-fun pluginEntriesFrom(classPathFiles: Iterable<File>): List<Pair<String, String>> =
+fun pluginEntriesFrom(classPathFiles: Iterable<File>, pluginEntryCache: PluginEntryCache): List<Pair<String, String>> =
     classPathFiles
         .asSequence()
         .filter { it.isFile && it.extension.equals("jar", true) }
-        .flatMap { pluginEntriesFrom(it).asSequence() }
+        .flatMap { pluginEntriesFrom(it, pluginEntryCache).asSequence() }
         .map { Pair(it.pluginId, it.implementationClass)}
         .toCollection(mutableListOf())
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/KotlinDslPluginEntryCache.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/KotlinDslPluginEntryCache.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.accessors
+
+import org.gradle.cache.FileLockManager
+import org.gradle.cache.IndexedCache
+import org.gradle.cache.IndexedCacheParameters
+import org.gradle.cache.PersistentCache
+import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
+import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory
+import org.gradle.internal.hash.ChecksumService
+import org.gradle.internal.hash.HashCode
+import org.gradle.internal.serialize.Decoder
+import org.gradle.internal.serialize.Encoder
+import org.gradle.internal.serialize.HashCodeSerializer
+import org.gradle.internal.serialize.Serializer
+import org.gradle.internal.service.scopes.Scope
+import org.gradle.internal.service.scopes.ServiceScope
+import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.PluginEntry
+import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.PluginEntryCache
+import java.io.File
+import java.lang.AutoCloseable
+import java.util.function.Supplier
+
+@ServiceScope(Scope.BuildTree::class)
+internal class KotlinDslPluginEntryCache(
+    cacheBuilderFactory: BuildTreeScopedCacheBuilderFactory,
+    inMemoryCacheDecoratorFactory: InMemoryCacheDecoratorFactory,
+    private val checksums: ChecksumService,
+) : PluginEntryCache, AutoCloseable {
+
+    private val cacheBuilder: PersistentCache =
+        cacheBuilderFactory
+            .createCacheBuilder("kotlin-dsl-plugin-entries")
+            .withDisplayName("Kotlin DSL Plugin Entries")
+            .withInitialLockMode(FileLockManager.LockMode.OnDemandEagerRelease)
+            .open()
+
+    private val cache: IndexedCache<HashCode, List<PluginEntry>> =
+        cacheBuilder.createIndexedCache(
+            IndexedCacheParameters.of("jar-entries", HashCodeSerializer(), PluginEntrySerializer)
+                .withCacheDecorator(
+                    inMemoryCacheDecoratorFactory.decorator(
+                        /* maxEntriesToKeepInMemory = */ 1000,
+                        /* cacheInMemoryForShortLivedProcesses = */ true
+                    )
+                )
+        )
+
+    override fun computeIfAbsent(
+        jar: File,
+        producer: (File) -> List<PluginEntry>
+    ): List<PluginEntry> =
+        cache.get(checksums.md5(jar), Supplier {
+            producer.invoke(jar)
+        })
+
+    override fun close() {
+        cacheBuilder.close()
+    }
+
+    private object PluginEntrySerializer : Serializer<List<PluginEntry>> {
+
+        override fun read(decoder: Decoder): List<PluginEntry> =
+            buildList {
+                repeat(decoder.readSmallInt()) {
+                    add(PluginEntry(decoder.readString(), decoder.readString()))
+                }
+            }
+
+        override fun write(encoder: Encoder, value: List<PluginEntry>) {
+            encoder.writeSmallInt(value.size)
+            value.forEach { entry ->
+                encoder.writeString(entry.pluginId)
+                encoder.writeString(entry.implementationClass)
+            }
+        }
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/services/KotlinScriptServices.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/services/KotlinScriptServices.kt
@@ -29,6 +29,10 @@ class KotlinScriptServices : AbstractGradleModuleServices() {
         registration.addProvider(org.gradle.kotlin.dsl.provider.BuildServices)
     }
 
+    override fun registerBuildTreeServices(registration: ServiceRegistration) {
+        registration.addProvider(org.gradle.kotlin.dsl.accessors.BuildTreeServices)
+    }
+
     override fun registerGlobalServices(registration: ServiceRegistration) {
         registration.addProvider(org.gradle.kotlin.dsl.support.GlobalServices)
     }

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/PluginSpecBuilderAccessorsClassPathTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/PluginSpecBuilderAccessorsClassPathTest.kt
@@ -18,18 +18,16 @@ package org.gradle.kotlin.dsl.accessors
 
 import org.gradle.kotlin.dsl.concurrent.withSynchronousIO
 import org.gradle.kotlin.dsl.fixtures.assertFailsWith
-
 import org.gradle.kotlin.dsl.fixtures.classLoaderFor
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.gradle.kotlin.dsl.fixtures.pluginDescriptorEntryFor
+import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.PluginEntry
+import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.PluginEntryCache
 import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.pluginEntriesFrom
-
 import org.gradle.kotlin.dsl.support.useToRun
 import org.gradle.kotlin.dsl.support.zipTo
-
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
-
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.hasItems
@@ -37,14 +35,12 @@ import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
-
 import java.io.File
 import java.util.zip.ZipException
 
@@ -60,7 +56,7 @@ class PluginSpecBuilderAccessorsClassPathTest : TestWithClassPath() {
 
         // when:
         val exception = assertFailsWith(IllegalArgumentException::class) {
-            pluginEntriesFrom(emptyJar)
+            pluginEntriesFrom(emptyJar, NoCachePluginEntryCache)
         }
 
         // then:
@@ -90,9 +86,10 @@ class PluginSpecBuilderAccessorsClassPathTest : TestWithClassPath() {
         // when:
         withSynchronousIO {
             buildPluginDependencySpecAccessorsFor(
+                pluginEntryCache = NoCachePluginEntryCache,
                 pluginDescriptorsClassPath = classPathOf(pluginsJar),
                 srcDir = srcDir,
-                binDir = binDir
+                binDir = binDir,
             )
         }
 
@@ -193,4 +190,11 @@ class PluginSpecBuilderAccessorsClassPathTest : TestWithClassPath() {
                 }
             )
         }
+
+    object NoCachePluginEntryCache : PluginEntryCache {
+        override fun computeIfAbsent(
+            jar: File,
+            producer: (File) -> List<PluginEntry>
+        ): List<PluginEntry> = producer(jar)
+    }
 }

--- a/testing/architecture-test/src/changes/archunit-store/injected-services-should-have-service-scope-applied.txt
+++ b/testing/architecture-test/src/changes/archunit-store/injected-services-should-have-service-scope-applied.txt
@@ -20,6 +20,7 @@ Class <org.gradle.internal.file.PathToFileResolver> is not annotated with @Servi
 Class <org.gradle.internal.nativeintegration.filesystem.FileSystem> is not annotated with @ServiceScope in (FileSystem.java:0)
 Class <org.gradle.internal.nativeintegration.network.HostnameLookup> is not annotated with @ServiceScope in (HostnameLookup.java:0)
 Class <org.gradle.internal.reflect.Instantiator> is not annotated with @ServiceScope in (Instantiator.java:0)
+Class <org.gradle.kotlin.dsl.internal.sharedruntime.codegen.PluginEntryCache> is not annotated with @ServiceScope in (PluginEntry.kt:0)
 Class <org.gradle.normalization.InputNormalizationHandler> is not annotated with @ServiceScope in (InputNormalizationHandler.java:0)
 Class <org.gradle.process.internal.JavaExecHandleFactory> is not annotated with @ServiceScope in (JavaExecHandleFactory.java:0)
 Class <org.gradle.process.internal.JavaForkOptionsFactory> is not annotated with @ServiceScope in (JavaForkOptionsFactory.java:0)


### PR DESCRIPTION
`pluginEntriesFrom` opens and reads JAR files to extract plugin metadata. This method is called multiple times with the same classpath during a single build, resulting in redundant I/O and allocations.

Introduce a `KotlinDslPluginEntryCache` to avoid redundantly scanning JAR files and loading plugin descriptor properties files.

Build invocations re-generating plugin spec builders accessors are doing too much work and allocations. Keeping a cross-build in-memory cache would be holding up memory unnecessarily for all the build invocations that don't regenerate these accessors.

Register `KotlinDslPluginEntryCache` as a build-tree scoped service holding a persistent cache decorated with an in-memory cache.

The in-memory decorator cache keeps a maximum of arbitrarily 1000 entries to avoid redundant processing of the same JARs at the build-tree scope.

In an extreme scenario with 1000 different JARs processed at the build-tree scope, with each 10 plugin descriptors with very long plugin IDs and implementation class names (10000 plugins total), the in-memory cache size could be ~3.5MB (~48B per key, ~3.6KB per value). A more reasonable scenario with 200 different JARs and 200 plugins total would hold ~40KB of heap.

The persistent cross-build cache allows build invocations which trigger generating plugin spec builder accessors to quickly read the plugin entries from the cache without scanning the JARs. The underlying persistent store is cleaned up daily with 7 days LRU strategy.

Thread the cache service through the different call sites: plugin spec builder accessor generation, precompiled script plugin support, and Gradle API build-time extensions generation.

Because of the latter, the `pluginEntriesFrom` function is shared with the gradle/gradle build logic. The build logic using `pluginEntriesFrom` has its own `PluginEntryCache` implementation that only caches in-memory over a short-lived task action using a simple map.

* Fixes https://github.com/gradle/gradle/issues/37021

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
