### PR TITLE
Fix issue with non-imperative script not attaching project feature context

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ProjectReportTaskIntegrationTest.groovy
+++ b/platforms/core-configuration/base-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ProjectReportTaskIntegrationTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForIsolatedProjects
 import org.gradle.internal.declarativedsl.settings.ProjectTypeFixture
 import org.gradle.util.internal.TextUtil
+import spock.lang.Issue
 
 /**
  * Integration tests for the `:projects` task, which reports the project structure and project types.
@@ -522,5 +523,15 @@ For example, try running gradle :common:tasks
 To see a list of the tasks of a project, run gradle <project-path>:tasks
 For example, try running gradle :tasks
 """
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37045")
+    def "reports projects when root project has no imperative statements"() {
+        buildFile << """
+            void foo() { }
+        """
+
+        expect:
+        succeeds "projects"
     }
 }

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ProjectReportTask.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ProjectReportTask.java
@@ -18,7 +18,6 @@ package org.gradle.api.tasks.diagnostics;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
-import org.gradle.api.internal.project.DefaultProject;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectOrderingUtil;
 import org.gradle.api.tasks.diagnostics.internal.ProjectDetails;
@@ -130,7 +129,10 @@ public abstract class ProjectReportTask extends AbstractProjectBasedReportTask<P
 
     private static List<ProjectFeatureImplementation<?, ?>> getProjectTypesFor(Project project) {
         List<ProjectFeatureImplementation<?, ?>> results = new ArrayList<>(1);
-        results.addAll(ProjectFeatureSupportInternal.getContext((DefaultProject) project).childrenDefinitions().keySet());
+        ProjectFeatureSupportInternal.ProjectFeatureDefinitionContext featureDefinitionContext = ProjectFeatureSupportInternal.tryGetContext(project);
+        if (featureDefinitionContext != null) {
+            results.addAll(featureDefinitionContext.childrenDefinitions().keySet());
+        }
         return results;
     }
 


### PR DESCRIPTION
When a build script has no imperative statements, we defer script execution.  However, the `ProjectReportTask.getProjectTypesFor()` method gets called before the script actually executes, which means that the feature context object has not been attached yet.  

Since applying a project type would be an imperative statement, we should never hit this case when a project type is applied.  So we can simply check if the context exists in `getProjectTypesFor()` and move on if it doesn't.

Fixes #37045. 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
