### PR TITLE
Increate test worker memory, so it can process larger stacks

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -469,7 +469,7 @@ class PerformanceTestExtension(
             useJUnitPlatform()
             // We need 5G of heap to parse large JFR recordings when generating flamegraphs.
             // If we drop JFR as profiler and switch to something else, we can reduce the memory.
-            jvmArgs("-Xmx5g", "-XX:+HeapDumpOnOutOfMemoryError")
+            jvmArgs("-Xmx8g", "-XX:+HeapDumpOnOutOfMemoryError")
             if (project.performanceTestVerbose.isPresent) {
                 testLogging.showStandardStreams = true
             }


### PR DESCRIPTION
Ran into some problems when trying to run AdHoc performance scenarios on slow performance tests.
Even with reduced `runs` amount (~10), the stacks are simply too large.

This PR bumps up the worker memory to 8GB (completely arbitrary incrase), with the hopes of it making these OOM problems go away.