### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ systemProp.develocity.internal.testdistribution.logWorkerReadyMessage=true
 # Default ReadyForNightly performance baseline
 defaultRfnPerformanceBaselines=9.5.0-commit-56c1a30b990
 # Default ReadyForRelease performance baseline
-defaultRfrPerformanceBaselines=9.5.0-commit-2ad550a892e
+defaultRfrPerformanceBaselines=9.5.0-commit-56c1a30b990
 systemProp.dependency.analysis.test.analysis=false
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
It is required for RfR as well. This is the same issue with Android perf
 tests and the new DV plugin / Gradle 9.5.0 interaction.