### PR TITLE
Bump plugin-publish-plugin to 2.1.1

### DIFF
--- a/gradle/dependency-management/build.versions.toml
+++ b/gradle/dependency-management/build.versions.toml
@@ -51,7 +51,7 @@ log4jCore = { group = "org.apache.logging.log4j", name = "log4j-core", version.r
 nullaway = { module = "com.uber.nullaway:nullaway", version = "0.12.10" }
 nullawayPlugin = { module = "net.ltgt.gradle:gradle-nullaway-plugin", version = "2.2.0" }
 pdfbox = { module = "org.apache.pdfbox:pdfbox", version = "2.0.24" } # Flexmark 0.34.60 brings in a vulnerable version of pdfbox
-publishPlugin = { module = "com.gradle.publish:plugin-publish-plugin", version = "2.1.0" }
+publishPlugin = { module = "com.gradle.publish:plugin-publish-plugin", version = "2.1.1" }
 qdox = { module = "com.thoughtworks.qdox:qdox", version = "2.0.3" }
 testRetryPlugin = { module = "org.gradle:test-retry-gradle-plugin", version = "1.6.2" }
 woodstox = { module = "com.fasterxml.woodstox:woodstox-core", version = "6.4.0" } # CVE-2022-40152 on lower versions


### PR DESCRIPTION
This version bundles the capability plugin v1.0.0 that has no
"incubating" API warning.