### PR TITLE
Add toolchain support for Groovydoc task (fixes #15283)

### DIFF
--- a/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocToolchainIntegrationTest.groovy
+++ b/platforms/jvm/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocToolchainIntegrationTest.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy
+
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
+import org.gradle.internal.jvm.Jvm
+import org.gradle.testing.fixture.GroovyCoverage
+import org.junit.Assume
+
+import static org.gradle.util.internal.GroovyDependencyUtil.groovyModuleDependency
+
+@TargetCoverage({GroovyCoverage.SUPPORTS_GROOVYDOC})
+class GroovyDocToolchainIntegrationTest extends MultiVersionIntegrationSpec implements JavaToolchainFixture {
+
+    def setup() {
+        file("src/main/groovy/pkg/Thing.groovy") << """
+            package pkg
+
+            class Thing {}
+        """
+
+        buildFile << """
+            plugins {
+                id("groovy")
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                implementation "${groovyModuleDependency("groovy", versionNumber)}"
+            }
+        """
+    }
+
+    def "uses #what toolchain #when for Groovy "() {
+        def currentJdk = Jvm.current()
+        def otherJdk = AvailableJavaHomes.getDifferentVersion()
+        Assume.assumeTrue("Requires a JDK different from the current one", otherJdk != null)
+        def selectJdk = { it == "other" ? otherJdk : it == "current" ? currentJdk : null }
+
+        if (withTool != null) {
+            configureGroovydocTool(selectJdk(withTool))
+        }
+        if (withJavaExtension != null) {
+            configureJavaPluginToolchainVersion(selectJdk(withJavaExtension))
+        }
+
+        def targetJdk = selectJdk(target)
+
+        when:
+        withInstallations(currentJdk, otherJdk).run(":groovydoc", "--info")
+
+        then:
+        executedAndNotSkipped(":groovydoc")
+        outputContains("Running groovydoc with toolchain '${targetJdk.javaHome.absolutePath}'")
+        file("build/docs/groovydoc/pkg/Thing.html").exists()
+
+        where:
+        what             | when                         | withTool | withJavaExtension | target
+        "current JVM"    | "when nothing is configured" | null     | null              | "current"
+        "java extension" | "when configured"            | null     | "other"           | "other"
+        "assigned tool"  | "when configured"            | "other"  | null              | "other"
+        "assigned tool"  | "over java extension"        | "other"  | "current"         | "other"
+    }
+
+    def "up-to-date depends on the toolchain for Groovy "() {
+        def currentJdk = Jvm.current()
+        def otherJdk = AvailableJavaHomes.getDifferentVersion()
+        Assume.assumeTrue("Requires a JDK different from the current one", otherJdk != null)
+
+        buildFile << """
+            groovydoc {
+                javaLauncher = javaToolchains.launcherFor {
+                    languageVersion = JavaLanguageVersion.of(
+                        providers.gradleProperty("changed").isPresent()
+                            ? ${otherJdk.javaVersion.majorVersion}
+                            : ${currentJdk.javaVersion.majorVersion}
+                    )
+                }
+            }
+        """
+
+        when:
+        withInstallations(currentJdk, otherJdk).run(":groovydoc")
+        then:
+        executedAndNotSkipped(":groovydoc")
+
+        when:
+        withInstallations(currentJdk, otherJdk).run(":groovydoc")
+        then:
+        skipped(":groovydoc")
+
+        when:
+        withInstallations(currentJdk, otherJdk).run(":groovydoc", "-Pchanged", "--info")
+        then:
+        executedAndNotSkipped(":groovydoc")
+        outputContains("Value of input property 'javaLauncher.metadata.languageVersion' has changed for task ':groovydoc'")
+
+        when:
+        withInstallations(currentJdk, otherJdk).run(":groovydoc", "-Pchanged")
+        then:
+        skipped(":groovydoc")
+    }
+
+    private void configureGroovydocTool(Jvm jdk) {
+        buildFile << """
+            groovydoc {
+                javaLauncher = javaToolchains.launcherFor {
+                    languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
+                }
+            }
+        """
+    }
+}

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.javadoc;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
@@ -37,6 +38,9 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
+import org.gradle.internal.jvm.JpmsConfiguration;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.workers.WorkerExecutor;
 import org.jspecify.annotations.Nullable;
 
@@ -87,7 +91,24 @@ public abstract class Groovydoc extends SourceTask {
     private Set<Link> links = new LinkedHashSet<Link>();
 
     @Inject
+    public Groovydoc() {
+        getJavaLauncher().convention(getJavaToolchainService().launcherFor(spec -> {}));
+    }
+
+    @Inject
     protected abstract WorkerExecutor getWorkerExecutor();
+
+    @Inject
+    protected abstract JavaToolchainService getJavaToolchainService();
+
+    /**
+     * The Java launcher used to start the worker process for generating Groovydoc.
+     *
+     * @since 9.6.0
+     */
+    @Incubating
+    @Nested
+    public abstract Property<JavaLauncher> getJavaLauncher();
 
     @TaskAction
     protected void generate() {
@@ -105,7 +126,12 @@ public abstract class Groovydoc extends SourceTask {
         fsOperations.delete(spec -> spec.delete(tmpDir));
         fsOperations.copy(spec -> spec.from(getSource()).into(tmpDir));
 
-        getWorkerExecutor().classLoaderIsolation().submit(GroovydocAntAction.class, parameters -> {
+        JavaLauncher launcher = getJavaLauncher().get();
+        int javaVersionMajor = Integer.parseInt(launcher.getMetadata().getLanguageVersion().toString());
+        getWorkerExecutor().processIsolation(spec -> {
+            spec.getForkOptions().setExecutable(launcher.getExecutablePath().getAsFile().getAbsolutePath());
+            spec.getForkOptions().jvmArgs(JpmsConfiguration.forGroovyCompilerWorker(javaVersionMajor));
+        }).submit(GroovydocAntAction.class, parameters -> {
             parameters.getAntLibraryClasspath().from(getClasspath());
             parameters.getAntLibraryClasspath().from(getGroovyClasspath());
             parameters.getSource().convention(getSource());

--- a/platforms/jvm/plugins-groovy/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/platforms/jvm/plugins-groovy/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -176,6 +176,7 @@ public abstract class GroovyBasePlugin implements Plugin<Project> {
             groovydoc.getConventionMapping().map("destinationDir", () -> javaPluginExtension(project).getDocsDir().dir("groovydoc").get().getAsFile());
             groovydoc.getConventionMapping().map("docTitle", () -> ReportUtilities.getApiDocTitleFor(project));
             groovydoc.getConventionMapping().map("windowTitle", () -> ReportUtilities.getApiDocTitleFor(project));
+            groovydoc.getJavaLauncher().convention(getJavaLauncher(project));
             groovydoc.getAccess().convention(GroovydocAccess.PROTECTED);
             groovydoc.getIncludeAuthor().convention(false);
             groovydoc.getProcessScripts().convention(true);


### PR DESCRIPTION
Fixes #15283 

### Context
Adds Java toolchain support to the `Groovydoc` task, resolving a long-standing inconsistency where `GroovyCompile`, `Javadoc`, `ScalaDoc`, and code quality tasks all  supported toolchains but `Groovydoc` did not.

 ### Usage

  ```groovy
  // Automatically uses the project toolchain
  java {
      toolchain {
          languageVersion = JavaLanguageVersion.of(17)
      }
  }

  // Or configure per-task
  groovydoc {
      javaLauncher = javaToolchains.launcherFor {
          languageVersion = JavaLanguageVersion.of(21)
      }
  }
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
