### PR TITLE
Print all params of slow SQL to troubleshoot

### DIFF
--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy
@@ -58,6 +58,24 @@ abstract class AbstractWritableResultsStore<T extends PerformanceTestResult> imp
         return String.join(' or ', Collections.nCopies(channelPatterns.size(), "channel like ?"))
     }
 
+    protected static List<Object> createHistoryQueryParams(
+        PerformanceExperiment experiment,
+        Timestamp minDate,
+        List<String> channelPatterns,
+        List<String> teamcityBuildIds,
+        int mostRecentN
+    ) {
+        List<Object> params = new ArrayList<>(5 + channelPatterns.size() + teamcityBuildIds.size())
+        params.add(experiment.getScenario().getClassName())
+        params.add(experiment.getScenario().getTestName())
+        params.add(experiment.getTestProject())
+        params.add(minDate)
+        params.addAll(channelPatterns)
+        params.addAll(teamcityBuildIds)
+        params.add(mostRecentN)
+        return params
+    }
+
     @Override
     public Map<PerformanceExperimentOnOs, Long> getEstimatedExperimentDurationsInMillis() {
         return this.<Map<PerformanceExperimentOnOs, Long>>withConnection("load estimated runtimes") { connection ->

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -187,6 +187,7 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
                     executionsForName.setString(++idx, teamcityBuildId);
                 }
                 executionsForName.setInt(++idx, mostRecentN);
+                List<Object> executionsForNameParams = createHistoryQueryParams(experiment, minDate, channelPatterns, teamcityBuildIds, mostRecentN);
                 long executionsForNameStartTime = System.currentTimeMillis();
                 ResultSet executionsForNameRs = null;
                 try (ResultSet testExecutions = executionsForName.executeQuery()) {
@@ -242,7 +243,7 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
                     }
                     return new CrossBuildPerformanceTestHistory(experiment, ImmutableList.copyOf(builds), results);
                 } finally {
-                    PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("executionsForName", executionsForNameSql, List.of(experiment.getScenario().getClassName(),  experiment.getScenario().getTestName(), experiment.getTestProject(), minDate), executionsForNameRs, executionsForNameStartTime).toJson());
+                    PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("executionsForName", executionsForNameSql, executionsForNameParams, executionsForNameRs, executionsForNameStartTime).toJson());
                 }
             }
         });

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -268,6 +268,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                     executionsForName.setString(++idx, teamcityBuildId);
                 }
                 executionsForName.setInt(++idx, mostRecentN);
+                List<Object> executionsForNameParams = createHistoryQueryParams(experiment, minDate, channelPatterns, teamcityBuildIds, mostRecentN);
 
                 long executionsForNameStartTime = System.currentTimeMillis();
                 ResultSet executionsForNameRs = null;
@@ -299,7 +300,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                         allBranches.add(performanceResults.getVcsBranch());
                     }
                 } finally {
-                    PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("executionsForName", executionsForNameSql, List.of(experiment.getScenario().getClassName(), experiment.getScenario().getTestName(), experiment.getTestProject(), minDate), executionsForNameRs, executionsForNameStartTime).toJson());
+                    PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("executionsForName", executionsForNameSql, executionsForNameParams, executionsForNameRs, executionsForNameStartTime).toJson());
                 }
 
                 operationsForExecution.setFetchSize(10 * results.size());
@@ -315,6 +316,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                     operationsForExecution.setString(++idx, teamcityBuildId);
                 }
                 operationsForExecution.setInt(++idx, mostRecentN);
+                List<Object> operationsForExecutionParams = createHistoryQueryParams(experiment, minDate, channelPatterns, teamcityBuildIds, mostRecentN);
 
                 long operationsForExecutionStartTime = System.currentTimeMillis();
                 ResultSet operationsForExecutionRs = null;
@@ -338,7 +340,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                         }
                     }
                 } finally {
-                    PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("operationsForExecution", operationsForExecutionSql, List.of(experiment.getScenario().getClassName(), experiment.getScenario().getTestName(), experiment.getTestProject(), minDate), operationsForExecutionRs, operationsForExecutionStartTime).toJson());
+                    PerformanceDatabase.logProfilingWithCallStack(SQLProfilingData.create("operationsForExecution", operationsForExecutionSql, operationsForExecutionParams, operationsForExecutionRs, operationsForExecutionStartTime).toJson());
                 }
                 return new CrossVersionPerformanceTestHistory(experiment, new ArrayList<>(allVersions), new ArrayList<>(allBranches), Lists.newArrayList(results.values()));
             }


### PR DESCRIPTION
Can help with https://github.com/gradle/gradle-private/issues/5000

This query keeps being slow (~24s) even after we built a index. Print all params in profiling log to help us troubleshoot.