### PR TITLE
 Fix plugin tutorial: correct includeBuild reference and AsciiDoc formatting

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/tutorials/developing-plugins/part7_use_consumer_project.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/tutorials/developing-plugins/part7_use_consumer_project.adoc
@@ -83,7 +83,7 @@ include::sample[dir="snippets/plugins/plugin-tutorial/groovy",files="settings.gr
 The key line here is `includeBuild("plugin")` inside the `pluginManagement {}` block.
 This makes all the plugins from the `plugin` project available to other projects in the composite build by their ID.
 
-Finally, we need to update the `plugin`'s build file to account for the composite build setup.
+Finally, we need to update the `plugin` project's build file to account for the composite build setup.
 We'll change the `id` from a local file to a standard `String`.
 
 ====

--- a/platforms/documentation/docs/src/snippets/plugins/plugin-tutorial/groovy/settings.gradle
+++ b/platforms/documentation/docs/src/snippets/plugins/plugin-tutorial/groovy/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'plugin-tutorial'
 
-includeBuild('consumer')
+includeBuild('plugin')

--- a/platforms/documentation/docs/src/snippets/plugins/plugin-tutorial/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/plugins/plugin-tutorial/kotlin/settings.gradle.kts
@@ -1,3 +1,3 @@
 rootProject.name = "plugin-tutorial"
 
-includeBuild("consumer")
+includeBuild("plugin")


### PR DESCRIPTION
## Summary                                                                                                                                                                
https://docs.gradle.org/current/userguide/part7_use_consumer_project.html#step_1_create_a_consumer_project

  - Fix root `settings.gradle(.kts)` snippets to use `includeBuild("plugin")` instead of `includeBuild("consumer")`
  - Fix AsciiDoc backtick rendering issue in part 7 where `` `plugin`'s `` caused mismatched inline code formatting   

  
<img width="322" height="176" alt="Screenshot 2026-03-19 at 3 24 00 PM" src="https://github.com/user-attachments/assets/ba7fa608-cb98-45be-85a8-8254e53551aa" />

<img width="984" height="89" alt="Screenshot 2026-03-19 at 3 24 07 PM" src="https://github.com/user-attachments/assets/6c39efd4-08e7-4d4e-93db-788745c59d6e" />


### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
