### PR TITLE
Speed up FileBackedBlockStore

### DIFF
--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/btree/FileBackedBlockStore.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/btree/FileBackedBlockStore.java
@@ -27,6 +27,7 @@ import java.io.RandomAccessFile;
 public class FileBackedBlockStore implements BlockStore {
     private final File cacheFile;
     private RandomAccessFile file;
+    private boolean writable;
     private ByteOutput output;
     private ByteInput input;
     private long nextBlock;
@@ -47,7 +48,13 @@ public class FileBackedBlockStore implements BlockStore {
         this.factory = factory;
         try {
             cacheFile.getParentFile().mkdirs();
-            file = openRandomAccessFile();
+            try {
+                file = randomAccessFile("rw");
+                writable = true;
+            } catch (FileNotFoundException e) {
+                file = randomAccessFile("r");
+                writable = false;
+            }
             output = new ByteOutput(file);
             input = new ByteInput(file);
             currentFileSize = file.length();
@@ -60,14 +67,6 @@ public class FileBackedBlockStore implements BlockStore {
         }
     }
 
-    private RandomAccessFile openRandomAccessFile() throws FileNotFoundException {
-        try {
-            return randomAccessFile("rw");
-        } catch (FileNotFoundException e) {
-            return randomAccessFile("r");
-        }
-    }
-
     private RandomAccessFile randomAccessFile(String mode) throws FileNotFoundException {
         return new RandomAccessFile(cacheFile, mode);
     }
@@ -75,6 +74,9 @@ public class FileBackedBlockStore implements BlockStore {
     @Override
     public void close() {
         try {
+            if (writable) {
+                file.setLength(currentFileSize);
+            }
             file.close();
         } catch (IOException e) {
             throw UncheckedException.throwAsUncheckedException(e);
@@ -83,12 +85,7 @@ public class FileBackedBlockStore implements BlockStore {
 
     @Override
     public void clear() {
-        try {
-            file.setLength(0);
-            currentFileSize = 0;
-        } catch (IOException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        }
+        currentFileSize = 0;
         nextBlock = 0;
     }
 
@@ -220,11 +217,11 @@ public class FileBackedBlockStore implements BlockStore {
                 throw new IllegalArgumentException("Block payload exceeds maximum size");
             }
             outputStream.writeInt((int) bytesWritten);
+
             output.done();
 
             // Pad
             if (currentFileSize < finalSize) {
-                file.setLength(finalSize);
                 currentFileSize = finalSize;
             }
         }

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/btree/FileBackedBlockStore.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/btree/FileBackedBlockStore.java
@@ -74,10 +74,13 @@ public class FileBackedBlockStore implements BlockStore {
     @Override
     public void close() {
         try {
-            if (writable) {
-                file.setLength(currentFileSize);
+            try {
+                if (writable) {
+                    file.setLength(currentFileSize);
+                }
+            } finally {
+                file.close();
             }
-            file.close();
         } catch (IOException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/BTreeIndexedCacheTest.java
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/BTreeIndexedCacheTest.java
@@ -388,6 +388,17 @@ public class BTreeIndexedCacheTest {
         cache.close();
     }
 
+    @Test
+    public void canReadFromReadOnlyFile() {
+        createCache();
+        cache.put("1", 1);
+        verifyAndCloseCache();
+        cacheFile.setReadOnly();
+        createCache();
+        assertThat(cache.get("1"), equalTo(1));
+        verifyAndCloseCache();
+    }
+
     private void checkAdds(Integer... values) {
         checkAdds(Arrays.asList(values));
     }


### PR DESCRIPTION
Resurrection of https://github.com/gradle/gradle/pull/28344.

We only need to flush padding information to disk when we release the file to another process. This drastically reduces ftruncate system calls, which may be slow in some environments like EBS volumes on AWS.

Fixes #28236
