### PR TITLE
Include filename in ZipException from ClassBytesRepository

### DIFF
--- a/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/support/ClassBytesRepository.kt
+++ b/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/support/ClassBytesRepository.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.internal.sharedruntime.support
 import java.io.Closeable
 import java.io.File
 import java.util.jar.JarFile
+import java.util.zip.ZipException
 
 
 private
@@ -137,7 +138,13 @@ class ClassBytesRepository(
 
     private
     fun openJarFile(file: File) =
-        openJars.computeIfAbsent(file, ::JarFile)
+        openJars.computeIfAbsent(file) {
+            try {
+                JarFile(it)
+            } catch (e: ZipException) {
+                throw ZipException("${e.message} (file: $it)").apply { initCause(e) }
+            }
+        }
 
     override fun close() {
         openJars.values.forEach(JarFile::close)

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
@@ -29,13 +29,17 @@ import org.gradle.kotlin.dsl.internal.sharedruntime.support.ClassBytesRepository
 import org.gradle.kotlin.dsl.internal.sharedruntime.support.classFilePathCandidatesFor
 import org.gradle.kotlin.dsl.internal.sharedruntime.support.kotlinSourceNameOf
 
+import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.CoreMatchers.notNullValue
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
+
+import java.util.zip.ZipException
 
 
 class ClassBytesRepositoryTest : AbstractKotlinIntegrationTest() {
@@ -180,6 +184,22 @@ class ClassBytesRepositoryTest : AbstractKotlinIntegrationTest() {
                 repository.allSourceNames,
                 equalTo(listOf(canonicalNameOf<DeepThought>(), canonicalNameOf<LightThought>()))
             )
+        }
+    }
+
+    @Test
+    fun `reports filename when jar is corrupt`() {
+        val corruptJar = withFile("corrupt.jar", "this is not a valid zip file")
+        try {
+            ClassBytesRepository(
+                platformClassLoader = ClassLoaderUtils.getPlatformClassLoader(),
+                classPathFiles = listOf(corruptJar)
+            ).use { repository ->
+                repository.allClassesBytesBySourceName().toList()
+            }
+            fail("Expected ZipException")
+        } catch (e: ZipException) {
+            assertThat(e.message, containsString(corruptJar.absolutePath))
         }
     }
 


### PR DESCRIPTION
When a corrupt JAR is encountered during Kotlin DSL class resolution, the resulting ZipException now includes the file path, making it possible to identify and remove the offending file without manually scanning the entire Gradle cache.

* Fixes https://github.com/gradle/gradle/issues/33628

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
