### PR TITLE
[infra] Undeprecate getIsX() property getters and add missing ones

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectTaskLister;
 import org.gradle.api.internal.project.taskfactory.TaskIdentity;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Console;
@@ -96,9 +95,7 @@ public abstract class TaskReportTask extends ConventionReportTask {
 
     // kotlin source compatibility
     @Internal
-    @Deprecated
     public Property<Boolean> getIsShowDetail() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsShowDetail()", "getShowDetail()");
         return getShowDetail();
     }
 

--- a/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
+++ b/platforms/core-execution/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
@@ -17,7 +17,6 @@
 package org.gradle.caching.http;
 
 import org.gradle.api.Action;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Nested;
@@ -117,13 +116,8 @@ public abstract class HttpBuildCache extends AbstractBuildCache {
 
     /**
      * This method exists only for Kotlin source backward compatibility.
-     *
-     * @deprecated This method is deprecated and will be removed in the next major version of Gradle.
-     * Use {@link #getAllowUntrustedServer()} instead.
      **/
-    @Deprecated
     public Property<Boolean> getIsAllowUntrustedServer() {
-        ProviderApiDeprecationLogger.logDeprecation(HttpBuildCache.class, "getIsAllowUntrustedServer()", "getAllowUntrustedServer()");
         return getAllowUntrustedServer();
     }
 
@@ -149,12 +143,8 @@ public abstract class HttpBuildCache extends AbstractBuildCache {
 
     /**
      * This method exists only for Kotlin source backward compatibility.
-     * @deprecated This method is deprecated and will be removed in the next major version of Gradle.
-     * Use {@link #getAllowInsecureProtocol()} instead.
      **/
-    @Deprecated
     public Property<Boolean> getIsAllowInsecureProtocol() {
-        ProviderApiDeprecationLogger.logDeprecation(HttpBuildCache.class, "getIsAllowInsecureProtocol()", "getAllowInsecureProtocol()");
         return getAllowInsecureProtocol();
     }
 
@@ -178,12 +168,8 @@ public abstract class HttpBuildCache extends AbstractBuildCache {
 
     /**
      * This method exists only for Kotlin source backward compatibility.
-     * @deprecated This method is deprecated and will be removed in the next major version of Gradle.
-     * Use {@link #getUseExpectContinue()} instead.
      **/
-    @Deprecated
     public Property<Boolean> getIsUseExpectContinue() {
-        ProviderApiDeprecationLogger.logDeprecation(HttpBuildCache.class, "getIsUseExpectContinue()", "getUseExpectContinue()");
         return getUseExpectContinue();
     }
 

--- a/platforms/jvm/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/platforms/jvm/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -24,7 +24,6 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileType;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.plugins.antlr.internal.AntlrExecuter;
 import org.gradle.api.plugins.antlr.internal.AntlrResult;
 import org.gradle.api.plugins.antlr.internal.AntlrSourceGenerationException;
@@ -89,9 +88,7 @@ public abstract class AntlrTask extends SourceTask {
     public abstract Property<Boolean> getTrace();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsTrace() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsTrace()", "getTrace()");
         return getTrace();
     }
 
@@ -103,9 +100,7 @@ public abstract class AntlrTask extends SourceTask {
     public abstract Property<Boolean> getTraceLexer();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsTraceLexer() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsTraceLexer()", "getTraceLexer()");
         return getTraceLexer();
     }
 
@@ -117,9 +112,7 @@ public abstract class AntlrTask extends SourceTask {
     public abstract Property<Boolean> getTraceParser();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsTraceParser() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsTraceParser()", "getTraceParser()");
         return getTraceParser();
     }
 
@@ -131,9 +124,7 @@ public abstract class AntlrTask extends SourceTask {
     public abstract Property<Boolean> getTraceTreeWalker();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsTraceTreeWalker() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsTraceTreeWalker()", "getTraceTreeWalker()");
         return getTraceTreeWalker();
     }
 

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Checkstyle.java
@@ -22,7 +22,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.plugins.quality.internal.CheckstyleAction;
 import org.gradle.api.plugins.quality.internal.CheckstyleActionParameters;
 import org.gradle.api.plugins.quality.internal.CheckstyleReportsImpl;
@@ -282,9 +281,7 @@ public abstract class Checkstyle extends AbstractCodeQualityTask implements Repo
     public abstract Property<Boolean> getShowViolations();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsShowViolations() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsShowViolations()", "getShowViolations()");
         return getShowViolations();
     }
 
@@ -307,10 +304,8 @@ public abstract class Checkstyle extends AbstractCodeQualityTask implements Repo
      * @since 9.0
      */
     @Internal
-    @Deprecated
     @ReplacesEagerProperty(adapter = IsIgnoreFailuresAdapter.class)
     public Property<Boolean> getIsIgnoreFailures() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsIgnoreFailures()", "getIgnoreFailures()");
         return getIgnoreFailuresProperty();
     }
 

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CheckstyleExtension.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CheckstyleExtension.java
@@ -18,7 +18,6 @@ package org.gradle.api.plugins.quality;
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.resources.TextResource;
@@ -131,9 +130,7 @@ public abstract class CheckstyleExtension extends CodeQualityExtension {
     @ReplacesEagerProperty(originalType = boolean.class)
     public abstract Property<Boolean> getShowViolations();
 
-    @Deprecated
     public Property<Boolean> getIsShowViolations() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsShowViolations()", "getShowViolations()");
         return getShowViolations();
     }
 

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeQualityExtension.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/CodeQualityExtension.java
@@ -16,7 +16,6 @@
 package org.gradle.api.plugins.quality;
 
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
@@ -53,9 +52,7 @@ public abstract class CodeQualityExtension {
     @ReplacesEagerProperty(originalType = boolean.class)
     public abstract Property<Boolean> getIgnoreFailures();
 
-    @Deprecated
     public Property<Boolean> getIsIgnoreFailures() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsIgnoreFailures()", "getIgnoreFailures()");
         return getIgnoreFailures();
     }
 

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
@@ -23,7 +23,6 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.RegularFile;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.quality.internal.PmdAction;
 import org.gradle.api.plugins.quality.internal.PmdActionParameters;
@@ -288,9 +287,7 @@ public abstract class Pmd extends AbstractCodeQualityTask implements Reporting<P
     public abstract Property<Boolean> getConsoleOutput();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsConsoleOutput() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsConsoleOutput()", "getConsoleOutput()");
         return getConsoleOutput();
     }
 

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdExtension.java
@@ -17,7 +17,6 @@ package org.gradle.api.plugins.quality;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.resources.TextResource;
@@ -162,9 +161,7 @@ public abstract class PmdExtension extends CodeQualityExtension {
     @ReplacesEagerProperty(originalType = boolean.class)
     public abstract Property<Boolean> getConsoleOutput();
 
-    @Deprecated
     public Property<Boolean> getIsConsoleOutput() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsConsoleOutput()", "getConsoleOutput()");
         return getConsoleOutput();
     }
 

--- a/platforms/jvm/groovy-compiler-worker/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
+++ b/platforms/jvm/groovy-compiler-worker/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
@@ -68,9 +67,7 @@ public abstract class GroovyCompileOptions implements Serializable {
     public abstract Property<Boolean> getFailOnError();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsFailOnError() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsFailOnError()", "getFailOnError()");
         return getFailOnError();
     }
 
@@ -82,9 +79,7 @@ public abstract class GroovyCompileOptions implements Serializable {
     public abstract Property<Boolean> getVerbose();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsVerbose() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsVerbose()", "getVerbose()");
         return getVerbose();
     }
 
@@ -96,9 +91,7 @@ public abstract class GroovyCompileOptions implements Serializable {
     public abstract Property<Boolean> getListFiles();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsListFiles() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsListFiles()", "getListFiles()");
         return getListFiles();
     }
 
@@ -117,9 +110,7 @@ public abstract class GroovyCompileOptions implements Serializable {
     public abstract Property<Boolean> getFork();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsFork() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsFork()", "getFork()");
         return getFork();
     }
 
@@ -184,9 +175,7 @@ public abstract class GroovyCompileOptions implements Serializable {
     public abstract Property<Boolean> getJavaAnnotationProcessing();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsJavaAnnotationProcessing() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsJavaAnnotationProcessing()", "getJavaAnnotationProcessing()");
         return getJavaAnnotationProcessing();
     }
 
@@ -200,9 +189,7 @@ public abstract class GroovyCompileOptions implements Serializable {
     public abstract Property<Boolean> getParameters();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsParameters() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsParameters()", "getParameters()");
         return getParameters();
     }
 
@@ -278,9 +265,7 @@ public abstract class GroovyCompileOptions implements Serializable {
     public abstract Property<Boolean> getKeepStubs();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsKeepStubs() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsKeepStubs()", "getKeepStubs()");
         return getKeepStubs();
     }
 

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
@@ -95,10 +95,7 @@ public abstract class JacocoTaskExtension {
     public abstract Property<Boolean> getEnabled();
 
     @Internal
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
     public Property<Boolean> getIsEnabled() {
-        // TODO: add deprecation message
         return getEnabled();
     }
 
@@ -165,10 +162,7 @@ public abstract class JacocoTaskExtension {
     public abstract Property<Boolean> getIncludeNoLocationClasses();
 
     @Internal
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
     public Property<Boolean> getIsIncludeNoLocationClasses() {
-        // TODO: add deprecation message
         return getIncludeNoLocationClasses();
     }
 
@@ -188,10 +182,7 @@ public abstract class JacocoTaskExtension {
     public abstract Property<Boolean> getDumpOnExit();
 
     @Internal
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
     public Property<Boolean> getIsDumpOnExit() {
-        // TODO: add deprecation message
         return getDumpOnExit();
     }
 
@@ -237,10 +228,7 @@ public abstract class JacocoTaskExtension {
     public abstract Property<Boolean> getJmx();
 
     @Internal
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
     public Property<Boolean> getIsJmx() {
-        // TODO: add deprecation message
         return getJmx();
     }
 

--- a/platforms/jvm/javadoc/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/platforms/jvm/javadoc/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -27,7 +27,6 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.provider.PropertyFactory;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.internal.tasks.compile.CompilationSourceDirs;
 import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
@@ -329,10 +328,8 @@ public abstract class Javadoc extends SourceTask {
     @ReplacesEagerProperty(originalType = boolean.class)
     public abstract Property<Boolean> getFailOnError();
 
-    @Deprecated
     @ReplacedBy("getFailOnError()")
     public Property<Boolean> getIsFailOnError() {
-        ProviderApiDeprecationLogger.logDeprecation(Javadoc.class, "getIsFailOnError()", "failOnError");
         return getFailOnError();
     }
 

--- a/platforms/jvm/javadoc/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
+++ b/platforms/jvm/javadoc/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -328,9 +327,7 @@ public abstract class CoreJavadocOptions implements MinimalJavadocOptions {
     }
 
     @Override
-    @Deprecated
     public Provider<Boolean> getIsVerbose() {
-        ProviderApiDeprecationLogger.logDeprecation(CoreJavadocOptions.class, "getIsVerbose()", "getVerbose()");
         return getVerbose();
     }
 
@@ -373,9 +370,7 @@ public abstract class CoreJavadocOptions implements MinimalJavadocOptions {
     public abstract Property<Boolean> getBreakIterator();
 
     @Override
-    @Deprecated
     public Property<Boolean> getIsBreakIterator() {
-        ProviderApiDeprecationLogger.logDeprecation(CoreJavadocOptions.class, "getIsBreakIterator()", "getBreakIterator()");
         return getBreakIterator();
     }
 

--- a/platforms/jvm/javadoc/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
+++ b/platforms/jvm/javadoc/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
@@ -136,7 +136,6 @@ public interface MinimalJavadocOptions {
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     Provider<Boolean> getIsVerbose();
 
     MinimalJavadocOptions quiet();
@@ -149,7 +148,6 @@ public interface MinimalJavadocOptions {
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     Property<Boolean> getIsBreakIterator();
 
     MinimalJavadocOptions breakIterator(boolean breakIterator);

--- a/platforms/jvm/javadoc/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
+++ b/platforms/jvm/javadoc/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
@@ -23,7 +23,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -193,9 +192,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsUse() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsUse()", "getUse()");
         return getUse();
     }
 
@@ -222,9 +219,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsVersion() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsVersion()", "getVersion()");
         return getVersion();
     }
 
@@ -250,9 +245,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsAuthor() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsAuthor()", "getAuthor()");
         return getAuthor();
     }
 
@@ -279,9 +272,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsSplitIndex() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsSplitIndex()", "getSplitIndex()");
         return getSplitIndex();
     }
 
@@ -477,9 +468,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsLinkSource() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsLinkSource()", "getLinkSource()");
         return getLinkSource();
     }
 
@@ -572,9 +561,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoDeprecated() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsNoDeprecated()", "getNoDeprecated()");
         return getNoDeprecated();
     }
 
@@ -603,9 +590,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoDeprecatedList() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsNoDeprecatedList()", "getNoDeprecatedList()");
         return getNoDeprecatedList();
     }
 
@@ -631,9 +616,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoSince() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsNoSince()", "getNoSince()");
         return getNoSince();
     }
 
@@ -661,9 +644,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoTree() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsNoTree()", "getNoTree()");
         return getNoTree();
     }
 
@@ -689,9 +670,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoIndex() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsNoIndex()", "getNoIndex()");
         return getNoIndex();
     }
 
@@ -717,9 +696,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoHelp() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsNoHelp()", "getNoHelp()");
         return getNoHelp();
     }
 
@@ -748,9 +725,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoNavBar() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsNoNavBar()", "getNoNavBar()");
         return getNoNavBar();
     }
 
@@ -815,9 +790,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsSerialWarn() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsSerialWarn()", "getSerialWarn()");
         return getSerialWarn();
     }
 
@@ -884,9 +857,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsKeyWords() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsKeyWords()", "getKeyWords()");
         return getKeyWords();
     }
 
@@ -965,9 +936,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsDocFilesSubDirs() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsDocFilesSubDirs()", "getDocFilesSubDirs()");
         return getDocFilesSubDirs();
     }
 
@@ -1022,9 +991,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoTimestamp() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsNoTimestamp()", "getNoTimestamp()");
         return getNoTimestamp();
     }
 
@@ -1048,9 +1015,7 @@ public abstract class StandardJavadocDocletOptions extends CoreJavadocOptions im
      * This method exists only for Kotlin source backward compatibility.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoComment() {
-        ProviderApiDeprecationLogger.logDeprecation(StandardJavadocDocletOptions.class, "getIsNoComment()", "getNoComment()");
         return getNoComment();
     }
 

--- a/platforms/jvm/jvm-compiler-worker/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/jvm-compiler-worker/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -77,9 +77,6 @@ public abstract class CompileOptions implements Serializable {
     @ReplacesEagerProperty(originalType = boolean.class)
     public abstract Property<Boolean> getFailOnError();
 
-    /**
-     * TODO: Add deprecation warning
-     */
     @ReplacedBy("failOnError")
     public Property<Boolean> getIsFailOnError() {
         return getFailOnError();
@@ -92,9 +89,6 @@ public abstract class CompileOptions implements Serializable {
     @ReplacesEagerProperty(originalType = boolean.class)
     public abstract Property<Boolean> getVerbose();
 
-    /**
-     * TODO: Add deprecation warning
-     */
     @ReplacedBy("verbose")
     public Property<Boolean> getIsVerbose() {
         return getVerbose();
@@ -107,9 +101,6 @@ public abstract class CompileOptions implements Serializable {
     @ReplacesEagerProperty(originalType = boolean.class)
     public abstract Property<Boolean> getListFiles();
 
-    /**
-     * TODO: Add deprecation warning
-     */
     @ReplacedBy("listFiles")
     public Property<Boolean> getIsListFiles() {
         return getListFiles();
@@ -124,9 +115,6 @@ public abstract class CompileOptions implements Serializable {
 
     /**
      * Sets whether to log details of usage of deprecated members or classes. Defaults to {@code false}.
-     *
-     * TODO: Add deprecation warning
-     *
      */
     @ReplacedBy("deprecation")
     public Property<Boolean> getIsDeprecation() {
@@ -142,8 +130,6 @@ public abstract class CompileOptions implements Serializable {
 
     /**
      * Sets whether to log warning messages. The default is {@code true}.
-     *
-     * TODO: Add deprecation warning
      */
     @ReplacedBy("warnings")
     public Property<Boolean> getIsWarnings() {
@@ -170,8 +156,6 @@ public abstract class CompileOptions implements Serializable {
     /**
      * Sets whether to include debugging information in the generated class files. Defaults
      * to {@code true}. See {@link DebugOptions#getDebugLevel()} for which debugging information will be generated.
-     *
-     * TODO: Add deprecation warning
      */
     @ReplacedBy("debug")
     public Property<Boolean> getIsDebug() {
@@ -206,8 +190,6 @@ public abstract class CompileOptions implements Serializable {
      * Sets whether to run the compiler in its own process. Note that this does
      * not necessarily mean that a new process will be created for each compile task.
      * Defaults to {@code false}.
-     *
-     * TODO: Add deprecation warning
      */
     @ReplacedBy("fork")
     public Property<Boolean> getIsFork() {
@@ -298,9 +280,6 @@ public abstract class CompileOptions implements Serializable {
     @ReplacesEagerProperty(originalType = boolean.class, fluentSetter = true)
     public abstract Property<Boolean> getIncremental();
 
-    /**
-     * TODO: Add deprecation warning
-     */
     @ReplacedBy("incremental")
     public Property<Boolean> getIsIncremental() {
         return getIncremental();

--- a/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/platforms/jvm/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -21,7 +21,6 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.internal.tasks.GroovydocAntAction;
 import org.gradle.api.internal.tasks.GroovydocParameters;
 import org.gradle.api.provider.Property;
@@ -177,9 +176,7 @@ public abstract class Groovydoc extends SourceTask {
     public abstract Property<Boolean> getUse();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsUse() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsUse()", "getUse()");
         return getUse();
     }
 
@@ -191,9 +188,7 @@ public abstract class Groovydoc extends SourceTask {
     public abstract Property<Boolean> getNoTimestamp();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoTimestamp() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsNoTimestamp()", "getNoTimestamp()");
         return getNoTimestamp();
     }
 
@@ -205,9 +200,7 @@ public abstract class Groovydoc extends SourceTask {
     public abstract Property<Boolean> getNoVersionStamp();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsNoVersionStamp() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsNoVersionStamp()", "getNoVersionStamp()");
         return getNoVersionStamp();
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -24,7 +24,6 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.provider.PropertyFactory;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -564,9 +563,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     @Internal
-    @Deprecated
     public Property<Boolean> getIsIgnoreExitValue() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsIgnoreExitValue()", "getIgnoreExitValue()");
         return getIgnoreExitValue();
     }
 

--- a/platforms/jvm/scala-compiler-worker/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
+++ b/platforms/jvm/scala-compiler-worker/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
@@ -18,7 +18,7 @@ package org.gradle.language.scala.tasks;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
+
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
@@ -66,9 +66,7 @@ public abstract class BaseScalaCompileOptions implements Serializable {
     public abstract Property<Boolean> getFailOnError();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsFailOnError() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsFailOnError()", "getFailOnError()");
         return getFailOnError();
     }
 
@@ -80,9 +78,7 @@ public abstract class BaseScalaCompileOptions implements Serializable {
     public abstract Property<Boolean> getDeprecation();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsDeprecation() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsDeprecation()", "getDeprecation()");
         return getDeprecation();
     }
 
@@ -94,9 +90,7 @@ public abstract class BaseScalaCompileOptions implements Serializable {
     public abstract Property<Boolean> getUnchecked();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsUnchecked() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsUnchecked()", "getUnchecked()");
         return getUnchecked();
     }
 
@@ -117,9 +111,7 @@ public abstract class BaseScalaCompileOptions implements Serializable {
     public abstract Property<Boolean> getOptimize();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsOptimize() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsOptimize()", "getOptimize()");
         return getOptimize();
     }
 
@@ -142,9 +134,7 @@ public abstract class BaseScalaCompileOptions implements Serializable {
     public abstract Property<Boolean> getForce();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsForce() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsForce()", "getForce()");
         return getForce();
     }
 
@@ -167,9 +157,7 @@ public abstract class BaseScalaCompileOptions implements Serializable {
     public abstract Property<Boolean> getListFiles();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsListFiles() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsListFiles()", "getListFiles()");
         return getListFiles();
     }
 

--- a/platforms/jvm/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDocOptions.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDocOptions.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.tasks.scala;
 
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
+
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -45,9 +45,7 @@ public abstract class ScalaDocOptions implements Serializable {
     public abstract Property<Boolean> getDeprecation();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsDeprecation() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsDeprecation()", "getDeprecation()");
         return getDeprecation();
     }
 
@@ -59,9 +57,7 @@ public abstract class ScalaDocOptions implements Serializable {
     public abstract Property<Boolean> getUnchecked();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsUnchecked() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsUnchecked()", "getUnchecked()");
         return getUnchecked();
     }
 

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -32,7 +32,6 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.provider.PropertyFactory;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestExecutableUtils;
 import org.gradle.api.internal.tasks.testing.TestExecuter;
@@ -1046,9 +1045,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      * Added for Kotlin source compatibility. Use {@link #getScanForTestClasses()} instead.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsScanForTestClasses() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsScanForTestClasses()", "getScanForTestClasses()");
         return getScanForTestClasses();
     }
 

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
@@ -23,7 +23,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.internal.tasks.testing.testng.TestNGTestRunner;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -331,9 +330,7 @@ public abstract class TestNGOptions extends TestFrameworkOptions {
     public abstract Property<Boolean> getUseDefaultListeners();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsUseDefaultListeners() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsUseDefaultListeners()", "getUseDefaultListeners()");
         return getUseDefaultListeners();
     }
 
@@ -380,9 +377,7 @@ public abstract class TestNGOptions extends TestFrameworkOptions {
     public abstract Property<Boolean> getPreserveOrder();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsPreserveOrder() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsPreserveOrder()", "getPreserveOrder()");
         return getPreserveOrder();
     }
 
@@ -405,9 +400,7 @@ public abstract class TestNGOptions extends TestFrameworkOptions {
     public abstract Property<Boolean> getGroupByInstances();
 
     @Internal
-    @Deprecated
     public Property<Boolean> getIsGroupByInstances() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsGroupByInstances()", "getGroupByInstances()");
         return getGroupByInstances();
     }
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -270,9 +270,7 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
 
     // kotlin source compatibility
     @Internal
-    @Deprecated
     public Property<Boolean> getIsShowSinglePathToDependency() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsShowSinglePathToDependency()", "getShowSinglePathToDependency()");
         return getShowSinglePathToDependency();
     }
 

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/JUnitXmlReport.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/JUnitXmlReport.java
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks.testing;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.provider.Property;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.tasks.Input;
@@ -42,9 +41,7 @@ public interface JUnitXmlReport extends DirectoryReport {
      * Used for Kotlin backward source compatibility after migration to Provider API.
      */
     @Internal
-    @Deprecated
     default Property<Boolean> getIsOutputPerTestCase() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsOutputPerTestCase()", "getOutputPerTestCase()");
         return getOutputPerTestCase();
     }
 

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFilter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFilter.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.tasks.testing;
 
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
@@ -150,9 +149,7 @@ public interface TestFilter {
      * Used for Kotlin source compatibility. use {@link #getFailOnNoMatchingTests()} instead.
      */
     @Internal
-    @Deprecated
     default Property<Boolean> getIsFailOnNoMatchingTests() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsFailOnNoMatchingTests()", "getFailOnNoMatchingTests()");
         return getFailOnNoMatchingTests();
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/UrlArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/UrlArtifactRepository.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.artifacts.repositories;
 
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
+
 import org.gradle.api.provider.Property;
 import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
 
@@ -63,9 +63,7 @@ public interface UrlArtifactRepository {
     /**
      * Added for Kotlin source compatibility.
      */
-    @Deprecated
     default Property<Boolean> getIsAllowInsecureProtocol() {
-        ProviderApiDeprecationLogger.logDeprecation(UrlArtifactRepository.class, "getIsAllowInsecureProtocol()", "getAllowInsecureProtocol()");
         return getAllowInsecureProtocol();
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/caching/configuration/BuildCache.java
+++ b/subprojects/core-api/src/main/java/org/gradle/caching/configuration/BuildCache.java
@@ -38,10 +38,8 @@ public interface BuildCache {
     /**
      * Controls whether the build cache is enabled.
      */
-    @Deprecated
     @ReplacedBy("getEnabled()")
     default Property<Boolean> getIsEnabled() {
-        // TODO: for Gradle 9.0 nag with deprecation once DevelocityConventionsPlugin is updated
         return getEnabled();
     }
 
@@ -56,10 +54,8 @@ public interface BuildCache {
      *
      * Added for Kotlin source compatibility.
      */
-    @Deprecated
     @ReplacedBy("getPush()")
     default Property<Boolean> getIsPush() {
-        // TODO: for Gradle 9.0 nag with deprecation once DevelocityConventionsPlugin is updated
         return getPush();
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/process/BaseExecSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/BaseExecSpec.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.process;
 
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.instrumentation.api.annotations.ReplacesEagerProperty;
@@ -39,9 +38,7 @@ public interface BaseExecSpec extends ProcessForkOptions {
     /**
      * Added for Kotlin DSL source compatibility.
      */
-    @Deprecated
     default Property<Boolean> getIsIgnoreExitValue() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsIgnoreExitValue()", "getIgnoreExitValue()");
         return getIgnoreExitValue();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
@@ -17,7 +17,7 @@ package org.gradle.api.tasks;
 
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.internal.ConventionTask;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
+
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
@@ -256,9 +256,7 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
      */
     @Override
     @Internal
-    @Deprecated
     public Property<Boolean> getIsIgnoreExitValue() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsIgnoreExitValue()", "getIgnoreExitValue()");
         return getIgnoreExitValue();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Delete.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Delete.java
@@ -79,6 +79,11 @@ public abstract class Delete extends ConventionTask implements DeleteSpec {
     @ReplacesEagerProperty(replacedAccessors = @ReplacedAccessor(value = GETTER, name = "isFollowSymlinks", originalType = boolean.class))
     public abstract Property<Boolean> getFollowSymlinks();
 
+    @Internal
+    public Property<Boolean> getIsFollowSymlinks() {
+        return getFollowSymlinks();
+    }
+
     /**
      * Returns the set of files which will be deleted by this task.
      *

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -24,7 +24,7 @@ import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.copy.CopyActionExecuter;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
+
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -255,9 +255,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * Used for Kotlin backward source compatibility after migration to Provider API.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsPreserveFileTimestamps() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsPreserveFileTimestamps()", "getPreserveFileTimestamps()");
         return getPreserveFileTimestamps();
     }
 
@@ -280,9 +278,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * Used for Kotlin backward source compatibility after migration to Provider API.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsReproducibleFileOrder() {
-        ProviderApiDeprecationLogger.logDeprecation(getClass(), "getIsReproducibleFileOrder()", "getReproducibleFileOrder()");
         return getReproducibleFileOrder();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.file.archive.ZipCopyAction;
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.DefaultZipCompressor;
 import org.gradle.api.internal.file.copy.ZipCompressor;
-import org.gradle.api.internal.provider.ProviderApiDeprecationLogger;
+
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -102,9 +102,7 @@ public abstract class Zip extends AbstractArchiveTask {
      * Added for Kotlin source compatibility. Use {@link #getZip64()} instead.
      */
     @Internal
-    @Deprecated
     public Property<Boolean> getIsZip64() {
-        ProviderApiDeprecationLogger.logDeprecation(Zip.class, "getIsZip64()", "getZip64()");
         return getZip64();
     }
 

--- a/testing/architecture-test/src/changes/archunit-store/explicit-properties.txt
+++ b/testing/architecture-test/src/changes/archunit-store/explicit-properties.txt
@@ -30,6 +30,7 @@ Method <org.gradle.api.tasks.AbstractExecTask.getIsIgnoreExitValue()> is not abs
 Method <org.gradle.api.tasks.AbstractExecTask.getStandardInput()> is not abstract
 Method <org.gradle.api.tasks.AbstractExecTask.getStandardOutput()> is not abstract
 Method <org.gradle.api.tasks.AbstractExecTask.getWorkingDir()> is not abstract
+Method <org.gradle.api.tasks.Delete.getIsFollowSymlinks()> is not abstract
 Method <org.gradle.api.tasks.Exec.getArgs()> is not abstract
 Method <org.gradle.api.tasks.Exec.getErrorOutput()> is not abstract
 Method <org.gradle.api.tasks.Exec.getIgnoreExitValue()> is not abstract


### PR DESCRIPTION
We can deprecate them later, but they are disturbance when doing a migration

Fixes https://github.com/gradle/gradle/issues/30073