### PR TITLE
Fix wrong location of JavaProcessStackTracesMonitor

### DIFF
--- a/build-logic/lifecycle/src/main/kotlin/PrintStackTracesOnTimeoutBuildService.kt
+++ b/build-logic/lifecycle/src/main/kotlin/PrintStackTracesOnTimeoutBuildService.kt
@@ -37,7 +37,7 @@ abstract class PrintStackTracesOnTimeoutBuildService @Inject constructor(private
                 execOperations.exec {
                     commandLine(
                         "${System.getProperty("java.home")}/bin/java",
-                        parameters.projectDirectory.file("testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java").get().asFile.absolutePath,
+                        parameters.projectDirectory.file("testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java").get().asFile.absolutePath,
                         parameters.projectDirectory.asFile.get().absolutePath
                     )
                 }


### PR DESCRIPTION
It was moved with the reference not updated.