### PR TITLE
Add hashing-services project

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -149,6 +149,7 @@
             <option value="$PROJECT_DIR$/platforms/core-execution/execution-e2e-tests" />
             <option value="$PROJECT_DIR$/platforms/core-execution/file-watching" />
             <option value="$PROJECT_DIR$/platforms/core-execution/hashing" />
+            <option value="$PROJECT_DIR$/platforms/core-execution/hashing-services" />
             <option value="$PROJECT_DIR$/platforms/core-execution/persistent-cache" />
             <option value="$PROJECT_DIR$/platforms/core-execution/request-handler-worker" />
             <option value="$PROJECT_DIR$/platforms/core-execution/scoped-persistent-cache" />


### PR DESCRIPTION
Adds hashing-services to gradle.xml, which was omitted when #37210 was merged.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
