### PR TITLE
Make console/SIGINT test deterministic

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/TaskbarProgressResetFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/TaskbarProgressResetFunctionalTest.groovy
@@ -61,14 +61,16 @@ class TaskbarProgressResetFunctionalTest extends AbstractIntegrationSpec {
         buildFile << """
             task block {
                 doFirst {
-                    Thread.sleep(10_000)
+                    ${server.callFromBuild("block")}
                 }
             }
         """
+        def block = server.expectAndBlock("block")
 
         when:
         def gradle = executer.withTasks("block").start()
 
+        block.waitForAllPendingCalls()
         // Wait until the progress bar has started emitting OSC 9;4 sequences.
         ConcurrentTestUtil.poll {
             assert gradle.standardOutput.contains(OSC_PROGRESS_PREFIX)
@@ -76,6 +78,7 @@ class TaskbarProgressResetFunctionalTest extends AbstractIntegrationSpec {
 
         gradle.sendSignal(SIGINT)
         gradle.waitForFailure()
+        block.releaseAll()
 
         then:
         gradle.standardOutput.contains(OSC_RESET)


### PR DESCRIPTION
Leverage the blocking server instead of relying on a long running operation.