### PR TITLE
Add regression test for #6854 (Scala analysis FAILED dependencies)

### DIFF
--- a/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
+++ b/platforms/jvm/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
@@ -272,6 +272,42 @@ class ScalaPluginIntegrationTest extends MultiVersionIntegrationSpec {
         Integer.valueOf(matcher.group(1)) >= 16
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/6854")
+    def "dependencies task does not show FAILED entries for incremental Scala analysis configurations"() {
+        given:
+        createDirs("producer", "consumer")
+        settingsFile << """
+            include 'producer', 'consumer'
+        """
+        buildFile << """
+            allprojects {
+                ${mavenCentralRepository()}
+            }
+            project(":producer") {
+                apply plugin: 'scala'
+                dependencies {
+                    implementation "${scalaDependency(version.toString())}"
+                }
+            }
+            project(":consumer") {
+                apply plugin: 'scala'
+                dependencies {
+                    implementation "${scalaDependency(version.toString())}"
+                    implementation project(":producer")
+                    implementation "org.apache.commons:commons-lang3:3.12.0"
+                }
+            }
+        """
+        file("producer/src/main/scala/Producer.scala") << 'class Producer'
+        file("consumer/src/main/scala/Consumer.scala") << 'class Consumer extends Producer'
+
+        when:
+        succeeds(":consumer:dependencies")
+
+        then:
+        !output.contains("FAILED")
+    }
+
     @Requires(IntegTestPreconditions.NotNoDaemonExecutor)
     def "Scala compiler daemon respects keepalive option"() {
         buildFile << """


### PR DESCRIPTION
## Summary
- Adds a regression test verifying that `gradle dependencies` does not show FAILED entries for incremental Scala analysis configurations
- Tests a multi-project Scala build with both project dependencies and external dependencies (commons-lang3)
- Confirms #6854 is fixed: the refactoring from per-source-set `incrementalScalaAnalysisFor*` configurations to lenient artifact views filtered to project components resolved the issue

## Test plan
- [x] Test passes on both Scala 2.13.16 and 3.7.1 via `integMultiVersionTest`

Closes #6854

🤖 Generated with [Claude Code](https://claude.com/claude-code)