### PR TITLE
Update task annotation validation errors

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/MissingPropertyAnnotationHandler.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/properties/annotations/MissingPropertyAnnotationHandler.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.properties.annotations;
 
 import org.gradle.api.problems.internal.GradleCoreProblemGroup;
+import org.gradle.api.tasks.Optional;
 import org.gradle.internal.reflect.annotations.PropertyAnnotationMetadata;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.util.internal.TextUtil;
@@ -40,9 +41,17 @@ public interface MissingPropertyAnnotationHandler {
             .forProperty(annotationMetadata.getPropertyName())
             .id(TextUtil.screamingSnakeToKebabCase(missingAnnotation), "Missing annotation", GradleCoreProblemGroup.validation().property())
             .contextualLabel("is missing " + displayName)
-            .documentedAt(userManual("validation_problems", missingAnnotation.toLowerCase(Locale.ROOT)))
-            .details("A property without annotation isn't considered during up-to-date checking")
-            .solution("Add " + displayName)
-            .solution("Mark it as @Internal");
+            .documentedAt(userManual("validation_problems", missingAnnotation.toLowerCase(Locale.ROOT)));
+        if (annotationMetadata.isAnnotationPresent(Optional.class)) {
+            problem
+                .details("@Optional is a modifier annotation and has no effect without an input or output annotation")
+                .solution("Add an input or output annotation")
+                .solution("Replace @Optional with @Internal for ignoring this property");
+        } else {
+            problem
+                .details("Properties must be annotated so that Gradle knows how to handle them during up-to-date checking")
+                .solution("Add " + displayName)
+                .solution("Mark it as @Internal");
+        }
     });
 }

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
@@ -877,6 +877,13 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
         }
 
         private void handleAnnotatedIgnoredMethod(Class<? extends Annotation> ignoredMethodAnnotation) {
+            List<Class<? extends Annotation>> disallowedAnnotations = ignoreAnnotationDisallowedModifiers(declaredAnnotations.values())
+                .<Class<? extends Annotation>>map(Annotation::annotationType)
+                .filter(annotationType -> !annotationType.equals(ignoredMethodAnnotation))
+                .collect(Collectors.toList());
+            // FQN required: java.util.Optional is also imported
+            boolean onlyOptional = disallowedAnnotations.size() == 1
+                && disallowedAnnotations.get(0).equals(org.gradle.api.tasks.Optional.class);
             visitPropertyError(problem ->
                 problem
                     .forProperty(propertyName)
@@ -885,15 +892,17 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
                         String.format(
                             "annotated with @%s should not be also annotated with %s",
                             ignoredMethodAnnotation.getSimpleName(),
-                            simpleAnnotationNames(ignoreAnnotationDisallowedModifiers(declaredAnnotations.values())
-                                .<Class<? extends Annotation>>map(Annotation::annotationType)
-                                .filter(annotationType -> !annotationType.equals(ignoredMethodAnnotation)))
+                            simpleAnnotationNames(disallowedAnnotations.stream())
                         )
                     )
                     .documentedAt(userManual("validation_problems", IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED.toLowerCase(Locale.ROOT)))
-                    .details("A property is ignored but also has input annotations")
-                    .solution("Remove the input annotations")
-                    .solution("Remove the @" + ignoredMethodAnnotation.getSimpleName() + " annotation")
+                    .details(onlyOptional
+                        ? "@" + ignoredMethodAnnotation.getSimpleName() + " properties are excluded from up-to-date checks; @Optional is redundant and not allowed here"
+                        : "A property is ignored but also has input annotations")
+                    .solution(onlyOptional
+                        ? "Remove the @Optional annotation"
+                        : "Remove the input annotations")
+                    .solution("Remove the @" + ignoredMethodAnnotation.getSimpleName() + " annotation" + (onlyOptional ? " and add an input or output annotation" : ""))
             );
         }
 

--- a/platforms/core-configuration/model-reflect/src/test/groovy/org/gradle/internal/reflect/validation/ValidationMessageCheckerTest.groovy
+++ b/platforms/core-configuration/model-reflect/src/test/groovy/org/gradle/internal/reflect/validation/ValidationMessageCheckerTest.groovy
@@ -275,7 +275,7 @@ ${validationMessage("annotation_invalid_in_context")}
         outputEquals """
 Type 'Task' property 'prop' is missing something cool.
 
-Reason: A property without annotation isn't considered during up-to-date checking.
+Reason: Properties must be annotated so that Gradle knows how to handle them during up-to-date checking.
 
 Possible solutions:
   1. Add something cool.

--- a/platforms/core-configuration/model-reflect/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/platforms/core-configuration/model-reflect/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -160,6 +160,20 @@ trait ValidationMessageChecker {
             .solution("Remove the @${config.ignoringAnnotation} annotation")
     }
 
+    String ignoredAnnotatedWithOptionalMessage(@DelegatesTo(value = IgnoredAnnotationPropertyMessage, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        ignoredAnnotatedWithOptionalConfig(spec).render()
+    }
+
+    IgnoredAnnotationPropertyMessage ignoredAnnotatedWithOptionalConfig(@DelegatesTo(value = IgnoredAnnotationPropertyMessage, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        def config = display(IgnoredAnnotationPropertyMessage, 'ignored_property_must_not_be_annotated', spec)
+        // @Optional-specific variant: hardcodes "@Optional" rather than using config.alsoAnnotatedWith,
+        // since the message and reason are tailored to the @Optional case
+        config.description("annotated with @${config.ignoringAnnotation} should not be also annotated with @Optional")
+            .reason("@${config.ignoringAnnotation} properties are excluded from up-to-date checks; @Optional is redundant and not allowed here")
+            .solution("Remove the @Optional annotation")
+            .solution("Remove the @${config.ignoringAnnotation} annotation and add an input or output annotation")
+    }
+
     String conflictingAnnotationsMessage(@DelegatesTo(value = ConflictingAnnotation, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
         ConflictingAnnotation config = conflictingAnnotationsConfig(spec)
         config.render()
@@ -212,9 +226,21 @@ trait ValidationMessageChecker {
     MissingAnnotation missingAnnotationConfig(@DelegatesTo(value = MissingAnnotation, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
         def config = display(MissingAnnotation, 'missing_annotation', spec)
         config.description("is missing ${config.kind}")
-            .reason("A property without annotation isn't considered during up-to-date checking")
+            .reason("Properties must be annotated so that Gradle knows how to handle them during up-to-date checking")
             .solution("Add ${config.kind}")
             .solution("Mark it as @Internal")
+    }
+
+    String missingAnnotationWithOptionalMessage(@DelegatesTo(value = MissingAnnotation, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        missingAnnotationWithOptionalConfig(spec).render()
+    }
+
+    MissingAnnotation missingAnnotationWithOptionalConfig(@DelegatesTo(value = MissingAnnotation, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        def config = display(MissingAnnotation, 'missing_annotation', spec)
+        config.description("is missing ${config.kind}")
+            .reason("@Optional is a modifier annotation and has no effect without an input or output annotation")
+            .solution("Add an input or output annotation")
+            .solution("Replace @Optional with @Internal for ignoring this property")
     }
 
     String ignoredAnnotationOnField(@DelegatesTo(value = IgnoredAnnotationOnField, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {

--- a/platforms/documentation/docs/src/docs/userguide/reference/task-development/implementing_custom_tasks.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/task-development/implementing_custom_tasks.adoc
@@ -1236,7 +1236,7 @@ When a task with an @OutputFile-annotated property is executed, Gradle will chec
 |Property is a file or directory and changes to it can be queried with `@InputChanges.getFileChanges()`
 
 |`@Optional`
-|Property is any type, its value does not have to be specified and validation checks are disabled
+|Modifier annotation — marks an input or output property as not required. Must be combined with an input or output annotation such as `@InputFile` or `@OutputDirectory`.
 
 |`@PathSensitive`
 |Property is one or more files and only the given part of the file path is important

--- a/platforms/documentation/docs/src/docs/userguide/unused/validation_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/unused/validation_problems.adoc
@@ -191,7 +191,7 @@ To fix this, either make the method public, or annotate another new or existing 
 [[ignored_property_must_not_be_annotated]]
 == Annotations on ignored properties
 
-This error indicates that you have a property which is annotated with an annotation which tells Gradle to ignore it (for example link:{javadocPath}/org/gradle/api/model/ReplacedBy.html[`@ReplacedBy`]) but is also annotated with an input annotation (for example link:{javadocPath}/org/gradle/api/tasks/InputFile.html[`@InputFile`]).
+This error indicates that you have a property which is annotated with an annotation which tells Gradle to ignore it (for example link:{javadocPath}/org/gradle/api/model/ReplacedBy.html[`@ReplacedBy`] or link:{javadocPath}/org/gradle/api/tasks/Internal.html[`@Internal`]) but is also annotated with an input annotation (for example link:{javadocPath}/org/gradle/api/tasks/InputFile.html[`@InputFile`]).
 
 This is an error because Gradle cannot determine if the property should actually be used for up-to-date checking, that is to say if it's actually an input or not.
 
@@ -199,6 +199,10 @@ To fix this, you must either:
 
 - remove the input annotations from the property, or
 - remove the ignoring annotation from the property.
+
+A specific case of this error is combining `@Internal` and link:{javadocPath}/org/gradle/api/tasks/Optional.html[`@Optional`].
+`@Internal` properties are already excluded from all validation, so adding `@Optional` is redundant and not allowed.
+To fix this, remove the `@Optional` annotation.
 
 [[conflicting_annotations]]
 == Conflicting annotations
@@ -227,6 +231,11 @@ As a consequence, up-to-date checking and caching won't work.
 To fix this problem, you need to annotate the property with the appropriate annotation, for example `@InputDirectory` for a property representing an input directory, or `@OutputDirectory` for a property representing an output directory.
 
 Alternatively, if the property is internal, that is to say that it shouldn't participate in up-to-date checking (it's not an input or an output), then you need to annotate it with link:{javadocPath}/org/gradle/api/tasks/Internal.html[@Internal].
+
+NOTE: A common mistake is to annotate a property with only link:{javadocPath}/org/gradle/api/tasks/Optional.html[`@Optional`].
+`@Optional` is a modifier annotation that must be combined with an input or output annotation such as `@InputFile`.
+Using `@Optional` alone does not suppress validation — it results in this error.
+If your intent is to exclude the property from up-to-date checking entirely, use `@Internal` instead.
 
 [[incompatible_annotations]]
 == Annotation is incompatible with the property type

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
@@ -136,7 +136,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
             verifyAll(receivedProblem(0)) {
                 fqid == 'validation:property-validation:missing-annotation'
                 contextualLabel == 'Type \'MyTask\' property \'badTime\' is missing an input or output annotation'
-                details == 'A property without annotation isn\'t considered during up-to-date checking'
+                details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
                 solutions == [
                     'Add an input or output annotation',
                     'Mark it as @Internal',
@@ -149,7 +149,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
             verifyAll(receivedProblem(1)) {
                 fqid == 'validation:property-validation:missing-annotation'
                 contextualLabel == 'Type \'MyTask\' property \'oldThing\' is missing an input or output annotation'
-                details == 'A property without annotation isn\'t considered during up-to-date checking'
+                details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
                 solutions == [
                     'Add an input or output annotation',
                     'Mark it as @Internal',
@@ -162,7 +162,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
             verifyAll(receivedProblem(2)) {
                 fqid == 'validation:property-validation:missing-annotation'
                 contextualLabel == 'Type \'MyTask\' property \'options.badNested\' is missing an input or output annotation'
-                details == 'A property without annotation isn\'t considered during up-to-date checking'
+                details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
                 solutions == [
                     'Add an input or output annotation',
                     'Mark it as @Internal',
@@ -176,7 +176,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
             verifyAll(receivedProblem(3)) {
                 fqid == 'validation:property-validation:missing-annotation'
                 contextualLabel == 'Type \'MyTask\' property \'ter\' is missing an input or output annotation'
-                details == 'A property without annotation isn\'t considered during up-to-date checking'
+                details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
                 solutions == [
                     'Add an input or output annotation',
                     'Mark it as @Internal',
@@ -404,7 +404,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
             verifyAll(receivedProblem(0)) {
                 fqid == 'validation:property-validation:missing-annotation'
                 contextualLabel == 'Type \'MyTask\' property \'badTime\' is missing an input or output annotation'
-                details == 'A property without annotation isn\'t considered during up-to-date checking'
+                details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
                 solutions == [
                     'Add an input or output annotation',
                     'Mark it as @Internal',
@@ -417,7 +417,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
             verifyAll(receivedProblem(1)) {
                 fqid == 'validation:property-validation:missing-annotation'
                 contextualLabel == 'Type \'MyTask\' property \'options.badNested\' is missing an input or output annotation'
-                details == 'A property without annotation isn\'t considered during up-to-date checking'
+                details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
                 solutions == [
                     'Add an input or output annotation',
                     'Mark it as @Internal',
@@ -793,7 +793,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
             verifyAll(receivedProblem(0)) {
                 fqid == 'validation:property-validation:missing-annotation'
                 contextualLabel == 'Type \'MyTask\' property \'readWrite\' is missing an input or output annotation'
-                details == 'A property without annotation isn\'t considered during up-to-date checking'
+                details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
                 solutions == [
                     'Add an input or output annotation',
                     'Mark it as @Internal',
@@ -896,6 +896,87 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
                 additionalData.asMap == [
                     'typeName' : 'MyTask',
                     'propertyName' : 'oldProperty',
+                ]
+            }
+        }
+    }
+
+    def "reports @Optional used without an input or output annotation"() {
+        javaTaskSource << """
+            import org.gradle.api.*;
+            import org.gradle.api.tasks.*;
+            import org.gradle.work.*;
+
+            @DisableCachingByDefault(because = "test task")
+            public class MyTask extends DefaultTask {
+                @Optional
+                public String getBadProperty() {
+                    return null;
+                }
+
+                @TaskAction public void execute() {}
+            }
+        """
+
+        expect:
+        assertValidationFailsWith([
+            error(missingAnnotationWithOptionalConfig { type('MyTask').property('badProperty').missingInputOrOutput() }, 'validation_problems', 'missing_annotation'),
+        ])
+
+        and:
+        if (isProblemsApiCheckEnabled()) {
+            verifyAll(receivedProblem(0)) {
+                fqid == 'validation:property-validation:missing-annotation'
+                contextualLabel == "Type 'MyTask' property 'badProperty' is missing an input or output annotation"
+                details == "@Optional is a modifier annotation and has no effect without an input or output annotation"
+                solutions == [
+                    'Add an input or output annotation',
+                    'Replace @Optional with @Internal for ignoring this property',
+                ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask',
+                    'propertyName' : 'badProperty',
+                ]
+            }
+        }
+    }
+
+    def "reports @Optional combined with @Internal"() {
+        javaTaskSource << """
+            import org.gradle.api.*;
+            import org.gradle.api.tasks.*;
+            import org.gradle.work.*;
+
+            @DisableCachingByDefault(because = "test task")
+            public class MyTask extends DefaultTask {
+                @Internal
+                @Optional
+                public String getBadProperty() {
+                    return null;
+                }
+
+                @TaskAction public void execute() {}
+            }
+        """
+
+        expect:
+        assertValidationFailsWith([
+            error(ignoredAnnotatedWithOptionalConfig { type('MyTask').property('badProperty').ignoring('Internal') }, 'validation_problems', 'ignored_property_must_not_be_annotated')
+        ])
+
+        and:
+        if (isProblemsApiCheckEnabled()) {
+            verifyAll(receivedProblem(0)) {
+                fqid == 'validation:property-validation:ignored-property-must-not-be-annotated'
+                contextualLabel == "Type 'MyTask' property 'badProperty' annotated with @Internal should not be also annotated with @Optional"
+                details == '@Internal properties are excluded from up-to-date checks; @Optional is redundant and not allowed here'
+                solutions == [
+                    'Remove the @Optional annotation',
+                    'Remove the @Internal annotation and add an input or output annotation',
+                ]
+                additionalData.asMap == [
+                    'typeName' : 'MyTask',
+                    'propertyName' : 'badProperty',
                 ]
             }
         }

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart1IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart1IntegrationTest.groovy
@@ -53,7 +53,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTask\' property \'tree.nonAnnotated\' is missing an input or output annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input or output annotation',
                 'Mark it as @Internal',
@@ -458,7 +458,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(1)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTransformAction\' property \'badTime\' is missing an input annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input annotation',
                 'Mark it as @Internal',
@@ -471,7 +471,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(2)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTransformAction\' property \'oldThing\' is missing an input annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input annotation',
                 'Mark it as @Internal',
@@ -573,7 +573,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(2)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTransformParameters\' property \'badTime\' is missing an input annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input annotation',
                 'Mark it as @Internal',
@@ -586,7 +586,7 @@ class ValidatePluginsPart1IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(3)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTransformParameters\' property \'oldThing\' is missing an input annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input annotation',
                 'Mark it as @Internal',

--- a/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
+++ b/platforms/extensibility/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsPart2IntegrationTest.groovy
@@ -442,7 +442,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(0)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTask\' property \'doubleIterableOptions.*.*.notAnnotated\' is missing an input or output annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input or output annotation',
                 'Mark it as @Internal',
@@ -456,7 +456,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(1)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTask\' property \'iterableMappedOptions.*.<key>.*.notAnnotated\' is missing an input or output annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input or output annotation',
                 'Mark it as @Internal',
@@ -470,7 +470,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(2)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTask\' property \'iterableOptions.*.notAnnotated\' is missing an input or output annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input or output annotation',
                 'Mark it as @Internal',
@@ -484,7 +484,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(3)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTask\' property \'mappedOptions.<key>.notAnnotated\' is missing an input or output annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input or output annotation',
                 'Mark it as @Internal',
@@ -498,7 +498,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(4)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTask\' property \'namedIterable.<name>.notAnnotated\' is missing an input or output annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input or output annotation',
                 'Mark it as @Internal',
@@ -512,7 +512,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(5)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTask\' property \'options.notAnnotated\' is missing an input or output annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input or output annotation',
                 'Mark it as @Internal',
@@ -526,7 +526,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(6)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTask\' property \'optionsList.*.notAnnotated\' is missing an input or output annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input or output annotation',
                 'Mark it as @Internal',
@@ -540,7 +540,7 @@ class ValidatePluginsPart2IntegrationTest extends AbstractIntegrationSpec implem
         verifyAll(receivedProblem(7)) {
             fqid == 'validation:property-validation:missing-annotation'
             contextualLabel == 'Type \'MyTask\' property \'providedOptions.notAnnotated\' is missing an input or output annotation'
-            details == 'A property without annotation isn\'t considered during up-to-date checking'
+            details == 'Properties must be annotated so that Gradle knows how to handle them during up-to-date checking'
             solutions == [
                 'Add an input or output annotation',
                 'Mark it as @Internal',

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/Internal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/Internal.java
@@ -29,6 +29,9 @@ import java.lang.annotation.Target;
  *
  * <p>This will cause the task <em>not</em> to be considered out-of-date when the property has changed.</p>
  *
+ * <p>Properties annotated with {@code @Internal} are not subject to presence validation and are treated as
+ * inherently optional. There is no need, and it is an error, to also annotate them with {@link org.gradle.api.tasks.Optional}.</p>
+ *
  * @since 3.0
  */
 @Documented

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/Optional.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/Optional.java
@@ -28,19 +28,23 @@ import java.lang.annotation.Target;
  * <p>This annotation should be attached to the getter method in Java or the property in Groovy.
  * Annotations on setters or just the field in Java are ignored.</p>
  *
- * <p>This annotation can be used with the following annotations:</p>
+ * <p><strong>This annotation must be combined with one of the following annotations.</strong>
  *
- * <ul> <li>{@link org.gradle.api.tasks.Input}</li>
- *
+ * <ul>
+ * <li>{@link org.gradle.api.tasks.Input}</li>
  * <li>{@link org.gradle.api.tasks.InputFile}</li>
- *
  * <li>{@link org.gradle.api.tasks.InputDirectory}</li>
- *
  * <li>{@link org.gradle.api.tasks.InputFiles}</li>
- *
+ * <li>{@link org.gradle.api.tasks.Nested}</li>
  * <li>{@link org.gradle.api.tasks.OutputFile}</li>
- *
- * <li>{@link org.gradle.api.tasks.OutputDirectory}</li> </ul>
+ * <li>{@link org.gradle.api.tasks.OutputFiles}</li>
+ * <li>{@link org.gradle.api.tasks.OutputDirectory}</li>
+ * <li>{@link org.gradle.api.tasks.OutputDirectories}</li>
+ * <li>{@link org.gradle.api.services.ServiceReference}</li>
+ * </ul>
+ * <p>
+ * Using {@code @Optional} alone, without an accompanying input or output annotation, is a validation error.
+ * If you want to express that the property should not be an input or output, you should mark it with {@link Internal} which implies optionality.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
These changes make it more explicit whenever the error is linked to having `@Optional` present, either with `@Internal` or alone.

This mainly introduces the following new error messages:
* First:
```
Execution failed for task ':validatePlugins' (registered by plugin 'org.gradle.java-gradle-plugin').
> Plugin validation failed with 1 problem:
    - Error: Type 'MyTask' property 'badProperty' is missing an input or output annotation.
      
      Reason: @Optional is a modifier annotation and has no effect without an input or output annotation.
      
      Possible solutions:
        1. Add an input or output annotation.
        2. Replace @Optional with @Internal for ignoring this property.
      
      For more information, please refer to https://docs.gradle.org/current/userguide/validation_problems.html#missing_annotation in the Gradle documentation.
  For more on how to annotate task properties, please refer to https://docs.gradle.org/current/userguide/incremental_build.html#sec:task_input_output_annotations in the Gradle documentation.
```
* Second:
```
Execution failed for task ':validatePlugins' (registered by plugin 'org.gradle.java-gradle-plugin').
> Plugin validation failed with 1 problem:
    - Error: Type 'MyTask' property 'badProperty' annotated with @Internal should not be also annotated with @Optional.
      
      Reason: @Internal properties are excluded from up-to-date checks; @Optional is redundant and not allowed here.
      
      Possible solutions:
        1. Remove the @Optional annotation.
        2. Remove the @Internal annotation and add an input or output annotation.
      
      For more information, please refer to https://docs.gradle.org/current/userguide/validation_problems.html#ignored_property_must_not_be_annotated in the Gradle documentation.
  For more on how to annotate task properties, please refer to https://docs.gradle.org/current/userguide/incremental_build.html#sec:task_input_output_annotations in the Gradle documentation.
```

It also has minor modifications on the previous message:

* Now:
```
Execution failed for task ':validatePlugins' (registered by plugin 'org.gradle.java-gradle-plugin').
> Plugin validation failed with 1 problem:
    - Error: Type 'MyTask' property 'tree.nonAnnotated' is missing an input or output annotation.
      
      Reason: Properties must be annotated so that Gradle knows how to handle them during up-to-date checking.
      
      Possible solutions:
        1. Add an input or output annotation.
        2. Mark it as @Internal.
      
      For more information, please refer to https://docs.gradle.org/current/userguide/validation_problems.html#missing_annotation in the Gradle documentation.
  For more on how to annotate task properties, please refer to https://docs.gradle.org/current/userguide/incremental_build.html#sec:task_input_output_annotations in the Gradle documentation.
```
* Before:
```
Execution failed for task ':validatePlugins' (registered by plugin 'org.gradle.java-gradle-plugin').
> Plugin validation failed with 1 problem:
    - Error: Type 'MyTask' property 'tree.nonAnnotated' is missing an input or output annotation.
      
      Reason: A property without annotation isn't considered during up-to-date checking.
      
      Possible solutions:
        1. Add an input or output annotation.
        2. Mark it as @Internal.
      
      For more information, please refer to https://docs.gradle.org/current/userguide/validation_problems.html#missing_annotation in the Gradle documentation.
  For more on how to annotate task properties, please refer to https://docs.gradle.org/current/userguide/incremental_build.html#sec:task_input_output_annotations in the Gradle documentation.
```