### PR TITLE
Hash segments of HTML test report

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestTaskIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestTaskIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.testing
 
 import com.google.common.base.Utf8
 import org.gradle.api.JavaVersion
+import org.gradle.api.internal.tasks.testing.report.generic.GenericHtmlTestReportGenerator
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.jvm.SupportedJavaVersions
 import org.gradle.test.fixtures.file.TestFile
@@ -74,8 +75,8 @@ abstract class AbstractTestTaskIntegrationTest extends AbstractTestingMultiVersi
         noExceptionThrown()
 
         and:
+        def htmlReportName = GenericHtmlTestReportGenerator.hashSegment(name) + "/index.html"
         // 255 is the filesystem limit on many systems, so we limit to that.
-        def htmlReportName = buildSafeFileName("", "-39OAC63KMJT6O") + "/index.html"
         def xmlReportName = buildSafeFileName("TEST-", "-5KFS1VR5035J6.xml")
         // These do an `any` check to give a better error message on failure
         file("build/reports/tests/test/").assertContainsDescendants(htmlReportName)

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterTestTaskIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterTestTaskIntegrationTest.groovy
@@ -19,8 +19,7 @@ package org.gradle.testing.junit.jupiter
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.AbstractTestTaskIntegrationTest
 import org.gradle.testing.fixture.JUnitCoverage
-
-import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_JUPITER
+import spock.lang.Issue
 
 @TargetCoverage({ JUnitCoverage.JUNIT_JUPITER })
 class JUnitJupiterTestTaskIntegrationTest extends AbstractTestTaskIntegrationTest implements JUnitJupiterMultiVersionTest {
@@ -50,5 +49,70 @@ class JUnitJupiterTestTaskIntegrationTest extends AbstractTestTaskIntegrationTes
                }
             }
         """.stripIndent()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/36996")
+    def "test task can write report for deeply nested test classes"() {
+        given:
+        def packageName = "org.gradle.testing.junit.jupiter.deeply.nested"
+        def className = packageName + ".FooBarQuxAndMoreWithExceedinglyLongPhrasesTest"
+        file("src/test/java/${className.replace('.', '/')}.java") << """
+            package ${packageName};
+
+            import org.junit.jupiter.api.Nested;
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+
+            public class FooBarQuxAndMoreWithExceedinglyLongPhrasesTest {
+                @Nested
+                public class ThisIsAVeryLongClassName {
+                    @Nested
+                    public class ThisIsAVeryLongClassName1 {
+                        @Nested
+                        public class ThisIsAVeryLongClassName2 {
+                            @Nested
+                            public class ThisIsAVeryLongClassName3 {
+                                @Nested
+                                public class ThisIsAVeryLongClassName4 {
+                                    @Nested
+                                    public class ThisIsAVeryLongClassName5 {
+                                        @Nested
+                                        public class ThisIsAVeryLongClassName6 {
+                                            @Test
+                                            public void thisIsAlsoARatherLongMethodName() {
+                                                assertEquals(1, 1);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'test'
+
+        then:
+        def results = resultsFor()
+        def classes = [
+            className,
+            "ThisIsAVeryLongClassName",
+            "ThisIsAVeryLongClassName1",
+            "ThisIsAVeryLongClassName2",
+            "ThisIsAVeryLongClassName3",
+            "ThisIsAVeryLongClassName4",
+            "ThisIsAVeryLongClassName5",
+            "ThisIsAVeryLongClassName6"
+        ]
+        List<String> segments = new ArrayList<>()
+        for (int i = 0; i < classes.size(); i++) {
+            segments.add(classes.subList(0, i + 1).join('$'))
+        }
+        results.assertTestPathsExecuted(
+            ':' + segments.join(':') + ":thisIsAlsoARatherLongMethodName"
+        )
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericHtmlTestReportGenerator.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/GenericHtmlTestReportGenerator.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.report.generic;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -34,7 +35,8 @@ import org.gradle.api.internal.tasks.testing.worker.TestEventSerializer;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.testing.TestOutputEvent;
-import org.gradle.internal.SafeFileLocationUtils;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.file.Deleter;
@@ -59,7 +61,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+import java.util.Base64;
 import java.util.stream.Collectors;
 
 /**
@@ -71,26 +73,31 @@ import java.util.stream.Collectors;
 public abstract class GenericHtmlTestReportGenerator implements TestReportGenerator {
 
     private static final Logger LOG = Logging.getLogger(GenericHtmlTestReportGenerator.class);
+    private static final HashFunction HASHER = Hashing.farmHashFingerprint64();
+
+    @VisibleForTesting
+    public static String hashSegment(String name) {
+        byte[] hashBytes = HASHER.hashUnencodedChars(name).asBytes();
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hashBytes);
+    }
 
     public static String getFilePath(org.gradle.util.Path path, boolean isLeaf) {
-        String filePath;
         if (path.segmentCount() == 0) {
-            filePath = "index.html";
-        } else if (isLeaf && !Objects.equals(path.getName(), "index")) {
-            // Avoid using a directory for each leaf node unless its name clashes (i.e. "index")
+            return "index.html";
+        } else if (isLeaf) {
+            // Avoid using a directory for each leaf node
             // This reduces VFS overhead from many directories for large test suites
             String prefix = String.join("/", Iterables.transform(
                 path.getParent().segments(),
-                name -> SafeFileLocationUtils.toSafeFileName(name, true)
+                GenericHtmlTestReportGenerator::hashSegment
             ));
-            filePath = prefix + (prefix.isEmpty() ? "" : "/") + SafeFileLocationUtils.toSafeFileName(path.getName() + ".html", false);
+            return prefix + (prefix.isEmpty() ? "" : "/") + hashSegment(path.getName()) + ".html";
         } else {
-            filePath = String.join("/", Iterables.transform(
+            return String.join("/", Iterables.transform(
                 path.segments(),
-                name -> SafeFileLocationUtils.toSafeFileName(name, true)
+                GenericHtmlTestReportGenerator::hashSegment
             )) + "/index.html";
         }
-        return filePath;
     }
 
     private static String getFilePath(TestTreeModel tree) {


### PR DESCRIPTION
This prevents easily going over the max file path length due to whatever name is generated for nodes by the test engine. Fixes #36996

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
