### PR TITLE
Change getContentCharset() signature back to String

### DIFF
--- a/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/CustomManifestInternalWrapper.java
+++ b/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/CustomManifestInternalWrapper.java
@@ -76,7 +76,7 @@ public class CustomManifestInternalWrapper implements ManifestInternal {
     }
 
     @Override
-    public @Nullable Provider<String> getContentCharset() {
+    public @Nullable Provider<String> getContentCharsetProvider() {
         return contentCharset;
     }
 

--- a/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/DefaultManifest.java
+++ b/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/DefaultManifest.java
@@ -93,8 +93,14 @@ public class DefaultManifest implements ManifestInternal {
     }
 
     @Override
-    public @Nullable Provider<String> getContentCharset() {
+    public @Nullable Provider<String> getContentCharsetProvider() {
         return contentCharsetProvider;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public String getContentCharset() {
+        return getEffectiveContentCharset();
     }
 
     private String getEffectiveContentCharset() {

--- a/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/DefaultManifestMergeSpec.java
+++ b/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/DefaultManifestMergeSpec.java
@@ -77,7 +77,7 @@ public class DefaultManifestMergeSpec implements ManifestMergeSpec {
     }
 
     public DefaultManifest merge(Manifest baseManifest, PathToFileResolver fileResolver) {
-        Provider<String> baseContentCharset = baseManifest instanceof ManifestInternal ? ((ManifestInternal)baseManifest).getContentCharset() : null;
+        Provider<String> baseContentCharset = baseManifest instanceof ManifestInternal ? ((ManifestInternal)baseManifest).getContentCharsetProvider() : null;
         DefaultManifest mergedManifest = new DefaultManifest(fileResolver, baseContentCharset);
         mergedManifest.getAttributes().putAll(baseManifest.getAttributes());
         mergedManifest.getSections().putAll(baseManifest.getSections());

--- a/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/ManifestInternal.java
+++ b/platforms/jvm/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/ManifestInternal.java
@@ -39,8 +39,20 @@ public interface ManifestInternal extends Manifest {
 
     /**
      * Returns the character set used to decode the manifest content, if known.
+     *
+     * @since 9.5.0
      */
-    @Nullable Provider<String> getContentCharset();
+    @Nullable Provider<String> getContentCharsetProvider();
+
+    /**
+     * Returns the character set used to decode the manifest content, if known.
+     *
+     * This method is deprecated and will be removed in Gradle 10.0.0. Use {@link #getContentCharsetProvider()} instead.
+     */
+    @Deprecated
+    @Nullable default String getContentCharset() {
+        return getContentCharsetProvider().get();
+    }
 
     /**
      * Writes the manifest into a stream.

--- a/platforms/jvm/platform-jvm/src/test/groovy/org/gradle/api/java/archives/internal/DefaultManifestTest.groovy
+++ b/platforms/jvm/platform-jvm/src/test/groovy/org/gradle/api/java/archives/internal/DefaultManifestTest.groovy
@@ -341,6 +341,17 @@ class DefaultManifestTest extends Specification {
         javaManifest.entries.get('AnotherSection').getValue('bazar') == 'cathedral'
     }
 
+    def "can get content char set using deprecated String method"() {
+        expect:
+        gradleManifest.getContentCharset() == DEFAULT_MANIFEST_CHARSET.get()
+
+        and:
+        new DefaultManifest(fileResolver, 'UTF-16').getContentCharset() == 'UTF-16'
+
+        and:
+        new DefaultManifest(fileResolver, TestUtil.providerFactory().provider {'UTF-16'}).getContentCharset() == 'UTF-16'
+    }
+
     /**
      * Remove blank lines to exercise Ant's Manifest interoperability.
      * Need to work at bytes level to prevent breaking split multi-bytes characters here.


### PR DESCRIPTION
Intellij is using `ManifestInternal.getContentCharset()` in a model builder which is causing a NoSuchMethod error now.  We're changing the signature back to keep this working.

Fixes #37400 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
