### PR TITLE
Fix toolchain downloads failing when Content-Disposition header lacks filename parameter

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiIntegrationTest.groovy
@@ -159,6 +159,44 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractIntegrationSpec {
         result.assertNotOutput(testPath)
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/37104")
+    @Requires(IntegTestPreconditions.Java11HomeAvailable)
+    def "toolchain download succeeds when server sends Content-Disposition attachment without filename"() {
+        given:
+        Assume.assumeFalse(JavaVersion.current() == JavaVersion.VERSION_11)
+
+        def jdkRepository = new JdkRepository(JavaVersion.VERSION_11)
+        def uri = jdkRepository.start()
+        jdkRepository.expectHead()
+        jdkRepository.expectGetWithContentDispositionAttachment()
+
+        executer
+            .requireOwnGradleUserHomeDir("needs to not have cached toolchains")
+            .withToolchainDownloadEnabled()
+
+        settingsFile << """
+            ${applyToolchainResolverPlugin("CustomToolchainResolver", singleUrlResolverCode(uri))}
+        """
+
+        buildFile << """
+            apply plugin: "java"
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(11)
+                }
+            }
+        """
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        expect:
+        succeeds("compileJava")
+
+        cleanup:
+        jdkRepository.stop()
+    }
+
     def "custom toolchain registries are consulted in order"() {
         settingsFile << """
             ${applyToolchainResolverPlugin("CustomToolchainResolver", customToolchainResolverCode(), DEFAULT_PLUGIN, NO_TOOLCHAIN_MANAGEMENT)}

--- a/platforms/jvm/toolchains-jvm-shared/src/testFixtures/groovy/org/gradle/jvm/toolchain/JdkRepository.groovy
+++ b/platforms/jvm/toolchains-jvm-shared/src/testFixtures/groovy/org/gradle/jvm/toolchain/JdkRepository.groovy
@@ -72,6 +72,14 @@ class JdkRepository {
         }))
     }
 
+    void expectGetWithContentDispositionAttachment() {
+        server.expect(server.get(archiveName, { e ->
+            e.getResponseHeaders().add("Content-Disposition", "attachment")
+            e.sendResponseHeaders(200, 0)
+            IOUtils.copy(archiveFile, e.getResponseBody())
+        }))
+    }
+
     void stop() {
         server.stop()
         archiveFile.delete()

--- a/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResponseResource.java
+++ b/platforms/software/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResponseResource.java
@@ -24,10 +24,15 @@ import org.gradle.internal.resource.transfer.ExternalResourceReadResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 
 public class HttpResponseResource implements ExternalResourceReadResponse {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpResponseResource.class);
@@ -80,31 +85,210 @@ public class HttpResponseResource implements ExternalResourceReadResponse {
     private String getFilename() {
         String disposition = response.getHeader("Content-Disposition");
         if (disposition != null) {
-            // extracts file name from header field
-            int beginIndex = disposition.indexOf("filename=\"");
-            if (beginIndex > 0) {
-                int endIndex = disposition.indexOf(';', beginIndex + 11); // find the next semicolon
-                endIndex = endIndex < 0 ? disposition.length() : endIndex; // if no semicolon is found, then there is nothing else in the disposition
-                endIndex -= 1; // ignore the closing quotes
-                return disposition.substring(beginIndex + 10, endIndex);
-            }
-
-            beginIndex = disposition.indexOf("filename=");
-            if (beginIndex > 0) {
-                int endIndex = disposition.indexOf(';', beginIndex + 10); // find the next semicolon
-                endIndex = endIndex < 0 ? disposition.length() : endIndex; // if no semicolon is found, then there is nothing else in the disposition
-                return disposition.substring(beginIndex + 9, endIndex);
-            }
-        } else {
-            // extracts file name from URL
-            URI uri = response.getEffectiveUri() == null ? source : response.getEffectiveUri();
-            String sourceInStringForm = uri.toString();
-            int fileNameIndex = sourceInStringForm.lastIndexOf("/");
-            if (fileNameIndex >= 0) {
-                return sourceInStringForm.substring(fileNameIndex + 1);
+            String fromHeader = extractFilenameFromContentDisposition(disposition);
+            if (fromHeader != null && !fromHeader.isEmpty()) {
+                return fromHeader;
             }
         }
+
+        URI effectiveUri = response.getEffectiveUri() != null ? response.getEffectiveUri() : source;
+        return extractFilenameFromUri(effectiveUri);
+    }
+
+    private static String extractFilenameFromUri(URI uri) {
+        String path = uri.getPath();
+        if (path != null && !path.isEmpty()) {
+            int lastSlash = path.lastIndexOf('/');
+            String candidate = lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+            if (!candidate.isEmpty()) {
+                return candidate;
+            }
+        }
+
+        String rawUri = uri.toString();
+        int lastSlash = rawUri.lastIndexOf('/');
+        if (lastSlash >= 0 && lastSlash + 1 < rawUri.length()) {
+            String candidate = rawUri.substring(lastSlash + 1);
+            int queryStart = candidate.indexOf('?');
+            if (queryStart >= 0) {
+                candidate = candidate.substring(0, queryStart);
+            }
+            int fragmentStart = candidate.indexOf('#');
+            if (fragmentStart >= 0) {
+                candidate = candidate.substring(0, fragmentStart);
+            }
+            if (!candidate.isEmpty()) {
+                return candidate;
+            }
+        }
+
         return null;
+    }
+
+    /**
+     * Parses the Content-Disposition header value to extract a filename.
+     * Supports both {@code filename} (RFC 2183) and {@code filename*} (RFC 5987) parameters,
+     * preferring {@code filename*} when both are present.
+     */
+    static String extractFilenameFromContentDisposition(String disposition) {
+        if (disposition == null) {
+            return null;
+        }
+
+        String filename = null;
+        String filenameStar = null;
+
+        for (String part : splitHeaderParameters(disposition)) {
+            String trimmedPart = part.trim();
+            if (trimmedPart.isEmpty()) {
+                continue;
+            }
+            int equalsIndex = trimmedPart.indexOf('=');
+            if (equalsIndex <= 0) {
+                continue;
+            }
+
+            String paramName = trimmedPart.substring(0, equalsIndex).trim().toLowerCase(Locale.ROOT);
+            String rawValue = trimmedPart.substring(equalsIndex + 1).trim();
+            String paramValue = unquoteAndUnescape(rawValue);
+
+            if ("filename*".equals(paramName)) {
+                String decoded = decodeRfc5987(paramValue);
+                if (decoded != null && !decoded.isEmpty()) {
+                    filenameStar = decoded;
+                }
+            } else if ("filename".equals(paramName)) {
+                if (paramValue != null && !paramValue.isEmpty()) {
+                    filename = paramValue;
+                }
+            }
+        }
+
+        return filenameStar != null ? filenameStar : filename;
+    }
+
+    /**
+     * Splits a header value on semicolons, respecting quoted strings.
+     */
+    private static List<String> splitHeaderParameters(String headerValue) {
+        List<String> parts = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        boolean escaped = false;
+
+        for (int i = 0; i < headerValue.length(); i++) {
+            char ch = headerValue.charAt(i);
+
+            if (escaped) {
+                current.append(ch);
+                escaped = false;
+                continue;
+            }
+
+            if (ch == '\\' && inQuotes) {
+                current.append(ch);
+                escaped = true;
+                continue;
+            }
+
+            if (ch == '"') {
+                inQuotes = !inQuotes;
+                current.append(ch);
+                continue;
+            }
+
+            if (ch == ';' && !inQuotes) {
+                parts.add(current.toString());
+                current.setLength(0);
+                continue;
+            }
+
+            current.append(ch);
+        }
+
+        parts.add(current.toString());
+        return parts;
+    }
+
+    /**
+     * Removes surrounding quotes and unescapes quoted-pairs (backslash-escaped characters).
+     */
+    private static String unquoteAndUnescape(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() < 2 || trimmed.charAt(0) != '"' || trimmed.charAt(trimmed.length() - 1) != '"') {
+            return trimmed;
+        }
+
+        String inner = trimmed.substring(1, trimmed.length() - 1);
+        StringBuilder result = new StringBuilder(inner.length());
+        boolean escaped = false;
+        for (int i = 0; i < inner.length(); i++) {
+            char ch = inner.charAt(i);
+            if (escaped) {
+                result.append(ch);
+                escaped = false;
+            } else if (ch == '\\') {
+                escaped = true;
+            } else {
+                result.append(ch);
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * Decodes an RFC 5987 encoded value: {@code charset'language'percent-encoded-value}.
+     */
+    private static String decodeRfc5987(String value) {
+        if (value == null) {
+            return null;
+        }
+        int firstQuote = value.indexOf('\'');
+        if (firstQuote < 0) {
+            return null;
+        }
+        int secondQuote = value.indexOf('\'', firstQuote + 1);
+        if (secondQuote < 0) {
+            return null;
+        }
+
+        String charsetName = value.substring(0, firstQuote).trim();
+        if (charsetName.isEmpty()) {
+            return null;
+        }
+
+        String encoded = value.substring(secondQuote + 1);
+        try {
+            byte[] bytes = percentDecodeToBytes(encoded);
+            return new String(bytes, Charset.forName(charsetName));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static byte[] percentDecodeToBytes(String input) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream(input.length());
+        for (int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+            if (ch == '%') {
+                if (i + 2 >= input.length()) {
+                    throw new IllegalArgumentException("Incomplete percent-encoding at index " + i);
+                }
+                int high = Character.digit(input.charAt(i + 1), 16);
+                int low = Character.digit(input.charAt(i + 2), 16);
+                if (high < 0 || low < 0) {
+                    throw new IllegalArgumentException("Invalid percent-encoding at index " + i);
+                }
+                output.write((high << 4) + low);
+                i += 2;
+            } else {
+                output.write((byte) ch);
+            }
+        }
+        return output.toByteArray();
     }
 
     public long getContentLength() {

--- a/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResponseResourceTest.groovy
+++ b/platforms/software/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResponseResourceTest.groovy
@@ -76,6 +76,66 @@ class HttpResponseResourceTest extends Specification {
         1 * response.close()
     }
 
+    def "falls back to URL path when Content-Disposition has no filename"() {
+        given:
+        def url = new URI("https://example.com/jdks-bin/jdk-17.0.1.tar.gz")
+        response.getHeader("Content-Disposition") >> 'attachment'
+
+        expect:
+        new HttpResponseResource(method, url, response).metaData.filename == "jdk-17.0.1.tar.gz"
+    }
+
+    def "extracts filename from URL when no Content-Disposition header"() {
+        given:
+        def url = new URI("https://example.com/jdks-bin/jdk-17.0.1.tar.gz")
+
+        expect:
+        new HttpResponseResource(method, url, response).metaData.filename == "jdk-17.0.1.tar.gz"
+    }
+
+    def "extracts filename from effective URI when available"() {
+        given:
+        def effectiveUri = new URI("https://cdn.example.com/jdk-redirected.tar.gz")
+        response.getEffectiveUri() >> effectiveUri
+
+        expect:
+        resource().metaData.filename == "jdk-redirected.tar.gz"
+    }
+
+    def "extracts filename from URL path ignoring query parameters"() {
+        given:
+        def url = new URI("https://example.com/jdks/jdk-17.tar.gz?token=abc&expires=123")
+
+        expect:
+        new HttpResponseResource(method, url, response).metaData.filename == "jdk-17.tar.gz"
+    }
+
+    def "extracts filename from Content-Disposition header"() {
+        expect:
+        HttpResponseResource.extractFilenameFromContentDisposition(header) == expected
+
+        where:
+        header                                                                          | expected
+        null                                                                            | null
+        'attachment'                                                                    | null
+        'inline'                                                                        | null
+        'attachment; creation-date="today"'                                             | null
+        'attachment; filename=""'                                                        | null
+        'attachment; filename='                                                          | null
+        'attachment; filename="example.tar.gz"'                                         | "example.tar.gz"
+        'attachment; filename=example.tar.gz'                                           | "example.tar.gz"
+        'attachment; FILENAME="Example.TXT"'                                            | "Example.TXT"
+        'attachment; FileName=Example.TXT'                                              | "Example.TXT"
+        'attachment ; filename = "a.txt" '                                              | "a.txt"
+        'attachment; filename="jdk-17.tar.gz"; size=12345'                              | "jdk-17.tar.gz"
+        'attachment; filename="a;b.txt"; size=123'                                      | "a;b.txt"
+        'attachment; filename="a\\"b.txt"'                                              | 'a"b.txt'
+        "attachment; filename*=UTF-8''na%C3%AFve%20file.txt"                            | "na\u00EFve file.txt"
+        "attachment; filename*=iso-8859-1'en'%A3%20rates.txt"                           | "\u00A3 rates.txt"
+        "attachment; filename=\"fallback.txt\"; filename*=UTF-8''%E2%82%AC%20rates.txt" | "\u20AC rates.txt"
+        "attachment; filename=\"fallback.txt\"; filename*=UTF-8''%ZZ%20bad"             | "fallback.txt"
+    }
+
     HttpResponseResource resource() {
         new HttpResponseResource(method, sourceUrl, response)
     }


### PR DESCRIPTION
Fixes #37104

### Context

When downloading JDK toolchains from corporate repositories that return a `Content-Disposition: attachment` header without a `filename` parameter, Gradle fails with:

  > Can't determine filename for resource located at: ...

The root cause is in `HttpResponseResource.getFilename()`: when a `Content-Disposition` header is present but contains no `filename` parameter, the URL-based filename fallback is never reached because it sits inside the `else` branch (only executed when the header is entirely absent).

This affects any organization using an internal artifact repository or proxy that serves JDK archives with a bare `Content-Disposition: attachment` header, which is valid per RFC 2183.

This PR:
  - Restructures `getFilename()` so the URL path fallback always runs when the header provides no usable filename
  - Replaces the fragile `indexOf`: based Content-Disposition parsing with a robust implementation that handles case-insensitive parameter names (RFC 2616), quoted strings with escapes, semicolons inside quotes, and RFC 5987 `filename*` encoding
  - Adds unit tests covering all parsing edge cases and an integration test that reproduces the exact failure scenario from the issue


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
