### PR TITLE
Fix backward compatibility issues with `--generate-diffs` parameter

### DIFF
--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -48,12 +48,16 @@ abstract class AdHocPerformanceScenario(
             param("checks", "all")
             text("runs", "40", display = ParameterDisplay.PROMPT, allowEmpty = false)
             text("warmups", "10", display = ParameterDisplay.PROMPT, allowEmpty = false)
-            text(
+            select(
                 "generateDiffs",
-                "true",
+                "",
                 display = ParameterDisplay.PROMPT,
-                allowEmpty = false,
-                description = "Whether to generate differential flame graphs after profiling",
+                description = "Skips differential flame graph generation to avoid OOM in large adhoc tests.",
+                options =
+                    listOf(
+                        "Generate diffs" to "",
+                        "Skip diffs generation" to "--no-generate-diffs",
+                    ),
             )
             text(
                 "scenario",
@@ -108,7 +112,7 @@ abstract class AdHocPerformanceScenario(
                         performanceTestCommandLine(
                             "clean performance:%testProject%PerformanceAdHocTest --tests \"%scenario%\"",
                             "%performance.baselines%",
-                            """--warmups %warmups% --runs %runs% --checks %checks% --profiler %profiler% --generate-diffs %generateDiffs% %additional.gradle.parameters%""",
+                            """--warmups %warmups% --runs %runs% --checks %checks% --profiler %profiler% %generateDiffs% %additional.gradle.parameters%""",
                             os,
                             arch,
                             "%testJavaVersion%",


### PR DESCRIPTION
Fixes a problem caused by
 - https://github.com/gradle/gradle/pull/37093

Where older branches have no clear way of executing ad-hoc tests anymore.
This is solved by defaulting on no additional option, and rely on the build-in default in the task. 
This allows past and future branches to default on a policy without any problem.

An explicit flag is only added if skipping is selected.