### PR TITLE
Add sync-only Isolated Projects flag

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParametersProvider.kt
@@ -98,6 +98,7 @@ object BuildModelParametersProvider {
             // TODO:isolated should this also disable IP?
             ccDisabledReason != null -> vintageMode(requirements, startParameter, options, ccDisabledReason)
             startParameter.isolatedProjects.get() -> isolatedProjectsMode(requirements, startParameter, options)
+            startParameter.isolatedProjectsSync.get() -> isolatedProjectsSyncMode(requirements, startParameter, options)
             startParameter.configurationCache.get() ->
                 if (requirements.isCreatesModel) {
                     // CC by itself does not yet support caching models or caching of the work graph that runs before model building
@@ -231,6 +232,26 @@ object BuildModelParametersProvider {
                 modelAsProjectDependency = false,
                 resilientModelBuilding = false
             )
+        }
+    }
+
+    private
+    fun isolatedProjectsSyncMode(
+        requirements: BuildActionModelRequirements,
+        startParameter: StartParameterInternal,
+        options: InternalOptions
+    ): BuildModelParameters {
+
+        if (!startParameter.configurationCache.get() && startParameter.configurationCache.isExplicit) {
+            throw GradleException("Configuration Cache cannot be disabled when Isolated Projects is enabled.")
+        }
+
+        return if (requirements.isCreatesModel) {
+            // Sync: use full Isolated Projects mode
+            isolatedProjectsMode(requirements, startParameter, options)
+        } else {
+            // Build: use Configuration Cache mode (CC is implicitly enabled by this flag)
+            configurationCacheTasksOnlyMode(requirements, startParameter, options)
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
@@ -435,6 +435,103 @@ class BuildModelParametersProviderTest extends Specification {
         value << ['true', 'tasks']
     }
 
+    def "parameters when isolated projects sync is enabled for building models"() {
+        given:
+        def params = parameters(runsTasks: false, createsModel: true) {
+            isolatedProjectsSync = Option.Value.value(true)
+        }
+
+        expect:
+        checkParameters(params.toDisplayMap(), defaults() + [
+            modelBuilding: true,
+            parallelProjectExecution: true,
+            configurationCache: true,
+            configurationCacheParallelStore: true,
+            configurationCacheParallelLoad: true,
+            isolatedProjects: true,
+            parallelProjectConfiguration: true,
+            parallelModelBuilding: true,
+            invalidateCoupledProjects: true,
+            modelAsProjectDependency: true
+        ])
+    }
+
+    def "parameters when isolated projects sync is enabled for running tasks"() {
+        given:
+        def params = parameters(runsTasks: true, createsModel: false) {
+            isolatedProjectsSync = Option.Value.value(true)
+        }
+
+        expect:
+        checkParameters(params.toDisplayMap(), defaults() + [
+            configurationCache: true,
+            configurationCacheParallelLoad: true,
+        ])
+    }
+
+    def "parameters when isolated projects sync is enabled for running tasks and building models"() {
+        given:
+        def params = parameters(runsTasks: true, createsModel: true) {
+            isolatedProjectsSync = Option.Value.value(true)
+        }
+
+        expect:
+        checkParameters(params.toDisplayMap(), defaults() + [
+            modelBuilding: true,
+            parallelProjectExecution: true,
+            configurationCache: true,
+            configurationCacheParallelStore: true,
+            configurationCacheParallelLoad: true,
+            isolatedProjects: true,
+            parallelProjectConfiguration: true,
+            parallelModelBuilding: true,
+            invalidateCoupledProjects: true,
+            modelAsProjectDependency: true
+        ])
+    }
+
+    def "configuration cache cannot be disabled when isolated projects sync enabled"() {
+        when:
+        parameters(runsTasks: true, createsModel: false) {
+            isolatedProjectsSync = Option.Value.value(true)
+            configurationCache = Option.Value.value(false)
+        }
+
+        then:
+        def e = thrown(GradleException)
+        e.message == "Configuration Cache cannot be disabled when Isolated Projects is enabled."
+    }
+
+    def "isolated projects sync does not enable isolated projects for builds"() {
+        given:
+        def params = parameters(runsTasks: true, createsModel: false) {
+            isolatedProjectsSync = Option.Value.value(true)
+        }
+
+        expect:
+        !params.isIsolatedProjects()
+        params.isConfigurationCache()
+    }
+
+    def "full isolated projects flag takes precedence over sync-only flag"() {
+        given:
+        def params = parameters(runsTasks: true, createsModel: false) {
+            isolatedProjects = Option.Value.value(true)
+            isolatedProjectsSync = Option.Value.value(true)
+        }
+
+        expect:
+        checkParameters(params.toDisplayMap(), defaults() + [
+            parallelProjectExecution: true,
+            configurationCache: true,
+            configurationCacheParallelStore: true,
+            configurationCacheParallelLoad: true,
+            isolatedProjects: true,
+            parallelProjectConfiguration: true,
+            invalidateCoupledProjects: true,
+        ])
+    }
+
     def "configuration cache cannot be disabled when isolated projects enabled"() {
         when:
         parameters(runsTasks: true, createsModel: false) {

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -142,6 +142,7 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isVfsVerboseLogging());
             valueSerializer.write(encoder, startParameter.getConfigurationCache());
             valueSerializer.write(encoder, startParameter.getIsolatedProjects());
+            valueSerializer.write(encoder, startParameter.getIsolatedProjectsSync());
             encoder.writeString(startParameter.getConfigurationCacheProblems().name());
             encoder.writeBoolean(startParameter.isConfigurationCacheIgnoreInputsDuringStore());
             encoder.writeBoolean(startParameter.isConfigurationCacheIgnoreUnsupportedBuildEventsListeners());
@@ -241,6 +242,7 @@ public class BuildActionSerializer {
             startParameter.setVfsVerboseLogging(decoder.readBoolean());
             startParameter.setConfigurationCache(valueSerializer.read(decoder));
             startParameter.setIsolatedProjects(valueSerializer.read(decoder));
+            startParameter.setIsolatedProjectsSync(valueSerializer.read(decoder));
             startParameter.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.valueOf(decoder.readString()));
             startParameter.setConfigurationCacheIgnoreInputsDuringStore(decoder.readBoolean());
             startParameter.setConfigurationCacheIgnoreUnsupportedBuildEventsListeners(decoder.readBoolean());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -37,6 +37,7 @@ public class StartParameterInternal extends StartParameter {
 
     private Option.Value<Boolean> configurationCache = Option.Value.defaultValue(false);
     private Option.Value<Boolean> isolatedProjects = Option.Value.defaultValue(false);
+    private Option.Value<Boolean> isolatedProjectsSync = Option.Value.defaultValue(false);
     private ConfigurationCacheProblemsOption.Value configurationCacheProblems = ConfigurationCacheProblemsOption.Value.FAIL;
     private boolean configurationCacheDebug;
     private boolean configurationCacheIgnoreInputsDuringStore = false;
@@ -85,6 +86,7 @@ public class StartParameterInternal extends StartParameter {
         p.vfsVerboseLogging = vfsVerboseLogging;
         p.configurationCache = configurationCache;
         p.isolatedProjects = isolatedProjects;
+        p.isolatedProjectsSync = isolatedProjectsSync;
         p.configurationCacheProblems = configurationCacheProblems;
         p.configurationCacheMaxProblems = configurationCacheMaxProblems;
         p.configurationCacheIgnoredFileSystemCheckInputs = configurationCacheIgnoredFileSystemCheckInputs;
@@ -189,6 +191,14 @@ public class StartParameterInternal extends StartParameter {
 
     public void setIsolatedProjects(Option.Value<Boolean> isolatedProjects) {
         this.isolatedProjects = isolatedProjects;
+    }
+
+    public Option.Value<Boolean> getIsolatedProjectsSync() {
+        return isolatedProjectsSync;
+    }
+
+    public void setIsolatedProjectsSync(Option.Value<Boolean> isolatedProjectsSync) {
+        this.isolatedProjectsSync = isolatedProjectsSync;
     }
 
     public ConfigurationCacheProblemsOption.Value getConfigurationCacheProblems() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -90,6 +90,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         new ConfigurationCacheHeapDumpDir(),
         new ConfigurationCacheFineGrainedPropertyTracking(),
         new IsolatedProjectsOption(),
+        new IsolatedProjectsSyncOption(),
         new ProblemReportGenerationOption(),
         new PropertyUpgradeReportOption(),
         new TaskGraphOption(),
@@ -685,6 +686,19 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         @Override
         public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
             settings.setIsolatedProjects(Option.Value.value(value));
+        }
+    }
+
+    public static class IsolatedProjectsSyncOption extends BooleanBuildOption<StartParameterInternal> {
+        public static final String PROPERTY_NAME = "org.gradle.unsafe.isolated-projects.sync";
+
+        public IsolatedProjectsSyncOption() {
+            super(PROPERTY_NAME);
+        }
+
+        @Override
+        public void applyTo(boolean value, StartParameterInternal settings, Origin origin) {
+            settings.setIsolatedProjectsSync(Option.Value.value(value));
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `org.gradle.unsafe.isolated-projects.sync` build option that enables Isolated Projects for IDE sync (model building) while leaving regular builds unaffected
- Sync operations (`isCreatesModel=true`) use full IP mode; build operations (`isRunsTasks=true`) use Configuration Cache mode only
- Same CC validation as full IP: Configuration Cache cannot be explicitly disabled when this flag is enabled
- Full IP flag takes precedence when both are set

## Motivation
This provides a migration path toward full Isolated Projects adoption. Users can benefit from IP during IDE sync without requiring their entire build to be IP-compliant.

## Test plan
- [x] Unit tests in `BuildModelParametersProviderTest` covering sync, build, mixed, CC validation, precedence, and isolation verification
- [x] Manual verification: flag detected from `gradle.properties`
- [x] Manual verification: builds use CC mode (no IP)
- [x] Manual verification: sync activates IP mode with "Isolated Projects is an incubating feature." message
- [x] Manual verification: `--no-configuration-cache` correctly fails with CC validation error
- [x] Manual verification: cross-project access violation detected during sync

Fixes https://github.com/gradle/gradle/issues/37026

Signed-off-by: Paul Hundal <paulhundal530@gmail.com>