### PR TITLE
fix: adjust timeout in test

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/TaskbarProgressResetFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/TaskbarProgressResetFunctionalTest.groovy
@@ -61,7 +61,7 @@ class TaskbarProgressResetFunctionalTest extends AbstractIntegrationSpec {
         buildFile << """
             task block {
                 doFirst {
-                    Thread.sleep(10_000)
+                    Thread.sleep(60_000)
                 }
             }
         """


### PR DESCRIPTION
the timeout length doesn't influence the runtime length of the test, because the task run is intended to be aborted early.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
