### PR TITLE
addAllLater inherits frozen entries from FreezableAttributeContainer

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -250,7 +250,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         this.domainObjectContext = domainObjectContext;
 
         this.displayName = Describables.memoize(new ConfigurationDescription(identityPath));
-        this.configurationAttributes = new FreezableAttributeContainer(configurationServices.getAttributesFactory().mutable(), this.displayName);
+        this.configurationAttributes = configurationServices.getAttributesFactory().freezable(configurationServices.getAttributesFactory().mutable(), this.displayName);
 
         this.resolutionAccess = new ConfigurationResolutionAccess();
         this.resolvableDependencies = configurationServices.getObjectFactory().newInstance(ConfigurationResolvableDependencies.class, this);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -65,7 +65,7 @@ public abstract class DefaultVariant implements ConfigurationVariantInternal {
         this.artifactNotationParser = artifactNotationParser;
 
         this.displayName = Describables.of(parentDisplayName, "variant", name);
-        this.attributes = new FreezableAttributeContainer(attributesFactory.mutable(parentAttributes), displayName);
+        this.attributes = attributesFactory.freezable(attributesFactory.mutable(parentAttributes), displayName);
         this.artifacts = new DefaultPublishArtifactSet(displayName, domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class), fileCollectionFactory, taskDependencyFactory);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/AttributesFactory.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.attributes;
 
+import org.gradle.api.Describable;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.service.scopes.Scope;
@@ -35,6 +36,11 @@ public interface AttributesFactory {
      * Returns an empty mutable attribute container with the given fallback.
      */
     AttributeContainerInternal mutable(AttributeContainerInternal fallback);
+
+    /**
+     * Create a {@link FreezableAttributeContainer} from the given {@link AttributeContainerInternal}.
+     */
+    FreezableAttributeContainer freezable(AttributeContainerInternal container, Describable owner);
 
     /**
      * Returns a new attribute container which attaches a primary container and a fallback container. Changes

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesFactory.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.attributes;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Describable;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.provider.PropertyFactory;
@@ -64,6 +65,11 @@ public final class DefaultAttributesFactory implements AttributesFactory {
     @Override
     public AttributeContainerInternal mutable(AttributeContainerInternal fallback) {
         return join(fallback, mutable());
+    }
+
+    @Override
+    public FreezableAttributeContainer freezable(AttributeContainerInternal fallback, Describable owner) {
+        return new FreezableAttributeContainer(fallback, owner, propertyFactory);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/FreezableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/FreezableAttributeContainer.java
@@ -19,6 +19,8 @@ import org.gradle.api.Describable;
 import org.gradle.api.Named;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.provider.PropertyFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
@@ -30,12 +32,15 @@ import java.util.Set;
  */
 public final class FreezableAttributeContainer extends AbstractAttributeContainer {
 
+    private final Property<AttributeContainerInternal> delegate;
     private final Describable owner;
 
-    private AttributeContainerInternal delegate;
-
-    public FreezableAttributeContainer(AttributeContainerInternal delegate, Describable owner) {
-        this.delegate = delegate;
+    public FreezableAttributeContainer(
+        AttributeContainerInternal delegate,
+        Describable owner,
+        PropertyFactory propertyFactory
+    ) {
+        this.delegate = propertyFactory.property(AttributeContainerInternal.class).value(delegate);
         this.owner = owner;
     }
 
@@ -43,47 +48,47 @@ public final class FreezableAttributeContainer extends AbstractAttributeContaine
      * Prevent further mutations to this attribute container.
      */
     public void freeze() {
-        this.delegate = delegate.asImmutable();
+        this.delegate.set(delegate.get().asImmutable());
     }
 
     @Override
     public String toString() {
-        return delegate.toString();
+        return delegate.get().toString();
     }
 
     @Override
     public ImmutableAttributes asImmutable() {
-        return delegate.asImmutable();
+        return delegate.get().asImmutable();
     }
 
     @Override
     public Map<Attribute<?>, ?> asMap() {
-        return delegate.asMap();
+        return delegate.get().asMap();
     }
 
     @Override
     public Set<Attribute<?>> keySet() {
-        return delegate.keySet();
+        return delegate.get().keySet();
     }
 
     @Override
     public <T> AttributeContainer attribute(Attribute<T> key, T value) {
         assertMutable();
-        delegate.attribute(key, value);
+        delegate.get().attribute(key, value);
         return this;
     }
 
     @Override
     public <T> AttributeContainer attributeProvider(Attribute<T> key, Provider<? extends T> provider) {
         assertMutable();
-        delegate.attributeProvider(key, provider);
+        delegate.get().attributeProvider(key, provider);
         return this;
     }
 
     @Override
     public AttributeContainer addAllLater(AttributeContainer other) {
         assertMutable();
-        delegate.addAllLater(other);
+        delegate.get().addAllLater(other);
         return this;
     }
 
@@ -93,33 +98,33 @@ public final class FreezableAttributeContainer extends AbstractAttributeContaine
         if (!isValidAttributeRequest(key)) {
             return null;
         }
-        return delegate.getAttribute(key);
+        return delegate.get().getAttribute(key);
     }
 
     @Override
     public Provider<Map<Attribute<?>, AttributeEntry<?>>> getEntriesProvider() {
-        return delegate.getEntriesProvider();
+        return delegate.flatMap(AttributeContainerInternal::getEntriesProvider);
     }
 
     @Override
     public boolean isEmpty() {
-        return delegate.isEmpty();
+        return delegate.get().isEmpty();
     }
 
     @Override
     public boolean contains(Attribute<?> key) {
-        return delegate.contains(key);
+        return delegate.get().contains(key);
     }
 
     private void assertMutable() {
-        if (delegate instanceof ImmutableAttributes) {
+        if (delegate.get() instanceof ImmutableAttributes) {
             throw new IllegalStateException(String.format("Cannot change attributes of %s after it has been locked for mutation", owner.getDisplayName()));
         }
     }
 
     @Override
     public <T extends Named> T named(Class<T> type, String name) {
-        return delegate.named(type, name);
+        return delegate.get().named(type, name);
     }
 
     @Override
@@ -129,13 +134,13 @@ public final class FreezableAttributeContainer extends AbstractAttributeContaine
         }
 
         FreezableAttributeContainer that = (FreezableAttributeContainer) o;
-        return owner.equals(that.owner) && delegate.equals(that.delegate);
+        return owner.equals(that.owner) && delegate.get().equals(that.delegate.get());
     }
 
     @Override
     public int hashCode() {
         int result = owner.hashCode();
-        result = 31 * result + delegate.hashCode();
+        result = 31 * result + delegate.get().hashCode();
         return result;
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/FreezableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/FreezableAttributeContainerTest.groovy
@@ -17,17 +17,25 @@
 package org.gradle.api.internal.attributes
 
 import org.gradle.api.Describable
+import org.gradle.api.Named
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.util.AttributeTestUtil
+import spock.lang.Issue
+
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Unit tests for the {@link FreezableAttributeContainer} class.
  */
 final class FreezableAttributeContainerTest extends BaseAttributeContainerTest {
+
+    def factory = AttributeTestUtil.attributesFactory()
+
     @Override
     protected FreezableAttributeContainer createContainer(Map<Attribute<?>, ?> attributes = [:], Map<Attribute<?>, ?> moreAttributes = [:]) {
-        def mutableContainer = AttributeTestUtil.attributesFactory().mutable()
-        FreezableAttributeContainer container = new FreezableAttributeContainer(mutableContainer, { "owner" } as Describable);
+        def mutableContainer = factory.mutable()
+        FreezableAttributeContainer container = factory.freezable(mutableContainer, { "owner" } as Describable)
         attributes.forEach { key, value ->
             container.attribute(key, value)
         }
@@ -50,4 +58,45 @@ final class FreezableAttributeContainerTest extends BaseAttributeContainerTest {
             assert it[Attribute.of("test", String)] == "b" // Second attribute to be added remains
         }
     }
+
+    interface Foo extends Named {}
+
+    @Issue("https://github.com/gradle/gradle/issues/37256")
+    def "can addAllLater with freezable container as a source, when frozen container uses itself to instantiate named object"() {
+        def attr = Attribute.of("test", Foo)
+
+        def freezable = createContainer()
+        freezable.attributeProvider(attr, new DefaultProvider<Foo>(() -> {
+            freezable.named(Foo, "value")
+        }))
+
+        def other = factory.mutable()
+        other.addAllLater(freezable)
+        freezable.freeze()
+
+        expect:
+        other.getAttribute(attr).name == "value"
+    }
+
+    def "attributes sourced from addAllLater are frozen"() {
+        def attr = Attribute.of("test", String)
+        def freezable = createContainer()
+
+        AtomicReference<String> value = new AtomicReference<>("initial")
+        freezable.attributeProvider(attr, new DefaultProvider<String>(() -> value.get()))
+
+        def other = factory.mutable()
+        other.addAllLater(freezable)
+
+        expect:
+        other.getAttribute(attr) == "initial"
+
+        when:
+        freezable.freeze()
+        value.set("final")
+
+        then:
+        other.getAttribute(attr) == "initial"
+    }
+
 }


### PR DESCRIPTION
Previously, addAllLater would retain a mutable reference to the entries of a FreezableAttributeContainer. This caused some providers which relied on the named method of a FreezableAttributeContainer to throw exceptions after the container was frozen but consumers of the frozen container's entries still held a mutable reference to its unfrozen entries.

Fixes: https://github.com/gradle/gradle/issues/37256

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
