### PR TITLE
Remove ad hoc "new blank issue" from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Ask for help
     url: http://help.gradle.org/
     about: If you need help with Gradle or have a usage question, please reach our community instead of creating an issue.
-  - name: Create an issue without template
-    url: https://github.com/gradle/gradle/issues/new?template=blank
-    about: This option is only available for repository maintainers.


### PR DESCRIPTION
Now GitHub has a built-in way to achieve that, which is available only for maintainers for real.

It removes the bottom option (visible for everyone) in favor of the top one (which only maintainers see):
<img width="100%" height="100%" alt="image" src="https://github.com/user-attachments/assets/abbf5637-99e3-4d12-bffa-f86da9e2bacb" />
