### PR TITLE
Convert some TAPI integration tests back to cross-version tests

### DIFF
--- a/platforms/ide/tooling-api/build.gradle.kts
+++ b/platforms/ide/tooling-api/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     integTestImplementation(testFixtures(projects.launcher))
 
     crossVersionTestImplementation(projects.jvmServices)
+    crossVersionTestImplementation(projects.internalIntegTesting)
     crossVersionTestImplementation(projects.internalTesting)
     crossVersionTestImplementation(testFixtures(projects.buildProcessServices))
     crossVersionTestImplementation(testFixtures(projects.problemsApi))

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -14,23 +14,19 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.tooling
+package org.gradle.integtests.tooling.m8
 
 import org.apache.commons.io.output.TeeOutputStream
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.executer.ExecutionResult
+import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import org.gradle.integtests.tooling.fixture.TestOutputStream
-import org.gradle.integtests.tooling.fixture.TextUtil
-import org.gradle.integtests.tooling.fixture.ToolingApi
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import org.gradle.test.precondition.Requires
-import org.gradle.test.preconditions.IntegTestPreconditions
+import org.gradle.util.GradleVersion
 
 @LeaksFileHandles
-@Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "because toolingApi.requireIsolatedToolingApi()")
-class ToolingApiLoggingIntegrationTest extends AbstractIntegrationSpec {
-
-    ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
+class ToolingApiLoggingCrossVersionSpec extends ToolingApiSpecification {
 
     def setup() {
         toolingApi.requireIsolatedToolingApi()
@@ -43,7 +39,6 @@ class ToolingApiLoggingIntegrationTest extends AbstractIntegrationSpec {
     def "client receives same stdout and stderr when in verbose mode as if running from the command-line in debug mode"() {
         toolingApi.verboseLogging = true
 
-        settingsFile.touch()
         file("build.gradle") << """
 System.err.println "sys err logging xxx"
 
@@ -59,7 +54,7 @@ project.logger.debug("debug logging yyy");
         when:
         def stdOut = new TestOutputStream()
         def stdErr = new TestOutputStream()
-        toolingApi.withConnection {
+        withConnection {
             def build = it.newBuild()
             build.standardOutput = new TeeOutputStream(stdOut, System.out)
             build.standardError = new TeeOutputStream(stdErr, System.err)
@@ -76,11 +71,19 @@ project.logger.debug("debug logging yyy");
         out.count("lifecycle logging yyy") == 1
         out.count("warn logging yyy") == 1
         out.count("println logging yyy") == 1
-        out.count("logging xxx") == 0
+        if (targetVersion.baseVersion >= GradleVersion.version("4.7")) {
+            // Handling of error log message changed
+            out.count("error logging xxx") == 1
+            out.count("sys err logging xxx") == 1
 
-        err.count("logging yyy") == 0
-        err.count("error logging xxx") == 1
-        err.count("sys err logging xxx") == 1
+            err.count("logging") == 0
+        }  else {
+            out.count("logging xxx") == 0
+
+            err.count("logging yyy") == 0
+            err.count("error logging xxx") == 1
+            err.count("sys err logging xxx") == 1
+        }
 
         and:
         shouldNotContainProviderLogging(out)
@@ -103,32 +106,27 @@ project.logger.info ("info logging");
 project.logger.debug("debug logging");
 """
         when:
-        succeeds("help")
+        def commandLineResult = runUsingCommandLine()
 
         and:
-        def stdOut = new TestOutputStream()
-        def stdErr = new TestOutputStream()
-        toolingApi.withConnection {
-            def builder = newBuild().forTasks("help")
-                .setStandardOutput(new TeeOutputStream(stdOut, System.out))
-                .setStandardError(new TeeOutputStream(stdErr, System.err))
-
-            if (GradleContextualExecuter.configCache) {
-                builder.addArguments("--configuration-cache")
-            }
-
-            builder.run()
-        }
+        withBuild()
 
         then:
-        def out = stdOut.toString()
-        def err = stdErr.toString()
-        normalizeTapi(out) == normalizeCmdline(result.output)
-        TextUtil.normaliseLineSeparators(err) == TextUtil.normaliseLineSeparators(result.error)
+        def out = result.output
+        def err = result.error
+        def commandLineOutput = removeStartupWarnings(commandLineResult.output)
+        normaliseOutput(out) == normaliseOutput(commandLineOutput)
+        err == commandLineResult.error
 
         and:
-        err.count("System.err \u03b1\u03b2") == 1
-        err.count("error logging \u03b1\u03b2") == 1
+        def errLogging
+        if (targetDist.toolingApiMergesStderrIntoStdout) {
+            errLogging = out
+        } else {
+            errLogging = err
+        }
+        errLogging.count("System.err \u03b1\u03b2") == 1
+        errLogging.count("error logging \u03b1\u03b2") == 1
 
         and:
         out.count("lifecycle logging \u03b1\u03b2") == 1
@@ -144,30 +142,41 @@ project.logger.debug("debug logging");
         err.count("debug") == 0
     }
 
-    private static String normalizeTapi(String output) {
-        while (
-            output.startsWith('Calculating task graph as no cached configuration is available for tasks: help')
-        ) {
+    private static removeStartupWarnings(String output) {
+        while (output.startsWith('Starting a Gradle Daemon') || output.startsWith('Parallel execution is an incubating feature.')) {
             output = output.substring(output.indexOf('\n') + 1)
         }
-        normalize(output)
+        output
     }
 
-    private static normalizeCmdline(String output) {
-        while (
-            output.startsWith('Parallel Configuration Cache is an incubating feature.')
-        ) {
-            output = output.substring(output.indexOf('\n') + 1)
+    private ExecutionResult runUsingCommandLine() {
+        Jvm jvm = ToolingApi.getJvmOverride(targetDist)
+        def executer = new NoDaemonGradleExecuter(targetDist, temporaryFolder, getBuildContext())
+            .tap {
+                if (jvm != null) {
+                    withJvm(jvm)
+                }
+            }
+            .withCommandLineGradleOpts("-Dorg.gradle.deprecation.trace=false") //suppress deprecation stack trace
+            .noExtraLogging() // use default logging level, NoDaemonGradleExecuter sets --info otherwise
+
+        if (targetDist.toolingApiMergesStderrIntoStdout) {
+            // The TAPI provider merges the streams, so need to merge the streams for command-line execution too
+            executer.withArgument("--console=plain")
+            executer.withTestConsoleAttached()
+            // We changed the test console system property values in 4.9, need to use "both" instead of "BOTH"
+            if (targetVersion.baseVersion >= GradleVersion.version("4.8")
+                    && targetVersion.baseVersion < GradleVersion.version("4.9")) {
+                executer.withCommandLineGradleOpts("-Dorg.gradle.internal.console.test-console=both")
+            }
         }
-        normalize(output)
+
+        return executer.run()
     }
 
-    private static normalize(String output) {
-        while (output.startsWith('Starting a Gradle Daemon')) {
-            output = output.substring(output.indexOf('\n') + 1)
-        }
-        TextUtil.normaliseLineSeparators(output)
+    String normaliseOutput(String output) {
         // Must replace both build result formats for cross compat
+        return output
             .replaceAll(/Unable to list file systems to check whether they can be watched.*\n/, '')
             .replaceFirst(/Parallel Configuration Cache is an incubating feature.\n/, '')
             .replaceFirst(/Support for .* was deprecated.*\n/, '')

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/ClientShutdownCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/ClientShutdownCrossVersionSpec.groovy
@@ -14,29 +14,25 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.tooling
+package org.gradle.integtests.tooling.r22
 
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleExecuter
-import org.gradle.integtests.tooling.fixture.ToolingApi
+import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.tooling.model.gradle.GradleBuild
 import org.junit.Rule
 
-@Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "explicitly requires a daemon")
-class ClientShutdownIntegrationTest extends AbstractIntegrationSpec {
-    private static final JVM_OPTS = ["-Xmx1024m", "-XX:+HeapDumpOnOutOfMemoryError"] + ToolingApiSpecification.NORMALIZED_BUILD_JVM_OPTS
+class ClientShutdownCrossVersionSpec extends ToolingApiSpecification {
+    private static final JVM_OPTS = ["-Xmx1024m", "-XX:+HeapDumpOnOutOfMemoryError"] + NORMALIZED_BUILD_JVM_OPTS
 
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
 
-    ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
-
     def setup() {
-        settingsFile.touch()
         toolingApi.requireIsolatedToolingApi()
         toolingApi.requireIsolatedUserHome()
     }
@@ -57,7 +53,7 @@ class ClientShutdownIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "cleans up idle daemons when tooling API session is shutdown"() {
-        toolingApi.withConnection { connection ->
+        withConnection { connection ->
             connection.model(GradleBuild).setJvmArguments(buildJvmArguments).get()
         }
         toolingApi.daemons.daemon.assertIdle()
@@ -69,6 +65,7 @@ class ClientShutdownIntegrationTest extends AbstractIntegrationSpec {
         toolingApi.daemons.daemon.stops()
     }
 
+    @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "explicitly requires a daemon")
     def "cleans up busy daemons once they become idle when tooling API session is shutdown"() {
         given:
         server.start()
@@ -76,7 +73,7 @@ class ClientShutdownIntegrationTest extends AbstractIntegrationSpec {
 task slow { doLast { ${server.callFromBuild('sync')} } }
 """
         def sync = server.expectAndBlock('sync')
-        toolingApi.withConnection { connection ->
+        withConnection { connection ->
             connection.model(GradleBuild).setJvmArguments(buildJvmArguments).get()
         }
         toolingApi.daemons.daemon.assertIdle()
@@ -101,7 +98,7 @@ task slow { doLast { ${server.callFromBuild('sync')} } }
 
     def "shutdown ignores daemons that are no longer running"() {
         given:
-        toolingApi.withConnection { connection ->
+        withConnection { connection ->
             connection.model(GradleBuild).setJvmArguments(buildJvmArguments).get()
         }
         toolingApi.daemons.daemon.assertIdle()
@@ -114,12 +111,13 @@ task slow { doLast { ${server.callFromBuild('sync')} } }
         noExceptionThrown()
     }
 
+    @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "explicitly requires a daemon")
     def "shutdown ignores daemons that were not started by client"() {
         given:
         daemonExecutor().run()
         toolingApi.daemons.daemon.assertIdle()
 
-        toolingApi.withConnection { connection ->
+        withConnection { connection ->
             connection.model(GradleBuild).setJvmArguments(buildJvmArguments).get()
         }
         toolingApi.daemons.daemon.assertIdle()
@@ -132,7 +130,13 @@ task slow { doLast { ${server.callFromBuild('sync')} } }
     }
 
     private GradleExecuter daemonExecutor() {
-        executer
+        Jvm jvm = ToolingApi.getJvmOverride(targetDist)
+        new NoDaemonGradleExecuter(targetDist, temporaryFolder, getBuildContext())
+            .tap {
+                if (jvm != null) {
+                    withJvm(jvm)
+                }
+            }
             .withDaemonBaseDir(toolingApi.daemonBaseDir)
             .withBuildJvmOpts(buildJvmArguments)
             .useOnlyRequestedJvmOpts()

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r64/DaemonReuseCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r64/DaemonReuseCrossVersionSpec.groovy
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.tooling
+package org.gradle.integtests.tooling.r64
 
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.tooling.fixture.ToolingApi
+import org.gradle.integtests.fixtures.executer.NoDaemonGradleExecuter
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.internal.jvm.Jvm
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 
-@Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "requires a daemon")
-class DaemonReuseIntegrationTest extends AbstractIntegrationSpec {
-
-    ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
+class DaemonReuseCrossVersionSpec extends ToolingApiSpecification {
 
     def setup() {
         toolingApi.requireIsolatedDaemons()
@@ -41,6 +38,7 @@ class DaemonReuseIntegrationTest extends AbstractIntegrationSpec {
         assertSameDaemon(original)
     }
 
+    @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "requires a daemon")
     def "tooling API client reuses existing daemon started by CLI"() {
         runBuildViaCLI()
         def original = getDaemonUID()
@@ -50,6 +48,7 @@ class DaemonReuseIntegrationTest extends AbstractIntegrationSpec {
         assertSameDaemon(original)
     }
 
+    @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor, reason = "requires a daemon")
     def "CLI reuses existing daemon started by TAPI"() {
         runBuildViaTAPI()
         def original = getDaemonUID()
@@ -68,20 +67,27 @@ class DaemonReuseIntegrationTest extends AbstractIntegrationSpec {
     }
 
     private void runBuildViaTAPI() {
-        toolingApi.withConnection {
+        withConnection {
             def build = newBuild()
-            build.setJvmArguments(ToolingApiSpecification.NORMALIZED_BUILD_JVM_OPTS + "-Djava.io.tmpdir=${buildContext.getTmpDir().absolutePath}".toString())
+            build.setJvmArguments(NORMALIZED_BUILD_JVM_OPTS + "-Djava.io.tmpdir=${buildContext.getTmpDir().absolutePath}".toString())
             build.forTasks("help")
             build.run()
         }
     }
 
     private void runBuildViaCLI() {
-        executer
+        Jvm jvm = ToolingApi.getJvmOverride(targetDist)
+
+        new NoDaemonGradleExecuter(toolingApi.getDistribution(), temporaryFolder, buildContext)
+            .tap {
+                if (jvm != null) {
+                    withJvm(jvm)
+                }
+            }
             .withDaemonBaseDir(toolingApi.daemonBaseDir)
             .requireDaemon()
             .useOnlyRequestedJvmOpts()
-            .withArguments("-Dorg.gradle.jvmargs=${ToolingApiSpecification.NORMALIZED_BUILD_JVM_OPTS.join(" ")} -Djava.io.tmpdir=${buildContext.getTmpDir().absolutePath}")
+            .withArguments("-Dorg.gradle.jvmargs=${NORMALIZED_BUILD_JVM_OPTS.join(" ")} -Djava.io.tmpdir=${buildContext.getTmpDir().absolutePath}")
             .withTasks("help")
             .run()
     }

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
@@ -246,14 +246,16 @@ class ToolingApi implements TestRule {
             error = new TeeOutputStream(stderr, System.err)
         }
 
+        return new ToolingApiConnector(connector, getJvmOverride(dist)?.javaHome, output, error)
+    }
 
+    public static Jvm getJvmOverride(GradleDistribution distribution) {
         Jvm jvm = null
-        if (!dist.daemonWorksWith(Jvm.current().javaVersionMajor)) {
-            jvm = AvailableJavaHomes.getAvailableJdk { dist.daemonWorksWith(it.javaMajorVersion) }
+        if (!distribution.daemonWorksWith(Jvm.current().javaVersionMajor)) {
+            jvm = AvailableJavaHomes.getAvailableJdk { distribution.daemonWorksWith(it.javaMajorVersion) }
             Assume.assumeThat("JVM compatible with the distribution daemon", jvm, IsNot.not(null));
         }
-
-        return new ToolingApiConnector(connector, jvm?.javaHome, output, error)
+        return jvm
     }
 
     /**


### PR DESCRIPTION
- Revert the conversion of ClientShutdownCrossVersionSpec, DaemonReuseCrossVersionSpec, and ToolingApiLoggingCrossVersionSpec from cross-version tests to integration tests (done in #34620)
- These tests must remain cross-version tests because the integration test variants do not provide the desired test coverage
- Fixes https://github.com/gradle/gradle-private/issues/5129

| Test | Executions |
| --- | --- |
| `ClientShutdownCrossVersionSpec` | +325 |
| `DaemonReuseCrossVersionSpec` | +195 |
| `ToolingApiLoggingCrossVersionSpec` | +182 |