### PR TITLE
Clarify invalid JVM installation warning when configuration cache is enabled

### DIFF
--- a/platforms/jvm/jvm-services/src/integTest/groovy/org/gradle/jvm/toolchain/InvalidJvmInstallationReportingIntegrationTest.groovy
+++ b/platforms/jvm/jvm-services/src/integTest/groovy/org/gradle/jvm/toolchain/InvalidJvmInstallationReportingIntegrationTest.groovy
@@ -29,7 +29,7 @@ import java.util.regex.Pattern
 class InvalidJvmInstallationReportingIntegrationTest extends AbstractIntegrationSpec {
 
     @Requires([IntegTestPreconditions.NotNoDaemonExecutor, IntegTestPreconditions.DifferentJdkAvailable])
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/36734")
+    @ToBeFixedForConfigurationCache(because = "With CC enabled, toolchain detection is not re-triggered on cache hit, so the warning is not emitted on the second build")
     def "invalid JDK is cached only for current build if in daemon"() {
         // Require a different JDK to be able to find the logs of its probing for system properties
         def existingJdk = AvailableJavaHomes.differentJdk
@@ -74,7 +74,9 @@ class InvalidJvmInstallationReportingIntegrationTest extends AbstractIntegration
         results.every { result ->
             def expectedErrorMessages = [invalidJdkHome1, invalidJdkHome2].collect {
                 "Invalid Java installation found at '${it.canonicalPath}' (Gradle property 'org.gradle.java.installations.paths'). " +
-                    "It will be re-checked in the next build. This might have performance impact if it keeps failing. " +
+                    "It will be re-checked in the next build. " +
+                    "If the configuration cache is enabled, the re-check will happen only after the cache is invalidated. " +
+                    "This might have performance impact if it keeps failing. " +
                     "Run the 'javaToolchains' task for more details."
             }
             expectedErrorMessages.every { countMatches(it, result.plainTextOutput) == 1 }

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/InvalidInstallationWarningReporter.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/InvalidInstallationWarningReporter.java
@@ -44,7 +44,9 @@ public class InvalidInstallationWarningReporter implements BiConsumer<Installati
         if (!metadata.isValidInstallation()) {
             logger.warn(
                 "Invalid Java installation found at {}. " +
-                    "It will be re-checked in the next build. This might have performance impact if it keeps failing. " +
+                    "It will be re-checked in the next build. " +
+                    "If the configuration cache is enabled, the re-check will happen only after the cache is invalidated. " +
+                    "This might have performance impact if it keeps failing. " +
                     "Run the 'javaToolchains' task for more details.",
                 installationLocation.getDisplayName()
             );

--- a/platforms/jvm/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/InvalidInstallationWarningReporterTest.groovy
+++ b/platforms/jvm/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/InvalidInstallationWarningReporterTest.groovy
@@ -57,7 +57,9 @@ class InvalidInstallationWarningReporterTest extends Specification {
         then:
         1 * mockLogger.warn(
             "Invalid Java installation found at {}. " +
-                "It will be re-checked in the next build. This might have performance impact if it keeps failing. " +
+                "It will be re-checked in the next build. " +
+                "If the configuration cache is enabled, the re-check will happen only after the cache is invalidated. " +
+                "This might have performance impact if it keeps failing. " +
                 "Run the 'javaToolchains' task for more details.",
             location.displayName
         )


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/36734

### Context

When an invalid JVM installation is detected, Gradle emits a warning saying "It will be re-checked in the next build." This is misleading when the configuration cache is enabled because toolchain detection results are cached and won't be re-evaluated until the cache is invalidated.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
