### PR TITLE
Support producing Perfetto traces for performance tests

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -318,6 +318,15 @@ val Project.performanceDbPassword: Provider<String>
 val Project.performanceTestVerbose: Provider<String>
     get() = gradleProperty(PERFORMANCE_TEST_VERBOSE)
 
+/**
+ * Run with `-PperformanceTest.buildOperationTrace=true` to produce a build operation trace (including Perfetto trace) for tested invocation.
+ *
+ * Producing a trace has significant overhead, so it should only be used for sanity-checking and troubleshooting performance tests.
+ *
+ * For details see `--build-ops-trace` in [Gradle Profiler](https://github.com/gradle/gradle-profiler) documentation.
+ */
+val Project.performanceTestBuildOperationTrace: Provider<Boolean>
+    get() = propertyFromAnySource("performanceTest.buildOperationTrace").asBooleanOrFalse()
 
 val Project.propertiesForPerformanceDb: Map<String, String>
     get() {

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -97,6 +97,9 @@ abstract class PerformanceTest extends DistributionTest {
     abstract Property<String> getChannel()
 
     @Internal
+    abstract Property<Boolean> getBuildOperationTrace()
+
+    @Internal
     String buildId
 
     @Internal
@@ -336,6 +339,7 @@ abstract class PerformanceTest extends DistributionTest {
             addSystemPropertyIfExist(result, "org.gradle.performance.execution.channel", channel.get())
             addSystemPropertyIfExist(result, "org.gradle.performance.debugArtifactsDirectory", getDebugArtifactsDirectory())
             addSystemPropertyIfExist(result, "org.gradle.performance.db.profiling.output", new File(debugArtifactsDirectory, "db-profiling.txt").absolutePath)
+            addSystemPropertyIfExist(result, "org.gradle.performance.buildOperationTrace", buildOperationTrace.get())
             addSystemPropertyIfExist(result, "gradleBuildBranch", branchName)
 
             if (profiler.isPresent() && profiler.get() != "none") {

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -31,6 +31,7 @@ import gradlebuild.basics.performanceChannel
 import gradlebuild.basics.performanceDependencyBuildIds
 import gradlebuild.basics.performanceGeneratorMaxProjects
 import gradlebuild.basics.performanceStage
+import gradlebuild.basics.performanceTestBuildOperationTrace
 import gradlebuild.basics.performanceTestVerbose
 import gradlebuild.basics.propertiesForPerformanceDb
 import gradlebuild.basics.releasedVersionsFile
@@ -435,6 +436,7 @@ class PerformanceTestExtension(
             resultsJson = project.layout.buildDirectory.file("${this.name}/${Config.performanceTestResultsJson}").get().asFile
             addDatabaseParameters(project.propertiesForPerformanceDb)
             channel = project.performanceChannel
+            buildOperationTrace = project.performanceTestBuildOperationTrace
             testClassesDirs = performanceSourceSet.output.classesDirs
             classpath = performanceSourceSet.runtimeClasspath
 

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractBuildExperimentRunner.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractBuildExperimentRunner.java
@@ -124,7 +124,8 @@ public abstract class AbstractBuildExperimentRunner implements BuildExperimentRu
             .setSysProperties(emptyMap())
             .setWarmupCount(warmupsForExperiment(experiment))
             .setIterations(invocationsForExperiment(experiment))
-            .setCsvFormat(Format.LONG);
+            .setCsvFormat(Format.LONG)
+            .setBuildOperationsTrace(Boolean.getBoolean("org.gradle.performance.buildOperationTrace"));
     }
 
     private File outputDirFor(String testId, BuildExperimentSpec spec) {

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/GradleBuildExperimentRunner.java
@@ -220,7 +220,6 @@ public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {
             .add(jvmOptsFromGradleProperties)
             .addAll(invocationSpec.getJvmArguments())
             .build();
-        boolean isBuildOperationsTrace = false;
         return new GradleScenarioDefinition(
             OutputDirSelectorUtil.fileSafeNameFor(experimentSpec.getDisplayName()),
             experimentSpec.getDisplayName(),
@@ -238,7 +237,7 @@ public class GradleBuildExperimentRunner extends AbstractBuildExperimentRunner {
             invocationSettings.getOutputDir(),
             actualJvmArgs,
             invocationSettings.getBuildOperationMeasurements(),
-            isBuildOperationsTrace
+            invocationSettings.isBuildOperationsTrace()
         );
     }
 


### PR DESCRIPTION
Allows passing `-PperformanceTest.buildOperationTrace=true` to an invocation of a performance test to make it produce a build operation trace and a Perfetto trace.

This is useful to sanity check that a performance test does what you expect or troubleshoot one.

**The parameter can be provided when running an ad-hoc performance test:**
<img width="796" height="236" alt="image" src="https://github.com/user-attachments/assets/5b855909-852b-414c-8eb1-2d9e9886a4fc" />

---

**Then the traces can be found in the `Artifacts`, after the job finishes:**
<img width="957" height="783" alt="image" src="https://github.com/user-attachments/assets/3287c28b-bba3-42e9-80f4-613701e771d6" />
