### PR TITLE
Let ModelRuleSourceDetector be lenient to linkage errors to propagate failures to plugin application time

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/inspect/ModelRuleSourceDetector.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/inspect/ModelRuleSourceDetector.java
@@ -31,6 +31,9 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.model.RuleSource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.concurrent.ThreadSafe;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
@@ -44,56 +47,47 @@ import java.util.concurrent.ExecutionException;
 @ServiceScope(Scope.Global.class)
 public class ModelRuleSourceDetector {
 
-    private static final Comparator<Class<?>> COMPARE_BY_CLASS_NAME = new Comparator<Class<?>>() {
-        @Override
-        public int compare(Class<?> left, Class<?> right) {
-            return left.getName().compareTo(right.getName());
-        }
-    };
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModelRuleSourceDetector.class);
+
+    private static final Comparator<Class<?>> COMPARE_BY_CLASS_NAME = Comparator.comparing(Class::getName);
 
     final LoadingCache<Class<?>, Collection<Reference<Class<? extends RuleSource>>>> cache = CacheBuilder.newBuilder()
-            .weakKeys()
-            .build(new CacheLoader<Class<?>, Collection<Reference<Class<? extends RuleSource>>>>() {
-                @Override
-                public Collection<Reference<Class<? extends RuleSource>>> load(@SuppressWarnings("NullableProblems") Class<?> container) throws Exception {
-                    if (isRuleSource(container)) {
-                        Class<? extends RuleSource> castClass = Cast.uncheckedCast(container);
-                        return ImmutableSet.<Reference<Class<? extends RuleSource>>>of(new WeakReference<Class<? extends RuleSource>>(castClass));
-                    }
+        .weakKeys()
+        .build(new CacheLoader<Class<?>, Collection<Reference<Class<? extends RuleSource>>>>() {
+            @Override
+            public Collection<Reference<Class<? extends RuleSource>>> load(@SuppressWarnings("NullableProblems") Class<?> container) {
+                if (isRuleSource(container)) {
+                    Class<? extends RuleSource> castClass = Cast.uncheckedCast(container);
+                    return ImmutableSet.of(new WeakReference<>(castClass));
+                }
 
-                    Class<?>[] declaredClasses = container.getDeclaredClasses();
+                Class<?>[] declaredClasses = declaredClassesOf(container);
+                if (declaredClasses.length == 0) {
+                    return Collections.emptySet();
+                }
 
-                    if (declaredClasses.length == 0) {
-                        return Collections.emptySet();
-                    } else {
-                        Class<?>[] sortedDeclaredClasses = new Class<?>[declaredClasses.length];
-                        System.arraycopy(declaredClasses, 0, sortedDeclaredClasses, 0, declaredClasses.length);
-                        Arrays.sort(sortedDeclaredClasses, COMPARE_BY_CLASS_NAME);
+                Class<?>[] sortedDeclaredClasses = new Class<?>[declaredClasses.length];
+                System.arraycopy(declaredClasses, 0, sortedDeclaredClasses, 0, declaredClasses.length);
+                Arrays.sort(sortedDeclaredClasses, COMPARE_BY_CLASS_NAME);
 
-                        ImmutableList.Builder<Reference<Class<? extends RuleSource>>> found = ImmutableList.builder();
-                        for (Class<?> declaredClass : sortedDeclaredClasses) {
-                            if (isRuleSource(declaredClass)) {
-                                Class<? extends RuleSource> castClass = Cast.uncheckedCast(declaredClass);
-                                found.add(new WeakReference<Class<? extends RuleSource>>(castClass));
-                            }
-                        }
-
-                        return found.build();
+                ImmutableList.Builder<Reference<Class<? extends RuleSource>>> found = ImmutableList.builder();
+                for (Class<?> declaredClass : sortedDeclaredClasses) {
+                    if (isRuleSource(declaredClass)) {
+                        Class<? extends RuleSource> castClass = Cast.uncheckedCast(declaredClass);
+                        found.add(new WeakReference<>(castClass));
                     }
                 }
-            });
+
+                return found.build();
+            }
+        });
 
     // TODO return a richer data structure that provides meta data about how the source was found, for use is diagnostics
     public Iterable<Class<? extends RuleSource>> getDeclaredSources(Class<?> container) {
         try {
             return FluentIterable.from(cache.get(container))
-                    .transform(new Function<Reference<Class<? extends RuleSource>>, Class<? extends RuleSource>>() {
-                        @Override
-                        public Class<? extends RuleSource> apply(Reference<Class<? extends RuleSource>> input) {
-                            return input.get();
-                        }
-                    })
-                    .filter(Predicates.notNull());
+                .transform((Function<Reference<Class<? extends RuleSource>>, Class<? extends RuleSource>>) Reference::get)
+                .filter(Predicates.notNull());
         } catch (ExecutionException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
@@ -103,7 +97,21 @@ public class ModelRuleSourceDetector {
         return !Iterables.isEmpty(getDeclaredSources(container));
     }
 
-    private boolean isRuleSource(Class<?> clazz) {
-        return RuleSource.class.isAssignableFrom(clazz);
+    private static boolean isRuleSource(Class<?> clazz) {
+        try {
+            return RuleSource.class.isAssignableFrom(clazz);
+        } catch (LinkageError e) {
+            LOGGER.debug("Could not inspect class {}, skipping rule source detection", clazz.getName(), e);
+            return false;
+        }
+    }
+
+    private static Class<?>[] declaredClassesOf(Class<?> clazz) {
+        try {
+            return clazz.getDeclaredClasses();
+        } catch (LinkageError e) {
+            LOGGER.debug("Could not load declared classes of {}, skipping rule source detection", clazz.getName(), e);
+            return new Class<?>[0];
+        }
     }
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/model/internal/inspect/ModelRuleSourceDetectorTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/model/internal/inspect/ModelRuleSourceDetectorTest.groovy
@@ -16,9 +16,12 @@
 
 package org.gradle.model.internal.inspect
 
+import com.google.common.io.Files
+import org.codehaus.groovy.control.CompilerConfiguration
 import org.gradle.model.RuleSource
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import spock.lang.Specification
+import spock.lang.TempDir
 
 class ModelRuleSourceDetectorTest extends Specification {
 
@@ -90,15 +93,44 @@ class ModelRuleSourceDetectorTest extends Specification {
 
         where:
         impl << [
-                "class SomeThing {}",
-                "class SomeThing extends ${RuleSource.name} {}",
-                "class SomeThing { static class Inner extends ${RuleSource.name} { } }",
+            "class SomeThing {}",
+            "class SomeThing extends ${RuleSource.name} {}",
+            "class SomeThing { static class Inner extends ${RuleSource.name} { } }",
         ]
     }
 
     def "detected sources are returned ordered by class name"() {
         expect:
         detector.getDeclaredSources(SourcesNotDeclaredAlphabetically).toList() == [SourcesNotDeclaredAlphabetically.A, SourcesNotDeclaredAlphabetically.B]
+    }
+
+    @TempDir
+    File tempDir
+
+    def "lenient to class loading errors"() {
+        given: "base class and an outer class with an inner that extends it"
+        def compileDir = new File(tempDir, "compile").tap { it.mkdirs() }
+        def compileLoader = new GroovyClassLoader(
+            getClass().classLoader,
+            new CompilerConfiguration().tap { it.targetDirectory = compileDir }
+        )
+        compileLoader.parseClass("class MissingBase {}")
+        compileLoader.parseClass("class Outer { static class BrokenInner extends MissingBase {} }")
+
+        and: "copy Outer class files, skip MissingBase, and classload"
+        def isolatedDir = new File(tempDir, "isolated").tap { it.mkdirs() }
+        compileDir.eachFileRecurse { file ->
+            if (file.name.startsWith("Outer") && file.name.endsWith(".class")) {
+                Files.copy(file, new File(isolatedDir, file.name))
+            }
+        }
+        def brokenOuterClass = new URLClassLoader(
+            [isolatedDir.toURI().toURL()] as URL[],
+            getClass().classLoader
+        ).loadClass("Outer")
+
+        expect: "detector handles this gracefully"
+        detector.getDeclaredSources(brokenOuterClass).toList() == []
     }
 
     private void addClass(GroovyClassLoader cl, String impl) {

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PluginClassLoadingIntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PluginClassLoadingIntegrationTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.devel.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class PluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
+
+    def "plugin can be applied when its jar contains classes referencing missing classes"() {
+        given:
+        pluginJarWithMissingClasses("""System.out.println("It works!");""")
+
+        when:
+        succeeds("help")
+
+        then:
+        outputContains("It works!")
+    }
+
+    def "reports NoClassDefFoundError from plugin apply when using missing class"() {
+        given:
+        pluginJarWithMissingClasses("new BrokenInner();")
+
+        when:
+        executer.withArgument("--stacktrace")
+        fails("help")
+
+        then:
+        failure.assertHasDescription("A problem occurred evaluating root project")
+        failure.assertHasErrorOutput("Caused by: java.lang.NoClassDefFoundError: example/Base")
+        failure.assertHasErrorOutput("at example.MyPlugin.apply(MyPlugin.java:")
+    }
+
+    private String pluginJarWithMissingClasses(String applyCode) {
+        // a plugin jar with a broken inner class
+        file("plugin-build/settings.gradle") << "include 'base', 'plugin'"
+        file("plugin-build/base/build.gradle") << """
+            plugins { id 'java' }
+        """
+        file("plugin-build/base/src/main/java/example/Base.java") << """
+            package example;
+            public class Base {}
+        """
+        file("plugin-build/plugin/build.gradle") << """
+            plugins { id 'java' }
+            dependencies {
+                compileOnly gradleApi()
+                compileOnly project(':base')
+            }
+        """
+        file("plugin-build/plugin/src/main/java/example/MyPlugin.java") << """
+            package example;
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            public class MyPlugin implements Plugin<Project> {
+                public void apply(Project project) {
+                    $applyCode
+                }
+                public static class BrokenInner extends Base {}
+            }
+        """
+        executer.inDirectory(file("plugin-build")).withTasks("jar").run()
+
+        // plugin jar on the buildscript classpath without base library
+        buildFile << """
+            buildscript {
+                dependencies {
+                    classpath files("plugin-build/plugin/build/libs/plugin.jar")
+                }
+            }
+            apply plugin: example.MyPlugin
+        """
+    }
+}


### PR DESCRIPTION
When a plugin jar contains classes with unresolvable dependencies (e.g. a `compileOnly` dependency missing at runtime), `ModelRuleSourceDetector` crashes the build with a raw `NoClassDefFoundError` during rule source scanning. This can happen before Gradle even attempts to apply the plugin, producing a confusing error with no indication of what went wrong even if the offending class is not used by the plugin.

With this PR:
* If a broken class is a sibling of the applied plugin, the build succeeds
* If the plugin itself uses the missing class, the build fails at plugin application time with a clear `NoClassDefFoundError` pointing at the plugin's `apply()` method, instead of a cryptic error from the scanning layer

----

* Fixes https://github.com/gradle/gradle/issues/36946


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
