### PR TITLE
Check for actual files in SubprojectsInfo

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/SubprojectsInfo.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/SubprojectsInfo.kt
@@ -81,12 +81,15 @@ abstract class SubprojectsInfo : DefaultTask() {
         return GradleSubproject(
             subprojectDir.name,
             rootPath.relativize(subprojectDir.toPath()).invariantSeparatorsPathString,
-            subprojectDir.hasDescendantDir("src/test"),
-            subprojectDir.hasDescendantDir("src/integTest"),
-            subprojectDir.hasDescendantDir("src/crossVersionTest")
+            subprojectDir.hasDescendantDirWithFiles("src/test"),
+            subprojectDir.hasDescendantDirWithFiles("src/integTest"),
+            subprojectDir.hasDescendantDirWithFiles("src/crossVersionTest")
         )
     }
 
     private
-    fun File.hasDescendantDir(descendant: String) = resolve(descendant).isDirectory
+    fun File.hasDescendantDirWithFiles(descendant: String): Boolean {
+        val dir = resolve(descendant)
+        return dir.isDirectory && dir.walk().any { it.isFile }
+    }
 }


### PR DESCRIPTION
hasDescendantDirWithFiles now returns false for directories that exist but contain only empty subdirectories, ensuring subproject metadata accurately reflects whether tests actually exist or not.

Without this, you can have an empty test directory (perhaps because all the tests were moved out) but the json generation marks it as having tests (because it only looks for the directory and not whether it contains anything).  However, because there are no files, git does not produce the directory on CI and the `checkSubprojectsInfo` task fails there because it thinks the subprojects info is out of date.  This can be confusing because running `generateSubprojectsInfo` locally doesn't actually change the json file, but it still fails on CI.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
