### PR TITLE
Make ant-impl an api-java project

### DIFF
--- a/platforms/software/ant-impl/build.gradle.kts
+++ b/platforms/software/ant-impl/build.gradle.kts
@@ -1,5 +1,8 @@
 plugins {
-    id("gradlebuild.distribution.implementation-java")
+    // We need to use api-java here because we have public api classes (specifically AntTarget) in this project
+    // That class is here because it depends on core for ConventionTask.  If ConventionTask is pulled up out of core,
+    // presumably AntTarget could then move up to ant-api and this project could apply implementation-java instead.
+    id("gradlebuild.distribution.api-java")
 }
 
 description = "Implementation of Gradle's Ant integration"


### PR DESCRIPTION
This project was busted out of `core` in #36907.
 
For now, ant-impl needs to be an api-java project because it contains `AntTarget`, which is a public api class with a dependency on core (for `ConventionTask`).  Once `ConventionTask` is pulled out of core, presumably we could pull `AntTarget` higher up, potentially to the ant-api project and make ant-impl an implementation-java project.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
