### PR TITLE
Fix problem with multiple bindings to the same name in the same plugin

### DIFF
--- a/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/features/internal/ProjectFeatureFixture.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/features/internal/ProjectFeatureFixture.groovy
@@ -30,11 +30,13 @@ import org.gradle.features.internal.builders.definitions.ProjectFeatureNestedDef
 import org.gradle.features.internal.builders.definitions.ProjectFeatureThatBindsToDefinitionWithNoBuildModeClassBuilder
 import org.gradle.features.internal.builders.definitions.ProjectTypeDefinitionClassBuilder
 import org.gradle.features.internal.builders.definitions.ProjectTypeDefinitionThatRegistersANestedBindingLocationClassBuilder
+import org.gradle.features.internal.builders.definitions.ProjectTypeDefinitionWithMultipleNestedBindingLocations
 import org.gradle.features.internal.builders.features.KotlinProjectFeaturePluginClassBuilder
 import org.gradle.features.internal.builders.features.KotlinProjectFeaturePluginClassThatBindsWithClassBuilder
 import org.gradle.features.internal.builders.features.KotlinReifiedProjectFeaturePluginClassBuilder
 import org.gradle.features.internal.builders.features.NotAProjectFeaturePluginClassBuilder
 import org.gradle.features.internal.builders.features.ProjectFeaturePluginClassBuilder
+import org.gradle.features.internal.builders.features.ProjectFeaturePluginThatBindsMultipleFeaturesToTheSameName
 import org.gradle.features.internal.builders.features.ProjectFeaturePluginThatInjectsUnknownServiceClassBuilder
 import org.gradle.features.internal.builders.features.ProjectFeaturePluginThatUsesUnsafeServicesClassBuilder
 import org.gradle.features.internal.builders.features.ProjectFeatureThatBindsWithClassBuilder
@@ -383,6 +385,18 @@ trait ProjectFeatureFixture extends ProjectTypeFixture {
         def projectType = new ProjectTypeThatBindsWithClassBuilder(projectTypeDefinition)
         def projectFeatureDefinition = new ProjectFeatureDefinitionThatUsesClassInjectedMethods()
         def projectFeature = new ProjectFeatureThatBindsWithClassBuilder(projectFeatureDefinition)
+        def settingsBuilder = new SettingsPluginClassBuilder()
+            .registersProjectType(projectType.projectTypePluginClassName)
+            .registersProjectFeature(projectFeature.projectFeaturePluginClassName)
+        return withProjectFeature(projectTypeDefinition, projectType, projectFeatureDefinition, projectFeature, settingsBuilder)
+    }
+
+    PluginBuilder withProjectFeaturePluginThatBindsToMultipleTargets() {
+        def projectTypeDefinition = new ProjectTypeDefinitionWithMultipleNestedBindingLocations()
+        def projectType = new ProjectTypePluginClassBuilder(projectTypeDefinition)
+        def projectFeatureDefinition = new ProjectFeatureDefinitionClassBuilder()
+        def projectFeature = new ProjectFeaturePluginThatBindsMultipleFeaturesToTheSameName(projectFeatureDefinition, "${projectTypeDefinition.publicTypeClassName}.Bar")
+            .bindingTypeClassName("${projectTypeDefinition.fullyQualifiedPublicTypeClassName}.Foo")
         def settingsBuilder = new SettingsPluginClassBuilder()
             .registersProjectType(projectType.projectTypePluginClassName)
             .registersProjectFeature(projectFeature.projectFeaturePluginClassName)

--- a/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/features/internal/builders/definitions/ProjectTypeDefinitionWithMultipleNestedBindingLocations.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/features/internal/builders/definitions/ProjectTypeDefinitionWithMultipleNestedBindingLocations.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features.internal.builders.definitions
+
+import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition
+import org.gradle.features.binding.BuildModel
+import org.gradle.features.binding.Definition
+
+class ProjectTypeDefinitionWithMultipleNestedBindingLocations extends ProjectTypeDefinitionClassBuilder {
+    @Override
+    String getPublicTypeClassContent() {
+        return """
+            package org.gradle.test;
+
+            import ${HiddenInDefinition.class.name};
+
+            import org.gradle.api.Action;
+            import org.gradle.api.model.ObjectFactory;
+            import org.gradle.api.provider.ListProperty;
+            import org.gradle.api.provider.Property;
+            import org.gradle.api.tasks.Nested;
+            import ${Definition.class.name};
+            import ${BuildModel.class.name};
+
+            import javax.inject.Inject;
+
+            public interface ${publicTypeClassName} extends ${Definition.class.simpleName}<${publicTypeClassName}.${buildModelTypeClassName}> {
+                Property<String> getId();
+
+                @Nested
+                Foo getFoo();
+
+                @Nested
+                Bar getBar();
+
+                @${HiddenInDefinition.class.simpleName}
+                default void foo(Action<? super Foo> action) {
+                    action.execute(getFoo());
+                }
+
+                @${HiddenInDefinition.class.simpleName}
+                default void bar(Action<? super Bar> action) {
+                    action.execute(getBar());
+                }
+
+                ${maybeInjectedServiceDeclaration}
+
+                interface Foo extends ${Definition.class.simpleName}<BuildModel.None> {
+                    public abstract Property<String> getBar();
+
+                    ${maybeNestedInjectedServiceDeclaration}
+                }
+
+                interface Bar extends ${Definition.class.simpleName}<BuildModel.None> {
+                    public abstract Property<String> getBaz();
+
+                    ${maybeNestedInjectedServiceDeclaration}
+                }
+
+                interface ${buildModelTypeClassName} extends BuildModel {
+                    Property<String> getId();
+                }
+            }
+        """
+    }
+
+    @Override
+    String getBuildModelMapping() {
+        return """
+                context.registerBuildModel(definition.getFoo());
+                context.registerBuildModel(definition.getBar());
+            """
+    }
+}

--- a/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/features/internal/builders/features/ProjectFeaturePluginThatBindsMultipleFeaturesToTheSameName.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/testFixtures/groovy/org/gradle/features/internal/builders/features/ProjectFeaturePluginThatBindsMultipleFeaturesToTheSameName.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.features.internal.builders.features
+
+import org.gradle.features.annotations.BindsProjectFeature
+import org.gradle.features.binding.ProjectFeatureBinding
+import org.gradle.features.binding.ProjectFeatureBindingBuilder
+import org.gradle.features.internal.builders.definitions.ProjectFeatureDefinitionClassBuilder
+
+class ProjectFeaturePluginThatBindsMultipleFeaturesToTheSameName extends ProjectFeaturePluginClassBuilder {
+    private final String anotherBindingTypeClassName
+
+    ProjectFeaturePluginThatBindsMultipleFeaturesToTheSameName(ProjectFeatureDefinitionClassBuilder definition, String anotherBindingTypeClassName) {
+        super(definition)
+        this.anotherBindingTypeClassName = anotherBindingTypeClassName
+    }
+
+    @Override
+    protected String getClassContent() {
+        return """
+            package org.gradle.test;
+
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import ${BindsProjectFeature.class.name};
+            import ${ProjectFeatureBindingBuilder.class.name};
+            import static ${ProjectFeatureBindingBuilder.class.name}.bindingToTargetDefinition;
+            import ${ProjectFeatureBinding.class.name};
+
+            @${BindsProjectFeature.class.simpleName}(${projectFeaturePluginClassName}.Binding.class)
+            public class ${projectFeaturePluginClassName} implements Plugin<Project> {
+
+                static class Binding implements ${ProjectFeatureBinding.class.simpleName} {
+                    @Override public void bind(${ProjectFeatureBindingBuilder.class.simpleName} builder) {
+                        builder.${bindingMethodName}(
+                            "${name}",
+                            ${definition.publicTypeClassName}.class,
+                            ${bindingTypeClassName}.class,
+                            (context, definition, model, parent) -> {
+                                Services services = context.getObjectFactory().newInstance(Services.class);
+                                System.out.println("Binding ${definition.publicTypeClassName}");
+                                System.out.println("${name} model class: " + model.getClass().getSimpleName());
+                                System.out.println("${name} parent model class: " + context.getBuildModel(parent).getClass().getSimpleName());
+
+                                ${definition.buildModelMapping}
+
+                                services.getTaskRegistrar().register("print${definition.publicTypeClassName}1Configuration", task -> {
+                                    task.doLast(t -> {
+                                        ${definition.displayDefinitionPropertyValues()}
+                                        ${definition.displayModelPropertyValues()}
+                                    });
+                                });
+                            }
+                        )
+                        ${maybeDeclareDefinitionImplementationType()}
+                        ${maybeDeclareBuildModelImplementationType()}
+                        ${maybeDeclareBindingModifiers()};
+
+                        builder.${bindingMethodName}(
+                            "${name}",
+                            ${definition.publicTypeClassName}.class,
+                            ${anotherBindingTypeClassName}.class,
+                            (context, definition, model, parent) -> {
+                                Services services = context.getObjectFactory().newInstance(Services.class);
+                                System.out.println("Binding ${definition.publicTypeClassName}");
+                                System.out.println("${name} model class: " + model.getClass().getSimpleName());
+                                System.out.println("${name} parent model class: " + context.getBuildModel(parent).getClass().getSimpleName());
+
+                                ${definition.buildModelMapping}
+
+                                services.getTaskRegistrar().register("print${definition.publicTypeClassName}2Configuration", task -> {
+                                    task.doLast(t -> {
+                                        ${definition.displayDefinitionPropertyValues()}
+                                        ${definition.displayModelPropertyValues()}
+                                    });
+                                });
+                            }
+                        );
+                    }
+
+                    ${servicesInterface}
+                }
+
+                @Override
+                public void apply(Project project) {
+
+                }
+            }
+        """
+    }
+}

--- a/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/ProjectFeatureDeclarationIntegrationTest.groovy
+++ b/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/ProjectFeatureDeclarationIntegrationTest.groovy
@@ -558,6 +558,58 @@ class ProjectFeatureDeclarationIntegrationTest extends AbstractIntegrationSpec i
         outputContains("Binding FeatureDefinition")
     }
 
+    def 'can declare and configure a project feature that binds to multiple types with the same name'() {
+        given:
+        PluginBuilder pluginBuilder = withProjectFeaturePluginThatBindsToMultipleTargets()
+        pluginBuilder.addBuildScriptContent pluginBuildScriptForJava
+        pluginBuilder.prepareToExecute()
+
+        settingsFile() << pluginsFromIncludedBuild
+
+        buildFile() << """
+            testProjectType {
+                id = "test"
+                foo {
+                    bar = "foo"
+                    feature {
+                        text = "foo"
+                        fizz {
+                            buzz = "foo-baz"
+                        }
+                    }
+                }
+                bar {
+                    baz = "bar"
+                    feature {
+                        text = "bar"
+                        fizz {
+                            buzz = "bar-baz"
+                        }
+                    }
+                }
+            }
+        """ << DeclarativeTestUtils.nonDeclarativeSuffixForKotlinDsl
+
+        when:
+        run(":printFeatureDefinition1Configuration")
+
+        then:
+        outputContains("definition text = foo")
+        outputContains("definition fizz.buzz = foo-baz")
+
+        when:
+        run(":printFeatureDefinition2Configuration")
+
+        then:
+        outputContains("definition text = bar")
+        outputContains("definition fizz.buzz = bar-baz")
+
+        and:
+        outputContains("Applying ProjectTypeImplPlugin")
+        outputContains("Binding TestProjectTypeDefinition")
+        outputContains("Binding FeatureDefinition")
+    }
+
     static String getDeclarativeScriptThatConfiguresOnlyTestProjectFeature() {
         return """
             testProjectType {

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureImplementation.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureImplementation.java
@@ -152,18 +152,41 @@ public class DefaultProjectFeatureImplementation<OwnDefinition extends Definitio
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
         DefaultProjectFeatureImplementation<?, ?> that = (DefaultProjectFeatureImplementation<?, ?>) o;
-        return Objects.equals(featureName, that.featureName) && Objects.equals(definitionPublicType, that.definitionPublicType) && Objects.equals(pluginClass, that.pluginClass);
+        return Objects.equals(featureName, that.featureName)
+            && Objects.equals(definitionPublicType, that.definitionPublicType)
+            && Objects.equals(definitionImplementationType, that.definitionImplementationType)
+            && definitionSafety == that.definitionSafety
+            && applyActionSafety == that.applyActionSafety
+            && Objects.equals(targetDefinitionType, that.targetDefinitionType)
+            && Objects.equals(buildModelType, that.buildModelType)
+            && Objects.equals(buildModelImplementationType, that.buildModelImplementationType)
+            && Objects.equals(pluginClass, that.pluginClass)
+            && Objects.equals(registeringPluginClass, that.registeringPluginClass)
+            && Objects.equals(defaults, that.defaults)
+            && Objects.equals(registeringPluginId, that.registeringPluginId)
+            && Objects.equals(applyActionFactory, that.applyActionFactory);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(featureName, definitionPublicType, pluginClass);
+        return Objects.hash(
+            featureName,
+            definitionPublicType,
+            definitionImplementationType,
+            definitionSafety,
+            applyActionSafety,
+            targetDefinitionType,
+            buildModelType,
+            buildModelImplementationType,
+            pluginClass,
+            registeringPluginClass,
+            defaults,
+            registeringPluginId,
+            applyActionFactory
+        );
     }
 }

--- a/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/features/internal/binding/DefaultProjectFeatureDeclarationsTest.groovy
+++ b/platforms/extensibility/plugin-use/src/test/groovy/org/gradle/features/internal/binding/DefaultProjectFeatureDeclarationsTest.groovy
@@ -246,6 +246,7 @@ class DefaultProjectFeatureDeclarationsTest extends Specification {
         SubClassOfParentDefinition           | ParentBuildModel           | "build model is same as registered definition's inherited build model"
         ParentDefinition                     | SubClassOfParentBuildModel | "build model is sub class of registered definition's build model"
         SubClassOfParentBuildModelDefinition | ParentBuildModel           | "build model is super class of registered definition's build model"
+        DefinitionWithNoBuildModel           | DefinitionWithNoBuildModel | "definition is the same with no build model"
     }
 
     def "can declare two plugins with the same feature name if they bind to different targets (#description)"() {
@@ -305,10 +306,11 @@ class DefaultProjectFeatureDeclarationsTest extends Specification {
         implementations.get("test").size() == 2
 
         where:
-        targetType       | anotherTargetType       | description
-        ParentDefinition | AnotherParentDefinition | "different definitions"
-        ParentBuildModel | AnotherParentBuildModel | "different build models"
-        ParentDefinition | AnotherParentBuildModel | "different definition and build model"
+        targetType                 | anotherTargetType                 | description
+        ParentDefinition           | AnotherParentDefinition           | "different definitions"
+        ParentBuildModel           | AnotherParentBuildModel           | "different build models"
+        ParentDefinition           | AnotherParentBuildModel           | "different definition and build model"
+        DefinitionWithNoBuildModel | AnotherDefinitionWithNoBuildModel | "different definitions with no build model"
     }
 
     private interface ParentDefinition extends Definition<ParentBuildModel> { }
@@ -324,6 +326,10 @@ class DefaultProjectFeatureDeclarationsTest extends Specification {
     private interface AnotherParentDefinition extends Definition<AnotherParentBuildModel> { }
 
     private interface AnotherParentBuildModel extends BuildModel { }
+
+    private interface DefinitionWithNoBuildModel extends Definition<BuildModel.None> { }
+
+    private interface AnotherDefinitionWithNoBuildModel extends Definition<BuildModel.None> { }
 
     private interface TestDefinition extends Definition<TestModel> { }
 


### PR DESCRIPTION
Previously, we had an insufficient hashCode for `ProjectFeatureImplementation` so that when we had multiple instances being put into a set at some point, we were failing to add a feature with the same name in the same plugin.

Fixes #36812 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
