### PR TITLE
Enable zip64 for performance test results zip

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -514,6 +514,7 @@ class PerformanceTestExtension(
             }
             destinationDirectory = project.layout.buildDirectory
             archiveFileName = "test-results-${junitXmlDir.name}.zip"
+            isZip64 = true
         }
 }
 


### PR DESCRIPTION
We have large enough performance measurement scenarios where the resulting ZIP can be more than 4GB large, requiring ZIP64.