### PR TITLE
"merge" `release9x` to `master` so we can delete the `release9x` branch for now and it's commits are reachable from more than just the tag

### DIFF
--- a/.teamcity/scripts/CheckBadMerge.java
+++ b/.teamcity/scripts/CheckBadMerge.java
@@ -79,8 +79,8 @@ public class CheckBadMerge {
         }
 
         List<String> commitBranches = branchesOf(commit);
-        if (commitBranches.contains("origin/release")) {
-            System.out.println(commit + " is a merge commit already on release, ignoring.");
+        if (commitBranches.stream().anyMatch(b -> b.startsWith("origin/release"))) {
+            System.out.println(commit + " is a merge commit already on a release branch, ignoring.");
             System.out.println("  Branches: " + commitBranches);
             return;
         }


### PR DESCRIPTION
"merge" `release9x` to `master` so we can delete the `release9x` branch for now