### PR TITLE
Skip known build scan publication failure

### DIFF
--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ResultAssertion.java
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ResultAssertion.java
@@ -38,6 +38,12 @@ import static org.gradle.integtests.fixtures.executer.OutputScrapingExecutionRes
  * TODO: This class could probably use a better name, maybe something like GradleDeprecationVerifier
  */
 public class ResultAssertion implements Action<ExecutionResult> {
+    // Remove thsi after https://github.com/gradle/dv/issues/63627 is fixed
+    private static final Pattern KNOWN_DEVELOCITY_BUILD_SCAN_FAILURE = Pattern.compile(
+        "(?ms)^A build scan cannot be produced as an error occurred gathering build data\\.\\R"
+            + ".*?^----------\\R.*?^----------\\R?"
+    );
+
     private final List<ExpectedDeprecationWarning> expectedDeprecationWarnings;
     private final List<ExpectedDeprecationWarning> maybeExpectedDeprecationWarnings;
 
@@ -118,6 +124,7 @@ public class ResultAssertion implements Action<ExecutionResult> {
     }
 
     private void validate(String output, String displayName) {
+        output = KNOWN_DEVELOCITY_BUILD_SCAN_FAILURE.matcher(output).replaceAll("");
         List<String> lines = getLines(output);
         int i = 0;
         boolean insideVariantDescriptionBlock = false;


### PR DESCRIPTION
Android smoke tests are flaky recently because of https://github.com/gradle/dv/issues/63627, [example](https://ge.gradle.org/s/5ic5ysmnwdzvs/tests/task/:smoke-test:configCacheAndroidProjectSmokeTest/details/org.gradle.smoketests.AndroidProjectCachingSmokeTest/can%20cache%20android%20application%20(agp%3D9.0.1)?top-execution=1). This is more annoying than other because each retry takes ~6m - and we test many AGP versions, the accumulated retry time might even trigger a timeout.

This PR skips detecting that stacktrace:

```
java.lang.AssertionError: Standard output line 705 contains an unexpected stack trace: 	at com.gradle.develocity.DevelocityException.a(SourceFile:25)	
=====	
Parallel Configuration Cache is an incubating feature.	
Calculating task graph as no cached configuration is available for tasks: assembleDebug	
Type-safe project accessors is an incubating feature.	
> Task :build-logic:convention:checkKotlinGradlePluginConfigurationErrors SKIPPED	
> Task :build-logic:convention:pluginDescriptors	
> Task :build-logic:convention:processResources	
> Task :build-logic:convention:compileKotlin	
> Task :build-logic:convention:compileJava NO-SOURCE	
> Task :build-logic:convention:classes	
> Task :build-logic:convention:jar

...

BUILD SUCCESSFUL in 0s	
1916 actionable tasks: 1477 executed, 439 from cache	
A build scan cannot be produced as an error occurred gathering build data.	
Please report this problem via https://gradle.com/help and include the following via copy/paste:	
----------	
Gradle version: 9.6.0-20260401205350+0000	
Plugin version: 4.4.0	
com.gradle.scan.plugin.internal.operations.a: Build operation dispatch of progress notification org.gradle.internal.execution.steps.IdentityCacheStep$DefaultExecuteDeferredWorkProgressDetails@e227ffc failed.	
Operation context: 	
	org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor$1 (1): {}	
	org.gradle.internal.buildtree.BuildOperationFiringBuildTreeWorkExecutor$1 (76925): {}	
	org.gradle.execution.RunRootBuildWorkBuildOperationType$Details (76926): {getBuildStartTime=1775079188972}	
	org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails (93146): {buildPath=:, taskPath=:app:mergeExtDexDemoDebug, taskClass=com.android.build.gradle.internal.tasks.DexMergingTask, taskId=399}	
	org.gradle.api.internal.tasks.execution.TaskExecution$1 (93147): {}	
	org.gradle.internal.execution.steps.CaptureMutableStateBeforeExecutionStep$Operation$Details$1 (93148): {}	
Caused by: java.lang.IllegalStateException: Attempt to retrieve ID for 'com.gradle.scan.plugin.internal.c.b.a.e@601e0dbb' without previously assigning ID.	
	at com.gradle.scan.plugin.internal.j.h.d(SourceFile:88)	
	at com.gradle.scan.plugin.internal.c.n.c.a(SourceFile:49)	
	at com.gradle.scan.plugin.internal.c.b.a.d.lambda$attach$0(SourceFile:33)	
	at com.gradle.scan.plugin.internal.operations.b$b.a(SourceFile:108)	
	at com.gradle.scan.plugin.internal.operations.b$b.progress(SourceFile:98)	
	at com.gradle.scan.plugin.internal.operations.b.a(SourceFile:60)	
	at com.gradle.scan.plugin.internal.operations.n.a(SourceFile:48)	
	at com.gradle.scan.plugin.internal.operations.d.a(SourceFile:107)	
	at com.gradle.scan.plugin.internal.operations.h.a(SourceFile:45)	
	at com.gradle.scan.plugin.internal.r.a$a.a(SourceFile:31)	
	at com.gradle.scan.plugin.internal.r.a$a.a(SourceFile:20)	
	at com.gradle.scan.plugin.internal.r.a.c(SourceFile:67)	
----------	
Configuration cache entry stored.	
Build operation trace: /home/tcagent1/agent/work/f63322e10dd6b396/testing/smoke-test/build/tmp/test files/AndroidProj.Test/knyps/original/operations-log.txt	
=====	
```