### PR TITLE
Avoid IO when estimating metadata fetching cost

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -300,16 +300,18 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
 
         @Override
         public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
-            ModuleMetadataCache.CachedMetadata cachedMetadata = moduleMetadataCache.getCachedModuleDescriptor(delegate, moduleComponentIdentifier);
+            ModuleMetadataCache.CachedMetadata cachedMetadata = moduleMetadataCache.getInMemoryCachedModuleDescriptor(delegate, moduleComponentIdentifier);
             if (cachedMetadata == null) {
                 return estimateCostViaRemoteAccess(moduleComponentIdentifier);
             }
+
             if (cachedMetadata.isMissing()) {
                 if (cacheExpirationControl.missingModuleExpiry(moduleComponentIdentifier, cachedMetadata.getAge()).isMustCheck()) {
                     return estimateCostViaRemoteAccess(moduleComponentIdentifier);
                 }
-                return MetadataFetchingCost.CHEAP;
+                return MetadataFetchingCost.MISSING;
             }
+
             ExternalModuleComponentGraphResolveState state = getProcessedMetadata(metadataProcessor.getRulesHash(), cachedMetadata);
             if (state.getMetadata().isChanging()) {
                 if (cacheExpirationControl.changingModuleExpiry(moduleComponentIdentifier, cachedMetadata.getModuleVersion(), cachedMetadata.getAge()).isMustCheck()) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/FilteredModuleComponentRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/FilteredModuleComponentRepository.java
@@ -25,7 +25,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.api.internal.artifacts.repositories.ArtifactResolutionDetails;
 import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
-import org.gradle.internal.Factory;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.ExternalModuleComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -129,9 +128,14 @@ public class FilteredModuleComponentRepository implements ModuleComponentReposit
 
         @Override
         public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return whenModulePresent(moduleComponentIdentifier.getModuleIdentifier(), moduleComponentIdentifier,
-                    () -> delegate.estimateMetadataFetchingCost(moduleComponentIdentifier),
-                    () -> MetadataFetchingCost.CHEAP);
+            ModuleIdentifier id = moduleComponentIdentifier.getModuleIdentifier();
+            DefaultArtifactResolutionDetails details = new DefaultArtifactResolutionDetails(id, moduleComponentIdentifier);
+            filterAction.execute(details);
+            if (details.notFound) {
+                return MetadataFetchingCost.MISSING;
+            }
+
+            return delegate.estimateMetadataFetchingCost(moduleComponentIdentifier);
         }
 
         private void whenModulePresent(ModuleIdentifier id, @Nullable ModuleComponentIdentifier moduleComponentIdentifier, Runnable present, Runnable absent) {
@@ -144,14 +148,6 @@ public class FilteredModuleComponentRepository implements ModuleComponentReposit
             }
         }
 
-        private <T> T whenModulePresent(ModuleIdentifier id, ModuleComponentIdentifier moduleComponentIdentifier, Factory<T> present, Factory<T> absent) {
-            DefaultArtifactResolutionDetails details = new DefaultArtifactResolutionDetails(id, moduleComponentIdentifier);
-            filterAction.execute(details);
-            if (details.notFound) {
-                return absent.create();
-            }
-            return present.create();
-        }
     }
 
     private static class DefaultArtifactResolutionDetails implements ArtifactResolutionDetails {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -88,9 +88,9 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
             for (ModuleComponentRepository<ExternalModuleComponentGraphResolveState> repository : repositories) {
                 ModuleComponentRepositoryAccess<ExternalModuleComponentGraphResolveState> localAccess = repository.getLocalAccess();
                 MetadataFetchingCost fetchingCost = localAccess.estimateMetadataFetchingCost((ModuleComponentIdentifier) identifier);
-                if (fetchingCost.isFast()) {
+                if (fetchingCost == MetadataFetchingCost.FAST) {
                     return true;
-                } else if (fetchingCost.isExpensive()) {
+                } else if (fetchingCost == MetadataFetchingCost.EXPENSIVE) {
                     return false;
                 }
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -159,7 +159,7 @@ public class StartParameterResolutionOverride {
 
         @Override
         public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return MetadataFetchingCost.CHEAP;
+            return MetadataFetchingCost.MISSING;
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/AbstractModuleMetadataCache.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/AbstractModuleMetadataCache.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.util.internal.BuildCommencedTimeProvider;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,12 @@ public abstract class AbstractModuleMetadataCache implements ModuleMetadataCache
     public CachedMetadata getCachedModuleDescriptor(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id) {
         final ModuleComponentAtRepositoryKey key = createKey(repository, id);
         return get(key);
+    }
+
+    @Override
+    public CachedMetadata getInMemoryCachedModuleDescriptor(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id) {
+        final ModuleComponentAtRepositoryKey key = createKey(repository, id);
+        return getInMemoryCachedValue(key);
     }
 
     @Override
@@ -66,4 +73,11 @@ public abstract class AbstractModuleMetadataCache implements ModuleMetadataCache
     protected abstract CachedMetadata store(ModuleComponentAtRepositoryKey key, ModuleMetadataCacheEntry entry, CachedMetadata cachedMetaData);
 
     protected abstract CachedMetadata get(ModuleComponentAtRepositoryKey key);
+
+    /**
+     * Return the metadata if it is cached in memory. Or null if it is cached, but only
+     * available on-disk, or if the metadata is not cached.
+     */
+    protected abstract @Nullable CachedMetadata getInMemoryCachedValue(ModuleComponentAtRepositoryKey key);
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
@@ -30,16 +30,17 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
+
     private final long ageMillis;
-    private final ModuleComponentResolveMetadata metadata;
+    private final @Nullable ModuleComponentResolveMetadata metadata;
 
     private volatile Map<Integer, ExternalModuleComponentGraphResolveState> processedMetadataByRules;
 
-    DefaultCachedMetadata(ModuleMetadataCacheEntry entry, ModuleComponentResolveMetadata metadata, BuildCommencedTimeProvider timeProvider) {
+    DefaultCachedMetadata(ModuleMetadataCacheEntry entry, @Nullable ModuleComponentResolveMetadata metadata, BuildCommencedTimeProvider timeProvider) {
         this(timeProvider.getCurrentTime() - entry.createTimestamp, metadata);
     }
 
-    private DefaultCachedMetadata(long age, ModuleComponentResolveMetadata metadata) {
+    private DefaultCachedMetadata(long age, @Nullable ModuleComponentResolveMetadata metadata) {
         this.ageMillis = age;
         this.metadata = metadata;
     }
@@ -51,16 +52,18 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
 
     @Override
     public ModuleSources getModuleSources() {
+        assert metadata != null;
         return metadata.getSources();
     }
 
     @Override
     public ResolvedModuleVersion getModuleVersion() {
-        return isMissing() ? null : new DefaultResolvedModuleVersion(getMetadata().getModuleVersionId());
+        return metadata == null ? null : new DefaultResolvedModuleVersion(metadata.getModuleVersionId());
     }
 
     @Override
     public ModuleComponentResolveMetadata getMetadata() {
+        assert metadata != null;
         return metadata;
     }
 
@@ -99,4 +102,5 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
         ModuleComponentResolveMetadata asImmutable = copy.asImmutable();
         return new DefaultCachedMetadata(ageMillis, asImmutable);
     }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/InMemoryModuleMetadataCache.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/InMemoryModuleMetadataCache.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
 import org.gradle.util.internal.BuildCommencedTimeProvider;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,6 +45,11 @@ public class InMemoryModuleMetadataCache extends AbstractModuleMetadataCache {
             }
         }
         return metadata;
+    }
+
+    @Override
+    protected @Nullable CachedMetadata getInMemoryCachedValue(ModuleComponentAtRepositoryKey key) {
+        return inMemoryCache.get(key);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
@@ -32,6 +32,8 @@ public interface ModuleMetadataCache {
 
     CachedMetadata getCachedModuleDescriptor(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id);
 
+    CachedMetadata getInMemoryCachedModuleDescriptor(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id);
+
     interface CachedMetadata {
         ResolvedModuleVersion getModuleVersion();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/PersistentModuleMetadataCache.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/PersistentModuleMetadataCache.java
@@ -35,6 +35,7 @@ import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.util.internal.BuildCommencedTimeProvider;
+import org.jspecify.annotations.Nullable;
 
 public class PersistentModuleMetadataCache extends AbstractModuleMetadataCache {
 
@@ -94,6 +95,11 @@ public class PersistentModuleMetadataCache extends AbstractModuleMetadataCache {
             }
             return new DefaultCachedMetadata(entry, entry.configure(metadata), timeProvider);
         });
+    }
+
+    @Override
+    protected @Nullable CachedMetadata getInMemoryCachedValue(ModuleComponentAtRepositoryKey key) {
+        return null;
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/TwoStageModuleMetadataCache.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/TwoStageModuleMetadataCache.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
 import org.gradle.util.internal.BuildCommencedTimeProvider;
+import org.jspecify.annotations.Nullable;
 
 public class TwoStageModuleMetadataCache extends AbstractModuleMetadataCache {
     private final AbstractModuleMetadataCache readOnlyCache;
@@ -31,6 +32,15 @@ public class TwoStageModuleMetadataCache extends AbstractModuleMetadataCache {
     protected CachedMetadata store(ModuleComponentAtRepositoryKey key, ModuleMetadataCacheEntry entry, CachedMetadata cachedMetaData) {
         writableCache.store(key, entry, cachedMetaData);
         return cachedMetaData;
+    }
+
+    @Override
+    protected @Nullable CachedMetadata getInMemoryCachedValue(ModuleComponentAtRepositoryKey key) {
+        CachedMetadata writeEntry = writableCache.getInMemoryCachedValue(key);
+        if (writeEntry != null) {
+            return writeEntry;
+        }
+        return readOnlyCache.getInMemoryCachedValue(key);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/BuildTreeLocalComponentProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/BuildTreeLocalComponentProvider.java
@@ -34,6 +34,12 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface BuildTreeLocalComponentProvider {
 
     /**
+     * @return True if this registry has a cached component for the given project,
+     * or false if the component is not yet computed.
+     */
+    boolean hasCachedComponent(ProjectIdentity targetProjectId);
+
+    /**
      * Get the local component for the target project.
      *
      * @param targetProjectId the project to get the local component for

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
@@ -54,6 +54,12 @@ public class DefaultLocalComponentRegistry implements LocalComponentRegistry {
     }
 
     @Override
+    public boolean hasCachedComponent(ProjectComponentIdentifier identifier) {
+        ProjectIdentity targetProjectId = ((ProjectComponentIdentifierInternal) identifier).getProjectIdentity();
+        return componentProvider.hasCachedComponent(targetProjectId);
+    }
+
+    @Override
     public LocalComponentGraphResolveState getComponent(ProjectComponentIdentifier projectIdentifier) {
         ProjectIdentity targetProjectId = ((ProjectComponentIdentifierInternal) projectIdentifier).getProjectIdentity();
         Path targetProjectPath = targetProjectId.getBuildTreePath();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentRegistry.java
@@ -30,8 +30,16 @@ import javax.annotation.concurrent.ThreadSafe;
 @ServiceScope(Scope.Project.class)
 @ThreadSafe
 public interface LocalComponentRegistry {
+
+    /**
+     * @return True if this registry has a cached component for the given identifier,
+     * or false if the component is not yet computed.
+     */
+    boolean hasCachedComponent(ProjectComponentIdentifier identifier);
+
     /**
      * @return The component metadata for the supplied identifier.
      */
     LocalComponentGraphResolveState getComponent(ProjectComponentIdentifier projectIdentifier);
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -66,8 +66,7 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
 
     @Override
     public void resolve(ComponentSelector selector, ComponentOverrideMetadata overrideMetadata, VersionSelector acceptor, @Nullable VersionSelector rejector, BuildableComponentIdResolveResult result, ImmutableAttributes consumerAttributes) {
-        if (selector instanceof DefaultProjectComponentSelector) {
-            DefaultProjectComponentSelector projectSelector = (DefaultProjectComponentSelector) selector;
+        if (selector instanceof DefaultProjectComponentSelector projectSelector) {
             ProjectComponentIdentifier projectId = projectSelector.toIdentifier();
             LocalComponentGraphResolveState component = localComponentRegistry.getComponent(projectId);
             if (rejector != null && rejector.accept(component.getModuleVersionId().getVersion())) {
@@ -80,8 +79,7 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
 
     @Override
     public void resolve(ComponentIdentifier identifier, ComponentOverrideMetadata componentOverrideMetadata, final BuildableComponentResolveResult result) {
-        if (isProjectModule(identifier)) {
-            ProjectComponentIdentifier projectId = (ProjectComponentIdentifier) identifier;
+        if (identifier instanceof ProjectComponentIdentifier projectId) {
             LocalComponentGraphResolveState component = localComponentRegistry.getComponent(projectId);
             result.resolved(component, ComponentGraphSpecificResolveState.EMPTY_STATE);
         }
@@ -89,24 +87,24 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
 
     @Override
     public boolean isFetchingMetadataCheap(ComponentIdentifier identifier) {
+        if (identifier instanceof ProjectComponentIdentifier projectId) {
+            return localComponentRegistry.hasCachedComponent(projectId);
+        }
         return true;
     }
 
     @Override
     public void resolveArtifactsWithType(ComponentArtifactResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
-        if (isProjectModule(component.getId())) {
+        if (component.getId() instanceof ProjectComponentIdentifier) {
             throw new UnsupportedOperationException("Resolving artifacts by type is not yet supported for project modules");
         }
     }
 
     @Override
     public void resolveArtifact(ComponentArtifactResolveMetadata component, ComponentArtifactMetadata artifact, BuildableArtifactResolveResult result) {
-        if (isProjectModule(artifact.getComponentId())) {
+        if (artifact.getComponentId() instanceof ProjectComponentIdentifier) {
             artifactResolver.resolveArtifact(component, artifact, result);
         }
     }
 
-    private static boolean isProjectModule(ComponentIdentifier componentId) {
-        return componentId instanceof ProjectComponentIdentifier;
-    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -58,7 +58,6 @@ import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolv
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 import org.gradle.internal.resolve.result.BuildableTypedResolveResult;
 import org.gradle.internal.resolve.result.DefaultResourceAwareResolveResult;
-import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.ExternalResourceRepository;
 import org.gradle.internal.resource.local.ByteArrayReadableContent;
@@ -385,6 +384,7 @@ public abstract class ExternalResourceResolver implements ConfiguredModuleCompon
     }
 
     protected abstract class LocalRepositoryAccess extends AbstractRepositoryAccess {
+
         @Override
         public String toString() {
             return "local > " + ExternalResourceResolver.this;
@@ -400,13 +400,10 @@ public abstract class ExternalResourceResolver implements ConfiguredModuleCompon
 
         @Override
         protected final void resolveMetaDataArtifacts(ComponentArtifactResolveMetadata module, BuildableArtifactSetResolveResult result) {
-            if (!(module.getId() instanceof ModuleComponentIdentifier)) {
-                return;
+            if (module.getId() instanceof ModuleComponentIdentifier moduleId) {
+                ModuleDescriptorArtifactMetadata artifact = getMetaDataArtifactFor(moduleId);
+                result.resolved(Collections.singleton(artifact));
             }
-
-            ModuleComponentIdentifier moduleId = (ModuleComponentIdentifier) module.getId();
-            ModuleDescriptorArtifactMetadata artifact = getMetaDataArtifactFor(moduleId);
-            result.resolved(Collections.singleton(artifact));
         }
 
         @Override
@@ -416,8 +413,9 @@ public abstract class ExternalResourceResolver implements ConfiguredModuleCompon
 
         @Override
         public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
-            return MetadataFetchingCost.CHEAP;
+            return MetadataFetchingCost.FAST;
         }
+
     }
 
     protected abstract class RemoteRepositoryAccess extends AbstractRepositoryAccess {
@@ -497,40 +495,9 @@ public abstract class ExternalResourceResolver implements ConfiguredModuleCompon
 
         @Override
         public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
-            if (ExternalResourceResolver.this.local) {
-                ModuleComponentArtifactMetadata artifact = getMetaDataArtifactFor(moduleComponentIdentifier);
-                if (createArtifactResolver().artifactExists(artifact, NoOpResourceAwareResolveResult.INSTANCE)) {
-                    return MetadataFetchingCost.FAST;
-                }
-                return MetadataFetchingCost.CHEAP;
-            }
             return MetadataFetchingCost.EXPENSIVE;
         }
-    }
 
-    private static class NoOpResourceAwareResolveResult implements ResourceAwareResolveResult {
-
-        private static final NoOpResourceAwareResolveResult INSTANCE = new NoOpResourceAwareResolveResult();
-
-        @Override
-        public List<String> getAttempted() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public void attempted(String locationDescription) {
-
-        }
-
-        @Override
-        public void attempted(ExternalResourceName location) {
-
-        }
-
-        @Override
-        public void applyTo(ResourceAwareResolveResult target) {
-            throw new UnsupportedOperationException();
-        }
     }
 
     private static class DefaultComponentVersionsLister implements ComponentMetadataListerDetails {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MetadataFetchingCost.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MetadataFetchingCost.java
@@ -16,27 +16,24 @@
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
 public enum MetadataFetchingCost {
+
     /**
-     * Can return metadata immediately. It must <b>not</b> be used in case the metadata is missing,
-     * even if it's cheap to tell it's missing. Use {@link #CHEAP} in that case.
+     * The metadata is present and immediately available. Retrieving the component metadata
+     * does not require disk or network IO, or acquiring locks for shared resources, like
+     * project locks.
      */
     FAST,
-    /**
-     * Can return metadata in a cheap way, or tell that it's missing in a cheap way. The difference with
-     * {@link #FAST} is that we can use it for missing metadata.
-     */
-    CHEAP,
-    /**
-     * Cannot return metadata without an expensive call, typically involving parsing a descriptor
-     * or accessing the network
-     */
-    EXPENSIVE;
 
-    public boolean isFast() {
-        return this == FAST;
-    }
+    /**
+     * The metadata is not necessarily present and not immediately available. Determining its
+     * presence or retrieving the component metadata would require disk or network IO, or
+     * acquiring locks for shared resources, like project locks.
+     */
+    EXPENSIVE,
 
-    public boolean isExpensive() {
-        return this == EXPENSIVE;
-    }
+    /**
+     * The metadata is immediately known to be not present.
+     */
+    MISSING
+
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
@@ -166,7 +166,7 @@ class CachingModuleComponentRepositoryTest extends Specification {
         cacheExpirationControl.missingModuleExpiry(_, _) >> Stub(CacheExpirationControl.Expiry) {
             isMustCheck() >> mustRefreshMissingModule
         }
-        moduleDescriptorCache.getCachedModuleDescriptor(_, module) >> Stub(ModuleMetadataCache.CachedMetadata) {
+        moduleDescriptorCache.getInMemoryCachedModuleDescriptor(_, module) >> Stub(ModuleMetadataCache.CachedMetadata) {
             isMissing() >> true
             getAge() >> Duration.ofMillis(100)
         }
@@ -179,10 +179,10 @@ class CachingModuleComponentRepositoryTest extends Specification {
 
         where:
         mustRefreshMissingModule | remoteAnswer                   | expected
-        false                    | MetadataFetchingCost.CHEAP     | MetadataFetchingCost.CHEAP
-        false                    | MetadataFetchingCost.FAST      | MetadataFetchingCost.CHEAP
-        false                    | MetadataFetchingCost.EXPENSIVE | MetadataFetchingCost.CHEAP
-        true                     | MetadataFetchingCost.CHEAP     | MetadataFetchingCost.CHEAP
+        false                    | MetadataFetchingCost.MISSING   | MetadataFetchingCost.MISSING
+        false                    | MetadataFetchingCost.FAST      | MetadataFetchingCost.MISSING
+        false                    | MetadataFetchingCost.EXPENSIVE | MetadataFetchingCost.MISSING
+        true                     | MetadataFetchingCost.MISSING   | MetadataFetchingCost.MISSING
         true                     | MetadataFetchingCost.FAST      | MetadataFetchingCost.FAST
         true                     | MetadataFetchingCost.EXPENSIVE | MetadataFetchingCost.EXPENSIVE
     }
@@ -194,7 +194,7 @@ class CachingModuleComponentRepositoryTest extends Specification {
         cacheExpirationControl.changingModuleExpiry(_, _, _) >> Stub(CacheExpirationControl.Expiry) {
             isMustCheck() >> mustRefreshChangingModule
         }
-        moduleDescriptorCache.getCachedModuleDescriptor(_, module) >> Stub(ModuleMetadataCache.CachedMetadata) {
+        moduleDescriptorCache.getInMemoryCachedModuleDescriptor(_, module) >> Stub(ModuleMetadataCache.CachedMetadata) {
             getProcessedMetadata(_) >> Stub(ExternalModuleComponentGraphResolveState) {
                 getMetadata() >> Stub(ModuleComponentResolveMetadata) {
                     isChanging() >> true
@@ -211,10 +211,10 @@ class CachingModuleComponentRepositoryTest extends Specification {
 
         where:
         mustRefreshChangingModule | remoteAnswer                   | expected
-        false                     | MetadataFetchingCost.CHEAP     | MetadataFetchingCost.FAST
+        false                     | MetadataFetchingCost.MISSING   | MetadataFetchingCost.FAST
         false                     | MetadataFetchingCost.FAST      | MetadataFetchingCost.FAST
         false                     | MetadataFetchingCost.EXPENSIVE | MetadataFetchingCost.FAST
-        true                      | MetadataFetchingCost.CHEAP     | MetadataFetchingCost.CHEAP
+        true                      | MetadataFetchingCost.MISSING   | MetadataFetchingCost.MISSING
         true                      | MetadataFetchingCost.FAST      | MetadataFetchingCost.FAST
         true                      | MetadataFetchingCost.EXPENSIVE | MetadataFetchingCost.EXPENSIVE
     }
@@ -226,7 +226,7 @@ class CachingModuleComponentRepositoryTest extends Specification {
         cacheExpirationControl.moduleExpiry(_, _, _) >> Stub(CacheExpirationControl.Expiry) {
             isMustCheck() >> mustRefreshModule
         }
-        moduleDescriptorCache.getCachedModuleDescriptor(_, module) >> Stub(ModuleMetadataCache.CachedMetadata) {
+        moduleDescriptorCache.getInMemoryCachedModuleDescriptor(_, module) >> Stub(ModuleMetadataCache.CachedMetadata) {
             getProcessedMetadata(_) >> Stub(ExternalModuleComponentGraphResolveState)
             getAge() >> Duration.ofMillis(100)
         }
@@ -239,10 +239,10 @@ class CachingModuleComponentRepositoryTest extends Specification {
 
         where:
         mustRefreshModule | remoteAnswer                   | expected
-        false             | MetadataFetchingCost.CHEAP     | MetadataFetchingCost.FAST
+        false             | MetadataFetchingCost.MISSING   | MetadataFetchingCost.FAST
         false             | MetadataFetchingCost.FAST      | MetadataFetchingCost.FAST
         false             | MetadataFetchingCost.EXPENSIVE | MetadataFetchingCost.FAST
-        true              | MetadataFetchingCost.CHEAP     | MetadataFetchingCost.CHEAP
+        true              | MetadataFetchingCost.MISSING   | MetadataFetchingCost.MISSING
         true              | MetadataFetchingCost.FAST      | MetadataFetchingCost.FAST
         true              | MetadataFetchingCost.EXPENSIVE | MetadataFetchingCost.EXPENSIVE
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildTreeLocalComponentProvider.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildTreeLocalComponentProvider.java
@@ -91,6 +91,11 @@ public class DefaultBuildTreeLocalComponentProvider implements BuildTreeLocalCom
     }
 
     @Override
+    public boolean hasCachedComponent(ProjectIdentity targetProjectId) {
+        return components.hasValue(targetProjectId.getBuildTreePath());
+    }
+
+    @Override
     public LocalComponentGraphResolveState getComponent(ProjectIdentity targetProjectId, Path sourceBuild) {
         Path projectIdentityPath = targetProjectId.getBuildTreePath();
         ensureBuildConfigured(targetProjectId.getBuildPath(), sourceBuild);

--- a/subprojects/core/src/main/java/org/gradle/internal/model/InMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/InMemoryCacheFactory.java
@@ -105,6 +105,11 @@ public class InMemoryCacheFactory {
         }
 
         @Override
+        public boolean hasValue(K key) {
+            return delegate.containsKey(key);
+        }
+
+        @Override
         public V get(K key) {
             // Try to load the value without locking
             // See https://bugs.openjdk.org/browse/JDK-8161372
@@ -124,12 +129,18 @@ public class InMemoryCacheFactory {
     }
 
     private static class IdentityLoadingCache<K, V> implements InMemoryLoadingCache<K, V> {
+
         private final InMemoryLoadingCache<IdentityKey<K>, V> delegate;
 
         public IdentityLoadingCache(int maxConcurrency, Function<K, V> loader) {
             this.delegate = new DefaultLoadingCache<>(maxConcurrency, key ->
                 loader.apply(key.value)
             );
+        }
+
+        @Override
+        public boolean hasValue(K key) {
+            return delegate.hasValue(new IdentityKey<>(key));
         }
 
         @Override
@@ -141,9 +152,11 @@ public class InMemoryCacheFactory {
         public void invalidate() {
             delegate.invalidate();
         }
+
     }
 
     private static class IdentityKey<T> {
+
         private final T value;
 
         private IdentityKey(T value) {
@@ -160,9 +173,11 @@ public class InMemoryCacheFactory {
         public int hashCode() {
             return System.identityHashCode(value);
         }
+
     }
 
     private static class CalculatedValueCache<K, V> implements InMemoryLoadingCache<K, V> {
+
         private final InMemoryLoadingCache<K, CalculatedValue<V>> delegate;
 
         public CalculatedValueCache(
@@ -180,6 +195,11 @@ public class InMemoryCacheFactory {
         }
 
         @Override
+        public boolean hasValue(K key) {
+            return delegate.hasValue(key);
+        }
+
+        @Override
         public V get(K key) {
             CalculatedValue<V> calculatedValue = delegate.get(key);
             // Calculate the value after adding the entry to the cache, so that
@@ -192,6 +212,7 @@ public class InMemoryCacheFactory {
         public void invalidate() {
             delegate.invalidate();
         }
+
     }
 
     private static class DefaultInterner<T> implements InMemoryInterner<T> {
@@ -211,6 +232,7 @@ public class InMemoryCacheFactory {
         public void invalidate() {
             delegate.invalidate();
         }
+
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/model/InMemoryLoadingCache.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/InMemoryLoadingCache.java
@@ -22,6 +22,12 @@ package org.gradle.internal.model;
 public interface InMemoryLoadingCache<K, V> {
 
     /**
+     * Return true if this cache has a cached value for the given entry,
+     * false otherwise.
+     */
+    boolean hasValue(K key);
+
+    /**
      * Get the value corresponding to the given key, loading the value
      * on demand if it is not already present in the cache.
      *


### PR DESCRIPTION
In dependency resolution we try to estimate whether it is expensive to resolve a component's metadata, and if so, we resolve that component's metadata in parallel. Previously, this estimate itself could be expensive, triggering IO or waiting on project locks. This even happened if a component was cached locally on-disk but not yet loaded into memory.

We update implementations of metadata fetching to never touch IO or acquire shared locks, so that all IO and locking is performed in parallel.

We further update the confusing FAST/EXPENSIVE/CHEAP terminology to FAST/EXPENSIVE/MISSING, as CHEAP was easy to confuse with FAST, and in practice only represented scenarios where metadata was missing and known to be missing.


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
