### PR TITLE
Add POM files as a consumable variant

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/artifact_views.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/artifact_views.adoc
@@ -82,6 +82,22 @@ include::{snippetsPath}/reference/dependency-management/controlling-dependency-r
 When this API is used, the attributes used for variant reselection are specified solely by the `ArtifactView.getAttributes()` method.
 The graph resolution attributes specified on the configuration are completely ignored during variant reselection.
 
+=== Resolving POM files
+
+Similarly, you can use variant reselection to resolve the POM metadata files for all dependencies.
+For external Maven modules without Gradle Module Metadata, Gradle derives a `metadata` variant containing the module's POM file and its parent POM chain.
+
+NOTE: This example uses incubating APIs.
+
+====
+include::sample[dir="snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/kotlin",files="build.gradle.kts[tags=pom-variant-reselection]"]
+include::sample[dir="snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/groovy",files="build.gradle[tags=pom-variant-reselection]"]
+====
+
+The resolved files include both direct and transitive dependency POM files, as well as any parent POMs referenced in the POM hierarchy.
+
+NOTE: The POM variant is only available for Maven modules that do not publish Gradle Module Metadata.
+
 [[sec:performing_lenient_artifact_selection]]
 == 2. Performing lenient artifact selection and resolution
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/artifact_views.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/artifact_views.adoc
@@ -85,7 +85,8 @@ The graph resolution attributes specified on the configuration are completely ig
 === Resolving POM files
 
 Similarly, you can use variant reselection to resolve the POM metadata files for all dependencies.
-For external Maven modules without Gradle Module Metadata, Gradle derives a `metadata` variant containing the module's POM file and its parent POM chain.
+Gradle provides a `metadata` variant for all Maven dependencies, containing the module's POM file and its parent POM chain.
+For project dependencies that apply the `maven-publish` plugin, the generated POM is also available.
 
 NOTE: This example uses incubating APIs.
 
@@ -95,8 +96,6 @@ include::sample[dir="snippets/reference/dependency-management/controlling-depend
 ====
 
 The resolved files include both direct and transitive dependency POM files, as well as any parent POMs referenced in the POM hierarchy.
-
-NOTE: The POM variant is only available for Maven modules that do not publish Gradle Module Metadata.
 
 [[sec:performing_lenient_artifact_selection]]
 == 2. Performing lenient artifact selection and resolution

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/artifact_views.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/artifact_views.adoc
@@ -97,6 +97,19 @@ include::sample[dir="snippets/reference/dependency-management/controlling-depend
 
 The resolved files include both direct and transitive dependency POM files, as well as any parent POMs referenced in the POM hierarchy.
 
+==== Extracting license information from POMs
+
+The resolved POM files can be parsed to extract metadata such as license information.
+Since some modules declare licenses in a parent POM rather than the module's own POM, you may need to walk the parent chain.
+All parent POMs are included in the resolved file set, so the chain can be resolved locally without additional network requests:
+
+NOTE: This example uses incubating APIs.
+
+====
+include::sample[dir="snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/kotlin",files="build.gradle.kts[tags=pom-license-extraction]"]
+include::sample[dir="snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/groovy",files="build.gradle[tags=pom-license-extraction]"]
+====
+
 [[sec:performing_lenient_artifact_selection]]
 == 2. Performing lenient artifact selection and resolution
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/variant_attributes.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/variant_attributes.adoc
@@ -103,16 +103,16 @@ They are *not publishable*, and will produce an error if added to a component wh
 [[sec:metadata-category]]
 When the `Category` attribute is present with the incubating value `org.gradle.category=metadata` on a variant, that variant contains build metadata artifacts such as POM files.
 
-For external Maven modules without Gradle Module Metadata, Gradle automatically derives a `metadata` variant that exposes the module's POM file and its parent POM chain.
-You can resolve these POM files using an link:artifact_views.adoc[artifact view] with variant reselection:
+For Maven modules, Gradle automatically provides a `metadata` variant that exposes the module's POM file and its parent POM chain.
+This works for all Maven dependencies — whether they publish Gradle Module Metadata or not.
+For project dependencies that apply the `maven-publish` plugin, the generated POM is also available as a `metadata` variant.
+
+You can resolve POM files for all dependencies using an link:artifact_views.adoc[artifact view] with variant reselection:
 
 ====
 include::sample[dir="snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/kotlin",files="build.gradle.kts[tags=pom-variant-reselection]"]
 include::sample[dir="snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/groovy",files="build.gradle[tags=pom-variant-reselection]"]
 ====
-
-NOTE: The POM variant is only available for Maven modules that do not publish Gradle Module Metadata.
-When Gradle Module Metadata is present, only the variants explicitly declared in that metadata are used.
 
 [%header%autowidth,compact]
 |===

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/variant_attributes.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/controlling-dependency-resolution/variant_attributes.adoc
@@ -87,6 +87,11 @@ As a plugin author, these attributes, and the way they are defined, can serve as
 | Indicates what kind of verification task produced this output.
 | `VerificationType` values built from constants defined in link:{javadocPath}/org/gradle/api/attributes/VerificationType.html[VerificationType]
 | No default, no compatibility
+
+| link:{javadocPath}/org/gradle/api/attributes/MetadataFormat.html#METADATA_FORMAT_ATTRIBUTE[`org.gradle.metadata.format`]
+| Indicates the format of a `org.gradle.category=metadata` variant
+| `MetadataFormat` values built from constants defined in link:{javadocPath}/org/gradle/api/attributes/MetadataFormat.html[MetadataFormat]
+| No default, no compatibility
 |===
 
 [[sec:verification-category]]
@@ -94,6 +99,20 @@ When the `Category` attribute is present with the incubating value `org.gradle.c
 
 These variants are meant to contain only the results of running verification tasks, such as test results or code coverage reports.
 They are *not publishable*, and will produce an error if added to a component which is published.
+
+[[sec:metadata-category]]
+When the `Category` attribute is present with the incubating value `org.gradle.category=metadata` on a variant, that variant contains build metadata artifacts such as POM files.
+
+For external Maven modules without Gradle Module Metadata, Gradle automatically derives a `metadata` variant that exposes the module's POM file and its parent POM chain.
+You can resolve these POM files using an link:artifact_views.adoc[artifact view] with variant reselection:
+
+====
+include::sample[dir="snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/kotlin",files="build.gradle.kts[tags=pom-variant-reselection]"]
+include::sample[dir="snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/groovy",files="build.gradle[tags=pom-variant-reselection]"]
+====
+
+NOTE: The POM variant is only available for Maven modules that do not publish Gradle Module Metadata.
+When Gradle Module Metadata is present, only the variants explicitly declared in that metadata are used.
 
 [%header%autowidth,compact]
 |===

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/groovy/build.gradle
@@ -93,3 +93,15 @@ tasks.register("resolveSources", ResolveFiles) {
     }.files)
 }
 // end::variant-reselection[]
+
+// tag::pom-variant-reselection[]
+tasks.register("resolvePoms", ResolveFiles) {
+    files.from(configurations.runtimeClasspath.incoming.artifactView {
+        withVariantReselection()
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.METADATA))
+            attribute(MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objects.named(MetadataFormat, MetadataFormat.MAVEN))
+        }
+    }.files)
+}
+// end::pom-variant-reselection[]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/groovy/build.gradle
@@ -105,3 +105,43 @@ tasks.register("resolvePoms", ResolveFiles) {
     }.files)
 }
 // end::pom-variant-reselection[]
+
+// tag::pom-license-extraction[]
+tasks.register("extractLicenses") {
+    def pomArtifacts = configurations.runtimeClasspath.incoming.artifactView {
+        withVariantReselection()
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.METADATA))
+            attribute(MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objects.named(MetadataFormat, MetadataFormat.MAVEN))
+        }
+    }.artifacts
+    doLast {
+        // Index all resolved POMs by filename for parent chain lookups
+        def pomsByFilename = pomArtifacts.collectEntries { [it.file.name, it.file] }
+
+        pomArtifacts.each { artifact ->
+            def componentId = artifact.id.componentIdentifier
+            def pom = new XmlSlurper().parse(artifact.file)
+
+            // Look for <licenses> in this POM, then walk parent chain if not found
+            def licenses = pom.licenses.license
+            if (licenses.size() == 0) {
+                def current = pom
+                while (licenses.size() == 0 && current.parent.size() > 0) {
+                    def parentArtifactId = current.parent.artifactId.text()
+                    def parentVersion = current.parent.version.text()
+                    def parentFile = pomsByFilename["${parentArtifactId}-${parentVersion}.pom"]
+                    if (!parentFile) break
+                    current = new XmlSlurper().parse(parentFile)
+                    licenses = current.licenses.license
+                }
+            }
+
+            if (licenses.size() > 0) {
+                def names = licenses.collect { it.name.text() }
+                println "${componentId}: ${names.join(', ')}"
+            }
+        }
+    }
+}
+// end::pom-license-extraction[]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/kotlin/build.gradle.kts
@@ -85,3 +85,17 @@ tasks.register<ResolveFiles>("resolveSources") {
     })
 }
 // end::variant-reselection[]
+
+// tag::pom-variant-reselection[]
+tasks.register<ResolveFiles>("resolvePoms") {
+    files.from(configurations.runtimeClasspath.map {
+        it.incoming.artifactView {
+            withVariantReselection()
+            attributes {
+                attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.METADATA))
+                attribute(MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objects.named(MetadataFormat.MAVEN))
+            }
+        }.files
+    })
+}
+// end::pom-variant-reselection[]

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/controlling-dependency-resolution/performingResolution-artifactResolution/kotlin/build.gradle.kts
@@ -99,3 +99,53 @@ tasks.register<ResolveFiles>("resolvePoms") {
     })
 }
 // end::pom-variant-reselection[]
+
+// tag::pom-license-extraction[]
+tasks.register("extractLicenses") {
+    val pomArtifacts = configurations.runtimeClasspath.map {
+        it.incoming.artifactView {
+            withVariantReselection()
+            attributes {
+                attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.METADATA))
+                attribute(MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objects.named(MetadataFormat.MAVEN))
+            }
+        }.artifacts
+    }
+    doLast {
+        // Index all resolved POMs by filename for parent chain lookups
+        val pomsByFilename = pomArtifacts.get().associate { it.file.name to it.file }
+        val dbf = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+        val db = dbf.newDocumentBuilder()
+
+        pomArtifacts.get().forEach { artifact ->
+            val doc = db.parse(artifact.file)
+            val componentId = artifact.id.componentIdentifier
+
+            // Look for <licenses> in this POM, then walk parent chain if not found
+            var licenses = doc.getElementsByTagName("license")
+            if (licenses.length == 0) {
+                // Walk parent chain: parse <parent> to find the parent POM file
+                var current = doc
+                while (licenses.length == 0) {
+                    val parents = current.getElementsByTagName("parent")
+                    if (parents.length == 0) break
+                    val parent = parents.item(0) as org.w3c.dom.Element
+                    val parentArtifactId = parent.getElementsByTagName("artifactId").item(0)?.textContent ?: break
+                    val parentVersion = parent.getElementsByTagName("version").item(0)?.textContent ?: break
+                    val parentFile = pomsByFilename["$parentArtifactId-$parentVersion.pom"] ?: break
+                    current = db.parse(parentFile)
+                    licenses = current.getElementsByTagName("license")
+                }
+            }
+
+            if (licenses.length > 0) {
+                val names = (0 until licenses.length).mapNotNull { i ->
+                    (licenses.item(i) as org.w3c.dom.Element)
+                        .getElementsByTagName("name").item(0)?.textContent
+                }
+                println("$componentId: ${names.joinToString(", ")}")
+            }
+        }
+    }
+}
+// end::pom-license-extraction[]

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
@@ -17,204 +17,142 @@
 package org.gradle.integtests.resolve.derived
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.test.fixtures.server.http.MavenHttpModule
 
+/**
+ * Tests for POM variant resolution via ArtifactView with variant reselection.
+ */
 class PomVariantResolutionIntegrationTest extends AbstractHttpDependencyResolutionTest {
-    MavenHttpModule direct
-    MavenHttpModule transitive
 
-    def setup() {
-        buildFile << """
-            plugins {
-                id 'java'
-            }
+    def "can resolve POM files for direct and transitive dependencies"() {
+        def transitive = mavenHttpRepo.module("test", "transitive", "1.0").publish()
+        def direct = mavenHttpRepo.module("test", "direct", "1.0").dependsOn(transitive).publish()
 
-            repositories {
-                maven { url = '$mavenHttpRepo.uri' }
-            }
+        buildFile.text = pomResolveBuildFile()
 
-            dependencies {
-                implementation 'test:direct:1.0'
-            }
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+        succeeds('resolvePom')
+        outputContains('direct-1.0.pom')
+        outputContains('transitive-1.0.pom')
+    }
 
-            abstract class Resolve extends DefaultTask {
-                @InputFiles
-                abstract ConfigurableFileCollection getArtifacts()
+    def "POM variant includes parent POMs"() {
+        def parent = mavenHttpRepo.module("test", "parent-a", "1.0").hasPackaging("pom").publish()
+        def transitive = mavenHttpRepo.module("test", "transitive-a", "1.0").publish()
+        def direct = mavenHttpRepo.module("test", "direct-a", "1.0").dependsOn(transitive).parent("test", "parent-a", "1.0").publish()
 
-                @Internal
-                List<String> expectedFiles = []
+        buildFile.text = pomResolveBuildFile('test:direct-a:1.0')
 
-                @TaskAction
-                void assertThat() {
-                    assert artifacts.files*.name.sort() == expectedFiles.sort()
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+        parent.pom.allowGetOrHead()
+        succeeds('resolvePom')
+        outputContains('direct-a-1.0.pom')
+        outputContains('parent-a-1.0.pom')
+        outputContains('transitive-a-1.0.pom')
+    }
+
+    def "POM variant includes grandparent POMs"() {
+        def grandparent = mavenHttpRepo.module("test", "grandparent-b", "1.0").hasPackaging("pom").publish()
+        def parent = mavenHttpRepo.module("test", "parent-b", "1.0").hasPackaging("pom").parent("test", "grandparent-b", "1.0").publish()
+        def transitive = mavenHttpRepo.module("test", "transitive-b", "1.0").publish()
+        def direct = mavenHttpRepo.module("test", "direct-b", "1.0").dependsOn(transitive).parent("test", "parent-b", "1.0").publish()
+
+        buildFile.text = pomResolveBuildFile('test:direct-b:1.0')
+
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+        parent.pom.allowGetOrHead()
+        grandparent.pom.allowGetOrHead()
+        succeeds('resolvePom')
+        outputContains('direct-b-1.0.pom')
+        outputContains('grandparent-b-1.0.pom')
+        outputContains('parent-b-1.0.pom')
+        outputContains('transitive-b-1.0.pom')
+    }
+
+    def "POM variant includes both versions when two modules share a parent at different versions"() {
+        def parentV1 = mavenHttpRepo.module("test", "parent-c", "1.0").hasPackaging("pom").publish()
+        def parentV2 = mavenHttpRepo.module("test", "parent-c", "2.0").hasPackaging("pom").publish()
+        def transitive = mavenHttpRepo.module("test", "transitive-c", "1.0").parent("test", "parent-c", "2.0").publish()
+        def direct = mavenHttpRepo.module("test", "direct-c", "1.0").dependsOn(transitive).parent("test", "parent-c", "1.0").publish()
+
+        buildFile.text = pomResolveBuildFile('test:direct-c:1.0')
+
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+        parentV1.pom.allowGetOrHead()
+        parentV2.pom.allowGetOrHead()
+        succeeds('resolvePom')
+        outputContains('direct-c-1.0.pom')
+        outputContains('parent-c-1.0.pom')
+        outputContains('parent-c-2.0.pom')
+        outputContains('transitive-c-1.0.pom')
+    }
+
+    def "POM variant is synthesized when Gradle Module Metadata is present but has no pom variant"() {
+        def transitive = mavenHttpRepo.module("test", "transitive-d", "1.0").withModuleMetadata().publish()
+        def direct = mavenHttpRepo.module("test", "direct-d", "1.0").dependsOn(transitive).withModuleMetadata().publish()
+
+        buildFile.text = pomResolveBuildFile('test:direct-d:1.0')
+
+        expect:
+        direct.pom.allowGetOrHead()
+        direct.moduleMetadata.expectGet()
+        transitive.pom.allowGetOrHead()
+        transitive.moduleMetadata.expectGet()
+        succeeds('resolvePom')
+        outputContains('direct-d-1.0.pom')
+        outputContains('transitive-d-1.0.pom')
+    }
+
+    def "POM variant is not selected during normal dependency resolution"() {
+        def transitive = mavenHttpRepo.module("test", "transitive-e", "1.0").publish()
+        def direct = mavenHttpRepo.module("test", "direct-e", "1.0").dependsOn(transitive).publish()
+
+        buildFile.text = """
+            plugins { id 'java' }
+            repositories { maven { url = '$mavenHttpRepo.uri' } }
+            dependencies { implementation 'test:direct-e:1.0' }
+            task resolveRuntime {
+                def files = configurations.runtimeClasspath.incoming.files
+                doLast {
+                    def fileNames = files*.name
+                    assert !fileNames.any { it.endsWith('.pom') }
                 }
             }
+        """
 
-            task resolvePom(type: Resolve) {
-                def artifactView = configurations.runtimeClasspath.incoming.artifactView {
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+        direct.artifact.expectGet()
+        transitive.artifact.expectGet()
+        succeeds('resolveRuntime')
+    }
+
+    private String pomResolveBuildFile(String dependency = 'test:direct:1.0') {
+        return """
+            plugins { id 'java' }
+            repositories { maven { url = '$mavenHttpRepo.uri' } }
+            dependencies { implementation '$dependency' }
+            task resolvePom {
+                def view = configurations.runtimeClasspath.incoming.artifactView {
                     withVariantReselection()
                     attributes {
                         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.METADATA))
                         attribute(MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objects.named(MetadataFormat, MetadataFormat.MAVEN))
                     }
                 }
-                artifacts.from(artifactView.files)
-            }
-
-            task resolveRuntime(type: Resolve) {
-                artifacts.from(configurations.runtimeClasspath.incoming.files)
-            }
-        """
-        transitive = mavenHttpRepo.module("test", "transitive", "1.0")
-        direct = mavenHttpRepo.module("test", "direct", "1.0")
-        direct.dependsOn(transitive)
-    }
-
-    def "can resolve POM files for direct and transitive dependencies"() {
-        transitive.publish()
-        direct.publish()
-
-        buildFile << """
-            tasks.resolvePom {
-                expectedFiles = ['direct-1.0.pom', 'transitive-1.0.pom']
+                def files = view.files
+                doLast {
+                    files.each { println it.name }
+                }
             }
         """
-        expect:
-        direct.pom.allowGetOrHead()
-        transitive.pom.allowGetOrHead()
-
-        succeeds('resolvePom')
-    }
-
-    def "POM variant includes parent POMs"() {
-        def parent = mavenHttpRepo.module("test", "parent", "1.0")
-        parent.hasPackaging("pom")
-        parent.publish()
-
-        direct.parent("test", "parent", "1.0")
-        transitive.publish()
-        direct.publish()
-
-        buildFile << """
-            tasks.resolvePom {
-                expectedFiles = ['direct-1.0.pom', 'parent-1.0.pom', 'transitive-1.0.pom']
-            }
-        """
-        expect:
-        direct.pom.allowGetOrHead()
-        transitive.pom.allowGetOrHead()
-        parent.pom.allowGetOrHead()
-
-        succeeds('resolvePom')
-    }
-
-    def "POM variant includes grandparent POMs"() {
-        def grandparent = mavenHttpRepo.module("test", "grandparent", "1.0")
-        grandparent.hasPackaging("pom")
-        grandparent.publish()
-
-        def parent = mavenHttpRepo.module("test", "parent", "1.0")
-        parent.hasPackaging("pom")
-        parent.parent("test", "grandparent", "1.0")
-        parent.publish()
-
-        direct.parent("test", "parent", "1.0")
-        transitive.publish()
-        direct.publish()
-
-        buildFile << """
-            tasks.resolvePom {
-                expectedFiles = ['direct-1.0.pom', 'grandparent-1.0.pom', 'parent-1.0.pom', 'transitive-1.0.pom']
-            }
-        """
-        expect:
-        direct.pom.allowGetOrHead()
-        transitive.pom.allowGetOrHead()
-        parent.pom.allowGetOrHead()
-        grandparent.pom.allowGetOrHead()
-
-        succeeds('resolvePom')
-    }
-
-    def "POM variant includes both versions when two modules share a parent at different versions"() {
-        def parentV1 = mavenHttpRepo.module("test", "parent", "1.0")
-        parentV1.hasPackaging("pom")
-        parentV1.publish()
-
-        def parentV2 = mavenHttpRepo.module("test", "parent", "2.0")
-        parentV2.hasPackaging("pom")
-        parentV2.publish()
-
-        direct.parent("test", "parent", "1.0")
-        transitive.parent("test", "parent", "2.0")
-        transitive.publish()
-        direct.publish()
-
-        buildFile << """
-            tasks.resolvePom {
-                expectedFiles = ['direct-1.0.pom', 'parent-1.0.pom', 'parent-2.0.pom', 'transitive-1.0.pom']
-            }
-        """
-        expect:
-        direct.pom.allowGetOrHead()
-        transitive.pom.allowGetOrHead()
-        parentV1.pom.allowGetOrHead()
-        parentV2.pom.allowGetOrHead()
-
-        succeeds('resolvePom')
-    }
-
-    def "POM variant is not available when Gradle Module Metadata is present"() {
-        transitive.withModuleMetadata()
-        transitive.publish()
-        direct.withModuleMetadata()
-        direct.publish()
-
-        buildFile << """
-            tasks.resolvePom {
-                expectedFiles = []
-            }
-        """
-        expect:
-        direct.pom.allowGetOrHead()
-        direct.moduleMetadata.expectGet()
-        transitive.pom.allowGetOrHead()
-        transitive.moduleMetadata.expectGet()
-
-        succeeds('resolvePom')
-    }
-
-    def "POM variant is not selected during normal dependency resolution"() {
-        transitive.publish()
-        direct.publish()
-
-        buildFile << """
-            tasks.resolveRuntime {
-                expectedFiles = ['direct-1.0.jar', 'transitive-1.0.jar']
-            }
-        """
-        expect:
-        direct.pom.allowGetOrHead()
-        transitive.pom.allowGetOrHead()
-        direct.artifact.expectGet()
-        transitive.artifact.expectGet()
-
-        succeeds('resolveRuntime')
-    }
-
-    def "POM file content is valid XML"() {
-        transitive.publish()
-        direct.publish()
-
-        buildFile << """
-            tasks.resolvePom {
-                expectedFiles = ['direct-1.0.pom', 'transitive-1.0.pom']
-            }
-        """
-        expect:
-        direct.pom.allowGetOrHead()
-        transitive.pom.allowGetOrHead()
-
-        succeeds('resolvePom')
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.derived
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.test.fixtures.server.http.MavenHttpModule
+
+class PomVariantResolutionIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    MavenHttpModule direct
+    MavenHttpModule transitive
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+
+            repositories {
+                maven { url = '$mavenHttpRepo.uri' }
+            }
+
+            dependencies {
+                implementation 'test:direct:1.0'
+            }
+
+            abstract class Resolve extends DefaultTask {
+                @InputFiles
+                abstract ConfigurableFileCollection getArtifacts()
+
+                @Internal
+                List<String> expectedFiles = []
+
+                @TaskAction
+                void assertThat() {
+                    assert artifacts.files*.name.sort() == expectedFiles.sort()
+                }
+            }
+
+            task resolvePom(type: Resolve) {
+                def artifactView = configurations.runtimeClasspath.incoming.artifactView {
+                    withVariantReselection()
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.METADATA))
+                        attribute(MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objects.named(MetadataFormat, MetadataFormat.MAVEN))
+                    }
+                }
+                artifacts.from(artifactView.files)
+            }
+
+            task resolveRuntime(type: Resolve) {
+                artifacts.from(configurations.runtimeClasspath.incoming.files)
+            }
+        """
+        transitive = mavenHttpRepo.module("test", "transitive", "1.0")
+        direct = mavenHttpRepo.module("test", "direct", "1.0")
+        direct.dependsOn(transitive)
+    }
+
+    def "can resolve POM files for direct and transitive dependencies"() {
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            tasks.resolvePom {
+                expectedFiles = ['direct-1.0.pom', 'transitive-1.0.pom']
+            }
+        """
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+
+        succeeds('resolvePom')
+    }
+
+    def "POM variant is not selected during normal dependency resolution"() {
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            tasks.resolveRuntime {
+                expectedFiles = ['direct-1.0.jar', 'transitive-1.0.jar']
+            }
+        """
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+        direct.artifact.expectGet()
+        transitive.artifact.expectGet()
+
+        succeeds('resolveRuntime')
+    }
+
+    def "POM file content is valid XML"() {
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            tasks.resolvePom {
+                expectedFiles = ['direct-1.0.pom', 'transitive-1.0.pom']
+            }
+        """
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+
+        succeeds('resolvePom')
+    }
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
@@ -86,6 +86,28 @@ class PomVariantResolutionIntegrationTest extends AbstractHttpDependencyResoluti
         succeeds('resolvePom')
     }
 
+    def "POM variant includes parent POMs"() {
+        def parent = mavenHttpRepo.module("test", "parent", "1.0")
+        parent.hasPackaging("pom")
+        parent.publish()
+
+        direct.parent("test", "parent", "1.0")
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            tasks.resolvePom {
+                expectedFiles = ['direct-1.0.pom', 'parent-1.0.pom', 'transitive-1.0.pom']
+            }
+        """
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+        parent.pom.allowGetOrHead()
+
+        succeeds('resolvePom')
+    }
+
     def "POM variant is not available when Gradle Module Metadata is present"() {
         transitive.withModuleMetadata()
         transitive.publish()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
@@ -108,6 +108,34 @@ class PomVariantResolutionIntegrationTest extends AbstractHttpDependencyResoluti
         succeeds('resolvePom')
     }
 
+    def "POM variant includes grandparent POMs"() {
+        def grandparent = mavenHttpRepo.module("test", "grandparent", "1.0")
+        grandparent.hasPackaging("pom")
+        grandparent.publish()
+
+        def parent = mavenHttpRepo.module("test", "parent", "1.0")
+        parent.hasPackaging("pom")
+        parent.parent("test", "grandparent", "1.0")
+        parent.publish()
+
+        direct.parent("test", "parent", "1.0")
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            tasks.resolvePom {
+                expectedFiles = ['direct-1.0.pom', 'grandparent-1.0.pom', 'parent-1.0.pom', 'transitive-1.0.pom']
+            }
+        """
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+        parent.pom.allowGetOrHead()
+        grandparent.pom.allowGetOrHead()
+
+        succeeds('resolvePom')
+    }
+
     def "POM variant is not available when Gradle Module Metadata is present"() {
         transitive.withModuleMetadata()
         transitive.publish()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
@@ -86,6 +86,26 @@ class PomVariantResolutionIntegrationTest extends AbstractHttpDependencyResoluti
         succeeds('resolvePom')
     }
 
+    def "POM variant is not available when Gradle Module Metadata is present"() {
+        transitive.withModuleMetadata()
+        transitive.publish()
+        direct.withModuleMetadata()
+        direct.publish()
+
+        buildFile << """
+            tasks.resolvePom {
+                expectedFiles = []
+            }
+        """
+        expect:
+        direct.pom.allowGetOrHead()
+        direct.moduleMetadata.expectGet()
+        transitive.pom.allowGetOrHead()
+        transitive.moduleMetadata.expectGet()
+
+        succeeds('resolvePom')
+    }
+
     def "POM variant is not selected during normal dependency resolution"() {
         transitive.publish()
         direct.publish()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/PomVariantResolutionIntegrationTest.groovy
@@ -136,6 +136,34 @@ class PomVariantResolutionIntegrationTest extends AbstractHttpDependencyResoluti
         succeeds('resolvePom')
     }
 
+    def "POM variant includes both versions when two modules share a parent at different versions"() {
+        def parentV1 = mavenHttpRepo.module("test", "parent", "1.0")
+        parentV1.hasPackaging("pom")
+        parentV1.publish()
+
+        def parentV2 = mavenHttpRepo.module("test", "parent", "2.0")
+        parentV2.hasPackaging("pom")
+        parentV2.publish()
+
+        direct.parent("test", "parent", "1.0")
+        transitive.parent("test", "parent", "2.0")
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            tasks.resolvePom {
+                expectedFiles = ['direct-1.0.pom', 'parent-1.0.pom', 'parent-2.0.pom', 'transitive-1.0.pom']
+            }
+        """
+        expect:
+        direct.pom.allowGetOrHead()
+        transitive.pom.allowGetOrHead()
+        parentV1.pom.allowGetOrHead()
+        parentV2.pom.allowGetOrHead()
+
+        succeeds('resolvePom')
+    }
+
     def "POM variant is not available when Gradle Module Metadata is present"() {
         transitive.withModuleMetadata()
         transitive.publish()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -77,6 +77,7 @@ public enum CacheLayout {
         .changedTo(105, "8.1-rc-2")
         .changedTo(106, "8.2-milestone-1")
         .changedTo(107, "8.11-rc-1")
+        .changedTo(108, "9.6-rc-1")
     ),
 
     RESOURCES(MODULES, "resources", introducedIn("1.9-rc-1")),

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -40,8 +40,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
+import com.google.common.collect.ImmutableList;
+
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -85,12 +88,14 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
         PomReader pomReader = new PomReader(resource, moduleIdentifierFactory);
         GradlePomModuleDescriptorBuilder mdBuilder = new GradlePomModuleDescriptorBuilder(pomReader, gradleVersionSelectorScheme, mavenVersionSelectorScheme);
 
-        doParsePom(parserSettings, mdBuilder, pomReader);
+        List<ModuleComponentIdentifier> parentPomChain = new ArrayList<>();
+        doParsePom(parserSettings, mdBuilder, pomReader, parentPomChain);
 
         List<MavenDependencyDescriptor> dependencies = mdBuilder.getDependencies();
         ModuleComponentIdentifier cid = mdBuilder.getComponentIdentifier();
         MutableMavenModuleResolveMetadata metadata = metadataFactory.create(cid, dependencies);
         metadata.setStatus(mdBuilder.getStatus());
+        metadata.setParentPomChain(ImmutableList.copyOf(parentPomChain));
         if (pomReader.getRelocation() != null) {
             metadata.setPackaging("pom");
             metadata.setRelocated(true);
@@ -101,7 +106,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
         return ParseResult.of(metadata, pomReader.hasGradleMetadataMarker());
     }
 
-    private void doParsePom(DescriptorParseContext parserSettings, GradlePomModuleDescriptorBuilder mdBuilder, PomReader pomReader) throws IOException, SAXException {
+    private void doParsePom(DescriptorParseContext parserSettings, GradlePomModuleDescriptorBuilder mdBuilder, PomReader pomReader, List<ModuleComponentIdentifier> parentPomChain) throws IOException, SAXException {
         pomReader.resolveGAV();
 
         String groupId = pomReader.getGroupId();
@@ -122,6 +127,9 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
                     new DefaultImmutableVersionConstraint(parentVersion));
                 PomReader parentPomReader = parsePomForSelector(parserSettings, parentId, pomReader.getAllPomProperties());
                 pomReader.setPomParent(parentPomReader);
+                // Collect parent POM identifier for the parent chain
+                parentPomChain.add(DefaultModuleComponentIdentifier.newId(
+                    DefaultModuleIdentifier.newId(parentGroupId, parentArtifactId), parentVersion));
 
                 // Current POM can derive version/artifactId from parent. Resolve GAV and substitute values
                 pomReader.resolveGAV();
@@ -226,9 +234,13 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
     }
 
     private PomReader parsePomResource(DescriptorParseContext parseContext, LocallyAvailableExternalResource localResource, Map<String, String> childProperties) throws SAXException, IOException {
+        return parsePomResource(parseContext, localResource, childProperties, new ArrayList<>());
+    }
+
+    private PomReader parsePomResource(DescriptorParseContext parseContext, LocallyAvailableExternalResource localResource, Map<String, String> childProperties, List<ModuleComponentIdentifier> parentPomChain) throws SAXException, IOException {
         PomReader pomReader = new PomReader(localResource, moduleIdentifierFactory, childProperties);
         GradlePomModuleDescriptorBuilder mdBuilder = new GradlePomModuleDescriptorBuilder(pomReader, gradleVersionSelectorScheme, mavenVersionSelectorScheme);
-        doParsePom(parseContext, mdBuilder, pomReader);
+        doParsePom(parseContext, mdBuilder, pomReader, parentPomChain);
         return pomReader;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -125,11 +125,12 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
                 ModuleComponentSelector parentId = DefaultModuleComponentSelector.newSelector(
                     DefaultModuleIdentifier.newId(parentGroupId, parentArtifactId),
                     new DefaultImmutableVersionConstraint(parentVersion));
-                PomReader parentPomReader = parsePomForSelector(parserSettings, parentId, pomReader.getAllPomProperties());
-                pomReader.setPomParent(parentPomReader);
-                // Collect parent POM identifier for the parent chain
+                // Collect parent POM identifier for the parent chain before recursing,
+                // so that grandparent POMs are also accumulated into the same list
                 parentPomChain.add(DefaultModuleComponentIdentifier.newId(
                     DefaultModuleIdentifier.newId(parentGroupId, parentArtifactId), parentVersion));
+                PomReader parentPomReader = parsePomForSelector(parserSettings, parentId, pomReader.getAllPomProperties(), parentPomChain);
+                pomReader.setPomParent(parentPomReader);
 
                 // Current POM can derive version/artifactId from parent. Resolve GAV and substitute values
                 pomReader.resolveGAV();
@@ -231,6 +232,12 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
         VersionSelector acceptor = mavenVersionSelectorScheme.parseSelector(selector.getVersion());
         LocallyAvailableExternalResource localResource = parseContext.getMetaDataArtifact(selector, acceptor, ArtifactType.MAVEN_POM);
         return parsePomResource(parseContext, localResource, childProperties);
+    }
+
+    private PomReader parsePomForSelector(DescriptorParseContext parseContext, ModuleComponentSelector selector, Map<String, String> childProperties, List<ModuleComponentIdentifier> parentPomChain) throws IOException, SAXException {
+        VersionSelector acceptor = mavenVersionSelectorScheme.parseSelector(selector.getVersion());
+        LocallyAvailableExternalResource localResource = parseContext.getMetaDataArtifact(selector, acceptor, ArtifactType.MAVEN_POM);
+        return parsePomResource(parseContext, localResource, childProperties, parentPomChain);
     }
 
     private PomReader parsePomResource(DescriptorParseContext parseContext, LocallyAvailableExternalResource localResource, Map<String, String> childProperties) throws SAXException, IOException {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenVariantAttributesFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenVariantAttributesFactory.java
@@ -20,6 +20,7 @@ import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.DocsType;
 import org.gradle.api.attributes.LibraryElements;
+import org.gradle.api.attributes.MetadataFormat;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -104,6 +105,17 @@ public class DefaultMavenVariantAttributesFactory implements MavenVariantAttribu
             result = attributesFactory.concat(result, Bundling.BUNDLING_ATTRIBUTE, objectInstantiator.named(Bundling.class, Bundling.EXTERNAL));
             result = attributesFactory.concat(result, DocsType.DOCS_TYPE_ATTRIBUTE, objectInstantiator.named(DocsType.class, DocsType.JAVADOC));
             result = attributesFactory.concat(result, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(Usage.JAVA_RUNTIME, objectInstantiator));
+            return result;
+        });
+    }
+
+    @Override
+    public ImmutableAttributes pomVariant(ImmutableAttributes original) {
+        List<Object> key = ImmutableList.of(original, Category.METADATA, MetadataFormat.MAVEN);
+        return concatCache.computeIfAbsent(key, k -> {
+            ImmutableAttributes result = original;
+            result = attributesFactory.concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(Category.METADATA, objectInstantiator));
+            result = attributesFactory.concat(result, MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objectInstantiator.named(MetadataFormat.class, MetadataFormat.MAVEN));
             return result;
         });
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenVariantAttributesFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenVariantAttributesFactory.java
@@ -39,5 +39,6 @@ public interface MavenVariantAttributesFactory {
     ImmutableAttributes platformWithUsage(ImmutableAttributes original, String usage, boolean enforced);
     ImmutableAttributes sourcesVariant(ImmutableAttributes original);
     ImmutableAttributes javadocVariant(ImmutableAttributes original);
+    ImmutableAttributes pomVariant(ImmutableAttributes original);
 
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -106,8 +106,32 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
         for (ComponentVariant variant : variants) {
             configurations.add(new LazyVariantBackedConfigurationMetadata(getId(), variant, getAttributes(), getAttributesFactory(), variantMetadataRules));
         }
+        // When explicit variants exist (e.g. from Gradle Module Metadata) but don't include
+        // a POM variant, synthesize one if the module supports it (e.g. Maven modules always have a POM).
+        if (!hasVariantNamed(variants, "pom")) {
+            Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> supplemental = maybeDeriveSupplementalVariants();
+            supplemental.ifPresent(list -> configurations.addAll(list));
+        }
         return addVariantsByRule(Optional.of(configurations.build()));
 
+    }
+
+    private static boolean hasVariantNamed(ImmutableList<? extends ComponentVariant> variants, String name) {
+        for (ComponentVariant variant : variants) {
+            if (name.equals(variant.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns supplemental variants to add when explicit variants (e.g. from GMM) are present
+     * but missing certain always-available variants. For example, Maven modules always have a POM file.
+     * By default returns empty. Subclasses can override.
+     */
+    protected Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> maybeDeriveSupplementalVariants() {
+        return Optional.empty();
     }
 
     private Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> addVariantsByRule(Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> variants) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -106,28 +106,15 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
         for (ComponentVariant variant : variants) {
             configurations.add(new LazyVariantBackedConfigurationMetadata(getId(), variant, getAttributes(), getAttributesFactory(), variantMetadataRules));
         }
-        // When explicit variants exist (e.g. from Gradle Module Metadata) but don't include
-        // a POM variant, synthesize one if the module supports it (e.g. Maven modules always have a POM).
-        if (!hasVariantNamed(variants, "pom")) {
-            Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> supplemental = maybeDeriveSupplementalVariants();
-            supplemental.ifPresent(list -> configurations.addAll(list));
-        }
+        Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> supplemental = maybeDeriveSupplementalVariants();
+        supplemental.ifPresent(list -> configurations.addAll(list));
         return addVariantsByRule(Optional.of(configurations.build()));
 
     }
 
-    private static boolean hasVariantNamed(ImmutableList<? extends ComponentVariant> variants, String name) {
-        for (ComponentVariant variant : variants) {
-            if (name.equals(variant.getName())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     /**
-     * Returns supplemental variants to add when explicit variants (e.g. from GMM) are present
-     * but missing certain always-available variants. For example, Maven modules always have a POM file.
+     * Returns supplemental variants to add alongside the explicit variants (e.g. from GMM).
+     * For example, Maven modules always have a POM file that can be exposed as a metadata variant.
      * By default returns empty. Subclasses can override.
      */
     protected Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> maybeDeriveSupplementalVariants() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
@@ -87,15 +87,33 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         return graphVariants.orElse(Collections.emptyList());
     }
 
+    @SuppressWarnings("unchecked")
     private Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> buildVariantsForGraphTraversal(List<? extends ComponentVariant> variants) {
         if (variants.isEmpty()) {
             return maybeDeriveVariants();
         }
-        ImmutableList.Builder<ModuleConfigurationMetadata> configurations = new ImmutableList.Builder<>();
+        ImmutableList.Builder<ExternalModuleVariantGraphResolveMetadata> configurations = new ImmutableList.Builder<>();
         for (ComponentVariant variant : variants) {
             configurations.add(new RealisedVariantBackedConfigurationMetadata(getId(), variant, getAttributes(), getAttributesFactory()));
         }
+        if (!hasVariantNamed(variants, "pom")) {
+            Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> supplemental = maybeDeriveSupplementalVariants();
+            supplemental.ifPresent(configurations::addAll);
+        }
         return Optional.of(configurations.build());
+    }
+
+    private static boolean hasVariantNamed(List<? extends ComponentVariant> variants, String name) {
+        for (ComponentVariant variant : variants) {
+            if (name.equals(variant.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> maybeDeriveSupplementalVariants() {
+        return Optional.empty();
     }
 
     protected static class NameOnlyVariantResolveMetadata implements VariantResolveMetadata {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
@@ -96,20 +96,9 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         for (ComponentVariant variant : variants) {
             configurations.add(new RealisedVariantBackedConfigurationMetadata(getId(), variant, getAttributes(), getAttributesFactory()));
         }
-        if (!hasVariantNamed(variants, "pom")) {
-            Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> supplemental = maybeDeriveSupplementalVariants();
-            supplemental.ifPresent(configurations::addAll);
-        }
+        Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> supplemental = maybeDeriveSupplementalVariants();
+        supplemental.ifPresent(configurations::addAll);
         return Optional.of(configurations.build());
-    }
-
-    private static boolean hasVariantNamed(List<? extends ComponentVariant> variants, String name) {
-        for (ComponentVariant variant : variants) {
-            if (name.equals(variant.getName())) {
-                return true;
-            }
-        }
-        return false;
     }
 
     protected Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> maybeDeriveSupplementalVariants() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleComponentSelectorSerializer;
@@ -160,6 +161,14 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
                 alternative = IvyArtifactNameSerializer.INSTANCE.read(decoder);
             }
             boolean optional = decoder.readBoolean();
+            // Read per-artifact component ID if present (for parent POM artifacts etc.)
+            boolean hasExplicitComponentId = decoder.readBoolean();
+            if (hasExplicitComponentId) {
+                String cidGroup = decoder.readString();
+                String cidModule = decoder.readString();
+                String cidVersion = decoder.readString();
+                cid = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(cidGroup, cidModule), cidVersion);
+            }
 
             if (optional) {
                 artifacts.add(new ModuleComponentOptionalArtifactMetadata(cid, artifactName));
@@ -226,6 +235,16 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
                     IvyArtifactNameSerializer.INSTANCE.write(encoder, artifact.getAlternativeArtifact().get().getName());
                 }
                 encoder.writeBoolean(artifact.isOptionalArtifact());
+                // Write whether this artifact has a different component ID than the owning module
+                if (componentId instanceof ModuleComponentIdentifier) {
+                    ModuleComponentIdentifier mcid = (ModuleComponentIdentifier) componentId;
+                    encoder.writeBoolean(true);
+                    encoder.writeString(mcid.getGroup());
+                    encoder.writeString(mcid.getModule());
+                    encoder.writeString(mcid.getVersion());
+                } else {
+                    encoder.writeBoolean(false);
+                }
             }
         }
         encoder.writeSmallInt(fileArtifactsCount);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -67,6 +67,26 @@ public class JavaEcosystemVariantDerivationStrategy extends AbstractStatelessDer
         return null;
     }
 
+    @Override
+    public ImmutableList<? extends ModuleConfigurationMetadata> deriveSupplementalVariants(ModuleComponentResolveMetadata metadata) {
+        if (metadata instanceof DefaultMavenModuleResolveMetadata) {
+            DefaultMavenModuleResolveMetadata md = (DefaultMavenModuleResolveMetadata) metadata;
+            DefaultConfigurationMetadata runtimeConfiguration = (DefaultConfigurationMetadata) md.getConfiguration("runtime");
+            if (runtimeConfiguration == null) {
+                // GMM modules may not have a "runtime" configuration — use "compile" or any available config as base
+                runtimeConfiguration = (DefaultConfigurationMetadata) md.getConfiguration("compile");
+            }
+            if (runtimeConfiguration == null) {
+                return null;
+            }
+            ImmutableAttributes attributes = md.getAttributes();
+            return ImmutableList.of(
+                libraryWithPomVariant(runtimeConfiguration, attributes, metadata)
+            );
+        }
+        return null;
+    }
+
     /**
      * Synthesizes a "sources" variant since maven metadata cannot represent it
      *

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -21,6 +21,8 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenVariantAttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.maven.DefaultMavenModuleResolveMetadata;
+import org.gradle.internal.component.model.DefaultIvyArtifactName;
+import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 
 import javax.inject.Inject;
@@ -94,13 +96,22 @@ public class JavaEcosystemVariantDerivationStrategy extends AbstractStatelessDer
     }
 
     /**
-     * Synthesizes a "pom" variant to expose the POM metadata file as a consumable artifact.
+     * Synthesizes a "pom" variant to expose the POM metadata file and its parent POM chain as consumable artifacts.
      */
     private DefaultConfigurationMetadata libraryWithPomVariant(DefaultConfigurationMetadata runtimeConfiguration, ImmutableAttributes originAttributes, ModuleComponentResolveMetadata metadata) {
+        DefaultMavenModuleResolveMetadata md = (DefaultMavenModuleResolveMetadata) metadata;
+        ImmutableList.Builder<ModuleComponentArtifactMetadata> artifacts = ImmutableList.builder();
+        // Add the module's own POM
+        artifacts.add(metadata.optionalArtifact("pom", "pom", null));
+        // Add parent POM chain
+        for (ModuleComponentIdentifier parentId : md.getParentPomChain()) {
+            IvyArtifactName parentArtifactName = new DefaultIvyArtifactName(parentId.getModule(), "pom", "pom", null);
+            artifacts.add(new ModuleComponentOptionalArtifactMetadata(parentId, parentArtifactName));
+        }
         return runtimeConfiguration.mutate()
             .withName("pom")
             .withAttributes(mavenAttributesFactory.pomVariant(originAttributes))
-            .withArtifacts(ImmutableList.of(metadata.optionalArtifact("pom", "pom", null)))
+            .withArtifacts(artifacts.build())
             .withoutConstraints()
             .build();
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -56,6 +56,7 @@ public class JavaEcosystemVariantDerivationStrategy extends AbstractStatelessDer
                 libraryRuntimeScope(runtimeConfiguration, attributes),
                 libraryWithSourcesVariant(runtimeConfiguration, attributes, metadata),
                 libraryWithJavadocVariant(runtimeConfiguration, attributes, metadata),
+                libraryWithPomVariant(runtimeConfiguration, attributes, metadata),
                 platformWithUsageAttribute(compileConfiguration, attributes, Usage.JAVA_API, false, shadowedPlatformCapability),
                 platformWithUsageAttribute(runtimeConfiguration, attributes, Usage.JAVA_RUNTIME, false, shadowedPlatformCapability),
                 platformWithUsageAttribute(compileConfiguration, attributes, Usage.JAVA_API, true, shadowedEnforcedPlatformCapability),
@@ -88,6 +89,18 @@ public class JavaEcosystemVariantDerivationStrategy extends AbstractStatelessDer
             .withName("javadoc")
             .withAttributes(mavenAttributesFactory.javadocVariant(originAttributes))
             .withArtifacts(ImmutableList.of(metadata.optionalArtifact("jar", "jar", "javadoc")))
+            .withoutConstraints()
+            .build();
+    }
+
+    /**
+     * Synthesizes a "pom" variant to expose the POM metadata file as a consumable artifact.
+     */
+    private DefaultConfigurationMetadata libraryWithPomVariant(DefaultConfigurationMetadata runtimeConfiguration, ImmutableAttributes originAttributes, ModuleComponentResolveMetadata metadata) {
+        return runtimeConfiguration.mutate()
+            .withName("pom")
+            .withAttributes(mavenAttributesFactory.pomVariant(originAttributes))
+            .withArtifacts(ImmutableList.of(metadata.optionalArtifact("pom", "pom", null)))
             .withoutConstraints()
             .build();
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantDerivationStrategy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantDerivationStrategy.java
@@ -27,4 +27,14 @@ import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 public interface VariantDerivationStrategy {
     boolean derivesVariants();
     ImmutableList<? extends ModuleConfigurationMetadata> derive(ModuleComponentResolveMetadata metadata);
+
+    /**
+     * Returns variants that should be present even when the module has explicit variants
+     * (e.g. from Gradle Module Metadata) that don't already include them.
+     * For example, Maven modules always have a POM file regardless of GMM.
+     * Returns null if no supplemental variants should be added.
+     */
+    default ImmutableList<? extends ModuleConfigurationMetadata> deriveSupplementalVariants(ModuleComponentResolveMetadata metadata) {
+        return null;
+    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -63,6 +63,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
     private final String packaging;
     private final boolean relocated;
     private final String snapshotTimestamp;
+    private final ImmutableList<ModuleComponentIdentifier> parentPomChain;
 
     private ImmutableList<? extends ModuleConfigurationMetadata> derivedVariants;
 
@@ -77,6 +78,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
         relocated = metadata.isRelocated();
         snapshotTimestamp = metadata.getSnapshotTimestamp();
         dependencies = metadata.getDependencies();
+        parentPomChain = metadata.getParentPomChain();
     }
 
     private DefaultMavenModuleResolveMetadata(DefaultMavenModuleResolveMetadata metadata, ModuleSources sources, VariantDerivationStrategy derivationStrategy) {
@@ -87,6 +89,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
         relocated = metadata.relocated;
         snapshotTimestamp = metadata.snapshotTimestamp;
         dependencies = metadata.dependencies;
+        parentPomChain = metadata.parentPomChain;
 
         copyCachedState(metadata, metadata.getVariantDerivationStrategy() != derivationStrategy);
     }
@@ -240,6 +243,11 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
     @Override
     public ImmutableList<MavenDependencyDescriptor> getDependencies() {
         return dependencies;
+    }
+
+    @Override
+    public ImmutableList<ModuleComponentIdentifier> getParentPomChain() {
+        return parentPomChain;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -108,6 +108,18 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
         return Optional.ofNullable(getDerivedVariants());
     }
 
+    @Override
+    protected Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> maybeDeriveSupplementalVariants() {
+        VariantDerivationStrategy strategy = getVariantDerivationStrategy();
+        if (strategy.derivesVariants()) {
+            ImmutableList<? extends ModuleConfigurationMetadata> supplemental = strategy.deriveSupplementalVariants(this);
+            if (supplemental != null) {
+                return Optional.of(supplemental);
+            }
+        }
+        return Optional.empty();
+    }
+
     protected Optional<List<? extends ModuleConfigurationMetadata>> deriveVariants() {
         return Optional.ofNullable(getDerivedVariants());
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -266,7 +266,8 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
         return relocated == that.relocated
             && Objects.equal(dependencies, that.dependencies)
             && Objects.equal(packaging, that.packaging)
-            && Objects.equal(snapshotTimestamp, that.snapshotTimestamp);
+            && Objects.equal(snapshotTimestamp, that.snapshotTimestamp)
+            && Objects.equal(parentPomChain, that.parentPomChain);
     }
 
     @Override
@@ -275,7 +276,8 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
             dependencies,
             packaging,
             relocated,
-            snapshotTimestamp);
+            snapshotTimestamp,
+            parentPomChain);
     }
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMutableMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMutableMavenModuleResolveMetadata.java
@@ -43,6 +43,7 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
     private String snapshotTimestamp;
     private final ImmutableList<MavenDependencyDescriptor> dependencies;
     private final ImmutableMap<String, Configuration> configurationDefinitions;
+    private ImmutableList<ModuleComponentIdentifier> parentPomChain = ImmutableList.of();
 
     public DefaultMutableMavenModuleResolveMetadata(ModuleVersionIdentifier id,
                                                     ModuleComponentIdentifier componentIdentifier,
@@ -76,6 +77,7 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
         this.relocated = metadata.isRelocated();
         this.snapshotTimestamp = metadata.getSnapshotTimestamp();
         this.dependencies = metadata.getDependencies();
+        this.parentPomChain = metadata.getParentPomChain();
         this.objectInstantiator = objectInstantiator;
         this.configurationDefinitions = GradlePomModuleDescriptorBuilder.MAVEN2_CONFIGURATIONS;
     }
@@ -134,6 +136,16 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
     @Override
     public ImmutableList<MavenDependencyDescriptor> getDependencies() {
         return dependencies;
+    }
+
+    @Override
+    public ImmutableList<ModuleComponentIdentifier> getParentPomChain() {
+        return parentPomChain;
+    }
+
+    @Override
+    public void setParentPomChain(ImmutableList<ModuleComponentIdentifier> parentPomChain) {
+        this.parentPomChain = parentPomChain;
     }
 
     NamedObjectInstantiator getObjectInstantiator() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenModuleResolveMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.external.model.maven;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -39,4 +40,10 @@ public interface MavenModuleResolveMetadata extends ModuleComponentResolveMetada
     String getSnapshotTimestamp();
 
     ImmutableList<MavenDependencyDescriptor> getDependencies();
+
+    /**
+     * Returns the chain of parent POM identifiers, from immediate parent to root ancestor.
+     * Empty if this module has no parent POM.
+     */
+    ImmutableList<ModuleComponentIdentifier> getParentPomChain();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MutableMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MutableMavenModuleResolveMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.external.model.maven;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -43,4 +44,10 @@ public interface MutableMavenModuleResolveMetadata extends MutableModuleComponen
      * Returns the dependency declarations of this component.
      */
     ImmutableList<MavenDependencyDescriptor> getDependencies();
+
+    /**
+     * Returns the chain of parent POM identifiers, from immediate parent to root.
+     */
+    ImmutableList<ModuleComponentIdentifier> getParentPomChain();
+    void setParentPomChain(ImmutableList<ModuleComponentIdentifier> parentPomChain);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -234,6 +234,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
     private final String packaging;
     private final boolean relocated;
     private final String snapshotTimestamp;
+    private final ImmutableList<ModuleComponentIdentifier> parentPomChain;
 
     private final ImmutableList<? extends ModuleConfigurationMetadata> derivedVariants;
 
@@ -247,6 +248,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         relocated = metadata.isRelocated();
         snapshotTimestamp = metadata.getSnapshotTimestamp();
         dependencies = metadata.getDependencies();
+        parentPomChain = metadata.getParentPomChain();
         this.derivedVariants = ImmutableList.copyOf(derivedVariants);
     }
 
@@ -257,6 +259,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         relocated = metadata.relocated;
         snapshotTimestamp = metadata.snapshotTimestamp;
         dependencies = metadata.dependencies;
+        parentPomChain = metadata.parentPomChain;
         this.derivedVariants = metadata.derivedVariants;
     }
 
@@ -316,6 +319,11 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
     @Override
     public ImmutableList<MavenDependencyDescriptor> getDependencies() {
         return dependencies;
+    }
+
+    @Override
+    public ImmutableList<ModuleComponentIdentifier> getParentPomChain() {
+        return parentPomChain;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -268,6 +268,18 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         return Optional.of(getDerivedVariants());
     }
 
+    @Override
+    protected Optional<List<? extends ExternalModuleVariantGraphResolveMetadata>> maybeDeriveSupplementalVariants() {
+        VariantDerivationStrategy strategy = getVariantDerivationStrategy();
+        if (strategy.derivesVariants()) {
+            ImmutableList<? extends ModuleConfigurationMetadata> supplemental = strategy.deriveSupplementalVariants(this);
+            if (supplemental != null) {
+                return Optional.of(supplemental);
+            }
+        }
+        return Optional.empty();
+    }
+
     ImmutableList<? extends ModuleConfigurationMetadata> getDerivedVariants() {
         return derivedVariants;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -342,7 +342,8 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         return relocated == that.relocated
             && Objects.equal(dependencies, that.dependencies)
             && Objects.equal(packaging, that.packaging)
-            && Objects.equal(snapshotTimestamp, that.snapshotTimestamp);
+            && Objects.equal(snapshotTimestamp, that.snapshotTimestamp)
+            && Objects.equal(parentPomChain, that.parentPomChain);
     }
 
     @Override
@@ -351,6 +352,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
             dependencies,
             packaging,
             relocated,
-            snapshotTimestamp);
+            snapshotTimestamp,
+            parentPomChain);
     }
 }

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomVariantIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomVariantIntegTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.maven
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class MavenPublishPomVariantIntegTest extends AbstractIntegrationSpec {
+
+    def "can resolve POM variant from project dependency with maven-publish"() {
+        settingsFile << """
+            include 'lib', 'consumer'
+        """
+
+        file('lib/build.gradle') << """
+            plugins {
+                id 'java-library'
+                id 'maven-publish'
+            }
+
+            group = 'com.example'
+            version = '1.0'
+
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+
+        file('consumer/build.gradle') << """
+            plugins {
+                id 'java-library'
+            }
+
+            dependencies {
+                implementation project(':lib')
+            }
+
+            task resolvePom {
+                def pomFiles = configurations.runtimeClasspath.incoming.artifactView {
+                    withVariantReselection()
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.METADATA))
+                        attribute(MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objects.named(MetadataFormat, MetadataFormat.MAVEN))
+                    }
+                }.files
+                doLast {
+                    def names = pomFiles*.name
+                    assert names.size() == 1 : "Expected 1 POM file but got: \${names}"
+                    assert names[0].endsWith('.xml') || names[0].endsWith('.pom') : "Expected POM file but got: \${names[0]}"
+                }
+            }
+        """
+
+        expect:
+        succeeds(':consumer:resolvePom')
+    }
+}

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomVariantIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomVariantIntegTest.groovy
@@ -71,4 +71,37 @@ class MavenPublishPomVariantIntegTest extends AbstractIntegrationSpec {
         expect:
         succeeds(':consumer:resolvePom')
     }
+
+    def "pomElements is not included in published Gradle Module Metadata"() {
+        settingsFile << "rootProject.name = 'lib'"
+
+        buildFile << """
+            plugins {
+                id 'java-library'
+                id 'maven-publish'
+            }
+
+            group = 'com.example'
+            version = '1.0'
+
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+                repositories {
+                    maven { url = uri("\$buildDir/repo") }
+                }
+            }
+        """
+
+        when:
+        succeeds 'generateMetadataFileForMavenPublication'
+
+        then:
+        def gmm = file('build/publications/maven/module.json').text
+        !gmm.contains('pomElements')
+        !gmm.contains('"category": "metadata"')
+    }
 }

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -22,9 +22,14 @@ import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.MetadataFormat;
+import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -116,11 +121,44 @@ public abstract class MavenPublishPlugin implements Plugin<Project> {
             publish.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
         }));
 
+        final boolean[] pomElementsWired = {false};
         mavenPublications.all(publication -> {
             createGenerateMetadataTask(tasks, publication, mavenPublications, buildDirectory);
-            createGeneratePomTask(tasks, publication, buildDirectory);
+            TaskProvider<GenerateMavenPom> pomTask = createGeneratePomTask(tasks, publication, buildDirectory);
             createLocalInstallTask(tasks, publishLocalLifecycleTask, publication);
             createPublishTasksForEachMavenRepo(tasks, publishLifecycleTask, publication, repositories);
+            maybeCreatePomElements(project, publication, pomTask, pomElementsWired);
+        });
+    }
+
+    private void maybeCreatePomElements(Project project, MavenPublicationInternal publication, TaskProvider<GenerateMavenPom> pomTask, boolean[] pomElementsWired) {
+        project.getGradle().projectsEvaluated(gradle -> {
+            if (pomElementsWired[0]) {
+                return;
+            }
+            if (!publication.getComponent().isPresent()) {
+                return;
+            }
+            SoftwareComponentInternal component = publication.getComponent().get();
+            if (!(component instanceof AdhocComponentWithVariants)) {
+                return;
+            }
+            pomElementsWired[0] = true;
+
+            ConfigurationContainer configurations = project.getConfigurations();
+            configurations.consumable("pomElements", pomElements -> {
+                pomElements.setDescription("POM metadata elements for the '" + publication.getName() + "' publication.");
+                pomElements.attributes(attrs -> {
+                    attrs.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.METADATA));
+                    attrs.attribute(MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objectFactory.named(MetadataFormat.class, MetadataFormat.MAVEN));
+                });
+                pomElements.getOutgoing().artifact(pomTask);
+            });
+
+            ((AdhocComponentWithVariants) component).addVariantsFromConfiguration(
+                configurations.getByName("pomElements"),
+                variant -> {}
+            );
         });
     }
 
@@ -166,7 +204,7 @@ public abstract class MavenPublishPlugin implements Plugin<Project> {
         publishLocalLifecycleTask.configure(task -> task.dependsOn(installTaskName));
     }
 
-    private void createGeneratePomTask(TaskContainer tasks, final MavenPublicationInternal publication, final DirectoryProperty buildDir) {
+    private TaskProvider<GenerateMavenPom> createGeneratePomTask(TaskContainer tasks, final MavenPublicationInternal publication, final DirectoryProperty buildDir) {
         final String publicationName = publication.getName();
         String descriptorTaskName = "generatePomFileFor" + capitalize(publicationName) + "Publication";
         TaskProvider<GenerateMavenPom> generatorTask = tasks.register(descriptorTaskName, GenerateMavenPom.class, generatePomTask -> {
@@ -178,6 +216,7 @@ public abstract class MavenPublishPlugin implements Plugin<Project> {
             }
         });
         publication.setPomGenerator(generatorTask);
+        return generatorTask;
     }
 
     private void createGenerateMetadataTask(final TaskContainer tasks, final MavenPublicationInternal publication, final Set<? extends MavenPublicationInternal> publications, final DirectoryProperty buildDir) {

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -22,14 +22,11 @@ import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.MetadataFormat;
-import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
-import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -127,38 +124,21 @@ public abstract class MavenPublishPlugin implements Plugin<Project> {
             TaskProvider<GenerateMavenPom> pomTask = createGeneratePomTask(tasks, publication, buildDirectory);
             createLocalInstallTask(tasks, publishLocalLifecycleTask, publication);
             createPublishTasksForEachMavenRepo(tasks, publishLifecycleTask, publication, repositories);
-            maybeCreatePomElements(project, publication, pomTask, pomElementsWired);
+            if (!pomElementsWired[0]) {
+                pomElementsWired[0] = true;
+                createPomElements(project, publication, pomTask);
+            }
         });
     }
 
-    private void maybeCreatePomElements(Project project, MavenPublicationInternal publication, TaskProvider<GenerateMavenPom> pomTask, boolean[] pomElementsWired) {
-        project.getGradle().projectsEvaluated(gradle -> {
-            if (pomElementsWired[0]) {
-                return;
-            }
-            if (!publication.getComponent().isPresent()) {
-                return;
-            }
-            SoftwareComponentInternal component = publication.getComponent().get();
-            if (!(component instanceof AdhocComponentWithVariants)) {
-                return;
-            }
-            pomElementsWired[0] = true;
-
-            ConfigurationContainer configurations = project.getConfigurations();
-            configurations.consumable("pomElements", pomElements -> {
-                pomElements.setDescription("POM metadata elements for the '" + publication.getName() + "' publication.");
-                pomElements.attributes(attrs -> {
-                    attrs.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.METADATA));
-                    attrs.attribute(MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objectFactory.named(MetadataFormat.class, MetadataFormat.MAVEN));
-                });
-                pomElements.getOutgoing().artifact(pomTask);
+    private void createPomElements(Project project, MavenPublicationInternal publication, TaskProvider<GenerateMavenPom> pomTask) {
+        project.getConfigurations().consumable("pomElements", pomElements -> {
+            pomElements.setDescription("POM metadata elements for the '" + publication.getName() + "' publication.");
+            pomElements.attributes(attrs -> {
+                attrs.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.METADATA));
+                attrs.attribute(MetadataFormat.METADATA_FORMAT_ATTRIBUTE, objectFactory.named(MetadataFormat.class, MetadataFormat.MAVEN));
             });
-
-            ((AdhocComponentWithVariants) component).addVariantsFromConfiguration(
-                configurations.getByName("pomElements"),
-                variant -> {}
-            );
+            pomElements.getOutgoing().artifact(pomTask);
         });
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
@@ -71,4 +71,13 @@ public interface Category extends Named {
      */
     @Incubating
     String VERIFICATION = "verification";
+
+    /**
+     * The metadata category, for variants which contain build metadata artifacts
+     * such as POM files or Ivy descriptors.
+     *
+     * @since 9.6.0
+     */
+    @Incubating
+    String METADATA = "metadata";
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/MetadataFormat.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/MetadataFormat.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.attributes;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.Named;
+
+/**
+ * Attribute to qualify the format of metadata artifacts.
+ * <p>
+ * This attribute is usually found on variants that have the {@link Category} attribute
+ * valued at {@link Category#METADATA metadata}.
+ *
+ * @since 9.6.0
+ */
+@Incubating
+public interface MetadataFormat extends Named {
+
+    /**
+     * The attribute to indicate the metadata format of a variant.
+     *
+     * @since 9.6.0
+     */
+    Attribute<MetadataFormat> METADATA_FORMAT_ATTRIBUTE = Attribute.of("org.gradle.metadata.format", MetadataFormat.class);
+
+    /**
+     * Maven POM metadata format.
+     *
+     * @since 9.6.0
+     */
+    String MAVEN = "maven";
+}


### PR DESCRIPTION
## Summary

Exposes Maven POM files as a variant-aware artifact so consumers can resolve a published module's POM (and its full parent chain) via `ArtifactView` with `withVariantReselection()`.

### New public API (incubating)

- `Category.METADATA` — new category for tooling-only metadata variants
- `MetadataFormat` attribute with `MAVEN` constant — disambiguates which metadata format a variant carries

### Resolution

- `JavaEcosystemVariantDerivationStrategy` synthesizes a `pom` variant for Maven modules
  - Works for **all Maven dependencies**, including those that publish Gradle Module Metadata: when GMM is present, the POM variant is added supplementally alongside the explicit GMM variants
  - Includes the full `<parent>` chain as additional artifacts (Option B2)
- `AbstractLazyModuleComponentResolveMetadata` / `AbstractRealisedModuleComponentResolveMetadata` always invoke `deriveSupplementalVariants` to add the metadata variant — no gate on existing variant names
- Parent POM chain is plumbed through `GradlePomModuleDescriptorParser`, propagated through metadata copies, and serialized in the cache (cache layout version bumped)
- Per-artifact component IDs are preserved through serialization so parent POM artifacts resolve from the correct module

### Publishing

- `MavenPublishPlugin` registers a consumable `pomElements` configuration so **project** dependencies can resolve the producing project's POM via the same query
- `pomElements` is **not** included in the published Gradle Module Metadata — it is only a local resolution affordance
- Regression test asserts the GMM produced by `generateMetadataFileForMavenPublication` does not contain `pomElements` or `"category": "metadata"`

### Documentation

- User-manual section on resolving POMs with `withVariantReselection()`
- Worked example: extracting license information from a dependency's POM

## Known follow-up

- The synthesized `pom` variant carries `Category=metadata`. Under the default attribute compatibility rule, a consumer that does not specify `Category` matches *any* producer value, which makes the metadata variant compete with normal-resolution variants in tests that use bare configurations (e.g. `MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest`). Needs a `Category` compatibility rule that makes producer-`Category=metadata` incompatible with consumer-silent, mirroring how `Category=verification` stays out of normal classpath resolution.

## Test plan

- [x] Resolve POM for direct + transitive Maven deps
- [x] Resolve parent and grandparent POMs via the parent chain
- [x] Resolve POM variant for Maven modules that also publish GMM
- [x] Resolve POM variant for project dependencies via `pomElements`
- [x] Shared parent POM at different versions resolves correctly
- [x] `pomElements` is **not** present in published GMM (regression test)
- [x] Existing `DerivedVariantsResolutionIntegrationTest` passes
- [ ] `Category=metadata` compatibility rule (follow-up — see Known follow-up)
- [ ] `sanityCheck` (binary compat, architecture tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)