### PR TITLE
Optimize slow queries

### DIFF
--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy
@@ -19,6 +19,8 @@ package org.gradle.performance.results
 import com.google.common.collect.ImmutableMap
 import groovy.transform.CompileStatic
 
+import java.sql.PreparedStatement
+import java.sql.SQLException
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
@@ -58,6 +60,96 @@ abstract class AbstractWritableResultsStore<T extends PerformanceTestResult> imp
         return String.join(' or ', Collections.nCopies(channelPatterns.size(), "channel like ?"))
     }
 
+    protected static List<String> distinctValues(List<String> values) {
+        return new ArrayList<>(new LinkedHashSet<>(values))
+    }
+
+    /**
+     * Builds a UNION-based history query for testExecution lookups.
+     *
+     * Why this exists:
+     * - The old single-query form used one large OR predicate:
+     *   {@code (... channel like ? ... OR teamcitybuildid in (...))}.
+     * - On MySQL, that shape can trigger unstable plans (e.g. broad startTime scans).
+     * - Splitting into two selective branches and joining with {@code UNION DISTINCT}
+     *   gives the optimizer a more predictable path.
+     *
+     * Query shape produced:
+     * - Channel branch (only when {@code channelPatterns} is non-empty):
+     *   {@code select <columns> from testExecution ... and (channel like ? or ...)}
+     * - Build ID branch (only when {@code teamcityBuildIds} is non-empty):
+     *   {@code select <columns> from testExecution ... and teamcitybuildid in (?, ...)}
+     * - Branches are combined using {@code union distinct}.
+     *
+     * Parameter binding contract:
+     * - This method only generates SQL text.
+     * - Parameter order is defined by {@link #bindHistoryQueryParams}:
+     *   1) channel branch fixed params + channel patterns
+     *   2) build-id branch fixed params + build IDs
+     *   3) any outer query params (e.g. LIMIT) are bound by callers.
+     *
+     * Edge cases:
+     * - If both lists are empty, returns a no-op query
+     *   ({@code select ... from testExecution where 1 = 0}) to keep SQL valid.
+     */
+    protected static String createHistoryFilterUnionSql(String selectColumns, List<String> channelPatterns, List<String> teamcityBuildIds) {
+        String baseSqlTemplate = """
+            select %s
+            from testExecution
+            where testClass = ?
+              and testId = ?
+              and testProject = ?
+              and startTime >= ?
+              and %s
+            """
+        List<String> branches = new ArrayList<>(2)
+        if (!channelPatterns.isEmpty()) {
+            branches.add(baseSqlTemplate.formatted(selectColumns, "(${channelPatternQueryFor(channelPatterns)})"))
+        }
+        if (!teamcityBuildIds.isEmpty()) {
+            String teamCityBuildIdInClause = "teamcitybuildid in (${String.join(',', Collections.nCopies(teamcityBuildIds.size(), '?'))})"
+            branches.add(baseSqlTemplate.formatted(selectColumns, teamCityBuildIdInClause))
+        }
+        if (branches.isEmpty()) {
+            return """
+                select ${selectColumns}
+                from testExecution
+                where 1 = 0
+                """
+        }
+        return String.join(" union distinct ", branches)
+    }
+
+    protected static void bindHistoryQueryParams(
+        PreparedStatement statement,
+        PerformanceExperiment experiment,
+        Timestamp minDate,
+        List<String> channelPatterns,
+        List<String> teamcityBuildIds,
+        int mostRecentN
+    ) throws SQLException {
+        int idx = 0
+        if (!channelPatterns.isEmpty()) {
+            statement.setString(++idx, experiment.getScenario().getClassName())
+            statement.setString(++idx, experiment.getScenario().getTestName())
+            statement.setString(++idx, experiment.getTestProject())
+            statement.setTimestamp(++idx, minDate)
+            for (String channelPattern : channelPatterns) {
+                statement.setString(++idx, channelPattern)
+            }
+        }
+        if (!teamcityBuildIds.isEmpty()) {
+            statement.setString(++idx, experiment.getScenario().getClassName())
+            statement.setString(++idx, experiment.getScenario().getTestName())
+            statement.setString(++idx, experiment.getTestProject())
+            statement.setTimestamp(++idx, minDate)
+            for (String teamcityBuildId : teamcityBuildIds) {
+                statement.setString(++idx, teamcityBuildId)
+            }
+        }
+        statement.setInt(++idx, mostRecentN)
+    }
+
     protected static List<Object> createHistoryQueryParams(
         PerformanceExperiment experiment,
         Timestamp minDate,
@@ -74,6 +166,19 @@ abstract class AbstractWritableResultsStore<T extends PerformanceTestResult> imp
         params.addAll(teamcityBuildIds)
         params.add(mostRecentN)
         return params
+    }
+
+    protected static Boolean toNullableBoolean(Object value) {
+        if (value == null) {
+            return null
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue() != 0
+        }
+        return Boolean.valueOf(value.toString())
     }
 
     @Override

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -43,6 +43,14 @@ import static org.gradle.performance.results.ResultsStoreHelper.toList;
 
 public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> extends AbstractWritableResultsStore<R> {
 
+    private static final String EXECUTIONS_FOR_NAME_SQL_TEMPLATE = """
+        select h.id, h.startTime, h.endTime, h.versionUnderTest, h.operatingSystem, h.jvm, h.vcsBranch,
+               h.vcsCommit, h.testGroup, h.channel, h.host, h.teamCityBuildId
+        from (%s) as h
+        order by h.startTime desc
+        limit ?
+        """;
+
     private final String resultType;
 
     public BaseCrossBuildResultsStore(String resultType) {
@@ -166,28 +174,19 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
     @Override
     public CrossBuildPerformanceTestHistory getTestResults(final PerformanceExperiment experiment, final int mostRecentN, final int maxDaysOld, final List<String> channelPatterns, List<String> teamcityBuildIds) {
         return withConnection("load results", connection -> {
-            String buildIdQuery = teamcityBuildIdQueryFor(teamcityBuildIds);
-            String channelPatternQuery = channelPatternQueryFor(channelPatterns);
-            String executionsForNameSql = "select id, startTime, endTime, versionUnderTest, operatingSystem, jvm, vcsBranch, vcsCommit, testGroup, channel, host, teamCityBuildId from testExecution where testClass = ? and testId = ? and testProject = ? and startTime >= ? and (" + channelPatternQuery + buildIdQuery + ") order by startTime desc limit ?";
+            List<String> distinctChannelPatterns = distinctValues(channelPatterns);
+            List<String> distinctTeamcityBuildIds = distinctValues(teamcityBuildIds);
+            String historyProjection = "id, startTime, endTime, versionUnderTest, operatingSystem, jvm, vcsBranch, vcsCommit, testGroup, channel, host, teamCityBuildId";
+            String baseHistorySql = createHistoryFilterUnionSql(historyProjection, distinctChannelPatterns, distinctTeamcityBuildIds);
+            String executionsForNameSql = EXECUTIONS_FOR_NAME_SQL_TEMPLATE.formatted(baseHistorySql);
             String operationsForExecutionSql = "select displayName, tasks, args, gradleOpts, daemon, totalTime, cleanTasks from testOperation where testExecution = ?";
             try (
                 PreparedStatement executionsForName = connection.prepareStatement(executionsForNameSql);
                 PreparedStatement operationsForExecution = connection.prepareStatement(operationsForExecutionSql);
             ) {
-                int idx = 0;
-                executionsForName.setString(++idx, experiment.getScenario().getClassName());
-                executionsForName.setString(++idx, experiment.getScenario().getTestName());
-                executionsForName.setString(++idx, experiment.getTestProject());
                 Timestamp minDate = Timestamp.valueOf(LocalDate.now().minusDays(maxDaysOld).atStartOfDay());
-                executionsForName.setTimestamp(++idx, minDate);
-                for (String channelPattern : channelPatterns) {
-                    executionsForName.setString(++idx, channelPattern);
-                }
-                for (String teamcityBuildId : teamcityBuildIds) {
-                    executionsForName.setString(++idx, teamcityBuildId);
-                }
-                executionsForName.setInt(++idx, mostRecentN);
-                List<Object> executionsForNameParams = createHistoryQueryParams(experiment, minDate, channelPatterns, teamcityBuildIds, mostRecentN);
+                bindHistoryQueryParams(executionsForName, experiment, minDate, distinctChannelPatterns, distinctTeamcityBuildIds, mostRecentN);
+                List<Object> executionsForNameParams = createHistoryQueryParams(experiment, minDate, distinctChannelPatterns, distinctTeamcityBuildIds, mostRecentN);
                 long executionsForNameStartTime = System.currentTimeMillis();
                 ResultSet executionsForNameRs = null;
                 try (ResultSet testExecutions = executionsForName.executeQuery()) {
@@ -229,7 +228,7 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
                                 List<String> cleanTasks = toList(resultSet.getObject(7));
                                 List<String> args = toList(resultSet.getObject(3));
                                 List<String> gradleOpts = toList(resultSet.getObject(4));
-                                Boolean daemon = (Boolean) resultSet.getObject(5);
+                                Boolean daemon = toNullableBoolean(resultSet.getObject(5));
                                 BuildDisplayInfo displayInfo = new BuildDisplayInfo(experiment.getTestProject(), displayName, tasksToRun, cleanTasks, args, gradleOpts, daemon);
 
                                 MeasuredOperation operation = new MeasuredOperation();

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -65,6 +65,20 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
             "WHERE (CHANNEL = ? or CHANNEL= ?) AND STARTTIME > ? AND DIFFCONFIDENCE > 0.97\n" +
             "GROUP BY TESTCLASS, TESTID, TESTPROJECT";
 
+    private static final String EXECUTIONS_FOR_NAME_SQL_TEMPLATE = """
+        select h.id, h.startTime, h.endTime, h.targetVersion, h.tasks, h.args, h.gradleOpts, h.daemon,
+               h.operatingSystem, h.jvm, h.vcsBranch, h.vcsCommit, h.channel, h.host, h.cleanTasks, h.teamCityBuildId
+        from (%s) as h
+        order by h.startTime desc
+        limit ?
+        """;
+
+    private static final String OPERATIONS_FOR_EXECUTION_SQL_TEMPLATE = """
+        select version, testExecution, totalTime
+        from testOperation
+        join (select t.id from (%s) as t order by t.startTime desc limit ?) as executionIds
+          on executionIds.id = testOperation.testExecution
+        """;
 
     // Only the flakiness detection results within 90 days will be considered.
     private static final int FLAKINESS_DETECTION_DAYS = 90;
@@ -240,11 +254,13 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
         List<String> teamcityBuildIds
     ) {
         return withConnection("load results", connection -> {
-            String buildIdQuery = teamcityBuildIdQueryFor(teamcityBuildIds);
-            String channelPatternQuery = channelPatternQueryFor(channelPatterns);
-            String executionsForNameSql = "select id, startTime, endTime, targetVersion, tasks, args, gradleOpts, daemon, operatingSystem, jvm, vcsBranch, vcsCommit, channel, host, cleanTasks, teamCityBuildId from testExecution where testClass = ? and testId = ? and testProject = ? and startTime >= ? and (" + channelPatternQuery + buildIdQuery + ") order by startTime desc limit ?";
-            String operationsForExecutionSql = "select version, testExecution, totalTime from testOperation "
-                + "where testExecution in (select t.* from ( select id from testExecution where testClass = ? and testId = ? and testProject = ? and startTime >= ? and (" + channelPatternQuery + buildIdQuery + ") order by startTime desc limit ?) as t)";
+            List<String> distinctChannelPatterns = distinctValues(channelPatterns);
+            List<String> distinctTeamcityBuildIds = distinctValues(teamcityBuildIds);
+            String historyProjection = "id, startTime, endTime, targetVersion, tasks, args, gradleOpts, daemon, operatingSystem, jvm, vcsBranch, vcsCommit, channel, host, cleanTasks, teamCityBuildId";
+            String baseHistorySql = createHistoryFilterUnionSql(historyProjection, distinctChannelPatterns, distinctTeamcityBuildIds);
+            String executionsForNameSql = EXECUTIONS_FOR_NAME_SQL_TEMPLATE.formatted(baseHistorySql);
+            String operationExecutionIdsSql = createHistoryFilterUnionSql("id, startTime", distinctChannelPatterns, distinctTeamcityBuildIds);
+            String operationsForExecutionSql = OPERATIONS_FOR_EXECUTION_SQL_TEMPLATE.formatted(operationExecutionIdsSql);
             try (
                 PreparedStatement executionsForName = connection.prepareStatement(executionsForNameSql);
                 PreparedStatement operationsForExecution = connection.prepareStatement(operationsForExecutionSql);
@@ -253,22 +269,11 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                 Set<String> allVersions = new TreeSet<>(Comparator.comparing(this::resolveGradleVersion));
                 Set<String> allBranches = new TreeSet<>();
 
-                int idx = 0;
                 executionsForName.setFetchSize(mostRecentN);
-                executionsForName.setString(++idx, experiment.getScenario().getClassName());
-                executionsForName.setString(++idx, experiment.getScenario().getTestName());
-                executionsForName.setString(++idx, experiment.getTestProject());
-
                 Timestamp minDate = Timestamp.valueOf(LocalDate.now().minusDays(maxDaysOld).atStartOfDay());
-                executionsForName.setTimestamp(++idx, minDate);
-                for (String channelPattern : channelPatterns) {
-                    executionsForName.setString(++idx, channelPattern);
-                }
-                for (String teamcityBuildId : teamcityBuildIds) {
-                    executionsForName.setString(++idx, teamcityBuildId);
-                }
-                executionsForName.setInt(++idx, mostRecentN);
-                List<Object> executionsForNameParams = createHistoryQueryParams(experiment, minDate, channelPatterns, teamcityBuildIds, mostRecentN);
+                bindHistoryQueryParams(executionsForName, experiment, minDate, distinctChannelPatterns, distinctTeamcityBuildIds, mostRecentN);
+                List<Object> executionsForNameParams = createHistoryQueryParams(experiment, minDate, distinctChannelPatterns, distinctTeamcityBuildIds, mostRecentN);
+                String primaryChannelPattern = distinctChannelPatterns.isEmpty() ? "" : distinctChannelPatterns.get(0);
 
                 long executionsForNameStartTime = System.currentTimeMillis();
                 ResultSet executionsForNameRs = null;
@@ -286,10 +291,10 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                         performanceResults.setTasks(ResultsStoreHelper.toList(testExecutions.getObject(5)));
                         performanceResults.setArgs(ResultsStoreHelper.toList(testExecutions.getObject(6)));
                         performanceResults.setGradleOpts(ResultsStoreHelper.toList(testExecutions.getObject(7)));
-                        performanceResults.setDaemon((Boolean) testExecutions.getObject(8));
+                        performanceResults.setDaemon(toNullableBoolean(testExecutions.getObject(8)));
                         performanceResults.setOperatingSystem(testExecutions.getString(9));
                         performanceResults.setJvm(testExecutions.getString(10));
-                        performanceResults.setVcsBranch(mapVcsBranch(channelPatterns.get(0), testExecutions.getString(11).trim()));
+                        performanceResults.setVcsBranch(mapVcsBranch(primaryChannelPattern, testExecutions.getString(11).trim()));
                         performanceResults.setVcsCommits(ResultsStoreHelper.split(testExecutions.getString(12)));
                         performanceResults.setChannel(testExecutions.getString(13));
                         performanceResults.setHost(testExecutions.getString(14));
@@ -304,19 +309,8 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                 }
 
                 operationsForExecution.setFetchSize(10 * results.size());
-                idx = 0;
-                operationsForExecution.setString(++idx, experiment.getScenario().getClassName());
-                operationsForExecution.setString(++idx, experiment.getScenario().getTestName());
-                operationsForExecution.setString(++idx, experiment.getTestProject());
-                operationsForExecution.setTimestamp(++idx, minDate);
-                for (String channelPattern : channelPatterns) {
-                    operationsForExecution.setString(++idx, channelPattern);
-                }
-                for (String teamcityBuildId : teamcityBuildIds) {
-                    operationsForExecution.setString(++idx, teamcityBuildId);
-                }
-                operationsForExecution.setInt(++idx, mostRecentN);
-                List<Object> operationsForExecutionParams = createHistoryQueryParams(experiment, minDate, channelPatterns, teamcityBuildIds, mostRecentN);
+                bindHistoryQueryParams(operationsForExecution, experiment, minDate, distinctChannelPatterns, distinctTeamcityBuildIds, mostRecentN);
+                List<Object> operationsForExecutionParams = createHistoryQueryParams(experiment, minDate, distinctChannelPatterns, distinctTeamcityBuildIds, mostRecentN);
 
                 long operationsForExecutionStartTime = System.currentTimeMillis();
                 ResultSet operationsForExecutionRs = null;


### PR DESCRIPTION
### Context

Fixes https://github.com/gradle/gradle-private/issues/4986

According to the profiling log, history queries in `CrossVersionResultsStore` and `BaseCrossBuildResultsStore` could be as slow as 70s. SQL explain showed MySQL choosing poor plans for the old SQL:

```
SELECT id, startTime, ...
FROM testExecution
WHERE testClass = ? AND testId = ? AND testProject = ?
  AND startTime >= ?
  AND (channel LIKE ? OR channel LIKE ? OR teamCityBuildId IN (?, ?))
ORDER BY startTime DESC
LIMIT ?;
```

It scans by STARTTIME and filtering 170k+ rows instead of using composite indexes.

### Solution
Replace the single OR-based filter with a `UNION DISTINCT` of two branches: one for channel patterns and one for teamCityBuildId. Each branch can use its index, avoiding the slow full scan. Then we perform an `ORDER BY` on the subquery result.

```
SELECT h.id, h.startTime, ...
FROM (
  SELECT id, startTime, ...
  FROM testExecution
  WHERE testClass = ? AND testId = ? AND testProject = ?
    AND startTime >= ?
    AND (channel LIKE ? OR channel LIKE ?)
  UNION DISTINCT
  SELECT id, startTime, ...
  FROM testExecution
  WHERE testClass = ? AND testId = ? AND testProject = ?
    AND startTime >= ?
    AND teamCityBuildId IN (?, ?)
) AS h
ORDER BY h.startTime DESC
LIMIT ?;
```

Profiling result shows that all queries are <500ms now.