### PR TITLE
Reduce ClassNotFoundException overhead in classloader hierarchy

### DIFF
--- a/platforms/core-execution/worker-process-services/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
+++ b/platforms/core-execution/worker-process-services/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
@@ -28,6 +28,7 @@ import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.classloader.ClassLoaderHierarchy;
+import org.gradle.internal.classloader.ClassNotFoundExceptionNoStackTrace;
 import org.gradle.internal.classloader.ClassLoaderSpec;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classloader.ClassLoaderVisitor;
@@ -148,6 +149,7 @@ public class WorkerProcessClassPathProvider implements ClassPathProvider {
                 BootstrapSecurityManager.class,
                 EncodedStream.EncodedInput.class,
                 ClassLoaderUtils.class,
+                ClassNotFoundExceptionNoStackTrace.class,
                 FilteringClassLoader.class,
                 FilteringClassLoader.Action.class,
                 FilteringClassLoader.Trie.Builder.class,

--- a/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/CachingClassLoader.java
+++ b/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/CachingClassLoader.java
@@ -50,7 +50,7 @@ public class CachingClassLoader extends ClassLoader implements DelegatingClassLo
         if (cachedValue instanceof Class) {
             return (Class<?>) cachedValue;
         } else if (cachedValue == MISSING) {
-            throw new ClassNotFoundException(name);
+            throw new ClassNotFoundExceptionNoStackTrace(name);
         }
         Class<?> result;
         try {

--- a/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/ClassNotFoundExceptionNoStackTrace.java
+++ b/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/ClassNotFoundExceptionNoStackTrace.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classloader;
+
+/**
+ * A ClassNotFoundException that skips filling in the stack trace for performance.
+ * Used in classloader negative caching where the exception is caught and ignored
+ * by the caller, making the stack trace unnecessary overhead.
+ */
+public class ClassNotFoundExceptionNoStackTrace extends ClassNotFoundException {
+    public ClassNotFoundExceptionNoStackTrace(String name) {
+        super(name);
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/platforms/core-runtime/classloaders/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -89,22 +89,24 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
 
     @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (classAllowed(name)) {
+            // Class is in our allowed set — super.loadClass() handles parent delegation
+            // (which includes the platform classloader), so no need to try EXT_CLASS_LOADER separately
+            Class<?> cl = super.loadClass(name, false);
+            if (resolve) {
+                resolveClass(cl);
+            }
+            return cl;
+        }
+
+        // Not in allowed set — check if it's a system/platform class
         try {
             return EXT_CLASS_LOADER.loadClass(name);
         } catch (ClassNotFoundException ignore) {
             // ignore
         }
 
-        if (!classAllowed(name)) {
-            throw new ClassNotFoundException(name + " not found.");
-        }
-
-        Class<?> cl = super.loadClass(name, false);
-        if (resolve) {
-            resolveClass(cl);
-        }
-
-        return cl;
+        throw new ClassNotFoundExceptionNoStackTrace(name + " not found.");
     }
 
     @Nullable


### PR DESCRIPTION
Avoid filling stack traces for ClassNotFoundExceptions that are caught and ignored by callers. CachingClassLoader negative cache hits and FilteringClassLoader rejections now throw a lightweight exception. FilteringClassLoader also reorders its logic to skip the EXT_CLASS_LOADER attempt for classes in the allowed set, eliminating ~90% of CNFE throws.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
