### PR TITLE
Align ProjectIdentity and Project display names

### DIFF
--- a/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/incompatible-variants/tests/runtimeClasspath.out
+++ b/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/incompatible-variants/tests/runtimeClasspath.out
@@ -1,6 +1,6 @@
 
 > Task :consumer:dependencyInsight
-project :producer
+project ':producer'
   Variant runtimeElements:
     | Attribute Name                 | Provided     | Requested    |
     |--------------------------------|--------------|--------------|
@@ -29,20 +29,20 @@ project :producer
     | org.gradle.usage               | java-runtime | java-runtime |
     | org.gradle.jvm.environment     |              | standard-jvm |
    Failures:
-      - Could not resolve project :producer.
+      - Could not resolve project ':producer'.
           - Module 'org.gradle.demo:producer' has been rejected:
-               Cannot select module with conflict on capability 'org.gradle.demo:producer-db-support:1.0' also provided by ['project :producer' (postgresSupportRuntimeElements)]
-      - Could not resolve project :producer.
+               Cannot select module with conflict on capability 'org.gradle.demo:producer-db-support:1.0' also provided by ['project ':producer'' (postgresSupportRuntimeElements)]
+      - Could not resolve project ':producer'.
           - Module 'org.gradle.demo:producer' has been rejected:
-               Cannot select module with conflict on capability 'org.gradle.demo:producer-db-support:1.0' also provided by ['project :producer' (mysqlSupportRuntimeElements)]
+               Cannot select module with conflict on capability 'org.gradle.demo:producer-db-support:1.0' also provided by ['project ':producer'' (mysqlSupportRuntimeElements)]
 
-project :producer
+project ':producer'
 \--- runtimeClasspath
 
-project :producer FAILED
+project ':producer' FAILED
 \--- runtimeClasspath
 
-project :producer FAILED
+project ':producer' FAILED
 \--- runtimeClasspath
 
 A web-based, searchable dependency report is available by adding the --scan option.

--- a/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/requiring-features/tests/runtimeClasspath.out
+++ b/platforms/documentation/docs/src/snippets/how-to/dependency-management/dependency-management/requiring-features/tests/runtimeClasspath.out
@@ -13,7 +13,7 @@ mysql:mysql-connector-java:8.0.14
     | org.gradle.jvm.version         |              | 11           |
 
 mysql:mysql-connector-java:8.0.14
-\--- project :producer
+\--- project ':producer'
      \--- runtimeClasspath
 
 A web-based, searchable dependency report is available by adding the --scan option.

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/advanced/performingResolution-resolutionResult/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/advanced/performingResolution-resolutionResult/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "example"

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/advanced/performingResolution-resolutionResult/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/advanced/performingResolution-resolutionResult/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "example"

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/advanced/performingResolution-resolutionResult/tests/dot.out
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/advanced/performingResolution-resolutionResult/tests/dot.out
@@ -1,7 +1,7 @@
 digraph {
-    "root project ::runtimeClasspath" [shape=box]
+    "root project 'example':runtimeClasspath" [shape=box]
     "com.google.guava:guava:33.2.1-jre:jreRuntimeElements" [shape=box]
-    "root project ::runtimeClasspath" -> "com.google.guava:guava:33.2.1-jre:jreRuntimeElements"
+    "root project 'example':runtimeClasspath" -> "com.google.guava:guava:33.2.1-jre:jreRuntimeElements"
     "com.google.guava:failureaccess:1.0.2:runtime" [shape=box]
     "com.google.guava:guava:33.2.1-jre:jreRuntimeElements" -> "com.google.guava:failureaccess:1.0.2:runtime"
     "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava:runtime" [shape=box]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/artifactTransforms-minify/tests/artifactTransformMinify.out
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/artifactTransforms-minify/tests/artifactTransformMinify.out
@@ -3,7 +3,7 @@
 > Task :producer:classes
 > Task :producer:jar
 
-> Transform producer.jar (project :producer) with Minify
+> Transform producer.jar (project ':producer') with Minify
 Nothing to minify - using producer.jar unchanged
 
 > Task :resolveRuntimeClasspath

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/performingResolution-resolutionResult/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/performingResolution-resolutionResult/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "example"

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/performingResolution-resolutionResult/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/performingResolution-resolutionResult/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "example"

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/performingResolution-resolutionResult/tests/dot.out
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-dependencies/performingResolution-resolutionResult/tests/dot.out
@@ -1,7 +1,7 @@
 digraph {
-    "root project ::runtimeClasspath" [shape=box]
+    "root project 'example':runtimeClasspath" [shape=box]
     "com.google.guava:guava:33.2.1-jre:jreRuntimeElements" [shape=box]
-    "root project ::runtimeClasspath" -> "com.google.guava:guava:33.2.1-jre:jreRuntimeElements"
+    "root project 'example':runtimeClasspath" -> "com.google.guava:guava:33.2.1-jre:jreRuntimeElements"
     "com.google.guava:failureaccess:1.0.2:runtime" [shape=box]
     "com.google.guava:guava:33.2.1-jre:jreRuntimeElements" -> "com.google.guava:failureaccess:1.0.2:runtime"
     "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava:runtime" [shape=box]

--- a/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioMultiProjectIntegrationTest.groovy
+++ b/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioMultiProjectIntegrationTest.groovy
@@ -436,7 +436,7 @@ class VisualStudioMultiProjectIntegrationTest extends AbstractVisualStudioIntegr
         then:
         resultDebug.assertNoTasksScheduled()
         resultDebug.assertHasCause("Could not resolve all dependencies for configuration ':exe:nativeRuntimeDebug'.")
-        resultDebug.assertHasCause("Could not resolve project :lib.")
+        resultDebug.assertHasCause("Could not resolve project ':lib'.")
         installation('exe/build/install/main/debug').assertNotInstalled()
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TransformProgressEventCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TransformProgressEventCrossVersionSpec.groovy
@@ -248,7 +248,7 @@ class TransformProgressEventCrossVersionSpec extends ToolingApiSpecification {
 
     String applyTransform(String transformName, String project = ":lib") {
         if (targetVersion.baseVersion >= GradleVersion.version("6.6")) {
-            return "Transform lib.jar (project $project) with $transformName"
+            return "Transform lib.jar (project ${projectDisplayName(project)}) with $transformName"
         } else {
             return "Transform artifact lib.jar (project $project) with $transformName"
         }
@@ -256,9 +256,17 @@ class TransformProgressEventCrossVersionSpec extends ToolingApiSpecification {
 
     String transformTarget(String project = ":lib") {
         if (targetVersion.baseVersion >= GradleVersion.version("6.6")) {
-            return "lib.jar (project $project)"
+            return "lib.jar (project ${projectDisplayName(project)})"
         } else {
             return "artifact lib.jar (project $project)"
+        }
+    }
+
+    String projectDisplayName(String project) {
+        if (targetVersion.baseVersion >= GradleVersion.version("9.6")) {
+            return "'$project'"
+        } else {
+            return project
         }
     }
 

--- a/platforms/jvm/java-platform/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/platforms/jvm/java-platform/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -159,7 +159,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         fails ":checkDeps"
 
         then:
-        failure.assertThatCause(Matchers.startsWith("No matching variant of project :platform was found."))
+        failure.assertThatCause(Matchers.startsWith("No matching variant of project ':platform' was found."))
     }
 
     def "can enforce a local platform dependency"() {

--- a/platforms/jvm/plugins-application/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/platforms/jvm/plugins-application/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -81,9 +81,9 @@ class JavaApplicationOutgoingVariantsIntegrationTest extends AbstractIntegration
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.status=release}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.status=release}
         """)
@@ -101,9 +101,9 @@ class JavaApplicationOutgoingVariantsIntegrationTest extends AbstractIntegration
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -123,7 +123,7 @@ class JavaApplicationOutgoingVariantsIntegrationTest extends AbstractIntegration
         result.assertTasksScheduled(":other-java:compileJava", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
         """)
     }
 
@@ -143,9 +143,9 @@ class JavaApplicationOutgoingVariantsIntegrationTest extends AbstractIntegration
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -169,9 +169,9 @@ class JavaApplicationOutgoingVariantsIntegrationTest extends AbstractIntegration
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -191,9 +191,9 @@ class JavaApplicationOutgoingVariantsIntegrationTest extends AbstractIntegration
         result.assertTasksScheduled(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         assertResolveOutput("""
             files: [main, file-dep.jar, main, implementation-1.0.jar, runtime-only-1.0.jar]
-            main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
+            main (project ':java') {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
+            main (project ':other-java') {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -213,9 +213,9 @@ class JavaApplicationOutgoingVariantsIntegrationTest extends AbstractIntegration
         result.assertTasksScheduled(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         assertResolveOutput("""
             files: [main, file-dep.jar, main, implementation-1.0.jar, runtime-only-1.0.jar]
-            main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
+            main (project ':java') {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
+            main (project ':other-java') {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)

--- a/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -58,11 +58,11 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
 
         then:
         failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':compileClasspath'.
-   > Could not resolve project :producer.
+   > Could not resolve project ':producer'.
      Required by:
          root project 'test'
-      > Dependency resolution is looking for a library compatible with JVM runtime version 6, but 'project :producer' is only compatible with JVM runtime version 7 or newer.""")
-        failure.assertHasResolution("Change the dependency on 'project :producer' to an earlier version that supports JVM runtime version 6.")
+      > Dependency resolution is looking for a library compatible with JVM runtime version 6, but 'project ':producer'' is only compatible with JVM runtime version 7 or newer.""")
+        failure.assertHasResolution("Change the dependency on 'project ':producer'' to an earlier version that supports JVM runtime version 6.")
     }
 
     def "can select the most appropriate producer variant (#expected) based on target compatibility (#requested)"() {
@@ -140,11 +140,11 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
         then:
         failure.assertHasErrorOutput("""
 > Could not resolve all dependencies for configuration ':compileClasspath'.
-   > Could not resolve project :producer.
+   > Could not resolve project ':producer'.
      Required by:
          root project 'test'
-      > Dependency resolution is looking for a library compatible with JVM runtime version 6, but 'project :producer' is only compatible with JVM runtime version 7 or newer.""")
-        failure.assertHasResolution("Change the dependency on 'project :producer' to an earlier version that supports JVM runtime version 6.")
+      > Dependency resolution is looking for a library compatible with JVM runtime version 6, but 'project ':producer'' is only compatible with JVM runtime version 7 or newer.""")
+        failure.assertHasResolution("Change the dependency on 'project ':producer'' to an earlier version that supports JVM runtime version 6.")
 
         when:
         buildFile << """

--- a/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryFeatureCompilationIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryFeatureCompilationIntegrationTest.groovy
@@ -147,8 +147,8 @@ class JavaLibraryFeatureCompilationIntegrationTest extends AbstractIntegrationSp
                     } as Set
                 }
                 doLast {
-                    assert incomingCompileClasspath.get() == ['project :b', 'project :c', 'project :e'] as Set // only API dependencies
-                    assert incomingRuntimeClasspath.get() == ['project :b', 'project :c', 'project :d', 'project :g'] as Set // all dependencies (except compile only)
+                    assert incomingCompileClasspath.get() == ['project \\':b\\'', 'project \\':c\\'', 'project \\':e\\''] as Set // only API dependencies
+                    assert incomingRuntimeClasspath.get() == ['project \\':b\\'', 'project \\':c\\'', 'project \\':d\\'', 'project \\':g\\''] as Set // all dependencies (except compile only)
                 }
             }
         """
@@ -415,8 +415,8 @@ class JavaLibraryFeatureCompilationIntegrationTest extends AbstractIntegrationSp
                     } as Set
                 }
                 doLast {
-                    assert incomingCompileClasspath.get() == ['project :b', 'project :c'] as Set // only API dependencies
-                    assert incomingRuntimeClasspath.get() == ['project :b', 'project :c', 'project :d'] as Set // all dependencies
+                    assert incomingCompileClasspath.get() == ['project \\':b\\'', 'project \\':c\\''] as Set // only API dependencies
+                    assert incomingRuntimeClasspath.get() == ['project \\':b\\'', 'project \\':c\\'', 'project \\':d\\''] as Set // all dependencies
                     assert runtimeClasspath.files.name as Set == ['b-my-feature.jar', 'c.jar', 'd.jar'] as Set
                 }
             }

--- a/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java-library/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -92,10 +92,10 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, api-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar}
             api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.status=release}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.status=release}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.status=release}
         """)
@@ -115,10 +115,10 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, api-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -140,7 +140,7 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         assertResolveOutput("""
             files: [main, api-1.0.jar, compile-only-api-1.0.jar]
-            main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-api}
+            main (project ':java') {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-api}
             api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
             compile-only-api-1.0.jar (test:compile-only-api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
         """)
@@ -164,10 +164,10 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, api-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
        """)
@@ -192,10 +192,10 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, api-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -217,10 +217,10 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         assertResolveOutput("""
             files: [main, file-dep.jar, api-1.0.jar, main, implementation-1.0.jar, runtime-only-1.0.jar]
-            main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
+            main (project ':java') {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
-            main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
+            main (project ':other-java') {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -242,10 +242,10 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         assertResolveOutput("""
             files: [main, file-dep.jar, api-1.0.jar, main, implementation-1.0.jar, runtime-only-1.0.jar]
-            main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
+            main (project ':java') {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
-            main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
+            main (project ':other-java') {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -109,9 +109,9 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) ${expectedAttributes}
             runtime-only-1.0.jar (test:runtime-only:1.0) ${expectedAttributes}
         """)
@@ -131,9 +131,9 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -155,7 +155,7 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
         """)
     }
 
@@ -177,9 +177,9 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -204,9 +204,9 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java.jar, file-dep.jar, other-java.jar, implementation-1.0.jar, runtime-only-1.0.jar]
-            java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java.jar (project ':java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            other-java.jar (project ':other-java') {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -228,9 +228,9 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":consumer:resolve")
         assertResolveOutput("""
             files: [main, file-dep.jar, main, implementation-1.0.jar, runtime-only-1.0.jar]
-            main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
+            main (project ':java') {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
+            main (project ':other-java') {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -252,9 +252,9 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         assertResolveOutput("""
             files: [main, file-dep.jar, main, implementation-1.0.jar, runtime-only-1.0.jar]
-            main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
+            main (project ':java') {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
+            main (project ':other-java') {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}
             implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
             runtime-only-1.0.jar (test:runtime-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}
         """)
@@ -277,7 +277,7 @@ project(':consumer') {
         result.assertTasksScheduled(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:javadoc", ":java:javadocJar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java-javadoc.jar]
-            java-javadoc.jar (project :java) {artifactType=jar, org.gradle.category=documentation, org.gradle.dependency.bundling=external, org.gradle.docstype=javadoc, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java-javadoc.jar (project ':java') {artifactType=jar, org.gradle.category=documentation, org.gradle.dependency.bundling=external, org.gradle.docstype=javadoc, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
         """)
     }
 
@@ -298,7 +298,7 @@ project(':consumer') {
         result.assertTasksScheduled(":java:sourcesJar", ":consumer:resolve")
         assertResolveOutput("""
             files: [java-sources.jar]
-            java-sources.jar (project :java) {artifactType=jar, org.gradle.category=documentation, org.gradle.dependency.bundling=external, org.gradle.docstype=sources, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
+            java-sources.jar (project ':java') {artifactType=jar, org.gradle.category=documentation, org.gradle.dependency.bundling=external, org.gradle.docstype=sources, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
         """)
     }
 

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
@@ -117,7 +117,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         then:
         !deprecated(alternatives)
         !valid(alternatives)        || output.contains("> Task :resolve\n\n")
-        !doesNotExist(alternatives) || errorOutput.contains("A dependency was declared on configuration '$configuration' of 'project :sub' but no variant with that configuration name exists.")
+        !doesNotExist(alternatives) || errorOutput.contains("A dependency was declared on configuration '$configuration' of 'project ':sub'' but no variant with that configuration name exists.")
 
         where:
         plugin         | configuration                  | alternatives

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -465,8 +465,8 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         fails ":app:assemble"
 
         and:
-        failure.assertHasCause("Could not resolve project :greeter")
-        failure.assertHasCause("No matching variant of project :greeter was found. The consumer was configured to find attribute 'org.gradle.native.architecture' with value '${currentArchitecture}', attribute 'org.gradle.native.debuggable' with value 'true', attribute 'org.gradle.native.operatingSystem' with value '${currentOsFamilyName.toLowerCase()}', attribute 'org.gradle.native.optimized' with value 'false', attribute 'org.gradle.usage' with value 'native-runtime' but:")
+        failure.assertHasCause("Could not resolve project ':greeter'")
+        failure.assertHasCause("No matching variant of project ':greeter' was found. The consumer was configured to find attribute 'org.gradle.native.architecture' with value '${currentArchitecture}', attribute 'org.gradle.native.debuggable' with value 'true', attribute 'org.gradle.native.operatingSystem' with value '${currentOsFamilyName.toLowerCase()}', attribute 'org.gradle.native.optimized' with value 'false', attribute 'org.gradle.usage' with value 'native-runtime' but:")
     }
 
     def "fails when dependency library does not specify the same target architecture"() {
@@ -500,7 +500,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         fails ":app:assemble"
 
         and:
-        failure.assertHasCause("Could not resolve project :greeter")
+        failure.assertHasCause("Could not resolve project ':greeter'")
         failure.assertHasErrorOutput("Incompatible because this component declares attribute 'org.gradle.native.architecture' with value 'foo', attribute 'org.gradle.usage' with value 'native-link' and the consumer needed attribute 'org.gradle.native.architecture' with value '${currentArchitecture}', attribute 'org.gradle.usage' with value 'native-runtime'")
     }
 
@@ -613,7 +613,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         expect:
         fails ":app:assemble"
 
-        failure.assertHasCause """No matching variant of project :hello was found. The consumer was configured to find attribute 'org.gradle.native.architecture' with value '${currentArchitecture}', attribute 'org.gradle.native.debuggable' with value 'true', attribute 'org.gradle.native.operatingSystem' with value '${currentOsFamilyName}', attribute 'org.gradle.native.optimized' with value 'false', attribute 'org.gradle.usage' with value 'native-runtime' but:
+        failure.assertHasCause """No matching variant of project ':hello' was found. The consumer was configured to find attribute 'org.gradle.native.architecture' with value '${currentArchitecture}', attribute 'org.gradle.native.debuggable' with value 'true', attribute 'org.gradle.native.operatingSystem' with value '${currentOsFamilyName}', attribute 'org.gradle.native.optimized' with value 'false', attribute 'org.gradle.usage' with value 'native-runtime' but:
   - Variant 'cppApiElements':
       - Incompatible because this component declares attribute 'org.gradle.usage' with value 'cplusplus-api' and the consumer needed attribute 'org.gradle.usage' with value 'native-runtime'
       - Other compatible attributes:

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
@@ -488,8 +488,8 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         fails ":app:assemble"
 
         and:
-        failure.assertHasCause("Could not resolve project :greeter.")
-        failure.assertHasCause("No matching variant of project :greeter was found. The consumer was configured to find attribute 'org.gradle.native.architecture' with value '${currentHostArchName}', attribute 'org.gradle.native.debuggable' with value 'true', attribute 'org.gradle.native.operatingSystem' with value '${currentHostOperatingSystemName}', attribute 'org.gradle.native.optimized' with value 'false', attribute 'org.gradle.usage' with value 'native-runtime' but:\n" +
+        failure.assertHasCause("Could not resolve project ':greeter'.")
+        failure.assertHasCause("No matching variant of project ':greeter' was found. The consumer was configured to find attribute 'org.gradle.native.architecture' with value '${currentHostArchName}', attribute 'org.gradle.native.debuggable' with value 'true', attribute 'org.gradle.native.operatingSystem' with value '${currentHostOperatingSystemName}', attribute 'org.gradle.native.optimized' with value 'false', attribute 'org.gradle.usage' with value 'native-runtime' but:\n" +
                                "  - No variants exist.")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest.groovy
@@ -77,8 +77,8 @@ class ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest exten
         failure.assertHasCause("Could not resolve all files for configuration ':compileClasspath'.")
         failure.assertHasCause("Could not resolve org.apache.httpcomponents:httpclient.")
         failure.assertHasCause("""Component is the target of multiple version constraints with conflicting requirements:
-4.1.0 - directly in 'project :a' (apiElements)
-4.2.0 - directly in 'project :b' (apiElements) (1 other path to this version)""")
+4.1.0 - directly in 'project ':a'' (apiElements)
+4.2.0 - directly in 'project ':b'' (apiElements) (1 other path to this version)""")
 
         and: "Helpful resolutions are provided"
         failure.assertHasResolution("Run with :dependencyInsight --configuration compileClasspath --dependency org.apache.httpcomponents:httpclient to get more insight on how to solve the conflict.")
@@ -148,8 +148,8 @@ class ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest exten
         failure.assertHasCause("Could not resolve all files for configuration ':compileClasspath'.")
         failure.assertHasCause("Could not resolve org.apache.httpcomponents:httpclient.")
         failure.assertHasCause("""Component is the target of multiple version constraints with conflicting requirements:
-4.1.0 - directly in 'project :a' (apiElements)
-4.2.0 - transitively via 'project :b' (apiElements) (1 other path to this version)""")
+4.1.0 - directly in 'project ':a'' (apiElements)
+4.2.0 - transitively via 'project ':b'' (apiElements) (1 other path to this version)""")
 
         and: "Helpful resolutions are provided"
         failure.assertHasResolution("Run with :dependencyInsight --configuration compileClasspath --dependency org.apache.httpcomponents:httpclient to get more insight on how to solve the conflict.")
@@ -219,10 +219,10 @@ class ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest exten
         failure.assertHasCause("Could not resolve all files for configuration ':compileClasspath'.")
         failure.assertHasCause("Could not resolve org.apache.httpcomponents:httpclient.")
         failure.assertHasCause("""Component is the target of multiple version constraints with conflicting requirements:
-4.5 - directly in 'project :c' (apiElements)
-4.5.8 - transitively via 'project :b' (apiElements)
-4.5.10 - transitively via 'project :b' (apiElements)
-4.5.11 - directly in 'project :a' (apiElements)""")
+4.5 - directly in 'project ':c'' (apiElements)
+4.5.8 - transitively via 'project ':b'' (apiElements)
+4.5.10 - transitively via 'project ':b'' (apiElements)
+4.5.11 - directly in 'project ':a'' (apiElements)""")
 
         and: "Helpful resolutions are provided"
         failure.assertHasResolution("Run with :dependencyInsight --configuration compileClasspath --dependency org.apache.httpcomponents:httpclient to get more insight on how to solve the conflict.")
@@ -280,8 +280,8 @@ class ModuleRejectedIncompatibleConstraintsFailureDescriberIntegrationTest exten
         failure.assertHasCause("Could not resolve all files for configuration ':compileClasspath'.")
         failure.assertHasCause("Could not resolve org.apache.httpcomponents:httpclient.")
         failure.assertHasCause("""Component is the target of multiple version constraints with conflicting requirements:
-4.5.1 - directly in 'project :a' (apiElements) (1 other path to this version)
-4.5.2 - directly in 'project :c' (apiElements)""")
+4.5.1 - directly in 'project ':a'' (apiElements) (1 other path to this version)
+4.5.2 - directly in 'project ':c'' (apiElements)""")
 
         and: "Helpful resolutions are provided"
         failure.assertHasResolution("Run with :dependencyInsight --configuration compileClasspath --dependency org.apache.httpcomponents:httpclient to get more insight on how to solve the conflict.")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/internal/component/resolution/failure/ResolutionFailureHandlerIntegrationTest.groovy
@@ -96,8 +96,8 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         assertFailureDescriptionCorrect()
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve root project :.")
-        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. There are several available matching variants of root project :
+        failure.assertHasCause("Could not resolve root project 'example'.")
+        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. There are several available matching variants of root project 'example'
         The only attribute distinguishing these variants is 'shape'. Add this attribute to the consumer's configuration to resolve the ambiguity:
           - Value: 'round' selects variant: 'blueRoundElements'
           - Value: 'square' selects variant: 'blueSquareElements'
@@ -111,7 +111,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Problems are reported"
         verifyAll(receivedProblem(0)) {
             fqid == 'dependency-variant-resolution:ambiguous-variants'
-            additionalData.asMap['requestTarget'] == "root project :"
+            additionalData.asMap['requestTarget'] == "root project 'example'"
             additionalData.asMap['problemId'] == ResolutionFailureProblemId.AMBIGUOUS_VARIANTS.name()
             additionalData.asMap['problemDisplayName'] == "Multiple variants exist that would match the request"
         }
@@ -126,8 +126,8 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         assertFailureDescriptionCorrect()
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve root project :.")
-        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. However we cannot choose between the following variants of root project ::
+        failure.assertHasCause("Could not resolve root project 'example'.")
+        assertFullMessageCorrect("""      > The consumer was configured to find attribute 'color' with value 'blue'. However we cannot choose between the following variants of root project 'example':
           - blueRoundTransparentElements
           - blueSquareOpaqueElements
           - blueSquareTransparentElements
@@ -152,7 +152,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Problems are reported"
         verifyAll(receivedProblem(0)) {
             fqid == 'dependency-variant-resolution:ambiguous-variants'
-            additionalData.asMap['requestTarget'] == "root project :"
+            additionalData.asMap['requestTarget'] == "root project 'example'"
             additionalData.asMap['problemId'] == ResolutionFailureProblemId.AMBIGUOUS_VARIANTS.name()
             additionalData.asMap['problemDisplayName'] == "Multiple variants exist that would match the request"
         }
@@ -204,11 +204,11 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         assertFailureDescriptionCorrect()
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve root project :.")
-        assertFullMessageCorrect("""   > Could not resolve root project :.
+        failure.assertHasCause("Could not resolve root project 'example'.")
+        assertFullMessageCorrect("""   > Could not resolve root project 'example'.
      Required by:
          root project 'example'
-      > No matching variant of root project : was found. The consumer was configured to find attribute 'color' with value 'green' but:
+      > No matching variant of root project 'example' was found. The consumer was configured to find attribute 'color' with value 'green' but:
           - Variant 'default':
               - Incompatible because this component declares attribute 'color' with value 'blue' and the consumer needed attribute 'color' with value 'green'""")
 
@@ -219,7 +219,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Problems are reported"
         verifyAll(receivedProblem(0)) {
             fqid == 'dependency-variant-resolution:no-compatible-variants'
-            additionalData.asMap['requestTarget'] == "root project :"
+            additionalData.asMap['requestTarget'] == "root project 'example'"
             additionalData.asMap['problemId'] == ResolutionFailureProblemId.NO_COMPATIBLE_VARIANTS.name()
             additionalData.asMap['problemDisplayName'] == "No variants exist that would match the request"
         }
@@ -273,10 +273,10 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         assertFailureDescriptionCorrect()
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve root project :.")
+        failure.assertHasCause("Could not resolve root project 'example'.")
         assertFullMessageCorrect("""     Required by:
          root project 'example'
-      > Configuration 'mismatch' in root project : does not match the consumer attributes
+      > Configuration 'mismatch' in root project 'example' does not match the consumer attributes
         Configuration 'mismatch':
           - Incompatible because this component declares attribute 'color' with value 'blue' and the consumer needed attribute 'color' with value 'green'
 """)
@@ -303,10 +303,10 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         assertFailureDescriptionCorrect()
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve project :producer.")
+        failure.assertHasCause("Could not resolve project ':producer'.")
         assertFullMessageCorrect("""     Required by:
          root project 'example'
-      > No matching variant of project :producer was found. The consumer was configured to find attribute 'color' with value 'green' but:
+      > No matching variant of project ':producer' was found. The consumer was configured to find attribute 'color' with value 'green' but:
           - No variants exist.""")
 
         and: "Helpful resolutions are provided"
@@ -316,7 +316,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Problems are reported"
         verifyAll(receivedProblem(0)) {
             fqid == 'dependency-variant-resolution:no-compatible-variants'
-            additionalData.asMap['requestTarget'] == "project :producer"
+            additionalData.asMap['requestTarget'] == "project ':producer'"
             additionalData.asMap['problemId'] == ResolutionFailureProblemId.NO_COMPATIBLE_VARIANTS.name()
             additionalData.asMap['problemDisplayName'] == "No variants exist that would match the request"
         }
@@ -331,13 +331,13 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         assertFailureDescriptionCorrect()
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve root project :.")
+        failure.assertHasCause("Could not resolve root project 'example'.")
         assertFullMessageCorrect("""Required by:
          root project 'example'
-      > A dependency was declared on configuration 'absent' of 'root project :' but no variant with that configuration name exists.""")
+      > A dependency was declared on configuration 'absent' of 'root project 'example'' but no variant with that configuration name exists.""")
 
         and: "Helpful resolutions are provided"
-        failure.assertHasResolution("To determine which configurations are available in the target root project :, run :outgoingVariants.")
+        failure.assertHasResolution("To determine which configurations are available in the target root project 'example', run :outgoingVariants.")
         assertSuggestsReviewingAlgorithm()
 
         and: "Problems are reported"
@@ -363,7 +363,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         assertFailureDescriptionCorrect()
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasCause("Could not resolve root project :.")
+        failure.assertHasCause("Could not resolve root project 'example'.")
         assertFullMessageCorrect("""     Required by:
          root project 'example'
       > Multiple incompatible variants of org.example:example:1.0 were selected:
@@ -392,7 +392,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         assertFailureDescriptionCorrect()
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        assertFullMessageCorrect("""   > No variants of root project : match the consumer attributes:
+        assertFullMessageCorrect("""   > No variants of root project 'example' match the consumer attributes:
        - Configuration ':myElements' declares attribute 'color' with value 'blue':
            - Incompatible because this component declares attribute 'artifactType' with value 'jar' and the consumer needed attribute 'artifactType' with value 'dll'
        - Configuration ':myElements' variant secondary declares attribute 'color' with value 'blue':
@@ -405,7 +405,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Problems are reported"
         verifyAll(receivedProblem(0)) {
             fqid == 'dependency-variant-resolution:no-compatible-artifact'
-            additionalData.asMap['requestTarget'] == "root project :"
+            additionalData.asMap['requestTarget'] == "root project 'example'"
             additionalData.asMap['problemId'] == ResolutionFailureProblemId.NO_COMPATIBLE_ARTIFACT.name()
             additionalData.asMap['problemDisplayName'] == "No artifacts exist that would match the request"
         }
@@ -419,7 +419,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
 
         and: "Has error output"
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        assertFullMessageCorrect("""   > Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
+        assertFullMessageCorrect("""   > Found multiple transformation chains that produce a variant of 'root project 'example'' with requested attributes:
        - color 'red'
        - shape 'round'
      Found the following transformation chains:
@@ -454,7 +454,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Problems are reported"
         verifyAll(receivedProblem(0)) {
             fqid == 'dependency-variant-resolution:ambiguous-artifact-transform'
-            additionalData.asMap['requestTarget'] == "root project :"
+            additionalData.asMap['requestTarget'] == "root project 'example'"
             additionalData.asMap['problemId'] == ResolutionFailureProblemId.AMBIGUOUS_ARTIFACT_TRANSFORM.name()
             additionalData.asMap['problemDisplayName'] == "Multiple artifacts transforms exist that would satisfy the request"
         }
@@ -469,7 +469,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Has error output"
         assertFailureDescriptionCorrect()
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        assertFullMessageCorrect("""   > More than one variant of root project : matches the consumer attributes:
+        assertFullMessageCorrect("""   > More than one variant of root project 'example' matches the consumer attributes:
        - Configuration ':default' variant v1
        - Configuration ':default' variant v2""")
 
@@ -480,7 +480,7 @@ class ResolutionFailureHandlerIntegrationTest extends AbstractIntegrationSpec {
         and: "Problems are reported"
         verifyAll(receivedProblem(0)) {
             fqid == 'dependency-variant-resolution:ambiguous-artifacts'
-            additionalData.asMap['requestTarget'] == "root project :"
+            additionalData.asMap['requestTarget'] == "root project 'example'"
             additionalData.asMap['problemId'] == ResolutionFailureProblemId.AMBIGUOUS_ARTIFACTS.name()
             additionalData.asMap['problemDisplayName'] == "Multiple artifacts exist that would match the request"
         }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -163,10 +163,10 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
                 inputs.files defaultFiles
                 doLast {
                     assert defaultFiles.collect { it.name } == ['lib.jar', 'lib-util.jar', 'ui.jar', 'some-jar-1.0.jar']
-                    assert defaultArtifacts.collect { it.id.displayName }  == ['lib.jar (project :lib)', 'lib-util.jar', 'ui.jar (project :ui)', 'some-jar-1.0.jar (org:test:1.0)']
+                    assert defaultArtifacts.collect { it.id.displayName }  == ["lib.jar (project ':lib')", 'lib-util.jar', "ui.jar (project ':ui')", 'some-jar-1.0.jar (org:test:1.0)']
 
                     assert optionalFiles.collect { it.name } == ['lib.jar', 'lib-util.jar', 'ui.jar', 'some-jar-1.0.jar']
-                    assert optionalArtifacts.collect { it.id.displayName }  == ['lib.jar (project :lib)', 'lib-util.jar', 'ui.jar (project :ui)', 'some-jar-1.0.jar (org:test:1.0)']
+                    assert optionalArtifacts.collect { it.id.displayName }  == ["lib.jar (project ':lib')", 'lib-util.jar', "ui.jar (project ':ui')", 'some-jar-1.0.jar (org:test:1.0)']
                 }
             }
         """
@@ -273,7 +273,7 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
                 inputs.files viewFiles
                 doLast {
                     assert viewFiles.collect { it.name } == ['lib.classes', 'lib-util.classes', 'ui.classes', 'some-classes-1.0.classes']
-                    assert viewArtifacts.collect { it.id.displayName } == ['lib.classes (project :lib)', 'lib-util.classes', 'ui.classes (project :ui)', 'some-classes-1.0.classes (org:test2:1.0)']
+                    assert viewArtifacts.collect { it.id.displayName } == ["lib.classes (project ':lib')", 'lib-util.classes', "ui.classes (project ':ui')", 'some-classes-1.0.classes (org:test2:1.0)']
                 }
             }
         """
@@ -745,7 +745,7 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
 
         then:
         outputContains("files: [test-lib.jar, transformed-a1.jar, transformed-b2.jar, test-1.0.jar]")
-        outputContains("components: [test-lib.jar, project :lib, project :ui, org:test:1.0]")
+        outputContains("components: [test-lib.jar, project ':lib', project ':ui', org:test:1.0]")
         outputContains("variants: [{artifactType=jar}, {artifactType=jar, buildType=debug, flavor=one, usage=transformed}, {artifactType=jar, usage=transformed}, {artifactType=jar, org.gradle.status=integration}]")
     }
 
@@ -975,7 +975,7 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
         fails "resolveView"
         failure.assertHasDescription("Could not determine the dependencies of task ':app:resolveView'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':app:compile'.")
-        failure.assertHasCause("""The consumer was configured to find attribute 'artifactType' with value 'jar', attribute 'usage' with value 'api'. However we cannot choose between the following variants of project :lib:
+        failure.assertHasCause("""The consumer was configured to find attribute 'artifactType' with value 'jar', attribute 'usage' with value 'api'. However we cannot choose between the following variants of project ':lib':
   - Configuration ':lib:compile' declares attribute 'artifactType' with value 'jar', attribute 'usage' with value 'api':
       - Unmatched attribute:
           - Provides buildType 'n/a' but the consumer didn't ask for it
@@ -1113,7 +1113,7 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
         }
         failure.assertHasCause("Could not resolve all files for configuration ':app:compile'.")
 
-        failure.assertHasCause("""No variants of project :lib match the consumer attributes:
+        failure.assertHasCause("""No variants of project ':lib' match the consumer attributes:
   - Configuration ':lib:compile' declares attribute 'usage' with value 'api':
       - Incompatible because this component declares attribute 'artifactType' with value 'jar' and the consumer needed attribute 'artifactType' with value 'dll'
   - Configuration ':lib:compile' variant debug declares attribute 'usage' with value 'api':
@@ -1231,9 +1231,9 @@ class ArtifactSelectionIntegrationTest extends AbstractHttpDependencyResolutionT
         fails(":app:resolve")
         resolve.assertFailurePresent(failure)
         failure.assertHasCause("Could not resolve all files for configuration ':app:compile'.")
-        failure.assertHasCause("Could not select a variant of project :lib that matches the consumer attributes.")
+        failure.assertHasCause("Could not select a variant of project ':lib' that matches the consumer attributes.")
         failure.assertHasCause("Unexpected type for attribute 'attr' provided. Expected a value of type java.lang.String but found a value of type java.lang.Boolean.")
-        failure.assertHasCause("Could not select a variant of project :ui that matches the consumer attributes.")
+        failure.assertHasCause("Could not select a variant of project ':ui' that matches the consumer attributes.")
         failure.assertHasCause("Unexpected type for attribute 'attr' provided. Expected a value of type java.lang.String but found a value of type java.lang.Integer.")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
@@ -266,13 +266,13 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
         fails("useCompileConfiguration")
         failure.assertHasDescription("Could not determine the dependencies of task ':useCompileConfiguration'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
-        failure.assertHasCause("""Unable to find a matching variant of project :child:
+        failure.assertHasCause("""Unable to find a matching variant of project ':child':
   - No variants exist.""")
 
         fails("useCompileConfiguration")
         failure.assertHasDescription("Could not determine the dependencies of task ':useCompileConfiguration'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
-        failure.assertHasCause("""Unable to find a matching variant of project :child:
+        failure.assertHasCause("""Unable to find a matching variant of project ':child':
   - No variants exist.""")
 
         where:
@@ -303,12 +303,12 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
         fails("useCompileConfiguration")
         failure.assertHasDescription("Could not determine the dependencies of task ':useCompileConfiguration'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
-        failure.assertHasCause("More than one variant of project :child matches the consumer attributes:")
+        failure.assertHasCause("More than one variant of project ':child' matches the consumer attributes:")
 
         fails("useCompileConfiguration")
         failure.assertHasDescription("Could not determine the dependencies of task ':useCompileConfiguration'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
-        failure.assertHasCause("More than one variant of project :child matches the consumer attributes:")
+        failure.assertHasCause("More than one variant of project ':child' matches the consumer attributes:")
 
         where:
         fluid << [true, false]

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
@@ -145,7 +145,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         result.assertTaskSkipped(":a:producer")
         result.assertTaskSkipped(":b:producer")
         outputContains("files = [a.thing, b.thing, a.out, b.out, lib1-6500.jar]")
-        outputContains("artifacts = [a.thing (a.thing), b.thing (b.thing), a.out (project :a), b.out (project :b), lib1-6500.jar (group:lib1:6500)]")
+        outputContains("artifacts = [a.thing (a.thing), b.thing (b.thing), a.out (project ':a'), b.out (project ':b'), lib1-6500.jar (group:lib1:6500)]")
         outputContains("variants = [{artifactType=thing}, {artifactType=thing}, {artifactType=out}, {artifactType=out}, {artifactType=jar, org.gradle.status=release}]")
         outputContains("variant capabilities = [[], [], [capability group='test', name='a', version='unspecified'], [capability group='test', name='b', version='unspecified'], [capability group='group', name='lib1', version='6500']]")
 
@@ -161,7 +161,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         result.assertTaskExecuted(":a:producer")
         result.assertTaskSkipped(":b:producer")
         outputContains("files = [a.thing, b.thing, a.out, b.out, lib1-6500.jar]")
-        outputContains("artifacts = [a.thing (a.thing), b.thing (b.thing), a.out (project :a), b.out (project :b), lib1-6500.jar (group:lib1:6500)]")
+        outputContains("artifacts = [a.thing (a.thing), b.thing (b.thing), a.out (project ':a'), b.out (project ':b'), lib1-6500.jar (group:lib1:6500)]")
         outputContains("variants = [{artifactType=thing}, {artifactType=thing}, {artifactType=out}, {artifactType=out}, {artifactType=jar, org.gradle.status=release}]")
         outputContains("variant capabilities = [[], [], [capability group='test', name='a', version='unspecified'], [capability group='test', name='b', version='unspecified'], [capability group='group', name='lib1', version='6500']]")
     }
@@ -284,7 +284,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         then:
         assertTransformed("a.jar", "b.jar")
         outputContains("files = [a.jar.green, b.jar.green]")
-        outputContains("artifacts = [a.jar.green (project :a), b.jar.green (project :b)]")
+        outputContains("artifacts = [a.jar.green (project ':a'), b.jar.green (project ':b')]")
         outputContains("variants = [{artifactType=jar, color=green}, {artifactType=jar, color=green}]")
 
         when:
@@ -298,7 +298,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         result.assertTaskSkipped(":b:producer")
         assertTransformed()
         outputContains("files = [a.jar.green, b.jar.green]")
-        outputContains("artifacts = [a.jar.green (project :a), b.jar.green (project :b)]")
+        outputContains("artifacts = [a.jar.green (project ':a'), b.jar.green (project ':b')]")
         outputContains("variants = [{artifactType=jar, color=green}, {artifactType=jar, color=green}]")
 
         when:
@@ -312,7 +312,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         result.assertTaskSkipped(":b:producer")
         assertTransformed("a.jar")
         outputContains("files = [a.jar.green, b.jar.green]")
-        outputContains("artifacts = [a.jar.green (project :a), b.jar.green (project :b)]")
+        outputContains("artifacts = [a.jar.green (project ':a'), b.jar.green (project ':b')]")
         outputContains("variants = [{artifactType=jar, color=green}, {artifactType=jar, color=green}]")
     }
 
@@ -537,7 +537,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         then:
         assertTransformed("root.blue", "root.additional.blue", "a.additional.blue", "a.jar")
         outputContains("files = [root.additional.blue.green, root.blue.green, a.jar.green, a.additional.blue.green]")
-        outputContains("artifacts = [root.additional.blue.green (root.additional.blue), root.blue.green (root.blue), a.jar.green (project :a), a.additional.blue.green (a.additional.blue)]")
+        outputContains("artifacts = [root.additional.blue.green (root.additional.blue), root.blue.green (root.blue), a.jar.green (project ':a'), a.additional.blue.green (a.additional.blue)]")
         outputContains("variants = [{artifactType=blue, color=green}, {artifactType=blue, color=green}, {artifactType=jar, color=green}, {artifactType=blue, color=green}]")
 
         when:
@@ -550,7 +550,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         result.assertTaskOrder(":additionalFile", ":resolveArtifacts")
         assertTransformed()
         outputContains("files = [root.additional.blue.green, root.blue.green, a.jar.green, a.additional.blue.green]")
-        outputContains("artifacts = [root.additional.blue.green (root.additional.blue), root.blue.green (root.blue), a.jar.green (project :a), a.additional.blue.green (a.additional.blue)]")
+        outputContains("artifacts = [root.additional.blue.green (root.additional.blue), root.blue.green (root.blue), a.jar.green (project ':a'), a.additional.blue.green (a.additional.blue)]")
         outputContains("variants = [{artifactType=blue, color=green}, {artifactType=blue, color=green}, {artifactType=jar, color=green}, {artifactType=blue, color=green}]")
     }
 
@@ -1111,7 +1111,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         outputContains("processing a.blue")
         failure.assertHasFailure("Execution failed for task ':resolve' (registered in build file 'build.gradle').") {
             it.assertHasCause("Failed to transform root.blue to match attributes {artifactType=blue, color=green}.")
-            it.assertHasCause("Failed to transform a.jar (project :a) to match attributes {artifactType=jar, color=green}.")
+            it.assertHasCause("Failed to transform a.jar (project ':a') to match attributes {artifactType=jar, color=green}.")
             it.assertHasCause("Failed to transform a.blue to match attributes {artifactType=blue, color=green}.")
         }
         failure.assertHasFailures(1)
@@ -1127,7 +1127,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         outputContains("processing a.blue")
         failure.assertHasFailure("Execution failed for task ':resolve' (registered in build file 'build.gradle').") {
             it.assertHasCause("Failed to transform root.blue to match attributes {artifactType=blue, color=green}.")
-            it.assertHasCause("Failed to transform a.jar (project :a) to match attributes {artifactType=jar, color=green}.")
+            it.assertHasCause("Failed to transform a.jar (project ':a') to match attributes {artifactType=jar, color=green}.")
             it.assertHasCause("Failed to transform a.blue to match attributes {artifactType=blue, color=green}.")
         }
         failure.assertHasFailures(1)
@@ -1166,7 +1166,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         outputContains("processing a.jar")
         outputContains("processing b.jar")
         failure.assertHasFailure("Execution failed for task ':resolve' (registered in build file 'build.gradle').") {
-            it.assertHasCause("Failed to transform a.jar (project :a) to match attributes {artifactType=jar, color=green}.")
+            it.assertHasCause("Failed to transform a.jar (project ':a') to match attributes {artifactType=jar, color=green}.")
             // TODO - should collect all failures rather than stopping on first failure
         }
 
@@ -1179,7 +1179,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractInte
         outputContains("processing a.jar")
         outputContains("processing b.jar")
         failure.assertHasFailure("Execution failed for task ':resolve' (registered in build file 'build.gradle').") {
-            it.assertHasCause("Failed to transform a.jar (project :a) to match attributes {artifactType=jar, color=green}.")
+            it.assertHasCause("Failed to transform a.jar (project ':a') to match attributes {artifactType=jar, color=green}.")
             // TODO - should collect all failures rather than stopping on first failure
         }
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -459,7 +459,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
 
         resolve.expectGraph(":impl") {
             root(":impl", "depsub:impl:") {
-                edge("project :api", "org.utils:api:1.5") {
+                edge("project ':api'", "org.utils:api:1.5") {
                     selectedByRule()
                 }
             }
@@ -749,7 +749,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         resolve.expectGraph(":impl") {
             root(":impl", "depsub:impl:") {
                 module("org.utils:api:2.0")
-                edge("project :api", "org.utils:api:2.0").byConflictResolution("between versions 2.0 and 1.6").selectedByRule()
+                edge("project ':api'", "org.utils:api:2.0").byConflictResolution("between versions 2.0 and 1.6").selectedByRule()
             }
         }
     }
@@ -1681,7 +1681,7 @@ Required by:
         fails(":checkDeps")
 
         then:
-        failure.assertHasCause("Could not find libC.type (project :libC)")
+        failure.assertHasCause("Could not find libC.type (project ':libC')")
 
         when:
         succeeds(":checkDeps", "-DwithoutArtifacts=true")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MetadataArtifactResolveTestFixture.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MetadataArtifactResolveTestFixture.groovy
@@ -207,6 +207,7 @@ task verify {
     def rootId = configurations.${config}.incoming.resolutionResult.root.id
     def componentResults = runARQ(rootId).components
     def componentArtifactsResults = runARQ(rootId).resolvedComponents
+    def projName = project.name
 
     doLast {
         assert rootId instanceof ProjectComponentIdentifier
@@ -214,7 +215,7 @@ task verify {
 
         // Check generic component result
         def componentResult = componentResults.iterator().next()
-        assert componentResult.id.displayName == "root project :"
+        assert componentResult.id.displayName == "root project '\${projName}'"
         assert componentResult instanceof $expectedComponentResult.name
 """
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependenciesIntegrationTest.groovy
@@ -128,7 +128,7 @@ class ProjectDependenciesIntegrationTest extends AbstractDependencyResolutionTes
 
         expect:
         succeeds 'dependencies', '--configuration', 'compileClasspath'
-        outputContains 'project :sub'
+        outputContains "project ':sub'"
     }
 
     def "can declare project dependency on root project using project path string"() {
@@ -148,7 +148,7 @@ class ProjectDependenciesIntegrationTest extends AbstractDependencyResolutionTes
 
         expect:
         succeeds 'sub:dependencies', '--configuration', 'compileClasspath'
-        outputContains 'root project :'
+        outputContains "root project 'root'"
     }
 
     def "can add constraint on root project"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -400,7 +400,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
 
         and:
         failure.assertHasCause("Could not resolve all dependencies for configuration ':b:compile'.")
-        failure.assertHasCause("Could not find b.jar (project :a).")
+        failure.assertHasCause("Could not find b.jar (project ':a').")
     }
 
     def "non-transitive project dependency includes only the artifacts of the target configuration"() {
@@ -791,6 +791,7 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
     def "suggests outgoingVariants command when targetConfiguration not found in local project"() {
         given:
         settingsFile << """
+            rootProject.name = 'myProject'
             includeBuild 'included'
         """
 
@@ -834,9 +835,9 @@ class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec im
         succeeds(expectedCommand)
 
         where:
-        declaredDependency   | projectDescription  | expectedCommand
-        "project(':')"       | "root project :"         | ":outgoingVariants"
-        "'org:included:1.0'" | "project :included" | ":included:outgoingVariants"
+        declaredDependency   | projectDescription           | expectedCommand
+        "project(':')"       | "root project 'myProject'"   | ":outgoingVariants"
+        "'org:included:1.0'" | "project ':included'"        | ":included:outgoingVariants"
     }
 
     def "can resolve a variant of a child project during configuration from a parent project when the child project resolves a configuration during configuration time"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -54,8 +54,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:foo:17'
-   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{strictly 15}' because of the following reason: what not""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:17'
+   Dependency path: 'root project 'test'' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{strictly 15}' because of the following reason: what not""")
 
     }
 
@@ -255,8 +255,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:foo:1.1'
-   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{require 1.0; reject 1.1}'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:1.1'
+   Dependency path: 'root project 'test'' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{require 1.0; reject 1.1}'""")
     }
 
     void "honors multiple rejections #rejects using dynamic versions using dependency notation #rejects"() {
@@ -290,8 +290,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:foo:1.1'
-   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{require 1.0; reject ${rejects.join(' & ')}}'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:1.1'
+   Dependency path: 'root project 'test'' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{require 1.0; reject ${rejects.join(' & ')}}'""")
 
         where:
         rejects << [
@@ -332,8 +332,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
-   Dependency path: 'root project :' (conf) --> 'org:foo:1.0'
-   Constraint path: 'root project :' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{reject all versions}'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:1.0'
+   Constraint path: 'root project 'test'' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:{reject all versions}'""")
 
     }
 
@@ -388,11 +388,11 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:a:1.0' (runtime) --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
-   Dependency path: 'root project :' (conf) --> 'org:c:1.0' (runtime) --> 'org:b:1.1'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:a:1.0' (runtime) --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
+   Dependency path: 'root project 'test'' (conf) --> 'org:c:1.0' (runtime) --> 'org:b:1.1'""")
 
         and:
-        failure.assertHasNoCause("Dependency path: 'root project :' (conf) --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
+        failure.assertHasNoCause("Dependency path: 'root project 'test'' (conf) --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
     }
 
     def "handles dependency cycles"() {
@@ -447,11 +447,11 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:a:1.0' (runtime) --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
-   Dependency path: 'root project :' (conf) --> 'org:c:1.0' (runtime) --> 'org:b:1.1'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:a:1.0' (runtime) --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
+   Dependency path: 'root project 'test'' (conf) --> 'org:c:1.0' (runtime) --> 'org:b:1.1'""")
 
         and:
-        failure.assertHasNoCause("Dependency path: 'root project :' (conf) --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
+        failure.assertHasNoCause("Dependency path: 'root project 'test'' (conf) --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
     }
 
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -496,6 +496,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         """
 
         settingsFile << """
+            rootProject.name = 'test'
             dependencyResolutionManagement {
                 repositories {
                     maven {
@@ -534,12 +535,12 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             assert op.result.resolvedDependenciesCount == 3
             def resolvedComponents = op.result.components
             assert resolvedComponents.size() == 8
-            assert resolvedComponents.'root project :'.repoId == null
+            assert resolvedComponents."root project 'test'".repoId == null
             assert resolvedComponents.'org.foo:direct1:1.0'.repoId == maven1Id
             assert resolvedComponents.'org.foo:direct2:1.0'.repoId == maven2Id
             assert resolvedComponents.'org.foo:transitive1:1.0'.repoId == maven1Id
             assert resolvedComponents.'org.foo:transitive2:1.0'.repoId == maven2Id
-            assert resolvedComponents.'project :child'.repoId == null
+            assert resolvedComponents."project ':child'".repoId == null
             assert resolvedComponents.'org.foo:child-transitive1:1.0'.repoId == maven1Id
             assert resolvedComponents.'org.foo:child-transitive2:1.0'.repoId == maven2Id
             return true
@@ -583,7 +584,10 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             }
         """
 
-        settingsFile << "include 'child'"
+        settingsFile << """
+            rootProject.name = 'test'
+            include 'child'
+        """
 
         file("child/build.gradle") << """
             plugins {
@@ -610,8 +614,8 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         def repoId = repoId('maven1', op.details)
         def resolvedComponents = op.result.components
         resolvedComponents.size() == 4
-        resolvedComponents.'root project :'.repoId == null
-        resolvedComponents.'project :child'.repoId == null
+        resolvedComponents."root project 'test'".repoId == null
+        resolvedComponents."project ':child'".repoId == null
         resolvedComponents.'org.foo:direct1:1.0'.repoId == repoId
         resolvedComponents.'org.foo:transitive1:1.0'.repoId == repoId
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvePOMIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvePOMIntegrationTest.groovy
@@ -83,7 +83,7 @@ class ResolvePOMIntegrationTest extends AbstractIntegrationSpec {
         expect:
         fails "build"
         failure.assertHasCause("Could not resolve all dependencies for configuration ':app:runtimeClasspath'")
-        failure.assertHasCause("Could not find lib.pom (project :included-logging:lib)")
+        failure.assertHasCause("Could not find lib.pom (project ':included-logging:lib')")
     }
 
     def "resolving a @pom artifact from an included build replacing an external library does not fail the build with a lenient configuration"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
@@ -163,8 +163,8 @@ class ForcingUsingStrictlyPlatformAlignmentTest extends AbstractAlignmentSpec {
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:databind' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:databind:{strictly 2.7.9}'
-   Constraint path: 'root project :' (conf) --> 'org:core:2.9.4' ($coreVariant) --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
+   Dependency path: 'root project 'test'' (conf) --> 'org:databind:{strictly 2.7.9}'
+   Constraint path: 'root project 'test'' (conf) --> 'org:core:2.9.4' ($coreVariant) --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
     }
 
     def "fails if forcing a virtual platform version by forcing multiple leaves with different versions, including transitively"() {
@@ -214,8 +214,8 @@ include 'other'
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:databind' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:databind:{strictly 2.7.9}'
-   Constraint path: 'root project :' (conf) --> 'project :other' (conf) --> 'org:core:2.9.4' ($coreVariant) --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
+   Dependency path: 'root project 'test'' (conf) --> 'org:databind:{strictly 2.7.9}'
+   Constraint path: 'root project 'test'' (conf) --> 'project ':other'' (conf) --> 'org:core:2.9.4' ($coreVariant) --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
     }
 
     String getCoreVariant() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
@@ -170,7 +170,7 @@ Instead, a resolvable ('canBeResolved=true') dependency configuration that exten
         fails 'a:check'
 
         then:
-        failure.assertHasCause "A dependency was declared on configuration 'internal' of 'project :b' but no variant with that configuration name exists."
+        failure.assertHasCause "A dependency was declared on configuration 'internal' of 'project ':b'' but no variant with that configuration name exists."
 
         where:
         role                    | code
@@ -208,7 +208,7 @@ Instead, a resolvable ('canBeResolved=true') dependency configuration that exten
         fails 'a:check'
 
         then:
-        failure.assertHasCause """Unable to find a matching variant of project :b:
+        failure.assertHasCause """Unable to find a matching variant of project ':b':
   - No variants exist."""
 
         where:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
@@ -466,20 +466,20 @@ baz:1.0 requested
         then:
         outputContains """
 testCompileClasspath
-   project :lib (apiElements)
+   project ':lib' (apiElements)
       org:dep:1.0 (compile)
-   project :tool (testFixturesApiElements)
-      project :tool (apiElements)
+   project ':tool' (testFixturesApiElements)
+      project ':tool' (apiElements)
          com:baz:1.0 (compile)
       com:foo:1.0 (compile)
 """
 
         and:
         outputContains """testRuntimeClasspath
-   project :lib (runtimeElements)
+   project ':lib' (runtimeElements)
       org:dep:1.0 (runtime)
-   project :tool (testFixturesRuntimeElements)
-      project :tool (runtimeElements)
+   project ':tool' (testFixturesRuntimeElements)
+      project ':tool' (runtimeElements)
          com:baz:1.0 (runtime)
       com:foo:1.0 (runtime)
       com:bar:1.0 (runtime)
@@ -565,21 +565,21 @@ testCompileClasspath
         then:
         outputContains("""
 testCompileClasspath
-   project :producer (apiElements)
+   project ':producer' (apiElements)
       org:baz:1.0 (compile)
-   project :producer (testFixturesApiElements)
-      project :producer (apiElements)
+   project ':producer' (testFixturesApiElements)
+      project ':producer' (apiElements)
       org:foo:1.0 (compile)
 """)
 
         and:
         outputContains("""
 testRuntimeClasspath
-   project :producer (runtimeElements)
+   project ':producer' (runtimeElements)
       org:baz:1.0 (runtime)
       org:gaz:1.0 (runtime)
-   project :producer (testFixturesRuntimeElements)
-      project :producer (runtimeElements)
+   project ':producer' (testFixturesRuntimeElements)
+      project ':producer' (runtimeElements)
       org:foo:1.0 (runtime)
       org:bar:1.0 (runtime)
       org:baz:1.0 (runtime)
@@ -589,6 +589,7 @@ testRuntimeClasspath
     def "reports if we try to get dependencies from a different variant"() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         settingsFile << """
+            rootProject.name = 'test'
             include 'producer'
             dependencyResolutionManagement {
                 ${mavenTestRepository()}
@@ -619,7 +620,7 @@ testRuntimeClasspath
                 def rootComponent = result.map { it.root }
                 def allComponents = result.map { it.allComponents }
                 doLast {
-                    def childComponent = allComponents.get().find { it.toString() == 'project :producer' }
+                    def childComponent = allComponents.get().find { it.toString() == "project ':producer'" }
                     def childVariant = childComponent.variants[0]
                     // try to get dependencies for child variant on the wrong component
                     println(rootComponent.get().getDependenciesForVariant(childVariant))
@@ -631,7 +632,7 @@ testRuntimeClasspath
         fails 'resolve'
 
         then:
-        failure.assertHasCause("Variant 'apiElements' doesn't belong to resolved component 'root project :'. There's no resolved variant with the same name. Most likely you are using a variant from another component to get the dependencies of this component.")
+        failure.assertHasCause("Variant 'apiElements' doesn't belong to resolved component 'root project 'test''. There's no resolved variant with the same name. Most likely you are using a variant from another component to get the dependencies of this component.")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/12643")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
@@ -123,11 +123,11 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
 
         then:
         outputContains("files: [test-lib.jar, a.jar, a-lib.jar, test-1.0.jar, b.jar, b-lib.jar, test2-1.0.jar]")
-        outputContains("ids: [test-lib.jar, a.jar (project :a), a-lib.jar, test-1.0.jar (org:test:1.0), b.jar (project :b), b-lib.jar, test2-1.0.jar (org:test2:1.0)]")
-        outputContains("unique ids: [test-lib.jar, a.jar (project :a), a-lib.jar, test-1.0.jar (org:test:1.0), b.jar (project :b), b-lib.jar, test2-1.0.jar (org:test2:1.0)]")
-        outputContains("display-names: [test-lib.jar, a.jar (project :a), a-lib.jar, test-1.0.jar (org:test:1.0), b.jar (project :b), b-lib.jar, test2-1.0.jar (org:test2:1.0)]")
-        outputContains("components: [test-lib.jar, project :a, a-lib.jar, org:test:1.0, project :b, b-lib.jar, org:test2:1.0]")
-        outputContains("unique components: [test-lib.jar, project :a, a-lib.jar, org:test:1.0, project :b, b-lib.jar, org:test2:1.0]")
+        outputContains("ids: [test-lib.jar, a.jar (project ':a'), a-lib.jar, test-1.0.jar (org:test:1.0), b.jar (project ':b'), b-lib.jar, test2-1.0.jar (org:test2:1.0)]")
+        outputContains("unique ids: [test-lib.jar, a.jar (project ':a'), a-lib.jar, test-1.0.jar (org:test:1.0), b.jar (project ':b'), b-lib.jar, test2-1.0.jar (org:test2:1.0)]")
+        outputContains("display-names: [test-lib.jar, a.jar (project ':a'), a-lib.jar, test-1.0.jar (org:test:1.0), b.jar (project ':b'), b-lib.jar, test2-1.0.jar (org:test2:1.0)]")
+        outputContains("components: [test-lib.jar, project ':a', a-lib.jar, org:test:1.0, project ':b', b-lib.jar, org:test2:1.0]")
+        outputContains("unique components: [test-lib.jar, project ':a', a-lib.jar, org:test:1.0, project ':b', b-lib.jar, org:test2:1.0]")
         outputContains("variants: [{artifactType=jar}, {artifactType=jar}, {artifactType=jar}, {artifactType=jar, org.gradle.status=release}, {artifactType=jar}, {artifactType=jar}, {artifactType=jar, org.gradle.status=release}]")
 
         where:
@@ -212,8 +212,8 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
 
         then:
         outputContains("files: [a1.jar, b2.jar]")
-        outputContains("ids: [a1.jar (project :a), b2.jar (project :b)]")
-        outputContains("components: [project :a, project :b]")
+        outputContains("ids: [a1.jar (project ':a'), b2.jar (project ':b')]")
+        outputContains("components: [project ':a', project ':b']")
         outputContains("variants: [{artifactType=jar, buildType=debug, flavor=one, usage=compile}, {artifactType=jar, flavor=two, usage=compile}]")
 
         where:
@@ -333,8 +333,8 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
 
         then:
         outputContains("files: [a1.jar, b2.jar]")
-        outputContains("ids: [a1.jar (project :a), b2.jar (project :b)]")
-        outputContains("components: [project :a, project :b]")
+        outputContains("ids: [a1.jar (project ':a'), b2.jar (project ':b')]")
+        outputContains("components: [project ':a', project ':b']")
         outputContains("variants: [{artifactType=jar, buildType=debug, flavor=one, usage=compile}, {artifactType=jar, flavor=two, usage=compile}]")
 
         and:
@@ -450,8 +450,8 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
 
         then:
         outputContains("files: [a1.jar, b2.jar]")
-        outputContains("ids: [a1.jar (project :a), b2.jar (project :b)]")
-        outputContains("components: [project :a, project :b]")
+        outputContains("ids: [a1.jar (project ':a'), b2.jar (project ':b')]")
+        outputContains("components: [project ':a', project ':b']")
         outputContains("variants: [{artifactType=jar, buildType=debug, flavor=one, usage=compile}, {artifactType=jar, flavor=two, usage=compile}]")
 
         and:
@@ -548,7 +548,7 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
         fails 'show'
 
         then:
-        failure.assertHasCause("""The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project :a:
+        failure.assertHasCause("""The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project ':a':
   - Configuration ':a:compile' variant var1 declares attribute 'usage' with value 'compile':
       - Unmatched attributes:
           - Provides artifactType 'jar' but the consumer didn't ask for it
@@ -663,7 +663,7 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
 
         then:
         outputContains("files: [test-lib.jar, transformed-a1.jar, transformed-b2.jar, test-1.0.jar]")
-        outputContains("components: [test-lib.jar, project :a, project :b, org:test:1.0]")
+        outputContains("components: [test-lib.jar, project ':a', project ':b', org:test:1.0]")
         outputContains("variants: [{artifactType=jar}, {artifactType=jar, buildType=debug, flavor=one, usage=transformed}, {artifactType=jar, usage=transformed}, {artifactType=jar, org.gradle.status=release}]")
     }
 
@@ -728,10 +728,10 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
 
         then:
         outputContains("files: [lib.jar, a/one/lib.jar, a/two/lib.jar, lib.jar, a/lib.jar, lib.jar, b/lib.jar]")
-        outputContains("ids: [lib.jar, lib.jar (project :a), lib.jar (project :a), lib.jar (project :a), lib.jar, lib.jar (project :b), lib.jar]")
-        outputContains("unique ids: [lib.jar, lib.jar (project :a), lib.jar (project :a), lib.jar (project :a), lib.jar, lib.jar (project :b), lib.jar]")
-        outputContains("components: [lib.jar, project :a, project :a, project :a, lib.jar, project :b, lib.jar]")
-        outputContains("unique components: [lib.jar, project :a, lib.jar, project :b, lib.jar]")
+        outputContains("ids: [lib.jar, lib.jar (project ':a'), lib.jar (project ':a'), lib.jar (project ':a'), lib.jar, lib.jar (project ':b'), lib.jar]")
+        outputContains("unique ids: [lib.jar, lib.jar (project ':a'), lib.jar (project ':a'), lib.jar (project ':a'), lib.jar, lib.jar (project ':b'), lib.jar]")
+        outputContains("components: [lib.jar, project ':a', project ':a', project ':a', lib.jar, project ':b', lib.jar]")
+        outputContains("unique components: [lib.jar, project ':a', lib.jar, project ':b', lib.jar]")
 
         where:
         expression                                                    | _
@@ -867,10 +867,10 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
 
         then:
         failure.assertHasCause("Could not resolve all artifacts for configuration ':compile'.")
-        failure.assertHasCause("""No matching variant of project :a was found. The consumer was configured to find attribute 'volume' with value '11' but:
+        failure.assertHasCause("""No matching variant of project ':a' was found. The consumer was configured to find attribute 'volume' with value '11' but:
   - Variant 'compile':
       - Incompatible because this component declares attribute 'volume' with value '8' and the consumer needed attribute 'volume' with value '11'""")
-        failure.assertHasCause("""No matching variant of project :b was found. The consumer was configured to find attribute 'volume' with value '11' but:
+        failure.assertHasCause("""No matching variant of project ':b' was found. The consumer was configured to find attribute 'volume' with value '11' but:
   - Variant 'compile':
       - Incompatible because this component declares attribute 'volume' with value '9' and the consumer needed attribute 'volume' with value '11'""")
 
@@ -1004,7 +1004,7 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
         failure.assertHasCause("Could not download test2-2.0.jar (org:test2:2.0)")
         failure.assertHasCause("broken 1")
         failure.assertHasCause("broken 2")
-        failure.assertHasCause("More than one variant of project :a matches the consumer attributes")
+        failure.assertHasCause("More than one variant of project ':a' matches the consumer attributes")
 
         where:
         expression                                                    | _
@@ -1088,13 +1088,13 @@ class ResolvedArtifactsApiIntegrationTest extends AbstractHttpDependencyResoluti
         succeeds 'resolveLenient'
 
         outputContains("failure 1: Could not find org:missing-module:1.0.")
-        outputContains("failure 2: Could not resolve project :b.")
+        outputContains("failure 2: Could not resolve project ':b'.")
         outputContains("failure 3: broken")
         outputContains("""failure 4: Could not find missing-artifact-1.0.jar (org:missing-artifact:1.0).
 Searched in the following locations:
     ${m1.artifact.uri}""")
         outputContains("failure 5: Could not download broken-artifact-1.0.jar (org:broken-artifact:1.0)")
-        outputContains("""failure 6: The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project :a:
+        outputContains("""failure 6: The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project ':a':
   - Configuration ':a:default' variant v1:
       - Unmatched attribute:
           - Doesn't say anything about usage (required 'compile')

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
@@ -325,7 +325,7 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
 
         expect:
         fails("show")
-        failure.assertHasCause("""The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project :a:
+        failure.assertHasCause("""The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project ':a':
   - Configuration ':a:compile' variant free declares attribute 'usage' with value 'compile':
       - Unmatched attributes:
           - Provides artifactType 'jar' but the consumer didn't ask for it
@@ -395,7 +395,7 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
 
         expect:
         fails("show")
-        failure.assertHasCause("""No variants of project :a match the consumer attributes:
+        failure.assertHasCause("""No variants of project ':a' match the consumer attributes:
   - Configuration ':a:compile' variant free declares attribute 'usage' with value 'compile':
       - Incompatible because this component declares attribute 'artifactType' with value 'jar', attribute 'flavor' with value 'free' and the consumer needed attribute 'artifactType' with value 'dll', attribute 'flavor' with value 'preview'
   - Configuration ':a:compile' variant paid declares attribute 'usage' with value 'compile':
@@ -601,7 +601,7 @@ class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTe
             failure.assertHasCause("Could not find test-1.0.jar (org:test:1.0).")
             failure.assertHasCause("Could not download test2-2.0.jar (org:test2:2.0)")
             failure.assertHasCause("broken 2")
-            failure.assertHasCause("The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project :a:")
+            failure.assertHasCause("The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project ':a':")
         } else {
             failure.assertHasDescription("Could not determine the dependencies of task ':show'.")
         }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -417,7 +417,7 @@ abstract class AbstractConfigurationAttributesResolveIntegrationTest extends Abs
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """Configuration 'bar' in project :b does not match the consumer attributes
+        failure.assertHasCause """Configuration 'bar' in project ':b' does not match the consumer attributes
 Configuration 'bar' declares attribute 'flavor' with value 'free':
   - Incompatible because this component declares attribute 'buildType' with value 'release' and the consumer needed attribute 'buildType' with value 'debug'"""
 
@@ -560,8 +560,8 @@ Configuration 'bar' declares attribute 'flavor' with value 'free':
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':a:checkDebug'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':a:_compileFreeDebug'.")
-        failure.assertHasCause("Could not resolve project :b.")
-        failure.assertHasCause("""No matching variant of project :b was found. The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free' but:
+        failure.assertHasCause("Could not resolve project ':b'.")
+        failure.assertHasCause("""No matching variant of project ':b' was found. The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free' but:
   - Variant 'bar':
       - Incompatible because this component declares attribute 'buildType' with value 'release' and the consumer needed attribute 'buildType' with value 'debug'
       - Other compatible attribute:
@@ -608,8 +608,8 @@ Configuration 'bar' declares attribute 'flavor' with value 'free':
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':a:checkDebug'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':a:compile'.")
-        failure.assertHasCause("Could not resolve project :b.")
-        failure.assertHasCause("""Cannot choose between the available variants of project :b:
+        failure.assertHasCause("Could not resolve project ':b'.")
+        failure.assertHasCause("""Cannot choose between the available variants of project ':b':
   - bar
   - foo
 All of them match the consumer attributes:
@@ -658,7 +658,7 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """No matching variant of project :b was found. The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free' but:
+        failure.assertHasCause """No matching variant of project ':b' was found. The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free' but:
   - No variants exist."""
     }
 
@@ -688,7 +688,7 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """No matching variant of project :b was found. The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free' but:
+        failure.assertHasCause """No matching variant of project ':b' was found. The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free' but:
   - No variants exist."""
     }
 
@@ -732,7 +732,7 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause "A dependency was declared on configuration 'someConf' of 'project :b' but no variant with that configuration name exists."
+        failure.assertHasCause "A dependency was declared on configuration 'someConf' of 'project ':b'' but no variant with that configuration name exists."
     }
 
     def "gives details about failing matches when it cannot select default configuration when no match is found and default configuration is not consumable"() {
@@ -770,7 +770,7 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """No matching variant of project :b was found. The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free' but:
+        failure.assertHasCause """No matching variant of project ':b' was found. The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free' but:
   - Variant 'bar':
       - Incompatible because this component declares attribute 'buildType' with value 'release', attribute 'flavor' with value 'paid' and the consumer needed attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'
   - Variant 'foo' declares attribute 'flavor' with value 'free':
@@ -894,7 +894,7 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause("""The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'. However we cannot choose between the following variants of project :b:
+        failure.assertHasCause("""The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'. However we cannot choose between the following variants of project ':b':
   - bar
   - foo
 All of them match the consumer attributes:
@@ -993,7 +993,7 @@ All of them match the consumer attributes:
         fails ':a:check'
 
         then:
-        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'debug'. However we cannot choose between the following variants of project :b:
+        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'debug'. However we cannot choose between the following variants of project ':b':
   - bar
   - foo
 All of them match the consumer attributes:
@@ -1045,7 +1045,7 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'. There are several available matching variants of project :b
+        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'. There are several available matching variants of project ':b'
 The only attribute distinguishing these variants is 'extra'. Add this attribute to the consumer's configuration to resolve the ambiguity:
   - Value: 'extra 2' selects variant: 'bar'
   - Value: 'extra' selects variant: 'foo'"""
@@ -1117,7 +1117,7 @@ The only attribute distinguishing these variants is 'extra'. Add this attribute 
         fails ':a:check'
 
         then:
-        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'. However we cannot choose between the following variants of project :b:
+        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'. However we cannot choose between the following variants of project ':b':
   - compile
   - debug
 All of them match the consumer attributes:
@@ -1436,7 +1436,7 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'. There are several available matching variants of project :c
+        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'. There are several available matching variants of project ':c'
 The only attribute distinguishing these variants is 'extra'. Add this attribute to the consumer's configuration to resolve the ambiguity:
   - Value: 'extra' selects variant: 'foo'
   - Value: 'extra 2' selects variant: 'foo2'"""
@@ -1445,7 +1445,7 @@ The only attribute distinguishing these variants is 'extra'. Add this attribute 
         fails ':a:checkRelease'
 
         then:
-        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'release', attribute 'flavor' with value 'free'. There are several available matching variants of project :c
+        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'release', attribute 'flavor' with value 'free'. There are several available matching variants of project ':c'
 The only attribute distinguishing these variants is 'extra'. Add this attribute to the consumer's configuration to resolve the ambiguity:
   - Value: 'extra' selects variant: 'bar'
   - Value: 'extra 2' selects variant: 'bar2'"""

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -462,7 +462,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         failure.assertHasCause("""Could not find any version that matches org:test:[1.0,).""")
 
         and:
-        outputContains("Success for root project :")
+        outputContains("Success for root project 'test'")
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ProjectDependenciesAttributesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ProjectDependenciesAttributesIntegrationTest.groovy
@@ -88,7 +88,7 @@ class ProjectDependenciesAttributesIntegrationTest extends AbstractIntegrationSp
         fails ':checkDeps'
 
         then:
-        failure.assertHasCause("""No matching variant of project :dep was found. The consumer was configured to find attribute 'color' with value 'green' but:
+        failure.assertHasCause("""No matching variant of project ':dep' was found. The consumer was configured to find attribute 'color' with value 'green' but:
   - Variant 'blueVariant':
       - Incompatible because this component declares attribute 'color' with value 'blue' and the consumer needed attribute 'color' with value 'green'
   - Variant 'redVariant':

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -133,14 +133,14 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause("Could not resolve project :b.")
+        failure.assertHasCause("Could not resolve project ':b'.")
         failure.assertHasCause("Unexpected type for attribute 'flavor' provided. Expected a value of type Flavor but found a value of type java.lang.Integer.")
 
         when:
         fails ':a:checkRelease'
 
         then:
-        failure.assertHasCause("Could not resolve project :b.")
+        failure.assertHasCause("Could not resolve project ':b'.")
         failure.assertHasCause("Unexpected type for attribute 'flavor' provided. Expected a value of type Flavor but found a value of type java.lang.Integer.")
     }
 
@@ -386,7 +386,7 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'. However we cannot choose between the following variants of project :b:
+        failure.assertHasCause """The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free'. However we cannot choose between the following variants of project ':b':
   - foo2
   - foo3
 All of them match the consumer attributes:
@@ -1158,7 +1158,7 @@ All of them match the consumer attributes:
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':a:check'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':a:compile'.")
-        failure.assertHasCause("Could not resolve project :b.")
+        failure.assertHasCause("Could not resolve project ':b'.")
         failure.assertHasCause("Could not determine whether value paid is compatible with value free using FlavorCompatibilityRule.")
         failure.assertHasCause("Could not create an instance of type FlavorCompatibilityRule.")
         failure.assertHasCause("The constructor for type FlavorCompatibilityRule should be annotated with @Inject (javax.inject.Inject) for dependency injection.")
@@ -1220,7 +1220,7 @@ All of them match the consumer attributes:
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':a:check'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':a:compile'.")
-        failure.assertHasCause("Could not resolve project :b.")
+        failure.assertHasCause("Could not resolve project ':b'.")
         failure.assertHasCause("Could not determine whether value paid is compatible with value free using FlavorCompatibilityRule.")
         failure.assertHasCause("broken!")
     }
@@ -1294,7 +1294,7 @@ All of them match the consumer attributes:
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':a:check'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':a:compile'.")
-        failure.assertHasCause("Could not resolve project :b.")
+        failure.assertHasCause("Could not resolve project ':b'.")
         failure.assertHasCause("Could not select value from candidates [free, paid] using FlavorSelectionRule.")
         failure.assertHasCause("Could not create an instance of type FlavorSelectionRule.")
         failure.assertHasCause("The constructor for type FlavorSelectionRule should be annotated with @Inject (javax.inject.Inject) for dependency injection.")
@@ -1367,7 +1367,7 @@ All of them match the consumer attributes:
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':a:check'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':a:compile'.")
-        failure.assertHasCause("Could not resolve project :b.")
+        failure.assertHasCause("Could not resolve project ':b'.")
         failure.assertHasCause("Could not select value from candidates [free, paid] using FlavorSelectionRule.")
         failure.assertHasCause("broken!")
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
@@ -338,7 +338,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
                     artifact(name: "producer1-foo")
                     byReason("conflict resolution: latest version of capability org:foo")
                 }
-                edge("project :producer2", "project :producer1", "test:producer1:unspecified")
+                edge("project ':producer2'", "project :producer1", "test:producer1:unspecified")
             }
         }
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIssuesIntegrationTest.groovy
@@ -376,11 +376,11 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
                     configuration 'runtimeElements'
                     project(":shared", "test:shared:") {
                         artifact(classifier: 'one-preferred')
-                        byConflictResolution("Explicit selection of project :shared variant onePrefRuntimeElements")
+                        byConflictResolution("Explicit selection of project ':shared' variant onePrefRuntimeElements")
                     }
                     project(":shared", "test:shared:") {
                         artifact(classifier: 'two-preferred')
-                        byConflictResolution("Explicit selection of project :shared variant twoPrefRuntimeElements")
+                        byConflictResolution("Explicit selection of project ':shared' variant twoPrefRuntimeElements")
                     }
                 }
                 project(":shared", "test:shared:") {
@@ -982,7 +982,7 @@ class CapabilitiesConflictResolutionIssuesIntegrationTest extends AbstractIntegr
             root(":", ":test:") {
                 project(":producer", "test:producer:") {
                     variant('one-preferred', ['org.gradle.usage': 'foo'])
-                    byConflictResolution("Explicit selection of project :producer variant one-preferred")
+                    byConflictResolution("Explicit selection of project ':producer' variant one-preferred")
                     noArtifacts()
                 }
                 project(":producer", "test:producer:") {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -53,10 +53,11 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
 
         then:
         failure.assertHasCause("""Module 'test:b' has been rejected:
-   Cannot select module with conflict on capability 'org:capability:1.0' also provided by ['root project :' (compileClasspath)]""")
+   Cannot select module with conflict on capability 'org:capability:1.0' also provided by ['root project 'test'' (compileClasspath)]""")
     }
 
     def 'fails to resolve undeclared test fixture'() {
+        settingsFile << "rootProject.name = 'test'\n"
         buildFile << """
             apply plugin: 'java-library'
 
@@ -75,7 +76,7 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         succeeds 'dependencyInsight', '--configuration', 'compileClasspath', '--dependency', ':'
 
         then:
-        outputContains("Could not resolve root project :.")
+        outputContains("Could not resolve root project 'test'.")
     }
 
     def "can lazily define and request capability"() {
@@ -157,7 +158,7 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         fails("resolve")
 
         then:
-        failure.assertHasCause("Unable to find a variant of 'project :other' with the requested capabilities: ['org:capability', feature 'foo']")
+        failure.assertHasCause("Unable to find a variant of 'project ':other'' with the requested capabilities: ['org:capability', feature 'foo']")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/26377")
@@ -304,7 +305,7 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         fails("resolve")
 
         then:
-        failure.assertHasCause("No matching variant of project :other $description was found")
+        failure.assertHasCause("No matching variant of project ':other' $description was found")
         failure.assertHasErrorOutput("Incompatible because this component declares attribute 'org.gradle.category' with value 'foo' and the consumer needed attribute 'org.gradle.category' with value 'bar'")
 
         where:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
@@ -286,7 +286,7 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
 
         then:
         failure.assertHasCause("""Module 'org:test' has been rejected:
-   Cannot select module with conflict on capability 'org:capability:1.0' also provided by ['root project :' (conf)]""")
+   Cannot select module with conflict on capability 'org:capability:1.0' also provided by ['root project 'test'' (conf)]""")
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
@@ -147,7 +147,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
 
         then:
         failure.assertHasCause("""Module 'org:test' has been rejected:
-   Cannot select module with conflict on capability 'org:capability:1.0' also provided by ['root project :' (conf)]""")
+   Cannot select module with conflict on capability 'org:capability:1.0' also provided by ['root project 'test'' (conf)]""")
     }
 
     /**

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
@@ -94,8 +94,8 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:foo:1.1'
-   Constraint path: 'root project :' (conf) --> 'org:foo:{strictly 1.0}' because of the following reason: version resolved in configuration ':other' by consistent resolution"""
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:1.1'
+   Constraint path: 'root project 'test'' (conf) --> 'org:foo:{strictly 1.0}' because of the following reason: version resolved in configuration ':other' by consistent resolution"""
     }
 
     def "first level dependency can be downgraded only if it's a preferred version"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -124,8 +124,8 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
 
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
-   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:1.1'
-   Constraint path: 'root project :' (conf) --> 'org:foo:{reject all versions}'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:bar:1.0' (runtime) --> 'org:foo:1.1'
+   Constraint path: 'root project 'test'' (conf) --> 'org:foo:{reject all versions}'""")
     }
 
     void "dependency constraint is included into the result of resolution when a hard dependency is also added transitively"() {
@@ -867,7 +867,7 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
                     project(":bar", "org:bar:1.1") {
                         configuration = 'default'
                         noArtifacts()
-                        constraint("project :foo", "org:foo:1.1")
+                        constraint("project ':foo'", "org:foo:1.1")
                     }
                 }
                 project(":bar", "org:bar:1.1") {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
@@ -253,12 +253,12 @@ Searched in the following locations:
   - ${moduleA.ivy.uri}
 Required by:
     root project 'root' > group:projectC:0.99
-    root project 'root' > project :child1 > group:projectD:1.0GA""")
+    root project 'root' > project ':child1' > group:projectD:1.0GA""")
             .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.ivy.uri}
 Required by:
-    root project 'root' > project :child1 > group:projectD:1.0GA""")
+    root project 'root' > project ':child1' > group:projectD:1.0GA""")
         failure.assertHasResolutions(REPOSITORY_HINT,
             STACKTRACE_MESSAGE,
             INFO_DEBUG,

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleArtifactResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleArtifactResolutionIntegrationTest.groovy
@@ -82,7 +82,7 @@ repositories {
 
         when:
         fixture.requestComponent('IvyModule').requestArtifact('IvyDescriptorArtifact')
-               .expectUnresolvedComponentResult(new IllegalArgumentException("Cannot query artifacts for a project component (root project :)."))
+               .expectUnresolvedComponentResult(new IllegalArgumentException("Cannot query artifacts for a project component (root project '${testDirectory.name}')."))
                .expectNoMetadataFiles()
                .createVerifyTaskForProjectComponentIdentifier()
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractValidatingLockingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractValidatingLockingIntegrationTest.groovy
@@ -53,9 +53,9 @@ dependencies {
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (lockedConf) --> 'org:foo:1.+'
-   Dependency path: 'root project :' (lockedConf) --> 'org:foo:{strictly 1.1}'
-   Constraint path: 'root project :' (lockedConf) --> 'org:foo:{strictly 1.0}' because of the following reason: Dependency version enforced by Dependency Locking"""
+   Dependency path: 'root project 'depLock'' (lockedConf) --> 'org:foo:1.+'
+   Dependency path: 'root project 'depLock'' (lockedConf) --> 'org:foo:{strictly 1.1}'
+   Constraint path: 'root project 'depLock'' (lockedConf) --> 'org:foo:{strictly 1.0}' because of the following reason: Dependency version enforced by Dependency Locking"""
 
         where:
         unique << [true, false]
@@ -94,9 +94,9 @@ dependencies {
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (lockedConf) --> 'org:foo:1.+'
-   Dependency path: 'root project :' (lockedConf) --> 'org:foo:1.1'
-   Constraint path: 'root project :' (lockedConf) --> 'org:foo:{strictly 1.0}' because of the following reason: Dependency version enforced by Dependency Locking"""
+   Dependency path: 'root project 'depLock'' (lockedConf) --> 'org:foo:1.+'
+   Dependency path: 'root project 'depLock'' (lockedConf) --> 'org:foo:1.1'
+   Constraint path: 'root project 'depLock'' (lockedConf) --> 'org:foo:{strictly 1.0}' because of the following reason: Dependency version enforced by Dependency Locking"""
 
         where:
         unique << [true, false]

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
@@ -225,12 +225,12 @@ Searched in the following locations:
   - ${moduleA.pom.uri}
 Required by:
     root project 'root' > group:projectC:0.99
-    root project 'root' > project :child1 > group:projectD:1.0GA""")
+    root project 'root' > project ':child1' > group:projectD:1.0GA""")
             .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.pom.uri}
 Required by:
-    root project 'root' > project :child1 > group:projectD:1.0GA""")
+    root project 'root' > project ':child1' > group:projectD:1.0GA""")
         failure.assertHasResolutions(REPOSITORY_HINT,
             STACKTRACE_MESSAGE,
             INFO_DEBUG,

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenModuleArtifactResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenModuleArtifactResolutionIntegrationTest.groovy
@@ -80,7 +80,7 @@ repositories {
 
         when:
         fixture.requestComponent('MavenModule').requestArtifact('MavenPomArtifact')
-            .expectUnresolvedComponentResult(new IllegalArgumentException("Cannot query artifacts for a project component (root project :)."))
+            .expectUnresolvedComponentResult(new IllegalArgumentException("Cannot query artifacts for a project component (root project '${testDirectory.name}')."))
             .expectNoMetadataFiles()
             .createVerifyTaskForProjectComponentIdentifier()
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/AbstractDependencyMetadataRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/AbstractDependencyMetadataRulesIntegrationTest.groovy
@@ -866,8 +866,8 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
         then:
         fails 'checkDeps'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints:
-   Dependency path: 'root project :' ($variantToTest) --> 'org.test:moduleB:1.1'
-   ${defineAsConstraint? 'Constraint' : 'Dependency'} path: 'root project :' ($variantToTest) --> 'org.test:moduleA:1.0' ($variantToTest) --> 'org.test:moduleB:{strictly 1.0}'"""
+   Dependency path: 'root project 'test'' ($variantToTest) --> 'org.test:moduleB:1.1'
+   ${defineAsConstraint? 'Constraint' : 'Dependency'} path: 'root project 'test'' ($variantToTest) --> 'org.test:moduleA:1.0' ($variantToTest) --> 'org.test:moduleB:{strictly 1.0}'"""
 
         where:
         thing                    | defineAsConstraint
@@ -941,8 +941,8 @@ abstract class AbstractDependencyMetadataRulesIntegrationTest extends AbstractMo
         then:
         fails 'checkDeps'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints:
-   Dependency path: 'root project :' ($variantToTest) --> 'org.test:moduleB:1.1'
-   ${defineAsConstraint? 'Constraint' : 'Dependency'} path: 'root project :' ($variantToTest) --> 'org.test:moduleA:1.0' ($variantToTest) --> 'org.test:moduleB:{require 1.+; reject 1.1 & 1.2}'"""
+   Dependency path: 'root project 'test'' ($variantToTest) --> 'org.test:moduleB:1.1'
+   ${defineAsConstraint? 'Constraint' : 'Dependency'} path: 'root project 'test'' ($variantToTest) --> 'org.test:moduleA:1.0' ($variantToTest) --> 'org.test:moduleB:{require 1.+; reject 1.1 & 1.2}'"""
 
         where:
         thing                    | defineAsConstraint

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesIntegrationTest.groovy
@@ -71,7 +71,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         succeeds(":b:checkDeps")
         resolve.expectGraph(":b") {
             root(":b", "test:b:") {
-                edge("project :a", "org.gradle.test:a:1.3") {
+                edge("project ':a'", "org.gradle.test:a:1.3") {
                     selectedByRule()
                 }
             }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesPreferProjectModulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesPreferProjectModulesIntegrationTest.groovy
@@ -113,10 +113,10 @@ class DependencyResolveRulesPreferProjectModulesIntegrationTest extends Abstract
                     }
                     // 'Subproject_with_preferProjectModules' config DOES NOT influence this dependency
                     // and hence the higher version is picked from repo
-                    edge("project :ModuleC", "myorg:ModuleC:2.0")
+                    edge("project ':ModuleC'", "myorg:ModuleC:2.0")
                 }
                 module("myorg:ModuleB:1.0")
-                edge("project :ModuleC", "myorg:ModuleC:2.0")
+                edge("project ':ModuleC'", "myorg:ModuleC:2.0")
             }
         }
     }
@@ -175,7 +175,7 @@ class DependencyResolveRulesPreferProjectModulesIntegrationTest extends Abstract
                 }
                 // 'preferProjectModules()' is not inherited from 'baseConf'
                 // and hence the higher version is picked from repo
-                edge("project :ModuleC", "myorg:ModuleC:2.0")
+                edge("project ':ModuleC'", "myorg:ModuleC:2.0")
             }
         }
 
@@ -190,7 +190,7 @@ class DependencyResolveRulesPreferProjectModulesIntegrationTest extends Abstract
                         byConflictResolution("between versions 1.0 and 2.0")
                     }
                 }
-                project("project :ModuleC", "myorg:ModuleC:1.0") {
+                project("project ':ModuleC'", "myorg:ModuleC:1.0") {
                     noArtifacts()
                 }
             }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
@@ -275,9 +275,9 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:c' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:c:2.0'
-   Dependency path: 'root project :' (conf) --> 'org:a:1.0' (runtime) --> 'org:c:{strictly 1.0}'
-   Dependency path: 'root project :' (conf) --> 'org:a:1.0' (runtime) --> 'org:b:1.0' (runtime) --> 'org:c:2.0'"""
+   Dependency path: 'root project 'test'' (conf) --> 'org:c:2.0'
+   Dependency path: 'root project 'test'' (conf) --> 'org:a:1.0' (runtime) --> 'org:c:{strictly 1.0}'
+   Dependency path: 'root project 'test'' (conf) --> 'org:a:1.0' (runtime) --> 'org:b:1.0' (runtime) --> 'org:c:2.0'"""
     }
 
     def "strict from selected and later evicted modules are ignored"() {
@@ -548,8 +548,8 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'project :foo'
-   Constraint path: 'root project :' (conf) --> 'org:foo:{strictly 1.0}'""")
+   Dependency path: 'root project 'test'' (conf) --> 'project ':foo''
+   Constraint path: 'root project 'test'' (conf) --> 'org:foo:{strictly 1.0}'""")
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
@@ -596,8 +596,8 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:x1:1.0' (runtime) --> 'org:bar:1.0' (runtime) --> 'org:foo:2.0'
-   Constraint path: 'root project :' (conf) --> 'org:x1:1.0' (runtime) --> 'org:foo:{strictly 1.0}'"""
+   Dependency path: 'root project 'test'' (conf) --> 'org:x1:1.0' (runtime) --> 'org:bar:1.0' (runtime) --> 'org:foo:2.0'
+   Constraint path: 'root project 'test'' (conf) --> 'org:x1:1.0' (runtime) --> 'org:foo:{strictly 1.0}'"""
     }
 
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -472,8 +472,8 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         then:
         failure.assertHasCause "Could not resolve org:foo:{strictly 3.2}."
         failure.assertHasCause """Component is the target of multiple version constraints with conflicting requirements:
-3.1.1 - transitively via 'project :recklessLibrary' (conf)
-3.2 - directly in 'project :recklessLibrary' (conf)"""
+3.1.1 - transitively via 'project ':recklessLibrary'' (conf)
+3.2 - directly in 'project ':recklessLibrary'' (conf)"""
         failure.assertHasResolution("Run with :dependencyInsight --configuration conf --dependency org:foo to get more insight on how to solve the conflict.") &&
         failure.assertHasResolution("Debugging using the dependencyInsight report is described in more detail at: https://docs.gradle.org/${GradleVersion.current().version}/userguide/viewing_debugging_dependencies.html#sec:identifying-reason-dependency-selection.")
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -202,7 +202,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeGreen"
 
             transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
 
         checkExecuteTransformWorkOperations(executePlannedStepOps[0], 1)
@@ -280,7 +280,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeColor"
 
             transformerName == "MakeColor"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
 
         with(executePlannedStepOps[1].details) {
@@ -288,7 +288,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeColor"
 
             transformerName == "MakeColor"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
     }
 
@@ -365,7 +365,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeRed"
 
             transformerName == "MakeRed"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
 
         with(executePlannedStepOps[1].details) {
@@ -373,7 +373,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeGreen"
 
             transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
     }
 
@@ -435,7 +435,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeGreen"
 
             transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
     }
 
@@ -513,7 +513,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeRed"
 
             transformerName == "MakeRed"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
 
         with(executePlannedStepOps[1].details) {
@@ -521,7 +521,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeGreen"
 
             transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
     }
 
@@ -638,7 +638,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeColor"
 
             transformerName == "MakeColor"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
 
         checkExecuteTransformWorkOperations(executePlannedStepOps[0], 1)
@@ -648,7 +648,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeColor"
 
             transformerName == "MakeColor"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
 
         checkExecuteTransformWorkOperations(executePlannedStepOps[1], 2)
@@ -725,9 +725,9 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer])]")
 
-        result.groupedOutput.transform("MakeGreen", "producer.out1.jar (project :producer)")
+        result.groupedOutput.transform("MakeGreen", "producer.out1.jar (project ':producer')")
             .assertOutputContains("processing [producer.out1.jar]")
-        result.groupedOutput.transform("MakeGreen", "producer.out2.jar (project :producer)")
+        result.groupedOutput.transform("MakeGreen", "producer.out2.jar (project ':producer')")
             .assertOutputContains("processing [producer.out2.jar]")
 
         result.groupedOutput.task(":consumer:resolve")
@@ -772,12 +772,12 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         checkExecutePlannedStepOperation(executePlannedStepOps, expectedTransformId1, [
             transformActionClass: "MakeGreen",
             transformerName: "MakeGreen",
-            subjectName: "producer.out1.jar (project :producer)",
+            subjectName: "producer.out1.jar (project ':producer')",
         ])
         checkExecutePlannedStepOperation(executePlannedStepOps, expectedTransformId2, [
             transformActionClass: "MakeGreen",
             transformerName: "MakeGreen",
-            subjectName: "producer.out2.jar (project :producer)",
+            subjectName: "producer.out2.jar (project ':producer')",
         ])
 
         executePlannedStepOps.each {
@@ -862,12 +862,12 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         checkExecutePlannedStepOperation(executePlannedStepOps, expectedTransformId1, [
             transformActionClass: "MakeGreen",
             transformerName: "MakeGreen",
-            subjectName: "producer.jar (project :producer)",
+            subjectName: "producer.jar (project ':producer')",
         ])
         checkExecutePlannedStepOperation(executePlannedStepOps, expectedTransformId2, [
             transformActionClass: "MakeGreen",
             transformerName: "MakeGreen",
-            subjectName: "producer.jar (project :producer)",
+            subjectName: "producer.jar (project ':producer')",
         ])
 
         def executeWorkOps1 = buildOperations.children(executePlannedStepOps[0], ExecuteWorkBuildOperationType)
@@ -922,7 +922,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer])]")
 
-        result.groupedOutput.transform("MakeGreen", "producer.jar (project :producer)")
+        result.groupedOutput.transform("MakeGreen", "producer.jar (project ':producer')")
             .assertOutputContains("processing [producer.jar]")
 
 
@@ -956,7 +956,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeGreen"
 
             transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
+            subjectName == "producer.jar (project ':producer')"
         }
 
         checkExecuteTransformWorkOperations(executePlannedStepOp, 1)
@@ -1002,10 +1002,10 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer, Task :included:nested-producer:producer])]")
         outputContains("Task-only execution plan: [PlannedTask('Task :included:nested-producer:producer', deps=[])]")
 
-        result.groupedOutput.transform("MakeGreen", "producer.jar (project :producer)")
+        result.groupedOutput.transform("MakeGreen", "producer.jar (project ':producer')")
             .assertOutputContains("processing [producer.jar]")
 
-        result.groupedOutput.transform("MakeGreen", "nested-producer.jar (project :included:nested-producer)")
+        result.groupedOutput.transform("MakeGreen", "nested-producer.jar (project ':included:nested-producer')")
             .assertOutputContains("processing [nested-producer.jar]")
 
         result.groupedOutput.task(":consumer:resolve")
@@ -1056,12 +1056,12 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         checkExecutePlannedStepOperation(executePlannedStepOps, expectedTransformId1, [
             transformActionClass: "MakeGreen",
             transformerName: "MakeGreen",
-            subjectName: "producer.jar (project :producer)",
+            subjectName: "producer.jar (project ':producer')",
         ])
         checkExecutePlannedStepOperation(executePlannedStepOps, expectedTransformId2, [
             transformActionClass: "MakeGreen",
             transformerName: "MakeGreen",
-            subjectName: "nested-producer.jar (project :included:nested-producer)",
+            subjectName: "nested-producer.jar (project ':included:nested-producer')",
         ])
     }
 
@@ -1105,7 +1105,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         outputContains("Task-only execution plan: [PlannedTask('Task :rootConsumer', deps=[Task :included:consumer:resolve])]")
         outputContains("Task-only execution plan: [PlannedTask('Task :included:producer:producer', deps=[]), PlannedTask('Task :included:consumer:resolve', deps=[Task :included:producer:producer])]")
 
-        result.groupedOutput.transform("MakeGreen", "producer.jar (project :included:producer)")
+        result.groupedOutput.transform("MakeGreen", "producer.jar (project ':included:producer')")
             .assertOutputContains("processing [producer.jar]")
 
         result.groupedOutput.task(":included:consumer:resolve")
@@ -1143,7 +1143,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             transformActionClass == "MakeGreen"
 
             transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :included:producer)"
+            subjectName == "producer.jar (project ':included:producer')"
         }
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -79,8 +79,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
         then:
         output.count("files: [lib1.jar.txt, lib2.jar.txt, lib3.jar.txt, lib4-1.0.jar.txt]") == 2
-        output.count("artifacts: [lib1.jar.txt (project :lib), lib2.jar.txt (project :lib), lib3.jar.txt (lib3.jar), lib4-1.0.jar.txt (org.test.foo:lib4:1.0)]") == 2
-        output.count("components: [project :lib, project :lib, lib3.jar, org.test.foo:lib4:1.0]") == 2
+        output.count("artifacts: [lib1.jar.txt (project ':lib'), lib2.jar.txt (project ':lib'), lib3.jar.txt (lib3.jar), lib4-1.0.jar.txt (org.test.foo:lib4:1.0)]") == 2
+        output.count("components: [project ':lib', project ':lib', lib3.jar, org.test.foo:lib4:1.0]") == 2
 
         output.count("Transformed") == 4
         isTransformed("lib1.jar", "lib1.jar.txt")
@@ -238,8 +238,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         when:
         succeeds ":util:resolve"
 
-        def transformationPosition1 = output.indexOf("> Transform lib1.jar (project :lib) with FileSizer")
-        def transformationPosition2 = output.indexOf("> Transform lib2.jar (project :lib) with FileSizer")
+        def transformationPosition1 = output.indexOf("> Transform lib1.jar (project ':lib') with FileSizer")
+        def transformationPosition2 = output.indexOf("> Transform lib2.jar (project ':lib') with FileSizer")
         def taskPosition = output.indexOf("> Task :util:resolve")
 
         then:
@@ -269,8 +269,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         succeeds ":util:resolve", ":util2:resolve"
 
         then:
-        output.count("> Transform lib1.jar (project :lib) with FileSizer") == 1
-        output.count("> Transform lib2.jar (project :lib) with FileSizer") == 1
+        output.count("> Transform lib1.jar (project ':lib') with FileSizer") == 1
+        output.count("> Transform lib2.jar (project ':lib') with FileSizer") == 1
     }
 
     def "scheduled chained transformation is only invoked once per subject"() {
@@ -369,12 +369,12 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         run ":app1:resolveRed", ":app2:resolveYellow"
 
         then:
-        output.count("> Transform lib1.jar (project :lib) with MakeBlueToGreenThings") == 1
-        output.count("> Transform lib2.jar (project :lib) with MakeBlueToGreenThings") == 1
-        output.count("> Transform lib1.jar (project :lib) with MakeGreenToYellowThings") == 1
-        output.count("> Transform lib2.jar (project :lib) with MakeGreenToYellowThings") == 1
-        output.count("> Transform lib1.jar (project :lib) with MakeGreenToRedThings") == 1
-        output.count("> Transform lib2.jar (project :lib) with MakeGreenToRedThings") == 1
+        output.count("> Transform lib1.jar (project ':lib') with MakeBlueToGreenThings") == 1
+        output.count("> Transform lib2.jar (project ':lib') with MakeBlueToGreenThings") == 1
+        output.count("> Transform lib1.jar (project ':lib') with MakeGreenToYellowThings") == 1
+        output.count("> Transform lib2.jar (project ':lib') with MakeGreenToYellowThings") == 1
+        output.count("> Transform lib1.jar (project ':lib') with MakeGreenToRedThings") == 1
+        output.count("> Transform lib2.jar (project ':lib') with MakeGreenToRedThings") == 1
     }
 
     // This shows current behaviour, where the transform is executed even though the input artifact has not been created yet
@@ -563,11 +563,11 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
         then:
         output.count("files 1: [lib1.jar.size, lib2.jar.size, lib3.jar.size, lib4-1.0.jar.size]") == 2
-        output.count("artifacts 1: [lib1.jar.size (project :lib), lib2.jar.size (project :lib), lib3.jar.size (lib3.jar), lib4-1.0.jar.size (org.test.foo:lib4:1.0)]") == 2
-        output.count("components 1: [project :lib, project :lib, lib3.jar, org.test.foo:lib4:1.0]") == 2
+        output.count("artifacts 1: [lib1.jar.size (project ':lib'), lib2.jar.size (project ':lib'), lib3.jar.size (lib3.jar), lib4-1.0.jar.size (org.test.foo:lib4:1.0)]") == 2
+        output.count("components 1: [project ':lib', project ':lib', lib3.jar, org.test.foo:lib4:1.0]") == 2
         output.count("files 2: [lib1.jar.hash, lib2.jar.hash, lib3.jar.hash, lib4-1.0.jar.hash]") == 2
-        output.count("artifacts 2: [lib1.jar.hash (project :lib), lib2.jar.hash (project :lib), lib3.jar.hash (lib3.jar), lib4-1.0.jar.hash (org.test.foo:lib4:1.0)]") == 2
-        output.count("components 2: [project :lib, project :lib, lib3.jar, org.test.foo:lib4:1.0]") == 2
+        output.count("artifacts 2: [lib1.jar.hash (project ':lib'), lib2.jar.hash (project ':lib'), lib3.jar.hash (lib3.jar), lib4-1.0.jar.hash (org.test.foo:lib4:1.0)]") == 2
+        output.count("components 2: [project ':lib', project ':lib', lib3.jar, org.test.foo:lib4:1.0]") == 2
 
         output.count("Transformed") == 8
         isTransformed("lib1.jar", "lib1.jar.size")
@@ -873,11 +873,11 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
         then:
         output.count("files 1: [lib1.jar.size, lib2.jar.size, lib3.jar.size, lib4-1.0.jar.size]") == 2
-        output.count("artifacts 1: [lib1.jar.size (project :lib), lib2.jar.size (project :lib), lib3.jar.size (lib3.jar), lib4-1.0.jar.size (org.test.foo:lib4:1.0)]") == 2
-        output.count("components 1: [project :lib, project :lib, lib3.jar, org.test.foo:lib4:1.0]") == 2
+        output.count("artifacts 1: [lib1.jar.size (project ':lib'), lib2.jar.size (project ':lib'), lib3.jar.size (lib3.jar), lib4-1.0.jar.size (org.test.foo:lib4:1.0)]") == 2
+        output.count("components 1: [project ':lib', project ':lib', lib3.jar, org.test.foo:lib4:1.0]") == 2
         output.count("files 2: [lib1.jar.hash, lib2.jar.hash, lib3.jar.hash, lib4-1.0.jar.hash]") == 2
-        output.count("artifacts 2: [lib1.jar.hash (project :lib), lib2.jar.hash (project :lib), lib3.jar.hash (lib3.jar), lib4-1.0.jar.hash (org.test.foo:lib4:1.0)]") == 2
-        output.count("components 2: [project :lib, project :lib, lib3.jar, org.test.foo:lib4:1.0]") == 2
+        output.count("artifacts 2: [lib1.jar.hash (project ':lib'), lib2.jar.hash (project ':lib'), lib3.jar.hash (lib3.jar), lib4-1.0.jar.hash (org.test.foo:lib4:1.0)]") == 2
+        output.count("components 2: [project ':lib', project ':lib', lib3.jar, org.test.foo:lib4:1.0]") == 2
 
         output.count("Transformed") == 8
         isTransformed("lib1.jar", "lib1.jar.size")
@@ -908,8 +908,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
         then:
         failure.assertHasCause("Could not resolve all files for configuration ':app:compile'.")
-        failure.assertHasCause("Failed to transform lib1.jar (project :lib) to match attributes {artifactType=size, usage=api}")
-        failure.assertHasCause("Failed to transform lib2.jar (project :lib) to match attributes {artifactType=size, usage=api}")
+        failure.assertHasCause("Failed to transform lib1.jar (project ':lib') to match attributes {artifactType=size, usage=api}")
+        failure.assertHasCause("Failed to transform lib2.jar (project ':lib') to match attributes {artifactType=size, usage=api}")
         def outputDir1 = gradleUserHomeOutputDir("lib1.jar", "lib1.jar.txt")
         def outputDir2 = gradleUserHomeOutputDir("lib2.jar", "lib2.jar.txt")
         def outputDir3 = gradleUserHomeOutputDir("lib3.jar", "lib3.jar.txt")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformEdgeCasesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformEdgeCasesIntegrationTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.util.internal.ToBeImplemented
 class ArtifactTransformEdgeCasesIntegrationTest extends AbstractIntegrationSpec implements ArtifactTransformTestFixture {
     def "multiple distinct transformation chains fails with a reasonable message"() {
         file("my-initial-file.txt") << "Contents"
+        settingsFile << "rootProject.name = 'test'"
 
         buildKotlinFile << """
             val color = Attribute.of("color", String::class.java)
@@ -129,7 +130,7 @@ class ArtifactTransformEdgeCasesIntegrationTest extends AbstractIntegrationSpec 
 
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasErrorOutput("""   > Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
+        failure.assertHasErrorOutput("""   > Found multiple transformation chains that produce a variant of 'root project 'test'' with requested attributes:
        - color 'red'
        - matter 'liquid'
        - shape 'round'
@@ -238,6 +239,7 @@ class ArtifactTransformEdgeCasesIntegrationTest extends AbstractIntegrationSpec 
 
     def "multiple distinct transformation chains fails with a reasonable message with different transform types and non-corresponding from-to attribute pairs"() {
         file("my-initial-file.txt") << "Contents"
+        settingsFile << "rootProject.name = 'test'"
 
         buildKotlinFile << """
             val color = Attribute.of("color", String::class.java)
@@ -332,7 +334,7 @@ class ArtifactTransformEdgeCasesIntegrationTest extends AbstractIntegrationSpec 
 
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasErrorOutput("""   > Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
+        failure.assertHasErrorOutput("""   > Found multiple transformation chains that produce a variant of 'root project 'test'' with requested attributes:
        - color 'red'
        - matter 'liquid'
        - shape 'round'
@@ -377,6 +379,7 @@ class ArtifactTransformEdgeCasesIntegrationTest extends AbstractIntegrationSpec 
 
     def "multiple identical attribute transformations of distinct types should fail"() {
         file("my-initial-file.txt") << "Contents"
+        settingsFile << "rootProject.name = 'test'"
 
         buildKotlinFile << """
             val color = Attribute.of("color", String::class.java)
@@ -451,7 +454,7 @@ class ArtifactTransformEdgeCasesIntegrationTest extends AbstractIntegrationSpec 
         fails "forceResolution"
         failure.assertHasDescription("Could not determine the dependencies of task ':forceResolution'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':resolveMe'.")
-        failure.assertHasErrorOutput("""   > Found multiple transformation chains that produce a variant of 'root project :' with requested attributes:
+        failure.assertHasErrorOutput("""   > Found multiple transformation chains that produce a variant of 'root project 'test'' with requested attributes:
        - color 'red'
        - texture 'smooth'
      Found the following transformation chains:
@@ -700,7 +703,7 @@ class ArtifactTransformEdgeCasesIntegrationTest extends AbstractIntegrationSpec 
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':app:resolve'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':app:compileClasspath'.")
-        failure.assertHasErrorOutput("""Found multiple transformation chains that produce a variant of 'project :lib' with requested attributes:""")
+        failure.assertHasErrorOutput("""Found multiple transformation chains that produce a variant of 'project ':lib'' with requested attributes:""")
         failure.assertHasResolution("Remove one or more registered transforms, or add additional attributes to them to ensure only a single valid transformation chain exists.")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
@@ -892,7 +892,7 @@ class ArtifactTransformExecutionBuildOperationIntegrationTest extends AbstractIn
 
         // Check the final component ids do not change within the chain.
         outputContains("""components = ${
-            ((['file1.jar', 'file2.jar'] + (['Local Groovy'] * 11) + ['project :producer', 'com.test:test:4.2'])).collectMany {
+            ((['file1.jar', 'file2.jar'] + (['Local Groovy'] * 11) + ["project ':producer'", 'com.test:test:4.2'])).collectMany {
                 [it] * 3 // The multiplier creates three copies of everything.
             }
         }""")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -259,8 +259,8 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         outputContains("variants: [{artifactType=size, usage=api}, {artifactType=size, usage=api}]")
         outputContains("capabilities: [[capability group='root', name='lib', version='unspecified'], [capability group='root', name='lib', version='unspecified']]")
         // transformed outputs should belong to same component as original
-        outputContains("artifacts: [lib1.jar.txt (project :lib), lib2.jar.txt (project :lib)]")
-        outputContains("components: [project :lib, project :lib]")
+        outputContains("artifacts: [lib1.jar.txt (project ':lib'), lib2.jar.txt (project ':lib')]")
+        outputContains("components: [project ':lib', project ':lib']")
         file("app/build/libs").assertHasDescendants("lib1.jar.txt", "lib2.jar.txt")
         file("app/build/libs/lib1.jar.txt").text == file("lib/build/lib1.jar").length() as String
 
@@ -356,14 +356,14 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         and:
         def appOutput = result.groupedOutput.task(':app:resolve')
         appOutput.assertOutputContains("variants = [{artifactType=blue, contents=size, usage=api}]")
-        appOutput.assertOutputContains("components = [project :lib]")
-        appOutput.assertOutputContains("artifacts = [lib.blue (project :lib)]")
+        appOutput.assertOutputContains("components = [project ':lib']")
+        appOutput.assertOutputContains("artifacts = [lib.blue (project ':lib')]")
         appOutput.assertOutputContains("files = [lib.blue]")
 
         def app2Output = result.groupedOutput.task(':app2:resolve')
         app2Output.assertOutputContains("variants = [{artifactType=blue, contents=size, usage=api}]")
-        app2Output.assertOutputContains("components = [project :lib]")
-        app2Output.assertOutputContains("artifacts = [lib.blue.txt (project :lib)]")
+        app2Output.assertOutputContains("components = [project ':lib']")
+        app2Output.assertOutputContains("artifacts = [lib.blue.txt (project ':lib')]")
         app2Output.assertOutputContains("files = [lib.blue.txt]")
 
         and:
@@ -452,8 +452,8 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         outputContains("variants: [{artifactType=size, usage=api}, {artifactType=size, usage=api}, {artifactType=size}, {artifactType=size, org.gradle.status=release}, {artifactType=size, usage=api}, {artifactType=size, usage=api}, {artifactType=size, org.gradle.status=release}]")
         outputContains("capabilities: [[capability group='root', name='lib', version='unspecified'], [capability group='root', name='lib', version='unspecified'], [], [capability group='test', name='test', version='1.3'], [capability group='root', name='common', version='unspecified'], [capability group='root', name='common', version='unspecified'], [capability group='test', name='test-dependency', version='1.3']]")
         // transformed outputs should belong to same component as original
-        outputContains("artifacts: [lib1.jar.txt (project :lib), lib2.jar.txt (project :lib), file1.jar.txt (file1.jar), test-1.3.jar.txt (test:test:1.3), common.jar.txt (project :common), common-file.jar.txt (project :common), test-dependency-1.3.jar.txt (test:test-dependency:1.3)]")
-        outputContains("components: [project :lib, project :lib, file1.jar, test:test:1.3, project :common, project :common, test:test-dependency:1.3]")
+        outputContains("artifacts: [lib1.jar.txt (project ':lib'), lib2.jar.txt (project ':lib'), file1.jar.txt (file1.jar), test-1.3.jar.txt (test:test:1.3), common.jar.txt (project ':common'), common-file.jar.txt (project ':common'), test-dependency-1.3.jar.txt (test:test-dependency:1.3)]")
+        outputContains("components: [project ':lib', project ':lib', file1.jar, test:test:1.3, project ':common', project ':common', test:test-dependency:1.3]")
         file("app/build/libs").assertHasDescendants("common.jar.txt", "common-file.jar.txt", "file1.jar.txt", "lib1.jar.txt", "lib2.jar.txt", "test-1.3.jar.txt", "test-dependency-1.3.jar.txt")
         file("app/build/libs/lib1.jar.txt").text == file("lib/build/lib1.jar").length() as String
 
@@ -551,8 +551,8 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
 
         then:
         outputContains("variants: [{artifactType=size, usage=api}, {artifactType=size}, {artifactType=size}]")
-        outputContains("artifacts: [lib2.size (project :lib), lib1.size (lib1.size), lib1.jar.txt (lib1.jar)]")
-        outputContains("components: [project :lib, lib1.size, lib1.jar]")
+        outputContains("artifacts: [lib2.size (project ':lib'), lib1.size (lib1.size), lib1.jar.txt (lib1.jar)]")
+        outputContains("components: [project ':lib', lib1.size, lib1.jar]")
         file("app/build/libs").assertHasDescendants("lib1.jar.txt", "lib1.size", "lib2.size")
         file("app/build/libs/lib1.jar.txt").text == "9"
         file("app/build/libs/lib1.size").text == "some text"
@@ -609,8 +609,8 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
 
         and:
         outputContains("variants: [{artifactType=size, usage=api}, {artifactType=size, usage=api}]")
-        outputContains("artifacts: [lib1.jar (project :lib), lib2.zip (project :lib)]")
-        outputContains("components: [project :lib, project :lib]")
+        outputContains("artifacts: [lib1.jar (project ':lib'), lib2.zip (project ':lib')]")
+        outputContains("components: [project ':lib', project ':lib']")
         file("app/build/libs").assertHasDescendants("lib1.jar", "lib2.zip")
 
         and:
@@ -831,11 +831,11 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
 
         and:
         // The identifier's original filename should reference the filename from the source variant, not simply the prior transformed variant in the chain
-        outputContains("ids: [lib1.jar -> lib1.jar.blue.red (project :lib)]")
+        outputContains("ids: [lib1.jar -> lib1.jar.blue.red (project ':lib')]")
         outputContains("variants: [{artifactType=jar, color=red, javaVersion=7, usage=api}]")
         // Should belong to same component as the originals
-        outputContains("artifacts: [lib1.jar.blue.red (project :lib)]")
-        outputContains("components: [project :lib]")
+        outputContains("artifacts: [lib1.jar.blue.red (project ':lib')]")
+        outputContains("components: [project ':lib']")
         file("app/build/libs").assertHasDescendants("lib1.jar.blue.red")
 
         and:
@@ -898,8 +898,8 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         then:
         outputContains("variants: [{artifactType=size}, {artifactType=size, usage=api}]")
         // transformed outputs should belong to same component as original
-        outputContains("artifacts: [lib.jar.txt (lib.jar), lib.jar.txt (project :lib)]")
-        outputContains("components: [lib.jar, project :lib]")
+        outputContains("artifacts: [lib.jar.txt (lib.jar), lib.jar.txt (project ':lib')]")
+        outputContains("components: [lib.jar, project ':lib']")
         outputContains("files: [lib.jar.txt, lib.jar.txt]")
         outputContains("content: [4, 3]")
 
@@ -1289,7 +1289,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         fails "resolve"
 
         then:
-        failure.assertHasCause """Found multiple transformation chains that produce a variant of 'project :lib' with requested attributes:
+        failure.assertHasCause """Found multiple transformation chains that produce a variant of 'project ':lib'' with requested attributes:
   - artifactType 'transformed'
   - usage 'api'
 Found the following transformation chains:
@@ -1393,7 +1393,7 @@ Found the following transformation chains:
         fails "resolve"
 
         then:
-        failure.assertHasCause """Found multiple transformation chains that produce a variant of 'project :lib' with requested attributes:
+        failure.assertHasCause """Found multiple transformation chains that produce a variant of 'project ':lib'' with requested attributes:
   - artifactType 'transformed'
   - usage 'api'
 Found the following transformation chains:
@@ -2665,16 +2665,16 @@ Found the following transformation chains:
         run "app:resolve"
 
         then:
-        outputContains("Before transformer FileSizer on lib.jar (project :lib)")
-        outputContains("After transformer FileSizer on lib.jar (project :lib)")
+        outputContains("Before transformer FileSizer on lib.jar (project ':lib')")
+        outputContains("After transformer FileSizer on lib.jar (project ':lib')")
 
         and:
         def executeTransformationOp = buildOperations.only(ExecutePlannedTransformStepBuildOperationType)
         executeTransformationOp.failure == null
-        executeTransformationOp.displayName == "Transform lib.jar (project :lib) with FileSizer"
+        executeTransformationOp.displayName == "Transform lib.jar (project ':lib') with FileSizer"
         with(executeTransformationOp.details) {
             transformerName == "FileSizer"
-            subjectName == "lib.jar (project :lib)"
+            subjectName == "lib.jar (project ':lib')"
             this.with(plannedTransformStepIdentity) {
                 nodeType == "TRANSFORM_STEP"
                 consumerBuildPath == ":"
@@ -2738,16 +2738,16 @@ Found the following transformation chains:
         fails "app:resolve"
 
         then:
-        outputContains("Before transformer BrokenTransform on lib.jar (project :lib)")
-        outputContains("After transformer BrokenTransform on lib.jar (project :lib)")
+        outputContains("Before transformer BrokenTransform on lib.jar (project ':lib')")
+        outputContains("After transformer BrokenTransform on lib.jar (project ':lib')")
 
         and:
         def executeTransformationOp = buildOperations.only(ExecutePlannedTransformStepBuildOperationType)
         executeTransformationOp.failure != null
-        executeTransformationOp.displayName == "Transform lib.jar (project :lib) with BrokenTransform"
+        executeTransformationOp.displayName == "Transform lib.jar (project ':lib') with BrokenTransform"
         with(executeTransformationOp.details) {
             transformerName == "BrokenTransform"
-            subjectName == "lib.jar (project :lib)"
+            subjectName == "lib.jar (project ':lib')"
             this.with(plannedTransformStepIdentity) {
                 nodeType == "TRANSFORM_STEP"
                 consumerBuildPath == ":"
@@ -2806,7 +2806,7 @@ Found the following transformation chains:
         then:
         output.count("> Dependency:") == 1
         output.contains("> Dependency: task ':app:dependent' -> task ':app:resolve'")
-        output.contains("> Transform lib1.jar (project :lib) with FileSizer")
+        output.contains("> Transform lib1.jar (project ':lib') with FileSizer")
         output.contains("> Task :app:resolve")
     }
 
@@ -2875,7 +2875,7 @@ Found the following transformation chains:
 
         then:
         // Previously, this test would fail with an OOM.
-        failure.assertHasCause("No variants of root project : match the consumer attributes")
+        failure.assertHasCause("No variants of root project 'root' match the consumer attributes")
     }
 
     def declareTransform(String transformImplementation) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -339,7 +339,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
 
         then:
         failure.assertHasDescription("Execution failed for task ':a:resolve' (registered in build file 'build.gradle').")
-        failure.assertHasCause("Failed to transform b.jar (project :b) to match attributes {artifactType=jar, color=green}.")
+        failure.assertHasCause("Failed to transform b.jar (project ':b') to match attributes {artifactType=jar, color=green}.")
         failure.assertHasCause("No service of type interface ${serviceType} available.")
 
         where:
@@ -430,7 +430,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         then:
         failure.assertHasDescription("Execution failed for task ':a:resolve' (registered in build file 'build.gradle').")
         failure.assertHasCause("Could not resolve all files for configuration ':a:resolver'.")
-        failure.assertHasCause("Failed to transform b.jar (project :b) to match attributes {artifactType=jar, color=green}.")
+        failure.assertHasCause("Failed to transform b.jar (project ':b') to match attributes {artifactType=jar, color=green}.")
         failure.assertThatCause(matchesRegexp('Could not isolate parameters MakeGreen\\$Parameters_Decorated@.* of artifact transform MakeGreen'))
         failure.assertHasCause('Some problems were found with the configuration of the artifact transform parameter MakeGreen.Parameters.')
         assertPropertyValidationErrors(
@@ -518,7 +518,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         then:
         failure.assertHasDescription("Execution failed for task ':a:resolve' (registered in build file 'build.gradle').")
         failure.assertHasCause("Could not resolve all files for configuration ':a:resolver'.")
-        failure.assertHasCause("Failed to transform b.jar (project :b) to match attributes {artifactType=jar, color=green}.")
+        failure.assertHasCause("Failed to transform b.jar (project ':b') to match attributes {artifactType=jar, color=green}.")
         failure.assertThatCause(matchesRegexp('Could not isolate parameters MakeGreen\\$Parameters_Decorated@.* of artifact transform MakeGreen'))
         failure.assertHasCause('Some problems were found with the configuration of the artifact transform parameter MakeGreen.Parameters.')
         failure.assertHasCause(invalidUseOfCacheableAnnotation {
@@ -568,7 +568,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         then:
         failure.assertHasDescription("Execution failed for task ':a:resolve' (registered in build file 'build.gradle').")
         failure.assertHasCause("Could not resolve all files for configuration ':a:resolver'.")
-        failure.assertHasCause("Failed to transform b.jar (project :b) to match attributes {artifactType=jar, color=green}.")
+        failure.assertHasCause("Failed to transform b.jar (project ':b') to match attributes {artifactType=jar, color=green}.")
         failure.assertThatCause(matchesRegexp('Could not isolate parameters MakeGreen\\$Parameters_Decorated@.* of artifact transform MakeGreen'))
         failure.assertHasCause('A problem was found with the configuration of the artifact transform parameter MakeGreen.Parameters.')
         assertPropertyValidationErrors(bad: annotationInvalidInContext { annotation(ann.simpleName) })

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -740,7 +740,7 @@ project(':common') {
         fails("app:broken")
 
         then:
-        failure.assertHasCause("The consumer was configured to find attribute 'color' with value 'blue'. However we cannot choose between the following variants of project :lib:")
+        failure.assertHasCause("The consumer was configured to find attribute 'color' with value 'blue'. However we cannot choose between the following variants of project ':lib':")
 
         when:
         run("app:resolveView")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
@@ -234,7 +234,7 @@ ${artifactTransform("TestTransform")}
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':app:resolve'.")
         failure.assertHasCause("Could not resolve all dependencies for configuration ':app:compileClasspath'.")
-        failure.assertHasErrorOutput("""Found multiple transformation chains that produce a variant of 'project :lib' with requested attributes:""")
+        failure.assertHasErrorOutput("""Found multiple transformation chains that produce a variant of 'project ':lib'' with requested attributes:""")
         failure.assertHasResolution("Remove one or more registered transforms, or add additional attributes to them to ensure only a single valid transformation chain exists.")
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformLoggingIntegrationTest.groovy
@@ -167,11 +167,11 @@ class TransformLoggingIntegrationTest extends AbstractConsoleGroupedTaskFunction
         then:
         result.groupedOutput.transformCount == 2
 
-        result.groupedOutput.transform("GreenMultiplier", "lib1.jar (project :lib)")
+        result.groupedOutput.transform("GreenMultiplier", "lib1.jar (project ':lib')")
             .assertOutputContains("Creating multiplier")
             .assertOutputContains("Transforming lib1.jar to lib1.jar.green")
 
-        result.groupedOutput.transform("GreenMultiplier", "lib2.jar (project :lib)")
+        result.groupedOutput.transform("GreenMultiplier", "lib2.jar (project ':lib')")
             .assertOutputContains("Creating multiplier")
             .assertOutputContains("Transforming lib2.jar to lib2.jar.green")
 
@@ -227,8 +227,8 @@ class TransformLoggingIntegrationTest extends AbstractConsoleGroupedTaskFunction
         then:
         block.waitForAllPendingCalls()
         poll {
-            RichConsoleStyling.assertHasWorkInProgress(build, "> Transforming lib1.jar (project :lib) with Red > Red lib1.jar")
-            RichConsoleStyling.assertHasWorkInProgress(build, "> Transforming lib2.jar (project :lib) with Red > Red lib2.jar")
+            RichConsoleStyling.assertHasWorkInProgress(build, "> Transforming lib1.jar (project ':lib') with Red > Red lib1.jar")
+            RichConsoleStyling.assertHasWorkInProgress(build, "> Transforming lib2.jar (project ':lib') with Red > Red lib2.jar")
         }
 
         block.releaseAll()
@@ -245,7 +245,7 @@ class TransformLoggingIntegrationTest extends AbstractConsoleGroupedTaskFunction
         succeeds(":util:resolveBlue", "-DshowOutput")
         then:
         result.groupedOutput.transformCount == 4
-        def initialSubjects = ["lib1.jar (project :lib)", "lib2.jar (project :lib)"] as Set
+        def initialSubjects = ["lib1.jar (project ':lib')", "lib2.jar (project ':lib')"] as Set
         result.groupedOutput.subjectsFor('GreenMultiplier') == initialSubjects
         result.groupedOutput.subjectsFor('BlueMultiplier') == initialSubjects
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/AbstractRichVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/AbstractRichVersionConstraintsIntegrationTest.groovy
@@ -524,8 +524,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:foo:17'
-   Dependency path: 'root project :' (conf) --> 'project :other' (conf) --> 'org:foo:{strictly 15}'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:17'
+   Dependency path: 'root project 'test'' (conf) --> 'project ':other'' (conf) --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -566,8 +566,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:foo:{strictly 17}'
-   Dependency path: 'root project :' (conf) --> 'org:foo:{strictly 15}'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:{strictly 17}'
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -608,8 +608,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:foo:17'
-   Dependency path: 'root project :' (conf) --> 'org:bar:1' (runtime) --> 'org:foo:{strictly 15}'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:17'
+   Dependency path: 'root project 'test'' (conf) --> 'org:bar:1' (runtime) --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -707,8 +707,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:foo:15'
-   Dependency path: 'root project :' (conf) --> 'org:foo:{strictly [0,1]}'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:15'
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:{strictly [0,1]}'""")
     }
 
     void "can reject dependency versions of an external component"() {
@@ -845,8 +845,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
         then:
         def selected = GradleMetadataResolveRunner.gradleMetadataPublished || GradleMetadataResolveRunner.useMaven() ? 'runtime' : 'default'
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:foo:{require 1.0; reject 1.1}'
-   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' ($selected) --> 'org:foo:1.1'""")
+   Dependency path: 'root project 'test'' (conf) --> 'org:foo:{require 1.0; reject 1.1}'
+   Dependency path: 'root project 'test'' (conf) --> 'org:bar:1.0' ($selected) --> 'org:foo:1.1'""")
     }
 
     def "can reject a version range"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
@@ -88,9 +88,9 @@ class VersionConflictResolutionIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         outputContains("""runtimeClasspath - Runtime classpath of source set 'main'.
-+--- project :api
++--- project ':api'
 |    \\--- org:foo:1.3.3 FAILED
-\\--- project :impl
+\\--- project ':impl'
      \\--- org:foo:1.4.4 FAILED""")
 
         when:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnLibraryTooNewFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnLibraryTooNewFailureDescriberIntegrationTest.groovy
@@ -59,12 +59,12 @@ class TargetJVMVersionOnLibraryTooNewFailureDescriberIntegrationTest extends Abs
 
         then:
         failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':consumer:compileClasspath'.
-   > Could not resolve project :producer.
+   > Could not resolve project ':producer'.
      Required by:
          project ':consumer'
-      > Dependency resolution is looking for a library compatible with JVM runtime version $currentJava, but 'project :producer' is only compatible with JVM runtime version $tooHighJava or newer.""")
+      > Dependency resolution is looking for a library compatible with JVM runtime version $currentJava, but 'project ':producer'' is only compatible with JVM runtime version $tooHighJava or newer.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionByAttributesException.class.getName())
-        failure.assertHasResolution("Change the dependency on 'project :producer' to an earlier version that supports JVM runtime version $currentJava.")
+        failure.assertHasResolution("Change the dependency on 'project ':producer'' to an earlier version that supports JVM runtime version $currentJava.")
     }
 
     def 'JVM version too low even if other non-Library category variants available uses standard error message for non-plugin'() {
@@ -110,11 +110,11 @@ class TargetJVMVersionOnLibraryTooNewFailureDescriberIntegrationTest extends Abs
 
         then:
         failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration ':consumer:compileClasspath'.
-   > Could not resolve project :producer.
+   > Could not resolve project ':producer'.
      Required by:
          project ':consumer'
-      > Dependency resolution is looking for a library compatible with JVM runtime version $currentJava, but 'project :producer' is only compatible with JVM runtime version $tooHighJava or newer.""")
+      > Dependency resolution is looking for a library compatible with JVM runtime version $currentJava, but 'project ':producer'' is only compatible with JVM runtime version $tooHighJava or newer.""")
         failure.assertHasErrorOutput("Caused by: " + VariantSelectionByAttributesException.class.getName())
-        failure.assertHasResolution("Change the dependency on 'project :producer' to an earlier version that supports JVM runtime version $currentJava.")
+        failure.assertHasResolution("Change the dependency on 'project ':producer'' to an earlier version that supports JVM runtime version $currentJava.")
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/plugin/devel/variants/TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest.groovy
@@ -261,7 +261,7 @@ class TargetJVMVersionOnPluginTooNewFailureDescriberIntegrationTest extends Abst
 
         then:
         failure.assertHasErrorOutput("""> Could not resolve all dependencies for configuration 'classpath'.
-   > Could not resolve project :producer.
+   > Could not resolve project ':producer'.
      Required by:
          buildscript of root project 'consumer'
       > Dependency requires at least JVM runtime version ${higherVersion.javaVersion.majorVersion}. This build uses a Java ${lowerVersion.javaVersion.majorVersion} JVM.""")

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
@@ -41,8 +41,8 @@ class DefaultProjectComponentSelectorTest extends Specification {
         then:
         defaultBuildComponentSelector.projectPath == ":path"
         defaultBuildComponentSelector.projectIdentity == id
-        defaultBuildComponentSelector.displayName == "project :build:path"
-        defaultBuildComponentSelector.toString() == "project :build:path"
+        defaultBuildComponentSelector.displayName == "project ':build:path'"
+        defaultBuildComponentSelector.toString() == "project ':build:path'"
     }
 
     def "can compare with other instance (#projectPath)"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -284,7 +284,7 @@ empty=d
 
         then:
         def ex = thrown(IllegalStateException)
-        ex.getMessage().contains("Dependency locking cannot be used for project :foo")
+        ex.getMessage().contains("Dependency locking cannot be used for project ':foo'")
     }
 
     def 'fails to read a legacy lockfile if root could not be determined'() {
@@ -297,7 +297,7 @@ empty=d
 
         then:
         def ex = thrown(IllegalStateException)
-        ex.getMessage().contains("Dependency locking cannot be used for project :foo")
+        ex.getMessage().contains("Dependency locking cannot be used for project ':foo'")
     }
 
     def 'fails to write a unique lockfile if root could not be determined'() {
@@ -310,6 +310,6 @@ empty=d
 
         then:
         def ex = thrown(IllegalStateException)
-        ex.getMessage().contains("Dependency locking cannot be used for project :foo")
+        ex.getMessage().contains("Dependency locking cannot be used for project ':foo'")
     }
 }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
@@ -462,7 +462,7 @@ rootProject.name = 'root'
         compileClasspathConfiguration
         compileClasspathConfiguration.dependencies.size() == 4
         compileClasspathConfiguration.dependencies[0].module == null
-        compileClasspathConfiguration.dependencies[0].name == "project :a"
+        compileClasspathConfiguration.dependencies[0].name == "project ':a'"
         compileClasspathConfiguration.dependencies[0].resolvable == 'RESOLVED'
         compileClasspathConfiguration.dependencies[0].alreadyRendered == false
         compileClasspathConfiguration.dependencies[0].hasConflict == false
@@ -475,7 +475,7 @@ rootProject.name = 'root'
         compileClasspathConfiguration.dependencies[0].children[0].children.empty
 
         compileClasspathConfiguration.dependencies[1].module == null
-        compileClasspathConfiguration.dependencies[1].name == "project :b"
+        compileClasspathConfiguration.dependencies[1].name == "project ':b'"
         compileClasspathConfiguration.dependencies[1].resolvable == 'RESOLVED'
         compileClasspathConfiguration.dependencies[1].alreadyRendered == false
         compileClasspathConfiguration.dependencies[1].hasConflict == false
@@ -488,7 +488,7 @@ rootProject.name = 'root'
         compileClasspathConfiguration.dependencies[1].children[0].children.empty
 
         compileClasspathConfiguration.dependencies[2].module == null
-        compileClasspathConfiguration.dependencies[2].name == "project :a:c"
+        compileClasspathConfiguration.dependencies[2].name == "project ':a:c'"
         compileClasspathConfiguration.dependencies[2].resolvable == 'RESOLVED'
         compileClasspathConfiguration.dependencies[2].alreadyRendered == false
         compileClasspathConfiguration.dependencies[2].hasConflict == false
@@ -501,13 +501,13 @@ rootProject.name = 'root'
         compileClasspathConfiguration.dependencies[2].children[0].children.empty
 
         compileClasspathConfiguration.dependencies[3].module == null
-        compileClasspathConfiguration.dependencies[3].name == "project :d"
+        compileClasspathConfiguration.dependencies[3].name == "project ':d'"
         compileClasspathConfiguration.dependencies[3].resolvable == 'RESOLVED'
         compileClasspathConfiguration.dependencies[3].alreadyRendered == false
         compileClasspathConfiguration.dependencies[3].hasConflict == false
         compileClasspathConfiguration.dependencies[3].children.size() == 1
         compileClasspathConfiguration.dependencies[3].children[0].module == null
-        compileClasspathConfiguration.dependencies[3].children[0].name == "project :e"
+        compileClasspathConfiguration.dependencies[3].children[0].name == "project ':e'"
         compileClasspathConfiguration.dependencies[3].children[0].resolvable == 'RESOLVED'
         compileClasspathConfiguration.dependencies[3].children[0].alreadyRendered == false
         compileClasspathConfiguration.dependencies[3].children[0].hasConflict == false

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1466,14 +1466,14 @@ org:leaf:[1.5,2.0] FAILED
 
         then:
         outputContains """
-project :A FAILED
+project ':A' FAILED
    Failures:
-      - Could not resolve project :A.
-          - Unable to find a matching variant of project :A:
+      - Could not resolve project ':A'.
+          - Unable to find a matching variant of project ':A':
               - No variants exist.
           - Creating consumable variants is explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs.
 
-project :A FAILED
+project ':A' FAILED
 \\--- conf
 """
 
@@ -1482,15 +1482,15 @@ project :A FAILED
 
         then:
         outputContains """
-project :C FAILED
+project ':C' FAILED
    Failures:
-      - Could not resolve project :C.
-          - Unable to find a matching variant of project :C:
+      - Could not resolve project ':C'.
+          - Unable to find a matching variant of project ':C':
               - No variants exist.
           - Creating consumable variants is explained in more detail at https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs.
 
-project :C FAILED
-\\--- project :B
+project ':C' FAILED
+\\--- project ':B'
      \\--- conf
 """
 
@@ -1573,7 +1573,7 @@ org:leaf2:1.0
 
         then:
         outputContains """
-root project :
+root project 'root'
   Variant runtimeClasspath:
     | Attribute Name                 | Provided     | Requested    |
     |--------------------------------|--------------|--------------|
@@ -1593,9 +1593,9 @@ root project :
     | org.gradle.usage               | java-runtime | java-runtime |
     | org.gradle.jvm.environment     |              | standard-jvm |
 
-root project :
-\\--- project :impl
-     \\--- root project : (*)
+root project 'root'
+\\--- project ':impl'
+     \\--- root project 'root' (*)
 """
     }
 
@@ -1651,7 +1651,7 @@ org:leaf2:1.0
 
 org:leaf2:1.0
 \\--- org:leaf1:1.0
-     \\--- project :impl
+     \\--- project ':impl'
           \\--- runtimeClasspath
 """
     }
@@ -1694,7 +1694,7 @@ org:leaf2:1.0
 
         then:
         outputContains """
-project :impl
+project ':impl'
   Variant apiElements:
     | Attribute Name                 | Provided | Requested    |
     |--------------------------------|----------|--------------|
@@ -1705,7 +1705,7 @@ project :impl
     | org.gradle.usage               | java-api | java-api     |
     | org.gradle.jvm.environment     |          | standard-jvm |
 
-project :impl
+project ':impl'
 \\--- compileClasspath
 """
     }
@@ -1763,7 +1763,7 @@ org:leaf4:1.0
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
 org:leaf4:1.0
-\\--- project :impl
+\\--- project ':impl'
      \\--- compileClasspath
 """
     }
@@ -1873,7 +1873,7 @@ org:leaf2:1.0
 
         then:
         outputContains """
-project :api
+project ':api'
   Variant apiElements:
     | Attribute Name                 | Provided | Requested    |
     |--------------------------------|----------|--------------|
@@ -1884,8 +1884,8 @@ project :api
     | org.gradle.usage               | java-api | java-api     |
     | org.gradle.jvm.environment     |          | standard-jvm |
 
-project :api
-\\--- project :impl
+project ':api'
+\\--- project ':impl'
      \\--- compileClasspath
 """
 
@@ -1894,7 +1894,7 @@ project :api
 
         then:
         outputContains """
-project :some:deeply:nested
+project ':some:deeply:nested'
   Variant apiElements:
     | Attribute Name                 | Provided | Requested    |
     |--------------------------------|----------|--------------|
@@ -1905,7 +1905,7 @@ project :some:deeply:nested
     | org.gradle.usage               | java-api | java-api     |
     | org.gradle.jvm.environment     |          | standard-jvm |
 
-project :some:deeply:nested
+project ':some:deeply:nested'
 \\--- compileClasspath
 """
 
@@ -1914,7 +1914,7 @@ project :some:deeply:nested
 
         then:
         outputContains """
-project :some:deeply:nested
+project ':some:deeply:nested'
   Variant apiElements:
     | Attribute Name                 | Provided | Requested    |
     |--------------------------------|----------|--------------|
@@ -1925,7 +1925,7 @@ project :some:deeply:nested
     | org.gradle.usage               | java-api | java-api     |
     | org.gradle.jvm.environment     |          | standard-jvm |
 
-project :some:deeply:nested
+project ':some:deeply:nested'
 \\--- compileClasspath
 """
     }
@@ -1983,11 +1983,11 @@ org:leaf3:1.0
 
 org:leaf3:1.0
 \\--- org:leaf2:1.0
-     +--- project :api
-     |    \\--- project :impl
+     +--- project ':api'
+     |    \\--- project ':impl'
      |         \\--- compileClasspath
      \\--- org:leaf1:1.0
-          \\--- project :impl (*)
+          \\--- project ':impl' (*)
 
 """
     }
@@ -2608,8 +2608,8 @@ org:bar: FAILED
    Failures:
       - Could not resolve org:bar:{reject all versions}.
           - Module 'org:bar' has been rejected:
-               Dependency path: 'root project :' (compileClasspath) --> 'org:bar:[1.0,)' because of the following reason: rejected versions 1.2, 1.1, 1.0
-               Constraint path: 'root project :' (compileClasspath) --> 'org:bar:{reject all versions}' because of the following reason: Nope, you won't use this
+               Dependency path: 'root project 'insight-test'' (compileClasspath) --> 'org:bar:[1.0,)' because of the following reason: rejected versions 1.2, 1.1, 1.0
+               Constraint path: 'root project 'insight-test'' (compileClasspath) --> 'org:bar:{reject all versions}' because of the following reason: Nope, you won't use this
 
 org:bar:{reject all versions} FAILED
 \\--- compileClasspath
@@ -2627,8 +2627,8 @@ org:foo: (by constraint) FAILED
    Failures:
       - Could not resolve org:foo:{reject 1.0 & 1.1 & 1.2}.
           - Cannot find a version of 'org:foo' that satisfies the version constraints:
-               Dependency path: 'root project :' (compileClasspath) --> 'org:foo:[1.0,)' because of the following reason: rejected versions 1.2, 1.1, 1.0
-               Constraint path: 'root project :' (compileClasspath) --> 'org:foo:{reject 1.0 & 1.1 & 1.2}'
+               Dependency path: 'root project 'insight-test'' (compileClasspath) --> 'org:foo:[1.0,)' because of the following reason: rejected versions 1.2, 1.1, 1.0
+               Constraint path: 'root project 'insight-test'' (compileClasspath) --> 'org:foo:{reject 1.0 & 1.1 & 1.2}'
 
 org:foo:{reject 1.0 & 1.1 & 1.2} FAILED
 \\--- compileClasspath

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -60,7 +60,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
         run "a:dependencyInsight", "--dependency", ":b", "--configuration", "compileClasspath"
 
         then:
-        outputContains """project :b
+        outputContains """project ':b'
 ${variantOf("apiElements", [
             "org.gradle.category": of("library", "library"),
             "org.gradle.dependency.bundling": of("external", "external"),
@@ -70,7 +70,7 @@ ${variantOf("apiElements", [
             "org.gradle.jvm.environment": of("", "standard-jvm"),
         ])}
 
-project :b
+project ':b'
 \\--- compileClasspath"""
     }
 
@@ -95,7 +95,7 @@ project :b
         run "a:dependencyInsight", "--dependency", ":c", "--configuration", "runtimeClasspath"
 
         then:
-        outputContains """project :c
+        outputContains """project ':c'
 ${variantOf("runtimeElements", [
             "org.gradle.category": of("library", "library"),
             "org.gradle.dependency.bundling": of("external", "external"),
@@ -105,7 +105,7 @@ ${variantOf("runtimeElements", [
             "org.gradle.jvm.environment": of("", "standard-jvm"),
         ])}
 
-project :c
+project ':c'
 \\--- runtimeClasspath"""
     }
 
@@ -137,7 +137,7 @@ project :c
 
         then:
         ['b', 'c'].each { expectedProject ->
-            result.groupedOutput.task(":a:insight").assertOutputContains """project :$expectedProject
+            result.groupedOutput.task(":a:insight").assertOutputContains """project ':$expectedProject'
 -------------------
 Selected Variant(s)
 -------------------
@@ -214,7 +214,7 @@ ${variantOf('testResultsElementsForTest', [
             ])}
 
 
-project :$expectedProject
+project ':$expectedProject'
 \\--- compileClasspath
 """
         }
@@ -248,7 +248,7 @@ project :$expectedProject
 
         then:
         ['b', 'c'].each { expectedProject ->
-            result.groupedOutput.task(":a:insight").assertOutputContains """project :$expectedProject
+            result.groupedOutput.task(":a:insight").assertOutputContains """project ':$expectedProject'
 -------------------
 Selected Variant(s)
 -------------------
@@ -325,7 +325,7 @@ ${variantOf('testResultsElementsForTest', [
             ])}
 
 
-project :$expectedProject
+project ':$expectedProject'
 \\--- runtimeClasspath
 """
         }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -53,11 +53,11 @@ project(":c") {
         then:
         output.contains """
 compile
-\\--- project :c
-     \\--- project :a
-          +--- project :b
-          |    \\--- project :c (*)
-          \\--- project :c (*)
+\\--- project ':c'
+     \\--- project ':a'
+          +--- project ':b'
+          |    \\--- project ':c' (*)
+          \\--- project ':c' (*)
 """
         output.contains '(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.'
     }
@@ -88,9 +88,9 @@ compile
         then:
         output.contains """
 conf
-+--- project :A FAILED
-\\--- project :B
-     \\--- project :C FAILED
++--- project ':A' FAILED
+\\--- project ':B'
+     \\--- project ':C' FAILED
 """
     }
 
@@ -316,16 +316,16 @@ rootProject.name = 'root'
         then:
         output.contains """
 compileClasspath - Compile classpath for source set 'main'.
-+--- project :a
++--- project ':a'
 |    \\--- foo:bar:1.0 -> 3.0
 |         \\--- foo:baz:5.0
-+--- project :b
++--- project ':b'
 |    \\--- foo:bar:0.5.dont.exist -> 3.0 (*)
-+--- project :c
++--- project ':c'
 |    \\--- foo:bar:3.0 (*)
-+--- project :d
++--- project ':d'
 |    \\--- foo:bar:2.0 -> 3.0 (*)
-\\--- project :e
+\\--- project ':e'
      \\--- foo:bar:3.0 (*)
 """
     }
@@ -729,14 +729,14 @@ rootProject.name = 'root'
         then:
         output.contains """
 compileClasspath - Compile classpath for source set 'main'.
-+--- project :a
++--- project ':a'
 |    \\--- foo:bar:1.0 -> 2.0
-+--- project :b
++--- project ':b'
 |    \\--- foo:bar:0.5.dont.exist -> 2.0
-+--- project :a:c
++--- project ':a:c'
 |    \\--- foo:bar:2.0
-\\--- project :d
-     \\--- project :e
+\\--- project ':d'
+     \\--- project ':e'
           \\--- foo:bar:2.0
 """
     }
@@ -784,7 +784,7 @@ compileClasspath - Compile classpath for source set 'main'.
         then:
         output.contains """
 compile
-\\--- org.utils:api:1.3 -> project :api2
+\\--- org.utils:api:1.3 -> project ':api2'
 """
     }
 

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResultSpec.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResultSpec.groovy
@@ -40,7 +40,7 @@ class AbstractRenderableDependencyResultSpec extends Specification {
         dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('com.mockito', 'mockito'), '2.0')).name == 'org.mockito:mockito-core:1.0 -> com.mockito:mockito:2.0'
         dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('com.mockito.other', 'mockito-core'), '3.0')).name == 'org.mockito:mockito-core:1.0 -> com.mockito.other:mockito-core:3.0'
         dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('com.mockito.other', 'mockito-core'), '1.0')).name == 'org.mockito:mockito-core:1.0 -> com.mockito.other:mockito-core:1.0'
-        dep(requested, newProjectId(':a')).name == 'org.mockito:mockito-core:1.0 -> project :a'
+        dep(requested, newProjectId(':a')).name == "org.mockito:mockito-core:1.0 -> project ':a'"
     }
 
     def "renders name for ProjectComponentSelector"() {
@@ -48,9 +48,9 @@ class AbstractRenderableDependencyResultSpec extends Specification {
         def requested = TestComponentIdentifiers.newSelector(':a')
 
         expect:
-        dep(requested, newProjectId(':a')).name == 'project :a'
-        dep(requested, newProjectId(':b')).name == 'project :a -> project :b'
-        dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('org.somegroup', 'module'), '1.0')).name == 'project :a -> org.somegroup:module:1.0'
+        dep(requested, newProjectId(':a')).name == "project ':a'"
+        dep(requested, newProjectId(':b')).name == "project ':a' -> project ':b'"
+        dep(requested, DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('org.somegroup', 'module'), '1.0')).name == "project ':a' -> org.somegroup:module:1.0"
     }
 
     private AbstractRenderableDependencyResult dep(ComponentSelector requested, ComponentIdentifier selected) {

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
@@ -174,7 +174,7 @@ Required by:
                 assert selectors.size() == 3
                 assert selectors[0].displayName == 'org.test:buildB:1.2'
                 assert selectors[1].displayName == 'org.test:${dependencyName}:1.2'
-                assert selectors[2].displayName == 'project :${buildName}:a'
+                assert selectors[2].displayName == 'project \\':${buildName}:a\\''
                 assert selectors[2].buildPath == ':${buildName}'
                 assert selectors[2].projectPath == ':a'
             }

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
@@ -141,7 +141,7 @@ Required by:
                 def selectors = configurations.runtimeClasspath.incoming.resolutionResult.allDependencies.requested
                 assert selectors.size() == 2
                 assert selectors[0].displayName == 'org.test:${dependencyName}:1.2'
-                assert selectors[1].displayName == 'project :${buildName}:a'
+                assert selectors[1].displayName == 'project \\':${buildName}:a\\''
                 assert selectors[1].buildPath == ':${buildName}'
                 assert selectors[1].projectPath == ':a'
             }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildArtifactTransformIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildArtifactTransformIntegrationTest.groovy
@@ -75,8 +75,8 @@ class CompositeBuildArtifactTransformIntegrationTest extends AbstractCompositeBu
         assertTaskExecuted(":buildB", ":jar")
         assertTaskExecuted(":buildC", ":jar")
 
-        outputContains("Transformed artifact: buildB-1.0.jar.xform (project :buildB)")
-        outputContains("Transformed artifact: buildC-1.0.jar.xform (project :buildC)")
+        outputContains("Transformed artifact: buildB-1.0.jar.xform (project ':buildB')")
+        outputContains("Transformed artifact: buildC-1.0.jar.xform (project ':buildC')")
         output.count("Transforming") == 2
     }
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
@@ -78,8 +78,8 @@ class CompositeBuildBuildSrcIdentityIntegrationTest extends AbstractCompositeBui
         then:
         outputContains("""
 runtimeClasspath - Runtime classpath of source set 'main'.
-\\--- project :buildB:buildSrc:b1
-     \\--- project :buildB:buildSrc:b2
+\\--- project ':buildB:buildSrc:b1'
+     \\--- project ':buildB:buildSrc:b2'
 """)
 
         where:
@@ -163,7 +163,7 @@ Required by:
 
                 def selectors = configurations.runtimeClasspath.incoming.resolutionResult.allDependencies.requested
                 assert selectors.size() == 1
-                assert selectors[0].displayName == 'project :buildB:buildSrc:a'
+                assert selectors[0].displayName == 'project \\':buildB:buildSrc:a\\''
                 assert selectors[0].buildPath == ':buildB:buildSrc'
                 assert selectors[0].projectPath == ':a'
             }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -782,7 +782,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
 
         then:
         failure.assertHasCause("Could not resolve com.acme.external:external:1.0.")
-        failure.assertHasCause("""No matching variant of project :includedBuild was found. The consumer was configured to find attribute 'flavor' with value 'free' but:
+        failure.assertHasCause("""No matching variant of project ':includedBuild' was found. The consumer was configured to find attribute 'flavor' with value 'free' but:
   - Variant 'bar':
       - Incompatible because this component declares attribute 'flavor' with value 'blue' and the consumer needed attribute 'flavor' with value 'free'
   - Variant 'foo':
@@ -793,7 +793,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
 
         then:
         failure.assertHasCause("Could not resolve com.acme.external:external:1.0.")
-        failure.assertHasCause("""The consumer was configured to find attribute 'flavor' with value 'paid'. However we cannot choose between the following variants of project :includedBuild:
+        failure.assertHasCause("""The consumer was configured to find attribute 'flavor' with value 'paid'. However we cannot choose between the following variants of project ':includedBuild':
   - bar
   - foo
 All of them match the consumer attributes:

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -554,7 +554,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         checkDependenciesFails()
 
         then:
-        failure.assertHasCause("Module version 'org.test:b1:1.0' is not unique in composite: can be provided by [project :buildB:b1, project :buildC:b1].")
+        failure.assertHasCause("Module version 'org.test:b1:1.0' is not unique in composite: can be provided by [project ':buildB:b1', project ':buildC:b1'].")
     }
 
     def "reports failure to resolve dependencies when substitution is ambiguous within single participant"() {
@@ -582,7 +582,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         checkDependenciesFails()
 
         then:
-        failure.assertHasCause("Module version 'org.test:c1:1.0' is not unique in composite: can be provided by [project :buildC:c1, project :buildC:nested:c1].")
+        failure.assertHasCause("Module version 'org.test:c1:1.0' is not unique in composite: can be provided by [project ':buildC:c1', project ':buildC:nested:c1'].")
     }
 
     def "reports failure to resolve dependencies when transitive dependency substitution is ambiguous"() {
@@ -593,7 +593,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         checkDependenciesFails()
 
         then:
-        failure.assertHasCause("Module version 'org.test:b1:2.0' is not unique in composite: can be provided by [project :buildB:b1, project :buildC:b1].")
+        failure.assertHasCause("Module version 'org.test:b1:2.0' is not unique in composite: can be provided by [project ':buildB:b1', project ':buildC:b1'].")
     }
 
     def "resolve transitive project dependency that is ambiguous in the composite"() {
@@ -675,7 +675,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         checkDependenciesFails()
 
         then: "Build C does not have any configurations defined, and thus no variants exist"
-        failure.assertHasCause("""No matching variant of project :buildC was found. The consumer was configured to find a library for use during runtime, compatible with Java ${JavaVersion.current().majorVersion}, packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally but:
+        failure.assertHasCause("""No matching variant of project ':buildC' was found. The consumer was configured to find a library for use during runtime, compatible with Java ${JavaVersion.current().majorVersion}, packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally but:
   - No variants exist.""")
     }
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
@@ -70,8 +70,8 @@ class CompositeBuildIdentityIntegrationTest extends AbstractCompositeBuildIntegr
         then:
         outputContains("""
 runtimeClasspath - Runtime classpath of source set 'main'.
-\\--- org.test:${dependencyName}:1.0 -> project :${buildName}
-     \\--- project :${buildName}:b1
+\\--- org.test:${dependencyName}:1.0 -> project ':${buildName}'
+     \\--- project ':${buildName}:b1'
 """)
 
         where:
@@ -168,7 +168,7 @@ Required by:
 
                 selectors = buildRootProject.dependencies.requested
                 assert selectors.size() == 1
-                assert selectors[0].displayName == 'project :${buildName}:b1'
+                assert selectors[0].displayName == 'project \\':${buildName}:b1\\''
                 assert selectors[0].buildPath == ':${buildName}'
                 assert selectors[0].projectPath == ':b1'
             }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/project/ProjectIdentity.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/project/ProjectIdentity.java
@@ -119,11 +119,7 @@ public final class ProjectIdentity implements DisplayName {
         this.projectName = projectName;
 
         this.buildTreePath = computeProjectIdentityPath(buildPath, projectPath);
-
-        // TODO: This is inconsistent with DefaultProject.getDisplayName.
-        // We should change this to match that of DefaultProject.
-        String prefix = Path.ROOT.equals(buildTreePath) ? "root project" : "project";
-        this.displayName = Describables.memoize(Describables.of(prefix, buildTreePath.asString()));
+        this.displayName = computeDisplayName(buildTreePath, projectName);
     }
 
     /**
@@ -156,6 +152,13 @@ public final class ProjectIdentity implements DisplayName {
         return projectName;
     }
 
+    /**
+     * Returns the display name of this project in a human-readable format.
+     * <ul>
+     *     <li>For the root project: {@code root project 'projectName'}</li>
+     *     <li>For subprojects: {@code project ':identity:path:of:project'}</li>
+     * </ul>
+     */
     @Override
     public String getDisplayName() {
         return displayName.getDisplayName();
@@ -188,4 +191,11 @@ public final class ProjectIdentity implements DisplayName {
         return buildTreePath.hashCode();
     }
 
+    private static DisplayName computeDisplayName(Path buildTreePath, String projectName) {
+        return Describables.memoize(
+            Path.ROOT.equals(buildTreePath)
+                ? Describables.withTypeAndName("root project", projectName)
+                : Describables.withTypeAndName("project", buildTreePath.asString())
+        );
+    }
 }

--- a/subprojects/core-api/src/test/groovy/org/gradle/api/internal/project/ProjectIdentityTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/api/internal/project/ProjectIdentityTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project
+
+import org.gradle.util.Path
+import spock.lang.Specification
+
+class ProjectIdentityTest extends Specification {
+
+    // This display name format is what Project.toString() and Project.getDisplayName() produce.
+    // Changing it affects user-visible output in logs, error messages, and dependency reports.
+
+    def "root project of root build has display name with project name"() {
+        def identity = ProjectIdentity.forRootProject(Path.ROOT, "myApp")
+
+        expect:
+        identity.displayName == "root project 'myApp'"
+        identity.toString() == "root project 'myApp'"
+        identity.capitalizedDisplayName == "Root project 'myApp'"
+    }
+
+    def "subproject of root build has display name with identity path"() {
+        def identity = ProjectIdentity.forSubproject(Path.ROOT, Path.path(":sub"))
+
+        expect:
+        identity.displayName == "project ':sub'"
+        identity.toString() == "project ':sub'"
+        identity.capitalizedDisplayName == "Project ':sub'"
+    }
+
+    def "root project of included build has display name with build tree path"() {
+        def identity = ProjectIdentity.forRootProject(Path.path(":included"), "includedApp")
+
+        expect:
+        identity.displayName == "project ':included'"
+        identity.toString() == "project ':included'"
+    }
+
+    def "subproject of included build has display name with full identity path"() {
+        def identity = ProjectIdentity.forSubproject(Path.path(":included"), Path.path(":sub"))
+
+        expect:
+        identity.displayName == "project ':included:sub'"
+        identity.toString() == "project ':included:sub'"
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractDirectorySensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractDirectorySensitivityIntegrationSpec.groovy
@@ -22,7 +22,7 @@ import org.gradle.internal.fingerprint.DirectorySensitivity
 
 abstract class AbstractDirectorySensitivityIntegrationSpec extends AbstractIntegrationSpec {
 
-    public static final String TRANSFORM_EXECUTED = 'Transform bar.zip (project :bar) with AugmentTransform'
+    public static final String TRANSFORM_EXECUTED = "Transform bar.zip (project ':bar') with AugmentTransform"
 
     abstract void execute(String... tasks)
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractLineEndingSensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractLineEndingSensitivityIntegrationSpec.groovy
@@ -26,7 +26,7 @@ import java.lang.annotation.Annotation
 abstract class AbstractLineEndingSensitivityIntegrationSpec extends AbstractIntegrationSpec {
     private static final byte[] BINARY_CONTENT_WITH_LF = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0xff, 0xda, 0x0a] as byte[]
     private static final byte[] BINARY_CONTENT_WITH_CRLF = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0xff, 0xda, 0x0d, 0x0a] as byte[]
-    public static final String TRANSFORM_EXECUTED = 'Transform producer.zip (project :producer) with AugmentTransform'
+    public static final String TRANSFORM_EXECUTED = "Transform producer.zip (project ':producer') with AugmentTransform"
     public static final String TEXT_WITH_LINE_ENDINGS = "\nhere's a line\nhere's another line\n\n"
 
     def setup() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
@@ -69,8 +69,8 @@ class BuildSrcIdentityIntegrationTest extends AbstractIntegrationSpec {
         then:
         outputContains("""
 runtimeClasspath - Runtime classpath of source set 'main'.
-\\--- project :buildSrc:b1
-     \\--- project :buildSrc:b2
+\\--- project ':buildSrc:b1'
+     \\--- project ':buildSrc:b2'
 """)
 
         where:
@@ -182,7 +182,7 @@ Required by:
 
                 def selectors = configurations.runtimeClasspath.incoming.resolutionResult.allDependencies.requested
                 assert selectors.size() == 1
-                assert selectors[0].displayName == 'project :buildSrc:a'
+                assert selectors[0].displayName == "project ':buildSrc:a'"
                 assert selectors[0].buildPath == ':buildSrc'
                 assert selectors[0].projectPath == ':a'
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -878,16 +878,10 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     /**
      * Returns the display name of this project in a human-readable format.
-     * <p>
-     * Currently:
-     * <ul>
-     *     <li>For the root project: {@code root project 'projectName'}</li>
-     *     <li>For subprojects: {@code project ':identity:path:of:project'}</li>
-     * </ul>
      */
     @Override
     public String getDisplayName() {
-        return owner.getDisplayName().getDisplayName();
+        return getProjectIdentity().getDisplayName();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.initialization.ProjectDescriptorInternal;
 import org.gradle.initialization.ProjectDescriptorRegistry;
-import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factory;
 import org.gradle.internal.build.AllProjectsAccess;
@@ -314,12 +313,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
         @Override
         public DisplayName getDisplayName() {
-            Path identityPath = identity.getBuildTreePath();
-            if (identityPath.equals(Path.ROOT)) {
-                return Describables.withTypeAndName("root project", identity.getProjectName());
-            } else {
-                return Describables.withTypeAndName("project", identityPath.asString());
-            }
+            return identity;
         }
 
         @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifierTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/DefaultProjectComponentIdentifierTest.groovy
@@ -29,9 +29,9 @@ class DefaultProjectComponentIdentifierTest extends Specification {
         then:
         id.projectPath == ':subproject'
         id.projectName == 'subproject'
-        id.displayName == 'project :build:subproject'
+        id.displayName == "project ':build:subproject'"
         id.buildTreePath == ':build:subproject'
-        id.toString() == 'project :build:subproject'
+        id.toString() == "project ':build:subproject'"
     }
 
     def "can compare with other instance (#projectPath)"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -152,43 +152,43 @@ class DefaultProjectSpec extends Specification {
         def nestedChild2 = project("child2", nestedChild1, nestedBuild)
 
         expect:
-        rootProject.toString() == rootProject.owner.displayName.toString()
-        rootProject.displayName == rootProject.owner.displayName.toString()
+        rootProject.toString() == "root project 'root'"
+        rootProject.displayName == "root project 'root'"
         rootProject.path == ":"
         rootProject.buildTreePath == ':'
         rootProject.identityPath == Path.ROOT
         rootProject.projectIdentity == rootProject.owner.identity
 
-        child1.toString() == child1.owner.displayName.toString()
-        child1.displayName == child1.owner.displayName.toString()
+        child1.toString() == "project ':child1'"
+        child1.displayName == "project ':child1'"
         child1.path == ":child1"
         child1.buildTreePath == ":child1"
         child1.identityPath == Path.path(":child1")
         child1.projectIdentity == child1.owner.identity
 
-        child2.toString() == child2.owner.displayName.toString()
-        child2.displayName == child2.owner.displayName.toString()
+        child2.toString() == "project ':child1:child2'"
+        child2.displayName == "project ':child1:child2'"
         child2.path == ":child1:child2"
         child2.buildTreePath == ":child1:child2"
         child2.identityPath == Path.path(":child1:child2")
         child2.projectIdentity == child2.owner.identity
 
-        nestedRootProject.toString() == nestedRootProject.owner.displayName.toString()
-        nestedRootProject.displayName == nestedRootProject.owner.displayName.toString()
+        nestedRootProject.toString() == "project ':nested'"
+        nestedRootProject.displayName == "project ':nested'"
         nestedRootProject.path == ":"
         nestedRootProject.buildTreePath == ":nested"
         nestedRootProject.identityPath == Path.path(":nested")
         nestedRootProject.projectIdentity == nestedRootProject.owner.identity
 
-        nestedChild1.toString() == nestedChild1.owner.displayName.toString()
-        nestedChild1.displayName == nestedChild1.owner.displayName.toString()
+        nestedChild1.toString() == "project ':nested:child1'"
+        nestedChild1.displayName == "project ':nested:child1'"
         nestedChild1.path == ":child1"
         nestedChild1.buildTreePath == ":nested:child1"
         nestedChild1.identityPath == Path.path(":nested:child1")
         nestedChild1.projectIdentity == nestedChild1.owner.identity
 
-        nestedChild2.toString() == nestedChild2.owner.displayName.toString()
-        nestedChild2.displayName == nestedChild2.owner.displayName.toString()
+        nestedChild2.toString() == "project ':nested:child1:child2'"
+        nestedChild2.displayName == "project ':nested:child1:child2'"
         nestedChild2.path == ":child1:child2"
         nestedChild2.buildTreePath == ":nested:child1:child2"
         nestedChild2.identityPath == Path.path(":nested:child1:child2")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -596,7 +596,7 @@ class DefaultProjectTest extends Specification {
         project.project(Project.PATH_SEPARATOR + "unknownchild")
         then:
         def e = thrown(UnknownProjectException)
-        e.message == "Project with path ':unknownchild' could not be found in displayname."
+        e.message == "Project with path ':unknownchild' could not be found in root project 'root'."
     }
 
     def getProjectWithUnknownRelativePath() {
@@ -604,7 +604,7 @@ class DefaultProjectTest extends Specification {
         project.project("unknownchild")
         then:
         def e = thrown(UnknownProjectException)
-        e.message == "Project with path 'unknownchild' could not be found in displayname."
+        e.message == "Project with path 'unknownchild' could not be found in root project 'root'."
     }
 
     def getProjectWithEmptyPath() {
@@ -898,7 +898,7 @@ def scriptMethod(Closure closure) {
         project.name = "someNewName"
         then:
         def e = thrown(GroovyRuntimeException)
-        e.message == "Cannot set the value of read-only property 'name' for displayname of type ${Project.name}."
+        e.message == "Cannot set the value of read-only property 'name' for root project 'root' of type ${Project.name}."
     }
 
     def convertsAbsolutePathToAbsolutePath() {

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/PluginConfigurationAttributesIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/PluginConfigurationAttributesIntegrationTest.groovy
@@ -49,7 +49,7 @@ class PluginConfigurationAttributesIntegrationTest extends AbstractIntegrationSp
 
         then:
         fails("test")
-        result.assertHasErrorOutput("A dependency was declared on configuration '$configuration' of 'project :producer' but no variant with that configuration name exists.")
+        result.assertHasErrorOutput("A dependency was declared on configuration '$configuration' of 'project ':producer'' but no variant with that configuration name exists.")
 
         where:
         plugin       | configuration

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -672,9 +672,10 @@ class ResolveTestFixture {
 
         private NodeBuilder projectNode(String projectIdentityPath, String moduleVersion) {
             if (Objects.equals(Path.path(projectIdentityPath), Path.ROOT)) {
-                return node("project:$projectIdentityPath", "root project $projectIdentityPath", moduleVersion)
+                def projectName = moduleVersion.split(':')[1]
+                return node("project:$projectIdentityPath", "root project '$projectName'", moduleVersion)
             } else {
-                return node("project:$projectIdentityPath", "project $projectIdentityPath", moduleVersion)
+                return node("project:$projectIdentityPath", "project '$projectIdentityPath'", moduleVersion)
             }
         }
 


### PR DESCRIPTION
This allows for uniformly presenting the project display name, regardless of the relevant type being used:
- ProjectIdentity
- ProjectState
- Project

This is **not a breaking change** as the display name of the component identifier is not a public contract.

The changeset is large mainly due to the fact that `ProjectComponentIdentifier.getDisplayName()` was producing a string that was not aligned with that of `Project`'s display name, and the component identifier's display name was used in a lot of tests and fixtures for assertions.