### PR TITLE
Fix native-image capability detection on Windows by also checking for native-image.cmd

### DIFF
--- a/platforms/core-runtime/build-configuration/src/testFixtures/groovy/org/gradle/internal/buildconfiguration/fixture/DaemonJvmPropertiesFixture.groovy
+++ b/platforms/core-runtime/build-configuration/src/testFixtures/groovy/org/gradle/internal/buildconfiguration/fixture/DaemonJvmPropertiesFixture.groovy
@@ -94,6 +94,17 @@ trait DaemonJvmPropertiesFixture {
         assertJvmCriteria(version, vendor, implementation, testDir)
     }
 
+    /**
+     * Adds the native-image capability requirement to the daemon JVM criteria, preserving
+     * any criteria already written by {@link #writeJvmCriteria}.
+     */
+    void writeNativeImageCapableCriteria(TestFile testDir = testDirectory) {
+        TestFile daemonJvmPropertiesFile = getDaemonJvmPropertiesFile(testDir)
+        Properties properties = daemonJvmPropertiesFile.exists() ? GUtil.loadProperties(daemonJvmPropertiesFile) : new Properties()
+        properties.put(DaemonJvmPropertiesDefaults.TOOLCHAIN_NATIVE_IMAGE_CAPABLE_PROPERTY, "true")
+        daemonJvmPropertiesFile.writeProperties(properties)
+    }
+
     void writeToolchainDownloadUrls(String url, TestFile testDir = testDirectory) {
         TestFile daemonJvmPropertiesFile = getDaemonJvmPropertiesFile(testDir)
         Properties properties = daemonJvmPropertiesFile.exists() ? GUtil.loadProperties(daemonJvmPropertiesFile) : new Properties()

--- a/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
+++ b/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
@@ -71,7 +71,8 @@ public class DaemonCompatibilitySpec implements ExplainingSpec<DaemonContext> {
             if (daemonJvmCriteria.isCompatibleWith(potentialContext.getJavaVersion(), potentialContext.getJavaVendor())) {
                 if (daemonJvmCriteria.isNativeImageCapable()) {
                     // Need to assess that $JAVA_HOME/bin/native-image exists
-                    return new File(new File(potentialContext.getJavaHome(), "bin"), OperatingSystem.current().getExecutableName("native-image")).exists();
+                    // GraalVM and Liberica distributions ship native-image as a .cmd script on Windows
+                    return hasNativeImageTool(potentialContext.getJavaHome());
                 } else {
                     return true;
                 }
@@ -96,6 +97,17 @@ public class DaemonCompatibilitySpec implements ExplainingSpec<DaemonContext> {
             }
         } catch (IOException e) {
             // ignore
+        }
+        return false;
+    }
+
+    private static boolean hasNativeImageTool(File javaHome) {
+        File binDir = new File(javaHome, "bin");
+        if (new File(binDir, OperatingSystem.current().getExecutableName("native-image")).exists()) {
+            return true;
+        }
+        if (OperatingSystem.current().isWindows()) {
+            return new File(binDir, "native-image.cmd").exists();
         }
         return false;
     }

--- a/platforms/core-runtime/daemon-protocol/src/test/groovy/org/gradle/launcher/daemon/context/DaemonCompatibilitySpecSpec.groovy
+++ b/platforms/core-runtime/daemon-protocol/src/test/groovy/org/gradle/launcher/daemon/context/DaemonCompatibilitySpecSpec.groovy
@@ -27,8 +27,10 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.FileSystemTestPreconditions
+import org.gradle.test.preconditions.OsTestPreconditions
 
 import org.junit.Rule
+import spock.lang.Issue
 import spock.lang.Specification
 
 class DaemonCompatibilitySpecSpec extends Specification {
@@ -186,6 +188,76 @@ class DaemonCompatibilitySpecSpec extends Specification {
 
         where:
         clientStatus << [true, false]
+    }
+
+    def "native-image capable criteria is satisfied by the native-image executable"() {
+        javaHome.file("bin", OperatingSystem.current().getExecutableName("native-image")).touch()
+        clientWantsNativeCompatibleImage()
+
+        expect:
+        compatible
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/36118")
+    @Requires(OsTestPreconditions.Windows)
+    def "native-image capable criteria is satisfied by a #script script on Windows"() {
+        javaHome.file("bin/$script").touch()
+        clientWantsNativeCompatibleImage()
+
+        expect:
+        compatible
+
+        where:
+        // We test non-lowercase variants, but Windows is typically case-insensitive so these generally pass
+        // even if we don't explicitly support them.
+        // Testing case-sensitive behavior is not feasible as we would need elevated privileges to set that,
+        // or a local FS that is case-sensitive, which is not available in CI.
+        script << ["native-image.cmd", "native-image.CMD", "NATIVE-IMAGE.cmd"]
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/36118")
+    @Requires(OsTestPreconditions.Windows)
+    def "native-image capable criteria is satisfied when both the native-image executable and the .cmd script are present on Windows"() {
+        javaHome.file("bin", OperatingSystem.current().getExecutableName("native-image")).touch()
+        javaHome.file("bin/native-image.cmd").touch()
+        clientWantsNativeCompatibleImage()
+
+        expect:
+        compatible
+    }
+
+    @Requires(OsTestPreconditions.NotWindows)
+    def "native-image capable criteria is not satisfied by a native-image.cmd script on non-Windows OS"() {
+        javaHome.file("bin/native-image.cmd").touch()
+        clientWantsNativeCompatibleImage()
+
+        expect:
+        !compatible
+        unsatisfiedReason.contains "JVM is incompatible"
+    }
+
+    def "native-image capable criteria is not satisfied when no native-image tool is present"() {
+        clientWantsNativeCompatibleImage()
+
+        expect:
+        !compatible
+        unsatisfiedReason.contains "JVM is incompatible"
+    }
+
+    /**
+     * Sets up a request for a native-image capable daemon and a candidate whose JVM
+     * matches on everything except the presence of the native-image tool.
+     */
+    private void clientWantsNativeCompatibleImage() {
+        clientWants(new DaemonJvmCriteria.Spec(JavaLanguageVersion.of(17), JvmVendorSpec.BELLSOFT, JvmImplementation.VENDOR_SPECIFIC, true))
+
+        candidate.javaHome >> javaHome
+        candidate.javaVersion >> JavaLanguageVersion.of(17)
+        candidate.javaVendor >> "BellSoft"
+        candidate.daemonOpts >> []
+        candidate.priority >> DaemonPriority.NORMAL
+        candidate.shouldApplyInstrumentationAgent() >> false
+        candidate.nativeServicesMode >> NativeServices.NativeServicesMode.NOT_SET
     }
 
     def "context with same agent status"() {

--- a/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainIntegrationTest.groovy
+++ b/platforms/core-runtime/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonToolchainIntegrationTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.TestExecutionPreconditions
 import org.gradle.test.preconditions.InstalledJdkTestPreconditions
 import org.junit.Assume
+import spock.lang.Issue
 
 @Requires(value = TestExecutionPreconditions.NotEmbeddedExecutor, reason = "explicitly requests a daemon")
 class DaemonToolchainIntegrationTest extends AbstractIntegrationSpec implements DaemonJvmPropertiesFixture, JavaToolchainFixture {
@@ -157,5 +158,20 @@ class DaemonToolchainIntegrationTest extends AbstractIntegrationSpec implements 
         expect:
         fails("help")
         failure.assertHasDescription("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=10, vendor=IBM, implementation=vendor-specific, nativeImageCapable=false}")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/36118")
+    def "Given daemon toolchain criteria requiring native-image capability that doesn't match installed ones When executing any task Then fails with the expected message"() {
+        given:
+        // Java 10 is not available
+        def java10 = AvailableJavaHomes.getAvailableJdks(JavaVersion.VERSION_1_10)
+        Assume.assumeTrue(java10.isEmpty())
+        writeJvmCriteria(JavaVersion.VERSION_1_10)
+        writeNativeImageCapableCriteria()
+        captureJavaHome()
+
+        expect:
+        fails("help")
+        failure.assertHasDescription("Cannot find a Java installation on your machine (${OperatingSystem.current()}) matching: {languageVersion=10, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=true}")
     }
 }

--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
@@ -251,7 +251,7 @@ public interface JvmInstallationMetadata {
             if (getToolByExecutable("jar").exists()) {
                 capabilities.add(JavaInstallationCapability.JAR_TOOL);
             }
-            if (getToolByExecutable("native-image").exists()) {
+            if (hasNativeImageTool()) {
                 capabilities.add(JavaInstallationCapability.NATIVE_IMAGE);
             }
             boolean isJ9vm = jvmName.contains("J9");
@@ -259,6 +259,21 @@ public interface JvmInstallationMetadata {
                 capabilities.add(JavaInstallationCapability.J9_VIRTUAL_MACHINE);
             }
             return capabilities;
+        }
+
+        /**
+         * Checks for the native-image tool, which may be shipped as either an executable
+         * (native-image / native-image.exe) or a command script (native-image.cmd) on Windows.
+         */
+        private boolean hasNativeImageTool() {
+            if (getToolByExecutable("native-image").exists()) {
+                return true;
+            }
+            // GraalVM and Liberica distributions ship native-image as a .cmd script on Windows
+            if (OperatingSystem.current().isWindows()) {
+                return new File(new File(javaHome.toFile(), "bin"), "native-image.cmd").exists();
+            }
+            return false;
         }
 
         private File getToolByExecutable(String name) {

--- a/platforms/jvm/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/JvmInstallationMetadataTest.groovy
+++ b/platforms/jvm/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/JvmInstallationMetadataTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.jvm.inspection
+
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.OsTestPreconditions
+import org.junit.Rule
+import spock.lang.Issue
+import spock.lang.Specification
+
+/**
+ * Tests capability detection in {@link JvmInstallationMetadata}.
+ */
+class JvmInstallationMetadataTest extends Specification {
+
+    @Rule
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
+
+    @Issue("https://github.com/gradle/gradle/issues/36118")
+    @Requires(OsTestPreconditions.Windows)
+    def "detects native-image capability from #script script on Windows"() {
+        given:
+        def javaHome = jdkHome()
+        javaHome.file("bin/$script").touch()
+
+        expect:
+        metadataFor(javaHome).capabilities.contains(JavaInstallationCapability.NATIVE_IMAGE)
+
+        where:
+        // We test non-lowercase variants, but Windows is typically case-insensitive so these generally pass
+        // even if we don't explicitly support them.
+        // Testing case-sensitive behavior is not feasible as we would need elevated privileges to set that,
+        // or a local FS that is case-sensitive, which is not available in CI.
+        script << ["native-image.cmd", "native-image.CMD", "NATIVE-IMAGE.cmd"]
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/36118")
+    @Requires(OsTestPreconditions.Windows)
+    def "detects native-image capability when both the executable and the .cmd script are present on Windows"() {
+        given:
+        def javaHome = jdkHome()
+        javaHome.file("bin", OperatingSystem.current().getExecutableName("native-image")).touch()
+        javaHome.file("bin/native-image.cmd").touch()
+
+        expect:
+        metadataFor(javaHome).capabilities.contains(JavaInstallationCapability.NATIVE_IMAGE)
+    }
+
+    @Requires(OsTestPreconditions.NotWindows)
+    def "native-image.cmd script alone does not grant native-image capability on non-Windows OS"() {
+        given:
+        def javaHome = jdkHome()
+        javaHome.file("bin/native-image.cmd").touch()
+
+        expect:
+        !metadataFor(javaHome).capabilities.contains(JavaInstallationCapability.NATIVE_IMAGE)
+    }
+
+    def "does not detect native-image capability when no native-image tool is present"() {
+        given:
+        def javaHome = jdkHome()
+
+        expect:
+        !metadataFor(javaHome).capabilities.contains(JavaInstallationCapability.NATIVE_IMAGE)
+    }
+
+    private TestFile jdkHome() {
+        temporaryFolder.createDir("jdk")
+    }
+
+    private static JvmInstallationMetadata metadataFor(TestFile javaHome) {
+        JvmInstallationMetadata.from(
+            javaHome,
+            "17.0.1",
+            "BellSoft",
+            "OpenJDK Runtime Environment",
+            "17.0.1+12",
+            "OpenJDK 64-Bit Server VM",
+            "17.0.1+12",
+            "BellSoft",
+            "amd64"
+        )
+    }
+}


### PR DESCRIPTION
Fixes #36118


### Context

When requesting a JVM toolchain with `nativeImageCapable = true` on Windows, Gradle fails to detect the native-image tool because GraalVM and Liberica distributions ship it as `native-image.cmd` rather than `native-image.exe`. This causes the build to fail with "Toolchain installation does not provide the required capabilities: [NATIVE_IMAGE] even though the JDK was correctly downloaded and extracted.

The fix adds a fallback check for `native-image.cmd` on Windows in both the capability detection (`JvmInstallationMetadata`) and daemon compatibility check (`DaemonCompatibilitySpec`).

The native-image `.cmd` detection can only be exercised on Windows with a GraalVM or Liberica JDK installed. The existing capability detection logic (`gatherCapabilities`) uses `OperatingSystem.current()` internally, which cannot be overridden in unit tests. 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
