### PR TITLE
Severity is determined by reporting context, not problem spec

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemsServiceIntegTest.groovy
@@ -97,7 +97,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
         }
     }
 
-    def "notCompatibleWithConfigurationCache task problems are reported as Advice"() {
+    def "notCompatibleWithConfigurationCache task problems are reported as Warning"() {
         given:
         buildFile """
             task run {
@@ -115,7 +115,7 @@ class ConfigurationCacheProblemsServiceIntegTest extends AbstractConfigurationCa
         verifyAll(receivedProblem) {
             fqid == 'validation:configuration-cache:invocation-of-task-project-at-execution-time-is-unsupported-with-the-configuration-cache'
             contextualLabel == "invocation of 'Task.project' at execution time is unsupported with the configuration cache."
-            definition.severity == Severity.ADVICE
+            definition.severity == Severity.WARNING
         }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -24,7 +24,6 @@ import org.gradle.api.internal.project.taskfactory.TaskIdentity
 import org.gradle.api.logging.Logging
 import org.gradle.api.problems.ProblemGroup
 import org.gradle.api.problems.ProblemSpec
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.api.problems.internal.PropertyTraceDataSpec
@@ -282,11 +281,16 @@ class ConfigurationCacheProblems(
             contextualLabel(message)
             documentOfProblem(problem)
             locationOfProblem(problem)
-            severity(severity.toProblemSeverity())
             additionalDataInternal(PropertyTraceDataSpec::class.java) {
                 trace(problem.trace.containingUserCode)
             }
-        }.also { internalReporter.report(it) }
+        }.also {
+            if (severity == ProblemSeverity.Interrupting || (severity == ProblemSeverity.Deferred && !isWarningMode)) {
+                internalReporter.reportError(it)
+            } else {
+                internalReporter.report(it)
+            }
+        }
     }
 
     private
@@ -306,15 +310,6 @@ class ConfigurationCacheProblems(
 
     private
     fun PropertyTrace.buildLogic() = sequence.filterIsInstance<PropertyTrace.BuildLogic>().firstOrNull()
-
-    private
-    fun ProblemSeverity.toProblemSeverity() = when {
-        this == ProblemSeverity.Suppressed ||
-            this == ProblemSeverity.SuppressedSilently -> Severity.ADVICE
-
-        isWarningMode -> Severity.WARNING
-        else -> Severity.ERROR
-    }
 
     override fun getId(): String {
         return "configuration-cache"

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslScriptPluginFactory.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/DeclarativeDslScriptPluginFactory.kt
@@ -68,7 +68,7 @@ private fun reportEvaluationFailuresAsProblemsAndThrow(
             else -> emptyList() // TODO: report all other DCL failures as problems
         }
     }
-    problems.reporter.report(failureProblems)
+    problems.internalReporter.reportError(failureProblems)
     /**
      * Instead of [org.gradle.api.problems.ProblemReporter.throwing], we just throw
      * this single exception here to avoid duplicating the full message of the

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/SchemaBuildingFailureProblems.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/SchemaBuildingFailureProblems.kt
@@ -21,7 +21,6 @@ import org.gradle.api.problems.ProblemGroup
 import org.gradle.api.problems.ProblemId
 import org.gradle.api.problems.ProblemId.create
 import org.gradle.api.problems.ProblemSpec
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup.scripts
 import org.gradle.api.problems.internal.InternalProblems
 import org.gradle.declarative.dsl.evaluation.SchemaBuildingFailure
@@ -35,7 +34,6 @@ internal fun schemaBuildingFailuresAsProblems(
     problems: InternalProblems
 ): List<Problem> = stageFailure.failures.map { failure ->
     problems.reporter.create(schemaBuildingFailureProblemId(failure)) { problem ->
-        problem.severity(Severity.ERROR)
         problem.details(SchemaFailureMessageFormatter.failureMessage(failure))
         problem.solutionFor(failure)
     }

--- a/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/FlowParametersInstantiator.kt
+++ b/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/FlowParametersInstantiator.kt
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList
 import org.gradle.api.flow.FlowParameters
 import org.gradle.api.internal.tasks.AbstractTaskDependencyResolveContext
 import org.gradle.api.internal.tasks.properties.InspectionSchemeFactory
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.problems.internal.InternalProblem
 import org.gradle.api.problems.internal.InternalProblemReporter
@@ -56,13 +55,15 @@ class FlowParametersInstantiator(
 
     private
     fun <P : FlowParameters> validate(type: Class<P>, parameters: P) {
-        val problems = ImmutableList.builder<InternalProblem>()
+        val errors = ImmutableList.builder<InternalProblem>()
         inspection.propertyWalker.visitProperties(
             parameters,
             object : ProblemRecordingTypeValidationContext(type, { Optional.empty() }, problemsService) {
-                override fun recordProblem(problem: InternalProblem) {
-                    problems.add(problem)
+                override fun recordError(problem: InternalProblem) {
+                    errors.add(problem)
                 }
+
+                override fun recordWarning(problem: InternalProblem) = Unit
             },
             object : PropertyVisitor {
                 override fun visitServiceReference(propertyName: String, optional: Boolean, value: PropertyValue, serviceName: String?, buildServiceType: Class<out BuildService<*>>) {
@@ -73,11 +74,10 @@ class FlowParametersInstantiator(
                     value.taskDependencies.visitDependencies(
                         object : AbstractTaskDependencyResolveContext() {
                             override fun add(dependency: Any) {
-                                problems.add(
+                                errors.add(
                                     internalProblemReporter.internalCreate {
                                         id("invalid-dependency", "Property cannot carry dependency", GradleCoreProblemGroup.validation().property())
                                         contextualLabel("Property '$propertyName' cannot carry a dependency on $dependency as these are not yet supported.")
-                                        severity(Severity.ERROR)
                                     }
                                 )
                             }
@@ -86,7 +86,7 @@ class FlowParametersInstantiator(
                 }
             }
         )
-        DefaultTypeValidationContext.throwOnProblemsOf(type, problems.build())
+        DefaultTypeValidationContext.throwOnProblemsOf(type, errors.build())
     }
 
     private

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractTypeAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractTypeAnnotationHandler.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.properties.annotations;
 
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
@@ -45,12 +44,11 @@ public abstract class AbstractTypeAnnotationHandler implements TypeAnnotationHan
         Class<? extends Annotation> annotationType,
         Class<?>... appliesOnlyTo
     ) {
-        visitor.visitTypeProblem(problem ->
+        visitor.visitTypeError(problem ->
             problem.withAnnotationType(classWithAnnotationAttached)
                 .id("invalid-use-of-type-annotation", "Incorrect use of type annotation", GradleCoreProblemGroup.validation().type())
                 .contextualLabel("is incorrectly annotated with @" + annotationType.getSimpleName())
                 .documentedAt(Documentation.userManual("validation_problems", "invalid_use_of_cacheable_annotation"))
-                .severity(Severity.ERROR)
                 .details(String.format("This annotation only makes sense on %s types", Arrays.stream(appliesOnlyTo)
                     .map(Class::getSimpleName)
                     .collect(joining(", "))))

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
@@ -46,7 +46,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 import static org.gradle.internal.reflect.annotations.AnnotationCategory.TYPE;
 
@@ -132,13 +131,12 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
 
             PropertyAnnotationHandler annotationHandler = propertyAnnotationHandlers.get(propertyType);
             if (annotationHandler == null) {
-                validationContext.visitPropertyProblem(problem ->
+                validationContext.visitPropertyError(problem ->
                     problem
                         .forProperty(propertyAnnotationMetadata.getPropertyName())
                         .id(TextUtil.screamingSnakeToKebabCase(ANNOTATION_INVALID_IN_CONTEXT), "Invalid annotation in context", GradleCoreProblemGroup.validation().property())
                         .contextualLabel(String.format("is annotated with invalid property type @%s", propertyType.getSimpleName()))
                         .documentedAt(userManual("validation_problems", ANNOTATION_INVALID_IN_CONTEXT.toLowerCase(Locale.ROOT)))
-                        .severity(ERROR)
                         .details("The '@" + propertyType.getSimpleName() + "' annotation cannot be used in this context")
                         .solution("Remove the property")
                         .solution("Use a different annotation, e.g one of " + toListOfAnnotations(propertyAnnotationHandlers.keySet()))
@@ -154,23 +152,21 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
                 }
                 Class<? extends Annotation> annotationType = entry.getValue().annotationType();
                 if (!allowedModifiersForPropertyType.contains(annotationType)) {
-                    validationContext.visitPropertyProblem(problem ->
+                    validationContext.visitPropertyError(problem ->
                         problem
                             .forProperty(propertyAnnotationMetadata.getPropertyName())
                             .id(TextUtil.screamingSnakeToKebabCase(INCOMPATIBLE_ANNOTATIONS), "Incompatible annotations", GradleCoreProblemGroup.validation().property())
                             .contextualLabel("is annotated with @" + annotationType.getSimpleName() + " but that is not allowed for '" + propertyType.getSimpleName() + "' properties")
                             .documentedAt(userManual("validation_problems", INCOMPATIBLE_ANNOTATIONS.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("This modifier is used in conjunction with a property of type '" + propertyType.getSimpleName() + "' but this doesn't have semantics")
                             .solution("Remove the '@" + annotationType.getSimpleName() + "' annotation"));
                 } else if (!allowedPropertyModifiers.contains(annotationType)) {
-                    validationContext.visitPropertyProblem(problem ->
+                    validationContext.visitPropertyError(problem ->
                         problem
                             .forProperty(propertyAnnotationMetadata.getPropertyName())
                             .id(TextUtil.screamingSnakeToKebabCase(ANNOTATION_INVALID_IN_CONTEXT), "Invalid annotation in context", GradleCoreProblemGroup.validation().property())
                             .contextualLabel(String.format("is annotated with invalid modifier @%s", annotationType.getSimpleName()))
                             .documentedAt(userManual("validation_problems", ANNOTATION_INVALID_IN_CONTEXT.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("The '@" + annotationType.getSimpleName() + "' annotation cannot be used in this context")
                             .solution("Use a different annotation, e.g one of " + toListOfAnnotations(allowedPropertyModifiers))
                             .solution("Remove the annotation")
@@ -203,13 +199,12 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
 
             FunctionAnnotationHandler annotationHandler = functionAnnotationHandlers.get(functionType);
             if (annotationHandler == null) {
-                validationContext.visitPropertyProblem(problem ->
+                validationContext.visitPropertyError(problem ->
                     problem
                         .forFunction(functionAnnotationMetadata.getMethod().getName())
                         .id(TextUtil.screamingSnakeToKebabCase(ANNOTATION_INVALID_IN_CONTEXT), "Invalid annotation in context", GradleCoreProblemGroup.validation().type())
                         .contextualLabel(String.format("is annotated with invalid function type @%s", functionType.getSimpleName()))
                         .documentedAt(userManual("validation_problems", ANNOTATION_INVALID_IN_CONTEXT.toLowerCase(Locale.ROOT)))
-                        .severity(ERROR)
                         .details("The '@" + functionType.getSimpleName() + "' annotation cannot be used in this context")
                         .solution("Remove the method")
                         .solution("Use a different annotation, e.g one of " + toListOfAnnotations(functionAnnotationHandlers.keySet()))
@@ -225,23 +220,21 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
                 }
                 Class<? extends Annotation> annotationType = entry.getValue().annotationType();
                 if (!allowedModifiersForFunctionType.contains(annotationType)) {
-                    validationContext.visitPropertyProblem(problem ->
+                    validationContext.visitPropertyError(problem ->
                         problem
                             .forFunction(functionAnnotationMetadata.getMethod().getName())
                             .id(TextUtil.screamingSnakeToKebabCase(INCOMPATIBLE_ANNOTATIONS), "Incompatible annotations", GradleCoreProblemGroup.validation().type())
                             .contextualLabel("is annotated with @" + annotationType.getSimpleName() + " but that is not allowed for '" + functionType.getSimpleName() + "' functions")
                             .documentedAt(userManual("validation_problems", INCOMPATIBLE_ANNOTATIONS.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("This modifier is used in conjunction with a property of type '" + functionType.getSimpleName() + "' but this doesn't have semantics")
                             .solution("Remove the '@" + annotationType.getSimpleName() + "' annotation"));
                 } else if (!allowedFunctionModifiers.contains(annotationType)) {
-                    validationContext.visitPropertyProblem(problem ->
+                    validationContext.visitPropertyError(problem ->
                         problem
                             .forProperty(functionAnnotationMetadata.getMethod().getName())
                             .id(TextUtil.screamingSnakeToKebabCase(ANNOTATION_INVALID_IN_CONTEXT), "Invalid annotation in context", GradleCoreProblemGroup.validation().property())
                             .contextualLabel(String.format("is annotated with invalid modifier @%s", annotationType.getSimpleName()))
                             .documentedAt(userManual("validation_problems", ANNOTATION_INVALID_IN_CONTEXT.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("The '@" + annotationType.getSimpleName() + "' annotation cannot be used in this context")
                             .solution("Use a different annotation, e.g one of " + toListOfAnnotations(allowedPropertyModifiers))
                             .solution("Remove the annotation")

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/MissingPropertyAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/MissingPropertyAnnotationHandler.java
@@ -23,7 +23,6 @@ import org.gradle.util.internal.TextUtil;
 
 import java.util.Locale;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 /**
@@ -35,14 +34,13 @@ public interface MissingPropertyAnnotationHandler {
     MissingPropertyAnnotationHandler DO_NOTHING = (context, annotationMetadata, displayName) -> {};
 
 
-    MissingPropertyAnnotationHandler MISSING_INPUT_OUTPUT_HANDLER = (context, annotationMetadata, displayName) -> context.visitPropertyProblem(problem -> {
+    MissingPropertyAnnotationHandler MISSING_INPUT_OUTPUT_HANDLER = (context, annotationMetadata, displayName) -> context.visitPropertyError(problem -> {
         final String missingAnnotation = "MISSING_ANNOTATION";
         problem
             .forProperty(annotationMetadata.getPropertyName())
             .id(TextUtil.screamingSnakeToKebabCase(missingAnnotation), "Missing annotation", GradleCoreProblemGroup.validation().property())
             .contextualLabel("is missing " + displayName)
             .documentedAt(userManual("validation_problems", missingAnnotation.toLowerCase(Locale.ROOT)))
-            .severity(ERROR)
             .details("A property without annotation isn't considered during up-to-date checking")
             .solution("Add " + displayName)
             .solution("Mark it as @Internal");

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedValidationUtil.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedValidationUtil.java
@@ -24,7 +24,6 @@ import org.jspecify.annotations.NullMarked;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 /**
@@ -55,13 +54,12 @@ public class NestedValidationUtil {
         Class<?> beanType
     ) {
         getUnsupportedReason(beanType).ifPresent(reason ->
-            validationContext.visitPropertyProblem(problem ->
+            validationContext.visitPropertyError(problem ->
                 problem
                     .forProperty(propertyName)
                     .id("nested-type-unsupported", "Nested type unsupported", GradleCoreProblemGroup.validation().property())
                     .contextualLabel("with nested type '" + beanType.getName() + "' is not supported")
                     .documentedAt(userManual("validation_problems", "unsupported_nested_type"))
-                    .severity(ERROR)
                     .details(reason)
                     .solution("Use a different input annotation if type is not a bean")
                     .solution("Use a different package that doesn't conflict with standard Java or Kotlin types for custom types")
@@ -96,13 +94,12 @@ public class NestedValidationUtil {
         Class<?> keyType
     ) {
         if (!SUPPORTED_KEY_TYPES.contains(keyType) && !Enum.class.isAssignableFrom(keyType)) {
-            validationContext.visitPropertyProblem(problem ->
+            validationContext.visitPropertyError(problem ->
                 problem
                     .forProperty(propertyName)
                     .id("nested-map-unsupported-key-type", "Unsupported nested map key", GradleCoreProblemGroup.validation().property())
                     .contextualLabel("where key of nested map is of type '" + keyType.getName() + "'")
                     .documentedAt(userManual("validation_problems", "unsupported_key_type_of_nested_map"))
-                    .severity(ERROR)
                     .details("Key of nested map must be an enum or one of the following types: " + getSupportedKeyTypes())
                     .solution("Change type of key to an enum or one of the following types: " + getSupportedKeyTypes())
             );

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/DefaultTypeMetadataStoreTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/DefaultTypeMetadataStoreTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.internal.IConventionAware
 import org.gradle.api.internal.tasks.properties.DefaultPropertyTypeResolver
 import org.gradle.api.model.ReplacedBy
 import org.gradle.api.plugins.ExtensionAware
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
@@ -156,12 +155,11 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         _ * propertyAnnotationHandler.propertyRelevant >> true
         _ * propertyAnnotationHandler.annotationType >> SearchPath
         _ * propertyAnnotationHandler.validatePropertyMetadata(_, _) >> { PropertyMetadata metadata, TypeValidationContext context ->
-            context.visitPropertyProblem {
+            context.visitPropertyWarning {
                 it
                     .forProperty(metadata.propertyName)
                     .id("test-problem", "is broken", GradleCoreProblemGroup.validation().thisGroup())
                     .documentedAt(userManual("id", "section"))
-                    .severity(Severity.WARNING)
                     .details("Test")
             }
         }
@@ -169,12 +167,11 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         def methodAnnotationHandler = Stub(FunctionAnnotationHandler)
         _ * methodAnnotationHandler.annotationType >> SearchMethod
         _ * methodAnnotationHandler.validateFunctionMetadata(_, _) >> { FunctionMetadata metadata, TypeValidationContext context ->
-            context.visitTypeProblem {
+            context.visitTypeWarning {
                 it
                     .forFunction(metadata.getMethodName())
                     .id("test-problem", "is broken", GradleCoreProblemGroup.validation().thisGroup())
                     .documentedAt(userManual("id", "section"))
-                    .severity(Severity.WARNING)
                     .details("Test")
             }
         }
@@ -208,24 +205,22 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         _ * propertyAnnotationHandler.propertyRelevant >> false
         _ * propertyAnnotationHandler.annotationType >> SearchPath
         _ * propertyAnnotationHandler.validatePropertyMetadata(_, _) >> { PropertyMetadata metadata, TypeValidationContext context ->
-            context.visitPropertyProblem {
+            context.visitPropertyWarning {
                 it
                     .forProperty(metadata.propertyName)
                     .id("test-problem", "is broken", GradleCoreProblemGroup.validation().thisGroup())
                     .documentedAt(userManual("id", "section"))
-                    .severity(Severity.WARNING)
                     .details("Test")
             }
         }
         def methodAnnotationHandler = Stub(FunctionAnnotationHandler)
         _ * methodAnnotationHandler.annotationType >> SearchMethod
         _ * methodAnnotationHandler.validateFunctionMetadata(_, _) >> { FunctionMetadata metadata, TypeValidationContext context ->
-            context.visitTypeProblem {
+            context.visitTypeWarning {
                 it
                     .forFunction(metadata.getMethodName())
                     .id("test-problem", "is broken", GradleCoreProblemGroup.validation().thisGroup())
                     .documentedAt(userManual("id", "section"))
-                    .severity(Severity.WARNING)
                     .details("Test")
             }
         }
@@ -248,12 +243,11 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         def typeAnnotationHandler = Stub(TypeAnnotationHandler)
         _ * typeAnnotationHandler.annotationType >> CustomCacheable
         _ * typeAnnotationHandler.validateTypeMetadata(_, _) >> { Class type, TypeValidationContext context ->
-            context.visitTypeProblem {
+            context.visitTypeWarning {
                 it
                     .withAnnotationType(type)
                     .id("test-problem", "type is broken", GradleCoreProblemGroup.validation().thisGroup())
                     .documentedAt(userManual("id", "section"))
-                    .severity(Severity.WARNING)
                     .details("Test")
             }
         }
@@ -541,7 +535,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
     private List<String> collectProblems(TypeMetadata metadata) {
         def validationContext = DefaultTypeValidationContext.withoutRootType(false, TestUtil.problemsService())
         metadata.visitValidationFailures(null, validationContext)
-        return validationContext.problems.collect { normaliseLineSeparators(renderMinimalInformationAbout(it)) }
+        return validationContext.warnings.collect { normaliseLineSeparators(renderMinimalInformationAbout(it)) } + validationContext.errors.collect { normaliseLineSeparators(renderMinimalInformationAbout(it)) }
     }
 
     private static boolean isOfType(PropertyMetadata metadata, Class<? extends Annotation> type) {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/TestAnnotationHandlingSupport.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/properties/annotations/TestAnnotationHandlingSupport.groovy
@@ -86,7 +86,7 @@ trait TestAnnotationHandlingSupport {
         @Override
         void validateTypeMetadata(Class<?> classWithAnnotationAttached, TypeValidationContext visitor) {
             if (classWithAnnotationAttached.getAnnotation(ThisIsAThing)?.invalid()) {
-                visitor.visitTypeProblem {
+                visitor.visitTypeError {
                     it.label("Annotated as invalid thing!")
                 }
             }

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
@@ -34,7 +34,8 @@ import static java.util.stream.Collectors.toList;
 public class DefaultTypeValidationContext extends ProblemRecordingTypeValidationContext {
     public static final String MISSING_NORMALIZATION_ANNOTATION = "MISSING_NORMALIZATION_ANNOTATION";
     private final boolean reportCacheabilityProblems;
-    private final ImmutableList.Builder<InternalProblem> problems = ImmutableList.builder();
+    private final ImmutableList.Builder<InternalProblem> errors = ImmutableList.builder();
+    private final ImmutableList.Builder<InternalProblem> warnings = ImmutableList.builder();
 
     public static DefaultTypeValidationContext withRootType(Class<?> rootType, boolean cacheable, InternalProblems problems) {
         return new DefaultTypeValidationContext(rootType, cacheable, problems);
@@ -57,15 +58,24 @@ public class DefaultTypeValidationContext extends ProblemRecordingTypeValidation
 
 
     @Override
-    protected void recordProblem(InternalProblem problem) {
+    protected void recordError(InternalProblem problem) {
         if (onlyAffectsCacheableWork(problem.getDefinition().getId()) && !reportCacheabilityProblems) {
             return;
         }
-        problems.add(problem);
+        errors.add(problem);
     }
 
-    public ImmutableList<InternalProblem> getProblems() {
-        return problems.build();
+    @Override
+    protected void recordWarning(InternalProblem problem) {
+        warnings.add(problem);
+    }
+
+    public ImmutableList<InternalProblem> getErrors() {
+        return errors.build();
+    }
+
+    public ImmutableList<InternalProblem> getWarnings() {
+        return warnings.build();
     }
 
     public static void throwOnProblemsOf(Class<?> implementation, ImmutableList<InternalProblem> validationMessages) {

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/ProblemRecordingTypeValidationContext.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/ProblemRecordingTypeValidationContext.java
@@ -46,8 +46,13 @@ abstract public class ProblemRecordingTypeValidationContext implements TypeValid
     }
 
     @Override
-    public void visitTypeProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
-        recordProblem(getDefaultTypeAwareProblemBuilder(problemSpec).build());
+    public void visitTypeError(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        recordError(getDefaultTypeAwareProblemBuilder(problemSpec).build());
+    }
+
+    @Override
+    public void visitTypeWarning(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        recordWarning(getDefaultTypeAwareProblemBuilder(problemSpec).build());
     }
 
     private Optional<PluginId> pluginId() {
@@ -55,13 +60,15 @@ abstract public class ProblemRecordingTypeValidationContext implements TypeValid
     }
 
     @Override
-    public void visitPropertyProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
-        DefaultTypeAwareProblemBuilder problemBuilder = getDefaultTypeAwareProblemBuilder(problemSpec);
-        problemBuilder.withAnnotationType(rootType);
-        pluginId()
-            .map(PluginId::getId)
-            .ifPresent(id -> problemBuilder.additionalDataInternal(TypeValidationDataSpec.class, data -> data.pluginId(id)));
-        recordProblem(problemBuilder.build());
+    public void visitPropertyError(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        DefaultTypeAwareProblemBuilder problemBuilder = withAnnotationTypeAndPluginId(getDefaultTypeAwareProblemBuilder(problemSpec));
+        recordError(problemBuilder.build());
+    }
+
+    @Override
+    public void visitPropertyWarning(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        DefaultTypeAwareProblemBuilder problemBuilder = withAnnotationTypeAndPluginId(getDefaultTypeAwareProblemBuilder(problemSpec));
+        recordWarning(problemBuilder.build());
     }
 
     private @NonNull DefaultTypeAwareProblemBuilder getDefaultTypeAwareProblemBuilder(Action<? super TypeAwareProblemBuilder> problemSpec) {
@@ -70,5 +77,15 @@ abstract public class ProblemRecordingTypeValidationContext implements TypeValid
         return problemBuilder;
     }
 
-    abstract protected void recordProblem(InternalProblem problem);
+    private DefaultTypeAwareProblemBuilder withAnnotationTypeAndPluginId(DefaultTypeAwareProblemBuilder problemBuilder) {
+        problemBuilder.withAnnotationType(rootType);
+        pluginId()
+            .map(PluginId::getId)
+            .ifPresent(id -> problemBuilder.additionalDataInternal(TypeValidationDataSpec.class, data -> data.pluginId(id)));
+        return problemBuilder;
+    }
+
+    abstract protected void recordError(InternalProblem problem);
+
+    abstract protected void recordWarning(InternalProblem problem);
 }

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
@@ -67,7 +67,6 @@ import java.util.stream.Stream;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.joining;
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 import static org.gradle.internal.reflect.Methods.SIGNATURE_EQUIVALENCE;
 import static org.gradle.internal.reflect.annotations.AnnotationCategory.TYPE;
@@ -347,7 +346,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                     propertyBuilders.put(propertyName, metadataBuilder);
                     continue;
                 }
-                previouslySeenBuilder.visitPropertyProblem(problem ->
+                previouslySeenBuilder.visitPropertyError(problem ->
                     problem
                         .forProperty(propertyName)
                         .id(TextUtil.screamingSnakeToKebabCase(REDUNDANT_GETTERS), "Property has redundant getters", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
@@ -359,7 +358,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                             )
                         )
                         .documentedAt(userManual("validation_problems", REDUNDANT_GETTERS.toLowerCase(Locale.ROOT)))
-                        .severity(ERROR)
                         .details("Boolean property '" + propertyName + "' has both an `is` and a `get` getter")
                         .solution("Remove one of the getters")
                         .solution("Annotate one of the getters with @Internal")
@@ -396,7 +394,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                 // Function method annotations should not be applicable to fields and should throw a compile time error, but in the
                 // event that they are marked applicable to fields, we report them as a problem.  If we add an annotation that is somehow
                 // valid in this context, we'll need to handle it in some way to avoid the problem being generated.
-                validationContext.visitTypeProblem(problem ->
+                validationContext.visitTypeError(problem ->
                     problem.withAnnotationType(declaredField.getDeclaringClass())
                         .id(TextUtil.screamingSnakeToKebabCase(IGNORED_ANNOTATIONS_ON_PROPERTY), "Ignored annotations on property", GradleCoreProblemGroup.validation().type())
                         .contextualLabel(
@@ -407,7 +405,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                             )
                         )
                         .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_PROPERTY.toLowerCase(Locale.ROOT)))
-                        .severity(ERROR)
                         .details("Function annotations are ignored if they are placed on a field")
                         .solution("Remove the annotations")
                 );
@@ -449,7 +446,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                 .forEach(entry -> {
                     String fieldName = entry.getKey();
                     ImmutableMap<Class<? extends Annotation>, Annotation> fieldAnnotations = entry.getValue();
-                    validationContext.visitTypeProblem(problem ->
+                    validationContext.visitTypeError(problem ->
                         problem
                             .withAnnotationType(type)
                             .id(TextUtil.screamingSnakeToKebabCase(IGNORED_ANNOTATIONS_ON_FIELD), "Incorrect annotations on field", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
@@ -461,7 +458,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                                 )
                             )
                             .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_FIELD.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("Annotations on fields are only used if there's a corresponding getter for the field")
                             .solution("Add a getter for field '" + fieldName + "'")
                             .solution("Remove the annotations on '" + fieldName + "'")
@@ -542,13 +538,12 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
 
         if (privateGetter) {
             // At this point we must have annotations on this private getter
-            metadataBuilder.visitPropertyProblem(problem ->
+            metadataBuilder.visitPropertyError(problem ->
                 problem
                     .forProperty(propertyName)
                     .id(TextUtil.screamingSnakeToKebabCase(PRIVATE_GETTER_MUST_NOT_BE_ANNOTATED), "Private property with wrong annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("is private and annotated with %s", simpleAnnotationNames(annotations.keySet().stream())))
                     .documentedAt(userManual("validation_problems", PRIVATE_GETTER_MUST_NOT_BE_ANNOTATED.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Annotations on private getters are ignored")
                     .solution("Make the getter public")
                     .solution("Annotate the public version of the getter")
@@ -602,7 +597,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                     .id(TextUtil.screamingSnakeToKebabCase(PRIVATE_METHOD_MUST_NOT_BE_ANNOTATED), "Private method with wrong annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("is private and annotated with %s", simpleAnnotationNames(annotations.keySet().stream())))
                     .documentedAt(userManual("validation_problems", PRIVATE_METHOD_MUST_NOT_BE_ANNOTATED.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Annotations on private methods are ignored")
                     .solution("Make the method public")
                     .solution("Annotate the public version of the method")
@@ -619,13 +613,12 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
     private void validateSetterForMutableType(Method setterMethod, PropertyAccessorType setterAccessorType, TypeValidationContext validationContext, String propertyName) {
         Class<?> setterType = setterAccessorType.propertyTypeFor(setterMethod);
         if (isSetterProhibitedForType(setterType)) {
-            validationContext.visitPropertyProblem(problem ->
+            validationContext.visitPropertyError(problem ->
                 problem
                     .forProperty(propertyName)
                     .id(TextUtil.screamingSnakeToKebabCase(MUTABLE_TYPE_WITH_SETTER), "Mutable type with setter", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("of mutable type '%s' is writable", setterType.getName()))
                     .documentedAt(userManual("validation_problems", MUTABLE_TYPE_WITH_SETTER.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Properties of type '" + setterType.getName() + "' are already mutable")
                     .solution("Remove the '" + setterMethod.getName() + "' method")
             );
@@ -655,7 +648,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
 
     private static void validateNotAnnotatedForProperty(MethodKind methodKind, Method method, Set<Class<? extends Annotation>> annotationTypes, TypeValidationContext validationContext) {
         if (!annotationTypes.isEmpty()) {
-            validationContext.visitTypeProblem(problem ->
+            validationContext.visitTypeError(problem ->
                 problem.withAnnotationType(method.getDeclaringClass())
                     .id(TextUtil.screamingSnakeToKebabCase(IGNORED_ANNOTATIONS_ON_METHOD), "Ignored annotations on method", GradleCoreProblemGroup.validation().type())
                     .contextualLabel(
@@ -666,7 +659,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_METHOD.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Input/Output annotations are ignored if they are placed on something else than a getter")
                     .solution("Remove the annotations")
                     .solution("Rename the method")
@@ -678,7 +670,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
 
     private static void validateNotAnnotatedForPropertyGetter(Method method, Set<Class<? extends Annotation>> annotationTypes, TypeValidationContext validationContext) {
         if (!annotationTypes.isEmpty()) {
-            validationContext.visitTypeProblem(problem ->
+            validationContext.visitTypeError(problem ->
                 problem.withAnnotationType(method.getDeclaringClass())
                     .id(TextUtil.screamingSnakeToKebabCase(IGNORED_ANNOTATIONS_ON_PROPERTY), "Ignored annotations on property", GradleCoreProblemGroup.validation().type())
                     .contextualLabel(
@@ -689,7 +681,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_PROPERTY.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Function annotations are ignored if they are placed on a property getter")
                     .solution("Remove the annotations")
                     .solution("Rename the method")
@@ -699,7 +690,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
 
     private static void validateNotAnnotatedForStaticFunction(Method method, Set<Class<? extends Annotation>> annotationTypes, TypeValidationContext validationContext) {
         if (!annotationTypes.isEmpty()) {
-            validationContext.visitTypeProblem(problem ->
+            validationContext.visitTypeError(problem ->
                 problem.withAnnotationType(method.getDeclaringClass())
                     .id(TextUtil.screamingSnakeToKebabCase(IGNORED_ANNOTATIONS_ON_PROPERTY), "Ignored annotations on property", GradleCoreProblemGroup.validation().type())
                     .contextualLabel(
@@ -710,7 +701,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", IGNORED_ANNOTATIONS_ON_PROPERTY.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("Function annotations are ignored if they are placed on a static method")
                     .solution("Remove the annotations")
                     .solution("Make the method non-static")
@@ -861,8 +851,8 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
             return new DefaultPropertyAnnotationMetadata(propertyName, getMethod(), resolveAnnotations());
         }
 
-        private void visitPropertyProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
-            validationContext.visitPropertyProblem(problemSpec);
+        private void visitPropertyError(Action<? super TypeAwareProblemBuilder> problemSpec) {
+            validationContext.visitPropertyError(problemSpec);
         }
 
         @Override
@@ -887,7 +877,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         }
 
         private void handleAnnotatedIgnoredMethod(Class<? extends Annotation> ignoredMethodAnnotation) {
-            visitPropertyProblem(problem ->
+            visitPropertyError(problem ->
                 problem
                     .forProperty(propertyName)
                     .id(TextUtil.screamingSnakeToKebabCase(IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED), "Has wrong combination of annotations", GradleCoreProblemGroup.validation().property())
@@ -901,7 +891,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("A property is ignored but also has input annotations")
                     .solution("Remove the input annotations")
                     .solution("Remove the @" + ignoredMethodAnnotation.getSimpleName() + " annotation")
@@ -910,7 +899,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
 
         @Override
         protected void handleConflictingAnnotation(String source, AnnotationCategory category, Collection<Annotation> annotationsForCategory) {
-            visitPropertyProblem(problem ->
+            visitPropertyError(problem ->
                 problem
                     .forProperty(propertyName)
                     .id(TextUtil.screamingSnakeToKebabCase(CONFLICTING_ANNOTATIONS), StringUtils.capitalize(category.getDisplayName()) + " has conflicting annotation", GradleCoreProblemGroup.validation().property())
@@ -923,7 +912,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", CONFLICTING_ANNOTATIONS.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("The different annotations have different semantics and Gradle cannot determine which one to pick")
                     .solution("Choose between one of the conflicting annotations")
             );
@@ -950,7 +938,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         }
 
         private void visitFunctionProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
-            validationContext.visitTypeProblem(problemSpec);
+            validationContext.visitTypeError(problemSpec);
         }
 
         @Override
@@ -968,7 +956,6 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         )
                     )
                     .documentedAt(userManual("validation_problems", CONFLICTING_ANNOTATIONS.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details("The different annotations have different semantics and Gradle cannot determine which one to pick")
                     .solution("Choose between one of the conflicting annotations")
             );

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/DelegatingProblemBuilder.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/DelegatingProblemBuilder.java
@@ -131,8 +131,14 @@ class DelegatingProblemBuilder implements InternalProblemBuilder {
     }
 
     @Override
+    @Deprecated
     public InternalProblemBuilder severity(Severity severity) {
         return validateDelegate(delegate.severity(severity));
+    }
+
+    @Override
+    public InternalProblemBuilder internalSeverity(Severity severity) {
+        return validateDelegate(delegate.internalSeverity(severity));
     }
 
     @Override

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/ReplayingTypeValidationContext.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/ReplayingTypeValidationContext.java
@@ -23,22 +23,37 @@ import java.util.List;
 import java.util.function.BiConsumer;
 
 public class ReplayingTypeValidationContext implements TypeValidationContext {
-    private final List<BiConsumer<String, TypeValidationContext>> problems = new ArrayList<>();
+    private final List<BiConsumer<String, TypeValidationContext>> warnings = new ArrayList<>();
+    private final List<BiConsumer<String, TypeValidationContext>> errors = new ArrayList<>();
 
     @Override
-    public void visitTypeProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
-        problems.add((ownerProperty, validationContext) -> validationContext.visitTypeProblem(problemSpec));
+    public void visitTypeError(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        errors.add((ownerProperty, validationContext) -> validationContext.visitTypeError(problemSpec));
     }
 
     @Override
-    public void visitPropertyProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
-        problems.add((ownerProperty, validationContext) -> validationContext.visitPropertyProblem(builder -> {
+    public void visitTypeWarning(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        warnings.add((ownerProperty, validationContext) -> validationContext.visitTypeWarning(problemSpec));
+    }
+
+    @Override
+    public void visitPropertyError(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        errors.add((ownerProperty, validationContext) -> validationContext.visitPropertyError(builder -> {
+            problemSpec.execute(builder);
+            builder.parentProperty(ownerProperty);
+        }));
+    }
+
+    @Override
+    public void visitPropertyWarning(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        warnings.add((ownerProperty, validationContext) -> validationContext.visitPropertyWarning(builder -> {
             problemSpec.execute(builder);
             builder.parentProperty(ownerProperty);
         }));
     }
 
     public void replay(@Nullable String ownerProperty, TypeValidationContext target) {
-        problems.forEach(problem -> problem.accept(ownerProperty, target));
+        warnings.forEach(problem -> problem.accept(ownerProperty, target));
+        errors.forEach(problem -> problem.accept(ownerProperty, target));
     }
 }

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/TypeValidationContext.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/validation/TypeValidationContext.java
@@ -21,29 +21,53 @@ import org.gradle.api.Action;
 public interface TypeValidationContext {
 
     /**
-     * Visits a validation problem associated with the given type.
+     * Visits a validation error associated with the given type.
      * Callers are encouraged to provide as much information as they can on
      * the problem following the problem builder instructions.
      *
      * @param problemSpec the problem builder
      */
-    void visitTypeProblem(Action<? super TypeAwareProblemBuilder> problemSpec);
+    void visitTypeError(Action<? super TypeAwareProblemBuilder> problemSpec);
 
     /**
-     * Visits a validation problem associated with the given property.
+     * Visits a validation warning associated with the given type.
      * Callers are encouraged to provide as much information as they can on
      * the problem following the problem builder instructions.
      *
      * @param problemSpec the problem builder
      */
-    void visitPropertyProblem(Action<? super TypeAwareProblemBuilder> problemSpec);
+    void visitTypeWarning(Action<? super TypeAwareProblemBuilder> problemSpec);
+
+    /**
+     * Visits a validation error associated with the given property.
+     * Callers are encouraged to provide as much information as they can on
+     * the problem following the problem builder instructions.
+     *
+     * @param problemSpec the problem builder
+     */
+    void visitPropertyError(Action<? super TypeAwareProblemBuilder> problemSpec);
+
+    /**
+     * Visits a validation warning associated with the given property.
+     * Callers are encouraged to provide as much information as they can on
+     * the problem following the problem builder instructions.
+     *
+     * @param problemSpec the problem builder
+     */
+    void visitPropertyWarning(Action<? super TypeAwareProblemBuilder> problemSpec);
 
     TypeValidationContext NOOP = new TypeValidationContext() {
         @Override
-        public void visitPropertyProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {}
+        public void visitPropertyError(Action<? super TypeAwareProblemBuilder> problemSpec) {}
 
         @Override
-        public void visitTypeProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {}
+        public void visitPropertyWarning(Action<? super TypeAwareProblemBuilder> problemSpec) {}
+
+        @Override
+        public void visitTypeError(Action<? super TypeAwareProblemBuilder> problemSpec) {}
+
+        @Override
+        public void visitTypeWarning(Action<? super TypeAwareProblemBuilder> problemSpec) {}
     };
 
 }

--- a/platforms/core-configuration/model-reflect/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/platforms/core-configuration/model-reflect/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -20,7 +20,6 @@ import groovy.transform.Generated
 import groovy.transform.Memoized
 import groovy.transform.PackageScope
 import org.gradle.api.file.FileCollection
-import org.gradle.api.problems.Severity
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.reflect.DefaultTypeValidationContext
 import org.gradle.internal.reflect.annotations.AnnotationCategory
@@ -1031,8 +1030,10 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
 
         def validationContext = DefaultTypeValidationContext.withoutRootType(false, TestUtil.problemsService())
         metadata.visitValidationFailures(validationContext)
-        List<String> actualErrors = validationContext.problems
-            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it)) + (it.definition.severity == Severity.ERROR ? " [STRICT]" : "") as String) })
+        List<String> actualErrors = validationContext.warnings
+            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it))) })
+        actualErrors += validationContext.errors
+            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it)) + " [STRICT]") })
         actualErrors.sort()
         expectedErrors.sort()
         assert actualErrors == expectedErrors
@@ -1066,8 +1067,10 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
 
         def validationContext = DefaultTypeValidationContext.withoutRootType(false, TestUtil.problemsService())
         metadata.visitValidationFailures(validationContext)
-        List<String> actualErrors = validationContext.problems
-            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it)) + (it.definition.severity == Severity.ERROR ? " [STRICT]" : "") as String) })
+        List<String> actualErrors = validationContext.warnings
+            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it))) })
+        actualErrors += validationContext.errors
+            .collect({ (normaliseLineSeparators(TypeValidationProblemRenderer.renderMinimalInformationAbout(it)) + " [STRICT]") })
         actualErrors.sort()
         expectedErrors.sort()
         assert actualErrors == expectedErrors

--- a/platforms/core-execution/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/platforms/core-execution/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList
 import com.google.common.collect.Iterables
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.problems.ProblemId
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.cache.Cache
 import org.gradle.cache.ManualEvictionInMemoryCache
@@ -246,9 +245,8 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
             .withValidator { context ->
                 context
                     .forType(UnitOfWork, false)
-                    .visitPropertyProblem {
+                    .visitPropertyWarning {
                         it.id(ProblemId.create("test-problem", "Validation problem", GradleCoreProblemGroup.validation().type()))
-                            .severity(Severity.WARNING)
                             .documentedAt(Documentation.userManual("id", "section"))
                             .details("Test")
                     }
@@ -564,13 +562,11 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
     def "invalid work is not executed"() {
         def invalidWork = builder
             .withValidator { validationContext ->
-                validationContext.forType(Object, true).visitTypeProblem {
-                    it
-                        .withAnnotationType(Object)
+                validationContext.forType(Object, true).visitTypeError {
+                    it.withAnnotationType(Object)
                         .id(ProblemId.create("test-problem", "Validation error", GradleCoreProblemGroup.validation().type()))
                         .documentedAt(Documentation.userManual("id", "section"))
                         .details("Test")
-                        .severity(Severity.ERROR)
                 }
             }
             .withWork({ throw new RuntimeException("Should not get executed") })

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/WorkValidationContext.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/WorkValidationContext.java
@@ -30,7 +30,9 @@ public interface WorkValidationContext {
 
     InternalProblems getProblemsService();
 
-    List<InternalProblem> getProblems();
+    List<InternalProblem> getWarnings();
+
+    List<InternalProblem> getErrors();
 
     ImmutableSet<Class<?>> getValidatedTypes();
 

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/impl/DefaultExecutionProblemHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/impl/DefaultExecutionProblemHandler.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.execution.impl;
 
-import com.google.common.collect.ImmutableList;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblemReporter;
 import org.gradle.api.problems.internal.InternalProblems;
@@ -34,16 +32,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
-import static org.gradle.api.problems.Severity.ERROR;
-import static org.gradle.api.problems.Severity.WARNING;
 
 public class DefaultExecutionProblemHandler implements ExecutionProblemHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExecutionProblemHandler.class);
@@ -62,14 +53,8 @@ public class DefaultExecutionProblemHandler implements ExecutionProblemHandler {
     public void handleReportedProblems(Identity identity, UnitOfWork work, WorkValidationContext validationContext) {
         InternalProblems problemsService = validationContext.getProblemsService();
         InternalProblemReporter reporter = problemsService.getInternalReporter();
-        List<InternalProblem> problems = validationContext.getProblems();
-
-        Map<Severity, ImmutableList<InternalProblem>> problemsMap = problems.stream()
-            .collect(
-                groupingBy(p -> p.getDefinition().getSeverity(),
-                    mapping(identity(), toImmutableList())));
-        List<InternalProblem> warnings = problemsMap.getOrDefault(WARNING, ImmutableList.of());
-        List<InternalProblem> errors = problemsMap.getOrDefault(ERROR, ImmutableList.of());
+        List<InternalProblem> errors = validationContext.getErrors();
+        List<InternalProblem> warnings = validationContext.getWarnings();
 
         if (!warnings.isEmpty()) {
             for (InternalProblem warning : warnings) {

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/impl/DefaultWorkValidationContext.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/impl/DefaultWorkValidationContext.java
@@ -35,7 +35,8 @@ import java.util.function.Supplier;
 
 public class DefaultWorkValidationContext implements WorkValidationContext {
     private final Set<Class<?>> types = new HashSet<>();
-    private final ImmutableList.Builder<InternalProblem> problems = ImmutableList.builder();
+    private final ImmutableList.Builder<InternalProblem> errors = ImmutableList.builder();
+    private final ImmutableList.Builder<InternalProblem> warnings = ImmutableList.builder();
     private final TypeOriginInspector typeOriginInspector;
     private final InternalProblems problemsService;
 
@@ -55,18 +56,28 @@ public class DefaultWorkValidationContext implements WorkValidationContext {
         Supplier<Optional<PluginId>> pluginId = () -> typeOriginInspector.findPluginDefining(type);
         return new ProblemRecordingTypeValidationContext(type, pluginId, getProblemsService()) {
             @Override
-            protected void recordProblem(InternalProblem problem) {
+            protected void recordError(InternalProblem problem) {
                 if (DefaultTypeValidationContext.onlyAffectsCacheableWork(problem.getDefinition().getId()) && !cacheable) {
                     return;
                 }
-                problems.add(problem);
+                errors.add(problem);
+            }
+
+            @Override
+            protected void recordWarning(InternalProblem problem) {
+                warnings.add(problem);
             }
         };
     }
 
     @Override
-    public List<InternalProblem> getProblems() {
-        return problems.build();
+    public List<InternalProblem> getErrors() {
+        return errors.build();
+    }
+
+    @Override
+    public List<InternalProblem> getWarnings() {
+        return warnings.build();
     }
 
     @Override

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputFilePropertyAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputFilePropertyAnnotationHandler.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.execution.model.annotations;
 
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.IgnoreEmptyDirectories;
@@ -112,14 +111,13 @@ public abstract class AbstractInputFilePropertyAnnotationHandler extends Abstrac
     public void validatePropertyMetadata(PropertyMetadata propertyMetadata, TypeValidationContext validationContext) {
         validateUnsupportedInputPropertyValueTypes(propertyMetadata, validationContext, getAnnotationType());
         if (!propertyMetadata.hasAnnotationForCategory(NORMALIZATION)) {
-            validationContext.visitPropertyProblem(problem -> {
+            validationContext.visitPropertyError(problem -> {
                 String propertyName = propertyMetadata.getPropertyName();
                 problem
                     .forProperty(propertyName)
                     .id(MISSING_NORMALIZATION_ID.getName(), MISSING_NORMALIZATION_ID.getDisplayName(), MISSING_NORMALIZATION_ID.getGroup()) // TODO (donat) missing test coverage
                     .contextualLabel(String.format("is annotated with @%s but missing a normalization strategy", getAnnotationType().getSimpleName()))
                     .documentedAt(userManual("validation_problems", MISSING_NORMALIZATION_ANNOTATION.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details("If you don't declare the normalization, outputs can't be re-used between machines or locations on the same machine, therefore caching efficiency drops significantly")
                     .solution("Declare the normalization strategy by annotating the property with either @PathSensitive, @Classpath or @CompileClasspath");
             });

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputPropertyAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputPropertyAnnotationHandler.java
@@ -19,7 +19,6 @@ package org.gradle.internal.execution.model.annotations;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.TypeOf;
@@ -65,7 +64,7 @@ abstract class AbstractInputPropertyAnnotationHandler extends AbstractPropertyAn
         String... possibleSolutions
     ) {
         if (valueTypes.stream().anyMatch(unsupportedType::isAssignableFrom)) {
-            validationContext.visitPropertyProblem(problem -> {
+            validationContext.visitPropertyError(problem -> {
                     ProblemSpec describedProblem = problem
                         .forProperty(propertyMetadata.getPropertyName())
                         .id(TextUtil.screamingSnakeToKebabCase(UNSUPPORTED_VALUE_TYPE), "Unsupported value type", GradleCoreProblemGroup.validation().property())
@@ -77,7 +76,6 @@ abstract class AbstractInputPropertyAnnotationHandler extends AbstractPropertyAn
                             )
                         )
                         .documentedAt(userManual("validation_problems", UNSUPPORTED_VALUE_TYPE.toLowerCase(Locale.ROOT)))
-                        .severity(Severity.ERROR)
                         .details(String.format("%s is not supported on task properties annotated with @%s", unsupportedType.getSimpleName(), annotationType.getSimpleName()));
                     for (String possibleSolution : possibleSolutions) {
                         describedProblem.solution(possibleSolution);

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/InputPropertyAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/InputPropertyAnnotationHandler.java
@@ -20,7 +20,6 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
@@ -37,7 +36,6 @@ import java.net.URL;
 import java.util.List;
 import java.util.Locale;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.OPTIONAL;
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.REPLACES_EAGER_PROPERTY;
@@ -74,14 +72,13 @@ public class InputPropertyAnnotationHandler extends AbstractInputPropertyAnnotat
 
     private static void validateNotOptionalPrimitiveType(PropertyMetadata propertyMetadata, TypeValidationContext validationContext, Class<?> valueType) {
         if (valueType.isPrimitive() && propertyMetadata.isAnnotationPresent(Optional.class)) {
-            validationContext.visitPropertyProblem(problem ->
+            validationContext.visitPropertyError(problem ->
                 problem
                     .forProperty(propertyMetadata.getPropertyName())
                     .id(TextUtil.screamingSnakeToKebabCase(CANNOT_USE_OPTIONAL_ON_PRIMITIVE_TYPES), "Property should be annotated with @Optional", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("of type %s shouldn't be annotated with @Optional", valueType.getName()))
                     .documentedAt(userManual(VALIDATION_PROBLEMS, CANNOT_USE_OPTIONAL_ON_PRIMITIVE_TYPES.toLowerCase(Locale.ROOT)))
                     .details("Properties of primitive type cannot be optional")
-                    .severity(Severity.ERROR)
                     .solution("Remove the @Optional annotation")
                     .solution("Use the " + AsmClassGeneratorUtils.getWrapperTypeForPrimitiveType(valueType).getName() + " type instead")
             );
@@ -96,13 +93,12 @@ public class InputPropertyAnnotationHandler extends AbstractInputPropertyAnnotat
             || RegularFileProperty.class.isAssignableFrom(valueType)
             || java.nio.file.Path.class.isAssignableFrom(valueType)
             || FileCollection.class.isAssignableFrom(valueType)) {
-            validationContext.visitPropertyProblem(problem ->
+            validationContext.visitPropertyError(problem ->
                 problem
                     .forProperty(propertyMetadata.getPropertyName())
                     .id(TextUtil.screamingSnakeToKebabCase(INCORRECT_USE_OF_INPUT_ANNOTATION), "Incorrect use of @Input annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("has @Input annotation used on property of type '%s'", ModelType.of(valueType).getDisplayName()))
                     .documentedAt(userManual(VALIDATION_PROBLEMS, INCORRECT_USE_OF_INPUT_ANNOTATION.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details("A property of type '" + ModelType.of(valueType).getDisplayName() + "' annotated with @Input cannot determine how to interpret the file")
                     .solution("Annotate with @InputFile for regular files")
                     .solution("Annotate with @InputFiles for collections of files")
@@ -114,13 +110,12 @@ public class InputPropertyAnnotationHandler extends AbstractInputPropertyAnnotat
     private static void validateNotDirectoryType(PropertyMetadata propertyMetadata, TypeValidationContext validationContext, Class<?> valueType) {
         if (Directory.class.isAssignableFrom(valueType)
             || DirectoryProperty.class.isAssignableFrom(valueType)) {
-            validationContext.visitPropertyProblem(problem ->
+            validationContext.visitPropertyError(problem ->
                 problem
                     .forProperty(propertyMetadata.getPropertyName())
                     .id(TextUtil.screamingSnakeToKebabCase(INCORRECT_USE_OF_INPUT_ANNOTATION), "Incorrect use of @Input annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("has @Input annotation used on property of type '%s'", ModelType.of(valueType).getDisplayName()))
                     .documentedAt(userManual(VALIDATION_PROBLEMS, INCORRECT_USE_OF_INPUT_ANNOTATION.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details("A property of type '" + ModelType.of(valueType).getDisplayName() + "' annotated with @Input cannot determine how to interpret the file")
                     .solution("Annotate with @InputDirectory for directories")
             );
@@ -133,13 +128,12 @@ public class InputPropertyAnnotationHandler extends AbstractInputPropertyAnnotat
     private static void validateNotUrlType(PropertyMetadata propertyMetadata, TypeValidationContext validationContext) {
         List<Class<?>> valueTypes = unpackValueTypesOf(propertyMetadata);
         if (valueTypes.stream().anyMatch(URL.class::isAssignableFrom)) {
-            validationContext.visitPropertyProblem(problem ->
+            validationContext.visitPropertyError(problem ->
                 problem
                     .forProperty(propertyMetadata.getPropertyName())
                     .id(TextUtil.screamingSnakeToKebabCase(UNSUPPORTED_VALUE_TYPE) + "-for-input", "Unsupported value type for @Input annotation", GradleCoreProblemGroup.validation().property())
                     .contextualLabel(String.format("has @Input annotation used on type '%s' or a property of this type", URL.class.getName()))
                     .documentedAt(userManual(VALIDATION_PROBLEMS, UNSUPPORTED_VALUE_TYPE.toLowerCase(Locale.ROOT)))
-                    .severity(ERROR)
                     .details(String.format("Type '%s' is not supported on properties annotated with @Input because Java Serialization can be inconsistent for this type", URL.class.getName()))
                     .solution("Use type 'java.net.URI' instead")
             );

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/ServiceReferencePropertyAnnotationHandler.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/model/annotations/ServiceReferencePropertyAnnotationHandler.java
@@ -16,7 +16,6 @@
 package org.gradle.internal.execution.model.annotations;
 
 import com.google.common.reflect.TypeToken;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.ServiceReference;
@@ -64,13 +63,12 @@ public class ServiceReferencePropertyAnnotationHandler extends AbstractPropertyA
         ModelType<?> propertyType = ModelType.of(propertyMetadata.getDeclaredType().getType());
         List<ModelType<?>> typeVariables = Cast.uncheckedNonnullCast(propertyType.getTypeVariables());
         if (typeVariables.size() != 1 || !BuildService.class.isAssignableFrom(typeVariables.get(0).getRawClass())) {
-            validationContext.visitPropertyProblem(problem ->
+            validationContext.visitPropertyError(problem ->
                 problem
                     .forProperty(propertyMetadata.getPropertyName())
                     .id(TextUtil.screamingSnakeToKebabCase(SERVICE_REFERENCE_MUST_BE_A_BUILD_SERVICE), "Property has @ServiceReference annotation", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                     .contextualLabel(String.format("has @ServiceReference annotation used on property of type '%s' which is not a build service implementation", typeVariables.get(0).getName()))
                     .documentedAt(userManual("validation_problems", SERVICE_REFERENCE_MUST_BE_A_BUILD_SERVICE.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details(String.format("A property annotated with @ServiceReference must be of a type that implements '%s'", BuildService.class.getName()))
                     .solution(String.format("Make '%s' implement '%s'", typeVariables.get(0).getName(), BuildService.class.getName()))
                     .solution(String.format("Replace the @ServiceReference annotation on '%s' with @Internal and assign a value of type '%s' explicitly", propertyMetadata.getPropertyName(), typeVariables.get(0).getName()))

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.execution.steps;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblem;
@@ -37,7 +38,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 public abstract class ValidateStep<
@@ -96,7 +96,13 @@ public abstract class ValidateStep<
 
         problemHandler.handleReportedProblems(context.getIdentity(), work, validationContext);
 
-        return executeDelegate(work, context, validationContext.getProblems());
+        List<InternalProblem> problems = ImmutableList.<InternalProblem>builder()
+            .addAll(validationContext.getWarnings())
+            .addAll(validationContext.getErrors())
+            .build();
+
+        // TODO handle warnings and errors separately
+        return executeDelegate(work, context, problems);
     }
 
     protected abstract R executeDelegate(UnitOfWork work, C context, List<InternalProblem> problems);
@@ -133,14 +139,13 @@ public abstract class ValidateStep<
     private static void validateNestedInput(TypeValidationContext workValidationContext, String propertyName, ImplementationSnapshot implementation) {
         if (implementation instanceof UnknownImplementationSnapshot) {
             UnknownImplementationSnapshot unknownImplSnapshot = (UnknownImplementationSnapshot) implementation;
-            workValidationContext.visitPropertyProblem(problem -> problem
+            workValidationContext.visitPropertyError(problem -> problem
                 .forProperty(propertyName)
                 .id(TextUtil.screamingSnakeToKebabCase(UNKNOWN_IMPLEMENTATION_NESTED), "Unknown property implementation", GradleCoreProblemGroup.validation().property())
                 .contextualLabel(unknownImplSnapshot.getProblemDescription())
                 .documentedAt(userManual("validation_problems", "implementation_unknown"))
                 .details(unknownImplSnapshot.getReasonDescription())
                 .solution(unknownImplSnapshot.getSolutionDescription())
-                .severity(ERROR)
             );
         }
     }
@@ -148,13 +153,12 @@ public abstract class ValidateStep<
     private static void validateImplementation(TypeValidationContext workValidationContext, ImplementationSnapshot implementation, String descriptionPrefix, UnitOfWork work) {
         if (implementation instanceof UnknownImplementationSnapshot) {
             UnknownImplementationSnapshot unknownImplSnapshot = (UnknownImplementationSnapshot) implementation;
-            workValidationContext.visitPropertyProblem(problem -> problem
+            workValidationContext.visitPropertyError(problem -> problem
                 .id(TextUtil.screamingSnakeToKebabCase(UNKNOWN_IMPLEMENTATION), "Unknown property implementation", GradleCoreProblemGroup.validation().property())
                 .contextualLabel(descriptionPrefix + work + " " + unknownImplSnapshot.getProblemDescription())
                 .documentedAt(userManual("validation_problems", "implementation_unknown"))
                 .details(unknownImplSnapshot.getReasonDescription())
                 .solution(unknownImplSnapshot.getSolutionDescription())
-                .severity(ERROR)
             );
         }
     }

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/impl/DefaultExecutionProblemHandlerTest.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/impl/DefaultExecutionProblemHandlerTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.execution.impl
 
 import org.gradle.api.problems.Problem
 import org.gradle.api.problems.ProblemId
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.problems.internal.InternalProblem
 import org.gradle.api.problems.internal.ProblemsProgressEventEmitterHolder
@@ -57,13 +56,12 @@ class DefaultExecutionProblemHandlerTest extends Specification implements Valida
     def "fails when there is a single violation"() {
         expectReindentedValidationMessage()
         given:
-        validationContext.forType(JobType, true).visitTypeProblem {
+        validationContext.forType(JobType, true).visitTypeError {
             it
                 .withAnnotationType(Object)
                 .id(ProblemId.create("test-problem", "Validation error", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
                 .details("Test")
-                .severity(Severity.ERROR)
         }
 
         when:
@@ -82,20 +80,18 @@ class DefaultExecutionProblemHandlerTest extends Specification implements Valida
     def "fails when there are multiple violations"() {
         expectReindentedValidationMessage()
         given:
-        validationContext.forType(JobType, true).visitTypeProblem {
+        validationContext.forType(JobType, true).visitTypeError {
             it
                 .withAnnotationType(Object)
                 .id(ProblemId.create("test-problem-1", "Validation error #1", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
-                .severity(Severity.ERROR)
                 .details("Test")
         }
-        validationContext.forType(SecondaryJobType, true).visitTypeProblem {
+        validationContext.forType(SecondaryJobType, true).visitTypeError {
             it
                 .withAnnotationType(Object)
                 .id(ProblemId.create("test-problem-2", "Validation error #2", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
-                .severity(Severity.ERROR)
                 .details("Test")
         }
         when:
@@ -117,12 +113,11 @@ class DefaultExecutionProblemHandlerTest extends Specification implements Valida
     def "reports deprecation warning and invalidates VFS for validation warning"() {
         String expectedWarning = convertToSingleLine(dummyValidationProblem('java.lang.Object', null, 'Validation warning', 'Test').trim())
         given:
-        validationContext.forType(JobType, true).visitTypeProblem {
+        validationContext.forType(JobType, true).visitTypeWarning {
             it
                 .withAnnotationType(Object)
                 .id(ProblemId.create("test-problem", "Validation warning", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
-                .severity(Severity.WARNING)
                 .details("Test")
         }
         when:
@@ -146,20 +141,18 @@ class DefaultExecutionProblemHandlerTest extends Specification implements Valida
 
         given:
         def typeContext = validationContext.forType(JobType, true)
-        typeContext.visitTypeProblem {
+        typeContext.visitTypeError {
             it
                 .withAnnotationType(Object)
                 .id(ProblemId.create("test-problem", "Validation problem", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
-                .severity(Severity.ERROR)
                 .details("Test")
         }
-        typeContext.visitTypeProblem {
+        typeContext.visitTypeWarning {
             it
                 .withAnnotationType(Object)
                 .id(ProblemId.create("test-problem", "Validation problem", GradleCoreProblemGroup.validation().type()))
                 .documentedAt(userManual("id", "section"))
-                .severity(Severity.WARNING)
                 .details("Test")
         }
 

--- a/platforms/core-runtime/build-configuration/src/main/java/org/gradle/internal/buildconfiguration/DaemonJvmPropertiesConfigurator.java
+++ b/platforms/core-runtime/build-configuration/src/main/java/org/gradle/internal/buildconfiguration/DaemonJvmPropertiesConfigurator.java
@@ -19,7 +19,6 @@ package org.gradle.internal.buildconfiguration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.problems.ProblemReporter;
 import org.gradle.api.problems.Problems;
-import org.gradle.api.problems.Severity;
 import org.gradle.buildconfiguration.tasks.UpdateDaemonJvm;
 import org.gradle.configuration.project.ProjectConfigureAction;
 import org.gradle.internal.Pair;
@@ -28,12 +27,12 @@ import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainDownload;
-import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec;
-import org.gradle.jvm.toolchain.internal.JavaToolchainResolverService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
 import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainRequest;
+import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec;
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec;
+import org.gradle.jvm.toolchain.internal.JavaToolchainResolverService;
 import org.gradle.platform.Architecture;
 import org.gradle.platform.BuildPlatform;
 import org.gradle.platform.BuildPlatformFactory;
@@ -89,7 +88,6 @@ public class DaemonJvmPropertiesConfigurator implements ProjectConfigureAction {
                                 UnconfiguredToolchainRepositoriesResolver exception = new UnconfiguredToolchainRepositoriesResolver();
                                 throw reporter.throwing(exception, UpdateDaemonJvm.TASK_CONFIGURATION_PROBLEM_ID,
                                     problemSpec -> {
-                                        problemSpec.severity(Severity.ERROR);
                                         problemSpec.solution("Configure toolchain download repositories in your build settings.");
                                         problemSpec.documentedAt(Documentation.userManual("toolchains", "sub:download_repositories").getUrl());
                                 });
@@ -104,7 +102,6 @@ public class DaemonJvmPropertiesConfigurator implements ProjectConfigureAction {
                                 throw reporter.throwing(new IllegalStateException("Toolchain resolvers did not return download URLs providing a JDK matching " + toolchainSpec + " for any of the requested platforms " + platforms),
                                     UpdateDaemonJvm.TASK_CONFIGURATION_PROBLEM_ID,
                                     problemSpec -> {
-                                        problemSpec.severity(Severity.ERROR);
                                         problemSpec.solution("Use a toolchain download repository capable of resolving the toolchain spec for the given platforms.");
                                         problemSpec.documentedAt(Documentation.userManual("gradle_daemon", "sec:daemon_jvm_provisioning").getUrl());
                                     });

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -45,7 +45,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-import static org.gradle.api.problems.Severity.WARNING;
 import static org.gradle.internal.deprecation.DeprecationMessageBuilder.createDefaultDeprecationId;
 
 public class LoggingDeprecatedFeatureHandler implements FeatureHandler<DeprecatedFeatureUsage> {
@@ -110,9 +109,7 @@ public class LoggingDeprecatedFeatureHandler implements FeatureHandler<Deprecate
                         public void execute(DeprecationDataSpec data) {
                             data.type(usage.getType().toDeprecationDataType());
                         }
-                    })
-                    .severity(WARNING);
-
+                    });
                 if (usage.getType() == DeprecatedFeatureUsage.Type.USER_CODE_DIRECT) {
                     builder.stackLocation();
                 }

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -86,6 +86,13 @@ ProjectDependency dependency = project.getDependencyFactory().createProjectDepen
 implementation.getDependencies().add(dependency);
 ----
 
+[[deprecate_problem_spec_severity]]
+==== Deprecation of `ProblemSpec.severity()`
+
+Problem severity can no longer be set explicitly when creating a new instance.
+Instead, it is determined by the reporting method: `ProblemReporter.report()` produces warnings and `ProblemReporter.throwing()` produces errors.
+Calling `.severity()` on `ProblemSpec` is now a no-op and will be removed in Gradle 10.0.
+
 [[changes_9.5.0]]
 == Upgrading from 9.4.0 and earlier
 

--- a/platforms/documentation/docs/src/snippets/developingPlugins/problemReporting/kotlin/buildSrc/src/main/java/org/myorg/ProblemReportingPlugin.java
+++ b/platforms/documentation/docs/src/snippets/developingPlugins/problemReporting/kotlin/buildSrc/src/main/java/org/myorg/ProblemReportingPlugin.java
@@ -33,7 +33,6 @@ public class ProblemReportingPlugin implements Plugin<Project> {
         this.problemReporter.report(problemId, builder -> builder // <3>
             .details("The plugin 'x' is deprecated since version 2.5")
             .solution("Please use plugin 'y'")
-            .severity(Severity.WARNING)
             .additionalData(SomeData.class, additionalData -> {
                 additionalData.setName("Some name"); // <4>
             })

--- a/platforms/documentation/docs/src/snippets/ide/problems-api-usage/common/reporters/model-builder-plugin/src/main/java/reporters/ModelBuilder.java
+++ b/platforms/documentation/docs/src/snippets/ide/problems-api-usage/common/reporters/model-builder-plugin/src/main/java/reporters/ModelBuilder.java
@@ -25,7 +25,6 @@ public class ModelBuilder implements ToolingModelBuilder {
     @Override
     public Object buildAll(String modelName, Project project) {
         problems.getReporter().report(ProblemId.create("unused", "Demo model", ModelBuilderPlugin.PROBLEM_GROUP), problem -> problem
-            .severity(Severity.WARNING)
             .details("This is a demo model and doesn't do anything useful")
         );
         return new DefaultDemoModel();

--- a/platforms/documentation/docs/src/snippets/ide/problems-api-usage/common/reporters/standard-plugin/src/main/java/reporters/StandardPlugin.java
+++ b/platforms/documentation/docs/src/snippets/ide/problems-api-usage/common/reporters/standard-plugin/src/main/java/reporters/StandardPlugin.java
@@ -31,7 +31,6 @@ public class StandardPlugin implements Plugin<Project> {
         problems.getReporter().report(problemId, problem -> problem
                 .contextualLabel("The 'standard-plugin' is deprecated")
                 .documentedAt("https://github.com/gradle/gradle/README.md")
-                .severity(Severity.WARNING)
                 .solution("Please use a more recent plugin version")
                 .additionalData(SomeAdditionalData.class, additionalData -> {
                     additionalData.setName("Some name");

--- a/platforms/documentation/docs/src/snippets/ide/problems-api-usage/groovy/reporters/script-plugin/src/main/groovy/reporters.script.plugin.gradle
+++ b/platforms/documentation/docs/src/snippets/ide/problems-api-usage/groovy/reporters/script-plugin/src/main/groovy/reporters.script.plugin.gradle
@@ -12,7 +12,6 @@ def problemGroup = ProblemGroup.create("root", "Root Group")
 
 problems.getReporter().report(ProblemId.create('adhoc-script-deprecation', 'Deprecated script plugin', problemGroup)) {
     it.contextualLabel("Deprecated script plugin 'demo-script-plugin'")
-        .severity(Severity.WARNING)
         .solution("Please use 'standard-plugin-2' instead of this plugin")
 }
 
@@ -20,7 +19,6 @@ tasks.register('warningTask') {
     doLast {
         problems.getReporter().report(ProblemId.create('adhoc-task-deprecation', 'Deprecated task', problemGroup)) {
             it.contextualLabel("Task 'warningTask' is deprecated")
-                .severity(Severity.WARNING)
                 .solution("Please use 'warningTask2' instead of this task")
         }
     }
@@ -30,7 +28,6 @@ tasks.register('failingTask') {
     doLast {
         problems.getReporter().throwing(new RuntimeException("The 'failingTask' should not be called"), ProblemId.create('broken-task', 'Task should not be called', problemGroup)) {
             it.contextualLabel("Task 'failingTask' should not be called")
-                .severity(Severity.ERROR)
                 .solution("Please use 'successfulTask' instead of this task")
         }
     }

--- a/platforms/documentation/docs/src/snippets/ide/problems-api-usage/kotlin/reporters/script-plugin/src/main/kotlin/reporters/script.plugin.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/ide/problems-api-usage/kotlin/reporters/script-plugin/src/main/kotlin/reporters/script.plugin.gradle.kts
@@ -12,7 +12,6 @@ val problemGroup = ProblemGroup.create("root", "Root Group")
 
 problems.getReporter().report(ProblemId.create("adhoc-script-deprecation", "Deprecated script plugin", problemGroup)) {
     contextualLabel("Deprecated script plugin 'demo-script-plugin'")
-        .severity(Severity.WARNING)
         .solution("Please use 'standard-plugin-2' instead of this plugin")
 }
 
@@ -21,7 +20,6 @@ tasks {
         doLast {
             problems.getReporter().report(ProblemId.create("adhoc-task-deprecation", "Deprecated task", problemGroup)) {
                 contextualLabel("Task 'warningTask' is deprecated")
-                    .severity(Severity.WARNING)
                     .solution("Please use 'warningTask2' instead of this task")
             }
         }
@@ -31,7 +29,6 @@ tasks {
         doLast {
             problems.getReporter().throwing(RuntimeException("The 'failingTask' should not be called"), ProblemId.create("broken-task", "Task should not be called", problemGroup)) {
                     contextualLabel("Task 'failingTask' should not be called")
-                    .severity(Severity.ERROR)
                     .solution("Please use 'successfulTask' instead of this task")
             }
         }

--- a/platforms/documentation/docs/src/snippets/plugins/reportingProblems/groovy/plugin/src/main/groovy/org/example/HelloProblemsPlugin.groovy
+++ b/platforms/documentation/docs/src/snippets/plugins/reportingProblems/groovy/plugin/src/main/groovy/org/example/HelloProblemsPlugin.groovy
@@ -67,7 +67,6 @@ abstract class GreetTask extends DefaultTask {
             reporter.report(WARN_ID) { spec ->
 // tag::problems-spec[]
                 spec.details("No recipient configured")
-                    .severity(Severity.WARNING)
                     .solution('Set the recipient: tasks.greet { recipient = "World" }')
                     .documentedAt("https://gradle.org/hello-problems#recipient")
                     .additionalData(GreetProblemData) {
@@ -82,7 +81,6 @@ abstract class GreetTask extends DefaultTask {
 // tag::problems-throw[]
             throw reporter.throwing(new GradleException("forbidden value"), FAIL_ID) { spec ->
                 spec.details("Recipient 'fail' is not allowed")
-                    .severity(Severity.ERROR)
                     .solution('Choose another value, e.g. recipient = "World".')
                     .documentedAt("https://gradle.org/hello-problems#forbidden")
                     .additionalData(GreetProblemData) {

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.model.ReplacedBy
-import org.gradle.api.problems.Severity
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Destroys
@@ -961,13 +960,13 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
 
     static class DocumentedProblem {
         final String message
-        final Severity severity
+        final String severity
         final String id
         final String section
         final boolean defaultDocLink
         final ValidationMessageDisplayConfiguration config
 
-        DocumentedProblem(ValidationMessageDisplayConfiguration config, Severity severity, String id = "incremental_build", String section = "") {
+        DocumentedProblem(ValidationMessageDisplayConfiguration config, String severity, String id = "incremental_build", String section = "") {
             this.config = config
             this.message = config.render()
             this.severity = severity
@@ -976,7 +975,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
             this.defaultDocLink = (id == "incremental_build") && (section == "")
         }
 
-        DocumentedProblem(String message, Severity severity, String id = "incremental_build", String section = "") {
+        DocumentedProblem(String message, String severity, String id = "incremental_build", String section = "") {
             this.config = null
             this.message = message
             this.severity = severity

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/CommonPluginValidationTrait.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/CommonPluginValidationTrait.groovy
@@ -19,20 +19,17 @@ package org.gradle.plugin.devel.tasks
 import org.gradle.internal.reflect.validation.ValidationMessageDisplayConfiguration
 import org.gradle.test.fixtures.file.TestFile
 
-import static org.gradle.api.problems.Severity.ERROR
-import static org.gradle.api.problems.Severity.WARNING
-
 trait CommonPluginValidationTrait {
     static <T extends ValidationMessageDisplayConfiguration> AbstractPluginValidationIntegrationSpec.DocumentedProblem error(T message, String id = "incremental_build", String section = "") {
-        new AbstractPluginValidationIntegrationSpec.DocumentedProblem(message, ERROR, id, section)
+        new AbstractPluginValidationIntegrationSpec.DocumentedProblem(message, "error", id, section)
     }
 
     static <T extends ValidationMessageDisplayConfiguration> AbstractPluginValidationIntegrationSpec.DocumentedProblem warning(T message, String id = "incremental_build", String section = "") {
-        new AbstractPluginValidationIntegrationSpec.DocumentedProblem(message, WARNING, id, section)
+        new AbstractPluginValidationIntegrationSpec.DocumentedProblem(message, "warning", id, section)
     }
 
     static <T extends ValidationMessageDisplayConfiguration> AbstractPluginValidationIntegrationSpec.DocumentedProblem warning(String message, String id = "incremental_build", String section = "") {
-        new AbstractPluginValidationIntegrationSpec.DocumentedProblem(message, WARNING, id, section)
+        new AbstractPluginValidationIntegrationSpec.DocumentedProblem(message, "warning", id, section)
     }
 
     TestFile getJavaTaskSource() {

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/RuntimePluginValidationTrait.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/RuntimePluginValidationTrait.groovy
@@ -18,9 +18,6 @@ package org.gradle.plugin.devel.tasks
 
 import org.gradle.test.fixtures.file.TestFile
 
-import static org.gradle.api.problems.Severity.ERROR
-import static org.gradle.api.problems.Severity.WARNING
-
 trait RuntimePluginValidationTrait implements CommonPluginValidationTrait{
     @Override
     def setup() {
@@ -50,9 +47,9 @@ trait RuntimePluginValidationTrait implements CommonPluginValidationTrait{
 
     void assertValidationFailsWith(List<AbstractPluginValidationIntegrationSpec.DocumentedProblem> messages) {
         def expectedDeprecations = messages
-            .findAll { problem -> problem.severity == WARNING }
+            .findAll { problem -> problem.severity == "warning" }
         def expectedFailures = messages
-            .findAll { problem -> problem.severity == ERROR }
+            .findAll { problem -> problem.severity == "error" }
 
         expectedDeprecations.forEach { warning ->
             expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, warning.message, warning.id, warning.section)

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/TaskFromPluginValidationIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/TaskFromPluginValidationIntegrationTest.groovy
@@ -124,8 +124,6 @@ class TaskFromPluginValidationIntegrationTest extends AbstractIntegrationSpec im
         file("my-plugin/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblem.groovy") << """
 package org.gradle.integtests.fixtures.validation;
 
-import org.gradle.api.problems.Severity;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -138,7 +136,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target([ElementType.METHOD, ElementType.FIELD])
 public @interface ValidationProblem {
-    Severity value() default Severity.WARNING;
+    boolean fatal() default false;
 }
         """
     }
@@ -154,10 +152,9 @@ public @interface ValidationProblem {
     private void writeTaskInto(@GroovyBuildScriptLanguage String header = "", TestFile testFile) {
         testFile << """$header
             import org.gradle.integtests.fixtures.validation.ValidationProblem
-            import org.gradle.api.problems.Severity
 
             abstract class SomeTask extends DefaultTask {
-                @ValidationProblem(value=Severity.ERROR)
+                @ValidationProblem(fatal=true)
                 abstract Property<String> getInput()
 
                 @OutputFile

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsTrait.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsTrait.groovy
@@ -71,7 +71,7 @@ trait ValidatePluginsTrait implements CommonPluginValidationTrait, ValidationMes
         failure.assertHasCause "Plugin validation failed with ${messages.size()} problem${getPluralEnding(messages)}"
         messages.forEach { problem ->
             String indentedMessage = problem.message.replaceAll('\n', '\n    ').trim()
-            failure.assertThatCause(containsString("$problem.severity: $indentedMessage"))
+            failure.assertThatCause(containsString("${problem.severity.capitalize()}: $indentedMessage"))
         }
 
         // TODO (donat) do probably don't want to have this, as the explicit problem assertions are preferred

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
@@ -23,7 +23,6 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.problems.Problem;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemReporter;
 import org.gradle.api.problems.Problems;
@@ -62,7 +61,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllBytes;
 import static java.util.stream.Collectors.joining;
-import static org.gradle.api.problems.Severity.ERROR;
 
 /**
  * Validates plugins by checking property annotations on work items like tasks and artifact transforms.
@@ -159,19 +157,29 @@ public abstract class ValidatePlugins extends DefaultTask {
             });
         getWorkerExecutor().await();
 
-        List<? extends InternalProblem> problems = ValidationProblemSerialization.parseMessageList(new String(readAllBytes(getOutputFile().get().getAsFile().toPath()), UTF_8));
+        ValidationProblemSerialization.SerializationResult parsedProblems = ValidationProblemSerialization.deserialize(new String(readAllBytes(getOutputFile().get().getAsFile().toPath()), UTF_8));
+        List<? extends InternalProblem> warnings = parsedProblems.getWarnings();
+        List<? extends InternalProblem> errors = parsedProblems.getErrors();
 
-        Stream<String> messages = ValidationProblemSerialization.toPlainMessage(problems).sorted();
-        if (problems.isEmpty()) {
+        Stream<String> messages = Stream.concat(
+            ValidationProblemSerialization.toPlainWarning(warnings).sorted(),
+            ValidationProblemSerialization.toPlainError(errors).sorted()
+        );
+
+        if (errors.isEmpty() && warnings.isEmpty()) {
             getLogger().info("Plugin validation finished without warnings.");
         } else {
-            if (getFailOnWarning().get() || problems.stream().anyMatch(problem -> problem.getDefinition().getSeverity() == ERROR)) {
+            if (getFailOnWarning().get() || !errors.isEmpty()) {
                 if (getIgnoreFailures().get()) {
                     getLogger().warn("Plugin validation finished with errors. {} {}",
                         annotateTaskPropertiesDoc(),
                         messages.collect(joining()));
                 } else {
-                    reportProblems(problems);
+
+                    InternalProblemReporter reporter = getServices().get(InternalProblems.class)
+                        .getInternalReporter();
+                    reporter.report(warnings);
+                    reporter.reportError(errors);
                     throw WorkValidationException.forProblems(messages.collect(toImmutableList()))
                         .withSummaryForPlugin()
                         .getWithExplanation(annotateTaskPropertiesDoc());
@@ -181,11 +189,6 @@ public abstract class ValidatePlugins extends DefaultTask {
                     messages.collect(joining()));
             }
         }
-    }
-
-    private void reportProblems(List<? extends Problem> problems) {
-        InternalProblemReporter reporter = getServices().get(InternalProblems.class).getInternalReporter();
-        problems.forEach(reporter::report);
     }
 
     private String annotateTaskPropertiesDoc() {

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
@@ -17,7 +17,6 @@
 package org.gradle.plugin.devel.tasks.internal;
 
 import com.google.common.io.Files;
-import com.google.gson.Gson;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.transform.CacheableTransform;
 import org.gradle.api.artifacts.transform.TransformAction;
@@ -54,7 +53,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 public abstract class ValidateAction implements WorkAction<ValidateAction.Params> {
@@ -74,23 +72,22 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
 
     @Override
     public void execute() {
-        List<Problem> taskValidationProblems = new ArrayList<>();
+        List<Problem> taskValidationWarnings = new ArrayList<>();
+        List<Problem> taskValidationErrors = new ArrayList<>();
 
         Params params = getParameters();
 
-        params.getClasses().getAsFileTree().visit(new ValidationProblemCollector(taskValidationProblems, params, getProblems()));
-        storeResults(taskValidationProblems, params.getOutputFile());
+        params.getClasses().getAsFileTree().visit(new ValidationProblemCollector(taskValidationWarnings, taskValidationErrors, params, getProblems()));
+        storeResults(taskValidationWarnings, taskValidationErrors, params.getOutputFile());
     }
 
-
-    private static void storeResults(List<Problem> problemMessages, RegularFileProperty outputFile) {
+    private static void storeResults(List<Problem> warnings, List<Problem> errors, RegularFileProperty outputFile) {
         if (outputFile.isPresent()) {
             File output = outputFile.get().getAsFile();
             try {
                 //noinspection ResultOfMethodCallIgnored
                 output.createNewFile();
-                Gson gson = ValidationProblemSerialization.createGsonBuilder().create();
-                Files.asCharSink(output, StandardCharsets.UTF_8).write(gson.toJson(problemMessages));
+                Files.asCharSink(output, StandardCharsets.UTF_8).write(ValidationProblemSerialization.serialize(warnings, errors));
             } catch (IOException ex) {
                 throw new java.io.UncheckedIOException(ex);
             }
@@ -115,13 +112,15 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
 
     private static class ValidationProblemCollector extends EmptyFileVisitor {
         private final ClassLoader classLoader;
-        private final List<Problem> taskValidationProblems;
+        private final List<Problem> taskValidationWarnings;
+        private final List<Problem> taskValidationErrors;
         private final Params params;
         private final InternalProblems problems;
 
-        public ValidationProblemCollector(List<Problem> taskValidationProblems, Params params, InternalProblems problems) {
+        public ValidationProblemCollector(List<Problem> taskValidationWarnings, List<Problem> taskValidationErrors, Params params, InternalProblems problems) {
             this.classLoader = Thread.currentThread().getContextClassLoader();
-            this.taskValidationProblems = taskValidationProblems;
+            this.taskValidationErrors = taskValidationErrors;
+            this.taskValidationWarnings = taskValidationWarnings;
             this.params = params;
             this.problems = problems;
         }
@@ -140,15 +139,16 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
                     LOGGER.debug("Could not load class: " + className, e);
                     continue;
                 }
-                collectValidationProblems(clazz, taskValidationProblems, params.getEnableStricterValidation().get(), problems);
+                collectValidationProblems(clazz, taskValidationWarnings, taskValidationErrors, params.getEnableStricterValidation().get(), problems);
             }
         }
 
-        private static void collectValidationProblems(Class<?> topLevelBean, List<Problem> taskValidationProblems, boolean enableStricterValidation, InternalProblems problems) {
+        private static void collectValidationProblems(Class<?> topLevelBean, List<Problem> taskValidationWarnings, List<Problem> taskValidationErrors, boolean enableStricterValidation, InternalProblems problems) {
             DefaultTypeValidationContext validationContext = createTypeValidationContext(topLevelBean, enableStricterValidation, problems);
             PropertyValidationAccess.collectValidationProblems(topLevelBean, validationContext);
 
-            taskValidationProblems.addAll(validationContext.getProblems());
+            taskValidationWarnings.addAll(validationContext.getWarnings());
+            taskValidationErrors.addAll(validationContext.getErrors());
         }
 
         private static DefaultTypeValidationContext createTypeValidationContext(Class<?> topLevelBean, boolean enableStricterValidation, InternalProblems problems) {
@@ -188,13 +188,12 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
                 String disableCachingAnnotation = "@" + DisableCachingByDefault.class.getSimpleName();
                 String untrackedTaskAnnotation = "@" + UntrackedTask.class.getSimpleName();
                 String workType = isTask ? "task" : "transform action";
-                validationContext.visitTypeProblem(problem -> {
+                validationContext.visitTypeError(problem -> {
                         ProblemSpec builder = problem
                             .withAnnotationType(topLevelBean)
                             .id(TextUtil.screamingSnakeToKebabCase(ValidationTypes.NOT_CACHEABLE_WITHOUT_REASON), "Not cacheable without reason", GradleCoreProblemGroup.validation().type())
                             .contextualLabel("must be annotated either with " + cacheableAnnotation + " or with " + disableCachingAnnotation)
                             .documentedAt(userManual("validation_problems", "disable_caching_by_default"))
-                            .severity(ERROR)
                             .details("The " + workType + " author should make clear why a " + workType + " is not cacheable")
                             .solution("Add " + disableCachingAnnotation + "(because = ...)")
                             .solution("Add " + cacheableAnnotation);

--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
@@ -36,6 +36,7 @@ import org.gradle.api.problems.DocLink;
 import org.gradle.api.problems.FileLocation;
 import org.gradle.api.problems.LineInFileLocation;
 import org.gradle.api.problems.OffsetInFileLocation;
+import org.gradle.api.problems.Problem;
 import org.gradle.api.problems.ProblemGroup;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemLocation;
@@ -63,6 +64,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,15 +73,40 @@ import java.util.stream.Stream;
 
 @NullMarked
 public class ValidationProblemSerialization {
-    private static final GsonBuilder GSON_BUILDER = createGsonBuilder();
 
-    public static List<? extends InternalProblem> parseMessageList(String lines) {
-        Gson gson = GSON_BUILDER.create();
-        Type type = new TypeToken<List<DefaultProblem>>() {}.getType();
-        return gson.<List<DefaultProblem>>fromJson(lines, type);
+    public static class SerializationResult {
+        private final List<DefaultProblem> warnings;
+        private final List<DefaultProblem> errors;
+
+        public SerializationResult(List<DefaultProblem> warnings, List<DefaultProblem> errors) {
+            this.warnings = warnings;
+            this.errors = errors;
+        }
+
+        public List<DefaultProblem> getWarnings() {
+            return warnings;
+        }
+
+        public List<DefaultProblem> getErrors() {
+            return errors;
+        }
     }
 
-    public static GsonBuilder createGsonBuilder() {
+    private static final GsonBuilder GSON_BUILDER = createGsonBuilder();
+
+    public static SerializationResult deserialize(String lines) {
+        Gson gson = GSON_BUILDER.create();
+        Type type = new TypeToken<List<List<DefaultProblem>>>() {}.getType();
+        List<List<DefaultProblem>> lists = gson.fromJson(lines, type);
+        return new SerializationResult(lists.get(0), lists.get(1));
+    }
+
+    public static String serialize(List<Problem> warnings, List<Problem> errors) {
+        Gson gson = createGsonBuilder().create();
+        return gson.toJson(Arrays.asList(warnings, errors));
+    }
+
+    private static GsonBuilder createGsonBuilder() {
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapterFactory(new ProblemReportAdapterFactory());
         gsonBuilder.registerTypeAdapter(ProblemId.class, new ProblemIdInstanceCreator());
@@ -92,9 +119,17 @@ public class ValidationProblemSerialization {
     }
 
 
-    public static Stream<String> toPlainMessage(List<? extends InternalProblem> problems) {
+    public static Stream<String> toPlainWarning(List<? extends InternalProblem> problems) {
+        return toPlainMessage(problems, "Warning");
+    }
+
+    public static Stream<String> toPlainError(List<? extends InternalProblem> problems) {
+        return toPlainMessage(problems, "Error");
+    }
+
+    private static Stream<String> toPlainMessage(List<? extends InternalProblem> problems, String prefix) {
         return problems.stream()
-            .map(problem -> problem.getDefinition().getSeverity() + ": " + TypeValidationProblemRenderer.renderMinimalInformationAbout(problem));
+            .map(problem -> prefix + ": " + TypeValidationProblemRenderer.renderMinimalInformationAbout(problem));
     }
 
     /**
@@ -677,8 +712,7 @@ public class ValidationProblemSerialization {
                         propertyName,
                         methodName,
                         parentPropertyName,
-                        typeName
-                    );
+                        typeName);
                 case GENERAL_DATA:
                     return new DefaultGeneralData(generalData);
                 case PROPERTY_TRACE_DATA:

--- a/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
@@ -16,9 +16,8 @@
 
 package org.gradle.plugin.devel.tasks.internal
 
-import com.google.gson.Gson
+
 import org.gradle.api.problems.ProblemId
-import org.gradle.api.problems.Severity
 import org.gradle.api.problems.internal.AdditionalDataBuilderFactory
 import org.gradle.api.problems.internal.DefaultProblemReporter
 import org.gradle.api.problems.internal.DeprecationData
@@ -28,6 +27,7 @@ import org.gradle.api.problems.internal.GeneralData
 import org.gradle.api.problems.internal.GeneralDataSpec
 import org.gradle.api.problems.internal.GradleCoreProblemGroup
 import org.gradle.api.problems.internal.InternalDocLink
+import org.gradle.api.problems.internal.InternalProblem
 import org.gradle.api.problems.internal.InternalProblemReporter
 import org.gradle.api.problems.internal.IsolatableToBytesSerializer
 import org.gradle.api.problems.internal.ProblemSummarizer
@@ -45,7 +45,6 @@ class ValidationProblemSerializationTest extends Specification {
 
     def problemId = ProblemId.create("id", "label", GradleCoreProblemGroup.validation().type())
 
-    Gson gson = ValidationProblemSerialization.createGsonBuilder().create()
     InternalProblemReporter problemReporter = new DefaultProblemReporter(
         Stub(ProblemSummarizer),
         CurrentBuildOperationRef.instance(),
@@ -61,50 +60,52 @@ class ValidationProblemSerializationTest extends Specification {
         )
     )
 
-    def "can serialize and deserialize a validation problem"() {
+    def "can serialize and deserialize a validation problem"(boolean asWarning) {
         given:
         def problem = problemReporter.create(problemId, {})
 
         when:
-        def json = gson.toJson([problem])
-        def deserialized = ValidationProblemSerialization.parseMessageList(json)
+        def deserialized = serializeAndDeserialize(problem, asWarning)
 
         then:
-        deserialized.size() == 1
-        deserialized[0].definition.id.name == "id"
-        deserialized[0].definition.id.displayName == "label"
-        deserialized[0].definition.id.group.name == "type-validation"
-        deserialized[0].definition.id.group.displayName == "Gradle type validation"
-        deserialized[0].definition.id.group.parent.name == "validation"
-        deserialized[0].definition.id.group.parent.displayName == "Validation"
-        deserialized[0].definition.id.group.parent.parent == null
+        deserialized.definition.id.name == "id"
+        deserialized.definition.id.displayName == "label"
+        deserialized.definition.id.group.name == "type-validation"
+        deserialized.definition.id.group.displayName == "Gradle type validation"
+        deserialized.definition.id.group.parent.name == "validation"
+        deserialized.definition.id.group.parent.displayName == "Validation"
+        deserialized.definition.id.group.parent.parent == null
 
-        deserialized[0].originLocations.isEmpty()
-        deserialized[0].definition.documentationLink == null
+        deserialized.originLocations.isEmpty()
+        deserialized.definition.documentationLink == null
+
+        where:
+        asWarning << [false, true]
     }
 
-    def "can serialize and deserialize a validation problem with a location"() {
+    def "can serialize and deserialize a validation problem with a location"(boolean asWarning) {
         given:
         def problem = problemReporter.create(problemId) {
             it.lineInFileLocation("location", 1, 2, 3)
         }
 
         when:
-        def json = gson.toJson([problem])
-        def deserialized = ValidationProblemSerialization.parseMessageList(json)
+        def deserialized = serializeAndDeserialize(problem, asWarning)
 
         then:
-        deserialized.size() == 1
-        deserialized[0].definition.id.name == "id"
-        deserialized[0].definition.id.displayName == "label"
-        deserialized[0].originLocations[0].path == "location"
-        deserialized[0].originLocations[0].line == 1
-        deserialized[0].originLocations[0].column == 2
-        deserialized[0].originLocations[0].length == 3
-        deserialized[0].definition.documentationLink == null
+        deserialized.definition.id.name == "id"
+        deserialized.definition.id.displayName == "label"
+        deserialized.originLocations[0].path == "location"
+        deserialized.originLocations[0].line == 1
+        deserialized.originLocations[0].column == 2
+        deserialized.originLocations[0].length == 3
+        deserialized.definition.documentationLink == null
+
+        where:
+        asWarning << [false, true]
     }
 
-    def "can serialize and deserialize a validation problem with a documentation link"() {
+    def "can serialize and deserialize a validation problem with a documentation link"(boolean asWarning) {
         given:
         def problem = problemReporter.create(problemId) {
             it.documentedAt(new TestDocLink())
@@ -112,18 +113,142 @@ class ValidationProblemSerializationTest extends Specification {
         }
 
         when:
-        def json = gson.toJson([problem])
-        def deserialized = ValidationProblemSerialization.parseMessageList(json)
+        def deserialized = serializeAndDeserialize(problem, asWarning)
 
         then:
-        deserialized.size() == 1
-        deserialized[0].definition.id.name == "id"
-        deserialized[0].definition.id.displayName == "label"
-        deserialized[0].originLocations[0].path == "location"
-        deserialized[0].originLocations[0].line == 1
-        deserialized[0].originLocations[0].column == 1
-        deserialized[0].definition.documentationLink.getUrl() == "url"
-        deserialized[0].definition.documentationLink.getConsultDocumentationMessage() == "consult"
+        deserialized.definition.id.name == "id"
+        deserialized.definition.id.displayName == "label"
+        deserialized.originLocations[0].path == "location"
+        deserialized.originLocations[0].line == 1
+        deserialized.originLocations[0].column == 1
+        deserialized.definition.documentationLink.getUrl() == "url"
+        deserialized.definition.documentationLink.getConsultDocumentationMessage() == "consult"
+
+        where:
+        asWarning << [false, true]
+    }
+
+    def "can serialize and deserialize a validation problem with a cause"(boolean asWarning) {
+        given:
+        def problem = problemReporter.create(problemId) {
+            it.withException(new RuntimeException("cause"))
+        }
+
+        when:
+        def deserialized = serializeAndDeserialize(problem, asWarning)
+
+        then:
+        deserialized.definition.id.name == "id"
+        deserialized.definition.id.displayName == "label"
+        deserialized.originLocations == [] as List
+        deserialized.definition.documentationLink == null
+        deserialized.exception.message == "cause"
+
+        where:
+        asWarning << [false, true]
+    }
+
+    def "can serialize and deserialize a validation problem with a solution"(boolean asWarning) {
+        given:
+        def problem = problemReporter.create(problemId) {
+            it.solution("solution 0")
+                .solution("solution 1")
+        }
+
+        when:
+        def deserialized = serializeAndDeserialize(problem, asWarning)
+
+        then:
+        deserialized.definition.id.name == "id"
+        deserialized.definition.id.displayName == "label"
+        deserialized.originLocations == [] as List
+        deserialized.definition.documentationLink == null
+        deserialized.solutions[0] == "solution 0"
+        deserialized.solutions[1] == "solution 1"
+
+        where:
+        asWarning << [false, true]
+    }
+
+    def "can serialize and deserialize a validation problem with additional data"(boolean asWarning) {
+        given:
+        def problem = problemReporter.internalCreate {
+            it.id(problemId)
+                .additionalDataInternal(TypeValidationDataSpec.class) {
+                    it.propertyName("property")
+                    it.typeName("type")
+                    it.parentPropertyName("parent")
+                    it.pluginId("id")
+                }
+        }
+
+        when:
+        def deserialized = serializeAndDeserialize(problem, asWarning)
+
+        then:
+        deserialized.definition.id.name == "id"
+        deserialized.definition.id.displayName == "label"
+        deserialized.originLocations == [] as List
+        deserialized.definition.documentationLink == null
+        (deserialized.additionalData as TypeValidationData).propertyName == 'property'
+        (deserialized.additionalData as TypeValidationData).typeName == 'type'
+        (deserialized.additionalData as TypeValidationData).parentPropertyName == 'parent'
+        (deserialized.additionalData as TypeValidationData).pluginId == 'id'
+
+        where:
+        asWarning << [false, true]
+    }
+
+    def "can serialize generic additional data"(boolean asWarning) {
+        given:
+        def problem = problemReporter.internalCreate {
+            it.id(problemId)
+                .additionalDataInternal(GeneralDataSpec) {
+                    it.put('foo', 'bar')
+                }
+        }
+
+        when:
+        def deserialized = serializeAndDeserialize(problem, asWarning)
+
+        then:
+        deserialized.definition.id.name == "id"
+        deserialized.definition.id.displayName == "label"
+        deserialized.additionalData instanceof GeneralData
+        (deserialized.additionalData as GeneralData).asMap == ['foo' : 'bar']
+
+        where:
+        asWarning << [false, true]
+    }
+
+    def "can serialize deprecation additional data"(boolean asWarning) {
+        given:
+        def problem = problemReporter.internalCreate {
+            it.id(problemId)
+                .additionalDataInternal(DeprecationDataSpec) {
+                    it.type(DeprecationData.Type.BUILD_INVOCATION)
+                }
+        }
+
+        when:
+        def deserialized = serializeAndDeserialize(problem, asWarning)
+
+        then:
+        deserialized.definition.id.name == "id"
+        deserialized.definition.id.displayName == "label"
+        deserialized.additionalData instanceof DeprecationData
+        (deserialized.additionalData as DeprecationData).type == DeprecationData.Type.BUILD_INVOCATION
+
+        where:
+        asWarning << [false, true]
+    }
+
+    private static InternalProblem serializeAndDeserialize(InternalProblem problem, boolean asWarning) {
+        def json = asWarning ? ValidationProblemSerialization.serialize([problem], []) : ValidationProblemSerialization.serialize([], [problem])
+        def deserialized = ValidationProblemSerialization.deserialize(json)
+        def problems = asWarning ? deserialized.warnings : deserialized.errors
+        assert problems.size() == 1
+        return problems[0]
     }
 
     /**
@@ -141,137 +266,5 @@ class ValidationProblemSerializationTest extends Specification {
         String getConsultDocumentationMessage() {
             return "consult"
         }
-    }
-
-    def "can serialize and deserialize a validation problem with a cause"() {
-        given:
-        def problem = problemReporter.create(problemId) {
-            it.withException(new RuntimeException("cause"))
-        }
-
-        when:
-        def json = gson.toJson([problem])
-        def deserialized = ValidationProblemSerialization.parseMessageList(json)
-
-        then:
-        deserialized.size() == 1
-        deserialized[0].definition.id.name == "id"
-        deserialized[0].definition.id.displayName == "label"
-        deserialized[0].originLocations == [] as List
-        deserialized[0].definition.documentationLink == null
-        deserialized[0].exception.message == "cause"
-    }
-
-    def "can serialize and deserialize a validation problem with a severity"(Severity severity) {
-        given:
-        def problem = problemReporter.create(problemId) {
-            it.severity(severity)
-        }
-
-        when:
-        def json = gson.toJson([problem])
-        def deserialized = ValidationProblemSerialization.parseMessageList(json)
-
-        then:
-        deserialized.size() == 1
-        deserialized[0].definition.id.name == "id"
-        deserialized[0].definition.id.displayName == "label"
-        deserialized[0].originLocations == [] as List
-        deserialized[0].definition.documentationLink == null
-        deserialized[0].definition.severity == severity
-
-        where:
-        severity << Severity.values()
-    }
-
-    def "can serialize and deserialize a validation problem with a solution"() {
-        given:
-        def problem = problemReporter.create(problemId) {
-            it.solution("solution 0")
-                .solution("solution 1")
-        }
-
-        when:
-        def json = gson.toJson([problem])
-        def deserialized = ValidationProblemSerialization.parseMessageList(json)
-
-        then:
-        deserialized.size() == 1
-        deserialized[0].definition.id.name == "id"
-        deserialized[0].definition.id.displayName == "label"
-        deserialized[0].originLocations == [] as List
-        deserialized[0].definition.documentationLink == null
-        deserialized[0].solutions[0] == "solution 0"
-        deserialized[0].solutions[1] == "solution 1"
-    }
-
-    def "can serialize and deserialize a validation problem with additional data"() {
-        given:
-        def problem = problemReporter.internalCreate {
-            it.id(problemId)
-                .additionalDataInternal(TypeValidationDataSpec.class) {
-                    it.propertyName("property")
-                    it.typeName("type")
-                    it.parentPropertyName("parent")
-                    it.pluginId("id")
-                }
-        }
-
-        when:
-        def json = gson.toJson([problem])
-        def deserialized = ValidationProblemSerialization.parseMessageList(json)
-
-        then:
-        deserialized.size() == 1
-        deserialized[0].definition.id.name == "id"
-        deserialized[0].definition.id.displayName == "label"
-        deserialized[0].originLocations == [] as List
-        deserialized[0].definition.documentationLink == null
-        (deserialized[0].additionalData as TypeValidationData).propertyName == 'property'
-        (deserialized[0].additionalData as TypeValidationData).typeName == 'type'
-        (deserialized[0].additionalData as TypeValidationData).parentPropertyName == 'parent'
-        (deserialized[0].additionalData as TypeValidationData).pluginId == 'id'
-    }
-
-    def "can serialize generic additional data"() {
-        given:
-        def problem = problemReporter.internalCreate {
-            it.id(problemId)
-                .additionalDataInternal(GeneralDataSpec) {
-                    it.put('foo', 'bar')
-                }
-        }
-
-        when:
-        def json = gson.toJson([problem])
-        def deserialized = ValidationProblemSerialization.parseMessageList(json)
-
-        then:
-        deserialized.size() == 1
-        deserialized[0].definition.id.name == "id"
-        deserialized[0].definition.id.displayName == "label"
-        deserialized[0].additionalData instanceof GeneralData
-        (deserialized[0].additionalData as GeneralData).asMap == ['foo' : 'bar']
-    }
-
-    def "can serialize deprecation additional data"() {
-        given:
-        def problem = problemReporter.internalCreate {
-            it.id(problemId)
-                .additionalDataInternal(DeprecationDataSpec) {
-                    it.type(DeprecationData.Type.BUILD_INVOCATION)
-                }
-        }
-
-        when:
-        def json = gson.toJson([problem])
-        def deserialized = ValidationProblemSerialization.parseMessageList(json)
-
-        then:
-        deserialized.size() == 1
-        deserialized[0].definition.id.name == "id"
-        deserialized[0].definition.id.displayName == "label"
-        deserialized[0].additionalData instanceof DeprecationData
-        (deserialized[0].additionalData as DeprecationData).type == DeprecationData.Type.BUILD_INVOCATION
     }
 }

--- a/platforms/extensibility/plugin-development/src/testFixtures/groovy/org/gradle/plugin/devel/tasks/TaskValidationReportFixture.groovy
+++ b/platforms/extensibility/plugin-development/src/testFixtures/groovy/org/gradle/plugin/devel/tasks/TaskValidationReportFixture.groovy
@@ -17,7 +17,6 @@
 package org.gradle.plugin.devel.tasks
 
 import groovy.transform.CompileStatic
-import org.gradle.api.problems.Severity
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer
 import org.gradle.plugin.devel.tasks.internal.ValidationProblemSerialization
 
@@ -30,20 +29,23 @@ class TaskValidationReportFixture {
         this.reportFile = reportFile
     }
 
-    void verify(Map<String, Severity> messages) {
+    void verify(Map<String, String> messages) {
         def expectedReportContents = messages
             .collect { message, severity ->
                 "$severity: $message"
             }
             .join(PROBLEM_SEPARATOR)
             .replaceAll("\n+", "\n")
-        def reportText =
-            ValidationProblemSerialization.parseMessageList(reportFile.text)
-                .collect { it.definition.severity.toString() + ": " + TypeValidationProblemRenderer.renderMinimalInformationAbout(it) }
-                .sort()
-                .join(PROBLEM_SEPARATOR)
-                .replaceAll("\r\n", "\n")
-                .replaceAll("\n+", "\n")
+        def problems = ValidationProblemSerialization.deserialize(reportFile.text)
+        def warnings = problems.getWarnings()
+        def errors = problems.getErrors()
+
+        def reportText = (warnings.collect { "warning: " + TypeValidationProblemRenderer.renderMinimalInformationAbout(it) } +
+                errors.collect { "error: " + TypeValidationProblemRenderer.renderMinimalInformationAbout(it) })
+                    .sort()
+                    .join(PROBLEM_SEPARATOR)
+                    .replaceAll("\r\n", "\n")
+                    .replaceAll("\n+", "\n")
 
 
         def actualText = reportText

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureApplicator.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureApplicator.java
@@ -27,41 +27,39 @@ import org.gradle.api.artifacts.dsl.DependencyFactory;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
 import org.gradle.api.internal.DynamicObjectAware;
-import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Nested;
-import org.gradle.features.binding.ProjectFeatureApplyAction;
-import org.gradle.features.internal.file.DefaultProjectFeatureLayout;
-import org.gradle.features.file.ProjectFeatureLayout;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.model.ObjectFactoryFactory;
-import org.gradle.features.binding.BuildModel;
-import org.gradle.features.binding.Definition;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
-import org.gradle.features.binding.ProjectFeatureApplicationContext;
-import org.gradle.features.registration.ConfigurationRegistrar;
-import org.gradle.features.internal.registration.DefaultConfigurationRegistrar;
-import org.gradle.features.internal.registration.DefaultTaskRegistrar;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.features.registration.TaskRegistrar;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblemReporter;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.features.binding.BuildModel;
+import org.gradle.features.binding.Definition;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectFeatureApplyAction;
+import org.gradle.features.file.ProjectFeatureLayout;
+import org.gradle.features.internal.binding.ProjectFeatureSupportInternal.ProjectFeatureDefinitionContext;
+import org.gradle.features.internal.file.DefaultProjectFeatureLayout;
+import org.gradle.features.internal.registration.DefaultConfigurationRegistrar;
+import org.gradle.features.internal.registration.DefaultTaskRegistrar;
+import org.gradle.features.registration.ConfigurationRegistrar;
+import org.gradle.features.registration.TaskRegistrar;
 import org.gradle.internal.Cast;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.instantiation.managed.ManagedObjectRegistry;
 import org.gradle.internal.logging.text.TreeFormatter;
-
 import org.gradle.internal.reflect.annotations.PropertyAnnotationMetadata;
 import org.gradle.internal.reflect.annotations.TypeAnnotationMetadataStore;
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
 import org.gradle.internal.service.ServiceLookup;
 import org.gradle.internal.service.ServiceLookupException;
 import org.gradle.internal.service.UnknownServiceException;
-import org.gradle.features.internal.binding.ProjectFeatureSupportInternal.ProjectFeatureDefinitionContext;
 import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
@@ -492,9 +490,8 @@ abstract public class DefaultProjectFeatureApplicator implements ProjectFeatureA
                 .contextualLabel("Project feature '" + featureName + "' has an apply action that attempts to inject an unknown service with type '" + serviceType.getTypeName() + "'.")
                 .details("Services of type " + serviceType.getTypeName() + " are not available for injection into project feature apply actions.")
                 .solution("Remove the '" + serviceType.getTypeName() + "' injection from the apply action.")
-                .severity(Severity.ERROR)
             );
-            problemReporter.report(problem);
+            problemReporter.reportError(problem);
             throw new UnknownServiceException(serviceType, TypeValidationProblemRenderer.renderMinimalInformationAbout(problem));
         }
     }
@@ -549,9 +546,8 @@ abstract public class DefaultProjectFeatureApplicator implements ProjectFeatureA
                 .details(getSafeServicesListExplanation())
                 .solution("Mark the apply action as unsafe.")
                 .solution("Remove the '" + serviceType.getTypeName() + "' injection from the apply action.")
-                .severity(Severity.ERROR)
             );
-            problemReporter.report(problem);
+            problemReporter.reportError(problem);
             throw new UnknownServiceException(serviceType, TypeValidationProblemRenderer.renderMinimalInformationAbout(problem));
         }
     }

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureDeclarations.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/features/internal/binding/DefaultProjectFeatureDeclarations.java
@@ -22,6 +22,12 @@ import org.gradle.api.NamedDomainObjectCollectionSchema;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.internal.tasks.properties.InspectionScheme;
+import org.gradle.api.problems.internal.GradleCoreProblemGroup;
+import org.gradle.api.problems.internal.InternalProblem;
+import org.gradle.api.problems.internal.InternalProblemReporter;
+import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.tasks.Nested;
 import org.gradle.features.annotations.BindsProjectFeature;
 import org.gradle.features.annotations.BindsProjectType;
 import org.gradle.features.binding.BuildModel;
@@ -29,13 +35,6 @@ import org.gradle.features.binding.Definition;
 import org.gradle.features.binding.ProjectFeatureBinding;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.TargetTypeInformation;
-import org.gradle.api.internal.tasks.properties.InspectionScheme;
-import org.gradle.api.problems.Severity;
-import org.gradle.api.problems.internal.GradleCoreProblemGroup;
-import org.gradle.api.problems.internal.InternalProblem;
-import org.gradle.api.problems.internal.InternalProblemReporter;
-import org.gradle.api.reflect.TypeOf;
-import org.gradle.api.tasks.Nested;
 import org.gradle.internal.Pair;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.properties.annotations.TypeMetadata;
@@ -120,7 +119,6 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                 .contextualLabel("Project feature '" + projectFeatureName + "' is bound to 'BuildModel.None'")
                 .solution("Bind to a target definition type instead.")
                 .solution("Bind to a concrete build model type other than 'BuildModel.None'.")
-                .severity(Severity.ERROR)
             );
 
             throwTypeValidationException("Project feature '" + projectFeatureName + "' is bound to an invalid type:", singletonList(bindingTypeProblem));
@@ -146,7 +144,6 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                         .details("A project feature or type with a given name must bind to a unique target type.")
                         .contextualLabel("Project feature '" + projectFeatureName + "' is registered by both '" + pluginClass.getName() + "' and '" + existingPluginClass.getName() + "' but their bindings have overlapping target types.")
                         .solution("Remove one of the plugins from the build.")
-                        .severity(Severity.ERROR)
                     )
                 );
             });
@@ -220,7 +217,6 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                 .contextualLabel("Project feature '" + binding.getName() + "' has a definition with type '" + binding.getDefinitionType().getSimpleName() + "' which was declared safe but has an implementation type '" + binding.getDefinitionImplementationType().get().getSimpleName() + "'")
                 .solution("Mark the definition as unsafe.")
                 .solution("Remove the implementation type specification.")
-                .severity(Severity.ERROR)
             ));
         }
 
@@ -231,20 +227,18 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                 .contextualLabel("Project feature '" + binding.getName() + "' has a definition with type '" + binding.getDefinitionType().getSimpleName() + "' which was declared safe but is not an interface")
                 .solution("Mark the definition as unsafe.")
                 .solution("Refactor the type as an interface.")
-                .severity(Severity.ERROR)
             ));
         }
 
         validateDefinition(binding.getDefinitionType(), problems);
 
-        problemReporter.report(problems);
+        problemReporter.reportError(problems);
 
         throwTypeValidationException("Project feature '" + binding.getName() + "' has a definition type which was declared safe but has the following issues:", problems);
     }
 
     private static void throwTypeValidationException(String summary, List<InternalProblem> problems) {
         List<String> formattedErrors = problems.stream()
-            .filter(problem -> problem.getDefinition().getSeverity().equals(Severity.ERROR))
             .map(TypeValidationProblemRenderer::renderMinimalInformationAbout)
             .collect(Collectors.toList());
 
@@ -268,7 +262,6 @@ public class DefaultProjectFeatureDeclarations implements ProjectFeatureDeclarat
                     .contextualLabel("The definition type has @Inject annotated property '" + propertyMetadata.getPropertyName() + "' in type '" + definitionType.getSimpleName() + "'")
                     .solution("Mark the definition as unsafe.")
                     .solution("Remove the @Inject annotation from the '" + propertyMetadata.getPropertyName() + "' property.")
-                    .severity(Severity.ERROR)
                 ));
             }
 

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsApiBuildOperationIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsApiBuildOperationIntegrationTest.groovy
@@ -139,7 +139,6 @@ class ProblemsApiBuildOperationIntegrationTest extends AbstractIntegrationSpec {
                   .details("problem details")
                   .solution("solution 1")
                   .solution("solution 2")
-                  .severity(Severity.ERROR)
                   .withException(new IllegalArgumentException("problem exception"))
             }
         """
@@ -166,7 +165,7 @@ class ProblemsApiBuildOperationIntegrationTest extends AbstractIntegrationSpec {
                     url == 'https://example.org/doc'
                 }
             }
-            severity == Severity.ERROR.name()
+            severity == Severity.WARNING.name()
             contextualLabel == 'contextual label'
             solutions == ['solution 1', 'solution 2']
             details == 'problem details'

--- a/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/platforms/ide/problems-api/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -51,6 +51,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         verifyAll(receivedProblem) {
             definition.id.fqid == 'generic:type'
             definition.id.displayName == 'label'
+            definition.severity == Severity.WARNING
             with(oneLocation(StackTraceLocation).fileLocation) {
                 length == -1
                 column == -1
@@ -204,25 +205,6 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    def "can emit a problem with a severity"(Severity severity) {
-        given:
-        withReportProblemTask """
-            ${problemIdScript()}
-            problems.getReporter().report(problemId) {
-                it.severity(Severity.${severity.name()})
-            }
-        """
-
-        when:
-        run('reportProblem')
-
-        then:
-        receivedProblem.definition.severity == severity
-
-        where:
-        severity << Severity.values()
-    }
-
     def "can emit a problem with a solution"() {
         given:
         withReportProblemTask """
@@ -335,7 +317,10 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
         fails('reportProblem')
 
         then:
-        receivedProblem.exception.message == 'test'
+        verifyAll(receivedProblem) {
+            exception.message == 'test'
+            definition.severity == Severity.ERROR
+        }
     }
 
     def "can rethrow a caught exception"() {
@@ -365,8 +350,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
             ${problemIdScript()}
             for (int i = 0; i < 10; i++) {
                 problems.getReporter().report(problemId) {
-                        it.severity(Severity.WARNING)
-                        .solution("solution \$i")
+                    it.solution("solution \$i")
                 }
             }
         """
@@ -395,8 +379,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
             ${problemIdScript()}
             for (int i = 0; i < 10; i++) {
                 problems.getReporter().report(${ProblemId.name}.create("type\$i", "This is the heading problem text\$i", problemGroup)) {
-                        it.severity(Severity.WARNING)
-                        .details("This is a huge amount of extremely and very relevant details for this problem\$i")
+                    it.details("This is a huge amount of extremely and very relevant details for this problem\$i")
                         .solution("solution")
                 }
             }
@@ -429,8 +412,7 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
             ${problemIdScript()}
             for (int i = 0; i < 10; i++) {
                 problems.getReporter().report(${ProblemId.name}.create("type\$i", "This is the heading problem text\$i", problemGroup)) {
-                        it.severity(Severity.WARNING)
-                        .details("This is a huge amount of extremely and very relevant details for this problem\$i")
+                    it.details("This is a huge amount of extremely and very relevant details for this problem\$i")
                         .solution("solution")
                 }
             }
@@ -448,7 +430,6 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
             verifyAll(receivedProblem(num)) {
                 definition.id.displayName == "This is the heading problem text$num"
                 definition.id.name == "type$num"
-                definition.severity == Severity.WARNING
                 details == "This is a huge amount of extremely and very relevant details for this problem$num"
                 solutions == ["solution"]
             }
@@ -481,7 +462,6 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
             ${ProblemId.name} problemId = ${ProblemId.name}.create("prototype-project", "Project is a prototype", problemGroup)
             problems.getReporter().report(problemId) { spec ->
                 spec.contextualLabel("This is a prototype and not a guideline for modeling real-life projects")
-                spec.severity(Severity.WARNING)
                 spec.details("Complex build logic like the Problems API usage should be integrated into plugins")
                 spec.solution("Look up the samples index for real-life examples")
                 spec.documentedAt("https://example.com/some-problem")

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ProblemSpec.java
@@ -176,6 +176,8 @@ public interface ProblemSpec {
      * @param severity the severity
      * @return this
      * @since 8.6
+     * @deprecated Severity is now determined automatically: use {@link ProblemReporter#report} for warnings and {@link ProblemReporter#throwing} for errors.
      */
+    @Deprecated
     ProblemSpec severity(Severity severity);
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/Severity.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/Severity.java
@@ -25,9 +25,24 @@ import org.gradle.api.Incubating;
  */
 @Incubating
 public enum Severity {
+    /**
+     * Advice-level severity.
+     * @deprecated Only kept for backward compatibility. Will be removed in Gradle 10.0.
+     */
+    @Deprecated
     ADVICE("Advice"),
+
+    /**
+     * Warning-level severity, for problems that won't fail the build.
+     *
+     */
     WARNING("Warning"),
+
+    /**
+     * Error-level severity, for problems that will fail the build.
+     */
     ERROR("Error");
+
     private final String displayName;
 
     Severity(String displayName) {

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemBuilder.java
@@ -205,7 +205,14 @@ public class DefaultProblemBuilder implements InternalProblemBuilder {
     }
 
     @Override
+    @Deprecated
     public InternalProblemBuilder severity(Severity severity) {
+        // do nothing
+        return this;
+    }
+
+    @Override
+    public InternalProblemBuilder internalSeverity(Severity severity) {
         this.severity = severity;
         return this;
     }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemReporter.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/DefaultProblemReporter.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.problems.Problem;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemSpec;
+import org.gradle.api.problems.Severity;
 import org.gradle.internal.exception.ExceptionAnalyser;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.OperationIdentifier;
@@ -63,12 +64,25 @@ public class DefaultProblemReporter implements InternalProblemReporter {
     }
 
     @Override
+    public void reportError(Problem problem) {
+        problem = getBuilder(problem).internalSeverity(Severity.ERROR).build();
+        report(problem);
+    }
+
+    @Override
+    public void reportError(Collection<? extends Problem> problems) {
+        for (Problem problem : problems) {
+            reportError(problem);
+        }
+    }
+
+    @Override
     public RuntimeException throwing(Throwable exception, ProblemId problemId, Action<? super ProblemSpec> spec) {
         DefaultProblemBuilder problemBuilder = createProblemBuilder();
         problemBuilder.id(problemId);
         spec.execute(problemBuilder);
         problemBuilder.withException(exception);
-        report(problemBuilder.build());
+        report(addExceptionToProblem(exception, problemBuilder.build()));
         throw runtimeException(exception);
     }
 
@@ -89,7 +103,7 @@ public class DefaultProblemReporter implements InternalProblemReporter {
 
     @NonNull
     private InternalProblem addExceptionToProblem(Throwable exception, Problem problem) {
-        return getBuilder(problem).withException(transform(exception)).build();
+        return getBuilder(problem).internalSeverity(Severity.ERROR).withException(transform(exception)).build();
     }
 
     private static RuntimeException runtimeException(Throwable exception) {

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemBuilder.java
@@ -83,7 +83,10 @@ public interface InternalProblemBuilder extends InternalProblemSpec {
     InternalProblemBuilder withException(Throwable t);
 
     @Override
+    @Deprecated
     InternalProblemBuilder severity(Severity severity);
+
+    InternalProblemBuilder internalSeverity(Severity severity);
 
     ProblemsInfrastructure getInfrastructure();
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemReporter.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemReporter.java
@@ -21,6 +21,8 @@ import org.gradle.api.problems.Problem;
 import org.gradle.api.problems.ProblemReporter;
 import org.gradle.internal.operations.OperationIdentifier;
 
+import java.util.Collection;
+
 public interface InternalProblemReporter extends ProblemReporter {
 
     /**
@@ -32,6 +34,22 @@ public interface InternalProblemReporter extends ProblemReporter {
      * @param id The operation identifier.
      */
     void report(Problem problem, OperationIdentifier id);
+
+    /**
+     * Reports the target problem as it will cause the build to fail. Unlike {@link #throwing(Throwable, Problem)}, this method does not throw an exception.
+     * This is a temporary workaround as not all fatal problems can be reported via {@link #throwing(Throwable, Problem)} without significant refactoring. The goal is to eventually remove this method.
+     *
+     * @param problem The problem to report.
+     */
+    void reportError(Problem problem);
+
+    /**
+     * Reports the target problems as they will cause the build to fail. Unlike  {@link #throwing(Throwable, Collection)}, this method does not throw an exception.
+     * This is a temporary workaround as not all fatal problems can be reported via {@link #throwing(Throwable, Collection)} without significant refactoring. The goal is to eventually remove this method.
+     *
+     * @param problems The problems to report.
+     */
+    void reportError(Collection<? extends Problem> problems);
 
     InternalProblem internalCreate(Action<? super InternalProblemSpec> action);
 }

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemSpec.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/internal/InternalProblemSpec.java
@@ -119,6 +119,7 @@ public interface InternalProblemSpec extends ProblemSpec {
     InternalProblemSpec withException(Throwable t);
 
     @Override
+    @Deprecated
     InternalProblemSpec severity(Severity severity);
 
     /**

--- a/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemTest.groovy
+++ b/platforms/ide/problems-api/src/test/groovy/org/gradle/api/problems/internal/DefaultProblemTest.groovy
@@ -32,7 +32,7 @@ import spock.lang.Specification
 class DefaultProblemTest extends Specification {
     def "unbound builder result is equal to original"() {
         def additionalData = Mock(AdditionalData)
-        def problem = createTestProblem(severity, additionalData)
+        def problem = createTestProblem(additionalData)
         def newProblem = toBuilder(problem).build()
 
         expect:
@@ -46,9 +46,6 @@ class DefaultProblemTest extends Specification {
         newProblem.originLocations == problem.originLocations
 
         newProblem == problem
-
-        where:
-        severity << [Severity.WARNING, Severity.ERROR]
     }
 
     def InternalProblemBuilder toBuilder(DefaultProblem problem) {
@@ -70,7 +67,6 @@ class DefaultProblemTest extends Specification {
 
         where:
         changedAspect | changeClosure
-        "severity"    | { it.severity(Severity.WARNING) }
         "locations"   | { it.fileLocation("file") }
         "details"     | { it.details("details") }
     }
@@ -93,7 +89,7 @@ class DefaultProblemTest extends Specification {
                 Mock(ProblemStream)
             )
         )
-        def problem = createTestProblem(Severity.WARNING)
+        def problem = createTestProblem()
         def builder = toBuilder(problem)
         def newProblem = builder
             .solution("solution")
@@ -118,11 +114,11 @@ class DefaultProblemTest extends Specification {
         newProblem.class == DefaultProblem
     }
 
-    private static createTestProblem(Severity severity = Severity.ERROR, AdditionalData additionalData = null) {
+    private static createTestProblem(AdditionalData additionalData = null) {
         new DefaultProblem(
             new DefaultProblemDefinition(
                 ProblemId.create('message', "displayName", ProblemGroup.create("generic", "Generic")),
-                severity,
+                Severity.ERROR,
                 Documentation.userManual('id'),
             ),
             null,

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r813/ProblemProgressEventCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r813/ProblemProgressEventCrossVersionSpec.groovy
@@ -64,7 +64,6 @@ class ProblemProgressEventCrossVersionSpec extends ToolingApiSpecification {
                         .lineInFileLocation("/tmp/foo", 1, 2, 3)
                         $detailsConfig
                         .additionalData(SomeData, data -> data.setName("someData"))
-                        .severity(Severity.WARNING)
                         .solution("try this instead")
                     }
                 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/ProblemProgressEventCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r86/ProblemProgressEventCrossVersionSpec.groovy
@@ -98,7 +98,6 @@ class ProblemProgressEventCrossVersionSpec extends ToolingApiSpecification {
             for(int i = 0; i < 10; i++) {
                 getProblems().${ProblemsApiGroovyScriptUtils.report(targetVersion)} {
                     it.${ProblemsApiGroovyScriptUtils.id(targetVersion, "adhoc-deprecation", "The 'standard-plugin' is deprecated")}
-                        .severity(Severity.WARNING)
                         .solution("Please use 'standard-plugin-2' instead of this plugin")
                     }
             }
@@ -127,7 +126,6 @@ class ProblemProgressEventCrossVersionSpec extends ToolingApiSpecification {
                 .lineInFileLocation("/tmp/foo", 1, 2, 3)
                 $detailsConfig
                 .additionalData("aKey", "aValue")
-                .severity(Severity.WARNING)
                 .solution("try this instead")
             }
         """

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/ProblemProgressEventCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r87/ProblemProgressEventCrossVersionSpec.groovy
@@ -92,7 +92,6 @@ class ProblemProgressEventCrossVersionSpec extends ToolingApiSpecification {
                 .lineInFileLocation("/tmp/foo", 1, 2, 3)
                 $detailsConfig
                 .additionalData("aKey", "aValue")
-                .severity(Severity.WARNING)
                 .solution("try this instead")
             }
         """

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/ProblemProgressEventCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r88/ProblemProgressEventCrossVersionSpec.groovy
@@ -212,7 +212,6 @@ class ProblemProgressEventCrossVersionSpec extends ToolingApiSpecification {
             for(int i = 0; i < 10; i++) {
                 problems.${ProblemsApiGroovyScriptUtils.report(targetVersion, name, displayName)} {
                     it.${ProblemsApiGroovyScriptUtils.id(targetVersion, name, displayName)}
-                        .severity(Severity.WARNING)
                         .solution("Please use 'standard-plugin-2' instead of this plugin")
                     }
             }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r89/ProblemProgressEventCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r89/ProblemProgressEventCrossVersionSpec.groovy
@@ -96,7 +96,6 @@ class ProblemProgressEventCrossVersionSpec extends ToolingApiSpecification {
                 .lineInFileLocation("/tmp/foo", 1, 2, 3)
                 $detailsConfig
                 ${ProblemsApiGroovyScriptUtils.additionalData(targetVersion, 'aKey', 'aValue')}
-                .severity(Severity.WARNING)
                 .solution("try this instead")
             }
         """
@@ -149,7 +148,6 @@ class ProblemProgressEventCrossVersionSpec extends ToolingApiSpecification {
                 .lineInFileLocation("/tmp/foo", 1, 2, 3)
                 $detailsConfig
                 ${ProblemsApiGroovyScriptUtils.additionalData(targetVersion, 'aKey', 'aValue')}
-                .severity(Severity.WARNING)
                 .solution("try this instead")
             }
         """

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/Severity.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/events/problems/Severity.java
@@ -29,7 +29,7 @@ public interface Severity {
 
     // Note: the static fields must be in sync with entries from org.gradle.api.problems.Severity.
     /**
-     * Advice-level severity.
+     * Advice-level severity. Only emitted by Gradle versions &lt; 9.6.
      *
      * @since 8.6
      */
@@ -37,6 +37,7 @@ public interface Severity {
 
     /**
      * Warning-level severity.
+     * Gradle versions &lt; 9.6 allow explicitly setting severity to warning. Starting from 9.6, warning severity is auto-assigned to problems that won't fail the build.
      *
      * @since 8.6
      */
@@ -44,6 +45,7 @@ public interface Severity {
 
     /**
      * Error-level severity.
+     * Gradle versions &lt; 9.6 allow explicitly setting severity to error. Starting from 9.6, error severity is auto-assigned to problems that will fail the build.
      *
      * @since 8.6
      */

--- a/platforms/jvm/java-compiler-worker/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
+++ b/platforms/jvm/java-compiler-worker/src/main/java/org/gradle/api/internal/tasks/compile/DiagnosticToProblemListener.java
@@ -29,7 +29,6 @@ import org.gradle.api.problems.Problem;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemSpec;
 import org.gradle.api.problems.Problems;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblemReporter;
 
@@ -164,7 +163,7 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
 
     @VisibleForTesting
     void buildProblem(Diagnostic<? extends JavaFileObject> diagnostic, ProblemSpec spec) {
-        addSeverity(diagnostic, spec);
+        maybeAddSolution(diagnostic, spec);
         addLocations(diagnostic, spec);
 
         String label = toFormattedLabel(diagnostic);
@@ -198,10 +197,8 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
         spec.details(formattedMessage);
     }
 
-    private static void addSeverity(Diagnostic<? extends JavaFileObject> diagnostic, ProblemSpec spec) {
-        Severity severity = mapKindToSeverity(diagnostic.getKind());
-        spec.severity(severity);
-        if (severity == Severity.ERROR) {
+    private static void maybeAddSolution(Diagnostic<? extends JavaFileObject> diagnostic, ProblemSpec spec) {
+        if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
             spec.solution(CompilationFailedException.RESOLUTION_MESSAGE);
         }
     }
@@ -312,20 +309,6 @@ public class DiagnosticToProblemListener implements DiagnosticListener<JavaFileO
 
     private static String getPath(JavaFileObject fileObject) {
         return fileObject.getName();
-    }
-
-    private static Severity mapKindToSeverity(Diagnostic.Kind kind) {
-        switch (kind) {
-            case ERROR:
-                return Severity.ERROR;
-            case WARNING:
-            case MANDATORY_WARNING:
-                return Severity.WARNING;
-            case NOTE:
-            case OTHER:
-            default:
-                return Severity.ADVICE;
-        }
     }
 
     public List<Problem> getReportedProblems() {

--- a/platforms/jvm/java-compiler-worker/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/platforms/jvm/java-compiler-worker/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDecla
 import org.gradle.api.internal.tasks.compile.reflect.GradleStandardJavaFileManager;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblems;
@@ -138,7 +137,6 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
     }
 
     private static void buildProblemFrom(RuntimeException ex, ProblemSpec spec) {
-        spec.severity(Severity.ERROR);
         spec.contextualLabel(ex.getLocalizedMessage());
         spec.withException(ex);
     }

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.tasks.compile.MinimalJavaCompilerDaemonForkOption
 import org.gradle.api.internal.tasks.compile.incremental.compilerapi.constants.ConstantsAnalysisResult;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblemReporter;
 import org.gradle.initialization.ClassLoaderRegistry;
@@ -124,7 +123,6 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
                 throw problemReporter.throwing(new IllegalStateException(contextualMessage), problemId, problemSpec -> problemSpec
                     .contextualLabel(contextualMessage)
                     .solution("Check if the installation is not a JRE but a JDK.")
-                    .severity(Severity.ERROR)
                 );
             } else {
                 languageGroovyClasspath = languageGroovyClasspath.plus(Collections.singletonList(toolsJar));

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -97,9 +97,9 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
      * @param expectLineLocation Whether to expect a line location (defaults to true)
      * @param fileLocation Optional file location for additional verification
      */
-    void verifyWarningProblem(ReceivedProblem problem, boolean expectLineLocation = true, String fileLocation = null) {
+    void verifyRedundantCastProblem(ReceivedProblem problem, boolean expectLineLocation = true, String fileLocation = null, Severity severity = Severity.WARNING) {
         assertLocations(problem, expectLineLocation)
-        assert problem.severity == Severity.WARNING
+        assert problem.severity == severity
         assert problem.fqid == 'compilation:java:compiler.warn.redundant.cast'
         assert problem.definition.id.displayName == 'redundant cast to java.lang.String'
         assertRedundantCastInContextualLabel(problem.contextualLabel)
@@ -176,7 +176,7 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
         def result = run("compileJava")
 
         then:
-        (0..1).each { verifyWarningProblem(receivedProblem(it)) }
+        (0..1).each { verifyRedundantCastProblem(receivedProblem(it)) }
         result.error.contains("2 warnings\n")
     }
 
@@ -195,13 +195,13 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
         then:
         verifyAll(receivedProblem(0)) {
             assertLocations(it, false, false)
-            severity == Severity.ADVICE
+            severity == Severity.WARNING
             fqid == 'compilation:java:compiler.note.unchecked.filename'
             contextualLabel == "${buildFile.parentFile.path}/src/main/java/Foo.java uses unchecked or unsafe operations.".replace('/', File.separator)
         }
         verifyAll(receivedProblem(1)) {
             assertLocations(it, false, false)
-            severity == Severity.ADVICE
+            severity == Severity.WARNING
             fqid == 'compilation:java:compiler.note.unchecked.recompile'
             contextualLabel == "Recompile with -Xlint:unchecked for details."
         }
@@ -216,7 +216,7 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
         def result = run("compileJava")
 
         then:
-        (0..3).each { verifyWarningProblem(receivedProblem(it)) }
+        (0..3).each { verifyRedundantCastProblem(receivedProblem(it)) }
         result.error.contains("4 warnings\n")
     }
 
@@ -250,8 +250,8 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
         verifyErrorProblem(receivedProblem(1))
 
         // Warnings from main source set
-        verifyWarningProblem(receivedProblem(2))
-        verifyWarningProblem(receivedProblem(3))
+        verifyRedundantCastProblem(receivedProblem(2))
+        verifyRedundantCastProblem(receivedProblem(3))
 
         result.error.contains("2 errors\n")
         result.error.contains("2 warnings\n")
@@ -272,8 +272,8 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec impleme
         verifyWerrorProblem(receivedProblem(0))
 
         // The two expected warnings
-        verifyWarningProblem(receivedProblem(1), true, "$fooFileLocation:11")
-        verifyWarningProblem(receivedProblem(2), true, "$fooFileLocation:7")
+        verifyRedundantCastProblem(receivedProblem(1), true, "$fooFileLocation:11", Severity.ERROR)
+        verifyRedundantCastProblem(receivedProblem(2), true, "$fooFileLocation:7", Severity.ERROR)
 
         result.error.contains("1 error\n")
         result.error.contains("2 warnings\n")

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -80,7 +80,6 @@ import org.gradle.api.internal.initialization.ResettableConfiguration;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.provider.Provider;
@@ -1318,7 +1317,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                         properUsageDesc
                     )
                 );
-                spec.severity(Severity.ERROR);
             });
         } else if (isExclusivelyDeprecatedUsage(properUsages)) {
             DeprecationLogger.deprecateAction(String.format("Calling %s on %s", methodName, this))
@@ -1497,7 +1495,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         ProblemId id = ProblemId.create("method-not-allowed", "Method call not allowed", GradleCoreProblemGroup.configurationUsage());
         throw configurationServices.getProblems().getInternalReporter().throwing(ex, id, spec -> {
             spec.contextualLabel(ex.getMessage());
-            spec.severity(Severity.ERROR);
         });
     }
 
@@ -1657,7 +1654,6 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         ProblemId id = ProblemId.create("extend-detached-not-allowed", "Extending a detachedConfiguration is not allowed", GradleCoreProblemGroup.configurationUsage());
         throw configurationServices.getProblems().getInternalReporter().throwing(ex, id, spec -> {
             spec.contextualLabel(ex.getMessage());
-            spec.severity(Severity.ERROR);
         });
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -36,7 +36,6 @@ import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.api.provider.Provider;
@@ -155,7 +154,6 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         ProblemId id = ProblemId.create("method-not-allowed", "Method call not allowed", GradleCoreProblemGroup.configurationUsage());
         throw problemsService.getInternalReporter().throwing(ex, id, spec -> {
             spec.contextualLabel(ex.getMessage());
-            spec.severity(Severity.ERROR);
         });
     }
 
@@ -320,7 +318,6 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         ProblemId id = ProblemId.create("unexpected configuration usage", "Unexpected configuration usage", GradleCoreProblemGroup.configurationUsage());
         throw problemsService.getInternalReporter().throwing(ex, id, spec -> {
             spec.contextualLabel(ex.getMessage());
-            spec.severity(Severity.ERROR);
         });
     }
 
@@ -370,7 +367,6 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
             ProblemId id = ProblemId.create("name-not-allowed", "Configuration name not allowed", GradleCoreProblemGroup.configurationUsage());
             throw problemsService.getInternalReporter().throwing(ex, id, spec -> {
                 spec.contextualLabel(ex.getMessage());
-                spec.severity(Severity.ERROR);
             });
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransform.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransform.java
@@ -98,7 +98,6 @@ import java.util.function.Supplier;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.gradle.api.internal.tasks.properties.AbstractValidatingProperty.reportValueNotSet;
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 public class DefaultTransform implements Transform {
@@ -209,13 +208,12 @@ public class DefaultTransform implements Transform {
     public static void validateInputFileNormalizer(String propertyName, @Nullable FileNormalizer normalizer, boolean cacheable, TypeValidationContext validationContext) {
         if (cacheable) {
             if (normalizer == InputNormalizer.ABSOLUTE_PATH) {
-                validationContext.visitPropertyProblem(problem ->
+                validationContext.visitPropertyError(problem ->
                     problem
                         .forProperty(propertyName)
                         .id(TextUtil.screamingSnakeToKebabCase(CACHEABLE_TRANSFORM_CANT_USE_ABSOLUTE_SENSITIVITY), "Property declared to be sensitive to absolute paths", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                         .documentedAt(userManual("validation_problems", "cacheable_transform_cant_use_absolute_sensitivity"))
                         .contextualLabel("is declared to be sensitive to absolute paths")
-                        .severity(ERROR)
                         .details("This is not allowed for cacheable transforms")
                         .solution("Use a different normalization strategy via @PathSensitive, @Classpath or @CompileClasspath"));
             }
@@ -369,13 +367,12 @@ public class DefaultTransform implements Transform {
                     PropertyValue value,
                     OutputFilePropertyType filePropertyType
                 ) {
-                    validationContext.visitPropertyProblem(problem ->
+                    validationContext.visitPropertyError(problem ->
                         problem
                             .forProperty(propertyName)
                             .id(TextUtil.screamingSnakeToKebabCase(ARTIFACT_TRANSFORM_SHOULD_NOT_DECLARE_OUTPUT), "Artifact transform should not declare output", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                             .contextualLabel("declares an output")
                             .documentedAt(userManual("validation_problems", ARTIFACT_TRANSFORM_SHOULD_NOT_DECLARE_OUTPUT.toLowerCase(Locale.ROOT)))
-                            .severity(ERROR)
                             .details("is annotated with an output annotation")
                             .solution("Remove the output property and use the TransformOutputs parameter from transform(TransformOutputs) instead")
                     );
@@ -385,7 +382,7 @@ public class DefaultTransform implements Transform {
             FileCollectionStructureVisitor.NO_OP
         );
 
-        ImmutableList<InternalProblem> validationMessages = validationContext.getProblems();
+        ImmutableList<InternalProblem> validationMessages = validationContext.getErrors();
         if (!validationMessages.isEmpty()) {
             throw new DefaultMultiCauseException(
                 String.format(validationMessages.size() == 1

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformRegistrationFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformRegistrationFactory.java
@@ -129,7 +129,7 @@ public class DefaultTransformRegistrationFactory implements TransformRegistratio
                 DefaultTransform.validateInputFileNormalizer(propertyMetadata.getPropertyName(), dependenciesNormalizer, cacheable, validationContext);
             }
         }
-        DefaultTypeValidationContext.throwOnProblemsOf(implementation, validationContext.getProblems());
+        DefaultTypeValidationContext.throwOnProblemsOf(implementation, validationContext.getErrors());
         Transform transform = new DefaultTransform(
             implementation,
             parameterObject,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java
@@ -83,7 +83,6 @@ import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.T
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.UNDEFINED_ALIAS_REFERENCE;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.UNDEFINED_VERSION_REFERENCE;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.UNSUPPORTED_FILE_FORMAT;
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.RenderingUtils.quotedOxfordListOf;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
@@ -217,8 +216,7 @@ public abstract class DefaultVersionCatalogBuilder implements VersionCatalogBuil
         return builder.
             id(TextUtil.screamingSnakeToKebabCase(catalogProblemId.name()), catalogProblemId.getDisplayName(), GradleCoreProblemGroup.versionCatalog())
             .contextualLabel(message)
-            .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)))
-            .severity(ERROR);
+            .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)));
     }
 
     private static RuntimeException throwVersionCatalogProblemException(InternalProblems problemsService, InternalProblem problem) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/LibrariesSourceGenerator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/LibrariesSourceGenerator.java
@@ -61,7 +61,6 @@ import static org.gradle.api.internal.catalog.problems.DefaultCatalogProblemBuil
 import static org.gradle.api.internal.catalog.problems.DefaultCatalogProblemBuilder.throwError;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.ACCESSOR_NAME_CLASH;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.TOO_MANY_ENTRIES;
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.RenderingUtils.oxfordJoin;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
@@ -517,8 +516,7 @@ public class LibrariesSourceGenerator extends AbstractSourceGenerator {
     private static InternalProblemSpec configureVersionCatalogError(InternalProblemSpec spec, String message, VersionCatalogProblemId catalogProblemId) {
         return spec
             .id(TextUtil.screamingSnakeToKebabCase(catalogProblemId.name()), message, GradleCoreProblemGroup.versionCatalog()) // TODO is message stable?
-            .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)))
-            .severity(ERROR);
+            .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)));
     }
 
     private void assertUnique(List<String> names, String prefix, String suffix) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/exception/AbstractResolutionFailureException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/exception/AbstractResolutionFailureException.java
@@ -35,7 +35,6 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 
 /**
@@ -82,10 +81,9 @@ public abstract class AbstractResolutionFailureException extends StyledException
             builder.id(TextUtil.screamingSnakeToKebabCase(problemId.name()), problemId.getDisplayName(), GradleCoreProblemGroup.variantResolution())
                 .contextualLabel(getMessage())
                 .documentedAt(userManual("variant_model", "sec:variant-select-errors"))
-                .severity(ERROR)
                 .additionalDataInternal(ResolutionFailureDataSpec.class, data -> data.from(getFailure()));
         });
-        problemsService.getInternalReporter().report(problem);
+        problemsService.getInternalReporter().reportError(problem);
 
         return this;
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
@@ -394,11 +394,10 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
         executer.noDeprecationChecks()
         buildFile """
             import org.gradle.integtests.fixtures.validation.ValidationProblem
-            import org.gradle.api.problems.Severity
 
             @CacheableTask
             abstract class InvalidTask extends DefaultTask {
-                @ValidationProblem(value = Severity.WARNING)
+                @ValidationProblem(fatal=false)
                 abstract Property<String> getInput()
 
                 @OutputFile

--- a/subprojects/core/src/main/java/org/gradle/api/internal/catalog/parser/TomlCatalogFileParser.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/catalog/parser/TomlCatalogFileParser.java
@@ -67,7 +67,6 @@ import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.I
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.INVALID_PLUGIN_NOTATION;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.TOML_SYNTAX_ERROR;
 import static org.gradle.api.internal.catalog.problems.VersionCatalogProblemId.UNSUPPORTED_FORMAT_VERSION;
-import static org.gradle.api.problems.Severity.ERROR;
 import static org.gradle.internal.RenderingUtils.quotedOxfordListOf;
 import static org.gradle.internal.deprecation.Documentation.userManual;
 import static org.gradle.util.internal.TextUtil.getPluralEnding;
@@ -161,8 +160,7 @@ public class TomlCatalogFileParser {
             .contextualLabel(label)
             .documentedAt(userManual(VERSION_CATALOG_PROBLEMS, catalogProblemId.name().toLowerCase(Locale.ROOT)));
         InternalProblemSpec definingCategory = locationDefiner.apply(definingLocation);
-        return definingCategory
-            .severity(ERROR);
+        return definingCategory;
     }
 
     private void assertNoParseErrors(TomlParseResult result) {
@@ -188,7 +186,7 @@ public class TomlCatalogFileParser {
             })
                 .details("TOML syntax invalid.")
                 .solution("Fix the TOML file according to the syntax described at https://toml.io")
-        )).forEach(internalReporter::report);
+        )).forEach(internalReporter::reportError);
     }
 
     private String getProblemString(List<TomlParseError> errors) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/DefaultCatalogProblemBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/catalog/problems/DefaultCatalogProblemBuilder.java
@@ -49,7 +49,7 @@ public class DefaultCatalogProblemBuilder {
         formatter.startChildren();
         for (InternalProblem problem : problems) {
             formatter.node(getProblemString(problem));
-            problemsService.getInternalReporter().report(problem);
+            problemsService.getInternalReporter().reportError(problem);
         }
         formatter.endChildren();
         throw new InvalidUserDataException(formatter.toString());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ImperativeOnlyPluginTarget.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.plugins;
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.gradle.api.Plugin;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
@@ -74,8 +73,7 @@ public class ImperativeOnlyPluginTarget<T extends PluginAwareInternal> implement
         ProblemId id = ProblemId.create("target-type-mismatch", "Unexpected plugin type", GradleCoreProblemGroup.pluginApplication());
         throw problems.getInternalReporter()
             .throwing(new IllegalArgumentException(message), id, spec -> {
-                spec.severity(Severity.ERROR)
-                    .withException(new IllegalArgumentException(message))
+                spec.withException(new IllegalArgumentException(message))
                     .contextualLabel(message)
                     .documentedAt(Documentation.userManual("custom_plugins", "project_vs_settings_vs_init_plugins").toString());
             });

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/ProjectFeatureDeclarationPluginTarget.java
@@ -20,21 +20,20 @@ import com.google.common.reflect.TypeToken;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.features.annotations.BindsProjectFeature;
-import org.gradle.features.annotations.BindsProjectType;
 import org.gradle.api.initialization.Settings;
-import org.gradle.features.annotations.RegistersProjectFeatures;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
+import org.gradle.features.annotations.BindsProjectFeature;
+import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.annotations.RegistersProjectFeatures;
+import org.gradle.features.internal.binding.ProjectFeatureDeclarations;
 import org.gradle.internal.Cast;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.properties.annotations.TypeMetadata;
 import org.gradle.internal.reflect.DefaultTypeValidationContext;
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
-import org.gradle.features.internal.binding.ProjectFeatureDeclarations;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -113,23 +112,22 @@ public class ProjectFeatureDeclarationPluginTarget implements PluginTarget {
             projectTypePluginImplMetadata.getTypeAnnotationMetadata().getAnnotation(BindsProjectFeature.class).isPresent();
 
         if (!isBinding) {
-            typeValidationContext.visitTypeProblem(problem ->
+            typeValidationContext.visitTypeError(problem ->
                 problem.withAnnotationType(projectTypePluginImplClass)
                     .id("missing-software-type", "Missing project feature annotation", GradleCoreProblemGroup.validation().type())
                     .contextualLabel("is registered as a project feature plugin but does not expose a project feature")
-                    .severity(Severity.ERROR)
                     .details("This class was registered as a project feature plugin, but it does not expose a project feature. Project feature plugins must expose at least one project feature via either a @BindsProjectType or @BindsProjectFeature annotation on the plugin class.")
                     .solution("Remove " + projectTypePluginImplClass.getSimpleName() + " from the @RegistersSoftwareTypes or @RegistersProjectFeatures annotation on " + registeringPlugin.getSimpleName())
             );
         }
 
-        if (!typeValidationContext.getProblems().isEmpty()) {
+        if (!typeValidationContext.getErrors().isEmpty()) {
             throw new DefaultMultiCauseException(
-                String.format(typeValidationContext.getProblems().size() == 1
+                String.format(typeValidationContext.getErrors().size() == 1
                         ? "A problem was found with the %s plugin."
                         : "Some problems were found with the %s plugin.",
                     projectTypePluginImplClass.getSimpleName()),
-                typeValidationContext.getProblems().stream()
+                typeValidationContext.getErrors().stream()
                     .map(TypeValidationProblemRenderer::renderMinimalInformationAbout)
                     .sorted()
                     .map(InvalidUserDataException::new)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.properties;
 
 import com.google.common.base.Suppliers;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.provider.HasConfigurableValue;
 import org.gradle.api.provider.Provider;
@@ -49,12 +48,11 @@ public abstract class AbstractValidatingProperty implements ValidatingProperty {
     private static final String VALUE_NOT_SET = "VALUE_NOT_SET";
 
     public static void reportValueNotSet(String propertyName, TypeValidationContext context, boolean hasConfigurableValue) {
-        context.visitPropertyProblem(problem -> {
+        context.visitPropertyError(problem -> {
             ProblemSpec problemSpec = problem.forProperty(propertyName)
                 .id(TextUtil.screamingSnakeToKebabCase(VALUE_NOT_SET), "Value not set", GradleCoreProblemGroup.validation().property())
                 .contextualLabel("doesn't have a configured value")
                 .documentedAt(userManual("validation_problems", VALUE_NOT_SET.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details("This property isn't marked as optional and no value has been configured");
             if (hasConfigurableValue) {
                 problemSpec.solution("Assign a value to '" + propertyName + "'");

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultPropertyValidationContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultPropertyValidationContext.java
@@ -36,13 +36,23 @@ public class DefaultPropertyValidationContext implements PropertyValidationConte
     }
 
     @Override
-    public void visitTypeProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
-        delegate.visitTypeProblem(problemSpec);
+    public void visitTypeError(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        delegate.visitTypeError(problemSpec);
     }
 
     @Override
-    public void visitPropertyProblem(Action<? super TypeAwareProblemBuilder> problemSpec) {
-        delegate.visitPropertyProblem(problemSpec);
+    public void visitTypeWarning(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        delegate.visitTypeWarning(problemSpec);
+    }
+
+    @Override
+    public void visitPropertyError(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        delegate.visitPropertyError(problemSpec);
+    }
+
+    @Override
+    public void visitPropertyWarning(Action<? super TypeAwareProblemBuilder> problemSpec) {
+        delegate.visitPropertyWarning(problemSpec);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/ValidationActions.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/ValidationActions.java
@@ -20,7 +20,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.internal.GeneratedSubclass;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.internal.properties.InputFilePropertyType;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
@@ -158,14 +157,13 @@ public enum ValidationActions implements ValidationAction {
     private static final String INPUT_FILE_DOES_NOT_EXIST = "INPUT_FILE_DOES_NOT_EXIST";
 
     private static void reportMissingInput(PropertyValidationContext context, String kind, String propertyName, File input) {
-        context.visitPropertyProblem(problem -> {
+        context.visitPropertyError(problem -> {
             String lowerKind = kind.toLowerCase(Locale.ROOT);
             problem
                 .forProperty(propertyName)
                 .id(TextUtil.screamingSnakeToKebabCase(INPUT_FILE_DOES_NOT_EXIST), "Input file does not exist", GradleCoreProblemGroup.validation().property())
                 .contextualLabel("specifies " + lowerKind + " '" + input + "' which doesn't exist")
                 .documentedAt(userManual("validation_problems", INPUT_FILE_DOES_NOT_EXIST.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details("An input file was expected to be present but it doesn't exist")
                 .solution("Make sure the " + lowerKind + " exists before the task is called")
                 .solution("Make sure that the task which produces the " + lowerKind + " is declared as an input");
@@ -175,14 +173,13 @@ public enum ValidationActions implements ValidationAction {
     private static final String UNEXPECTED_INPUT_FILE_TYPE = "UNEXPECTED_INPUT_FILE_TYPE";
 
     private static void reportUnexpectedInputKind(PropertyValidationContext context, String kind, String propertyName, File input) {
-        context.visitPropertyProblem(problem -> {
+        context.visitPropertyError(problem -> {
             String lowerKind = kind.toLowerCase(Locale.ROOT);
             problem
                 .forProperty(propertyName)
                 .id(TextUtil.screamingSnakeToKebabCase(UNEXPECTED_INPUT_FILE_TYPE), "Unexpected input file type", GradleCoreProblemGroup.validation().property())
                 .contextualLabel(lowerKind + " '" + input + "' is not a " + lowerKind)
                 .documentedAt(userManual("validation_problems", "unexpected_input_file_type"))
-                .severity(Severity.ERROR)
                 .details("Expected an input to be a " + lowerKind + " but it was a " + actualKindOf(input))
                 .solution("Use a " + lowerKind + " as an input")
                 .solution("Declare the input as a " + actualKindOf(input) + " instead");
@@ -192,53 +189,49 @@ public enum ValidationActions implements ValidationAction {
     private static final String CANNOT_WRITE_OUTPUT = "CANNOT_WRITE_OUTPUT";
 
     private static void reportCannotWriteToDirectory(String propertyName, PropertyValidationContext context, File directory, String cause) {
-        context.visitPropertyProblem(problem ->
+        context.visitPropertyError(problem ->
             problem
                 .forProperty(propertyName)
                 .id(TextUtil.screamingSnakeToKebabCase(CANNOT_WRITE_OUTPUT), PROPERTY_IS_NOT_WRITABLE, GradleCoreProblemGroup.validation().property())
                 .contextualLabel("is not writable because " + cause)
                 .documentedAt(userManual("validation_problems", CANNOT_WRITE_OUTPUT.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details("Expected '" + directory + "' to be a directory but it's a " + actualKindOf(directory))
                 .solution("Make sure that the '" + propertyName + "' is configured to a directory")
         );
     }
 
     private static void reportFileTreeWithFileRoot(String propertyName, PropertyValidationContext context, File directory) {
-        context.visitPropertyProblem(problem ->
+        context.visitPropertyError(problem ->
             problem
                 .forProperty(propertyName)
                 .id(TextUtil.screamingSnakeToKebabCase(CANNOT_WRITE_OUTPUT), PROPERTY_IS_NOT_WRITABLE, GradleCoreProblemGroup.validation().property())
                 .contextualLabel("is not writable because '" + directory + "' is not a directory")
                 .documentedAt(userManual("validation_problems", CANNOT_WRITE_OUTPUT.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details("Expected the root of the file tree '" + directory + "' to be a directory but it's a " + actualKindOf(directory))
                 .solution("Make sure that the root of the file tree '" + propertyName + "' is configured to a directory")
         );
     }
 
     private static void reportCannotWriteFileToDirectory(String propertyName, PropertyValidationContext context, File file) {
-        context.visitPropertyProblem(problem ->
+        context.visitPropertyError(problem ->
             problem
                 .forProperty(propertyName)
                 .id(TextUtil.screamingSnakeToKebabCase(CANNOT_WRITE_OUTPUT), PROPERTY_IS_NOT_WRITABLE, GradleCoreProblemGroup.validation().property())
                 .contextualLabel("is not writable because '" + file + "' is not a file")
                 .documentedAt(userManual("validation_problems", CANNOT_WRITE_OUTPUT.toLowerCase(Locale.ROOT)))
                 .details("Cannot write a file to a location pointing at a directory")
-                .severity(Severity.ERROR)
                 .solution("Configure '" + propertyName + "' to point to a file, not a directory")
                 .solution("Annotate '" + propertyName + "' with @OutputDirectory instead of @OutputFiles")
         );
     }
 
     private static void reportCannotCreateParentDirectories(String propertyName, PropertyValidationContext context, File file, File ancestor) {
-        context.visitPropertyProblem(problem ->
+        context.visitPropertyError(problem ->
             problem
                 .forProperty(propertyName)
                 .id(TextUtil.screamingSnakeToKebabCase(CANNOT_WRITE_OUTPUT), PROPERTY_IS_NOT_WRITABLE, GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                 .contextualLabel("is not writable because '" + file + "' ancestor '" + ancestor + "' is not a directory")
                 .documentedAt(userManual("validation_problems", CANNOT_WRITE_OUTPUT.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details("Cannot create parent directories that are existing as file")
                 .solution("Configure '" + propertyName + "' to point to the correct location")
         );
@@ -258,13 +251,12 @@ public enum ValidationActions implements ValidationAction {
 
     private static void validateNotInReservedFileSystemLocation(String propertyName, PropertyValidationContext context, File location) {
         if (context.isInReservedFileSystemLocation(location)) {
-            context.visitPropertyProblem(problem ->
+            context.visitPropertyError(problem ->
                 problem
                     .forProperty(propertyName)
                     .id(TextUtil.screamingSnakeToKebabCase(CANNOT_WRITE_TO_RESERVED_LOCATION), "Cannot write to reserved location", GradleCoreProblemGroup.validation().property())
                     .contextualLabel("points to '" + location + "' which is managed by Gradle")
                     .documentedAt(userManual("validation_problems", CANNOT_WRITE_TO_RESERVED_LOCATION.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details("Trying to write an output to a read-only location which is for Gradle internal use only")
                     .solution("Select a different output location")
             );
@@ -291,13 +283,12 @@ public enum ValidationActions implements ValidationAction {
     private static final String UNSUPPORTED_NOTATION = "UNSUPPORTED_NOTATION";
 
     private static void reportUnsupportedValue(String propertyName, PropertyValidationContext context, String targetType, Object value, Collection<String> candidates) {
-        context.visitPropertyProblem(problem -> {
+        context.visitPropertyError(problem -> {
                 ProblemSpec describedProblem = problem
                     .forProperty(propertyName)
                     .id(TextUtil.screamingSnakeToKebabCase(UNSUPPORTED_NOTATION), "Property has unsupported value", GradleCoreProblemGroup.validation().property())
                     .contextualLabel("has unsupported value '" + value + "'")
                     .documentedAt(userManual("validation_problems", UNSUPPORTED_NOTATION.toLowerCase(Locale.ROOT)))
-                    .severity(Severity.ERROR)
                     .details("Type '" + typeOf(value) + "' cannot be converted to a " + targetType);
                 if (candidates.isEmpty()) {
                     describedProblem.solution("Use a value of type '" + targetType + "'");

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
@@ -22,7 +22,6 @@ import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GeneralDataSpec;
 import org.gradle.api.problems.internal.InternalProblemSpec;
 import org.gradle.api.problems.internal.InternalProblems;
@@ -112,7 +111,6 @@ public abstract class DefaultTaskSelector implements TaskSelector {
 
     private static ProblemSpec configureProblem(ProblemSpec spec, SelectionContext context) {
         ((InternalProblemSpec) spec).additionalDataInternal(GeneralDataSpec.class, data -> data.put("requestedPath", Objects.requireNonNull(context.getOriginalPath().asString())));
-        spec.severity(Severity.ERROR);
         return spec;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolvingBuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolvingBuildTaskScheduler.java
@@ -20,7 +20,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Task;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.configuration.project.BuiltInCommand;
@@ -93,7 +92,6 @@ public class TaskNameResolvingBuildTaskScheduler implements BuildTaskScheduler {
                     ProblemId id = ProblemId.create("init invocation problem", "Init invocation problem", GradleCoreProblemGroup.taskSelection());
                     throw problemsService.getInternalReporter().throwing(ex, id, spec -> {
                         spec.contextualLabel(ex.getMessage());
-                        spec.severity(Severity.ERROR);
                     });
                 });
             }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -18,7 +18,6 @@ package org.gradle.execution.plan;
 
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.InternalProblem;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.internal.deprecation.DeprecationLogger;
@@ -50,10 +49,11 @@ public class DefaultNodeValidator implements NodeValidator {
     @Override
     public boolean hasValidationProblems(LocalTaskNode node) {
         WorkValidationContext validationContext = validateNode(node);
-        List<? extends InternalProblem> problems = validationContext.getProblems();
-        logWarnings(problems);
-        reportErrors(problems, node.getTask(), validationContext);
-        return !problems.isEmpty();
+        List<? extends InternalProblem> warnings = validationContext.getWarnings();
+        List<? extends InternalProblem> errors = validationContext.getErrors();
+        logWarnings(warnings);
+        reportErrors(warnings, errors, node.getTask(), validationContext);
+        return !warnings.isEmpty() || !errors.isEmpty();
     }
 
     private WorkValidationContext validateNode(LocalTaskNode node) {
@@ -68,7 +68,6 @@ public class DefaultNodeValidator implements NodeValidator {
     private void logWarnings(List<? extends InternalProblem> problems) {
         // We are logging all the warnings that we encountered during validation here
         problems.stream()
-            .filter(DefaultNodeValidator::isWarning)
             .forEach(problem -> {
                 // Because our deprecation warning system doesn't support multiline strings (bummer!) both in rendering
                 // **and** testing (no way to capture multiline deprecation warnings), we have to resort to removing details
@@ -82,12 +81,10 @@ public class DefaultNodeValidator implements NodeValidator {
             });
     }
 
-    private void reportErrors(List<? extends InternalProblem> problems, TaskInternal task, WorkValidationContext validationContext) {
-        for (InternalProblem problem : problems) {
-            problemsService.getInternalReporter().report(problem);
-        }
-
-        Set<String> uniqueErrors = getUniqueErrors(problems);
+    private void reportErrors(List<? extends InternalProblem> warnings, List<? extends InternalProblem> errors, TaskInternal task, WorkValidationContext validationContext) {
+        problemsService.getInternalReporter().report(warnings);
+        problemsService.getInternalReporter().reportError(errors);
+        Set<String> uniqueErrors = getUniqueErrors(errors);
         if (!uniqueErrors.isEmpty()) {
             throw WorkValidationException.forProblems(uniqueErrors)
                 .withSummaryForContext(task.toString(), validationContext)
@@ -97,12 +94,7 @@ public class DefaultNodeValidator implements NodeValidator {
 
     private static Set<String> getUniqueErrors(List<? extends InternalProblem> problems) {
         return problems.stream()
-            .filter(problem -> !isWarning(problem))
             .map(TypeValidationProblemRenderer::renderMinimalInformationAbout)
             .collect(toImmutableSet());
-    }
-
-    private static boolean isWarning(InternalProblem problem) {
-        return problem.getDefinition().getSeverity().equals(Severity.WARNING);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/MissingTaskDependencyDetector.java
@@ -18,7 +18,6 @@ package org.gradle.execution.plan;
 
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
@@ -163,11 +162,10 @@ public class MissingTaskDependencyDetector {
     private static final String IMPLICIT_DEPENDENCY = "IMPLICIT_DEPENDENCY";
 
     private static void collectValidationProblem(Node producer, Node consumer, TypeValidationContext validationContext, String consumerProducerPath) {
-        validationContext.visitPropertyProblem(problem ->
+        validationContext.visitPropertyError(problem ->
             problem.id(TextUtil.screamingSnakeToKebabCase(IMPLICIT_DEPENDENCY), "Property has implicit dependency", GradleCoreProblemGroup.validation().property()) // TODO (donat) missing test coverage
                 .contextualLabel("Gradle detected a problem with the following location: '" + consumerProducerPath + "'")
                 .documentedAt(userManual("validation_problems", IMPLICIT_DEPENDENCY.toLowerCase(Locale.ROOT)))
-                .severity(Severity.ERROR)
                 .details(String.format("Task '%s' uses this output of task '%s' without declaring an explicit or implicit dependency. "
                         + "This can lead to incorrect results being produced, depending on what order the tasks are executed",
                     consumer,

--- a/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
@@ -21,7 +21,6 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.ProblemSpec;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GeneralDataSpec;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblemSpec;
@@ -183,7 +182,6 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
 
     private static void configureProblem(ProblemSpec spec, String message, String requestedPath) {
         spec.contextualLabel(message);
-        spec.severity(Severity.ERROR);
         ((InternalProblemSpec) spec).additionalDataInternal(GeneralDataSpec.class, data -> data.put("requestedPath", Objects.requireNonNull(requestedPath)));
     }
 

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
@@ -35,7 +35,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.Problems;
-import org.gradle.api.problems.Severity;
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
 import org.gradle.api.problems.internal.InternalProblems;
 import org.gradle.configuration.ImportsReader;
@@ -222,7 +221,6 @@ public abstract class DefaultScriptCompilationHandler implements ScriptCompilati
         throw ((InternalProblems) getProblemsService()).getInternalReporter().throwing(new ScriptCompilationException(message, e, source, lineNumber), problemId, builder -> builder
             .contextualLabel(message)
             .lineInFileLocation(source.getFileName(), lineNumber)
-            .severity(Severity.ERROR)
             .withException(new ScriptCompilationException(message, e, source, lineNumber))
         );
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/InspectionSchemeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/InspectionSchemeFactoryTest.groovy
@@ -67,7 +67,8 @@ class InspectionSchemeFactoryTest extends Specification {
         metadata.visitValidationFailures(null, validationContext)
 
         then:
-        validationContext.problems.isEmpty()
+        validationContext.warnings.isEmpty()
+        validationContext.errors.isEmpty()
 
         when:
         def properties = metadata.propertiesMetadata.groupBy { it.propertyName }
@@ -93,7 +94,8 @@ class InspectionSchemeFactoryTest extends Specification {
         metadata.visitValidationFailures(null, validationContext)
 
         then:
-        validationContext.problems.isEmpty()
+        validationContext.warnings.isEmpty()
+        validationContext.errors.isEmpty()
 
         when:
         def properties = metadata.propertiesMetadata.groupBy { it.propertyName }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblem.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblem.java
@@ -16,8 +16,6 @@
 package org.gradle.integtests.fixtures.validation;
 
 
-import org.gradle.api.problems.Severity;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -34,5 +32,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
 public @interface ValidationProblem {
-    Severity value() default Severity.WARNING;
+    boolean fatal() default false;
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblemPropertyAnnotationHandler.java
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblemPropertyAnnotationHandler.java
@@ -16,14 +16,15 @@
 package org.gradle.integtests.fixtures.validation;
 
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.Action;
 import org.gradle.api.problems.ProblemGroup;
-import org.gradle.api.problems.Severity;
 import org.gradle.internal.deprecation.Documentation;
 import org.gradle.internal.properties.PropertyValue;
 import org.gradle.internal.properties.PropertyVisitor;
 import org.gradle.internal.properties.annotations.AbstractPropertyAnnotationHandler;
 import org.gradle.internal.properties.annotations.PropertyMetadata;
 import org.gradle.internal.reflect.annotations.AnnotationCategory;
+import org.gradle.internal.reflect.validation.TypeAwareProblemBuilder;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 
 class ValidationProblemPropertyAnnotationHandler extends AbstractPropertyAnnotationHandler {
@@ -42,20 +43,34 @@ class ValidationProblemPropertyAnnotationHandler extends AbstractPropertyAnnotat
 
     @Override
     public void validatePropertyMetadata(PropertyMetadata propertyMetadata, TypeValidationContext validationContext) {
-        validationContext.visitPropertyProblem(problem ->
-            problem
-                .forProperty(propertyMetadata.getPropertyName())
-                .id("test-problem", "test problem", ProblemGroup.create("root", "root"))
-                .documentedAt(Documentation.userManual("id", "section"))
-                .severity(annotationValue(propertyMetadata))
-                .details("this is a test")
-        );
+        String propertyName = propertyMetadata.getPropertyName();
+        if (annotationValue(propertyMetadata)) {
+            validationContext.visitPropertyError(new ProblemBuilder(propertyName));
+        } else {
+            validationContext.visitPropertyWarning(new ProblemBuilder(propertyName));
+        }
     }
 
-    private Severity annotationValue(PropertyMetadata propertyMetadata) {
+    private boolean annotationValue(PropertyMetadata propertyMetadata) {
         return propertyMetadata.getAnnotationForCategory(AnnotationCategory.TYPE)
             .map(ValidationProblem.class::cast)
-            .map(ValidationProblem::value)
-            .orElse(Severity.WARNING);
+            .map(ValidationProblem::fatal)
+            .orElse(false);
+    }
+
+    private static class ProblemBuilder implements Action<TypeAwareProblemBuilder> {
+        private final String propertyName;
+
+        public ProblemBuilder(String propertyName) {
+            this.propertyName = propertyName;
+        }
+
+        @Override
+        public void execute(TypeAwareProblemBuilder problem) {
+            TypeAwareProblemBuilder builder = problem.forProperty(propertyName);
+            builder.id("test-problem", "test problem", ProblemGroup.create("root", "root"))
+                .documentedAt(Documentation.userManual("id", "section"))
+                .details("this is a test");
+        }
     }
 }

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.smoketests
 
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 
-import static org.gradle.api.problems.Severity.ERROR
-
 class NodePluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements ValidationMessageChecker {
     @Override
     Map<String, Versions> getPluginsToValidate() {
@@ -38,9 +36,9 @@ class NodePluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements 
             if (testedPluginId == 'com.moowork.node') {
                 onPlugin('com.moowork.node') {
                     failsWith([
-                            (missingAnnotationMessage { type('com.moowork.gradle.node.npm.NpmSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
-                            (methodShouldNotBeAnnotatedMessage {type('com.moowork.gradle.node.npm.NpmSetupTask').kind('setter').method('setArgs').annotation('Internal').includeLink()}): ERROR,
-                            (missingAnnotationMessage { type('com.moowork.gradle.node.yarn.YarnSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
+                        (missingAnnotationMessage { type('com.moowork.gradle.node.npm.NpmSetupTask').property('args').missingInputOrOutput().includeLink() }): "error",
+                        (methodShouldNotBeAnnotatedMessage {type('com.moowork.gradle.node.npm.NpmSetupTask').kind('setter').method('setArgs').annotation('Internal').includeLink()}): "error",
+                        (missingAnnotationMessage { type('com.moowork.gradle.node.yarn.YarnSetupTask').property('args').missingInputOrOutput().includeLink() }): "error",
                     ])
                 }
             } else {

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithPluginValidation.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithPluginValidation.groovy
@@ -17,7 +17,6 @@
 package org.gradle.smoketests
 
 import groovy.transform.SelfType
-import org.gradle.api.problems.Severity
 import org.gradle.plugin.devel.tasks.TaskValidationReportFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.TaskOutcome
@@ -139,7 +138,7 @@ trait WithPluginValidation {
         private final String pluginId
         private final File reportFile
 
-        private Map<String, Severity> messages = [:]
+        private Map<String, String> messages = [:]
 
         boolean skipped
         boolean tested
@@ -177,7 +176,7 @@ trait WithPluginValidation {
             messages = [:]
         }
 
-        void failsWith(Map<String, Severity> messages) {
+        void failsWith(Map<String, String> messages) {
             this.messages = messages
         }
     }


### PR DESCRIPTION
### Context

Severity is determined by reporting context, not problem spec Previously, problem reporters would set severity explicitly via `ProblemSpec.severity()`. This put the burden on every call site to get severity right, and made it easy for the severity to diverge from whether the build actually failed.

The new model: severity is determined by how and where a problem is reported. If reporting causes the build to fail, the infrastructure sets `ERROR` internally via `throwing()`. Otherwise the problem is treated as a warning. `ProblemSpec.severity()` now does nothing and is deprecated.

The change also adds `InternalProblemReporter.reportError()` and `InternalProblemBuilder.internalSeverity()` as temporary escape hatches for call sites where replacing exception throwing would require reworking build failure rendering and complex test fixtures. These are to be removed in a follow-up change.

Fixes https://github.com/gradle/gradle/issues/36515

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things