### PR TITLE
Use Expect/Continue to avoid broken pipe errors on PUT through authenticated proxies (#fixes 35389)

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractProxyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractProxyResolveIntegrationTest.groovy
@@ -207,6 +207,51 @@ repositories {
         proxyServer.requestCount == 0
     }
 
+    def "can publish artifact through authenticated proxy"() {
+        given:
+        def (proxyUserName, proxyPassword) = ['proxyUser', 'proxyPassword']
+        proxyServer.start(proxyUserName, proxyPassword)
+        setupServer()
+
+        and:
+        settingsFile << """
+rootProject.name = 'publish-test'
+"""
+        buildFile.text = """
+plugins {
+    id 'java'
+    id 'maven-publish'
+}
+
+group = 'org.gradle.test'
+version = '1.0'
+
+publishing {
+    repositories {
+        maven { url = "${repoServerUrl}" }
+    }
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
+"""
+
+        def publishModule = repo.module("org.gradle.test", "publish-test", "1.0")
+
+        when:
+        proxyServer.configureProxy(executer, proxyScheme, proxyUserName, proxyPassword)
+        publishModule.artifact.expectPublish()
+        publishModule.pom.expectPublish()
+        publishModule.rootMetaData.expectGetMissing()
+        publishModule.rootMetaData.expectPublish()
+        publishModule.moduleMetadata.expectPublish()
+
+        then:
+        succeeds('publish')
+    }
+
     def "passes target credentials to #authScheme authenticated server via proxy"() {
         given:
         def (proxyUserName, proxyPassword) = ['proxyUser', 'proxyPassword']

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
@@ -188,6 +188,13 @@ public class HttpClientConfigurer {
         builder.setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
     }
 
+    private static boolean hasProxyCredentials(HttpSettings httpSettings) {
+        HttpProxySettings.HttpProxy httpProxy = httpSettings.getProxySettings().getProxy();
+        HttpProxySettings.HttpProxy httpsProxy = httpSettings.getSecureProxySettings().getProxy();
+        return (httpProxy != null && httpProxy.credentials != null)
+            || (httpsProxy != null && httpsProxy.credentials != null);
+    }
+
     private void useCredentialsForProxy(CredentialsProvider credentialsProvider, HttpProxySettings.HttpProxy httpsProxy) {
         if (httpsProxy != null && httpsProxy.credentials != null) {
             AllSchemesAuthentication authentication1 = new AllSchemesAuthentication(httpsProxy.credentials);
@@ -289,6 +296,7 @@ public class HttpClientConfigurer {
             .setConnectTimeout(timeoutSettings.getConnectionTimeoutMs())
             .setSocketTimeout(timeoutSettings.getSocketTimeoutMs())
             .setMaxRedirects(httpSettings.getMaxRedirects())
+            .setExpectContinueEnabled(hasProxyCredentials(httpSettings))
             .build();
         builder.setDefaultRequestConfig(config);
     }

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerTest.groovy
@@ -149,12 +149,37 @@ class HttpClientConfigurerTest extends Specification {
 
         then:
         1 * httpSettings.authenticationSettings >> []
-        1 * httpSettings.proxySettings >> proxySettings
+        2 * httpSettings.proxySettings >> proxySettings
+        2 * httpSettings.secureProxySettings >> secureProxySettings
         1 * httpSettings.sslContextFactory >> sslContextFactory
         1 * timeoutSettings.connectionTimeoutMs >> 10000
         2 * timeoutSettings.socketTimeoutMs >> 30000
         httpClientBuilder.defaultRequestConfig.connectTimeout == 10000
         httpClientBuilder.defaultRequestConfig.socketTimeout == 30000
         httpClientBuilder.defaultSocketConfig.soKeepAlive
+    }
+
+    def "enables expect-continue when proxy credentials are configured"() {
+        httpSettings.authenticationSettings >> []
+        httpSettings.sslContextFactory >> sslContextFactory
+        proxySettings.proxy >> new HttpProxySettings.HttpProxy(PROXY_HOST, SOME_PORT, "proxyUser", "proxyPass")
+
+        when:
+        configurer.configure(httpClientBuilder)
+
+        then:
+        httpClientBuilder.defaultRequestConfig.expectContinueEnabled
+    }
+
+    def "does not enable expect-continue when proxy has no credentials"() {
+        httpSettings.authenticationSettings >> []
+        httpSettings.sslContextFactory >> sslContextFactory
+        proxySettings.proxy >> new HttpProxySettings.HttpProxy(PROXY_HOST, SOME_PORT, "", "")
+
+        when:
+        configurer.configure(httpClientBuilder)
+
+        then:
+        !httpClientBuilder.defaultRequestConfig.expectContinueEnabled
     }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/TestProxyServer.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/TestProxyServer.groovy
@@ -55,6 +55,14 @@ class TestProxyServer extends ExternalResource {
                 requestCountInternal.incrementAndGet()
                 return super.filterRequest(originalRequest, ctx)
             }
+
+            @Override
+            int getMaximumRequestBufferSizeInBytes() {
+                // Enable request buffering via HttpObjectAggregator so the proxy can handle
+                // HTTP/1.1 Expect: 100-Continue requests (used for PUT/POST through authenticated proxies).
+                // Without this, the proxy cannot relay the 100 Continue interim response properly.
+                return 10 * 1024 * 1024
+            }
         }
 
         def proxyAuthenticator = null


### PR DESCRIPTION
Fixes #35389 

### Context

Publishing artifacts (PUT) through authenticated HTTP proxies can fail with "Broken pipe" errors, especially for large uploads. This happens because the  proxy challenges with 407 (Proxy Authentication Required) while the client is already streaming the request body — the proxy closes the connection mid-upload.

This PR enables HTTP/1.1 `Expect: 100-Continue` when proxy credentials are configured. With this header, the client sends only the request headers first and waits for the proxy to respond. If the proxy needs authentication, it replies with 407 *before* the body is sent, avoiding the broken pipe. Once authenticated, the client receives `100 Continue` and streams the body safely.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
