### PR TITLE
Relax failure assertions to fix flaky tests

### DIFF
--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.util.GradleVersion
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static org.gradle.util.internal.TextUtil.normaliseLineSeparators
+import static org.hamcrest.CoreMatchers.startsWith
 
 @SuppressWarnings('IntegrationTestFixtures')
 class GradleRunnerBuildFailureIntegrationTest extends BaseGradleRunnerIntegrationTest {
@@ -164,7 +165,7 @@ $t.buildResult.output"""
 
         def failure = OutputScrapingExecutionFailure.from(t.buildResult.output, "")
         failure.assertTasksScheduled(':helloWorld')
-        failure.assertHasDescription("Execution failed for task ':helloWorld' (registered in build file 'build.gradle').")
+        failure.assertThatDescription(startsWith("Execution failed for task ':helloWorld'"))
         failure.assertHasCause('Unexpected exception')
 
         normaliseLineSeparators(t.message).startsWith(normaliseLineSeparators(expectedMessage))

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -23,6 +23,7 @@ import static org.gradle.integtests.fixtures.SuggestionsMessages.SCAN
 import static org.gradle.util.Matchers.containsLine
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.not
+import static org.hamcrest.CoreMatchers.startsWith
 import static org.junit.Assume.assumeTrue
 
 class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegrationTest {
@@ -67,7 +68,7 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
 
         expect:
         fails("check")
-        failure.assertHasDescription("Execution failed for task ':pmdTest' (registered in build file 'build.gradle').")
+        failure.assertThatDescription(startsWith("Execution failed for task ':pmdTest'"))
         failure.assertThatCause(containsString("2 PMD rule violations were found. See the report at:"))
         failure.assertHasResolutions(SCAN)
         file("build/reports/pmd/main.xml").assertContents(not(containsClass("org.gradle.Class1")))

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitTestFailureIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitTestFailureIntegrationTest.groovy
@@ -324,7 +324,7 @@ abstract class AbstractJUnitTestFailureIntegrationTest extends AbstractTestingMu
         } else {
             // In JUnit 4.0 to 4.4, a test class with an initialization error results in a test process failure; not a test execution failure,
             // so we cannot assert on test results. From 4.5 onwards, we get proper test execution failures.
-            failure.assertHasDescription("Execution failed for task ':test'.")
+            failure.assertThatDescription(startsWith("Execution failed for task ':test'"))
             failure.assertThatCause(startsWith("Could not execute test class 'org.gradle.Unloadable'."))
         }
     }

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/rc/WindowsResourcesUnsupportedIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/rc/WindowsResourcesUnsupportedIntegrationTest.groovy
@@ -23,6 +23,8 @@ import org.gradle.nativeplatform.fixtures.app.HelloWorldApp
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 
+import static org.hamcrest.CoreMatchers.startsWith
+
 class WindowsResourcesUnsupportedIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
     HelloWorldApp helloWorldApp = new CppHelloWorldApp()
@@ -87,7 +89,7 @@ model {
         fails "mainExecutable"
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileMainExecutableMainRc' (registered in build file 'build.gradle').")
+        failure.assertThatDescription(startsWith("Execution failed for task ':compileMainExecutableMainRc'"))
         failure.assertHasCause("Windows resource compiler is not available")
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIncludedBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIncludedBuildIntegrationTest.groovy
@@ -16,11 +16,12 @@
 
 package org.gradle.initialization.buildsrc
 
-
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.plugin.PluginBuilder
+
+import static org.hamcrest.CoreMatchers.startsWith
 
 @Flaky(because = "https://github.com/gradle/gradle-private/issues/4550")
 class BuildSrcIncludedBuildIntegrationTest extends AbstractIntegrationSpec {
@@ -319,7 +320,7 @@ class BuildSrcIncludedBuildIntegrationTest extends AbstractIntegrationSpec {
         when:
         fails("help")
         then:
-        failure.assertHasDescription("Execution failed for task ':included:compileJava' (registered in build file 'build.gradle').")
+        failure.assertThatDescription(startsWith("Execution failed for task ':included:compileJava'"))
         failure.assertHasCause("Compilation failed; see the compiler output below.")
     }
 


### PR DESCRIPTION
Use prefix matching for task failure descriptions instead of exact matches. This avoids brittle assertions on task registration provenance, which can vary between environments and caused integration tests to be flaky.
