### PR TITLE
TeamCity: test all cross version tests with the max supported Java version

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -232,14 +232,14 @@ data class CIBuildModel(
                             10,
                             TestType.ALL_VERSIONS_CROSS_VERSION,
                             Os.LINUX,
-                            JvmCategory.MIN_VERSION,
+                            JvmCategory.MAX_VERSION,
                             ALL_CROSS_VERSION_BUCKETS.size,
                         ),
                         TestCoverage(
                             11,
                             TestType.ALL_VERSIONS_CROSS_VERSION,
                             Os.WINDOWS,
-                            JvmCategory.MIN_VERSION,
+                            JvmCategory.MAX_VERSION,
                             ALL_CROSS_VERSION_BUCKETS.size,
                         ),
                         TestCoverage(


### PR DESCRIPTION
- Change cross version test coverage to run with `JvmCategory.MAX_VERSION` instead of `MIN_VERSION` on both Linux and Windows
- IDEs embed the Tooling API but don't limit themselves to Java 8/17; running the TAPI client on the max Java version catches cross-version problems ahead of TAPI users