### PR TITLE
Fix threadPoolFactoryClass configuration for TestNG >= 7.10

### DIFF
--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestRunner.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestRunner.java
@@ -182,7 +182,28 @@ public class TestNGTestRunner {
         }
     }
 
+    /**
+     * The setter for the thread pool factory has a different signature depending on TestNG version.
+     * This method uses reflection to detect the API and calls the version with the correct signature.
+     *
+     * TestNG >= 7.10 uses {@code setExecutorServiceFactory(IExecutorServiceFactory)}.
+     * TestNG 7.0–7.9 uses {@code setExecutorFactoryClass(String)}.
+     */
     private void setThreadPoolFactoryClass(TestNG testNg, String threadPoolFactoryClass) {
+        try {
+            Class<?> factoryInterface = Class.forName("org.testng.IExecutorServiceFactory", false, applicationClassLoader);
+            Class<?> factoryClass = applicationClassLoader.loadClass(threadPoolFactoryClass);
+            if (!factoryInterface.isAssignableFrom(factoryClass)) {
+                throw new InvalidUserDataException(String.format(
+                    "The thread pool factory class '%s' does not implement org.testng.IExecutorServiceFactory.", threadPoolFactoryClass));
+            }
+            Object factoryInstance = JavaReflectionUtil.newInstance(factoryClass);
+            JavaMethod.of(TestNG.class, Object.class, "setExecutorServiceFactory", factoryInterface).invoke(testNg, factoryInstance);
+            return;
+        } catch (ClassNotFoundException e) {
+            // New API not available, fall through to legacy API
+        }
+
         try {
             JavaMethod.of(TestNG.class, Object.class, "setExecutorFactoryClass", String.class).invoke(testNg, threadPoolFactoryClass);
         } catch (org.gradle.internal.reflect.NoSuchMethodException e) {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/TestNGCoverage.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/TestNGCoverage.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.util.internal.VersionNumber
 
 class TestNGCoverage {
-    final static String NEWEST = '7.5'
+    final static String NEWEST = '7.10.2'
 
     private static final String FIXED_ILLEGAL_ACCESS = '5.14.6' // Oldest version to support JDK 16+ without explicit --add-opens
 
@@ -38,6 +38,8 @@ class TestNGCoverage {
     private static final String BEFORE_BROKEN_PRESERVE_ORDER = '6.1.1' // Latest version before introduction of cbeust/testng#639 bug
     private static final String FIXED_BROKEN_PRESERVE_ORDER = '6.9.4'  // Fixes cbeust/testng#639 for preserve-order
 
+    private static final String LAST_BEFORE_NEW_EXECUTOR_API = '7.5' // Last version with setExecutorFactoryClass(String)
+
     public static final Set<String> ALL_VERSIONS = [
         '5.12.1', // Newest version without TestNG#setConfigFailurePolicy method (Added in 5.13)
         FIXED_ILLEGAL_ACCESS,
@@ -45,6 +47,7 @@ class TestNGCoverage {
         FIXED_BROKEN_PRESERVE_ORDER,
         BROKEN_ICLASS_LISTENER,
         FIXED_ICLASS_LISTENER,
+        LAST_BEFORE_NEW_EXECUTOR_API,
         NEWEST
       ]
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGThreadPoolFactoryIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGThreadPoolFactoryIntegrationTest.groovy
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.testng
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/28955")
+class TestNGThreadPoolFactoryIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can configure threadPoolFactoryClass with TestNG 7.10+ (new IExecutorServiceFactory API)"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'org.testng:testng:7.10.2'
+            }
+            test {
+                useTestNG {
+                    threadPoolFactoryClass = 'org.gradle.test.CustomExecutorServiceFactory'
+                }
+            }
+        """
+
+        file("src/test/java/org/gradle/test/CustomExecutorServiceFactory.java") << """
+            package org.gradle.test;
+
+            import java.util.concurrent.BlockingQueue;
+            import java.util.concurrent.ExecutorService;
+            import java.util.concurrent.ThreadFactory;
+            import java.util.concurrent.ThreadPoolExecutor;
+            import java.util.concurrent.TimeUnit;
+
+            public class CustomExecutorServiceFactory implements org.testng.IExecutorServiceFactory {
+                @Override
+                public ExecutorService create(
+                        int corePoolSize,
+                        int maximumPoolSize,
+                        long keepAliveTime,
+                        TimeUnit unit,
+                        BlockingQueue<Runnable> workQueue,
+                        ThreadFactory threadFactory) {
+                    return new ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+                }
+            }
+        """
+
+        file("src/test/java/org/gradle/test/SimpleTest.java") << """
+            package org.gradle.test;
+
+            import org.testng.annotations.Test;
+
+            public class SimpleTest {
+                @Test
+                public void testPass() {
+                    assert true;
+                }
+            }
+        """
+
+        when:
+        succeeds("test")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "can configure threadPoolFactoryClass with TestNG 7.5 (legacy setExecutorFactoryClass API)"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'org.testng:testng:7.5'
+            }
+            test {
+                useTestNG {
+                    threadPoolFactoryClass = 'org.gradle.test.CustomExecutorFactory'
+                }
+            }
+        """
+
+        // For the old API, we use reflection-based delegation to avoid
+        // compiling against complex internal TestNG classes.
+        file("src/test/java/org/gradle/test/CustomExecutorFactory.java") << """
+            package org.gradle.test;
+
+            import org.testng.thread.IExecutorFactory;
+            import org.testng.thread.ITestNGThreadPoolExecutor;
+            import org.testng.thread.IThreadWorkerFactory;
+            import org.testng.IDynamicGraph;
+            import org.testng.ISuite;
+            import org.testng.ITestNGMethod;
+
+            import java.util.Comparator;
+            import java.util.concurrent.BlockingQueue;
+            import java.util.concurrent.TimeUnit;
+
+            public class CustomExecutorFactory implements IExecutorFactory {
+                @Override
+                @SuppressWarnings({"unchecked", "rawtypes"})
+                public ITestNGThreadPoolExecutor newSuiteExecutor(
+                        String name,
+                        IDynamicGraph<ISuite> graph,
+                        IThreadWorkerFactory<ISuite> factory,
+                        int corePoolSize,
+                        int maximumPoolSize,
+                        long keepAliveTime,
+                        TimeUnit unit,
+                        BlockingQueue<Runnable> workQueue,
+                        Comparator<ISuite> comparator) {
+                    try {
+                        Class clazz = Class.forName("org.testng.internal.thread.graph.TestNGThreadPoolExecutor");
+                        return (ITestNGThreadPoolExecutor) clazz.getConstructors()[0].newInstance(
+                            name, graph, factory, corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, comparator);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                @Override
+                @SuppressWarnings({"unchecked", "rawtypes"})
+                public ITestNGThreadPoolExecutor newTestMethodExecutor(
+                        String name,
+                        IDynamicGraph<ITestNGMethod> graph,
+                        IThreadWorkerFactory<ITestNGMethod> factory,
+                        int corePoolSize,
+                        int maximumPoolSize,
+                        long keepAliveTime,
+                        TimeUnit unit,
+                        BlockingQueue<Runnable> workQueue,
+                        Comparator<ITestNGMethod> comparator) {
+                    try {
+                        Class clazz = Class.forName("org.testng.internal.thread.graph.TestNGThreadPoolExecutor");
+                        return (ITestNGThreadPoolExecutor) clazz.getConstructors()[0].newInstance(
+                            name, graph, factory, corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, comparator);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        """
+
+        file("src/test/java/org/gradle/test/SimpleTest.java") << """
+            package org.gradle.test;
+
+            import org.testng.annotations.Test;
+
+            public class SimpleTest {
+                @Test
+                public void testPass() {
+                    assert true;
+                }
+            }
+        """
+
+        when:
+        succeeds("test")
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
@@ -403,9 +403,12 @@ public abstract class TestNGOptions extends TestFrameworkOptions {
 
     /**
      * Sets a custom threadPoolExecutorFactory class.
-     * This should be a fully qualified class name and the class should implement org.testng.IExecutorFactory
-     * More details in https://github.com/testng-team/testng/pull/2042
-     * Requires TestNG 7.0 or higher
+     * This should be a fully qualified class name of a class with a public no-arg constructor.
+     * For TestNG 7.10 and above, the class should implement {@code org.testng.IExecutorServiceFactory}.
+     * For TestNG 7.0 through 7.9, the class should implement {@code org.testng.thread.IExecutorFactory}.
+     * More details in <a href="https://github.com/testng-team/testng/pull/2042">testng#2042</a>
+     * and <a href="https://github.com/testng-team/testng/pull/3095">testng#3095</a>.
+     * Requires TestNG 7.0 or higher.
      * @since 8.7
      */
     @Incubating


### PR DESCRIPTION
Fixes #28955

### Context

TestNG 7.10.0 replaced `setExecutorFactoryClass(String)` with `setExecutorServiceFactory(IExecutorServiceFactory)`. Gradle's TestNGTestRunner only tried the old method via reflection, so configuring `threadPoolFactoryClass` with TestNG >= 7.10 threw `InvalidUserDataException: The version of TestNG used does not support setting thread pool factory class`.

This PR updates `TestNGTestRunner.setThreadPoolFactoryClass()` to try the new API first (loading and instantiating the user's class as an `IExecutorServiceFactory`), then fall back to the legacy `setExecutorFactoryClass(String)` API for TestNG 7.0–7.9. This mirrors the existing pattern used for `setConfigFailurePolicy()`.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
