### PR TITLE
Package accessor generation output into JARs

### DIFF
--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -849,6 +849,14 @@
       }
     } ]
   }, {
+    "testId" : "org.gradle.performance.regression.kotlindsl.KotlinDslAccessorsPerformanceTest.generate accessors",
+    "groups" : [ {
+      "testProject" : "kotlinDslManyAccessors",
+      "coverage" : {
+        "per_day" : [ "linux" ]
+      }
+    } ]
+  }, {
     "testId" : "org.gradle.performance.regression.nativeplatform.NativeBuildDependentsPerformanceTest.run libA0:buildDependentsLibA00",
     "groups" : [ {
       "testProject" : "nativeDependents",

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -119,6 +119,23 @@ performanceTest.registerTestProject("ktsSmall", KtsProjectGeneratorTask) {
     daemonMemory = '512m'
 }
 
+// A single Kotlin DSL project whose build script applies a plugin that creates a large number of
+// Java source sets. Each source set contributes several configurations, and each configuration
+// becomes its own generated type-safe accessor class, so a great number of accessor classes are
+// generated for this single project. The number of source sets is the size parameter.
+performanceTest.registerTestProject("kotlinDslManyAccessors", KtsProjectGeneratorTask) {
+    projects = 1
+    sourceFiles = 0
+    createTestComponent = false
+    subProjectTemplates = ['kts-many-accessors']
+    additionalProjectFiles = [
+        'buildSrc/src/main/java/org/gradle/performance/kotlindsl/ManySourceSetsPlugin.java',
+        'buildSrc/src/main/resources/META-INF/gradle-plugins/many-source-sets.properties',
+    ]
+    templateArgs = [sourceSetCount: 500]
+    daemonMemory = '1536m'
+}
+
 // === Native Software Model ===
 performanceTest.registerTestProject("smallNative", NativeProjectGeneratorTask) {
     projects = 1

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/AccessorsClassPathModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/AccessorsClassPathModelCrossVersionSpec.groovy
@@ -22,6 +22,8 @@ import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVers
 
 import org.hamcrest.Matcher
 
+import java.util.zip.ZipFile
+
 import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.CoreMatchers.not
@@ -87,7 +89,7 @@ class AccessorsClassPathModelCrossVersionSpec extends AbstractKotlinScriptModelC
     private Matcher<Iterable<? super File>> hasAccessorsClasses() {
         return hasItem(
             matching({ it.appendText("accessors classes") }) { File file ->
-                new File(file, accessorsClassFilePath).isFile()
+                containsEntry(file, accessorsClassFilePath)
             }
         )
     }
@@ -95,9 +97,21 @@ class AccessorsClassPathModelCrossVersionSpec extends AbstractKotlinScriptModelC
     private Matcher<Iterable<? super File>> hasAccessorsSource() {
         return hasItem(
             matching({ it.appendText("accessors source") }) { File file ->
-                new File(file, accessorsSourceFilePath).isFile()
+                containsEntry(file, accessorsSourceFilePath)
             }
         )
+    }
+
+    private static boolean containsEntry(File file, String entryPath) {
+        if (file.isDirectory()) {
+            return new File(file, entryPath).isFile()
+        }
+        if (file.isFile() && file.name.endsWith(".jar")) {
+            return new ZipFile(file).withCloseable { zip ->
+                zip.getEntry(entryPath) != null
+            }
+        }
+        return false
     }
 
     private File setOfAutomaticAccessorsFor(Iterable<String> plugins) {
@@ -110,7 +124,7 @@ class AccessorsClassPathModelCrossVersionSpec extends AbstractKotlinScriptModelC
     private File accessorsClassFor(File buildFile) {
         return classPathFor(projectDir, buildFile)
             .tap { println(it) }
-            .find { it.isDirectory() && new File(it, accessorsClassFilePath).isFile() }
+            .find { containsEntry(it, accessorsClassFilePath) }
     }
 
     private String accessorsClassFilePath = "org/gradle/kotlin/dsl/ArchivesConfigurationAccessorsKt.class"

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r88/KotlinSettingsScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r88/KotlinSettingsScriptModelCrossVersionSpec.groovy
@@ -65,10 +65,13 @@ class KotlinSettingsScriptModelCrossVersionSpec extends AbstractKotlinScriptMode
     private List<File> accessorsClassPathFor(File buildFile) {
         return classPathFor(projectDir, buildFile)
             .tap { println(it) }
-            .findAll { isAccessorsDir(it) }
+            .findAll { isAccessorsPath(it) }
     }
 
-    private static boolean isAccessorsDir(File dir) {
-        return dir.isDirectory() && dir.path.contains("accessors")
+    private static boolean isAccessorsPath(File file) {
+        if (!file.path.contains("accessors")) {
+            return false
+        }
+        return file.isDirectory() || (file.isFile() && file.name.endsWith(".jar"))
     }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -42,7 +42,7 @@ import org.gradle.internal.execution.WorkOutput
 import org.gradle.internal.execution.caching.CachingDisabledReason
 import org.gradle.internal.execution.history.OverlappingOutputs
 import org.gradle.internal.execution.model.InputNormalizer
-import org.gradle.internal.file.TreeType.DIRECTORY
+import org.gradle.internal.file.TreeType.FILE
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.DirectorySensitivity
 import org.gradle.internal.fingerprint.LineEndingSensitivity
@@ -55,9 +55,7 @@ import org.gradle.internal.service.scopes.ServiceScope
 import org.gradle.internal.snapshot.ValueSnapshot
 import org.gradle.kotlin.dsl.cache.KotlinDslWorkspaceProvider
 import org.gradle.kotlin.dsl.provider.KotlinDslInternalOptions
-import org.gradle.kotlin.dsl.concurrent.AsyncIOScopeFactory
 import org.gradle.kotlin.dsl.concurrent.IO
-import org.gradle.kotlin.dsl.concurrent.runBlocking
 import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.KOTLIN_DSL_PACKAGE_NAME
 import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.fileHeaderFor
 import org.gradle.kotlin.dsl.internal.sharedruntime.support.ClassBytesRepository
@@ -77,11 +75,14 @@ import org.jetbrains.org.objectweb.asm.Opcodes.ACC_PUBLIC
 import org.jetbrains.org.objectweb.asm.Opcodes.ACC_SYNTHETIC
 import org.jetbrains.org.objectweb.asm.signature.SignatureReader
 import org.jetbrains.org.objectweb.asm.signature.SignatureVisitor
+import java.io.BufferedOutputStream
 import java.io.Closeable
 import java.io.File
+import java.io.FileOutputStream
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Pattern
+import java.util.zip.ZipOutputStream
 import javax.inject.Inject
 
 
@@ -92,7 +93,6 @@ class ProjectAccessorsClassPathGenerator @Inject internal constructor(
     private val executionEngine: ExecutionEngine,
     private val inputFingerprinter: InputFingerprinter,
     private val workspaceProvider: KotlinDslWorkspaceProvider,
-    private val asyncIO: AsyncIOScopeFactory,
     internalOptions: InternalOptions,
 ) {
 
@@ -128,11 +128,10 @@ class ProjectAccessorsClassPathGenerator @Inject internal constructor(
                     fileCollectionFactory,
                     inputFingerprinter,
                     workspaceProvider,
-                    asyncIO,
                     isDclEnabledForScriptTarget(scriptTarget),
-                    cachingDisabled,
-                )
-                executionEngine.createRequest(work)
+            cachingDisabled,
+        )
+         executionEngine.createRequest(work)
                     .execute()
                     .getOutputAs(AccessorsClassPath::class.java)
                     .get()
@@ -176,7 +175,6 @@ class GenerateProjectAccessors(
     private val fileCollectionFactory: FileCollectionFactory,
     private val inputFingerprinter: InputFingerprinter,
     private val workspaceProvider: KotlinDslWorkspaceProvider,
-    private val asyncIO: AsyncIOScopeFactory,
     private val isDclEnabled: Boolean,
     private val cachingDisabled: Boolean,
 ) : ImmutableUnitOfWork {
@@ -187,6 +185,12 @@ class GenerateProjectAccessors(
         const val CLASSPATH_INPUT_PROPERTY = "classpath"
         const val SOURCES_OUTPUT_PROPERTY = "sources"
         const val CLASSES_OUTPUT_PROPERTY = "classes"
+
+        /**
+         * Bump this version when the output format changes to invalidate
+         * existing workspaces that used a different layout (e.g. directories vs JARs).
+         */
+        const val OUTPUT_FORMAT_VERSION = 2
     }
 
     override fun getBuildOperationWorkType(): Optional<String> {
@@ -202,14 +206,12 @@ class GenerateProjectAccessors(
 
     override fun execute(executionContext: ExecutionContext): WorkOutput {
         val workspace = executionContext.workspace
-        asyncIO.runBlocking {
-            buildAccessorsFor(
-                scriptTargetSchema,
-                classPath,
-                srcDir = getSourcesOutputDir(workspace),
-                binDir = getClassesOutputDir(workspace)
-            )
-        }
+        buildAccessorsToJars(
+            scriptTargetSchema,
+            classPath,
+            classesJar = getClassesOutputFile(workspace),
+            sourcesJar = getSourcesOutputFile(workspace)
+        )
         return object : WorkOutput {
             override fun getDidWork() = WorkOutput.WorkResult.DID_WORK
 
@@ -218,12 +220,13 @@ class GenerateProjectAccessors(
     }
 
     override fun loadAlreadyProducedOutput(workspace: File) = AccessorsClassPath(
-        DefaultClassPath.of(getClassesOutputDir(workspace)),
-        DefaultClassPath.of(getSourcesOutputDir(workspace))
+        DefaultClassPath.of(getClassesOutputFile(workspace)),
+        DefaultClassPath.of(getSourcesOutputFile(workspace))
     )
 
     override fun identify(scalarInputs: Map<String, ValueSnapshot>, fileInputs: Map<String, CurrentFileCollectionFingerprint>): Identity {
         val hasher = Hashing.newHasher()
+        hasher.putInt(OUTPUT_FORMAT_VERSION)
         requireNotNull(scalarInputs[TARGET_SCHEMA_INPUT_PROPERTY]).appendToHasher(hasher)
         requireNotNull(scalarInputs[DCL_ENABLED_INPUT_PROPERTY]).appendToHasher(hasher)
         hasher.putHash(requireNotNull(fileInputs[CLASSPATH_INPUT_PROPERTY]).hash)
@@ -253,20 +256,20 @@ class GenerateProjectAccessors(
     }
 
     override fun visitOutputs(workspace: File, visitor: OutputVisitor) {
-        val sourcesOutputDir = getSourcesOutputDir(workspace)
-        val classesOutputDir = getClassesOutputDir(workspace)
-        visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, DIRECTORY, OutputFileValueSupplier.fromStatic(sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir)))
-        visitor.visitOutputProperty(CLASSES_OUTPUT_PROPERTY, DIRECTORY, OutputFileValueSupplier.fromStatic(classesOutputDir, fileCollectionFactory.fixed(classesOutputDir)))
+        val sourcesOutputFile = getSourcesOutputFile(workspace)
+        val classesOutputFile = getClassesOutputFile(workspace)
+        visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, FILE, OutputFileValueSupplier.fromStatic(sourcesOutputFile, fileCollectionFactory.fixed(sourcesOutputFile)))
+        visitor.visitOutputProperty(CLASSES_OUTPUT_PROPERTY, FILE, OutputFileValueSupplier.fromStatic(classesOutputFile, fileCollectionFactory.fixed(classesOutputFile)))
     }
 }
 
 
 private
-fun getClassesOutputDir(workspace: File) = File(workspace, "classes")
+fun getClassesOutputFile(workspace: File) = File(workspace, "classes.jar")
 
 
 private
-fun getSourcesOutputDir(workspace: File): File = File(workspace, "sources")
+fun getSourcesOutputFile(workspace: File) = File(workspace, "sources.jar")
 
 
 data class AccessorsClassPath(val bin: ClassPath, val src: ClassPath) {
@@ -296,6 +299,29 @@ fun IO.buildAccessorsFor(
         OutputPackage(packageName),
         format
     )
+}
+
+
+fun buildAccessorsToJars(
+    projectSchema: TypedProjectSchema,
+    classPath: ClassPath,
+    classesJar: File,
+    sourcesJar: File,
+    packageName: String = KOTLIN_DSL_PACKAGE_NAME,
+    format: AccessorFormat = AccessorFormats.default
+) {
+    val availableSchema = availableProjectSchemaFor(projectSchema, classPath)
+    ZipOutputStream(BufferedOutputStream(FileOutputStream(classesJar))).use { classesOut ->
+        ZipOutputStream(BufferedOutputStream(FileOutputStream(sourcesJar))).use { sourcesOut ->
+            emitAccessorsToJars(
+                availableSchema,
+                classesOut,
+                sourcesOut,
+                OutputPackage(packageName),
+                format
+            )
+        }
+    }
 }
 
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/BuildScopeServices.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/BuildScopeServices.kt
@@ -25,7 +25,6 @@ import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.service.Provides
 import org.gradle.internal.service.ServiceRegistrationProvider
 import org.gradle.kotlin.dsl.cache.KotlinDslWorkspaceProvider
-import org.gradle.kotlin.dsl.concurrent.AsyncIOScopeFactory
 
 
 internal
@@ -57,7 +56,6 @@ object BuildScopeServices : ServiceRegistrationProvider {
         executionEngine: ExecutionEngine,
         inputFingerprinter: InputFingerprinter,
         workspaceProvider: KotlinDslWorkspaceProvider,
-        asyncIO: AsyncIOScopeFactory,
         internalOptions: InternalOptions,
     ) = ProjectAccessorsClassPathGenerator(
         fileCollectionFactory,
@@ -65,7 +63,6 @@ object BuildScopeServices : ServiceRegistrationProvider {
         executionEngine,
         inputFingerprinter,
         workspaceProvider,
-        asyncIO,
         internalOptions,
     )
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Emitter.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Emitter.kt
@@ -21,8 +21,11 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.file.archive.ZipEntryConstants.CONSTANT_TIME_FOR_ZIP_ENTRIES
 import org.gradle.kotlin.dsl.concurrent.IO
 import org.gradle.kotlin.dsl.concurrent.writeFile
+import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.KOTLIN_DSL_PACKAGE_NAME
+import org.gradle.kotlin.dsl.internal.sharedruntime.support.appendReproducibleNewLine
 import org.gradle.kotlin.dsl.support.bytecode.InternalName
 import org.gradle.kotlin.dsl.support.bytecode.beginFileFacadeClassHeader
 import org.gradle.kotlin.dsl.support.bytecode.beginPublicClass
@@ -32,6 +35,8 @@ import org.gradle.kotlin.dsl.support.bytecode.moduleFileFor
 import org.gradle.kotlin.dsl.support.bytecode.moduleMetadataBytesFor
 import org.jetbrains.kotlin.lexer.KotlinLexer
 import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 
 internal
@@ -82,6 +87,113 @@ fun IO.makeAccessorOutputDirs(srcDir: File, binDir: File?, packagePath: String) 
         resolve(packagePath).mkdirs()
         resolve("META-INF").mkdir()
     }
+}
+
+
+internal
+fun emitAccessorsToJars(
+    projectSchema: ProjectSchema<TypeAccessibility>,
+    classesJar: ZipOutputStream,
+    sourcesJar: ZipOutputStream,
+    outputPackage: OutputPackage,
+    format: AccessorFormat
+): List<InternalName> {
+
+    val useLowPriorityOverloadResolution = projectSchema.scriptTarget is Settings
+    val moduleName = "classes"
+    val classNamesFromTypeStrings = ClassNamesFromTypeStrings()
+    val emittedClassNames =
+        accessorsFor(projectSchema).map { accessor ->
+            emitClassToJars(
+                accessor,
+                classesJar,
+                sourcesJar,
+                outputPackage,
+                format,
+                moduleName,
+                useLowPriorityOverloadResolution,
+                importsRequiredBy(accessor, classNamesFromTypeStrings)
+            )
+        }.toList()
+
+    classesJar.putReproducibleEntry(
+        "META-INF/$moduleName.kotlin_module",
+        moduleMetadataBytesFor(emittedClassNames)
+    )
+
+    return emittedClassNames
+}
+
+
+private
+fun emitClassToJars(
+    accessor: Accessor,
+    classesJar: ZipOutputStream,
+    sourcesJar: ZipOutputStream,
+    outputPackage: OutputPackage,
+    format: AccessorFormat,
+    moduleName: String,
+    useLowPriorityOverloadResolution: Boolean,
+    requiredImports: List<String>
+): InternalName {
+
+    val (simpleClassName, fragments) = fragmentsFor(accessor)
+    val className = InternalName("${outputPackage.path}/$simpleClassName")
+    val sourceCode = mutableListOf<String>()
+
+    fun collectSourceFragment(source: String) {
+        sourceCode.add(format(source))
+    }
+
+    val classBytes = generateAccessorBytecode(
+        className,
+        fragments,
+        ::collectSourceFragment,
+        moduleName,
+        useLowPriorityOverloadResolution
+    )
+    classesJar.putReproducibleEntry("$className.class", classBytes)
+
+    sourcesJar.putReproducibleEntry(
+        "${className.value.removeSuffix("Kt")}.kt",
+        accessorSourceContent(sourceCode, requiredImports, outputPackage.name)
+    )
+
+    return className
+}
+
+
+internal
+fun accessorSourceContent(
+    accessors: Iterable<String>,
+    imports: List<String> = emptyList(),
+    packageName: String = KOTLIN_DSL_PACKAGE_NAME
+): ByteArray {
+    val sb = StringBuilder()
+    sb.appendReproducibleNewLine(fileHeaderWithImportsFor(packageName))
+    if (imports.isNotEmpty()) {
+        imports.forEach {
+            sb.appendReproducibleNewLine("import $it")
+        }
+        sb.appendReproducibleNewLine()
+    }
+    accessors.forEach {
+        sb.appendReproducibleNewLine(it)
+        sb.appendReproducibleNewLine()
+    }
+    return sb.toString().toByteArray(Charsets.UTF_8)
+}
+
+
+internal
+fun ZipOutputStream.putReproducibleEntry(path: String, bytes: ByteArray) {
+    val entry = ZipEntry(path).apply {
+        time = CONSTANT_TIME_FOR_ZIP_ENTRIES
+        size = bytes.size.toLong()
+    }
+    putNextEntry(entry)
+    write(bytes)
+    closeEntry()
 }
 
 
@@ -145,15 +257,14 @@ fun sourceFileFor(className: InternalName, srcDir: File) =
     srcDir.resolve("${className.value.removeSuffix("Kt")}.kt")
 
 
-private
-fun IO.writeAccessorsBytecodeTo(
-    binDir: File,
+internal
+fun generateAccessorBytecode(
     className: InternalName,
     fragments: Sequence<AccessorFragment>,
     collectSourceFragment: (String) -> Unit,
     moduleName: String,
     useLowPriorityOverloadResolution: Boolean
-) {
+): ByteArray {
 
     val metadataWriter = beginFileFacadeClassHeader()
     val classWriter = beginPublicClass(className)
@@ -165,7 +276,20 @@ fun IO.writeAccessorsBytecodeTo(
     }
 
     val metadata = metadataWriter.closeHeader(moduleName)
-    val classBytes = classWriter.endKotlinClass(metadata)
+    return classWriter.endKotlinClass(metadata)
+}
+
+
+private
+fun IO.writeAccessorsBytecodeTo(
+    binDir: File,
+    className: InternalName,
+    fragments: Sequence<AccessorFragment>,
+    collectSourceFragment: (String) -> Unit,
+    moduleName: String,
+    useLowPriorityOverloadResolution: Boolean
+) {
+    val classBytes = generateAccessorBytecode(className, fragments, collectSourceFragment, moduleName, useLowPriorityOverloadResolution)
     val classFile = binDir.resolve("$className.class")
     writeFile(classFile, classBytes)
 }

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
@@ -129,6 +129,93 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
     }
 
     @Test
+    fun `#buildAccessorsToJars produces valid JARs with classes, sources and module metadata`() {
+
+        // given:
+        val schema =
+            TypedProjectSchema(
+                extensions = listOf(
+                    entry<Project, SourceSetContainer>("sourceSets"),
+                ),
+                containerElements = listOf(),
+                tasks = listOf(
+                    entry<TaskContainer, Delete>("clean")
+                ),
+                configurations = listOf(ConfigurationEntry("api")),
+                modelDefaults = listOf(),
+                projectFeatureEntries = emptyList(),
+                containerElementFactories = listOf(),
+                nestedModelEntries = listOf()
+            )
+
+        val classesJar = newFile("classes.jar")
+        val sourcesJar = newFile("sources.jar")
+
+        // when:
+        buildAccessorsToJars(schema, testRuntimeClassPath, classesJar, sourcesJar)
+
+        // then: classes JAR contains loadable .class entries
+        val classEntries = java.util.zip.ZipFile(classesJar).use { zip ->
+            zip.entries().asSequence().map { it.name }.filter { it.endsWith(".class") }.toList()
+        }
+        assert(classEntries.isNotEmpty()) {
+            "Expected .class entries in classes JAR"
+        }
+        withClassLoaderFor(classesJar) {
+            classEntries.forEach { entry ->
+                val className = entry.removeSuffix(".class").replace('/', '.')
+                val clazz = loadClass(className)
+                assert(clazz.declaredMethods.isNotEmpty()) {
+                    "Expected accessor methods in $className"
+                }
+            }
+        }
+
+        // and: classes JAR contains Kotlin module metadata
+        val metadataEntries = java.util.zip.ZipFile(classesJar).use { zip ->
+            zip.entries().asSequence().map { it.name }.filter { it.endsWith(".kotlin_module") }.toList()
+        }
+        assertEquals(listOf("META-INF/classes.kotlin_module"), metadataEntries)
+
+        // and: sources JAR contains .kt files under the correct package path
+        val sourceEntries = java.util.zip.ZipFile(sourcesJar).use { zip ->
+            zip.entries().asSequence().map { it.name }.filter { it.endsWith(".kt") }.toList()
+        }
+        assert(sourceEntries.isNotEmpty()) {
+            "Expected .kt source entries in sources JAR"
+        }
+        assert(sourceEntries.all { it.startsWith("org/gradle/kotlin/dsl/") }) {
+            "Expected all sources under org/gradle/kotlin/dsl/, found: $sourceEntries"
+        }
+    }
+
+    @Test
+    fun `#buildAccessorsToJars accessor classes work at runtime`() {
+
+        testAccessorsBuiltBy(::buildAccessorsToJarsAdapter)
+    }
+
+    private
+    fun buildAccessorsToJarsAdapter(schema: TypedProjectSchema, classPath: ClassPath, srcDir: File, binDir: File) {
+        val classesJar = File(binDir, "classes.jar")
+        buildAccessorsToJars(schema, classPath, classesJar, File(srcDir, "sources.jar"))
+        // Extract classes from JAR into binDir so the existing eval helper can use the directory
+        java.util.zip.ZipFile(classesJar).use { zip ->
+            zip.entries().asSequence().forEach { entry ->
+                if (!entry.isDirectory) {
+                    val outFile = File(binDir, entry.name)
+                    outFile.parentFile.mkdirs()
+                    zip.getInputStream(entry).use { input ->
+                        outFile.outputStream().use { output ->
+                            input.copyTo(output)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
     fun `#buildAccessorsFor (deprecated configurations)`() {
         val schema =
             TypedProjectSchema(

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
@@ -192,27 +192,15 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
     @Test
     fun `#buildAccessorsToJars accessor classes work at runtime`() {
 
-        testAccessorsBuiltBy(::buildAccessorsToJarsAdapter)
+        testAccessorsBuiltBy(::buildAccessorsToJarsDirect)
     }
 
     private
-    fun buildAccessorsToJarsAdapter(schema: TypedProjectSchema, classPath: ClassPath, srcDir: File, binDir: File) {
+    fun buildAccessorsToJarsDirect(schema: TypedProjectSchema, classPath: ClassPath, srcDir: File, binDir: File): AccessorsRoots {
         val classesJar = File(binDir, "classes.jar")
-        buildAccessorsToJars(schema, classPath, classesJar, File(srcDir, "sources.jar"))
-        // Extract classes from JAR into binDir so the existing eval helper can use the directory
-        java.util.zip.ZipFile(classesJar).use { zip ->
-            zip.entries().asSequence().forEach { entry ->
-                if (!entry.isDirectory) {
-                    val outFile = File(binDir, entry.name)
-                    outFile.parentFile.mkdirs()
-                    zip.getInputStream(entry).use { input ->
-                        outFile.outputStream().use { output ->
-                            input.copyTo(output)
-                        }
-                    }
-                }
-            }
-        }
+        val sourcesJar = File(srcDir, "sources.jar")
+        buildAccessorsToJars(schema, classPath, classesJar, sourcesJar)
+        return AccessorsRoots(DefaultClassPath.of(classesJar), DefaultClassPath.of(sourcesJar))
     }
 
     @Test
@@ -343,7 +331,7 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
         classPath: ClassPath,
         srcDir: File,
         binDir: File
-    ) {
+    ): AccessorsRoots {
         buildAccessorsFor(
             schema,
             classPath,
@@ -358,6 +346,7 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
                 classPath.asFiles
             )
         )
+        return AccessorsRoots(DefaultClassPath.of(binDir), DefaultClassPath.of(srcDir))
     }
 
     private
@@ -365,7 +354,7 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
         srcDir.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
 
     private
-    fun testAccessorsBuiltBy(buildAccessorsFor: (TypedProjectSchema, ClassPath, File, File) -> Unit) {
+    fun testAccessorsBuiltBy(buildAccessorsFor: (TypedProjectSchema, ClassPath, File, File) -> AccessorsRoots) {
 
         // given:
         val schema =
@@ -562,13 +551,13 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
         target: Project,
         script: String,
         classPath: ClassPath = testRuntimeClassPath,
-        buildAccessorsFor: (TypedProjectSchema, ClassPath, File, File) -> Unit = ::buildAccessorsFor
+        buildAccessorsFor: (TypedProjectSchema, ClassPath, File, File) -> AccessorsRoots = ::buildAccessorsFor
     ) {
 
         val srcDir = newFolder("src")
         val binDir = newFolder("bin")
 
-        buildAccessorsFor(schema, classPath, srcDir, binDir)
+        val roots = buildAccessorsFor(schema, classPath, srcDir, binDir)
 
         eval(
             script = script,
@@ -576,18 +565,23 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
             buildTreeRootDir = root,
             baseCacheDir = kotlinDslEvalBaseCacheDir,
             baseTempDir = kotlinDslEvalBaseTempDir,
-            scriptCompilationClassPath = DefaultClassPath.of(binDir) + classPath,
-            scriptRuntimeClassPath = DefaultClassPath.of(binDir)
+            scriptCompilationClassPath = roots.bin + classPath,
+            scriptRuntimeClassPath = roots.bin
         )
     }
 
     private
-    fun buildAccessorsFor(schema: TypedProjectSchema, classPath: ClassPath, srcDir: File, binDir: File) {
+    fun buildAccessorsFor(schema: TypedProjectSchema, classPath: ClassPath, srcDir: File, binDir: File): AccessorsRoots {
         withSynchronousIO {
             buildAccessorsFor(schema, classPath, srcDir, binDir)
         }
+        return AccessorsRoots(DefaultClassPath.of(binDir), DefaultClassPath.of(srcDir))
     }
 }
+
+
+private
+data class AccessorsRoots(val bin: ClassPath, val src: ClassPath)
 
 
 internal

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/kotlindsl/KotlinDslAccessorsPerformanceTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/kotlindsl/KotlinDslAccessorsPerformanceTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.regression.kotlindsl
+
+import org.gradle.performance.AbstractCrossVersionPerformanceTest
+import org.gradle.performance.annotations.RunFor
+import org.gradle.performance.annotations.Scenario
+import org.gradle.performance.mutator.RetryingClearGradleUserHomeMutator
+import org.gradle.profiler.mutations.AbstractScheduledMutator
+import org.gradle.profiler.mutations.ClearProjectCacheMutator
+import spock.lang.Issue
+
+import static org.gradle.performance.annotations.ScenarioType.PER_DAY
+import static org.gradle.performance.results.OperatingSystem.LINUX
+
+@Issue("https://github.com/gradle/gradle/issues/37279")
+@RunFor(
+    @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["kotlinDslManyAccessors"])
+)
+class KotlinDslAccessorsPerformanceTest extends AbstractCrossVersionPerformanceTest {
+
+    def "generate accessors"() {
+        given:
+        runner.tasksToRun = ['help']
+        runner.runs = 6
+        runner.useDaemon = false
+        // Clear the caches before each build so the Kotlin DSL type-safe accessors are regenerated
+        // and re-snapshotted every measured build, exercising the accessor generation output path.
+        runner.addBuildMutator { invocationSettings ->
+            new RetryingClearGradleUserHomeMutator(invocationSettings.gradleUserHome, AbstractScheduledMutator.Schedule.BUILD)
+        }
+        runner.addBuildMutator { invocationSettings ->
+            new ClearProjectCacheMutator(invocationSettings.projectDir, AbstractScheduledMutator.Schedule.BUILD)
+        }
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+    }
+}

--- a/testing/performance/src/templates/kts-many-accessors/build.gradle.kts
+++ b/testing/performance/src/templates/kts-many-accessors/build.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("many-source-sets")
+}
+
+// Touch a generated type-safe accessor so the compiled build script links the generated
+// accessor classpath. The "many-source-sets" plugin applies the "java" plugin and creates
+// a large number of source sets, each contributing several configurations, so a great number
+// of accessor classes are generated for this single project.
+logger.lifecycle("source sets: " + sourceSets.size)

--- a/testing/performance/src/templates/kts-many-accessors/buildSrc/src/main/java/org/gradle/performance/kotlindsl/ManySourceSetsPlugin.java
+++ b/testing/performance/src/templates/kts-many-accessors/buildSrc/src/main/java/org/gradle/performance/kotlindsl/ManySourceSetsPlugin.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.kotlindsl;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.SourceSetContainer;
+
+/**
+ * Applies the {@code java} plugin and creates a large number of source sets.
+ *
+ * <p>Each created source set contributes several configurations (e.g. {@code ...Implementation},
+ * {@code ...CompileOnly}, {@code ...RuntimeOnly}, {@code ...AnnotationProcessor}), and each
+ * configuration becomes its own generated Kotlin DSL type-safe accessor class. Applying this
+ * plugin from a {@code build.gradle.kts} {@code plugins {}} block therefore forces a great number
+ * of accessor classes to be generated for a single project.
+ *
+ * <p>The source set count is substituted by the performance test project generator.
+ */
+public class ManySourceSetsPlugin implements Plugin<Project> {
+
+    private static final int SOURCE_SET_COUNT = ${sourceSetCount};
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(JavaPlugin.class);
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        for (int i = 0; i < SOURCE_SET_COUNT; i++) {
+            sourceSets.create("generated" + i);
+        }
+    }
+}

--- a/testing/performance/src/templates/kts-many-accessors/buildSrc/src/main/resources/META-INF/gradle-plugins/many-source-sets.properties
+++ b/testing/performance/src/templates/kts-many-accessors/buildSrc/src/main/resources/META-INF/gradle-plugins/many-source-sets.properties
@@ -1,0 +1,1 @@
+implementation-class=org.gradle.performance.kotlindsl.ManySourceSetsPlugin


### PR DESCRIPTION
## Summary

- Instead of writing ~500 class files and ~500 source files per project, write directly into two JAR files (`classes.jar` and `sources.jar`)
- Reduces execution engine output snapshotting from ~1000 files to 2 files, eliminating a cost that was 82% as long as the actual generation
- Adds `OUTPUT_FORMAT_VERSION` to the identity hash to invalidate old directory-based workspaces

----

* Closes #37279

## Test plan

- [x] Unit tests: `ProjectAccessorsClassPathTest` — verifies JAR structure (classes, sources, module metadata) and runtime behavior
- [ ] Integration tests: `:kotlin-dsl:forkingIntegTest`
- [ ] Config cache tests: `:kotlin-dsl:configCacheIntegTest`
- [ ] Sanity check: `./gradlew sanityCheck`