### PR TITLE
Remove agent requirements

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -10,7 +10,6 @@ import common.customGradle
 import common.functionalTestParameters
 import common.getBuildScanCustomValueParam
 import common.gradleWrapper
-import common.requiresNotEc2Agent
 import common.requiresNotSharedHost
 import common.skipConditionally
 import jetbrains.buildServer.configs.kotlin.BuildSteps
@@ -64,8 +63,6 @@ class Gradleception(
             "Builds Gradle with the version of Gradle which is currently under development (twice)$descriptionSuffix"
 
         requirements {
-            // Gradleception is a heavy build which runs ~40m on EC2 agents but only ~20m on Hetzner agents
-            requiresNotEc2Agent()
             requiresNotSharedHost()
         }
 

--- a/.teamcity/src/main/kotlin/configurations/SmokeIdeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeIdeTests.kt
@@ -20,7 +20,6 @@ import common.FlakyTestStrategy
 import common.Os
 import common.buildScanTagParam
 import common.getBuildScanCustomValueParam
-import common.requiresNotEc2Agent
 import model.CIBuildModel
 import model.Stage
 
@@ -33,11 +32,6 @@ class SmokeIdeTests(
         id(buildTypeId(model) + suffix)
         name = "Smoke Ide Tests$suffix"
         description = "Tests against IDE sync process"
-
-        requirements {
-            // These tests are usually heavy and the build time is twice on EC2 agents
-            requiresNotEc2Agent()
-        }
 
         applyTestDefaults(
             model = model,

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -5,7 +5,6 @@ import common.JvmCategory
 import common.Os
 import common.buildScanTagParam
 import common.getBuildScanCustomValueParam
-import common.requiresNotEc2Agent
 import common.toCapitalized
 import model.CIBuildModel
 import model.Stage
@@ -27,11 +26,6 @@ class SmokeTests(
         if (flakyTestStrategy != FlakyTestStrategy.ONLY) {
             // No need to split in FlakyTestQuarantine
             tcParallelTests(splitNumber)
-        }
-
-        requirements {
-            // Smoke tests is usually heavy and the build time is twice on EC2 agents
-            requiresNotEc2Agent()
         }
 
         applyTestDefaults(

--- a/.teamcity/src/main/kotlin/projects/SmokeTestProject.kt
+++ b/.teamcity/src/main/kotlin/projects/SmokeTestProject.kt
@@ -1,0 +1,43 @@
+package projects
+
+import common.uuidPrefix
+import configurations.OsAwareBaseGradleBuildType
+import jetbrains.buildServer.configs.kotlin.DslContext
+import jetbrains.buildServer.configs.kotlin.Project
+import model.CIBuildModel
+import model.SpecificBuild
+import model.Stage
+
+/**
+ * Subproject under [StageProject] that groups smoke test build configurations.
+ */
+class SmokeTestProject(
+    model: CIBuildModel,
+    stage: Stage,
+    smokeBuildTypes: List<OsAwareBaseGradleBuildType>,
+) : Project({
+        id("${model.projectId}_Stage_${stage.stageName.id}_SmokeTest")
+        uuid = "${DslContext.uuidPrefix}_${model.projectId}_Stage_${stage.stageName.uuid}_SmokeTest"
+        name = "Smoke Test"
+        description = "Smoke tests against third-party plugins, Gradle build, and IDE sync"
+    }) {
+    init {
+        smokeBuildTypes.forEach(this::buildType)
+    }
+
+    companion object {
+        /**
+         * Specific builds shown under the "Smoke Test" subproject in Pull Request Feedback.
+         */
+        val pullRequestFeedbackSmokeBuilds: Set<SpecificBuild> =
+            setOf(
+                SpecificBuild.SmokeTestsMaxJavaVersion,
+                SpecificBuild.ConfigCacheAndroidProjectSmokeTests,
+                SpecificBuild.GradleBuildSmokeTests,
+                SpecificBuild.ConfigCacheSmokeTestsMaxJavaVersion,
+                SpecificBuild.ConfigCacheSmokeTestsMinJavaVersion,
+                SpecificBuild.SmokeIdeTests,
+                SpecificBuild.Gradleception,
+            )
+    }
+}

--- a/.teamcity/src/main/kotlin/projects/StageProject.kt
+++ b/.teamcity/src/main/kotlin/projects/StageProject.kt
@@ -76,7 +76,17 @@ class StageProject(
             stage.specificBuilds.map {
                 it.create(model, stage, FlakyTestStrategy.EXCLUDE)
             }
-        specificBuildTypes.forEach(this::buildType)
+
+        val (smokeBuildTypes, nonSmokeBuildTypes) =
+            stage.specificBuilds.zip(specificBuildTypes).partition { (spec, _) ->
+                spec in SmokeTestProject.pullRequestFeedbackSmokeBuilds
+            }
+        if (smokeBuildTypes.isNotEmpty()) {
+            subProject(SmokeTestProject(model, stage, smokeBuildTypes.map { it.second }))
+        }
+        nonSmokeBuildTypes.forEach { (_, buildType) ->
+            buildType(buildType)
+        }
 
         performanceTests =
             stage.performanceTests.map { createPerformanceTests(model, performanceTestBucketProvider, stage, it) } +

--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -20,7 +20,6 @@ import common.BuildToolBuildJvm
 import common.Os
 import common.VersionedSettingsBranch
 import common.paramsForBuildToolBuild
-import common.requiresNotEc2Agent
 import common.requiresOs
 import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.BuildType
@@ -40,7 +39,6 @@ abstract class BasePromotionBuildType(
 
         requirements {
             requiresOs(Os.LINUX)
-            requiresNotEc2Agent()
         }
 
         paramsForBuildToolBuild(BuildToolBuildJvm, Os.LINUX)


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/5147

In the past, there are some build types with agent requirements "not running on EC2". This PR removes these requirements and use agent pool compatibility instead.

This PR also groups the smoke tests to be a smoke test project in case we need to re-enable the limitation because TeamCity agent compatibility is project based.