### PR TITLE
Fix packageInfoData cache key for relative path of package-info files

### DIFF
--- a/build-logic-settings/architecture-docs/src/main/kotlin/gradlebuild/GeneratePackageInfoDataTask.kt
+++ b/build-logic-settings/architecture-docs/src/main/kotlin/gradlebuild/GeneratePackageInfoDataTask.kt
@@ -24,6 +24,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
@@ -51,6 +52,11 @@ abstract class GeneratePackageInfoDataTask : DefaultTask() {
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val packageInfoFiles: ConfigurableFileCollection
+
+    @get:Input
+    // Preserve the project path in the cache key, since packageInfoFiles are fingerprinted relative to each source root.
+    val packageInfoFilePaths: List<String>
+        get() = packageInfoFiles.files.map { it.relativeTo(baseDir).path.replace(File.separatorChar, '/') }.sorted()
 
     @get:OutputFile
     abstract val outputFile: RegularFileProperty


### PR DESCRIPTION
`packageInfoData` fingerprints its file inputs relative to each source root, which can hide moves between projects and reuse stale cached output. Add a derived input with repo-relative package-info paths so the cache key changes when files move while remaining relocatable across machines.
