### PR TITLE
Severity is determined by reporting context, not problem spec

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi812PlusCrossVersionTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi812PlusCrossVersionTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.tooling.events.ProgressEvent
 import org.gradle.tooling.events.ProgressListener
 import org.gradle.tooling.events.problems.LineInFileLocation
 import org.gradle.tooling.events.problems.Problem
-import org.gradle.tooling.events.problems.Severity
 import org.gradle.tooling.events.problems.SingleProblemEvent
 import org.gradle.util.GradleVersion
 
@@ -82,7 +81,6 @@ class ConfigurationCacheProblemsTapi812PlusCrossVersionTest extends ToolingApiSp
             definition.id.displayName == "registration of listener on 'Gradle.buildFinished' is unsupported"
             definition.id.group.displayName == "configuration cache validation"
             definition.id.group.name == "configuration-cache"
-            definition.severity == Severity.ERROR
             (locations[0] as LineInFileLocation).path == "build file 'build.gradle'" // FIXME: the path should not contain a prefix nor extra quotes
             if (targetVersion.baseVersion < GradleVersion.version("8.14")) {
                 (locations[1] as LineInFileLocation).path == buildFileLocation(buildFile, targetVersion)

--- a/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi813PlusCrossVersionTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/crossVersionTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsTapi813PlusCrossVersionTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.tooling.events.ProgressEvent
 import org.gradle.tooling.events.ProgressListener
 import org.gradle.tooling.events.problems.LineInFileLocation
 import org.gradle.tooling.events.problems.Problem
-import org.gradle.tooling.events.problems.Severity
 import org.gradle.tooling.events.problems.SingleProblemEvent
 import org.gradle.tooling.events.problems.internal.DefaultAdditionalData
 import org.gradle.util.GradleVersion
@@ -83,7 +82,6 @@ class ConfigurationCacheProblemsTapi813PlusCrossVersionTest extends ToolingApiSp
             definition.id.displayName == "registration of listener on 'Gradle.buildFinished' is unsupported"
             definition.id.group.displayName == "configuration cache validation"
             definition.id.group.name == "configuration-cache"
-            definition.severity == Severity.ERROR
             (originLocations[0] as LineInFileLocation).path == "build file 'build.gradle'" // FIXME: the path should not contain a prefix nor extra quotes
             if (targetVersion.baseVersion < GradleVersion.version("8.14")) {
                 originLocations.size() == 2

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
@@ -97,7 +97,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
         }
     }
 
-    def "notCompatibleWithConfigurationCache task problems are reported as Advice"() {
+    def "notCompatibleWithConfigurationCache task problems are reported as Warning"() {
         given:
         buildFile """
             task run {
@@ -115,7 +115,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
         verifyAll(receivedProblem) {
             fqid == 'validation:configuration-cache:invocation-of-task-project-at-execution-time-is-unsupported-with-the-configuration-cache'
             contextualLabel == "invocation of 'Task.project' at execution time is unsupported with the configuration cache."
-            definition.severity == Severity.ADVICE
+            definition.severity == Severity.WARNING
         }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -24,7 +24,6 @@ import org.gradle.api.internal.project.taskfactory.TaskIdentity
 import org.gradle.api.logging.Logging
 import org.gradle.api.problems.ProblemGroup
 import org.gradle.api.problems.ProblemSpec
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.api.problems.internal.PropertyTraceDataSpec
@@ -257,7 +256,7 @@ class ConfigurationCacheProblems(
     private
     fun onProblem(problem: PropertyProblem, severity: ProblemSeverity) {
         if (summarizer.onProblem(problem, severity)) {
-            problemsService.onProblem(problem, severity)
+            problemsService.onProblem(problem)
             report.onProblem(problem)
         }
 
@@ -271,7 +270,7 @@ class ConfigurationCacheProblems(
     val configCacheValidation: ProblemGroup = ProblemGroup.create("configuration-cache", "configuration cache validation", GradleCoreProblemGroup.validation().thisGroup())
 
     private
-    fun InternalProblems.onProblem(problem: PropertyProblem, severity: ProblemSeverity) {
+    fun InternalProblems.onProblem(problem: PropertyProblem) {
         val message = problem.message.render()
         internalReporter.internalCreate {
             id(
@@ -282,7 +281,6 @@ class ConfigurationCacheProblems(
             contextualLabel(message)
             documentOfProblem(problem)
             locationOfProblem(problem)
-            severity(severity.toProblemSeverity())
             additionalDataInternal(PropertyTraceDataSpec::class.java) {
                 trace(problem.trace.containingUserCode)
             }
@@ -306,15 +304,6 @@ class ConfigurationCacheProblems(
 
     private
     fun PropertyTrace.buildLogic() = sequence.filterIsInstance<PropertyTrace.BuildLogic>().firstOrNull()
-
-    private
-    fun ProblemSeverity.toProblemSeverity() = when {
-        this == ProblemSeverity.Suppressed ||
-            this == ProblemSeverity.SuppressedSilently -> Severity.ADVICE
-
-        isWarningMode -> Severity.WARNING
-        else -> Severity.ERROR
-    }
 
     override fun getId(): String {
         return "configuration-cache"

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslScriptPluginFactory.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslScriptPluginFactory.kt
@@ -68,7 +68,7 @@ private fun reportEvaluationFailuresAsProblemsAndThrow(
             else -> emptyList() // TODO: report all other DCL failures as problems
         }
     }
-    problems.reporter.report(failureProblems)
+    problems.internalReporter.reportError(failureProblems)
     /**
      * Instead of [org.gradle.api.problems.ProblemReporter.throwing], we just throw
      * this single exception here to avoid duplicating the full message of the

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/SchemaBuildingFailureProblems.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/SchemaBuildingFailureProblems.kt
@@ -21,7 +21,6 @@ import org.gradle.api.problems.ProblemGroup
 import org.gradle.api.problems.ProblemId
 import org.gradle.api.problems.ProblemId.create
 import org.gradle.api.problems.ProblemSpec
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup.scripts
 import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.declarative.dsl.evaluation.SchemaBuildingFailure
@@ -35,7 +34,6 @@ internal fun schemaBuildingFailuresAsProblems(
     problems: InternalProblems
 ): List<Problem> = stageFailure.failures.map { failure ->
     problems.reporter.create(schemaBuildingFailureProblemId(failure)) { problem ->
-        problem.severity(Severity.ERROR)
         problem.details(SchemaFailureMessageFormatter.failureMessage(failure))
         problem.solutionFor(failure)
     }

--- a/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/FlowParametersInstantiator.kt
+++ b/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/FlowParametersInstantiator.kt
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList
 import org.gradle.api.flow.FlowParameters
 import org.gradle.api.internal.tasks.AbstractTaskDependencyResolveContext
 import org.gradle.api.internal.tasks.properties.InspectionSchemeFactory
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.problems.internal.InternalProblem
 import org.gradle.api.problems.internal.InternalProblemReporter
@@ -77,7 +76,6 @@ class FlowParametersInstantiator(
                                     internalProblemReporter.internalCreate {
                                         id("invalid-dependency", "Property cannot carry dependency", GradleCoreProblemGroup.validation().property())
                                         contextualLabel("Property '$propertyName' cannot carry a dependency on $dependency as these are not yet supported.")
-                                        severity(Severity.ERROR)
                                     }
                                 )
                             }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -956,6 +956,7 @@ assert custom.prop.get() == "value 4"
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'strings',
+                'fatal' : true,
             ]
         }
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractTypeAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractTypeAnnotationHandler.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.properties.annotations;
 
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
@@ -50,7 +49,6 @@ public abstract class AbstractTypeAnnotationHandler implements TypeAnnotationHan
                 .id("invalid-use-of-type-annotation", "Incorrect use of type annotation", GradleCoreProblemGroup.validation().type())
                 .contextualLabel("is incorrectly annotated with @" + annotationType.getSimpleName())
                 .documentedAt(Documentation.userManual("validation_problems", "invalid_use_of_cacheable_annotation"))
-                .severity(Severity.ERROR)
                 .details(String.format("This annotation only makes sense on %s types", Arrays.stream(appliesOnlyTo)
                     .map(Class::getSimpleName)
                     .collect(joining(", "))))

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
@@ -46,7 +46,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 import static org.gradle.internal.reflect.annotations.AnnotationCategory.TYPE;
 
@@ -138,7 +137,6 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
                         .id(TextUtil.screamingSnakeToKebabCase(ANNOTATION_INVALID_IN_CONTEXT), "Invalid annotation in context", GradleCoreProblemGroup.validation().property())
                         .contextualLabel(String.format("is annotated with invalid property type @%s", propertyType.getSimpleName()))
                         .documentedAt(userManual("validation_problems", ANNOTATION_INVALID_IN_CONTEXT.toLowerCase(Locale.ROOT)))
-                        .severity(ERROR)
                         .details("The '@" + propertyType.getSimpleName() + "' annotation cannot be used in this context")
                         .solution("Remove the property")
                         .solution("Use a different annotation, e.g one of " + toListOfAnnotations(propertyAnnotationHandlers.keySet()))
@@ -160,7 +158,6 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
                             .id(TextUtil.screamingSnakeToKebabCase(INCOMPATIBLE_ANNOTATIONS), "Incompatible annotations", GradleCoreProblemGroup.validation().property())
                             .contextualLabel("is annotated with @" + annotationType.getSimpleName() + " but that is not allowed for '" + propertyType.getSimpleName() + "' properties")
                             .documentedAt(userManual("validation_problems", INCOMPATIBLE_ANNOTATIONS.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("This modifier is used in conjunction with a property of type '" + propertyType.getSimpleName() + "' but this doesn't have semantics")
                             .solution("Remove the '@" + annotationType.getSimpleName() + "' annotation"));
                 } else if (!allowedPropertyModifiers.contains(annotationType)) {
@@ -170,7 +167,6 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
                             .id(TextUtil.screamingSnakeToKebabCase(ANNOTATION_INVALID_IN_CONTEXT), "Invalid annotation in context", GradleCoreProblemGroup.validation().property())
                             .contextualLabel(String.format("is annotated with invalid modifier @%s", annotationType.getSimpleName()))
                             .documentedAt(userManual("validation_problems", ANNOTATION_INVALID_IN_CONTEXT.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("The '@" + annotationType.getSimpleName() + "' annotation cannot be used in this context")
                             .solution("Use a different annotation, e.g one of " + toListOfAnnotations(allowedPropertyModifiers))
                             .solution("Remove the annotation")
@@ -209,7 +205,6 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
                         .id(TextUtil.screamingSnakeToKebabCase(ANNOTATION_INVALID_IN_CONTEXT), "Invalid annotation in context", GradleCoreProblemGroup.validation().type())
                         .contextualLabel(String.format("is annotated with invalid function type @%s", functionType.getSimpleName()))
                         .documentedAt(userManual("validation_problems", ANNOTATION_INVALID_IN_CONTEXT.toLowerCase(Locale.ROOT)))
-                        .severity(ERROR)
                         .details("The '@" + functionType.getSimpleName() + "' annotation cannot be used in this context")
                         .solution("Remove the method")
                         .solution("Use a different annotation, e.g one of " + toListOfAnnotations(functionAnnotationHandlers.keySet()))
@@ -231,7 +226,6 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
                             .id(TextUtil.screamingSnakeToKebabCase(INCOMPATIBLE_ANNOTATIONS), "Incompatible annotations", GradleCoreProblemGroup.validation().type())
                             .contextualLabel("is annotated with @" + annotationType.getSimpleName() + " but that is not allowed for '" + functionType.getSimpleName() + "' functions")
                             .documentedAt(userManual("validation_problems", INCOMPATIBLE_ANNOTATIONS.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("This modifier is used in conjunction with a property of type '" + functionType.getSimpleName() + "' but this doesn't have semantics")
                             .solution("Remove the '@" + annotationType.getSimpleName() + "' annotation"));
                 } else if (!allowedFunctionModifiers.contains(annotationType)) {
@@ -241,7 +235,6 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
                             .id(TextUtil.screamingSnakeToKebabCase(ANNOTATION_INVALID_IN_CONTEXT), "Invalid annotation in context", GradleCoreProblemGroup.validation().property())
                             .contextualLabel(String.format("is annotated with invalid modifier @%s", annotationType.getSimpleName()))
                             .documentedAt(userManual("validation_problems", ANNOTATION_INVALID_IN_CONTEXT.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("The '@" + annotationType.getSimpleName() + "' annotation cannot be used in this context")
                             .solution("Use a different annotation, e.g one of " + toListOfAnnotations(allowedPropertyModifiers))
                             .solution("Remove the annotation")

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/MissingPropertyAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/MissingPropertyAnnotationHandler.java
@@ -23,7 +23,6 @@ import org.gradle.util.internal.TextUtil;
 
 import java.util.Locale;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 /**
@@ -42,7 +41,6 @@ public interface MissingPropertyAnnotationHandler {
             .id(TextUtil.screamingSnakeToKebabCase(missingAnnotation), "Missing annotation", GradleCoreProblemGroup.validation().property())
             .contextualLabel("is missing " + displayName)
             .documentedAt(userManual("validation_problems", missingAnnotation.toLowerCase(Locale.ROOT)))
-            .severity(ERROR)
             .details("A property without annotation isn't considered during up-to-date checking")
             .solution("Add " + displayName)
             .solution("Mark it as @Internal");

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedValidationUtil.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedValidationUtil.java
@@ -24,7 +24,6 @@ import org.jspecify.annotations.NullMarked;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 /**
@@ -61,7 +60,6 @@ public class NestedValidationUtil {
                     .id("nested-type-unsupported", "Nested type unsupported", GradleCoreProblemGroup.validation().property())
                     .contextualLabel("with nested type '" + beanType.getName() + "' is not supported")
                     .documentedAt(userManual("validation_problems", "unsupported_nested_type"))
-                    .severity(ERROR)
                     .details(reason)
                     .solution("Use a different input annotation if type is not a bean")
                     .solution("Use a different package that doesn't conflict with standard Java or Kotlin types for custom types")
@@ -102,7 +100,6 @@ public class NestedValidationUtil {
                     .id("nested-map-unsupported-key-type", "Unsupported nested map key", GradleCoreProblemGroup.validation().property())
                     .contextualLabel("where key of nested map is of type '" + keyType.getName() + "'")
                     .documentedAt(userManual("validation_problems", "unsupported_key_type_of_nested_map"))
-                    .severity(ERROR)
                     .details("Key of nested map must be an enum or one of the following types: " + getSupportedKeyTypes())
                     .solution("Change type of key to an enum or one of the following types: " + getSupportedKeyTypes())
             );

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/DefaultTypeMetadataStoreTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/DefaultTypeMetadataStoreTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.internal.IConventionAware
 import org.gradle.api.internal.tasks.properties.DefaultPropertyTypeResolver
 import org.gradle.api.model.ReplacedBy
 import org.gradle.api.plugins.ExtensionAware
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
@@ -161,7 +160,6 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
                     .forProperty(metadata.propertyName)
                     .id("test-problem", "is broken", GradleCoreProblemGroup.validation().thisGroup())
                     .documentedAt(userManual("id", "section"))
-                    .severity(Severity.WARNING)
                     .details("Test")
             }
         }
@@ -174,7 +172,6 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
                     .forFunction(metadata.getMethodName())
                     .id("test-problem", "is broken", GradleCoreProblemGroup.validation().thisGroup())
                     .documentedAt(userManual("id", "section"))
-                    .severity(Severity.WARNING)
                     .details("Test")
             }
         }
@@ -213,7 +210,6 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
                     .forProperty(metadata.propertyName)
                     .id("test-problem", "is broken", GradleCoreProblemGroup.validation().thisGroup())
                     .documentedAt(userManual("id", "section"))
-                    .severity(Severity.WARNING)
                     .details("Test")
             }
         }
@@ -225,7 +221,6 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
                     .forFunction(metadata.getMethodName())
                     .id("test-problem", "is broken", GradleCoreProblemGroup.validation().thisGroup())
                     .documentedAt(userManual("id", "section"))
-                    .severity(Severity.WARNING)
                     .details("Test")
             }
         }
@@ -253,7 +248,6 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
                     .withAnnotationType(type)
                     .id("test-problem", "type is broken", GradleCoreProblemGroup.validation().thisGroup())
                     .documentedAt(userManual("id", "section"))
-                    .severity(Severity.WARNING)
                     .details("Test")
             }
         }

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
@@ -67,7 +67,6 @@ import java.util.stream.Stream;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.joining;
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 import static org.gradle.internal.reflect.Methods.SIGNATURE_EQUIVALENCE;
 import static org.gradle.internal.reflect.annotations.AnnotationCategory.TYPE;
@@ -359,7 +358,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                             )
                         )
                         .documentedAt(userManual("validation_problems", REDUNDANT_GETTERS.toLowerCase(Locale.ROOT)))
-                        .severity(ERROR)
                         .details("Boolean property '" + propertyName + "' has both an `is` and a `get` getter")
                         .solution("Remove one of the getters")
                         .solution("Annotate one of the getters with @Internal")
@@ -407,7 +405,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                             )
                         )
                         .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_PROPERTY.toLowerCase(Locale.ROOT)))
-                        .severity(ERROR)
                         .details("Function annotations are ignored if they are placed on a field")
                         .solution("Remove the annotations")
                 );
@@ -461,7 +458,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                                 )
                             )
                             .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_FIELD.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("Annotations on fields are only used if there's a corresponding getter for the field")
                             .solution("Add a getter for field '" + fieldName + "'")
                             .solution("Remove the annotations on '" + fieldName + "'")
@@ -548,7 +544,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                     .id(TextUtil.screamingSnakeToKebabCase(PRIVATE_GETTER_MUST_NOT_BE_ANNOTATED), "Private property with wrong annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("is private and annotated with %s", simpleAnnotationNames(annotations.keySet().stream())))
                     .documentedAt(userManual("validation_problems", PRIVATE_GETTER_MUST_NOT_BE_ANNOTATED.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Annotations on private getters are ignored")
                     .solution("Make the getter public")
                     .solution("Annotate the public version of the getter")
@@ -602,7 +597,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                     .id(TextUtil.screamingSnakeToKebabCase(PRIVATE_METHOD_MUST_NOT_BE_ANNOTATED), "Private method with wrong annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("is private and annotated with %s", simpleAnnotationNames(annotations.keySet().stream())))
                     .documentedAt(userManual("validation_problems", PRIVATE_METHOD_MUST_NOT_BE_ANNOTATED.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Annotations on private methods are ignored")
                     .solution("Make the method public")
                     .solution("Annotate the public version of the method")
@@ -625,7 +619,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                     .id(TextUtil.screamingSnakeToKebabCase(MUTABLE_TYPE_WITH_SETTER), "Mutable type with setter", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("of mutable type '%s' is writable", setterType.getName()))
                     .documentedAt(userManual("validation_problems", MUTABLE_TYPE_WITH_SETTER.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Properties of type '" + setterType.getName() + "' are already mutable")
                     .solution("Remove the '" + setterMethod.getName() + "' method")
             );
@@ -666,7 +659,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_METHOD.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Input/Output annotations are ignored if they are placed on something else than a getter")
                     .solution("Remove the annotations")
                     .solution("Rename the method")
@@ -689,7 +681,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_PROPERTY.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Function annotations are ignored if they are placed on a property getter")
                     .solution("Remove the annotations")
                     .solution("Rename the method")
@@ -710,7 +701,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_PROPERTY.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Function annotations are ignored if they are placed on a static method")
                     .solution("Remove the annotations")
                     .solution("Make the method non-static")
@@ -901,7 +891,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("A property is ignored but also has input annotations")
                     .solution("Remove the input annotations")
                     .solution("Remove the @" + ignoredMethodAnnotation.getSimpleName() + " annotation")
@@ -923,7 +912,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", CONFLICTING_ANNOTATIONS.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("The different annotations have different semantics and Gradle cannot determine which one to pick")
                     .solution("Choose between one of the conflicting annotations")
             );
@@ -968,7 +956,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", CONFLICTING_ANNOTATIONS.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("The different annotations have different semantics and Gradle cannot determine which one to pick")
                     .solution("Choose between one of the conflicting annotations")
             );

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilder.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeAwareProblemBuilder.java
@@ -45,6 +45,12 @@ public class DefaultTypeAwareProblemBuilder extends DelegatingProblemBuilder imp
     }
 
     @Override
+    public TypeAwareProblemBuilder asWarning() {
+        this.additionalDataInternal(TypeValidationDataSpec.class, data -> data.fatal(false));
+        return this;
+    }
+
+    @Override
     public TypeAwareProblemBuilder forProperty(String propertyName) {
         this.additionalDataInternal(TypeValidationDataSpec.class, data -> data.propertyName(propertyName));
         return this;

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/DelegatingProblemBuilder.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/DelegatingProblemBuilder.java
@@ -131,8 +131,14 @@ class DelegatingProblemBuilder implements InternalProblemBuilder {
     }
 
     @Override
+    @Deprecated
     public InternalProblemBuilder severity(Severity severity) {
         return validateDelegate(delegate.severity(severity));
+    }
+
+    @Override
+    public InternalProblemBuilder internalSeverity(Severity severity) {
+        return validateDelegate(delegate.internalSeverity(severity));
     }
 
     @Override

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/TypeAwareProblemBuilder.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/TypeAwareProblemBuilder.java
@@ -29,4 +29,11 @@ public interface TypeAwareProblemBuilder extends InternalProblemSpec {
     TypeAwareProblemBuilder forFunction(String methodName);
 
     TypeAwareProblemBuilder parentProperty(@Nullable String parentProperty);
+
+    /**
+     * Mark the problems as warning, ie it won't fail the build.
+     *
+     * @return this
+     */
+    TypeAwareProblemBuilder asWarning();
 }

--- a/platforms/core-configuration/model-reflect/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/platforms/core-configuration/model-reflect/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -20,7 +20,6 @@ import groovy.transform.Generated
 import groovy.transform.Memoized
 import groovy.transform.PackageScope
 import org.gradle.api.file.FileCollection
-import org.gradle.api.problems.Severity
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.reflect.DefaultTypeValidationContext
 import org.gradle.internal.reflect.annotations.AnnotationCategory
@@ -1032,7 +1031,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         def validationContext = DefaultTypeValidationContext.withoutRootType(false, TestUtil.problemsService())
         metadata.visitValidationFailures(validationContext)
         List<String> actualErrors = validationContext.problems
-            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it)) + (it.definition.severity == Severity.ERROR ? " [STRICT]" : "") as String) })
+            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it)) + (it.additionalData.fatal ? " [STRICT]" : "") as String) })
         actualErrors.sort()
         expectedErrors.sort()
         assert actualErrors == expectedErrors
@@ -1067,7 +1066,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         def validationContext = DefaultTypeValidationContext.withoutRootType(false, TestUtil.problemsService())
         metadata.visitValidationFailures(validationContext)
         List<String> actualErrors = validationContext.problems
-            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it)) + (it.definition.severity == Severity.ERROR ? " [STRICT]" : "") as String) })
+            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it)) + (it.additionalData.fatal ? " [STRICT]" : "") as String) })
         actualErrors.sort()
         expectedErrors.sort()
         assert actualErrors == expectedErrors

--- a/platforms/core-execution/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/platforms/core-execution/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList
 import com.google.common.collect.Iterables
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.problems.ProblemId
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.cache.Cache
 import org.gradle.cache.ManualEvictionInMemoryCache
@@ -247,8 +246,8 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
                 context
                     .forType(UnitOfWork, false)
                     .visitPropertyProblem {
-                        it.id(ProblemId.create("test-problem", "Validation problem", GradleCoreProblemGroup.validation().type()))
-                            .severity(Severity.WARNING)
+                        it.asWarning()
+                            .id(ProblemId.create("test-problem", "Validation problem", GradleCoreProblemGroup.validation().type()))
                             .documentedAt(Documentation.userManual("id", "section"))
                             .details("Test")
                     }
@@ -565,12 +564,10 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
         def invalidWork = builder
             .withValidator { validationContext ->
                 validationContext.forType(Object, true).visitTypeProblem {
-                    it
-                        .withAnnotationType(Object)
+                    it.withAnnotationType(Object)
                         .id(ProblemId.create("test-problem", "Validation error", GradleCoreProblemGroup.validation().type()))
                         .documentedAt(Documentation.userManual("id", "section"))
                         .details("Test")
-                        .severity(Severity.ERROR)
                 }
             }
             .withWork({ throw new RuntimeException("Should not get executed") })

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/impl/DefaultExecutionProblemHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/impl/DefaultExecutionProblemHandler.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.execution.impl;
 
-import com.google.common.collect.ImmutableList;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblemReporter;
 import org.gradle.api.problems.internal.InternalProblems;
@@ -28,6 +26,7 @@ import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.execution.WorkValidationException;
 import org.gradle.internal.execution.steps.ValidateStep;
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
+import org.gradle.internal.validation.TypeValidationUtil;
 import org.gradle.internal.vfs.VirtualFileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,13 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
-import static org.gradle.api.problems.Severity.ERROR;
-import static org.gradle.api.problems.Severity.WARNING;
+import static java.util.stream.Collectors.partitioningBy;
 
 public class DefaultExecutionProblemHandler implements ExecutionProblemHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExecutionProblemHandler.class);
@@ -64,12 +58,9 @@ public class DefaultExecutionProblemHandler implements ExecutionProblemHandler {
         InternalProblemReporter reporter = problemsService.getInternalReporter();
         List<InternalProblem> problems = validationContext.getProblems();
 
-        Map<Severity, ImmutableList<InternalProblem>> problemsMap = problems.stream()
-            .collect(
-                groupingBy(p -> p.getDefinition().getSeverity(),
-                    mapping(identity(), toImmutableList())));
-        List<InternalProblem> warnings = problemsMap.getOrDefault(WARNING, ImmutableList.of());
-        List<InternalProblem> errors = problemsMap.getOrDefault(ERROR, ImmutableList.of());
+        Map<Boolean, List<InternalProblem>> collect = problems.stream().collect(partitioningBy(TypeValidationUtil::isFatal));
+        List<InternalProblem> errors = collect.get(true);
+        List<InternalProblem> warnings = collect.get(false);
 
         if (!warnings.isEmpty()) {
             for (InternalProblem warning : warnings) {

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputFilePropertyAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputFilePropertyAnnotationHandler.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.execution.model.annotations;
 
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.IgnoreEmptyDirectories;
@@ -119,7 +118,6 @@ public abstract class AbstractInputFilePropertyAnnotationHandler extends Abstrac
                     .id(MISSING_NORMALIZATION_ID.getName(), MISSING_NORMALIZATION_ID.getDisplayName(), MISSING_NORMALIZATION_ID.getGroup()) // TODO (donat) missing test coverage
                     .contextualLabel(String.format("is annotated with @%s but missing a normalization strategy", getAnnotationType().getSimpleName()))
                     .documentedAt(userManual("validation_problems", MISSING_NORMALIZATION_ANNOTATION.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details("If you don't declare the normalization, outputs can't be re-used between machines or locations on the same machine, therefore caching efficiency drops significantly")
                     .solution("Declare the normalization strategy by annotating the property with either @PathSensitive, @Classpath or @CompileClasspath");
             });

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputPropertyAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputPropertyAnnotationHandler.java
@@ -19,7 +19,6 @@ package org.gradle.internal.execution.model.annotations;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.TypeOf;
@@ -77,7 +76,6 @@ abstract class AbstractInputPropertyAnnotationHandler extends AbstractPropertyAn
                             )
                         )
                         .documentedAt(userManual("validation_problems", UNSUPPORTED_VALUE_TYPE.toLowerCase(Locale.ROOT)))
-                        .severity(Severity.ERROR)
                         .details(String.format("%s is not supported on task properties annotated with @%s", unsupportedType.getSimpleName(), annotationType.getSimpleName()));
                     for (String possibleSolution : possibleSolutions) {
                         describedProblem.solution(possibleSolution);

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/InputPropertyAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/InputPropertyAnnotationHandler.java
@@ -20,7 +20,6 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
@@ -37,7 +36,6 @@ import java.net.URL;
 import java.util.List;
 import java.util.Locale;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.OPTIONAL;
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.REPLACES_EAGER_PROPERTY;
@@ -81,7 +79,6 @@ public class InputPropertyAnnotationHandler extends AbstractInputPropertyAnnotat
                     .contextualLabel(String.format("of type %s shouldn't be annotated with @Optional", valueType.getName()))
                     .documentedAt(userManual(VALIDATION_PROBLEMS, CANNOT_USE_OPTIONAL_ON_PRIMITIVE_TYPES.toLowerCase(Locale.ROOT)))
                     .details("Properties of primitive type cannot be optional")
-                    .severity(Severity.ERROR)
                     .solution("Remove the @Optional annotation")
                     .solution("Use the " + AsmClassGeneratorUtils.getWrapperTypeForPrimitiveType(valueType).getName() + " type instead")
             );
@@ -102,7 +99,6 @@ public class InputPropertyAnnotationHandler extends AbstractInputPropertyAnnotat
                     .id(TextUtil.screamingSnakeToKebabCase(INCORRECT_USE_OF_INPUT_ANNOTATION), "Incorrect use of @Input annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("has @Input annotation used on property of type '%s'", ModelType.of(valueType).getDisplayName()))
                     .documentedAt(userManual(VALIDATION_PROBLEMS, INCORRECT_USE_OF_INPUT_ANNOTATION.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details("A property of type '" + ModelType.of(valueType).getDisplayName() + "' annotated with @Input cannot determine how to interpret the file")
                     .solution("Annotate with @InputFile for regular files")
                     .solution("Annotate with @InputFiles for collections of files")
@@ -120,7 +116,6 @@ public class InputPropertyAnnotationHandler extends AbstractInputPropertyAnnotat
                     .id(TextUtil.screamingSnakeToKebabCase(INCORRECT_USE_OF_INPUT_ANNOTATION), "Incorrect use of @Input annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("has @Input annotation used on property of type '%s'", ModelType.of(valueType).getDisplayName()))
                     .documentedAt(userManual(VALIDATION_PROBLEMS, INCORRECT_USE_OF_INPUT_ANNOTATION.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details("A property of type '" + ModelType.of(valueType).getDisplayName() + "' annotated with @Input cannot determine how to interpret the file")
                     .solution("Annotate with @InputDirectory for directories")
             );
@@ -139,7 +134,6 @@ public class InputPropertyAnnotationHandler extends AbstractInputPropertyAnnotat
                     .id(TextUtil.screamingSnakeToKebabCase(UNSUPPORTED_VALUE_TYPE) + "-for-input", "Unsupported value type for @Input annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("has @Input annotation used on type '%s' or a property of this type", URL.class.getName()))
                     .documentedAt(userManual(VALIDATION_PROBLEMS, UNSUPPORTED_VALUE_TYPE.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details(String.format("Type '%s' is not supported on properties annotated with @Input because Java Serialization can be inconsistent for this type", URL.class.getName()))
                     .solution("Use type 'java.net.URI' instead")
             );

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/ServiceReferencePropertyAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/ServiceReferencePropertyAnnotationHandler.java
@@ -16,7 +16,6 @@
 package org.gradle.internal.execution.model.annotations;
 
 import com.google.common.reflect.TypeToken;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.ServiceReference;
@@ -70,7 +69,6 @@ public class ServiceReferencePropertyAnnotationHandler extends AbstractPropertyA
                     .id(TextUtil.screamingSnakeToKebabCase(SERVICE_REFERENCE_MUST_BE_A_BUILD_SERVICE), "Property has @ServiceReference annotation", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                     .contextualLabel(String.format("has @ServiceReference annotation used on property of type '%s' which is not a build service implementation", typeVariables.get(0).getName()))
                     .documentedAt(userManual("validation_problems", SERVICE_REFERENCE_MUST_BE_A_BUILD_SERVICE.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details(String.format("A property annotated with @ServiceReference must be of a type that implements '%s'", BuildService.class.getName()))
                     .solution(String.format("Make '%s' implement '%s'", typeVariables.get(0).getName(), BuildService.class.getName()))
                     .solution(String.format("Replace the @ServiceReference annotation on '%s' with @Internal and assign a value of type '%s' explicitly", propertyMetadata.getPropertyName(), typeVariables.get(0).getName()))

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
@@ -37,7 +37,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 public abstract class ValidateStep<
@@ -140,7 +139,6 @@ public abstract class ValidateStep<
                 .documentedAt(userManual("validation_problems", "implementation_unknown"))
                 .details(unknownImplSnapshot.getReasonDescription())
                 .solution(unknownImplSnapshot.getSolutionDescription())
-                .severity(ERROR)
             );
         }
     }
@@ -154,7 +152,6 @@ public abstract class ValidateStep<
                 .documentedAt(userManual("validation_problems", "implementation_unknown"))
                 .details(unknownImplSnapshot.getReasonDescription())
                 .solution(unknownImplSnapshot.getSolutionDescription())
-                .severity(ERROR)
             );
         }
     }

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/impl/DefaultExecutionProblemHandlerTest.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/impl/DefaultExecutionProblemHandlerTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.execution.impl
 
 import org.gradle.api.problems.Problem
 import org.gradle.api.problems.ProblemId
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.problems.internal.InternalProblem
 import org.gradle.api.problems.internal.ProblemsProgressEventEmitterHolder
@@ -63,7 +62,6 @@ class DefaultExecutionProblemHandlerTest extends Specification implements Valida
                 .id(ProblemId.create("test-problem", "Validation error", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
                 .details("Test")
-                .severity(Severity.ERROR)
         }
 
         when:
@@ -87,7 +85,6 @@ class DefaultExecutionProblemHandlerTest extends Specification implements Valida
                 .withAnnotationType(Object)
                 .id(ProblemId.create("test-problem-1", "Validation error #1", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
-                .severity(Severity.ERROR)
                 .details("Test")
         }
         validationContext.forType(SecondaryJobType, true).visitTypeProblem {
@@ -95,7 +92,6 @@ class DefaultExecutionProblemHandlerTest extends Specification implements Valida
                 .withAnnotationType(Object)
                 .id(ProblemId.create("test-problem-2", "Validation error #2", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
-                .severity(Severity.ERROR)
                 .details("Test")
         }
         when:
@@ -120,9 +116,9 @@ class DefaultExecutionProblemHandlerTest extends Specification implements Valida
         validationContext.forType(JobType, true).visitTypeProblem {
             it
                 .withAnnotationType(Object)
+                .asWarning()
                 .id(ProblemId.create("test-problem", "Validation warning", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
-                .severity(Severity.WARNING)
                 .details("Test")
         }
         when:
@@ -151,15 +147,14 @@ class DefaultExecutionProblemHandlerTest extends Specification implements Valida
                 .withAnnotationType(Object)
                 .id(ProblemId.create("test-problem", "Validation problem", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
-                .severity(Severity.ERROR)
                 .details("Test")
         }
         typeContext.visitTypeProblem {
             it
                 .withAnnotationType(Object)
+                .asWarning()
                 .id(ProblemId.create("test-problem", "Validation problem", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
-                .severity(Severity.WARNING)
                 .details("Test")
         }
 

--- a/platforms/core-runtime/build-configuration/src/main/java/org/gradle/internal/buildconfiguration/DaemonJvmPropertiesConfigurator.java
+++ b/platforms/core-runtime/build-configuration/src/main/java/org/gradle/internal/buildconfiguration/DaemonJvmPropertiesConfigurator.java
@@ -19,7 +19,6 @@ package org.gradle.internal.buildconfiguration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.problems.ProblemReporter;
 import org.gradle.api.problems.Problems;
-import org.gradle.api.problems.Severity;
 import org.gradle.buildconfiguration.tasks.UpdateDaemonJvm;
 import org.gradle.configuration.project.ProjectConfigureAction;
 import org.gradle.internal.Pair;
@@ -28,12 +27,12 @@ import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainDownload;
-import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec;
-import org.gradle.jvm.toolchain.internal.JavaToolchainResolverService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
 import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainRequest;
+import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec;
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec;
+import org.gradle.jvm.toolchain.internal.JavaToolchainResolverService;
 import org.gradle.platform.Architecture;
 import org.gradle.platform.BuildPlatform;
 import org.gradle.platform.BuildPlatformFactory;
@@ -89,7 +88,6 @@ public class DaemonJvmPropertiesConfigurator implements ProjectConfigureAction {
                                 UnconfiguredToolchainRepositoriesResolver exception = new UnconfiguredToolchainRepositoriesResolver();
                                 throw reporter.throwing(exception, UpdateDaemonJvm.TASK_CONFIGURATION_PROBLEM_ID,
                                     problemSpec -> {
-                                        problemSpec.severity(Severity.ERROR);
                                         problemSpec.solution("Configure toolchain download repositories in your build settings.");
                                         problemSpec.documentedAt(Documentation.userManual("toolchains", "sub:download_repositories").getUrl());
                                 });
@@ -104,7 +102,6 @@ public class DaemonJvmPropertiesConfigurator implements ProjectConfigureAction {
                                 throw reporter.throwing(new IllegalStateException("Toolchain resolvers did not return download URLs providing a JDK matching " + toolchainSpec + " for any of the requested platforms " + platforms),
                                     UpdateDaemonJvm.TASK_CONFIGURATION_PROBLEM_ID,
                                     problemSpec -> {
-                                        problemSpec.severity(Severity.ERROR);
                                         problemSpec.solution("Use a toolchain download repository capable of resolving the toolchain spec for the given platforms.");
                                         problemSpec.documentedAt(Documentation.userManual("gradle_daemon", "sec:daemon_jvm_provisioning").getUrl());
                                     });

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -45,7 +45,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-import static org.gradle.api.problems.Severity.WARNING;
 import static org.gradle.internal.deprecation.DeprecationMessageBuilder.createDefaultDeprecationId;
 
 public class LoggingDeprecatedFeatureHandler implements FeatureHandler<DeprecatedFeatureUsage> {
@@ -110,9 +109,7 @@ public class LoggingDeprecatedFeatureHandler implements FeatureHandler<Deprecate
                         public void execute(DeprecationDataSpec data) {
                             data.type(usage.getType().toDeprecationDataType());
                         }
-                    })
-                    .severity(WARNING);
-
+                    });
                 if (usage.getType() == DeprecatedFeatureUsage.Type.USER_CODE_DIRECT) {
                     builder.stackLocation();
                 }

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -36,6 +36,18 @@ The previous step will help you identify potential problems by issuing deprecati
 . Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
+[[changes_9.6.0]]
+== Upgrading from 9.5.0 and earlier
+
+=== Deprecations
+
+[[deprecate_problem_spec_severity]]
+==== Deprecation of `ProblemSpec.severity()`
+
+Problem severity can no longer be set explicitly when creating a new instance.
+Instead, it is determined by the reporting method: `ProblemReporter.report()` produces warnings and `ProblemReporter.throwing()` produces errors.
+Calling `.severity()` on `ProblemSpec` is now a no-op and will be removed in Gradle 10.0.
+
 [[changes_9.5.0]]
 == Upgrading from 9.4.0 and earlier
 

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
@@ -145,6 +145,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'badTime',
+                    'fatal' : true,
                 ]
             }
             verifyAll(receivedProblem(1)) {
@@ -158,6 +159,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'oldThing',
+                    'fatal' : true,
                 ]
             }
             verifyAll(receivedProblem(2)) {
@@ -172,6 +174,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'parentPropertyName' : 'options',
                     'typeName' : 'MyTask',
                     'propertyName' : 'badNested',
+                    'fatal' : true,
                 ]
             }
             verifyAll(receivedProblem(3)) {
@@ -185,6 +188,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'ter',
+                    'fatal' : true,
                 ]
             }
 
@@ -275,7 +279,8 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 ]
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
-                    'propertyName' : 'primitive'
+                    'propertyName' : 'primitive',
+                    'fatal' : true,
                 ]
             }
         }
@@ -335,28 +340,40 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 contextualLabel == 'Type \'MyTask\' is incorrectly annotated with @CacheableTransform'
                 details == 'This annotation only makes sense on TransformAction types'
                 solutions == [ 'Remove the annotation' ]
-                additionalData.asMap == [ 'typeName' : 'MyTask' ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask',
+                    'fatal' : true,
+                ]
             }
             verifyAll(receivedProblem(1)) {
                 fqid == 'validation:type-validation:invalid-use-of-type-annotation'
                 contextualLabel == 'Type \'MyTask.Options\' is incorrectly annotated with @CacheableTask'
                 details == 'This annotation only makes sense on Task types'
                 solutions == [ 'Remove the annotation' ]
-                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask.Options',
+                    'fatal' : true,
+                ]
             }
             verifyAll(receivedProblem(2)) {
                 fqid == 'validation:type-validation:invalid-use-of-type-annotation'
                 contextualLabel == 'Type \'MyTask.Options\' is incorrectly annotated with @CacheableTransform'
                 details == 'This annotation only makes sense on TransformAction types'
                 solutions == [ 'Remove the annotation' ]
-                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask.Options',
+                    'fatal' : true,
+                ]
             }
             verifyAll(receivedProblem(3)) {
                 fqid == 'validation:type-validation:invalid-use-of-type-annotation'
                 contextualLabel == 'Type \'MyTask.Options\' is incorrectly annotated with @DisableCachingByDefault'
                 details == 'This annotation only makes sense on Task, TransformAction types'
                 solutions == [ 'Remove the annotation' ]
-                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask.Options',
+                    'fatal' : true,
+                ]
             }
         }
     }
@@ -413,6 +430,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'badTime',
+                    'fatal' : true,
                 ]
             }
             verifyAll(receivedProblem(1)) {
@@ -427,6 +445,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'parentPropertyName' : 'options',
                     'typeName' : 'MyTask',
                     'propertyName' : 'badNested',
+                    'fatal' : true,
                 ]
             }
         }
@@ -567,6 +586,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'mutablePropertyWithSetter',
+                    'fatal' : true,
                 ]
             }
         }
@@ -635,6 +655,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'badTime',
+                    'fatal' : true,
                 ]
             }
             verifyAll(receivedProblem(1)) {
@@ -649,6 +670,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'parentPropertyName' : 'options',
                     'typeName' : 'MyTask',
                     'propertyName' : 'badNested',
+                    'fatal' : true,
                 ]
             }
             verifyAll(receivedProblem(2)) {
@@ -662,6 +684,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'outputDir',
+                    'fatal' : true,
                 ]
             }
         }
@@ -718,7 +741,10 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData.asMap == [ 'typeName' : 'MyTask' ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask',
+                    'fatal' : true,
+                ]
             }
             verifyAll(receivedProblem(1)) {
                 fqid == 'validation:type-validation:ignored-annotations-on-method'
@@ -728,7 +754,10 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask.Options',
+                    'fatal' : true,
+                ]
             }
         }
     }
@@ -802,6 +831,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'readWrite',
+                    'fatal' : true,
                 ]
             }
             verifyAll(receivedProblem(1)) {
@@ -812,7 +842,10 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData.asMap == [ 'typeName' : 'MyTask' ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask',
+                    'fatal' : true,
+                ]
             }
             verifyAll(receivedProblem(2)) {
                 fqid == 'validation:type-validation:ignored-annotations-on-method'
@@ -822,7 +855,10 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData.asMap == [ 'typeName' : 'MyTask' ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask',
+                    'fatal' : true,
+                ]
             }
             verifyAll(receivedProblem(3)) {
                 fqid == 'validation:type-validation:ignored-annotations-on-method'
@@ -832,7 +868,10 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask.Options',
+                    'fatal' : true,
+                ]
             }
             verifyAll(receivedProblem(4)) {
                 fqid == 'validation:type-validation:ignored-annotations-on-method'
@@ -842,7 +881,10 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                     'Remove the annotations',
                     'Rename the method',
                 ]
-                additionalData.asMap == [ 'typeName' : 'MyTask.Options' ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask.Options',
+                    'fatal' : true,
+                ]
             }
         }
     }
@@ -897,6 +939,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'oldProperty',
+                    'fatal' : true,
                 ]
             }
         }
@@ -940,6 +983,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'file',
+                    'fatal' : true,
                 ]
             }
 

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/PublishedPluginsStricterValidationIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/PublishedPluginsStricterValidationIntegrationSpec.groovy
@@ -60,6 +60,7 @@ class PublishedPluginsStricterValidationIntegrationSpec extends AbstractIntegrat
             additionalData.asMap == [
                 'typeName': 'MyTask',
                 'propertyName': 'fileProp',
+                'fatal' : true,
             ]
         }
 

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/TaskFromPluginValidationIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/TaskFromPluginValidationIntegrationTest.groovy
@@ -124,8 +124,6 @@ class TaskFromPluginValidationIntegrationTest extends AbstractIntegrationSpec im
         file("my-plugin/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblem.groovy") << """
 package org.gradle.integtests.fixtures.validation;
 
-import org.gradle.api.problems.Severity;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -138,7 +136,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target([ElementType.METHOD, ElementType.FIELD])
 public @interface ValidationProblem {
-    Severity value() default Severity.WARNING;
+    boolean fatal() default false;
 }
         """
     }
@@ -154,10 +152,9 @@ public @interface ValidationProblem {
     private void writeTaskInto(@GroovyBuildScriptLanguage String header = "", TestFile testFile) {
         testFile << """$header
             import org.gradle.integtests.fixtures.validation.ValidationProblem
-            import org.gradle.api.problems.Severity
 
             abstract class SomeTask extends DefaultTask {
-                @ValidationProblem(value=Severity.ERROR)
+                @ValidationProblem(fatal=true)
                 abstract Property<String> getInput()
 
                 @OutputFile

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart1IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart1IntegrationTest.groovy
@@ -61,6 +61,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'tree',
                 'typeName' : 'MyTask',
                 'propertyName' : 'nonAnnotated',
+                'fatal' : true,
             ]
         }
 
@@ -113,6 +114,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'options',
                 'typeName' : 'MyTask',
                 'propertyName' : 'nestedThing',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -126,6 +128,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'thing',
+                'fatal' : true,
             ]
         }
 
@@ -186,6 +189,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'dirProp',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -196,6 +200,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'fileProp',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(2)) {
@@ -206,6 +211,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'filesProp',
+                'fatal' : true,
             ]
         }
     }
@@ -375,6 +381,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTransformAction',
                 'propertyName' : 'inputFile',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -388,6 +395,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTransformAction',
                 'propertyName' : 'badTime',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(2)) {
@@ -401,6 +409,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTransformAction',
                 'propertyName' : 'oldThing',
+                'fatal' : true,
             ]
         }
     }
@@ -480,6 +489,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTransformParameters',
                 'propertyName' : 'inputFile',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -490,6 +500,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTransformParameters',
                 'propertyName' : 'incrementalNonFileInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(2)) {
@@ -503,6 +514,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTransformParameters',
                 'propertyName' : 'badTime',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(3)) {
@@ -516,6 +528,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTransformParameters',
                 'propertyName' : 'oldThing',
+                'fatal' : true,
             ]
         }
 
@@ -555,7 +568,10 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                  'Add @CacheableTask',
                  'Add @UntrackedTask(because = ...)',
              ]
-             additionalData.asMap == [ 'typeName' : 'MyTask' ]
+             additionalData.asMap == [
+                 'typeName' : 'MyTask',
+                 'fatal' : true,
+             ]
          }
          verifyAll(receivedProblem(1)) {
              fqid == 'validation:type-validation:not-cacheable-without-reason'
@@ -565,7 +581,10 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                  'Add @DisableCachingByDefault(because = ...)',
                  'Add @CacheableTransform',
              ]
-             additionalData.asMap == [ 'typeName' : 'MyTransformAction' ]
+             additionalData.asMap == [
+                 'typeName' : 'MyTransformAction',
+                 'fatal' : true,
+             ]
          }
     }
 
@@ -658,6 +677,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'direct',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -671,6 +691,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'listPropertyInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(2)) {
@@ -684,6 +705,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'mapPropertyInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(3)) {
@@ -698,6 +720,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'nestedBean',
                 'typeName' : 'MyTask',
                 'propertyName' : 'nestedInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(4)) {
@@ -711,6 +734,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'propertyInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(5)) {
@@ -724,6 +748,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'providerInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(6)) {
@@ -737,6 +762,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'setPropertyInput',
+                'fatal' : true,
             ]
         }
 

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
@@ -96,6 +96,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'direct',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -106,6 +107,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'listPropertyInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(2)) {
@@ -116,6 +118,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'mapPropertyInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(3)) {
@@ -127,6 +130,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'nestedBean',
                 'typeName' : 'MyTask',
                 'propertyName' : 'nestedInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(4)) {
@@ -137,6 +141,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'propertyInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(5)) {
@@ -147,6 +152,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'providerInput',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(6)) {
@@ -157,6 +163,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'setPropertyInput',
+                'fatal' : true,
             ]
         }
     }
@@ -247,6 +254,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'file',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -261,6 +269,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'fileCollection',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(2)) {
@@ -275,6 +284,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'filePath',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(3)) {
@@ -289,6 +299,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'fileTree',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(4)) {
@@ -299,6 +310,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'inputDirectory',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(5)) {
@@ -309,6 +321,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'inputFile',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(6)) {
@@ -319,6 +332,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'inputFiles',
+                'fatal' : true,
             ]
         }
     }
@@ -450,6 +464,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'doubleIterableOptions.*.*',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -464,6 +479,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'iterableMappedOptions.*.<key>.*',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(2)) {
@@ -478,6 +494,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'iterableOptions.*',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(3)) {
@@ -492,6 +509,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'mappedOptions.<key>',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(4)) {
@@ -506,6 +524,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'namedIterable.<name>',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(5)) {
@@ -520,6 +539,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'options',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(6)) {
@@ -534,6 +554,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'optionsList.*',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(7)) {
@@ -548,6 +569,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
                 'parentPropertyName' : 'providedOptions',
                 'typeName' : 'MyTask',
                 'propertyName' : 'notAnnotated',
+                'fatal' : true,
             ]
         }
     }
@@ -657,6 +679,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : 'mapWithUnsupportedKey',
+                'fatal' : true,
             ]
         }
     }
@@ -701,6 +724,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             additionalData.asMap == [
                 'typeName' : 'MyTask',
                 'propertyName' : "my$typeName",
+                'fatal' : true,
             ]
         }
 
@@ -799,7 +823,8 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
             ]
             additionalData.asMap == [
                 'typeName' : 'MyTask',
-                'propertyName' : "my$typeName"
+                'propertyName' : "my$typeName",
+                'fatal' : true,
             ]
         }
 

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsTrait.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsTrait.groovy
@@ -60,12 +60,12 @@ trait ValidatePluginsTrait implements CommonPluginValidationTrait, ValidationMes
     void assertValidationFailsWith(List<AbstractPluginValidationIntegrationSpec.DocumentedProblem> messages) {
         fails "validatePlugins"
         def report = new TaskValidationReportFixture(file("build/reports/plugin-development/validation-report.json"))
-        report.verify(messages.collectEntries {
+        report.verify(messages.collect {
             def fullMessage = it.message
             if (!it.defaultDocLink) {
                 fullMessage = "${fullMessage}\n${learnAt(it.id, it.section)}"
             }
-            [(fullMessage): it.severity]
+            fullMessage
         })
 
         failure.assertHasCause "Plugin validation failed with ${messages.size()} problem${getPluralEnding(messages)}"

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
@@ -23,13 +23,11 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.problems.Problem;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemReporter;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblem;
-import org.gradle.api.problems.internal.InternalProblemReporter;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
@@ -47,6 +45,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.execution.WorkValidationException;
 import org.gradle.internal.jvm.SupportedJavaVersions;
+import org.gradle.internal.validation.TypeValidationUtil;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.plugin.devel.tasks.internal.ValidateAction;
@@ -62,7 +61,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllBytes;
 import static java.util.stream.Collectors.joining;
-import static org.gradle.api.problems.Severity.ERROR;
 
 /**
  * Validates plugins by checking property annotations on work items like tasks and artifact transforms.
@@ -165,13 +163,15 @@ public abstract class ValidatePlugins extends DefaultTask {
         if (problems.isEmpty()) {
             getLogger().info("Plugin validation finished without warnings.");
         } else {
-            if (getFailOnWarning().get() || problems.stream().anyMatch(problem -> problem.getDefinition().getSeverity() == ERROR)) {
+            if (getFailOnWarning().get() || problems.stream().anyMatch(problem -> TypeValidationUtil.isFatal(problem))) {
                 if (getIgnoreFailures().get()) {
                     getLogger().warn("Plugin validation finished with errors. {} {}",
                         annotateTaskPropertiesDoc(),
                         messages.collect(joining()));
                 } else {
-                    reportProblems(problems);
+                    getServices().get(InternalProblems.class)
+                        .getInternalReporter()
+                        .reportError(problems);
                     throw WorkValidationException.forProblems(messages.collect(toImmutableList()))
                         .withSummaryForPlugin()
                         .getWithExplanation(annotateTaskPropertiesDoc());
@@ -181,11 +181,6 @@ public abstract class ValidatePlugins extends DefaultTask {
                     messages.collect(joining()));
             }
         }
-    }
-
-    private void reportProblems(List<? extends Problem> problems) {
-        InternalProblemReporter reporter = getServices().get(InternalProblems.class).getInternalReporter();
-        problems.forEach(reporter::report);
     }
 
     private String annotateTaskPropertiesDoc() {

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
@@ -54,7 +54,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 public abstract class ValidateAction implements WorkAction<ValidateAction.Params> {
@@ -194,7 +193,6 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
                             .id(TextUtil.screamingSnakeToKebabCase(ValidationTypes.NOT_CACHEABLE_WITHOUT_REASON), "Not cacheable without reason", GradleCoreProblemGroup.validation().type())
                             .contextualLabel("must be annotated either with " + cacheableAnnotation + " or with " + disableCachingAnnotation)
                             .documentedAt(userManual("validation_problems", "disable_caching_by_default"))
-                            .severity(ERROR)
                             .details("The " + workType + " author should make clear why a " + workType + " is not cacheable")
                             .solution("Add " + disableCachingAnnotation + "(because = ...)")
                             .solution("Add " + cacheableAnnotation);

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
@@ -56,6 +56,7 @@ import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.PropertyTraceData;
 import org.gradle.api.problems.internal.TypeValidationData;
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
+import org.gradle.internal.validation.TypeValidationUtil;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -94,7 +95,11 @@ public class ValidationProblemSerialization {
 
     public static Stream<String> toPlainMessage(List<? extends InternalProblem> problems) {
         return problems.stream()
-            .map(problem -> problem.getDefinition().getSeverity() + ": " + TypeValidationProblemRenderer.renderMinimalInformationAbout(problem));
+            .map(problem -> severityLabel(problem) + ": " + TypeValidationProblemRenderer.renderMinimalInformationAbout(problem));
+    }
+
+    private static String severityLabel(InternalProblem problem) {
+        return TypeValidationUtil.isFatal(problem) ? "Error" : "Warning";
     }
 
     /**
@@ -552,6 +557,7 @@ public class ValidationProblemSerialization {
         public static final String PARENT_PROPERTY_NAME = "parentPropertyName";
         public static final String TYPE_NAME = "typeName";
         public static final String GENERAL_DATA_DATA = "data";
+        public static final String FATAL = "fatal";
 
         @Override
         public void write(JsonWriter out, AdditionalData value) throws IOException {
@@ -571,6 +577,7 @@ public class ValidationProblemSerialization {
                 out.name(FUNCTION_NAME).value(typeValidationData.getFunctionName());
                 out.name(PARENT_PROPERTY_NAME).value(typeValidationData.getParentPropertyName());
                 out.name(TYPE_NAME).value(typeValidationData.getTypeName());
+                out.name(FATAL).value(typeValidationData.isFatal());
             } else if (value instanceof GeneralData) {
                 out.name(ADDITIONAL_DATA_TYPE).value(GENERAL_DATA);
                 out.name(GENERAL_DATA_DATA);
@@ -604,6 +611,7 @@ public class ValidationProblemSerialization {
                 String name;
                 Map<String, String> generalData = null;
                 String propertyTrace = null;
+                Boolean fatal = true;
 
                 while (in.hasNext()) {
                     name = in.nextName();
@@ -636,6 +644,10 @@ public class ValidationProblemSerialization {
                             typeName = in.nextString();
                             break;
                         }
+                        case FATAL: {
+                            fatal = in.nextBoolean();
+                            break;
+                        }
                         case PROPERTY_TRACE: {
                             propertyTrace = in.nextString();
                             break;
@@ -661,13 +673,13 @@ public class ValidationProblemSerialization {
                 if (type == null) {
                     throw new JsonParseException("type must not be null");
                 }
-                return createAdditionalData(type, featureUsage, pluginId, propertyName, functionName, parentPropertyName, typeName, generalData, propertyTrace);
+                return createAdditionalData(type, featureUsage, pluginId, propertyName, functionName, parentPropertyName, typeName, generalData, propertyTrace, fatal);
             } finally {
                 in.endObject();
             }
         }
 
-        private static @NonNull AdditionalData createAdditionalData(String type, String featureUsage, String pluginId, String propertyName, String methodName, String parentPropertyName, String typeName, Map<String, String> generalData, String propertyTrace) {
+        private static @NonNull AdditionalData createAdditionalData(String type, String featureUsage, String pluginId, String propertyName, String methodName, String parentPropertyName, String typeName, Map<String, String> generalData, String propertyTrace, boolean fatal) {
             switch (type) {
                 case DEPRECATION_DATA:
                     return new DefaultDeprecationData(DeprecationData.Type.valueOf(featureUsage));
@@ -677,8 +689,8 @@ public class ValidationProblemSerialization {
                         propertyName,
                         methodName,
                         parentPropertyName,
-                        typeName
-                    );
+                        typeName,
+                        fatal);
                 case GENERAL_DATA:
                     return new DefaultGeneralData(generalData);
                 case PROPERTY_TRACE_DATA:

--- a/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.plugin.devel.tasks.internal
 
 import com.google.gson.Gson
 import org.gradle.api.problems.ProblemId
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.AdditionalDataBuilderFactory
 import org.gradle.api.problems.internal.DefaultProblemReporter
 import org.gradle.api.problems.internal.DeprecationData
@@ -162,28 +161,6 @@ class ValidationProblemSerializationTest extends Specification {
         deserialized[0].exception.message == "cause"
     }
 
-    def "can serialize and deserialize a validation problem with a severity"(Severity severity) {
-        given:
-        def problem = problemReporter.create(problemId) {
-            it.severity(severity)
-        }
-
-        when:
-        def json = gson.toJson([problem])
-        def deserialized = ValidationProblemSerialization.parseMessageList(json)
-
-        then:
-        deserialized.size() == 1
-        deserialized[0].definition.id.name == "id"
-        deserialized[0].definition.id.displayName == "label"
-        deserialized[0].originLocations == [] as List
-        deserialized[0].definition.documentationLink == null
-        deserialized[0].definition.severity == severity
-
-        where:
-        severity << Severity.values()
-    }
-
     def "can serialize and deserialize a validation problem with a solution"() {
         given:
         def problem = problemReporter.create(problemId) {
@@ -214,6 +191,7 @@ class ValidationProblemSerializationTest extends Specification {
                     it.typeName("type")
                     it.parentPropertyName("parent")
                     it.pluginId("id")
+                    it.fatal(false)
                 }
         }
 
@@ -231,6 +209,7 @@ class ValidationProblemSerializationTest extends Specification {
         (deserialized[0].additionalData as TypeValidationData).typeName == 'type'
         (deserialized[0].additionalData as TypeValidationData).parentPropertyName == 'parent'
         (deserialized[0].additionalData as TypeValidationData).pluginId == 'id'
+        (deserialized[0].additionalData as TypeValidationData).fatal == false
     }
 
     def "can serialize generic additional data"() {

--- a/platforms/extensibility/plugin-development/src/testFixtures/groovy/org/gradle/plugin/devel/tasks/TaskValidationReportFixture.groovy
+++ b/platforms/extensibility/plugin-development/src/testFixtures/groovy/org/gradle/plugin/devel/tasks/TaskValidationReportFixture.groovy
@@ -17,7 +17,6 @@
 package org.gradle.plugin.devel.tasks
 
 import groovy.transform.CompileStatic
-import org.gradle.api.problems.Severity
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer
 import org.gradle.plugin.devel.tasks.internal.ValidationProblemSerialization
 
@@ -30,16 +29,14 @@ class TaskValidationReportFixture {
         this.reportFile = reportFile
     }
 
-    void verify(Map<String, Severity> messages) {
+    void verify(List<String> messages) {
         def expectedReportContents = messages
-            .collect { message, severity ->
-                "$severity: $message"
-            }
+            .collect { message -> "Error: $message" }
             .join(PROBLEM_SEPARATOR)
             .replaceAll("\n+", "\n")
         def reportText =
             ValidationProblemSerialization.parseMessageList(reportFile.text)
-                .collect { it.definition.severity.toString() + ": " + TypeValidationProblemRenderer.renderMinimalInformationAbout(it) }
+                .collect { "Error: " + TypeValidationProblemRenderer.renderMinimalInformationAbout(it) }
                 .sort()
                 .join(PROBLEM_SEPARATOR)
                 .replaceAll("\r\n", "\n")

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureApplicator.java
@@ -27,41 +27,39 @@ import org.gradle.api.artifacts.dsl.DependencyFactory;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
 import org.gradle.api.internal.DynamicObjectAware;
-import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Nested;
-import org.gradle.features.binding.ProjectFeatureApplyAction;
-import org.gradle.features.internal.file.DefaultProjectFeatureLayout;
-import org.gradle.features.file.ProjectFeatureLayout;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.model.ObjectFactoryFactory;
-import org.gradle.features.binding.BuildModel;
-import org.gradle.features.binding.Definition;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
-import org.gradle.features.binding.ProjectFeatureApplicationContext;
-import org.gradle.features.registration.ConfigurationRegistrar;
-import org.gradle.features.internal.registration.DefaultConfigurationRegistrar;
-import org.gradle.features.internal.registration.DefaultTaskRegistrar;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.features.registration.TaskRegistrar;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblemReporter;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.features.binding.BuildModel;
+import org.gradle.features.binding.Definition;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectFeatureApplyAction;
+import org.gradle.features.file.ProjectFeatureLayout;
+import org.gradle.features.internal.binding.ProjectFeatureSupportInternal.ProjectFeatureDefinitionContext;
+import org.gradle.features.internal.file.DefaultProjectFeatureLayout;
+import org.gradle.features.internal.registration.DefaultConfigurationRegistrar;
+import org.gradle.features.internal.registration.DefaultTaskRegistrar;
+import org.gradle.features.registration.ConfigurationRegistrar;
+import org.gradle.features.registration.TaskRegistrar;
 import org.gradle.internal.Cast;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.instantiation.managed.ManagedObjectRegistry;
 import org.gradle.internal.logging.text.TreeFormatter;
-
 import org.gradle.internal.reflect.annotations.PropertyAnnotationMetadata;
 import org.gradle.internal.reflect.annotations.TypeAnnotationMetadataStore;
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
 import org.gradle.internal.service.ServiceLookup;
 import org.gradle.internal.service.ServiceLookupException;
 import org.gradle.internal.service.UnknownServiceException;
-import org.gradle.features.internal.binding.ProjectFeatureSupportInternal.ProjectFeatureDefinitionContext;
 import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
@@ -492,9 +490,8 @@ abstract public class DefaultProjectFeatureApplicator implements ProjectFeatureA
                 .contextualLabel("Project feature '" + featureName + "' has an apply action that attempts to inject an unknown service with type '" + serviceType.getTypeName() + "'.")
                 .details("Services of type " + serviceType.getTypeName() + " are not available for injection into project feature apply actions.")
                 .solution("Remove the '" + serviceType.getTypeName() + "' injection from the apply action.")
-                .severity(Severity.ERROR)
             );
-            problemReporter.report(problem);
+            problemReporter.reportError(problem);
             throw new UnknownServiceException(serviceType, TypeValidationProblemRenderer.renderMinimalInformationAbout(problem));
         }
     }
@@ -549,9 +546,8 @@ abstract public class DefaultProjectFeatureApplicator implements ProjectFeatureA
                 .details(getSafeServicesListExplanation())
                 .solution("Mark the apply action as unsafe.")
                 .solution("Remove the '" + serviceType.getTypeName() + "' injection from the apply action.")
-                .severity(Severity.ERROR)
             );
-            problemReporter.report(problem);
+            problemReporter.reportError(problem);
             throw new UnknownServiceException(serviceType, TypeValidationProblemRenderer.renderMinimalInformationAbout(problem));
         }
     }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureDeclarations.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureDeclarations.java
@@ -22,6 +22,12 @@ import org.gradle.api.NamedDomainObjectCollectionSchema;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.internal.tasks.properties.InspectionScheme;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
+import org.gradle.api.problems.internal.InternalProblem;
+import org.gradle.api.problems.internal.InternalProblemReporter;
+import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.tasks.Nested;
 import org.gradle.features.annotations.BindsProjectFeature;
 import org.gradle.features.annotations.BindsProjectType;
 import org.gradle.features.binding.BuildModel;
@@ -29,13 +35,6 @@ import org.gradle.features.binding.Definition;
 import org.gradle.features.binding.ProjectFeatureBinding;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.TargetTypeInformation;
-import org.gradle.api.internal.tasks.properties.InspectionScheme;
-import org.gradle.api.problems.Severity;
-import org.gradle.api.problems.internal.GradleCoreProblemGroup;
-import org.gradle.api.problems.internal.InternalProblem;
-import org.gradle.api.problems.internal.InternalProblemReporter;
-import org.gradle.api.reflect.TypeOf;
-import org.gradle.api.tasks.Nested;
 import org.gradle.internal.Pair;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.properties.annotations.TypeMetadata;
@@ -120,7 +119,6 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                 .contextualLabel("Project feature '" + projectFeatureName + "' is bound to 'BuildModel.None'")
                 .solution("Bind to a target definition type instead.")
                 .solution("Bind to a concrete build model type other than 'BuildModel.None'.")
-                .severity(Severity.ERROR)
             );
 
             throwTypeValidationException("Project feature '" + projectFeatureName + "' is bound to an invalid type:", singletonList(bindingTypeProblem));
@@ -146,7 +144,6 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                         .details("A project feature or type with a given name must bind to a unique target type.")
                         .contextualLabel("Project feature '" + projectFeatureName + "' is registered by both '" + pluginClass.getName() + "' and '" + existingPluginClass.getName() + "' but their bindings have overlapping target types.")
                         .solution("Remove one of the plugins from the build.")
-                        .severity(Severity.ERROR)
                     )
                 );
             });
@@ -220,7 +217,6 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                 .contextualLabel("Project feature '" + binding.getName() + "' has a definition with type '" + binding.getDefinitionType().getSimpleName() + "' which was declared safe but has an implementation type '" + binding.getDefinitionImplementationType().get().getSimpleName() + "'")
                 .solution("Mark the definition as unsafe.")
                 .solution("Remove the implementation type specification.")
-                .severity(Severity.ERROR)
             ));
         }
 
@@ -231,20 +227,18 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                 .contextualLabel("Project feature '" + binding.getName() + "' has a definition with type '" + binding.getDefinitionType().getSimpleName() + "' which was declared safe but is not an interface")
                 .solution("Mark the definition as unsafe.")
                 .solution("Refactor the type as an interface.")
-                .severity(Severity.ERROR)
             ));
         }
 
         validateDefinition(binding.getDefinitionType(), problems);
 
-        problemReporter.report(problems);
+        problemReporter.reportError(problems);
 
         throwTypeValidationException("Project feature '" + binding.getName() + "' has a definition type which was declared safe but has the following issues:", problems);
     }
 
     private static void throwTypeValidationException(String summary, List<InternalProblem> problems) {
         List<String> formattedErrors = problems.stream()
-            .filter(problem -> problem.getDefinition().getSeverity().equals(Severity.ERROR))
             .map(TypeValidationProblemRenderer::renderMinimalInformationAbout)
             .collect(Collectors.toList());
 
@@ -268,7 +262,6 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                     .contextualLabel("The definition type has @Inject annotated property '" + propertyMetadata.getPropertyName() + "' in type '" + definitionType.getSimpleName() + "'")
                     .solution("Mark the definition as unsafe.")
                     .solution("Remove the @Inject annotation from the '" + propertyMetadata.getPropertyName() + "' property.")
-                    .severity(Severity.ERROR)
                 ));
             }
 

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -51,6 +51,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             definition.id.fqid == 'generic:type'
             definition.id.displayName == 'label'
+            definition.severity == Severity.WARNING
             with(oneLocation(StackTraceLocation).fileLocation) {
                 length == -1
                 column == -1
@@ -204,25 +205,6 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    def "can emit a problem with a severity"(Severity severity) {
-        given:
-        withReportProblemTask """
-            ${problemIdScript()}
-            problems.getReporter().report(problemId) {
-                it.severity(Severity.${severity.name()})
-            }
-        """
-
-        when:
-        run('reportProblem')
-
-        then:
-        receivedProblem.definition.severity == severity
-
-        where:
-        severity << Severity.values()
-    }
-
     def "can emit a problem with a solution"() {
         given:
         withReportProblemTask """
@@ -335,7 +317,10 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         fails('reportProblem')
 
         then:
-        receivedProblem.exception.message == 'test'
+        verifyAll(receivedProblem) {
+            exception.message == 'test'
+            definition.severity == Severity.ERROR
+        }
     }
 
     def "can rethrow a caught exception"() {

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
@@ -176,6 +176,8 @@ public interface ProblemSpec {
      * @param severity the severity
      * @return this
      * @since 8.6
+     * @deprecated Severity is now determined automatically: use {@link ProblemReporter#report} for warnings and {@link ProblemReporter#throwing} for errors.
      */
+    @Deprecated
     ProblemSpec severity(Severity severity);
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/Severity.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/Severity.java
@@ -25,9 +25,24 @@ import org.gradle.api.Incubating;
  */
 @Incubating
 public enum Severity {
+    /**
+     * Advice-level severity.
+     * @deprecated Only kept for backward compatibility. Will be removed in Gradle 10.0.
+     */
+    @Deprecated
     ADVICE("Advice"),
+
+    /**
+     * Warning-level severity, for problems that won't the build.
+     *
+     */
     WARNING("Warning"),
+
+    /**
+     * Error-level severity, for problems that will fail the build.
+     */
     ERROR("Error");
+
     private final String displayName;
 
     Severity(String displayName) {

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
@@ -205,7 +205,14 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
     }
 
     @Override
+    @Deprecated
     public InternalProblemBuilder severity(Severity severity) {
+        // do nothing
+        return this;
+    }
+
+    @Override
+    public InternalProblemBuilder internalSeverity(Severity severity) {
         this.severity = severity;
         return this;
     }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemReporter.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemReporter.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.problems.Problem;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemSpec;
+import org.gradle.api.problems.Severity;
 import org.gradle.internal.exception.ExceptionAnalyser;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.OperationIdentifier;
@@ -63,12 +64,25 @@ public class DefaultProblemReporter implements InternalProblemReporter {
     }
 
     @Override
+    public void reportError(Problem problem) {
+        problem = getBuilder(problem).internalSeverity(Severity.ERROR).build();
+        report(problem);
+    }
+
+    @Override
+    public void reportError(Collection<? extends Problem> problems) {
+        for (Problem problem : problems) {
+            reportError(problem);
+        }
+    }
+
+    @Override
     public RuntimeException throwing(Throwable exception, ProblemId problemId, Action<? super ProblemSpec> spec) {
         DefaultProblemBuilder problemBuilder = createProblemBuilder();
         problemBuilder.id(problemId);
         spec.execute(problemBuilder);
         problemBuilder.withException(exception);
-        report(problemBuilder.build());
+        report(addExceptionToProblem(exception, problemBuilder.build()));
         throw runtimeException(exception);
     }
 
@@ -89,7 +103,7 @@ public class DefaultProblemReporter implements InternalProblemReporter {
 
     @NonNull
     private InternalProblem addExceptionToProblem(Throwable exception, Problem problem) {
-        return getBuilder(problem).withException(transform(exception)).build();
+        return getBuilder(problem).internalSeverity(Severity.ERROR).withException(transform(exception)).build();
     }
 
     private static RuntimeException runtimeException(Throwable exception) {

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultTypeValidationData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultTypeValidationData.java
@@ -30,13 +30,15 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
     private final String functionName;
     private final String parentPropertyName;
     private final String typeName;
+    private final boolean fatal;
 
-    public DefaultTypeValidationData(String pluginId, String propertyName, String functionName, String parentPropertyName, String typeName) {
+    public DefaultTypeValidationData(String pluginId, String propertyName, String functionName, String parentPropertyName, String typeName, boolean fatal) {
         this.pluginId = pluginId;
         this.propertyName = propertyName;
         this.functionName = functionName;
         this.parentPropertyName = parentPropertyName;
         this.typeName = typeName;
+        this.fatal = fatal;
     }
 
     @Override
@@ -62,6 +64,11 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
     @Override
     public String getTypeName() {
         return typeName;
+    }
+
+    @Override
+    public boolean isFatal() {
+        return fatal;
     }
 
     @Override
@@ -96,6 +103,7 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
         private String functionName;
         private String parentPropertyName;
         private String typeName;
+        private boolean fatal = true;
 
         public DefaultTypeValidationDataBuilder() {
         }
@@ -106,11 +114,12 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
             this.functionName = from.getFunctionName();
             this.parentPropertyName = from.getParentPropertyName();
             this.typeName = from.getTypeName();
+            this.fatal = from.isFatal();
         }
 
         @Override
         public DefaultTypeValidationData build() {
-            return new DefaultTypeValidationData(pluginId, propertyName, functionName, parentPropertyName, typeName);
+            return new DefaultTypeValidationData(pluginId, propertyName, functionName, parentPropertyName, typeName, fatal);
         }
 
         @Override
@@ -140,6 +149,12 @@ public class DefaultTypeValidationData implements TypeValidationData, Serializab
         @Override
         public TypeValidationDataSpec typeName(String typeName) {
             this.typeName = typeName;
+            return this;
+        }
+
+        @Override
+        public TypeValidationDataSpec fatal(boolean fatal) {
+            this.fatal = fatal;
             return this;
         }
     }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemBuilder.java
@@ -83,7 +83,10 @@ public interface InternalProblemBuilder extends InternalProblemSpec {
     InternalProblemBuilder withException(Throwable t);
 
     @Override
+    @Deprecated
     InternalProblemBuilder severity(Severity severity);
+
+    InternalProblemBuilder internalSeverity(Severity severity);
 
     ProblemsInfrastructure getInfrastructure();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemReporter.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemReporter.java
@@ -21,6 +21,8 @@ import org.gradle.api.problems.Problem;
 import org.gradle.api.problems.ProblemReporter;
 import org.gradle.internal.operations.OperationIdentifier;
 
+import java.util.Collection;
+
 public interface InternalProblemReporter extends ProblemReporter {
 
     /**
@@ -32,6 +34,22 @@ public interface InternalProblemReporter extends ProblemReporter {
      * @param id The operation identifier.
      */
     void report(Problem problem, OperationIdentifier id);
+
+    /**
+     * Reports the target problem as it will cause the build to fail. Unlike {@link #throwing(Throwable, Problem)}, this method does not throw an exception.
+     * This is a temporary workaround as not all fatal problems can be reported via {@link #throwing(Throwable, Problem)} without significant refactoring. The goal is to eventually remove this method.
+     *
+     * @param problem The problem to report.
+     */
+    void reportError(Problem problem);
+
+    /**
+     * Reports the target problems as they will cause the build to fail. Unlike  {@link #throwing(Throwable, Collection)}, this method does not throw an exception.
+     * This is a temporary workaround as not all fatal problems can be reported via {@link #throwing(Throwable, Collection)} without significant refactoring. The goal is to eventually remove this method.
+     *
+     * @param problems The problems to report.
+     */
+    void reportError(Collection<? extends Problem> problems);
 
     InternalProblem internalCreate(Action<? super InternalProblemSpec> action);
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemSpec.java
@@ -119,6 +119,7 @@ public interface InternalProblemSpec extends ProblemSpec {
     InternalProblemSpec withException(Throwable t);
 
     @Override
+    @Deprecated
     InternalProblemSpec severity(Severity severity);
 
     /**

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationData.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationData.java
@@ -27,4 +27,5 @@ public interface TypeValidationData extends AdditionalData {
     String getFunctionName();
     String getParentPropertyName();
     String getTypeName();
+    boolean isFatal();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationDataSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/TypeValidationDataSpec.java
@@ -25,4 +25,5 @@ public interface TypeValidationDataSpec extends AdditionalDataSpec {
     TypeValidationDataSpec functionName(String methodName);
     TypeValidationDataSpec parentPropertyName(String parentPropertyName);
     TypeValidationDataSpec typeName(String typeName);
+    TypeValidationDataSpec fatal(boolean fatal);
 }

--- a/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemTest.groovy
+++ b/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemTest.groovy
@@ -32,7 +32,7 @@ import spock.lang.Specification
 class DefaultProblemTest extends Specification {
     def "unbound builder result is equal to original"() {
         def additionalData = Mock(AdditionalData)
-        def problem = createTestProblem(severity, additionalData)
+        def problem = createTestProblem(additionalData)
         def newProblem = toBuilder(problem).build()
 
         expect:
@@ -46,9 +46,6 @@ class DefaultProblemTest extends Specification {
         newProblem.originLocations == problem.originLocations
 
         newProblem == problem
-
-        where:
-        severity << [Severity.WARNING, Severity.ERROR]
     }
 
     def InternalProblemBuilder toBuilder(DefaultProblem problem) {
@@ -70,7 +67,6 @@ class DefaultProblemTest extends Specification {
 
         where:
         changedAspect | changeClosure
-        "severity"    | { it.severity(Severity.WARNING) }
         "locations"   | { it.fileLocation("file") }
         "details"     | { it.details("details") }
     }
@@ -93,7 +89,7 @@ class DefaultProblemTest extends Specification {
                 Mock(ProblemStream)
             )
         )
-        def problem = createTestProblem(Severity.WARNING)
+        def problem = createTestProblem()
         def builder = toBuilder(problem)
         def newProblem = builder
             .solution("solution")
@@ -118,11 +114,11 @@ class DefaultProblemTest extends Specification {
         newProblem.class == DefaultProblem
     }
 
-    private static createTestProblem(Severity severity = Severity.ERROR, AdditionalData additionalData = null) {
+    private static createTestProblem(AdditionalData additionalData = null) {
         new DefaultProblem(
             new DefaultProblemDefinition(
                 ProblemId.create('message', "displayName", ProblemGroup.create("generic", "Generic")),
-                severity,
+                Severity.ERROR,
                 Documentation.userManual('id'),
             ),
             null,

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/Severity.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/Severity.java
@@ -29,7 +29,7 @@ public interface Severity {
 
     // Note: the static fields must be in sync with entries from org.gradle.api.problems.Severity.
     /**
-     * Advice-level severity.
+     * Advice-level severity. Only emitted by Gradle versions < 9.6.
      *
      * @since 8.6
      */
@@ -37,6 +37,7 @@ public interface Severity {
 
     /**
      * Warning-level severity.
+     * Gradle versions < 9.6 allow explicitly setting severity to warning, but starting from 9.6, they will only emit warnings for problems that won't the build.
      *
      * @since 8.6
      */
@@ -44,6 +45,7 @@ public interface Severity {
 
     /**
      * Error-level severity.
+     * Gradle versions < 9.6 allow explicitly setting severity to error, but starting from 9.6, they will only emit errors for problems that will fail the build.
      *
      * @since 8.6
      */

--- a/platforms/jvm/java-compiler-worker/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/java-compiler-worker/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -29,7 +29,6 @@ import org.gradle.api.problems.Problem;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemSpec;
 import org.gradle.api.problems.Problems;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblemReporter;
 
@@ -164,7 +163,7 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
 
     @VisibleForTesting
     void buildProblem(Diagnostic<? extends JavaFileObject> diagnostic, ProblemSpec spec) {
-        addSeverity(diagnostic, spec);
+        maybeAddSolution(diagnostic, spec);
         addLocations(diagnostic, spec);
 
         String label = toFormattedLabel(diagnostic);
@@ -198,10 +197,8 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
         spec.details(formattedMessage);
     }
 
-    private static void addSeverity(Diagnostic<? extends JavaFileObject> diagnostic, ProblemSpec spec) {
-        Severity severity = mapKindToSeverity(diagnostic.getKind());
-        spec.severity(severity);
-        if (severity == Severity.ERROR) {
+    private static void maybeAddSolution(Diagnostic<? extends JavaFileObject> diagnostic, ProblemSpec spec) {
+        if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
             spec.solution(CompilationFailedException.RESOLUTION_MESSAGE);
         }
     }
@@ -312,20 +309,6 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
 
     private static String getPath(JavaFileObject fileObject) {
         return fileObject.getName();
-    }
-
-    private static Severity mapKindToSeverity(Diagnostic.Kind kind) {
-        switch (kind) {
-            case ERROR:
-                return Severity.ERROR;
-            case WARNING:
-            case MANDATORY_WARNING:
-                return Severity.WARNING;
-            case NOTE:
-            case OTHER:
-            default:
-                return Severity.ADVICE;
-        }
     }
 
     public List<Problem> getReportedProblems() {

--- a/platforms/jvm/java-compiler-worker/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/platforms/jvm/java-compiler-worker/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDecla
 import org.gradle.api.internal.tasks.compile.reflect.GradleStandardJavaFileManager;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblems;
@@ -138,7 +137,6 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
     }
 
     private static void buildProblemFrom(RuntimeException ex, ProblemSpec spec) {
-        spec.severity(Severity.ERROR);
         spec.contextualLabel(ex.getLocalizedMessage());
         spec.withException(ex);
     }

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.tasks.compile.MinimalJavaCompilerDaemonForkOption
 import org.gradle.api.internal.tasks.compile.incremental.compilerapi.constants.ConstantsAnalysisResult;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblemReporter;
 import org.gradle.initialization.ClassLoaderRegistry;
@@ -124,7 +123,6 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
                 throw problemReporter.throwing(new IllegalStateException(contextualMessage), problemId, problemSpec -> problemSpec
                     .contextualLabel(contextualMessage)
                     .solution("Check if the installation is not a JRE but a JDK.")
-                    .severity(Severity.ERROR)
                 );
             } else {
                 languageGroovyClasspath = languageGroovyClasspath.plus(Collections.singletonList(toolsJar));

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -97,9 +97,9 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
      * @param expectLineLocation Whether to expect a line location (defaults to true)
      * @param fileLocation Optional file location for additional verification
      */
-    void verifyWarningProblem(ReceivedProblem problem, boolean expectLineLocation = true, String fileLocation = null) {
+    void verifyWarningProblem(ReceivedProblem problem, boolean expectLineLocation = true, String fileLocation = null, Severity severity = Severity.WARNING) {
         assertLocations(problem, expectLineLocation)
-        assert problem.severity == Severity.WARNING
+        assert problem.severity == severity
         assert problem.fqid == 'compilation:java:compiler.warn.redundant.cast'
         assert problem.definition.id.displayName == 'redundant cast to java.lang.String'
         assertRedundantCastInContextualLabel(problem.contextualLabel)
@@ -195,13 +195,13 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
         then:
         verifyAll(receivedProblem(0)) {
             assertLocations(it, false, false)
-            severity == Severity.ADVICE
+            severity == Severity.WARNING
             fqid == 'compilation:java:compiler.note.unchecked.filename'
             contextualLabel == "${buildFile.parentFile.path}/src/main/java/Foo.java uses unchecked or unsafe operations.".replace('/', File.separator)
         }
         verifyAll(receivedProblem(1)) {
             assertLocations(it, false, false)
-            severity == Severity.ADVICE
+            severity == Severity.WARNING
             fqid == 'compilation:java:compiler.note.unchecked.recompile'
             contextualLabel == "Recompile with -Xlint:unchecked for details."
         }
@@ -268,12 +268,13 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
         fails("compileJava")
 
         then:
+        true
         // Special -Werror error
         verifyWerrorProblem(receivedProblem(0))
 
         // The two expected warnings
-        verifyWarningProblem(receivedProblem(1), true, "$fooFileLocation:11")
-        verifyWarningProblem(receivedProblem(2), true, "$fooFileLocation:7")
+        verifyWarningProblem(receivedProblem(1), true, "$fooFileLocation:11", Severity.ERROR)
+        verifyWarningProblem(receivedProblem(2), true, "$fooFileLocation:7", Severity.ERROR)
 
         result.error.contains("1 error\n")
         result.error.contains("2 warnings\n")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -226,6 +226,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                     additionalData.asMap == [
                         'typeName': 'org.gradle.api.DefaultTask',
                         'propertyName': 'output',
+                        'fatal' : true,
                     ]
                 }
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -80,7 +80,6 @@ import org.gradle.api.internal.initialization.ResettableConfiguration;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.provider.Provider;
@@ -1318,7 +1317,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                         properUsageDesc
                     )
                 );
-                spec.severity(Severity.ERROR);
             });
         } else if (isExclusivelyDeprecatedUsage(properUsages)) {
             DeprecationLogger.deprecateAction(String.format("Calling %s on %s", methodName, this))
@@ -1497,7 +1495,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         ProblemId id = ProblemId.create("method-not-allowed", "Method call not allowed", GradleCoreProblemGroup.configurationUsage());
         throw configurationServices.getProblems().getInternalReporter().throwing(ex, id, spec -> {
             spec.contextualLabel(ex.getMessage());
-            spec.severity(Severity.ERROR);
         });
     }
 
@@ -1657,7 +1654,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         ProblemId id = ProblemId.create("extend-detached-not-allowed", "Extending a detachedConfiguration is not allowed", GradleCoreProblemGroup.configurationUsage());
         throw configurationServices.getProblems().getInternalReporter().throwing(ex, id, spec -> {
             spec.contextualLabel(ex.getMessage());
-            spec.severity(Severity.ERROR);
         });
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -36,7 +36,6 @@ import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.provider.Provider;
@@ -155,7 +154,6 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         ProblemId id = ProblemId.create("method-not-allowed", "Method call not allowed", GradleCoreProblemGroup.configurationUsage());
         throw problemsService.getInternalReporter().throwing(ex, id, spec -> {
             spec.contextualLabel(ex.getMessage());
-            spec.severity(Severity.ERROR);
         });
     }
 
@@ -320,7 +318,6 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         ProblemId id = ProblemId.create("unexpected configuration usage", "Unexpected configuration usage", GradleCoreProblemGroup.configurationUsage());
         throw problemsService.getInternalReporter().throwing(ex, id, spec -> {
             spec.contextualLabel(ex.getMessage());
-            spec.severity(Severity.ERROR);
         });
     }
 
@@ -370,7 +367,6 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
             ProblemId id = ProblemId.create("name-not-allowed", "Configuration name not allowed", GradleCoreProblemGroup.configurationUsage());
             throw problemsService.getInternalReporter().throwing(ex, id, spec -> {
                 spec.contextualLabel(ex.getMessage());
-                spec.severity(Severity.ERROR);
             });
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransform.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransform.java
@@ -98,7 +98,6 @@ import java.util.function.Supplier;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.gradle.api.internal.tasks.properties.AbstractValidatingProperty.reportValueNotSet;
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 public class DefaultTransform implements Transform {
@@ -215,7 +214,6 @@ public class DefaultTransform implements Transform {
                         .id(TextUtil.screamingSnakeToKebabCase(CACHEABLE_TRANSFORM_CANT_USE_ABSOLUTE_SENSITIVITY), "Property declared to be sensitive to absolute paths", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                         .documentedAt(userManual("validation_problems", "cacheable_transform_cant_use_absolute_sensitivity"))
                         .contextualLabel("is declared to be sensitive to absolute paths")
-                        .severity(ERROR)
                         .details("This is not allowed for cacheable transforms")
                         .solution("Use a different normalization strategy via @PathSensitive, @Classpath or @CompileClasspath"));
             }
@@ -375,7 +373,6 @@ public class DefaultTransform implements Transform {
                             .id(TextUtil.screamingSnakeToKebabCase(ARTIFACT_TRANSFORM_SHOULD_NOT_DECLARE_OUTPUT), "Artifact transform should not declare output", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                             .contextualLabel("declares an output")
                             .documentedAt(userManual("validation_problems", ARTIFACT_TRANSFORM_SHOULD_NOT_DECLARE_OUTPUT.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("is annotated with an output annotation")
                             .solution("Remove the output property and use the TransformOutputs parameter from transform(TransformOutputs) instead")
                     );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java
@@ -83,7 +83,6 @@ import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.T
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.UNDEFINED_ALIAS_REFERENCE;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.UNDEFINED_VERSION_REFERENCE;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.UNSUPPORTED_FILE_FORMAT;
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.RenderingUtils.quotedOxfordListOf;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
@@ -217,8 +216,7 @@ public abstract class DefaultVersionCatalogBuilder implements VersionCatalogBuil
         return builder.
             id(TextUtil.screamingSnakeToKebabCase(catalogProblemId.name()), catalogProblemId.getDisplayName(), GradleCoreProblemGroup.versionCatalog())
             .contextualLabel(message)
-            .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)))
-            .severity(ERROR);
+            .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)));
     }
 
     private static RuntimeException throwVersionCatalogProblemException(InternalProblems problemsService, InternalProblem problem) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/LibrariesSourceGenerator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/LibrariesSourceGenerator.java
@@ -61,7 +61,6 @@ import static org.gradle.api.internal.catalog.problems.DefaultCatalogProblemBuil
 import static org.gradle.api.internal.catalog.problems.DefaultCatalogProblemBuilder.throwError;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.ACCESSOR_NAME_CLASH;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.TOO_MANY_ENTRIES;
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.RenderingUtils.oxfordJoin;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
@@ -517,8 +516,7 @@ public class LibrariesSourceGenerator extends AbstractSourceGenerator {
     private static InternalProblemSpec configureVersionCatalogError(InternalProblemSpec spec, String message, VersionCatalogProblemId catalogProblemId) {
         return spec
             .id(TextUtil.screamingSnakeToKebabCase(catalogProblemId.name()), message, GradleCoreProblemGroup.versionCatalog()) // TODO is message stable?
-            .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)))
-            .severity(ERROR);
+            .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)));
     }
 
     private void assertUnique(List<String> names, String prefix, String suffix) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/exception/AbstractResolutionFailureException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/exception/AbstractResolutionFailureException.java
@@ -35,7 +35,6 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 /**
@@ -82,10 +81,9 @@ public abstract class AbstractResolutionFailureException extends StyledException
             builder.id(TextUtil.screamingSnakeToKebabCase(problemId.name()), problemId.getDisplayName(), GradleCoreProblemGroup.variantResolution())
                 .contextualLabel(getMessage())
                 .documentedAt(userManual("variant_model", "sec:variant-select-errors"))
-                .severity(ERROR)
                 .additionalDataInternal(ResolutionFailureDataSpec.class, data -> data.from(getFailure()));
         });
-        problemsService.getInternalReporter().report(problem);
+        problemsService.getReporter().report(problem);
 
         return this;
     }

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     api(projects.files)
     api(projects.loggingApi)
     api(projects.persistentCache)
+    api(projects.problemsApi)
     api(projects.processServicesApi)
     api(projects.resources)
     api(projects.startParameter)

--- a/subprojects/core-api/src/main/java/org/gradle/internal/validation/TypeValidationUtil.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/validation/TypeValidationUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.validation;
+
+import org.gradle.api.problems.AdditionalData;
+import org.gradle.api.problems.internal.InternalProblem;
+import org.gradle.api.problems.internal.TypeValidationData;
+import org.jspecify.annotations.NullMarked;
+
+
+/**
+ * Utility class for type validation-related problems.
+ */
+@NullMarked
+public class TypeValidationUtil {
+
+    public static boolean isFatal(InternalProblem problem) {
+        AdditionalData additionalData = problem.getAdditionalData();
+        if (additionalData instanceof TypeValidationData) {
+            return ((TypeValidationData) additionalData).isFatal();
+        }
+        return false;
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -407,6 +407,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec imple
             additionalData.asMap == [
                 'typeName' : 'CustomTask',
                 'propertyName' : 'brokenInputFile',
+                'fatal' : true,
             ]
         }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -186,7 +186,8 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             details == 'Gradle cannot track the implementation for classes loaded with an unknown classloader.'
             solutions == [ 'Load your class by using one of Gradle\'s built-in ways.' ]
             additionalData.asMap == [
-                'typeName' : 'CustomTask'
+                'typeName' : 'CustomTask',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -195,7 +196,8 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             details == 'Gradle cannot track the implementation for classes loaded with an unknown classloader.'
             solutions == [ 'Load your class by using one of Gradle\'s built-in ways.' ]
             additionalData.asMap == [
-                'typeName' : 'CustomTask'
+                'typeName' : 'CustomTask',
+                'fatal' : true
             ]
         }
     }
@@ -239,6 +241,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             solutions == [ 'Load your class by using one of Gradle\'s built-in ways.' ]
             additionalData.asMap == [
                 'typeName' : 'CustomTask',
+                'fatal' : true,
             ]
         }
 
@@ -553,7 +556,8 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             solutions == [ 'Load your class by using one of Gradle\'s built-in ways.' ]
             additionalData.asMap == [
                 'typeName' : 'CustomTask',
-                'propertyName' : 'bean'
+                'propertyName' : 'bean',
+                'fatal' : true,
             ]
         }
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
@@ -394,11 +394,10 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
         executer.noDeprecationChecks()
         buildFile """
             import org.gradle.integtests.fixtures.validation.ValidationProblem
-            import org.gradle.api.problems.Severity
 
             @CacheableTask
             abstract class InvalidTask extends DefaultTask {
-                @ValidationProblem(value = Severity.WARNING)
+                @ValidationProblem(fatal=false)
                 abstract Property<String> getInput()
 
                 @OutputFile

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -114,6 +114,7 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec imp
             additionalData.asMap == [
                 'typeName': 'org.gradle.api.DefaultTask',
                 'propertyName': 'input',
+                'fatal': true,
             ]
         }
 
@@ -191,6 +192,7 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec imp
             additionalData.asMap == [
                 'typeName': 'CustomTask',
                 'propertyName': 'input',
+                'fatal': true,
             ]
         }
 
@@ -284,6 +286,7 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec imp
             additionalData.asMap == [
                 'typeName': 'FooTask',
                 'propertyName': 'bar',
+                'fatal': true,
             ]
         }
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -719,6 +719,7 @@ task someTask(type: SomeTask) {
             additionalData.asMap == [
                 'typeName': 'org.gradle.api.DefaultTask',
                 'propertyName': 'input',
+                'fatal': true,
             ]
         }
 
@@ -760,6 +761,7 @@ task someTask(type: SomeTask) {
             additionalData.asMap == [
                 'typeName' : 'org.gradle.api.DefaultTask',
                 'propertyName' : 'output',
+                'fatal': true,
             ]
         }
         where:
@@ -797,6 +799,7 @@ task someTask(type: SomeTask) {
             additionalData.asMap == [
                 'typeName' : 'org.gradle.api.DefaultTask',
                 'propertyName' : 'output',
+                'fatal': true,
             ]
         }
         where:
@@ -840,6 +843,7 @@ task someTask(type: SomeTask) {
             additionalData.asMap == [
                 'typeName' : 'org.gradle.api.DefaultTask',
                 'propertyName' : 'output',
+                'fatal': true,
             ]
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/catalog/parser/TomlCatalogFileParser.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/catalog/parser/TomlCatalogFileParser.java
@@ -67,7 +67,6 @@ import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.I
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.INVALID_PLUGIN_NOTATION;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.TOML_SYNTAX_ERROR;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.UNSUPPORTED_FORMAT_VERSION;
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.RenderingUtils.quotedOxfordListOf;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 import static org.gradle.util.internal.TextUtil.getPluralEnding;
@@ -161,8 +160,7 @@ public class TomlCatalogFileParser {
             .contextualLabel(label)
             .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)));
         InternalProblemSpec definingCategory = locationDefiner.apply(definingLocation);
-        return definingCategory
-            .severity(ERROR);
+        return definingCategory;
     }
 
     private void assertNoParseErrors(TomlParseResult result) {
@@ -188,7 +186,7 @@ public class TomlCatalogFileParser {
             })
                 .details("TOML syntax invalid.")
                 .solution("Fix the TOML file according to the syntax described at https://toml.io")
-        )).forEach(internalReporter::report);
+        )).forEach(internalReporter::reportError);
     }
 
     private String getProblemString(List<TomlParseError> errors) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.plugins;
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
@@ -74,8 +73,7 @@ public class ImperativeOnlyPluginTarget<T extends PluginAwareInternal> implement
         ProblemId id = ProblemId.create("target-type-mismatch", "Unexpected plugin type", GradleCoreProblemGroup.pluginApplication());
         throw problems.getInternalReporter()
             .throwing(new IllegalArgumentException(message), id, spec -> {
-                spec.severity(Severity.ERROR)
-                    .withException(new IllegalArgumentException(message))
+                spec.withException(new IllegalArgumentException(message))
                     .contextualLabel(message)
                     .documentedAt(Documentation.userManual("custom_plugins", "project_vs_settings_vs_init_plugins").toString());
             });

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTarget.java
@@ -20,21 +20,20 @@ import com.google.common.reflect.TypeToken;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.features.annotations.BindsProjectFeature;
-import org.gradle.features.annotations.BindsProjectType;
 import org.gradle.api.initialization.Settings;
-import org.gradle.features.annotations.RegistersProjectFeatures;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
+import org.gradle.features.annotations.BindsProjectFeature;
+import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.annotations.RegistersProjectFeatures;
+import org.gradle.features.internal.binding.ProjectFeatureDeclarations;
 import org.gradle.internal.Cast;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.properties.annotations.TypeMetadata;
 import org.gradle.internal.reflect.DefaultTypeValidationContext;
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
-import org.gradle.features.internal.binding.ProjectFeatureDeclarations;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -117,7 +116,6 @@ public class ProjectFeatureDeclarationPluginTarget implements PluginTarget {
                 problem.withAnnotationType(projectTypePluginImplClass)
                     .id("missing-software-type", "Missing project feature annotation", GradleCoreProblemGroup.validation().type())
                     .contextualLabel("is registered as a project feature plugin but does not expose a project feature")
-                    .severity(Severity.ERROR)
                     .details("This class was registered as a project feature plugin, but it does not expose a project feature. Project feature plugins must expose at least one project feature via either a @BindsProjectType or @BindsProjectFeature annotation on the plugin class.")
                     .solution("Remove " + projectTypePluginImplClass.getSimpleName() + " from the @RegistersSoftwareTypes or @RegistersProjectFeatures annotation on " + registeringPlugin.getSimpleName())
             );

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.properties;
 
 import com.google.common.base.Suppliers;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.provider.HasConfigurableValue;
 import org.gradle.api.provider.Provider;
@@ -54,7 +53,6 @@ public abstract class AbstractValidatingProperty implements ValidatingProperty {
                 .id(TextUtil.screamingSnakeToKebabCase(VALUE_NOT_SET), "Value not set", GradleCoreProblemGroup.validation().property())
                 .contextualLabel("doesn't have a configured value")
                 .documentedAt(userManual("validation_problems", VALUE_NOT_SET.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details("This property isn't marked as optional and no value has been configured");
             if (hasConfigurableValue) {
                 problemSpec.solution("Assign a value to '" + propertyName + "'");

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/ValidationActions.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/ValidationActions.java
@@ -20,7 +20,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.internal.GeneratedSubclass;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.internal.properties.InputFilePropertyType;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
@@ -165,7 +164,6 @@ public enum ValidationActions implements ValidationAction {
                 .id(TextUtil.screamingSnakeToKebabCase(INPUT_FILE_DOES_NOT_EXIST), "Input file does not exist", GradleCoreProblemGroup.validation().property())
                 .contextualLabel("specifies " + lowerKind + " '" + input + "' which doesn't exist")
                 .documentedAt(userManual("validation_problems", INPUT_FILE_DOES_NOT_EXIST.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details("An input file was expected to be present but it doesn't exist")
                 .solution("Make sure the " + lowerKind + " exists before the task is called")
                 .solution("Make sure that the task which produces the " + lowerKind + " is declared as an input");
@@ -182,7 +180,6 @@ public enum ValidationActions implements ValidationAction {
                 .id(TextUtil.screamingSnakeToKebabCase(UNEXPECTED_INPUT_FILE_TYPE), "Unexpected input file type", GradleCoreProblemGroup.validation().property())
                 .contextualLabel(lowerKind + " '" + input + "' is not a " + lowerKind)
                 .documentedAt(userManual("validation_problems", "unexpected_input_file_type"))
-                .severity(Severity.ERROR)
                 .details("Expected an input to be a " + lowerKind + " but it was a " + actualKindOf(input))
                 .solution("Use a " + lowerKind + " as an input")
                 .solution("Declare the input as a " + actualKindOf(input) + " instead");
@@ -198,7 +195,6 @@ public enum ValidationActions implements ValidationAction {
                 .id(TextUtil.screamingSnakeToKebabCase(CANNOT_WRITE_OUTPUT), PROPERTY_IS_NOT_WRITABLE, GradleCoreProblemGroup.validation().property())
                 .contextualLabel("is not writable because " + cause)
                 .documentedAt(userManual("validation_problems", CANNOT_WRITE_OUTPUT.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details("Expected '" + directory + "' to be a directory but it's a " + actualKindOf(directory))
                 .solution("Make sure that the '" + propertyName + "' is configured to a directory")
         );
@@ -211,7 +207,6 @@ public enum ValidationActions implements ValidationAction {
                 .id(TextUtil.screamingSnakeToKebabCase(CANNOT_WRITE_OUTPUT), PROPERTY_IS_NOT_WRITABLE, GradleCoreProblemGroup.validation().property())
                 .contextualLabel("is not writable because '" + directory + "' is not a directory")
                 .documentedAt(userManual("validation_problems", CANNOT_WRITE_OUTPUT.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details("Expected the root of the file tree '" + directory + "' to be a directory but it's a " + actualKindOf(directory))
                 .solution("Make sure that the root of the file tree '" + propertyName + "' is configured to a directory")
         );
@@ -225,7 +220,6 @@ public enum ValidationActions implements ValidationAction {
                 .contextualLabel("is not writable because '" + file + "' is not a file")
                 .documentedAt(userManual("validation_problems", CANNOT_WRITE_OUTPUT.toLowerCase(Locale.ROOT)))
                 .details("Cannot write a file to a location pointing at a directory")
-                .severity(Severity.ERROR)
                 .solution("Configure '" + propertyName + "' to point to a file, not a directory")
                 .solution("Annotate '" + propertyName + "' with @OutputDirectory instead of @OutputFiles")
         );
@@ -238,7 +232,6 @@ public enum ValidationActions implements ValidationAction {
                 .id(TextUtil.screamingSnakeToKebabCase(CANNOT_WRITE_OUTPUT), PROPERTY_IS_NOT_WRITABLE, GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                 .contextualLabel("is not writable because '" + file + "' ancestor '" + ancestor + "' is not a directory")
                 .documentedAt(userManual("validation_problems", CANNOT_WRITE_OUTPUT.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details("Cannot create parent directories that are existing as file")
                 .solution("Configure '" + propertyName + "' to point to the correct location")
         );
@@ -264,7 +257,6 @@ public enum ValidationActions implements ValidationAction {
                     .id(TextUtil.screamingSnakeToKebabCase(CANNOT_WRITE_TO_RESERVED_LOCATION), "Cannot write to reserved location", GradleCoreProblemGroup.validation().property())
                     .contextualLabel("points to '" + location + "' which is managed by Gradle")
                     .documentedAt(userManual("validation_problems", CANNOT_WRITE_TO_RESERVED_LOCATION.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details("Trying to write an output to a read-only location which is for Gradle internal use only")
                     .solution("Select a different output location")
             );
@@ -297,7 +289,6 @@ public enum ValidationActions implements ValidationAction {
                     .id(TextUtil.screamingSnakeToKebabCase(UNSUPPORTED_NOTATION), "Property has unsupported value", GradleCoreProblemGroup.validation().property())
                     .contextualLabel("has unsupported value '" + value + "'")
                     .documentedAt(userManual("validation_problems", UNSUPPORTED_NOTATION.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details("Type '" + typeOf(value) + "' cannot be converted to a " + targetType);
                 if (candidates.isEmpty()) {
                     describedProblem.solution("Use a value of type '" + targetType + "'");

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
@@ -22,7 +22,6 @@ import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GeneralDataSpec;
 import org.gradle.api.problems.internal.InternalProblemSpec;
 import org.gradle.api.problems.internal.InternalProblems;
@@ -112,7 +111,6 @@ public abstract class DefaultTaskSelector implements TaskSelector {
 
     private static ProblemSpec configureProblem(ProblemSpec spec, SelectionContext context) {
         ((InternalProblemSpec) spec).additionalDataInternal(GeneralDataSpec.class, data -> data.put("requestedPath", Objects.requireNonNull(context.getOriginalPath().asString())));
-        spec.severity(Severity.ERROR);
         return spec;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolvingBuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolvingBuildTaskScheduler.java
@@ -20,7 +20,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Task;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.configuration.project.BuiltInCommand;
@@ -93,7 +92,6 @@ public class TaskNameResolvingBuildTaskScheduler implements BuildTaskScheduler {
                     ProblemId id = ProblemId.create("init invocation problem", "Init invocation problem", GradleCoreProblemGroup.taskSelection());
                     throw problemsService.getInternalReporter().throwing(ex, id, spec -> {
                         spec.contextualLabel(ex.getMessage());
-                        spec.severity(Severity.ERROR);
                     });
                 });
             }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -18,7 +18,6 @@ package org.gradle.execution.plan;
 
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.internal.deprecation.DeprecationLogger;
@@ -26,6 +25,7 @@ import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.execution.WorkValidationException;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
+import org.gradle.internal.validation.TypeValidationUtil;
 
 import java.util.List;
 import java.util.Set;
@@ -68,7 +68,7 @@ public class DefaultNodeValidator implements NodeValidator {
     private void logWarnings(List<? extends InternalProblem> problems) {
         // We are logging all the warnings that we encountered during validation here
         problems.stream()
-            .filter(DefaultNodeValidator::isWarning)
+            .filter(p -> !TypeValidationUtil.isFatal(p))
             .forEach(problem -> {
                 // Because our deprecation warning system doesn't support multiline strings (bummer!) both in rendering
                 // **and** testing (no way to capture multiline deprecation warnings), we have to resort to removing details
@@ -83,10 +83,7 @@ public class DefaultNodeValidator implements NodeValidator {
     }
 
     private void reportErrors(List<? extends InternalProblem> problems, TaskInternal task, WorkValidationContext validationContext) {
-        for (InternalProblem problem : problems) {
-            problemsService.getInternalReporter().report(problem);
-        }
-
+        problemsService.getInternalReporter().reportError(problems);
         Set<String> uniqueErrors = getUniqueErrors(problems);
         if (!uniqueErrors.isEmpty()) {
             throw WorkValidationException.forProblems(uniqueErrors)
@@ -97,12 +94,8 @@ public class DefaultNodeValidator implements NodeValidator {
 
     private static Set<String> getUniqueErrors(List<? extends InternalProblem> problems) {
         return problems.stream()
-            .filter(problem -> !isWarning(problem))
+            .filter(problem -> TypeValidationUtil.isFatal(problem))
             .map(TypeValidationProblemRenderer::renderMinimalInformationAbout)
             .collect(toImmutableSet());
-    }
-
-    private static boolean isWarning(InternalProblem problem) {
-        return problem.getDefinition().getSeverity().equals(Severity.WARNING);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
@@ -18,7 +18,6 @@ package org.gradle.execution.plan;
 
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
@@ -167,7 +166,6 @@ public class MissingTaskDependencyDetector {
             problem.id(TextUtil.screamingSnakeToKebabCase(IMPLICIT_DEPENDENCY), "Property has implicit dependency", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                 .contextualLabel("Gradle detected a problem with the following location: '" + consumerProducerPath + "'")
                 .documentedAt(userManual("validation_problems", IMPLICIT_DEPENDENCY.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details(String.format("Task '%s' uses this output of task '%s' without declaring an explicit or implicit dependency. "
                         + "This can lead to incorrect results being produced, depending on what order the tasks are executed",
                     consumer,

--- a/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
@@ -21,7 +21,6 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GeneralDataSpec;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblemSpec;
@@ -183,7 +182,6 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
 
     private static void configureProblem(ProblemSpec spec, String message, String requestedPath) {
         spec.contextualLabel(message);
-        spec.severity(Severity.ERROR);
         ((InternalProblemSpec) spec).additionalDataInternal(GeneralDataSpec.class, data -> data.put("requestedPath", Objects.requireNonNull(requestedPath)));
     }
 

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
@@ -35,7 +35,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.Problems;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.configuration.ImportsReader;
@@ -222,7 +221,6 @@ public abstract class DefaultScriptCompilationHandler implements ScriptCompilati
         throw ((InternalProblems) getProblemsService()).getInternalReporter().throwing(new ScriptCompilationException(message, e, source, lineNumber), problemId, builder -> builder
             .contextualLabel(message)
             .lineInFileLocation(source.getFileName(), lineNumber)
-            .severity(Severity.ERROR)
             .withException(new ScriptCompilationException(message, e, source, lineNumber))
         );
     }

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
@@ -150,6 +150,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
             additionalData.asMap == [
                 'typeName' : 'CustomTask',
                 'propertyName' : 'destFile',
+                'fatal' : true,
             ]
         }
         verifyAll(receivedProblem(1)) {
@@ -162,6 +163,7 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implemen
             additionalData.asMap == [
                 'typeName' : 'CustomTask',
                 'propertyName' : 'srcFile',
+                'fatal' : true,
             ]
         }
     }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblem.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblem.java
@@ -16,8 +16,6 @@
 package org.gradle.integtests.fixtures.validation;
 
 
-import org.gradle.api.problems.Severity;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -34,5 +32,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
 public @interface ValidationProblem {
-    Severity value() default Severity.WARNING;
+    boolean fatal() default false;
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblemPropertyAnnotationHandler.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblemPropertyAnnotationHandler.java
@@ -17,13 +17,13 @@ package org.gradle.integtests.fixtures.validation;
 
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.problems.ProblemGroup;
-import org.gradle.api.problems.Severity;
 import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.properties.PropertyValue;
 import org.gradle.internal.properties.PropertyVisitor;
 import org.gradle.internal.properties.annotations.AbstractPropertyAnnotationHandler;
 import org.gradle.internal.properties.annotations.PropertyMetadata;
 import org.gradle.internal.reflect.annotations.AnnotationCategory;
+import org.gradle.internal.reflect.validation.TypeAwareProblemBuilder;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 
 class ValidationProblemPropertyAnnotationHandler extends AbstractPropertyAnnotationHandler {
@@ -42,20 +42,22 @@ class ValidationProblemPropertyAnnotationHandler extends AbstractPropertyAnnotat
 
     @Override
     public void validatePropertyMetadata(PropertyMetadata propertyMetadata, TypeValidationContext validationContext) {
-        validationContext.visitPropertyProblem(problem ->
-            problem
-                .forProperty(propertyMetadata.getPropertyName())
-                .id("test-problem", "test problem", ProblemGroup.create("root", "root"))
+        boolean fatal = annotationValue(propertyMetadata);
+        validationContext.visitPropertyProblem(problem -> {
+            TypeAwareProblemBuilder builder = problem.forProperty(propertyMetadata.getPropertyName());
+            if (!fatal) {
+                builder = builder.asWarning();
+            }
+            builder.id("test-problem", "test problem", ProblemGroup.create("root", "root"))
                 .documentedAt(Documentation.userManual("id", "section"))
-                .severity(annotationValue(propertyMetadata))
-                .details("this is a test")
-        );
+                .details("this is a test");
+        });
     }
 
-    private Severity annotationValue(PropertyMetadata propertyMetadata) {
+    private boolean annotationValue(PropertyMetadata propertyMetadata) {
         return propertyMetadata.getAnnotationForCategory(AnnotationCategory.TYPE)
             .map(ValidationProblem.class::cast)
-            .map(ValidationProblem::value)
-            .orElse(Severity.WARNING);
+            .map(ValidationProblem::fatal)
+            .orElse(false);
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.smoketests
 
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 
-import static org.gradle.api.problems.Severity.ERROR
-
 class NodePluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements ValidationMessageChecker {
     @Override
     Map<String, Versions> getPluginsToValidate() {
@@ -38,9 +36,9 @@ class NodePluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements 
             if (testedPluginId == 'com.moowork.node') {
                 onPlugin('com.moowork.node') {
                     failsWith([
-                            (missingAnnotationMessage { type('com.moowork.gradle.node.npm.NpmSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
-                            (methodShouldNotBeAnnotatedMessage {type('com.moowork.gradle.node.npm.NpmSetupTask').kind('setter').method('setArgs').annotation('Internal').includeLink()}): ERROR,
-                            (missingAnnotationMessage { type('com.moowork.gradle.node.yarn.YarnSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
+                            (missingAnnotationMessage { type('com.moowork.gradle.node.npm.NpmSetupTask').property('args').missingInputOrOutput().includeLink() }),
+                            (methodShouldNotBeAnnotatedMessage {type('com.moowork.gradle.node.npm.NpmSetupTask').kind('setter').method('setArgs').annotation('Internal').includeLink()}),
+                            (missingAnnotationMessage { type('com.moowork.gradle.node.yarn.YarnSetupTask').property('args').missingInputOrOutput().includeLink() }),
                     ])
                 }
             } else {

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithPluginValidation.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithPluginValidation.groovy
@@ -17,7 +17,6 @@
 package org.gradle.smoketests
 
 import groovy.transform.SelfType
-import org.gradle.api.problems.Severity
 import org.gradle.plugin.devel.tasks.TaskValidationReportFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.TaskOutcome
@@ -139,7 +138,7 @@ trait WithPluginValidation {
         private final String pluginId
         private final File reportFile
 
-        private Map<String, Severity> messages = [:]
+        private List<String> messages = []
 
         boolean skipped
         boolean tested
@@ -174,10 +173,10 @@ trait WithPluginValidation {
         }
 
         void passes() {
-            messages = [:]
+            messages = []
         }
 
-        void failsWith(Map<String, Severity> messages) {
+        void failsWith(List<String> messages) {
             this.messages = messages
         }
     }


### PR DESCRIPTION
### Context

Severity is determined by reporting context, not problem spec Previously, problem reporters would set severity explicitly via `ProblemSpec.severity()`. This put the burden on every call site to get severity right, and made it easy for the severity to diverge from whether the build actually failed.

The new model: severity is determined by how and where a problem is reported. If reporting causes the build to fail, the infrastructure sets `ERROR` internally via `throwing()`. Otherwise the problem is treated as a warning. `ProblemSpec.severity()` now does nothing and is deprecated.

Add `InternalProblemReporter.reportError()` and `InternalProblemBuilder.internalSeverity()` as temporary escape hatches for call sites where replacing exception throwing would require reworking build failure rendering and complex test fixtures. These are to be removed in a follow-up change.

Fixes https://github.com/gradle/gradle/issues/36515

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things