### PR TITLE
Add internal flag to disable implicit parent project property lookup

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsParentProjectPropertyLookupIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsParentProjectPropertyLookupIntegrationTest.groovy
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cc.impl.isolated
+
+class IsolatedProjectsParentProjectPropertyLookupIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
+
+    private static final String DISABLE_PARENT_SCOPE = "-Dorg.gradle.internal.project.implicit-parent-properties=false"
+
+    // region Groovy DSL — no IP violations when parent scope is disabled
+
+    def "no IP violation when parent property lookup is disabled via dynamic resolution"() {
+        settingsFile """
+            include("sub")
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            println(foo)
+        """
+
+        when:
+        isolatedProjectsFails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not get unknown property 'foo' for project ':sub' of type org.gradle.api.Project.")
+    }
+
+    def "no IP violation on findProperty without implicit parent lookup"() {
+        settingsFile """
+            include("sub")
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            println("result: " + findProperty("foo"))
+        """
+
+        when:
+        isolatedProjectsRun("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: null")
+        fixture.assertStateStored {
+            projectsConfigured(":", ":sub")
+        }
+    }
+
+    def "no IP violation on hasProperty without implicit parent lookup"() {
+        settingsFile """
+            include("sub")
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            println("result: " + hasProperty("foo"))
+        """
+
+        when:
+        isolatedProjectsRun("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: false")
+        fixture.assertStateStored {
+            projectsConfigured(":", ":sub")
+        }
+    }
+
+    def "no IP violation on properties map access without implicit parent lookup"() {
+        settingsFile """
+            include("sub")
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            println("result: " + properties.containsKey("foo"))
+        """
+
+        when:
+        isolatedProjectsRun("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: false")
+        fixture.assertStateStored {
+            projectsConfigured(":", ":sub")
+        }
+    }
+
+    def "no IP violation on non-existing property access without implicit parent lookup"() {
+        settingsFile """
+            include("sub")
+        """
+        buildFile "sub/build.gradle", """
+            getProperty("doesNotExist")
+        """
+
+        when:
+        isolatedProjectsFails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not get unknown property 'doesNotExist' for project ':sub' of type org.gradle.api.Project.")
+    }
+
+    def "no IP violation on non-existing method call without implicit parent lookup"() {
+        settingsFile """
+            include("sub")
+        """
+        buildFile "sub/build.gradle", """
+            doesNotExist()
+        """
+
+        when:
+        isolatedProjectsFails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not find method doesNotExist() for arguments [] on project ':sub' of type org.gradle.api.Project.")
+    }
+
+    def "no IP violation on dynamic container element creation without implicit parent lookup"() {
+        settingsFile """
+            include("sub")
+        """
+        buildFile "sub/build.gradle", """
+            configurations { myConf { } }
+            println("result: " + configurations.findByName("myConf")?.name)
+        """
+
+        when:
+        isolatedProjectsRun("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: myConf")
+        fixture.assertStateStored {
+            projectsConfigured(":", ":sub")
+        }
+    }
+
+    def "no IP violation on properties access without implicit parent lookup"() {
+        settingsFile """
+            include("sub")
+        """
+        buildFile "sub/build.gradle", """
+            println("result: " + properties.size())
+        """
+
+        when:
+        isolatedProjectsRun("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: ")
+        fixture.assertStateStored {
+            projectsConfigured(":", ":sub")
+        }
+    }
+
+    def "IP violations still reported for explicit cross-project access even without implicit parent lookup"() {
+        settingsFile """
+            include("sub")
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            println(parent.ext.foo)
+        """
+
+        when:
+        isolatedProjectsFails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        fixture.assertStateStoredAndDiscarded {
+            projectsConfigured(":", ":sub")
+            problem("Build file 'sub/build.gradle': line 2: Project ':sub' cannot access 'ext' extension on another project ':'")
+        }
+    }
+
+    def "no IP violation for accidental parent extension configuration without implicit parent lookup"() {
+        settingsFile """
+            include("sub")
+        """
+        buildFile """
+            interface Foo {
+                Property<Integer> getValue()
+            }
+            extensions.create("foo", Foo)
+            foo { value = 42 }
+        """
+        buildFile "sub/build.gradle", """
+            foo { value = 99 }
+        """
+
+        when:
+        isolatedProjectsFails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not find method foo() for arguments")
+    }
+
+    def "deep nesting: no IP violation on transitive parent lookup without implicit parent lookup"() {
+        settingsFile """
+            include("sub")
+            include("sub:sub-a")
+        """
+        buildFile """
+            ext.transitive = "root"
+        """
+        buildFile "sub/sub-a/build.gradle", """
+            println(transitive)
+        """
+
+        when:
+        isolatedProjectsFails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not get unknown property 'transitive' for project ':sub:sub-a' of type org.gradle.api.Project.")
+    }
+
+    // endregion
+
+    // region Kotlin DSL — no IP violations when parent scope is disabled
+
+    def "no IP violation on Kotlin nullable delegated parent property without implicit parent lookup"() {
+        file("settings.gradle.kts") << """
+            include("sub")
+        """
+        file("build.gradle.kts") << """
+            extra["foo"] = "bar"
+        """
+        file("sub/build.gradle.kts") << """
+            val foo: String? by project
+            println("result: \$foo")
+        """
+
+        when:
+        isolatedProjectsRun("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: null")
+        fixture.assertStateStored {
+            projectsConfigured(":", ":sub")
+        }
+    }
+
+    def "no IP violation on Kotlin non-nullable delegated parent property without implicit parent lookup"() {
+        file("settings.gradle.kts") << """
+            include("sub")
+        """
+        file("build.gradle.kts") << """
+            extra["foo"] = "bar"
+        """
+        file("sub/build.gradle.kts") << """
+            val foo: String by project
+            println(foo)
+        """
+
+        when:
+        isolatedProjectsFails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasDescription("Cannot get non-null property 'foo' on project ':sub' as it does not exist")
+    }
+
+    // endregion
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ParentProjectPropertyLookupIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ParentProjectPropertyLookupIntegrationTest.groovy
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class ParentProjectPropertyLookupIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final String DISABLE_PARENT_SCOPE = "-Dorg.gradle.internal.project.implicit-parent-properties=false"
+
+    // region Status quo — parent lookup works by default
+
+    def "parent extra property is accessible from child by default"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            println("result: " + foo)
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        outputContains("result: bar")
+    }
+
+    // endregion
+
+    // region Parent lookup disabled — Groovy DSL
+
+    def "child cannot access parent extra property without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            println(foo)
+        """
+
+        when:
+        fails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not get unknown property 'foo' for project ':sub' of type org.gradle.api.Project.")
+    }
+
+    def "findProperty returns null for parent extra property without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            println("result: " + findProperty("foo"))
+        """
+
+        when:
+        succeeds("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: null")
+    }
+
+    def "hasProperty returns false for parent extra property without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            println("result: " + hasProperty("foo"))
+        """
+
+        when:
+        succeeds("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: false")
+    }
+
+    def "property() throws for parent extra property without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            property("foo")
+        """
+
+        when:
+        fails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not get unknown property 'foo' for project ':sub' of type org.gradle.api.Project.")
+    }
+
+    def "getProperty() throws for parent extra property without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            getProperty("foo")
+        """
+
+        when:
+        fails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not get unknown property 'foo' for project ':sub' of type org.gradle.api.Project.")
+    }
+
+    def "properties map does not contain parent extra properties without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile """
+            ext.foo = "bar"
+        """
+        buildFile "sub/build.gradle", """
+            println("result: " + properties.containsKey("foo"))
+        """
+
+        when:
+        succeeds("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: false")
+    }
+
+    def "child cannot access parent method without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile """
+            ext.greet = { -> "hello" }
+        """
+        buildFile "sub/build.gradle", """
+            greet()
+        """
+
+        when:
+        fails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not find method greet() for arguments [] on project ':sub' of type org.gradle.api.Project.")
+    }
+
+    def "child can still access own extra properties without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile "sub/build.gradle", """
+            ext.myProp = "mine"
+            println("result: " + myProp)
+        """
+
+        when:
+        succeeds("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: mine")
+    }
+
+    def "child can still access own gradle.properties without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        file("sub/gradle.properties") << "myProp=value"
+        buildFile "sub/build.gradle", """
+            println("result: " + myProp)
+        """
+
+        when:
+        succeeds("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: value")
+    }
+
+    def "build-scoped gradle.properties are visible in child regardless of implicit parent lookup (flag=#flagValue)"() {
+        settingsFile """
+            include 'sub'
+        """
+        file("gradle.properties") << "buildProp=fromBuildRoot"
+        buildFile "sub/build.gradle", """
+            println("result: " + buildProp)
+        """
+
+        when:
+        succeeds("help", *args)
+
+        then:
+        outputContains("result: fromBuildRoot")
+
+        where:
+        flagValue | args
+        true      | []
+        false     | [DISABLE_PARENT_SCOPE]
+    }
+
+    def "child gradle.properties shadows build-scoped gradle.properties regardless of implicit parent lookup (flag=#flagValue)"() {
+        settingsFile """
+            include 'sub'
+        """
+        file("gradle.properties") << "shared=root"
+        file("sub/gradle.properties") << "shared=child"
+        buildFile "sub/build.gradle", """
+            println("result: " + shared)
+        """
+
+        when:
+        succeeds("help", *args)
+
+        then:
+        outputContains("result: child")
+
+        where:
+        flagValue | args
+        true      | []
+        false     | [DISABLE_PARENT_SCOPE]
+    }
+
+    def "dynamic container element creation works without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile "sub/build.gradle", """
+            configurations { myConf { } }
+            println("result: " + configurations.findByName("myConf")?.name)
+        """
+
+        when:
+        succeeds("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: myConf")
+    }
+
+    def "dynamic container element creation no longer accidentally resolves from parent without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile """
+            ext.foo = "parentFoo"
+        """
+        buildFile "sub/build.gradle", """
+            configurations { foo { } }
+            println("result: " + configurations.findByName("foo")?.name)
+        """
+
+        when:
+        succeeds("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: foo")
+    }
+
+    def "accidental parent extension configuration is prevented without implicit parent lookup"() {
+        settingsFile """
+            include 'sub'
+        """
+        buildFile """
+            interface Foo {
+                Property<Integer> getValue()
+            }
+            extensions.create("foo", Foo)
+            foo { value = 42 }
+        """
+        buildFile "sub/build.gradle", """
+            foo { value = 99 }
+        """
+
+        when:
+        fails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not find method foo() for arguments")
+    }
+
+    def "transitive parent property lookup is disabled without implicit parent lookup"() {
+        settingsFile """
+            include 'sub', 'sub:sub-a'
+        """
+        buildFile """
+            ext.transitive = "root"
+        """
+        buildFile "sub/sub-a/build.gradle", """
+            println(transitive)
+        """
+
+        when:
+        fails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasCause("Could not get unknown property 'transitive' for project ':sub:sub-a' of type org.gradle.api.Project.")
+    }
+
+    // endregion
+
+    // region Parent lookup disabled — Kotlin DSL (by project)
+
+    def "nullable delegated property from parent returns null without implicit parent lookup"() {
+        file("settings.gradle.kts") << """
+            include("sub")
+        """
+        file("build.gradle.kts") << """
+            extra["foo"] = "bar"
+        """
+        file("sub/build.gradle.kts") << """
+            val foo: String? by project
+            println("result: \$foo")
+        """
+
+        when:
+        succeeds("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: null")
+    }
+
+    def "non-nullable delegated property from parent throws without implicit parent lookup"() {
+        file("settings.gradle.kts") << """
+            include("sub")
+        """
+        file("build.gradle.kts") << """
+            extra["foo"] = "bar"
+        """
+        file("sub/build.gradle.kts") << """
+            val foo: String by project
+            println(foo)
+        """
+
+        when:
+        fails("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        failure.assertHasDescription("Cannot get non-null property 'foo' on project ':sub' as it does not exist")
+    }
+
+    def "nullable delegated property from parent resolves with implicit parent lookup (default)"() {
+        file("settings.gradle.kts") << """
+            include("sub")
+        """
+        file("build.gradle.kts") << """
+            extra["foo"] = "bar"
+        """
+        file("sub/build.gradle.kts") << """
+            val foo: String? by project
+            println("result: \$foo")
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        outputContains("result: bar")
+    }
+
+    def "non-nullable delegated property from parent resolves with implicit parent lookup (default)"() {
+        file("settings.gradle.kts") << """
+            include("sub")
+        """
+        file("build.gradle.kts") << """
+            extra["foo"] = "bar"
+        """
+        file("sub/build.gradle.kts") << """
+            val foo: String by project
+            println("result: \$foo")
+        """
+
+        when:
+        succeeds("help")
+
+        then:
+        outputContains("result: bar")
+    }
+
+    def "own extra properties still accessible via Kotlin delegation without implicit parent lookup"() {
+        file("settings.gradle.kts") << """
+            include("sub")
+        """
+        file("sub/build.gradle.kts") << """
+            extra["myProp"] = "mine"
+            val myProp: String by project
+            println("result: \$myProp")
+        """
+
+        when:
+        succeeds("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: mine")
+    }
+
+    def "own gradle.properties accessible via Kotlin delegation without implicit parent lookup"() {
+        file("settings.gradle.kts") << """
+            include("sub")
+        """
+        file("sub/gradle.properties") << "myProp=value"
+        file("sub/build.gradle.kts") << """
+            val myProp: String by project
+            println("result: \$myProp")
+        """
+
+        when:
+        succeeds("help", DISABLE_PARENT_SCOPE)
+
+        then:
+        outputContains("result: value")
+    }
+
+    // endregion
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -82,11 +82,16 @@ import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator;
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
 import org.gradle.configuration.project.ProjectEvaluator;
+import org.gradle.features.internal.binding.ProjectFeatureApplicator;
+import org.gradle.features.internal.binding.ProjectFeatureDeclarations;
+import org.gradle.features.internal.binding.ProjectFeatureSupportInternal;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
+import org.gradle.internal.buildoption.InternalFlag;
+import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.extensibility.ExtensibleDynamicObject;
@@ -122,9 +127,6 @@ import org.gradle.model.internal.registry.ModelRegistry;
 import org.gradle.model.internal.type.ModelType;
 import org.gradle.normalization.InputNormalizationHandler;
 import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
-import org.gradle.features.internal.binding.ProjectFeatureApplicator;
-import org.gradle.features.internal.binding.ProjectFeatureDeclarations;
-import org.gradle.features.internal.binding.ProjectFeatureSupportInternal;
 import org.gradle.util.Configurable;
 import org.gradle.util.Path;
 import org.gradle.util.internal.ClosureBackedAction;
@@ -158,6 +160,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     private static final ModelType<ProjectIdentifier> PROJECT_IDENTIFIER_MODEL_TYPE = ModelType.of(ProjectIdentifier.class);
     private static final ModelType<ExtensionContainer> EXTENSION_CONTAINER_MODEL_TYPE = ModelType.of(ExtensionContainer.class);
     private static final Logger BUILD_LOGGER = Logging.getLogger(Project.class);
+
+    private static final InternalFlag IMPLICIT_PARENT_PROPERTIES = new InternalFlag("org.gradle.internal.project.implicit-parent-properties", true);
 
     private final ProjectState owner;
     private final ClassLoaderScope classLoaderScope;
@@ -238,9 +242,11 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         taskContainer = services.get(TaskContainerInternal.class);
         extensibleDynamicObject = new ExtensibleDynamicObject(this, Project.class, services.get(InstantiatorFactory.class).decorateLenient(services));
 
-        @Nullable DynamicObject parentInherited = services.get(CrossProjectModelAccess.class).parentProjectDynamicInheritedScope(this);
-        if (parentInherited != null) {
-            extensibleDynamicObject.setParent(parentInherited);
+        if (services.get(InternalOptions.class).getOption(IMPLICIT_PARENT_PROPERTIES).get()) {
+            DynamicObject parentInherited = services.get(CrossProjectModelAccess.class).parentProjectDynamicInheritedScope(this);
+            if (parentInherited != null) {
+                extensibleDynamicObject.setParent(parentInherited);
+            }
         }
         extensibleDynamicObject.addObject(taskContainer.getTasksAsDynamicObject(), ExtensibleDynamicObject.Location.AfterConvention);
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -42,6 +42,8 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.util.internal.PatternSets
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator
 import org.gradle.internal.Describables
+import org.gradle.internal.buildoption.DefaultInternalOptions
+import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.management.DependencyResolutionManagementInternal
 import org.gradle.internal.resource.DefaultTextFileResourceLoader
@@ -253,6 +255,7 @@ class DefaultProjectSpec extends Specification {
         serviceRegistry.add(InstantiatorFactory, Stub(InstantiatorFactory))
         serviceRegistry.add(AttributesSchema, Stub(AttributesSchema))
         serviceRegistry.add(ModelRegistry, Stub(ModelRegistry))
+        serviceRegistry.add(InternalOptions, new DefaultInternalOptions([:]))
         serviceRegistry.add(CrossProjectModelAccess, Stub(CrossProjectModelAccess))
         serviceRegistry.add(DependencyResolutionManagementInternal, Stub(DependencyResolutionManagementInternal))
         serviceRegistry.add(DynamicLookupRoutine, new DefaultDynamicLookupRoutine())

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -82,6 +82,8 @@ import org.gradle.initialization.ClassLoaderScopeRegistryListener
 import org.gradle.internal.Actions
 import org.gradle.internal.Describables
 import org.gradle.internal.build.BuildState
+import org.gradle.internal.buildoption.DefaultInternalOptions
+import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.logging.LoggingManagerInternal
@@ -241,6 +243,7 @@ class DefaultProjectTest extends Specification {
         serviceRegistryMock.get((Type) CrossProjectConfigurator) >> crossProjectConfigurator
         serviceRegistryMock.get(DependencyResolutionManagementInternal) >> dependencyResolutionManagement
         serviceRegistryMock.get(DomainObjectCollectionFactory) >> TestUtil.domainObjectCollectionFactory()
+        serviceRegistryMock.get(InternalOptions) >> new DefaultInternalOptions([:])
         serviceRegistryMock.get(CrossProjectModelAccess) >> new DefaultCrossProjectModelAccess(projectRegistry, instantiatorMock, gradleLifecycleActionExecutor)
         serviceRegistryMock.get(GradleLifecycleActionExecutor) >> gradleLifecycleActionExecutor
         serviceRegistryMock.get(ObjectFactory) >> objectFactory


### PR DESCRIPTION
The Groovy DSL resolution chain walks up to parent projects for unresolved properties and methods. This causes accidental cross-project configuration and spurious Isolated Projects violations for benign operations like findProperty, hasProperty, and dynamic container element creation.

Gate the parent scope in ExtensibleDynamicObject behind the internal flag `org.gradle.internal.project.implicit-parent-properties` (default true). When set to false, unresolved lookups fail immediately instead of falling through to the parent. Build-scoped gradle.properties are unaffected since they are merged into each project's own extra properties before configuration.

The flag also affects Kotlin DSL `by project` delegation, which shares the same DynamicObject chain.

Include integration tests for both Groovy and Kotlin DSL covering property access, method access, container creation, extension configuration, and transitive parent lookup — with and without Isolated Projects.