### PR TITLE
Add Best Practice to avoid Kotlin property delegates

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_general.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_general.adoc
@@ -808,3 +808,72 @@ This structure uses an extension type to hold values, allowing properties to be 
 === Tags
 
 <<tags_reference.adoc#tag:properties,`#properties`>>
+
+[[avoid_kotlin_property_delegates]]
+== Use Explicit API Instead of Kotlin Property Delegates
+
+Use explicit API calls like `tasks.register("name")`, `configurations.create("name")`, and `extra.set("name", value)` instead of the Kotlin DSL property delegate forms `by tasks.registering`, `by configurations.creating`, and `by extra`.
+
+=== Explanation
+
+The Kotlin DSL provides delegate extensions that derive entity names from the Kotlin variable name.
+This affects tasks (`by tasks.registering`, `by tasks.creating`), configurations (`by configurations.creating`), extra properties (`by extra`), and Gradle properties (`by project`, `by settings`).
+While these can appear concise, Kotlin property delegates are somewhat uncommon, even among experienced Kotlin developers, and can not be easily reproduced in other Gradle DSLs.
+
+The main risk is *implicit name coupling*: the registered entity's name is silently tied to the variable name.
+Renaming a variable renames the task or configuration, which can break CLI invocations, CI scripts, and dependent builds without any compiler warning.
+With the explicit API, the entity name is a visible string literal, and the variable can be named independently -- for example, `val verify = tasks.register("verifyCompatibilityWithPublishedArtifacts")` keeps a short local alias while preserving the descriptive task name.
+
+Avoid using any Kotlin property delegate offered by the Gradle Kotlin DSL.
+The explicit API is equally concise and avoids the pitfalls of implicit naming and delegate-specific correctness bugs.
+
+=== Example
+
+==== Don't Do This
+
+[.multi-language-sample]
+=====
+[source, kotlin]
+.build.gradle.kts
+----
+include::{snippetsPath}/bestPractices/avoidKotlinPropertyDelegates-avoid/kotlin/build.gradle.kts[tags=avoid-this]
+----
+=====
+
+<1> Configuration name is implicitly derived from the variable name `myLibs`. Renaming this variable silently renames the configuration.
+<2> `by extra` attaches a property whose name is derived from the variable. When used with a `Project` receiver (e.g. `var Project.prop by extra`), the delegate silently ignores the receiver and always reads from the declaring project's extra properties, returning wrong values in multi-project builds (link:https://github.com/gradle/gradle/issues/10979[#10979]).
+<3> Task name is implicitly derived from the variable name `greet`. Renaming this variable silently renames the task.
+
+==== Do This Instead
+
+++++
+<div style="text-align: right;">
+  <a class="download-project-link"
+     data-base-path="https://github.com/gradle/gradle/tree/master/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-do/"
+     href="https://download-directory.github.io/?url=https://github.com/gradle/gradle/tree/master/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-do/kotlin">
+    <img src="https://img.shields.io/badge/Download%20Project-GitHub-blue?logo=github&style=flat" alt="Download"/>
+  </a>
+</div>
+++++
+
+[.multi-language-sample]
+=====
+[source, kotlin]
+.build.gradle.kts
+----
+include::{snippetsPath}/bestPractices/avoidKotlinPropertyDelegates-do/kotlin/build.gradle.kts[tags=do-this]
+----
+=====
+
+<1> Configuration name is an explicit string `"myLibs"`. The variable can be renamed freely.
+<2> `extra.set` explicitly names the property. Use `extra["buildNumber"]` to read it back.
+<3> Task name is an explicit string `"greet"`. The variable can be renamed without affecting the task name.
+
+=== References
+
+- <<kotlin_dsl.adoc#kotdsl:kotlin_dsl,Kotlin DSL Primer>>
+- link:https://kotlinlang.org/docs/delegated-properties.html[Kotlin Delegated Properties]
+
+=== Tags
+
+<<tags_reference.adoc#tag:kotlin-dsl,`#kotlin-dsl`>>

--- a/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_index.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/best-practices/best_practices_index.adoc
@@ -50,6 +50,7 @@ Use this as a quick reference to track newly added recommendations, check adopti
 | <<best_practices_general.adoc#use_the_gradle_properties_file,Set build flags in gradle.properties>> | General | 9.0.0
 | <<best_practices_general.adoc#name_your_root_project,Name Your Root Project>> | General | 9.2.0
 | <<best_practices_general.adoc#do_not_use_gradle_properties_in_subprojects,Do not use gradle.properties in subprojects>> | General | 9.2.0
+| <<best_practices_general.adoc#avoid_kotlin_property_delegates,Use Explicit API Instead of Kotlin Property Delegates>> | General | 9.6.0
 
 | <<best_practices_structuring_builds.adoc#modularize_builds,Modularize Your Builds>> | Structuring Builds | 9.0.0
 | <<best_practices_structuring_builds.adoc#no_source_in_root,Do Not Put Source Files in the Root Project>> | Structuring Builds | 9.0.0

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-avoid/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-avoid/kotlin/build.gradle.kts
@@ -1,0 +1,11 @@
+// tag::avoid-this[]
+val myLibs by configurations.creating // <1>
+var buildNumber by extra(42) // <2>
+
+val greet by tasks.registering { // <3>
+    val configName = myLibs.name
+    doLast {
+        println("Configuration: $configName")
+    }
+}
+// end::avoid-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-avoid/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-avoid/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "avoid-kotlin-property-delegates-avoid"

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-avoid/tests/avoidKotlinPropertyDelegates.avoid.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-avoid/tests/avoidKotlinPropertyDelegates.avoid.out
@@ -1,0 +1,6 @@
+
+> Task :greet
+Configuration: myLibs
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-avoid/tests/avoidKotlinPropertyDelegates.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-avoid/tests/avoidKotlinPropertyDelegates.sample.conf
@@ -1,0 +1,3 @@
+executable: gradle
+args: greet
+expected-output-file: avoidKotlinPropertyDelegates.avoid.out

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-do/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-do/kotlin/build.gradle.kts
@@ -1,0 +1,11 @@
+// tag::do-this[]
+val myLibs = configurations.create("myLibs") // <1>
+extra.set("buildNumber", 42) // <2>
+
+val greet = tasks.register("greet") { // <3>
+    val configName = myLibs.name
+    doLast {
+        println("Configuration: $configName")
+    }
+}
+// end::do-this[]

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-do/kotlin/settings.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-do/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "avoid-kotlin-property-delegates-do"

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-do/tests/avoidKotlinPropertyDelegates.do.out
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-do/tests/avoidKotlinPropertyDelegates.do.out
@@ -1,0 +1,6 @@
+
+> Task :greet
+Configuration: myLibs
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-do/tests/avoidKotlinPropertyDelegates.sample.conf
+++ b/platforms/documentation/docs/src/snippets/bestPractices/avoidKotlinPropertyDelegates-do/tests/avoidKotlinPropertyDelegates.sample.conf
@@ -1,0 +1,3 @@
+executable: gradle
+args: greet
+expected-output-file: avoidKotlinPropertyDelegates.do.out


### PR DESCRIPTION
Document the recommendation to use explicit API calls instead of Kotlin DSL property delegates. This prevents implicit name coupling, where renaming a variable unexpectedly changes a task or configuration name, potentially breaking builds or CI scripts. It also avoids known correctness issues with property delegates (#10979).

./gradlew :docs:checkDeadInternalLinks -q :docs:docsTest --tests "*.bestPractices_avoidKotlinPropertyDelegates*"

<img width="1181" height="1988" alt="image" src="https://github.com/user-attachments/assets/7e734a9b-3fc0-4aa0-939f-f4861960cd3c" />
