### PR TITLE
WIP: Improve dependency resolution metadata resolution performance

### DIFF
--- a/platforms/jvm/java-platform/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/platforms/jvm/java-platform/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -184,7 +184,6 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
 
         when:
         module1.pom.expectGet()
-        module2.pom.expectGet()
         module1.artifact.expectGet()
 
         run ":checkDeps"

--- a/platforms/jvm/language-jvm/src/integTest/groovy/org/gradle/integtests/resolve/consistency/JavaProjectResolutionConsistencyIntegrationTest.groovy
+++ b/platforms/jvm/language-jvm/src/integTest/groovy/org/gradle/integtests/resolve/consistency/JavaProjectResolutionConsistencyIntegrationTest.groovy
@@ -144,7 +144,6 @@ class JavaProjectResolutionConsistencyIntegrationTest extends AbstractHttpDepend
         foo.pom.expectGet()
         foo.artifact.expectGet()
         bar.pom.expectGet()
-        transitive10.pom.expectGet()
         transitive11.pom.expectGet()
         transitive11.artifact.expectGet()
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -205,18 +205,16 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         given:
         MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')
         MavenHttpModule moduleC = publishMavenModule(mavenHttpRepo, 'c')
-        def moduleD = mavenHttpRepo.module(GROUP_ID, 'd', VERSION).dependsOn(moduleA).publish()
-        def moduleE = mavenHttpRepo.module(GROUP_ID, 'e', VERSION).dependsOn(moduleB).dependsOn(moduleC).publish()
+        def moduleD = mavenHttpRepo.module(GROUP_ID, 'd', VERSION).dependsOn(moduleB).dependsOn(moduleC).publish()
 
         buildFile << """
             ${mavenRepository(mavenHttpRepo)}
-            ${customConfigDependencyAssignment(moduleD, moduleE)}
+            ${customConfigDependencyAssignment(moduleA, moduleD)}
             ${configSyncTask()}
         """
 
         when:
         moduleD.pom.expectGet()
-        moduleE.pom.expectGet()
         moduleA.pom.expectGetBlocking()
         fails('resolve', '--max-workers=1')
 
@@ -224,7 +222,6 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         assertDependencyMetaDataReadTimeout(moduleA)
         failure.assertHasErrorOutput("There are 2 more failures with identical causes.")
         outputDoesNotContain("Could not resolve ${mavenModuleCoordinates(moduleD)}")
-        outputDoesNotContain("Could not resolve ${mavenModuleCoordinates(moduleE)}")
         !downloadedLibsDir.isDirectory()
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -370,9 +370,6 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
             'org:a:1.0' {
                 expectGetMetadata()
             }
-            'org:b:1.0' {
-                expectGetMetadata()
-            }
             'org:b:1.1' {
                 expectGetMetadata()
             }
@@ -427,9 +424,6 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         when:
         repositoryInteractions {
             'org:a:1.0' {
-                expectGetMetadata()
-            }
-            'org:b:1.0' {
                 expectGetMetadata()
             }
             'org:b:1.1' {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionIssuesIntegrationTest.groovy
@@ -80,62 +80,6 @@ class ResolutionIssuesIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
-    @NotYetImplemented
-    @Issue("https://github.com/gradle/gradle/issues/22326")
-    def "capability conflict skip"() {
-        settingsFile << """
-            include("app", "extension")
-
-            dependencyResolutionManagement {
-                ${mavenCentralRepository()}
-                components {
-                    withModule("org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec") {
-                        allVariants {
-                            withCapabilities {
-                                addCapability("javax.transaction", "javax.transaction-api", id.version)
-                            }
-                        }
-                    }
-                }
-            }
-        """
-
-        file("app/build.gradle") << """
-            plugins {
-                id("java-library")
-            }
-
-            dependencies {
-                // Change the order of these two dependencies to have the capability conflict detected
-                runtimeOnly("org.liquibase.ext:liquibase-hibernate5:4.4.3")
-                runtimeOnly("org.eclipse.jetty.aggregate:jetty-all:9.4.35.v20201120")
-            }
-        """
-
-        file("extension/build.gradle") << """
-            plugins {
-                id("java-library")
-            }
-
-            configurations.all {
-                resolutionStrategy.capabilitiesResolution.withCapability("javax.transaction:javax.transaction-api") {
-                    select("javax.transaction:javax.transaction-api:0")
-                }
-            }
-
-            dependencies {
-                implementation("org.hibernate:hibernate-core:5.5.7.Final")
-                implementation(project(":app"))
-            }
-        """
-
-        when:
-        succeeds(":extension:dependencies", "--configuration=runtimeClasspath")
-
-        then:
-        outputContains("org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.1.1.Final -> javax.transaction:javax.transaction-api:1.3")
-    }
-
     @Ignore("Original reproducer. Minified version below")
     @Requires(UnitTestPreconditions.Jdk17OrLater)
     @Issue("https://github.com/gradle/gradle/issues/22326#issuecomment-1617422240")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -412,7 +412,6 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
 
         a.pom.expectGet()
         b.pom.expectGet()
-        leaf1.pom.expectGet()
         leaf2.pom.expectGet()
 
         then:
@@ -609,11 +608,10 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
         def repoId = repoId('maven1', op.details)
         def resolvedComponents = op.result.components
-        resolvedComponents.size() == 4
+        resolvedComponents.size() == 3
         resolvedComponents.'root project :'.repoId == null
         resolvedComponents.'project :child'.repoId == null
         resolvedComponents.'org.foo:direct1:1.0'.repoId == repoId
-        resolvedComponents.'org.foo:transitive1:1.0'.repoId == repoId
     }
 
     def "resolved components contain their source repository id, even when they are structurally identical"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedConfigurationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedConfigurationIntegrationTest.groovy
@@ -179,7 +179,7 @@ class ResolvedConfigurationIntegrationTest extends AbstractHttpDependencyResolut
                     def resolved = compile.firstLevelModuleDependencies
 
                     assert resolved.size() == 3
-                    assert resolved.collect { it.moduleName } == ['hiphop', 'child', 'rock']
+                    assert resolved.collect { it.moduleName } == ['child', 'hiphop', 'rock']
 
                     def artifacts = compile.artifacts
 
@@ -255,7 +255,7 @@ class ResolvedConfigurationIntegrationTest extends AbstractHttpDependencyResolut
                     def artifacts = compile.artifacts.collect { it.file.name }
 
                     assert artifacts.size() == 5
-                    assert artifacts == ['a-1.0.jar', 'd-1.0.jar', 'e-1.0.jar', 'b-2.0.jar', 'f-1.0.jar']
+                    assert artifacts == ['a-1.0.jar', 'e-1.0.jar', 'd-1.0.jar', 'b-2.0.jar', 'f-1.0.jar']
 
                     def unresolved = compile.unresolvedModuleDependencies
                     assert unresolved.size() == 0
@@ -311,7 +311,7 @@ class ResolvedConfigurationIntegrationTest extends AbstractHttpDependencyResolut
                     def resolved = compile.firstLevelModuleDependencies
 
                     assert resolved.size() == 3
-                    assert resolved.collect { it.moduleName } == ['hiphop', 'child', 'rock']
+                    assert resolved.collect { it.moduleName } == ['child', 'hiphop', 'rock']
 
                     def artifacts = compile.artifacts
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -42,7 +42,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
 
         when:
         expectAlignment {
-            module('core') tries('1.0') alignsTo('1.1') byVirtualPlatform()
+            module('core') alignsTo('1.1') byVirtualPlatform()
             module('xml') tries('1.0') alignsTo('1.1') byVirtualPlatform()
             module('json') alignsTo('1.1') byVirtualPlatform()
         }
@@ -90,7 +90,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
 
         when:
         expectAlignment {
-            module('core') tries('1.0') alignsTo('1.1') byVirtualPlatform()
+            module('core') alignsTo('1.1') byVirtualPlatform()
             module('xml') tries('1.0') alignsTo('1.1') byVirtualPlatform()
             module('json') alignsTo('1.1') byVirtualPlatform()
 
@@ -192,7 +192,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         when:
         expectAlignment {
             module('xml') misses('1.1') alignsTo('1.0') byVirtualPlatform()
-            module('core') tries('1.0') alignsTo('1.1')
+            module('core') alignsTo('1.1')
             module('json') alignsTo('1.1') byVirtualPlatform()
         }
         run ':checkDeps'
@@ -291,7 +291,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         expectAlignment {
             module('core') misses('2.9.4.1') alignsTo('2.9.4') byVirtualPlatform()
             module('databind') tries('2.7.9') misses('2.9.4.1') alignsTo('2.9.4') byVirtualPlatform()
-            module('annotations') tries('2.7.9', '2.9.0') misses('2.9.4.1') alignsTo('2.9.4') byVirtualPlatform()
+            module('annotations') tries('2.9.0') misses('2.9.4.1') alignsTo('2.9.4') byVirtualPlatform()
             module('kt') alignsTo('2.9.4.1') byVirtualPlatform()
         }
         run ':checkDeps'
@@ -451,11 +451,12 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         expectAlignment {
             module('core') alignsTo('2.9.4') byPublishedPlatform()
             module('databind') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
-            module('annotations') tries('2.7.9') tries('2.9.0') alignsTo('2.9.4') byPublishedPlatform()
+            module('annotations') alignsTo('2.9.4') byPublishedPlatform()
             module('kt') alignsTo('2.9.4.1') byPublishedPlatform()
 
             doesNotGetPlatform("org", "platform", "2.7.9") // because of conflict resolution
             doesNotGetPlatform("org", "platform", "2.9.0") // because of conflict resolution
+            doesNotGetPlatform("org", "platform", "2.9.4") // because of conflict resolution
         }
         run ':checkDeps'
 
@@ -525,7 +526,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         when:
         expectAlignment {
             ['org', 'org2'].each { group ->
-                module('core') group(group) tries('1.0') alignsTo('1.1') byVirtualPlatform(group)
+                module('core') group(group) alignsTo('1.1') byVirtualPlatform(group)
                 module('xml') group(group) tries('1.0') alignsTo('1.1') byVirtualPlatform(group)
                 module('json') group(group) alignsTo('1.1') byVirtualPlatform(group)
             }
@@ -591,7 +592,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         expectAlignment {
             module('xml') alignsTo('1.0') byVirtualPlatform()
             module('core') alignsTo('1.0')
-            module('json') tries('1.1')
+            module('json')
             module('foo') group('org2') alignsTo('1.0')
             module('bar') group('org3') alignsTo('1.0')
             module('a') group('org4') tries('1.0') alignsTo('1.1')
@@ -652,9 +653,6 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
 
         when:
         repositoryInteractions {
-            'org:core:1.0' {
-                expectGetMetadata()
-            }
             'org:xml:1.0' {
                 expectResolve()
             }
@@ -710,7 +708,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
 
         when:
         expectAlignment {
-            module('core') tries('1.0') alignsTo('1.1') byVirtualPlatform('org', 'platform') byVirtualPlatform('org', 'platform2')
+            module('core') alignsTo('1.1') byVirtualPlatform('org', 'platform') byVirtualPlatform('org', 'platform2')
             module('xml') tries('1.0') alignsTo('1.1') byVirtualPlatform('org', 'platform') byVirtualPlatform('org', 'platform2')
             module('json') alignsTo('1.1') byVirtualPlatform('org', 'platform') byVirtualPlatform('org', 'platform2')
         }
@@ -789,7 +787,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         when:
         expectAlignment {
             module('core') {
-                group('org.apache.groovy') tries('2.4') alignsTo('2.5')
+                group('org.apache.groovy') alignsTo('2.5')
                 byPublishedPlatform('org.apache.groovy', 'platform')
                 byPublishedPlatform('org.springframework', 'spring-platform', '1.0')
             }
@@ -806,6 +804,8 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
 
             // Spring core intentionally doesn't belong to the Spring platform.
             module('core') group('org.springframework') tries('1.0') alignsTo('1.1')
+
+            doesNotGetPlatform("org.apache.groovy", "platform", "2.4") // because of conflict resolution
         }
         run ':checkDeps'
 
@@ -893,7 +893,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         when:
         expectAlignment {
             module('core') {
-                group('org.apache.groovy') tries('2.4') alignsTo('2.5')
+                group('org.apache.groovy') alignsTo('2.5')
                 byVirtualPlatform('org.apache.groovy', 'platform')
                 byPublishedPlatform('org.springframework', 'spring-platform', '1.0')
             }
@@ -971,7 +971,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
 
         when:
         expectAlignment {
-            module('core') tries('1.0') alignsTo('1.1') byVirtualPlatform()
+            module('core') alignsTo('1.1') byVirtualPlatform()
             module('xml') tries('1.0') alignsTo('1.1') byVirtualPlatform()
             module('json') alignsTo('1.1') byVirtualPlatform()
         }
@@ -1103,11 +1103,12 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         expectAlignment {
             module('core') alignsTo('2.9.4') byPublishedPlatform()
             module('databind') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
-            module('annotations') tries('2.7.9') tries('2.9.0') alignsTo('2.9.4') byPublishedPlatform()
+            module('annotations') alignsTo('2.9.4') byPublishedPlatform()
             module('kt') alignsTo('2.9.4.1') byPublishedPlatform()
 
             doesNotGetPlatform("org", "platform", "2.7.9") // because of conflict resolution
             doesNotGetPlatform("org", "platform", "2.9.0") // because of conflict resolution
+            doesNotGetPlatform("org", "platform", "2.9.4") // because of conflict resolution
         }
         run ':checkDeps'
 
@@ -1176,7 +1177,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                         module('org:core:2.9.4')
                         edge('org:annotations:2.9.0', 'org:annotations:2.9.4') {
                             byConstraint()
-                            byConflictResolution("between versions 2.9.4 and 2.9.0")
+                            byConflictResolution("between versions 2.9.4, 2.7.9 and 2.9.0")
                             edge("org:platform:2.9.4", "org:platform:2.9.4.1")
                         }
                     }
@@ -1399,7 +1400,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                     edge("org:foo:1.2", "org:foo:1.5") {
                         byConstraint("belongs to platform org:platform:1.5")
                         selectedByRule("substitution from 'org:foo:[1.2,)' to 'org:foo:1.0'")
-                        byConflictResolution("between versions 1.0 and 1.5")
+                        byConflictResolution("between versions 1.5 and 1.0")
                         module("org:bar:1.5") {
                             selectedByRule("substitution from 'org:bar:[1.2,)' to 'org:bar:1.0'")
                             byConflictResolution("between versions 1.5 and 1.0")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -835,14 +835,11 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
                         forced()
                         edge("org:annotations:2.8.0", "org:annotations:2.8.10") {
                             byConstraint("belongs to platform org:platform:2.8.11.1")
-                            byConflictResolution("between versions 2.8.10 and 2.8.0")
+                            byConflictResolution("between versions 2.8.0 and 2.8.10")
                             forced()
                         }
                         module("org:core:2.8.10")
                     }
-                }
-                if (forceNotation.contains("force = true")) {
-                    module("org:databind:2.8.11.1")
                 }
             }
         }
@@ -903,9 +900,6 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
                         }
                         module("org:core:2.6.7")
                     }
-                }
-                if (forceNotation.contains("force = true")) {
-                    module("org:databind:2.6.7.1")
                 }
             }
         }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
@@ -164,7 +164,7 @@ class ForcingUsingStrictlyPlatformAlignmentTest extends AbstractAlignmentSpec {
         then:
         failure.assertHasCause """Cannot find a version of 'org:databind' that satisfies the version constraints:
    Dependency path: 'root project :' (conf) --> 'org:databind:{strictly 2.7.9}'
-   Constraint path: 'root project :' (conf) --> 'org:core:2.9.4' ($coreVariant) --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
+   Constraint path: 'root project :' (conf) --> 'org:platform:2.9.4' (default) --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
     }
 
     def "fails if forcing a virtual platform version by forcing multiple leaves with different versions, including transitively"() {
@@ -319,7 +319,7 @@ include 'other'
                 module("com.amazonaws:aws-java-sdk-core:1.11.438") {
                     edge("org:cbor:2.6.7", "org:cbor:2.8.10") {
                         byConstraint("belongs to platform org:platform:2.8.11.1")
-                        byConflictResolution("between versions 2.8.10 and 2.6.7")
+                        byConflictResolution("between versions 2.6.7 and 2.8.10")
                         forced()
                         module("org:core:2.8.10") {
                             byConstraint("belongs to platform org:platform:2.8.11.1")
@@ -333,7 +333,7 @@ include 'other'
                         forced()
                         edge("org:annotations:2.8.0", "org:annotations:2.8.10") {
                             byConstraint("belongs to platform org:platform:2.8.11.1")
-                            byConflictResolution("between versions 2.8.10 and 2.8.0")
+                            byConflictResolution("between versions 2.8.0 and 2.8.10")
                             forced()
                         }
                         module("org:core:2.8.10")
@@ -390,7 +390,7 @@ include 'other'
                         forced()
                         edge("org:annotations:2.6.0", "org:annotations:2.6.7") {
                             byConstraint("belongs to platform org:platform:2.6.7.1")
-                            byConflictResolution("between versions 2.6.7 and 2.6.0")
+                            byConflictResolution("between versions 2.6.0 and 2.6.7")
                             forced()
                         }
                         module("org:core:2.6.7")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
@@ -124,6 +124,9 @@ class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResol
                 expectGetMetadata()
                 expectGetArtifact()
             }
+            'org:foo:1.0' {
+                expectGetMetadata()
+            }
             'org:foo:2.0' {
                 expectGetMetadata()
                 expectGetArtifact()
@@ -182,9 +185,6 @@ class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResol
                 expectGetMetadata()
             }
             'org:platform-b:1.0' {
-                expectGetMetadata()
-            }
-            'org:foo:1.0' {
                 expectGetMetadata()
             }
             'org:foo:2.0' {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
@@ -339,8 +339,10 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
             'org:a:1.0' {
                 expectGetMetadata()
             }
-            'org:c:1.0' {
-                expectGetMetadata()
+            if (gradleMetadataPublished) {
+                'org:c:1.0' {
+                    expectGetMetadata()
+                }
             }
         }
         run ':checkDeps'

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -292,9 +292,9 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
                     expectGetArtifact()
                 }
             }
-            'org:foo:3.1.1' {
-                expectGetMetadata()
-                if (platformType == ENFORCED_PLATFORM) {
+            if (platformType == ENFORCED_PLATFORM) {
+                'org:foo:3.1.1' {
+                    expectGetMetadata()
                     expectGetArtifact()
                 }
             }
@@ -457,11 +457,12 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
             'org:bar:2.0' {
                 expectGetMetadata()
             }
-            'org:foo:3.1.1' {
-                expectGetMetadata()
-            }
-            'org:foo:3.2' {
-                if (platformType != ENFORCED_PLATFORM) {
+            if (platformType == ENFORCED_PLATFORM) {
+                'org:foo:3.1.1' {
+                    expectGetMetadata()
+                }
+            } else {
+                'org:foo:3.2' {
                     expectGetMetadata()
                 }
             }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/AbstractRichVersionConstraintsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/AbstractRichVersionConstraintsIntegrationTest.groovy
@@ -845,8 +845,8 @@ abstract class AbstractRichVersionConstraintsIntegrationTest extends AbstractMod
         then:
         def selected = GradleMetadataResolveRunner.gradleMetadataPublished || GradleMetadataResolveRunner.useMaven() ? 'runtime' : 'default'
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints:
-   Dependency path: 'root project :' (conf) --> 'org:foo:{require 1.0; reject 1.1}'
-   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' ($selected) --> 'org:foo:1.1'""")
+   Dependency path: 'root project :' (conf) --> 'org:bar:1.0' ($selected) --> 'org:foo:1.1'
+   Dependency path: 'root project :' (conf) --> 'org:foo:{require 1.0; reject 1.1}'""")
     }
 
     def "can reject a version range"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/versions/VersionConflictResolutionIntegrationTest.groovy
@@ -1169,7 +1169,6 @@ parentFirst
             root(":", ":test:") {
                 module("org:a:1.0") {
                     edge("org:leaf:[2,6]", "org:leaf:5") {
-                        byReason("didn't match versions 10, 9, 8, 7")
                         byReason("didn't match versions 10, 9, 8, 7, 6")
                     }
                 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -80,6 +80,12 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     private boolean rejected;
     private boolean root;
 
+    /**
+     * -1 if we have not yet determined if the metadata is expensive to fetch,
+     * 0 if metadata is expensive to fetch, 1 if it is not expensive.
+     */
+    private byte metadataCheapToFetch = -1;
+
     ComponentState(long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, ComponentMetaDataResolver resolver) {
         this.resultId = resultId;
         this.module = module;
@@ -190,6 +196,13 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
      */
     public boolean alreadyResolved() {
         return resolveState != null || metadataResolveFailure != null;
+    }
+
+    public boolean isMetadataCheapToFetch() {
+        if (metadataCheapToFetch == -1) {
+            metadataCheapToFetch = (byte) (resolver.isFetchingMetadataCheap(componentIdentifier) ? 1 : 0);
+        }
+        return metadataCheapToFetch == 1;
     }
 
     public void resolve() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -306,6 +306,8 @@ public class DependencyGraphBuilder {
         ConflictResolution conflictResolution,
         ResolutionParameters.FailureResolutions failureResolutions
     ) {
+        assertHasValidGraphStructure(resolveState);
+
         ImmutableAttributesSchema consumerSchema = resolveState.getConsumerSchema();
         for (ModuleResolveState module : resolveState.getModules()) {
             ComponentState selected = module.getSelected();
@@ -343,8 +345,6 @@ public class DependencyGraphBuilder {
                 attachMultipleForceOnPlatformFailureToEdges(module);
             }
         }
-
-        assertHasValidGraphStructure(resolveState);
     }
 
     /**
@@ -359,18 +359,31 @@ public class DependencyGraphBuilder {
         }
 
         for (ModuleResolveState module : resolveState.getModules()) {
+            if (module.isInModuleConflict()) {
+                throw new IllegalStateException(String.format("Module %s is in conflict", module));
+            }
+            for (EdgeState unattachedEdge : module.getUnattachedEdges()) {
+                if (unattachedEdge.getFailure() == null) {
+                    throw new IllegalStateException(String.format("Module %s has non-failing unattached edge: %s", module, unattachedEdge));
+                }
+                if (!unattachedEdge.isUnattached()) {
+                    throw new IllegalStateException(String.format("Module %s has unattached edge that is not unattached: %s", module, unattachedEdge));
+                }
+            }
             for (ComponentState component : module.getVersions()) {
                 for (NodeState node : component.getNodes()) {
+                    if (node.isInCapabilityConflict()) {
+                        throw new IllegalStateException(String.format("Node %s is in capability conflict", node));
+                    }
                     for (EdgeState incomingEdge : node.getIncomingEdges()) {
                         NodeState from = incomingEdge.getFrom();
-                        // TODO: This condition currently fails, but should pass!
-//                        if (!from.getOutgoingEdges().contains(incomingEdge)) {
-//                            throw new IllegalStateException(String.format(
-//                                "Node %s has incoming edge from %s, but source node does not declare outgoing edge.",
-//                                node.getDisplayName(),
-//                                from.getDisplayName()
-//                            ));
-//                        }
+                        if (!from.getOutgoingEdges().contains(incomingEdge)) {
+                            throw new IllegalStateException(String.format(
+                                "Node %s has incoming edge from %s, but source node does not declare outgoing edge.",
+                                node.getDisplayName(),
+                                from.getDisplayName()
+                            ));
+                        }
                         if (!from.isSelected()) {
                             throw new IllegalStateException(String.format(
                                 "Node %s has an incoming edge from %s, but source node is not part of the graph.",
@@ -379,18 +392,35 @@ public class DependencyGraphBuilder {
                             ));
                         }
                     }
-//                    for (EdgeState outgoingEdge : node.getOutgoingEdges()) {
-//                        for (NodeState target : outgoingEdge.getTargetNodes()) {
-//                            // TODO: This condition currently fails, but should pass!
-//                            if (!target.getIncomingEdges().contains(outgoingEdge)) {
-//                                throw new IllegalStateException(String.format(
-//                                    "Node %s has an outgoing edge to node %s, but target node does not declare incoming edge.",
-//                                    node.getDisplayName(),
-//                                    target.getDisplayName()
-//                                ));
-//                            }
-//                        }
-//                    }
+                    for (EdgeState outgoingEdge : node.getOutgoingEdges()) {
+                        ModuleResolveState targetModule = outgoingEdge.getSelector().getTargetModule();
+                        if (outgoingEdge.isUnattached() && !targetModule.getUnattachedEdges().contains(outgoingEdge)) {
+                            throw new IllegalStateException(String.format(
+                                "Outgoing unattached edge %s has target module %s, but module does not declare edge as unattached",
+                                outgoingEdge,
+                                targetModule
+                            ));
+                        }
+                        for (NodeState target : outgoingEdge.getTargetNodes()) {
+                            if (!target.getIncomingEdges().contains(outgoingEdge)) {
+                                throw new IllegalStateException(String.format(
+                                    "Node %s has an outgoing edge to node %s, but target node does not declare incoming edge.",
+                                    node.getDisplayName(),
+                                    target.getDisplayName()
+                                ));
+                            }
+                        }
+                        boolean hasTargetNodes = !outgoingEdge.getTargetNodes().isEmpty();
+                        boolean hasFailure = outgoingEdge.getFailure() != null;
+                        if (hasTargetNodes == hasFailure) {
+                            // Edges must either have a target node or a failure, but not both, and not neither.
+                            throw new IllegalStateException(String.format(
+                                "Node %s has an outgoing edge %s with inconsistent target nodes and failure.",
+                                node.getDisplayName(),
+                                outgoingEdge
+                            ));
+                        }
+                    }
                 }
             }
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -166,75 +166,218 @@ public class DependencyGraphBuilder {
 
     /**
      * Traverses the dependency graph, resolving conflicts and building the paths from the root configuration.
+     *
+     * <p>The loop is structured around a strict priority order to maximize download batching:
+     * <ol>
+     *   <li><b>Node processing</b> — drain the node queue one at a time. Discovers outgoing edges
+     *       and registers their target modules for selection. Also cleans up nodes that have lost
+     *       all incoming edges.</li>
+     *   <li><b>Attachment</b> — attach edges for modules whose selected component already has
+     *       resolved metadata. This discovers new nodes (which feed back to step 1) without any IO.</li>
+     *   <li><b>Selection</b> — pick the best version for one pending module. If selection changes
+     *       or the selected component already has metadata, return to step 1 immediately.
+     *       Otherwise, the module needs a metadata download — continue selecting the next module.</li>
+     *   <li><b>Download</b> — all cheap work is exhausted. Batch-download metadata for every
+     *       module that still needs it, then return to step 1.</li>
+     *   <li><b>Conflict resolution</b> — only when all queues are empty. Resolve one conflict
+     *       and return to step 1.</li>
+     * </ol>
      */
     private void traverseGraph(final ResolveState resolveState) {
         resolveState.onMoreSelected(resolveState.getRoot());
-        final List<EdgeState> edges = new ArrayList<>();
+
+        List<EdgeState> edges = new ArrayList<>();
+        List<ComponentState> componentsToDownload = new ArrayList<>();
 
         ModuleConflictHandler moduleConflictHandler = resolveState.getModuleConflictHandler();
         CapabilitiesConflictHandler capabilitiesConflictHandler = resolveState.getCapabilitiesConflictHandler();
 
-        while (resolveState.peek() != null || moduleConflictHandler.hasConflicts() || capabilitiesConflictHandler.hasConflicts()) {
-            if (resolveState.peek() != null) {
-                final NodeState node = resolveState.pop();
-
-                if (node.contributesToGraph()) {
+        while (true) {
+            // Priority 1: Process nodes that may have lost incoming edges (removals).
+            // These nodes likely need their outgoing edges removed, which releases selectors
+            // and reduces work for attachment and selection.
+            if (resolveState.hasNextRemoval()) {
+                NodeState node = resolveState.nextRemoval();
+                if (node.doesNotContributeToGraph()) {
                     node.removeOutgoingEdges();
-                    continue;
-                }
-
-                // This node is part of the graph. Check if it conflicts with any other node in the graph.
-                if (capabilitiesConflictHandler.registerCandidate(node)) {
-                    // We have a conflict, so we need to resolve it first, since this node may not win the conflict.
-                    // There is no reason to continue processing this node otherwise.
-                    continue;
-                }
-
-                // This node is part of the graph and is not in conflict. Process its outgoing dependencies.
-                edges.clear();
-                node.visitOutgoingDependenciesAndCollectEdges(edges);
-                resolveEdges(node, edges, resolveState);
-            } else {
-                // We have some batched up conflicts. Resolve the first, and continue traversing the graph
-                if (moduleConflictHandler.hasConflicts()) {
-                    moduleConflictHandler.resolveNextConflict();
                 } else {
-                    capabilitiesConflictHandler.resolveNextConflict();
+                    processNodeAddition(node, edges, resolveState, capabilitiesConflictHandler);
                 }
+                continue;
             }
+
+            // Priority 2: Attach edges for modules with resolved metadata.
+            // This discovers new nodes (additions) without IO.
+            if (attachModulesWithResolvedMetadata(resolveState)) {
+                continue;
+            }
+
+            // Priority 3: Process nodes that gained incoming edges (additions).
+            // Deferred until after attachment so that nodes accumulate all incoming edges
+            // before recomputing inherited state (excludes, strict versions).
+            if (resolveState.hasNextAddition()) {
+                NodeState node = resolveState.nextAddition();
+                if (node.doesNotContributeToGraph()) {
+                    node.removeOutgoingEdges();
+                } else {
+                    processNodeAddition(node, edges, resolveState, capabilitiesConflictHandler);
+                }
+                continue;
+            }
+
+            // Priority 4: Select the next pending module
+            if (resolveState.hasNextSelection()) {
+                selectUntilActionable(resolveState);
+                continue;
+            }
+
+            // Priority 5: Download all pending metadata in one batch
+            if (downloadPendingMetadata(resolveState, componentsToDownload)) {
+                continue;
+            }
+
+            // Priority 6: Resolve conflicts
+            if (moduleConflictHandler.hasConflicts()) {
+                moduleConflictHandler.resolveNextConflict();
+                continue;
+            }
+            if (capabilitiesConflictHandler.hasConflicts()) {
+                capabilitiesConflictHandler.resolveNextConflict();
+                continue;
+            }
+
+            // All queues empty, no conflicts remaining — done.
+            break;
         }
     }
 
-    private void resolveEdges(
-        final NodeState node,
-        final List<EdgeState> dependencies,
-        final ResolveState resolveState
+    /**
+     * Processes a node that contributes to the graph: checks for capability conflicts,
+     * then visits its outgoing dependencies and registers their target modules.
+     */
+    private static void processNodeAddition(
+        NodeState node,
+        List<EdgeState> edges,
+        ResolveState resolveState,
+        CapabilitiesConflictHandler capabilitiesConflictHandler
     ) {
-        if (dependencies.isEmpty()) {
+        if (capabilitiesConflictHandler.registerCandidate(node)) {
             return;
         }
 
-        performSelectionSerially(dependencies, resolveState);
-        maybeDownloadMetadataInParallel(node, dependencies, buildOperationExecutor, resolveState.getComponentMetadataResolver());
-        attachToTargetRevisionsSerially(dependencies);
-    }
-
-    private static void performSelectionSerially(List<EdgeState> edges, ResolveState resolveState) {
+        edges.clear();
+        node.visitOutgoingDependenciesAndCollectEdges(edges);
         for (EdgeState edge : edges) {
-            // Selection of prior edges can cause the source node to enter a module conflict, thus
-            // causing further edges to be released.
-            if (edge.isUsed()) {
-                SelectorState selector = edge.getSelector();
-                ModuleResolveState module = selector.getTargetModule();
-
-                // TODO: It is odd that we have to check module.getSelectors().size() here.
-                //       We already have a selector, its module should know about it.
-                if (selector.canAffectSelection() && module.getSelectors().size() > 0) {
-                    // Have an unprocessed/new selector for this module. Need to re-select the target version (if there are any selectors that can be used).
-                    performSelection(resolveState, module);
-                }
+            SelectorState selector = edge.getSelector();
+            ModuleResolveState targetModule = selector.getTargetModule();
+            if (selector.canAffectSelection()) {
+                resolveState.enqueueForSelection(targetModule);
+            } else if (!targetModule.isQueuedForSelection()) {
+                resolveState.enqueueForAttachment(targetModule);
             }
         }
+    }
+
+    /**
+     * Iterates the attachment queue, attaching edges for modules whose selected component
+     * already has resolved metadata (or whose metadata is cheap to fetch synchronously).
+     * Modules that still need a download remain in the queue for later.
+     *
+     * @return true if any attachment was performed (meaning new nodes may be on the queue)
+     */
+    private static boolean attachModulesWithResolvedMetadata(ResolveState resolveState) {
+        boolean didWork = false;
+        while (resolveState.hasNextAttachment()) {
+            ModuleResolveState module = resolveState.nextAttachment();
+            if (module.isInModuleConflict() || module.getUnattachedEdges().isEmpty()) {
+                continue;
+            }
+            ComponentState selected = module.getSelected();
+            if (selected == null) {
+                continue;
+            }
+            if (!selected.alreadyResolved()) {
+                if (selected.isMetadataCheapToFetch()) {
+                    selected.getMetadataOrNull();
+                } else {
+                    resolveState.enqueueForDownload(module);
+                    continue;
+                }
+            }
+            module.attachUnattachedEdges();
+            didWork = true;
+        }
+        return didWork;
+    }
+
+    /**
+     * Pops modules from the selection queue one at a time and performs selection.
+     * Stops early and returns when:
+     * <ul>
+     *   <li>Selection changed (old nodes were enqueued for cleanup)</li>
+     *   <li>The selected component already has metadata (can be attached immediately)</li>
+     *   <li>The selection queue is empty</li>
+     * </ul>
+     * Modules that need a metadata download are enqueued for attachment but
+     * selection continues to the next module without returning.
+     */
+    @SuppressWarnings("ReferenceEquality")
+    private void selectUntilActionable(ResolveState resolveState) {
+        while (resolveState.hasNextSelection()) {
+            ModuleResolveState module = resolveState.nextSelection();
+
+            if (module.getSelectors().size() == 0) {
+                continue;
+            }
+
+            ComponentState previousSelection = module.getSelected();
+            performSelection(resolveState, module);
+            ComponentState newSelection = module.getSelected();
+
+            if (newSelection == null) {
+                continue; // Selection failed
+            }
+
+            resolveState.enqueueForAttachment(newSelection.getModule());
+
+            if (previousSelection != null && newSelection != previousSelection) {
+                // Selection changed — old nodes were enqueued. Return to drain them.
+                return;
+            }
+
+            if (newSelection.alreadyResolved()) {
+                // Metadata already available — return to attach immediately.
+                return;
+            }
+        }
+    }
+
+    /**
+     * Collects all modules in the attachment queue that still need a metadata download
+     * and downloads them in parallel.
+     *
+     * @return true if any downloads were performed
+     */
+    private boolean downloadPendingMetadata(
+        ResolveState resolveState,
+        List<ComponentState> componentsToDownload
+    ) {
+        componentsToDownload.clear();
+        while (resolveState.hasNextDownload()) {
+            ModuleResolveState module = resolveState.nextDownload();
+            ComponentState selected = module.getSelected();
+            if (selected != null && !selected.alreadyResolved() && !module.isInModuleConflict()) {
+                componentsToDownload.add(selected);
+            }
+        }
+        if (componentsToDownload.isEmpty()) {
+            return false;
+        }
+        downloadAllComponents(componentsToDownload, buildOperationExecutor);
+        for (ComponentState component : componentsToDownload) {
+            resolveState.enqueueForAttachment(component.getModule());
+        }
+        return true;
     }
 
     /**
@@ -260,42 +403,18 @@ public class DependencyGraphBuilder {
         }
     }
 
-    /**
-     * Prepares the resolution of edges, either serially or concurrently.
-     * It uses a simple heuristic to determine if we should perform concurrent resolution, based on the number of edges, and whether they have unresolved metadata.
-     */
-    private static void maybeDownloadMetadataInParallel(NodeState node, List<EdgeState> edges, BuildOperationExecutor buildOperationExecutor, ComponentMetaDataResolver componentMetaDataResolver) {
-        List<ComponentState> requiringDownload = null;
-        for (EdgeState edge : edges) {
-            ComponentState targetComponent = edge.getTargetComponent();
-            if (targetComponent != null && targetComponent.isNotEvicted() && !targetComponent.alreadyResolved()) {
-                if (!componentMetaDataResolver.isFetchingMetadataCheap(targetComponent.getComponentId())) {
-                    // Avoid initializing the list if there are no components requiring download (a common case)
-                    if (requiringDownload == null) {
-                        requiringDownload = new ArrayList<>();
-                    }
-                    requiringDownload.add(targetComponent);
-                }
-            }
-        }
-        // Only download in parallel if there is more than 1 component to download
-        if (requiringDownload != null && requiringDownload.size() > 1) {
-            final ImmutableList<ComponentState> toDownloadInParallel = ImmutableList.copyOf(requiringDownload);
-            LOGGER.debug("Submitting {} metadata files to resolve in parallel for {}", toDownloadInParallel.size(), node);
+    private static void downloadAllComponents(List<ComponentState> requiringDownload, BuildOperationExecutor buildOperationExecutor) {
+        if (requiringDownload.size() == 1) {
+            // Only one thing to download. No need to start any threads. Download synchronously.
+            ComponentState component = requiringDownload.get(0);
+            component.getMetadataOrNull();
+        } else if (requiringDownload.size() > 1) {
+            LOGGER.debug("Submitting {} metadata files to resolve in parallel", requiringDownload.size());
             buildOperationExecutor.runAll(buildOperationQueue -> {
-                for (final ComponentState componentState : toDownloadInParallel) {
+                for (final ComponentState componentState : requiringDownload) {
                     buildOperationQueue.add(new DownloadMetadataOperation(componentState));
                 }
             }, BuildOperationConstraint.UNCONSTRAINED);
-        }
-    }
-
-    private static void attachToTargetRevisionsSerially(List<EdgeState> edges) {
-        // the following only needs to be done serially to preserve ordering of dependencies in the graph: we have visited the edges
-        // but we still didn't add the result to the queue. Doing it from resolve threads would result in non-reproducible graphs, where
-        // edges could be added in different order. To avoid this, the addition of new edges is done serially.
-        for (EdgeState edge : edges) {
-            edge.attachToTargetNodes();
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -144,14 +144,7 @@ class EdgeState implements DependencyGraphEdge {
         if (selector == null || !selector.isResolved() || selector.getFailure() != null) {
             return null;
         }
-        ModuleResolveState targetModule = selector.getTargetModule();
-        if (targetModule.isInModuleConflict()) {
-            // Do not download metadata for modules in conflict, as the module might
-            // lose the conflict, and we want to avoid wasted IO.
-            return null;
-        }
-
-        return targetModule.getSelected();
+        return selector.getTargetModule().getSelected();
     }
 
     SelectorState getSelector() {
@@ -165,6 +158,9 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     void attachToTargetNodes() {
+        if (targetNodeSelectionFailure != null) {
+            return;
+        }
         ComponentState targetComponent = getTargetComponent();
         if (targetComponent == null || !isUsed()) {
             // The selector failed or the module has been deselected or the edge source has been deselected. Do not attach.
@@ -174,13 +170,12 @@ class EdgeState implements DependencyGraphEdge {
         // We should never try to attach edges to a node in a module that has no incoming hard edges.
         assert !targetComponent.getModule().isPending();
 
+        // Attachment requires selecting from the variants of the component. We
+        // must have already resolved these variants before attempting to attach.
+        assert targetComponent.alreadyResolved();
+
         calculateTargetNodes(targetComponent);
-        if (!targetNodes.isEmpty()) {
-            for (NodeState targetNode : targetNodes) {
-                targetNode.addIncomingEdge(this);
-            }
-            selector.getTargetModule().removeUnattachedEdge(this);
-        }
+        assert targetNodes.isEmpty() == unattached;
     }
 
     /**
@@ -190,10 +185,12 @@ class EdgeState implements DependencyGraphEdge {
      */
     void detachFromTargetNodes() {
         if (!targetNodes.isEmpty()) {
+            assert !unattached;
             for (NodeState targetNode : targetNodes) {
                 targetNode.removeIncomingEdge(this);
             }
             targetNodes.clear();
+            selector.getTargetModule().addUnattachedEdge(this);
         }
         targetNodeSelectionFailure = null;
     }
@@ -209,21 +206,13 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     /**
-     * Ensure this edge it up-to-date and attached to the proper nodes, effectively
-     * retargeting this edge from its previous potentially incorrect target, to
-     * the new correct target.
-     * <p>
-     * Useful for when the state of the destination has changed, for example
-     * when the selected component of the target module has changed.
+     * Clear a previous failure to attach to target nodes, so that this edge
+     * will retry to attach next time it is requested to do so. This method
+     * should be called whenever the graph state changes so that a previous failed
+     * attachment may now succeed.
      */
-    public void retarget() {
-        detachFromTargetNodes();
-        if (isUsed()) {
-            attachToTargetNodes();
-            if (targetNodes.isEmpty()) {
-                selector.getTargetModule().addUnattachedEdge(this); // Attach failed, mark it as such.
-            }
-        }
+    void clearTargetNodeSelectionFailure() {
+        this.targetNodeSelectionFailure = null;
     }
 
     @Override
@@ -234,27 +223,16 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     private void calculateTargetNodes(ComponentState targetComponent) {
+        assert unattached && targetNodes.isEmpty() && targetNodeSelectionFailure == null;
+
         ComponentGraphResolveState targetComponentState = targetComponent.getResolveStateOrNull();
-        targetNodes.clear(); // TODO: Why not `detachFromTargetNodes()`?
-        targetNodeSelectionFailure = null;
         if (targetComponentState == null) {
             targetComponent.getModule().getPlatformState().addOrphanEdge(this);
             // Broken version
             return;
         }
-        if (isConstraint) {
-            // We are a constraint and therefore may have deferred selection and attachment
-            // of some other module/edge. Make sure to attach that deferred edge now that we have
-            // performed selection.
-            List<EdgeState> unattachedEdges = targetComponent.getModule().getUnattachedEdges();
-            if (!unattachedEdges.isEmpty()) {
-                for (EdgeState unattachedEdge : new ArrayList<>(unattachedEdges)) {
-                    if (!unattachedEdge.isConstraint()) {
-                        unattachedEdge.attachToTargetNodes();
-                    }
-                }
-            }
 
+        if (isConstraint) {
             // A constraint by definition attaches to any other nodes in the component it constrains.
             for (NodeState node : targetComponent.getNodes()) {
                 if (node.isSelected() && !node.isRoot()) {
@@ -418,7 +396,7 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     @Override
-    public ModuleVersionResolveException getFailure() {
+    public @Nullable ModuleVersionResolveException getFailure() {
         if (targetNodeSelectionFailure != null) {
             return targetNodeSelectionFailure;
         }
@@ -563,10 +541,16 @@ class EdgeState implements DependencyGraphEdge {
         return transitiveExclusions;
     }
 
+    /**
+     * This must <strong>only</strong> be called from {@link ModuleResolveState#addUnattachedEdge}
+     */
     public void markUnattached() {
         this.unattached = true;
     }
 
+    /**
+     * This must <strong>only</strong> be called from {@link ModuleResolveState#removeUnattachedEdge}
+     */
     public void markNotUnattached() {
         this.unattached = false;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -41,7 +41,6 @@ import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -237,6 +236,7 @@ class EdgeState implements DependencyGraphEdge {
             for (NodeState node : targetComponent.getNodes()) {
                 if (node.isSelected() && !node.isRoot()) {
                     targetNodes.add(node);
+                    node.addIncomingEdge(this);
                 }
             }
 
@@ -249,6 +249,9 @@ class EdgeState implements DependencyGraphEdge {
                         return;
                     }
                 }
+            } else {
+                // If we have target nodes, we are no longer unattached.
+                selector.getTargetModule().removeUnattachedEdge(this);
             }
             return;
         }
@@ -276,6 +279,38 @@ class EdgeState implements DependencyGraphEdge {
                 targetNodeState = targetNodeState.getReplacement();
             }
             this.targetNodes.add(targetNodeState);
+            targetNodeState.addIncomingEdge(this);
+        }
+        if (!targetNodes.isEmpty()) {
+            attachConstraintsTargetingComponentToNodes(targetComponent, targetNodes);
+            selector.getTargetModule().removeUnattachedEdge(this);
+        }
+    }
+
+    /**
+     * Since constraints attach to all nodes of the selected component of the module they constrain,
+     * we must update all constraints already targeting nodes in the selected component to also
+     * attach to the nodes we just attached to.
+     */
+    @SuppressWarnings("ForLoopReplaceableByForEach") // Lots of iteration here -- iterators are visible in profiles otherwise
+    private static void attachConstraintsTargetingComponentToNodes(ComponentState targetComponent, List<NodeState> targetNodes1) {
+        List<NodeState> nodes = targetComponent.getNodes();
+        for (int i = 0; i < nodes.size(); i++) {
+            NodeState targetModuleNode = nodes.get(i);
+            List<EdgeState> incomingEdges = targetModuleNode.getIncomingEdges();
+            for (int j = 0; j < incomingEdges.size(); j++) {
+                EdgeState incomingEdge = incomingEdges.get(j);
+                if (incomingEdge.isConstraint()) {
+                    for (int k = 0; k < targetNodes1.size(); k++) {
+                        NodeState targetNode = targetNodes1.get(k);
+                        if (!incomingEdge.targetNodes.contains(targetNode)) {
+                            incomingEdge.clearTargetNodeSelectionFailure();
+                            incomingEdge.targetNodes.add(targetNode);
+                            targetNode.addIncomingEdge(incomingEdge);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -100,12 +100,12 @@ class EdgeState implements DependencyGraphEdge {
         this.dependencyState = new DependencyState(metadata, requested, ruleDescriptors, resolveFailure);
     }
 
-    boolean computeSelector(StrictVersionConstraints ancestorsStrictVersions, boolean deferSelection) {
+    boolean computeSelector(StrictVersionConstraints ancestorsStrictVersions) {
         boolean ignoreVersion = !dependencyState.isForced() && ancestorsStrictVersions.contains(dependencyState.getModuleIdentifier(resolveState.getComponentSelectorConverter()));
         SelectorState newSelector = resolveState.computeSelectorFor(dependencyState, ignoreVersion);
         if (this.selector != newSelector) {
             clearSelector();
-            newSelector.use(deferSelection);
+            newSelector.use();
             this.selector = newSelector;
             return true;
         }
@@ -548,7 +548,7 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     void recomputeSelectorAndRequeueTargetNodes(StrictVersionConstraints ancestorsStrictVersions, Collection<EdgeState> discoveredEdges) {
-        if (computeSelector(ancestorsStrictVersions, false)) {
+        if (computeSelector(ancestorsStrictVersions)) {
             discoveredEdges.add(this);
         }
         // TODO: If we compute the selector for this edge and it changes, we shouldn't add the (potentially) invalid target nodes to the queue.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -72,6 +72,8 @@ public class ModuleResolveState implements CandidateModule {
     private SelectorStateResolver<ComponentState> selectorStateResolver;
     private final PendingDependencies pendingDependencies;
     private @Nullable ComponentState selected;
+    private boolean queuedForSelection;
+    private boolean queuedForAttachment;
     private ImmutableAttributes mergedConstraintAttributes = ImmutableAttributes.EMPTY;
     private @Nullable AttributeMergingException attributeMergingError;
     private @Nullable VirtualPlatformState platformState;
@@ -109,6 +111,30 @@ public class ModuleResolveState implements CandidateModule {
         return resolveState;
     }
 
+    boolean enqueueForSelection() {
+        if (queuedForSelection) {
+            return false;
+        }
+        queuedForSelection = true;
+        return true;
+    }
+
+    void dequeueFromSelection() {
+        queuedForSelection = false;
+    }
+
+    boolean enqueueForAttachment() {
+        if (queuedForAttachment) {
+            return false;
+        }
+        queuedForAttachment = true;
+        return true;
+    }
+
+    void dequeueFromAttachment() {
+        queuedForAttachment = false;
+    }
+
     void setSelectorStateResolver(SelectorStateResolver<ComponentState> selectorStateResolver) {
         this.selectorStateResolver = selectorStateResolver;
     }
@@ -126,7 +152,7 @@ public class ModuleResolveState implements CandidateModule {
 
     @Override
     public String toString() {
-        return id.toString();
+        return id + (selected != null ? " (" + selected.getVersion() + ")" : "");
     }
 
     @Override
@@ -234,7 +260,7 @@ public class ModuleResolveState implements CandidateModule {
             for (NodeState node : newSelection.getNodes()) {
                 resolveState.onMoreSelected(node);
             }
-            attachUnattachedEdges();
+            resolveState.enqueueForAttachment(this);
         } else {
             changeSelection(newSelection);
         }
@@ -247,31 +273,55 @@ public class ModuleResolveState implements CandidateModule {
         this.selected = newSelection;
         this.replaced = !newSelection.getModule().getId().equals(getId());
 
+        // Override selectors before detaching edges, so that selector.getTargetModule()
+        // returns the winning module, and unattached edges are added to the winner.
+        for (SelectorState selector : selectors) {
+            selector.overrideSelection(newSelection);
+        }
+
+        // Selection changed. Edges which may have failed to attach in the past may
+        // succeed now. Clear their cached failures so they can retry.
+        clearUnattachedEdgeFailures();
+
         if (replaced) {
             this.overriddenSelection = true;
             newSelection.getModule().getPendingDependencies().retarget(pendingDependencies);
+            newSelection.getModule().getUnattachedEdges().addAll(unattachedEdges);
+            unattachedEdges.clear();
         }
 
         evictOtherComponents(newSelection);
 
         if (oldSelected != null && oldSelected != newSelection) {
             for (NodeState node : oldSelected.getNodes()) {
-                node.restartIncomingEdges();
+                node.detachIncomingEdges();
+            }
+            if (platformOwners != null) {
+                for (VirtualPlatformState owner : platformOwners) {
+                    owner.invalidateVirtualPlatformConstraints();
+                }
             }
         }
-        for (SelectorState selector : selectors) {
-            selector.overrideSelection(newSelection);
-        }
-        attachUnattachedEdges();
     }
 
-    private void attachUnattachedEdges() {
+    public void attachUnattachedEdges() {
         if (unattachedEdges.size() == 1) {
             EdgeState singleEdge = unattachedEdges.get(0);
-            singleEdge.retarget();
+            singleEdge.attachToTargetNodes();
         } else if (!unattachedEdges.isEmpty()) {
-            for (EdgeState edge : new ArrayList<>(unattachedEdges)) {
-                edge.retarget();
+            ArrayList<EdgeState> unattachedEdgesCopy = new ArrayList<>(unattachedEdges);
+            for (EdgeState edge : unattachedEdgesCopy) {
+                if (!edge.isConstraint()) {
+                    edge.attachToTargetNodes();
+                }
+            }
+            // Attach constraints after hard edges, since constraints targeting module
+            // by definition attach to any node that is the target of a hard edge targeting
+            // that same module
+            for (EdgeState edge : unattachedEdgesCopy) {
+                if (edge.isConstraint()) {
+                    edge.attachToTargetNodes();
+                }
             }
         }
     }
@@ -286,6 +336,17 @@ public class ModuleResolveState implements CandidateModule {
     public void removeUnattachedEdge(EdgeState edge) {
         if (unattachedEdges.remove(edge)) {
             edge.markNotUnattached();
+        }
+    }
+
+    /**
+     * Clears cached attachment failures on all unattached edges, so they will be
+     * retried on the next attachment round. Called when the module's state changes
+     * in a way that may allow previously-failed edges to succeed.
+     */
+    private void clearUnattachedEdgeFailures() {
+        for (EdgeState edge : unattachedEdges) {
+            edge.clearTargetNodeSelectionFailure();
         }
     }
 
@@ -313,7 +374,11 @@ public class ModuleResolveState implements CandidateModule {
 
     void addSelector(SelectorState selector) {
         selectors.add(selector);
+        ImmutableAttributes previousAttributes = mergedConstraintAttributes;
         mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selector);
+        if (mergedConstraintAttributes != previousAttributes) {
+            clearUnattachedEdgeFailures();
+        }
         if (overriddenSelection) {
             assert selected != null : "An overridden module cannot have selected == null";
             selector.overrideSelection(selected);
@@ -323,12 +388,16 @@ public class ModuleResolveState implements CandidateModule {
     void removeSelector(SelectorState selector) {
         selectors.remove(selector);
         boolean alreadyReused = selector.markForReuse();
+        ImmutableAttributes previousAttributes = mergedConstraintAttributes;
         mergedConstraintAttributes = ImmutableAttributes.EMPTY;
         for (SelectorState selectorState : selectors) {
             mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selectorState);
         }
+        if (mergedConstraintAttributes != previousAttributes) {
+            clearUnattachedEdgeFailures();
+        }
         if (!alreadyReused && selectors.size() != 0 && selected != null) {
-            maybeUpdateSelection();
+            resolveState.enqueueForSelection(this);
         }
     }
 
@@ -384,6 +453,7 @@ public class ModuleResolveState implements CandidateModule {
     }
 
     void disconnectIncomingEdge(NodeState removalSource, EdgeState incomingEdge) {
+        assert !replaced : "disconnectIncomingEdge() called on replaced module " + id;
         // Remove the unattached edge first, as clearing the selector may trigger re-selection and mutate the unattached edge
         removeUnattachedEdge(incomingEdge);
         incomingEdge.clearSelector();
@@ -410,11 +480,9 @@ public class ModuleResolveState implements CandidateModule {
     }
 
     private void clearIncomingUnattachedConstraints(NodeState removalSource) {
-        for (EdgeState unattachedEdge : unattachedEdges) {
+        for (EdgeState unattachedEdge : new ArrayList<>(unattachedEdges)) {
             disconnectIncomingConstraint(removalSource, unattachedEdge);
-            unattachedEdge.markNotUnattached();
         }
-        unattachedEdges.clear();
     }
 
     private void disconnectIncomingConstraint(NodeState removalSource, EdgeState incomingEdge) {
@@ -426,11 +494,13 @@ public class ModuleResolveState implements CandidateModule {
             // Only remove edges that come from a different node than the source of the dependency going
             // back to pending. The source of the removal is already removing outgoing edges from itself.
             from.removeOutgoingEdge(incomingEdge);
+            removeUnattachedEdge(incomingEdge);
         }
         pendingDependencies.registerConstraintProvider(from);
     }
 
     boolean isPending() {
+        assert !replaced : "isPending() called on replaced module " + id;
         return pendingDependencies.isPending();
     }
 
@@ -439,14 +509,6 @@ public class ModuleResolveState implements CandidateModule {
             return selected.getModule().getPendingDependencies();
         }
         return pendingDependencies;
-    }
-
-    void registerConstraintProvider(NodeState node) {
-        pendingDependencies.registerConstraintProvider(node);
-    }
-
-    void unregisterConstraintProvider(NodeState nodeState) {
-        pendingDependencies.unregisterConstraintProvider(nodeState);
     }
 
     @SuppressWarnings("ReferenceEquality") //TODO: evaluate errorprone suppression (https://github.com/gradle/gradle/issues/35864)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -111,6 +111,10 @@ public class ModuleResolveState implements CandidateModule {
         return resolveState;
     }
 
+    boolean isQueuedForSelection() {
+        return queuedForSelection;
+    }
+
     boolean enqueueForSelection() {
         if (queuedForSelection) {
             return false;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -74,6 +74,7 @@ public class ModuleResolveState implements CandidateModule {
     private @Nullable ComponentState selected;
     private boolean queuedForSelection;
     private boolean queuedForAttachment;
+    private boolean queuedForDownload;
     private ImmutableAttributes mergedConstraintAttributes = ImmutableAttributes.EMPTY;
     private @Nullable AttributeMergingException attributeMergingError;
     private @Nullable VirtualPlatformState platformState;
@@ -137,6 +138,18 @@ public class ModuleResolveState implements CandidateModule {
 
     void dequeueFromAttachment() {
         queuedForAttachment = false;
+    }
+
+    boolean enqueueForDownload() {
+        if (queuedForDownload) {
+            return false;
+        }
+        queuedForDownload = true;
+        return true;
+    }
+
+    void dequeueFromDownload() {
+        queuedForDownload = false;
     }
 
     void setSelectorStateResolver(SelectorStateResolver<ComponentState> selectorStateResolver) {
@@ -477,6 +490,7 @@ public class ModuleResolveState implements CandidateModule {
             for (NodeState node : selected.getNodes()) {
                 List<EdgeState> removedEdges = node.removeAllIncomingEdges();
                 for (EdgeState incomingEdge : removedEdges) {
+                    incomingEdge.getTargetNodes().clear(); // Sus
                     disconnectIncomingConstraint(removalSource, incomingEdge);
                 }
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -69,7 +69,6 @@ public class ModuleResolveState implements CandidateModule {
     private final Comparator<Version> versionComparator;
     private final VersionParser versionParser;
     final ResolveOptimizations resolveOptimizations;
-    private final boolean rootModule;
     private SelectorStateResolver<ComponentState> selectorStateResolver;
     private final PendingDependencies pendingDependencies;
     private @Nullable ComponentState selected;
@@ -91,7 +90,6 @@ public class ModuleResolveState implements CandidateModule {
         VersionParser versionParser,
         SelectorStateResolver<ComponentState> selectorStateResolver,
         ResolveOptimizations resolveOptimizations,
-        boolean rootModule,
         ConflictResolution conflictResolution
     ) {
         this.resolveState = resolveState;
@@ -101,7 +99,6 @@ public class ModuleResolveState implements CandidateModule {
         this.versionComparator = versionComparator;
         this.versionParser = versionParser;
         this.resolveOptimizations = resolveOptimizations;
-        this.rootModule = rootModule;
         this.pendingDependencies = new PendingDependencies(id);
         this.selectorStateResolver = selectorStateResolver;
         this.selectors = new ModuleSelectors<>(versionComparator, versionParser);
@@ -314,8 +311,8 @@ public class ModuleResolveState implements CandidateModule {
         return componentState;
     }
 
-    void addSelector(SelectorState selector, boolean deferSelection) {
-        selectors.add(selector, deferSelection);
+    void addSelector(SelectorState selector) {
+        selectors.add(selector);
         mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selector);
         if (overriddenSelection) {
             assert selected != null : "An overridden module cannot have selected == null";
@@ -456,10 +453,6 @@ public class ModuleResolveState implements CandidateModule {
     public void maybeUpdateSelection() {
         if (replaced) {
             // Never update selection for a replaced module
-            return;
-        }
-        if (!rootModule && selectors.checkDeferSelection()) {
-            // Selection deferred as we know another selector will be added soon
             return;
         }
         ComponentState newSelected = selectorStateResolver.selectBest(getId(), selectors);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
@@ -38,7 +38,6 @@ public class ModuleSelectors<T extends ResolvableSelectorState> implements Itera
 
     private final VersionParser versionParser;
     private final List<T> selectors = new ArrayList<>();
-    private boolean deferSelection;
     private boolean forced;
     private final Comparator<ResolvableSelectorState> selectorComparator;
 
@@ -85,21 +84,12 @@ public class ModuleSelectors<T extends ResolvableSelectorState> implements Itera
         }
     }
 
-    public boolean checkDeferSelection() {
-        if (deferSelection) {
-            deferSelection = false;
-            return true;
-        }
-        return false;
-    }
-
     @Override
     public Iterator<T> iterator() {
         return selectors.iterator();
     }
 
-    public void add(T selector, boolean deferSelection) {
-        this.deferSelection = deferSelection;
+    public void add(T selector) {
         if (selectors.isEmpty() || forced) {
             selectors.add(selector);
         } else {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -353,7 +353,7 @@ public class NodeState implements DependencyGraphNode {
                         module.getPendingDependencies().registerConstraintProvider(this);
                     } else {
                         for (EdgeState edge : edges) {
-                            doLinkOutgoingEdge(edge, discoveredEdges, resolutionFilter, ancestorsStrictVersions, module, false);
+                            doLinkOutgoingEdge(edge, discoveredEdges, resolutionFilter, ancestorsStrictVersions, module);
                         }
                     }
                 }
@@ -456,11 +456,10 @@ public class NodeState implements DependencyGraphNode {
         ModuleIdentifier moduleId = dependencyEdge.getDependencyState().getModuleIdentifier(resolveState.getComponentSelectorConverter());
         ModuleResolveState module = resolveState.getModule(moduleId);
 
-        boolean deferSelection = false;
         if (constraint) {
             registerActivatingConstraint(dependencyEdge, moduleId);
         } else {
-            deferSelection = module.getPendingDependencies().addIncomingHardEdge();
+            module.getPendingDependencies().addIncomingHardEdge();
         }
 
         if (constraint && module.isPending()) {
@@ -468,7 +467,7 @@ public class NodeState implements DependencyGraphNode {
             module.registerConstraintProvider(this);
         } else {
             // We are a hard edge, or we are a constraint but there is already another hard edge targeting the same module.
-            doLinkOutgoingEdge(dependencyEdge, discoveredEdges, resolutionFilter, ancestorsStrictVersions, module, deferSelection);
+            doLinkOutgoingEdge(dependencyEdge, discoveredEdges, resolutionFilter, ancestorsStrictVersions, module);
         }
     }
 
@@ -576,11 +575,10 @@ public class NodeState implements DependencyGraphNode {
         Collection<EdgeState> discoveredEdges,
         ExcludeSpec resolutionFilter,
         StrictVersionConstraints ancestorsStrictVersions,
-        ModuleResolveState module,
-        boolean deferSelection
+        ModuleResolveState module
     ) {
         dependencyEdge.updateTransitiveExcludes(resolutionFilter);
-        dependencyEdge.computeSelector(ancestorsStrictVersions, deferSelection);
+        dependencyEdge.computeSelector(ancestorsStrictVersions);
         module.addUnattachedEdge(dependencyEdge);
         discoveredEdges.add(dependencyEdge);
         outgoingEdges.add(dependencyEdge);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -86,7 +86,8 @@ public class NodeState implements DependencyGraphNode {
 
     @Nullable
     ExcludeSpec previousTraversalExclusions;
-    private boolean queued;
+    private boolean queuedForRemoval;
+    private boolean queuedForAddition;
 
     /**
      * The number of unresolved capability conflicts this node is involved in.
@@ -173,19 +174,28 @@ public class NodeState implements DependencyGraphNode {
         this.dependenciesMayChange = component.getModule().isVirtualPlatform();
     }
 
-    // the enqueue and dequeue methods are used for performance reasons
-    // in order to avoid tracking the set of enqueued nodes
-    boolean enqueue() {
-        if (queued) {
+    boolean enqueueForRemoval() {
+        if (queuedForRemoval || queuedForAddition) {
             return false;
         }
-        queued = true;
+        queuedForRemoval = true;
         return true;
     }
 
-    NodeState dequeue() {
-        queued = false;
-        return this;
+    void dequeueFromRemoval() {
+        queuedForRemoval = false;
+    }
+
+    boolean enqueueForAddition() {
+        if (queuedForAddition || queuedForRemoval) {
+            return false;
+        }
+        queuedForAddition = true;
+        return true;
+    }
+
+    void dequeueFromAddition() {
+        queuedForAddition = false;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -388,20 +388,7 @@ public class NodeState implements DependencyGraphNode {
      * * Making sure we no longer are registered as pending interest on nodes pointed by constraints
      */
     private void cleanupConstraints() {
-        // This part covers constraint that were taken into account between a selection being deferred and this node being scheduled for traversal
-        if (upcomingNoLongerPendingConstraints != null) {
-            for (ModuleIdentifier identifier : upcomingNoLongerPendingConstraints) {
-                ModuleResolveState module = resolveState.getModule(identifier);
-                for (EdgeState unattachedEdge : module.getUnattachedEdges()) {
-                    if (!unattachedEdge.getSelector().isResolved()) {
-                        // Unresolved - we have a selector that was deferred but the constraint has been removed in between
-                        NodeState from = unattachedEdge.getFrom();
-                        from.prepareToRecomputeEdge(unattachedEdge);
-                    }
-                }
-            }
-            upcomingNoLongerPendingConstraints = null;
-        }
+        this.upcomingNoLongerPendingConstraints = null;
         // This part covers constraint that might be triggered in the future if the node they point gains a real edge
         if (cachedFilteredEdges != null && !cachedFilteredEdges.isEmpty()) {
             // We may have registered this node as pending if it had constraints.
@@ -786,7 +773,10 @@ public class NodeState implements DependencyGraphNode {
             resolveState.onMoreSelected(this);
         } else {
             this.replacement = winner;
-            restartIncomingEdges();
+            for (EdgeState edge : incomingEdges) {
+                resolveState.enqueueForAttachment(edge.getSelector().getTargetModule());
+            }
+            detachIncomingEdges();
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -353,7 +353,7 @@ public class NodeState implements DependencyGraphNode {
                         module.getPendingDependencies().registerConstraintProvider(this);
                     } else {
                         for (EdgeState edge : edges) {
-                            doLinkOutgoingEdge(edge, discoveredEdges, resolutionFilter, ancestorsStrictVersions, module);
+                            doLinkOutgoingEdge(edge, discoveredEdges, resolutionFilter, ancestorsStrictVersions);
                         }
                     }
                 }
@@ -410,7 +410,7 @@ public class NodeState implements DependencyGraphNode {
                 if (edge.getDependencyMetadata().isConstraint()) {
                     ModuleResolveState targetModule = resolveState.getModule(edge.getDependencyState().getModuleIdentifier(resolveState.getComponentSelectorConverter()));
                     if (targetModule.isPending()) {
-                        targetModule.unregisterConstraintProvider(this);
+                        targetModule.getPendingDependencies().unregisterConstraintProvider(this);
                     }
                 }
             }
@@ -464,10 +464,10 @@ public class NodeState implements DependencyGraphNode {
 
         if (constraint && module.isPending()) {
             // No hard dependency targeting this module. Remember this constraint for later in case we see a hard dependency later.
-            module.registerConstraintProvider(this);
+            module.getPendingDependencies().registerConstraintProvider(this);
         } else {
             // We are a hard edge, or we are a constraint but there is already another hard edge targeting the same module.
-            doLinkOutgoingEdge(dependencyEdge, discoveredEdges, resolutionFilter, ancestorsStrictVersions, module);
+            doLinkOutgoingEdge(dependencyEdge, discoveredEdges, resolutionFilter, ancestorsStrictVersions);
         }
     }
 
@@ -574,12 +574,11 @@ public class NodeState implements DependencyGraphNode {
         EdgeState dependencyEdge,
         Collection<EdgeState> discoveredEdges,
         ExcludeSpec resolutionFilter,
-        StrictVersionConstraints ancestorsStrictVersions,
-        ModuleResolveState module
+        StrictVersionConstraints ancestorsStrictVersions
     ) {
         dependencyEdge.updateTransitiveExcludes(resolutionFilter);
         dependencyEdge.computeSelector(ancestorsStrictVersions);
-        module.addUnattachedEdge(dependencyEdge);
+        dependencyEdge.getSelector().getTargetModule().addUnattachedEdge(dependencyEdge);
         discoveredEdges.add(dependencyEdge);
         outgoingEdges.add(dependencyEdge);
     }
@@ -747,11 +746,11 @@ public class NodeState implements DependencyGraphNode {
      * Determine if this node should be processed when it is dequeued during traversal, or if it
      * instead be removed from the graph.
      * <p>
-     * False if this node has no incoming edges, or is in conflict and should temporarily not
+     * True if this node has no incoming edges, or is in conflict and should temporarily not
      * contribute to the graph. We need special handling for root since it does not yet have
      * its own module, but should never be considered a conflict participant.
      */
-    boolean contributesToGraph() {
+    boolean doesNotContributeToGraph() {
         return !isSelected() || isInCapabilityConflict() || (getComponent().getModule().isInModuleConflict() && !isRoot());
     }
 
@@ -1234,17 +1233,17 @@ public class NodeState implements DependencyGraphNode {
     }
 
     /**
-     * Called on losing nodes after conflict resolution to retarget their existing incoming
-     * edges to the winning node. This method must be called after any relevant state is updated
-     * so that retargeting chooses the correct new target node.
+     * Called on losing nodes after conflict resolution to detach their existing incoming
+     * edges from their existing node. This method must be called after any relevant state is updated
+     * so that detaching adds unattached edges to the winning module.
      */
-    void restartIncomingEdges() {
+    public void detachIncomingEdges() {
         if (incomingEdges.size() == 1) {
             EdgeState singleEdge = incomingEdges.get(0);
-            singleEdge.retarget();
+            singleEdge.detachFromTargetNodes();
         } else if (incomingEdges.size() > 1){
             for (EdgeState edge : new ArrayList<>(incomingEdges)) {
-                edge.retarget();
+                edge.detachFromTargetNodes();
             }
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependencies.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependencies.java
@@ -36,10 +36,10 @@ public class PendingDependencies {
         this.hardEdges = 0;
     }
 
-    boolean addIncomingHardEdge() {
+    void addIncomingHardEdge() {
         increaseHardEdgeCount();
         if (!hasConstraintProviders()) {
-            return false;
+            return;
         }
 
         assert hardEdges == 1;
@@ -48,8 +48,6 @@ public class PendingDependencies {
             node.prepareForConstraintNoLongerPending(moduleIdentifier);
         }
         constraintProvidingNodes.clear();
-
-        return true;
     }
 
     void registerConstraintProvider(NodeState nodeState) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -82,7 +82,11 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
     private final ComponentIdGenerator idGenerator;
     private final DependencyToComponentIdResolver idResolver;
     private final ComponentMetaDataResolver metaDataResolver;
-    private final Deque<NodeState> queue;
+    private final Deque<NodeState> removalQueue;
+    private final Deque<NodeState> additionQueue;
+    private final Deque<ModuleResolveState> selectionQueue;
+    private final Deque<ModuleResolveState> attachmentQueue;
+    private final Deque<ModuleResolveState> downloadQueue;
     private final ConflictResolution conflictResolution;
     private final ImmutableAttributes consumerAttributes;
     private final ImmutableAttributesSchema consumerSchema;
@@ -154,7 +158,11 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
         this.modules = new LinkedHashMap<>(graphSize);
         this.nodes = new LinkedHashMap<>(3 * graphSize / 2);
         this.selectors = new LinkedHashMap<>(5 * graphSize / 2);
-        this.queue = new ArrayDeque<>(graphSize);
+        this.removalQueue = new ArrayDeque<>(graphSize);
+        this.additionQueue = new ArrayDeque<>(graphSize);
+        this.selectionQueue = new ArrayDeque<>(graphSize);
+        this.attachmentQueue = new ArrayDeque<>(graphSize);
+        this.downloadQueue = new ArrayDeque<>(graphSize);
 
         // Create root component and module
         ModuleResolveState rootModule = getModule(rootModuleVersionId.getModule());
@@ -239,34 +247,100 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
         return selectorState;
     }
 
-    @Nullable
-    public NodeState peek() {
-        return queue.isEmpty() ? null : queue.getFirst();
+    public boolean hasNextRemoval() {
+        return !removalQueue.isEmpty();
     }
 
-    public NodeState pop() {
-        NodeState next = queue.removeFirst();
-        return next.dequeue();
+    public NodeState nextRemoval() {
+        NodeState next = removalQueue.removeFirst();
+        next.dequeueFromRemoval();
+        return next;
+    }
+
+    public boolean hasNextAddition() {
+        return !additionQueue.isEmpty();
+    }
+
+    public NodeState nextAddition() {
+        NodeState next = additionQueue.removeFirst();
+        next.dequeueFromAddition();
+        return next;
     }
 
     /**
-     * Called when a change is made to a configuration node, such that its dependency graph <em>may</em> now be larger than it previously was, and the node should be visited.
+     * Called when a change is made to a configuration node, such that its dependency graph
+     * <em>may</em> now be larger than it previously was, and the node should be visited.
+     * <p>
+     * Added to the addition queue (low-priority), processed after removals and attachment.
      */
     public void onMoreSelected(NodeState node) {
-        // Add to the end of the queue, so that we traverse the graph in breadth-wise order to pick up as many conflicts as
-        // possible before attempting to resolve them
-        if (node.enqueue()) {
-            queue.addLast(node);
+        if (node.enqueueForAddition()) {
+            additionQueue.addLast(node);
         }
     }
 
     /**
-     * Called when a change is made to a configuration node, such that its dependency graph <em>may</em> now be smaller than it previously was, and the node should be visited.
+     * Called when a change is made to a configuration node, such that its dependency graph
+     * <em>may</em> now be smaller than it previously was, and the node should be visited.
+     * <p>
+     * Added to the removal queue (high-priority), processed before attachment and additions.
      */
     public void onFewerSelected(NodeState node) {
-        // Add to the front of the queue, to flush out configurations that are no longer required.
-        if (node.enqueue()) {
-            queue.addFirst(node);
+        if (node.enqueueForRemoval()) {
+            removalQueue.addLast(node);
+        }
+    }
+
+    public boolean hasNextSelection() {
+        return !selectionQueue.isEmpty();
+    }
+
+    public ModuleResolveState nextSelection() {
+        ModuleResolveState next = selectionQueue.removeFirst();
+        next.dequeueFromSelection();
+        return next;
+    }
+
+    public void enqueueForSelection(ModuleResolveState module) {
+        if (module.enqueueForSelection()) {
+            selectionQueue.add(module);
+        }
+    }
+
+    public boolean hasNextAttachment() {
+        return !attachmentQueue.isEmpty();
+    }
+
+    public ModuleResolveState nextAttachment() {
+        ModuleResolveState next = attachmentQueue.removeFirst();
+        next.dequeueFromAttachment();
+        return next;
+    }
+
+    /**
+     * Routes a module to the attachment or download queue based on its metadata state.
+     * If metadata is already resolved or cheap to fetch, the module goes to the attachment queue.
+     * Otherwise, it goes to the download queue.
+     */
+    public void enqueueForAttachment(ModuleResolveState module) {
+        if (module.enqueueForAttachment()) {
+            attachmentQueue.add(module);
+        }
+    }
+
+    public boolean hasNextDownload() {
+        return !downloadQueue.isEmpty();
+    }
+
+    public ModuleResolveState nextDownload() {
+        ModuleResolveState next = downloadQueue.removeFirst();
+        next.dequeueFromDownload();
+        return next;
+    }
+
+    public void enqueueForDownload(ModuleResolveState module) {
+        if (module.enqueueForDownload()) {
+            downloadQueue.add(module);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -200,11 +200,7 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
         return root;
     }
 
-    public ComponentMetaDataResolver getComponentMetadataResolver() {
-        return metaDataResolver;
-    }
-
-    private ModuleResolveState getModule(ModuleIdentifier id) {
+    public ModuleResolveState getModule(ModuleIdentifier id) {
         return modules.computeIfAbsent(id, mid -> new ModuleResolveState(this, id, metaDataResolver, attributesFactory, versionComparator, versionParser, selectorStateResolver, resolveOptimizations, conflictResolution));
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -157,7 +157,7 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
         this.queue = new ArrayDeque<>(graphSize);
 
         // Create root component and module
-        ModuleResolveState rootModule = getModule(rootModuleVersionId.getModule(), true);
+        ModuleResolveState rootModule = getModule(rootModuleVersionId.getModule());
         ComponentState rootComponent = rootModule.getVersion(rootModuleVersionId, rootComponentId);
         rootComponent.setRoot();
         rootComponent.setState(rootComponentState, ComponentGraphSpecificResolveState.EMPTY_STATE);
@@ -200,16 +200,12 @@ public class ResolveState implements ComponentStateFactory<ComponentState> {
         return root;
     }
 
-    public ModuleResolveState getModule(ModuleIdentifier id) {
-        return getModule(id, false);
-    }
-
     public ComponentMetaDataResolver getComponentMetadataResolver() {
         return metaDataResolver;
     }
 
-    private ModuleResolveState getModule(ModuleIdentifier id, boolean rootModule) {
-        return modules.computeIfAbsent(id, mid -> new ModuleResolveState(this, id, metaDataResolver, attributesFactory, versionComparator, versionParser, selectorStateResolver, resolveOptimizations, rootModule, conflictResolution));
+    private ModuleResolveState getModule(ModuleIdentifier id) {
+        return modules.computeIfAbsent(id, mid -> new ModuleResolveState(this, id, metaDataResolver, attributesFactory, versionComparator, versionParser, selectorStateResolver, resolveOptimizations, conflictResolution));
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -113,10 +113,10 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         return isProjectSelector;
     }
 
-    public void use(boolean deferSelection) {
+    public void use() {
         outgoingEdgeCount++;
         if (outgoingEdgeCount == 1) {
-            targetModule.addSelector(this, deferSelection);
+            targetModule.addSelector(this);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/VirtualPlatformState.java
@@ -48,15 +48,7 @@ public class VirtualPlatformState {
         state.registerPlatformOwner(this);
         if (participatingModules.add(state)) {
             resolveOptimizations.declareVirtualPlatformInUse();
-            ComponentState platformComponent = platformModule.getSelected();
-            if (platformComponent != null) {
-                // There is a possibility that a platform version was selected before a new member
-                // of the platform was discovered. In this case, we need to restart the selection,
-                // or some members will not be upgraded
-                for (NodeState nodeState : platformComponent.getNodes()) {
-                    nodeState.markForVirtualPlatformRefresh();
-                }
-            }
+            invalidateVirtualPlatformConstraints();
             // If any versions of this platform previously failed to resolve
             // (e.g. an explicit platform dependency resolved before any
             // belongsTo edges were discovered), replace those failures with
@@ -69,6 +61,18 @@ public class VirtualPlatformState {
                 }
             }
             hasForcedParticipatingModule |= isParticipatingModuleForced(state);
+        }
+    }
+
+    void invalidateVirtualPlatformConstraints() {
+        ComponentState selected = platformModule.getSelected();
+        if (selected != null) {
+            // There is a possibility that a platform version was selected before a new member
+            // of the platform was discovered. In this case, we need to restart the selection,
+            // or some members will not be upgraded
+            for (NodeState nodeState : selected.getNodes()) {
+                nodeState.markForVirtualPlatformRefresh();
+            }
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -161,6 +161,9 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
         CapabilityConflict conflict = conflictTracker.updateClearAndReturnConflict();
 
         if (!conflict.isValidConflict()) {
+            for (NodeState node : conflict.nodes) {
+                node.onFilteredFromConflict();
+            }
             return;
         }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -330,7 +330,6 @@ class DependencyGraphBuilderTest extends Specification {
         def d = revision('d')
         def e = revision('e')
         traverses root, evicted
-        traverses evicted, c
         doesNotResolve c, d
         traverses root, b
         traverses b, selected
@@ -362,7 +361,6 @@ class DependencyGraphBuilderTest extends Specification {
         def d = revision('d')
         traverses root, evicted
         traverses evicted, c
-        traverses evicted, d
         traverses root, b
         traverses b, selected
         doesNotResolve selected, c
@@ -1031,10 +1029,12 @@ class DependencyGraphBuilderTest extends Specification {
         def evicted = revision('a', '1.1')
         def b = revision('b')
         def c = revision('c')
+        def d = revision('d')
         traverses root, evicted
         traversesBroken evicted, b
         traverses root, c
-        traverses c, selected
+        traverses c, d
+        traverses d, selected
 
         when:
         def result = resolve()
@@ -1048,7 +1048,7 @@ class DependencyGraphBuilderTest extends Specification {
         }
 
         and:
-        result.components == ids(root, selected, c)
+        result.components == ids(root, selected, c, d)
     }
 
     def "direct dependency can force a particular version"() {
@@ -1135,7 +1135,7 @@ class DependencyGraphBuilderTest extends Specification {
     def traverses(Map<String, ?> args = [:], TestComponent from, TestComponent to) {
         def selector = dependsOn(args, from, to)
         selectorResolvesTo(selector, to.component.id, to.component.metadata.moduleVersionId)
-        println "Traverse $from to ${to.component.id}"
+        println "Traverse ${from.component.id} to ${to.component.id}"
         1 * metaDataResolver.resolve(to.component.id, _, _) >> { ComponentIdentifier id, ComponentOverrideMetadata requestMetaData, BuildableComponentResolveResult result ->
             println "Called ${to.component.id}"
             result.resolved(to.component, Stub(ComponentGraphSpecificResolveState))

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectorsTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectorsTest.groovy
@@ -38,24 +38,23 @@ class ModuleSelectorsTest extends Specification {
         verifyEmpty(selectors)
     }
 
-    def 'can add a selector not marked as deferring'() {
+    def 'can add a selector'() {
         given:
         def selector = Mock(ResolvableSelectorState)
 
         when:
-        selectors.add(selector, false)
+        selectors.add(selector)
 
         then:
         selectors.size() == 1
         selectors.first() == selector
         selectors.iterator().next() == selector
-        !selectors.checkDeferSelection()
     }
 
     def 'can remove a selector'() {
         given:
         def selector = Mock(ResolvableSelectorState)
-        selectors.add(selector, false)
+        selectors.add(selector)
 
         when:
         def result = selectors.remove(selector)
@@ -65,37 +64,14 @@ class ModuleSelectorsTest extends Specification {
         verifyEmpty(selectors)
     }
 
-    def 'can ad a selector marked as deferring'() {
-        given:
-        def selector = Mock(ResolvableSelectorState)
-
-        when:
-        selectors.add(selector, true)
-
-        then:
-        selectors.checkDeferSelection()
-    }
-
-    def 'clears deferring state on first access'() {
-        given:
-        def selector = Mock(ResolvableSelectorState)
-        selectors.add(selector, true)
-
-        when:
-        selectors.checkDeferSelection()
-
-        then:
-        !selectors.checkDeferSelection()
-    }
-
     def 'can add 2 selectors'() {
         given:
         def selector1 = Mock(ResolvableSelectorState)
-        selectors.add(selector1, false)
+        selectors.add(selector1)
         def selector2 = Mock(ResolvableSelectorState)
 
         when:
-        selectors.add(selector2, false)
+        selectors.add(selector2)
 
         then:
         selectors.size() == 2
@@ -116,8 +92,8 @@ class ModuleSelectorsTest extends Specification {
         def selector2 = Mock(ResolvableSelectorState)
 
         when:
-        selectors.add(selector1, false)
-        selectors.add(selector2, false)
+        selectors.add(selector1)
+        selectors.add(selector2)
 
         then:
         selectors.size() == 2
@@ -143,7 +119,7 @@ class ModuleSelectorsTest extends Specification {
 
         when:
         indexes.each {
-            selectors.add(candidateSelectors[it], false)
+            selectors.add(candidateSelectors[it])
         }
         indexes.each {
             selectors.remove(candidateSelectors[it])
@@ -198,7 +174,6 @@ class ModuleSelectorsTest extends Specification {
         assert selectors.size() == 0
         assert selectors.first() == null
         assert !selectors.iterator().hasNext()
-        assert !selectors.checkDeferSelection()
     }
 
     ResolvableSelectorState dynamicSelector() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -270,7 +270,7 @@ class SelectorStateResolverTest extends Specification {
 
     ModuleSelectors moduleSelectors(List<? extends ResolvableSelectorState> selectors) {
         def moduleSelectors = new ModuleSelectors<ResolvableSelectorState>(versionComparator.asVersionComparator(), versionParser)
-        selectors.forEach { moduleSelectors.add(it, false) }
+        selectors.forEach { moduleSelectors.add(it) }
         return moduleSelectors
     }
 


### PR DESCRIPTION
Attempt to perform as much dependency graph traversal as possible before resorting to IO (downloading component metadata). This allows metadata batching to download more component metadata in parallel, reducing the frequency at which the resolution engine needs to stall for IO.

Preliminary performance tests show ~18% reduction in gradle/gradle sanityCheck --dry-run performance with a clean dependency resolution file cache.
<img width="1750" height="800" alt="image" src="https://github.com/user-attachments/assets/2e18bf2d-67e3-4b0a-ae3f-2d2e090a5655" />


### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
