### PR TITLE
Update Kotlin embedded compiler docs to include ARM64 architecture

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
@@ -29,7 +29,7 @@ TIP: If you are interested in migrating an existing Gradle build to the Kotlin D
 [[kotdsl:prerequisites]]
 == Prerequisites
 
-* The embedded Kotlin compiler works on Linux, macOS, Windows, Cygwin, FreeBSD, and Solaris on x86-64 architectures.
+* The embedded Kotlin compiler works on Linux, macOS, Windows, Cygwin, FreeBSD, and Solaris on x86-64 and ARM64 architectures.
 * Familiarity with Kotlin syntax and basic language features is recommended.
 Refer to the link:{kotlin-reference}[Kotlin documentation] and link:https://kotlinlang.org/docs/tutorials/koans.html[Kotlin Koans] to learn the basics.
 * Using the <<plugins_intermediate.adoc#sec:plugins_block,`plugins {}`>> block to declare Gradle plugins is highly recommended as it significantly improves the editing experience.


### PR DESCRIPTION
The embedded Kotlin compiler now supports ARM64 (aarch64) architectures in addition to x86-64, on Linux, macOS, and Windows.

This updates the documentation which previously only mentioned x86-64 architectures.

Fixes #37017