### PR TITLE
Fix TaskbarProgressResetFunctionalTest file leak

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/TaskbarProgressResetFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/TaskbarProgressResetFunctionalTest.groovy
@@ -90,7 +90,7 @@ class TaskbarProgressResetFunctionalTest extends AbstractIntegrationSpec {
         """
 
         when:
-        result = executer.withTasks("ok").run()
+        result = succeeds("ok")
 
         then:
         result.output.contains(OSC_RESET)


### PR DESCRIPTION
Remove BlockingHttpServer in favor of Thread.sleep() which is interruptible by SIGINT, and add requireIsolatedDaemons() so the daemon is killed during test cleanup instead of lingering and writing to the test directory.

Fixes: https://github.com/gradle/gradle-private/issues/5143

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
