### PR TITLE
Fix incremental compilation deleting class on source file rename

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractSourceIncrementalCompilationIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractSourceIncrementalCompilationIntegrationTest.groovy
@@ -17,10 +17,10 @@
 package org.gradle.java.compile.incremental
 
 import org.gradle.integtests.fixtures.CompiledLanguage
-import org.gradle.util.internal.ToBeImplemented
+
 import spock.lang.Issue
 
-import static org.junit.Assume.assumeTrue
+
 
 abstract class AbstractSourceIncrementalCompilationIntegrationTest extends AbstractJavaGroovyIncrementalCompilationSupport {
 
@@ -520,13 +520,7 @@ sourceSets {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/28916")
-    @ToBeImplemented
     def "recompiles classes on file typo rename"() {
-        // TODO: Delete this assume statement when fixed,
-        //  since for Java Cli mode it already works accidentally,
-        //  since Cli mode doesn't track file to class mapping accurately
-        assumeTrue(this.class != JavaSourceCliIncrementalCompilationIntegrationTest.class)
-
         def fileWithTypo = file("src/main/${languageName}/ATypo.${languageName}") << """
             class A {}
         """
@@ -540,10 +534,6 @@ sourceSets {
         run language.compileTaskName
 
         then:
-        // TODO: Fix this, A should be recompiled, e.g.:
-        //   outputs.hasFiles(file("A.class"))
-        //   outputs.recompiled("A")
-        outputs.deletedClasses("A")
-        outputs.noneRecompiled()
+        outputs.recompiledClasses("A")
     }
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.tasks.compile.incremental.compilerapi.deps.Genera
 import org.gradle.api.internal.tasks.compile.incremental.transaction.CompileTransaction;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.file.Deleter;
+import org.gradle.work.ChangeType;
 import org.gradle.work.FileChange;
 
 import java.io.File;
@@ -116,6 +117,11 @@ abstract class AbstractRecompilationSpecProvider implements RecompilationSpecPro
                 spec.setFullRebuildCause(rebuildClauseForChangedNonSourceFile(fileChange));
             }
             sourceFileChangeProcessor.processChange(changedClasses, spec);
+            // For added/modified files, record the source path directly so it's included
+            // in compilation even if the class-to-source reverse mapping is stale (see #28916).
+            if (fileChange.getChangeType() != ChangeType.REMOVED && !changedClasses.isEmpty()) {
+                spec.addSourcePath(relativeFilePath);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #28916

- When a source file is renamed (e.g., `ATypo.groovy` → `A.groovy`) but contains the same class, incremental compilation **deleted** `A.class` instead of recompiling it
- Root cause: the cached class-to-source reverse mapping returned the stale path (`ATypo.groovy`), so `narrowDownSourcesToCompile` filtered it out and no source was compiled — but the class file was still deleted
- Fix: record source paths for added/modified files directly during `processSourceChanges`, so the new file is always included in compilation regardless of stale cache state
- Updated the `@ToBeImplemented` test from PR #30232 to assert correct behavior

## Test plan

- [x] `JavaSourceIncrementalCompilationIntegrationTest.recompiles classes on file typo rename` — passes
- [x] `GroovySourceIncrementalCompilationIntegrationTest.recompiles classes on file typo rename` — passes
- [x] `JavaSourceCliIncrementalCompilationIntegrationTest.recompiles classes on file typo rename` — passes
- [x] All 288 `*IncrementalCompilationIntegrationTest` tests pass with 0 failures/regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)