### PR TITLE
Reject bad Property type arguments upon store with understandable message

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -93,7 +93,7 @@
   {
     "name": "bean-serialization-services",
     "path": "platforms/core-configuration/bean-serialization-services",
-    "unitTests": false,
+    "unitTests": true,
     "functionalTests": false,
     "crossVersionTests": false
   },

--- a/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/UnsupportedPropertyValueTypes.kt
+++ b/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/UnsupportedPropertyValueTypes.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.beans.services
+
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.provider.MapProperty
+
+/**
+ * Types that cannot be used as the value type `T` of a `Property<T>`
+ * in the configuration cache.
+ *
+ * A `Property<T>` where `T` matches one of these types (or a subtype)
+ * cannot survive a serialization round-trip: the codec that handles
+ * the resolved value produces a different type on deserialization
+ * than `Property<T>` expects, causing a confusing type-mismatch error
+ * at load time.
+ *
+ * Used by property codecs to fail fast at store time with a clear
+ * diagnostic message.
+ */
+object UnsupportedPropertyValueTypes {
+    private val unsupported: Map<Class<*>, String> = mapOf(
+        Configuration::class.java to "Use a @InputFiles ConfigurableFileCollection instead.",
+        SourceDirectorySet::class.java to "Use a @InputFiles ConfigurableFileCollection instead.",
+    )
+
+    /**
+     * Checks whether [valueType] is supported as a property value type
+     * for the given [propertyKind] (e.g., `Property`, `ListProperty`, `MapProperty`).
+     */
+    fun check(valueType: Class<*>, propertyKind: Class<*>): CheckResult {
+        val baseResolution = unsupported.entries
+            .firstOrNull { it.key.isAssignableFrom(valueType) }
+            ?.value
+            ?: return CheckResult.Supported
+
+        val resolution = when {
+            MapProperty::class.java.isAssignableFrom(propertyKind) ->
+                "Avoid using ${valueType.simpleName} as a MapProperty key or value."
+            else -> baseResolution
+        }
+
+        return CheckResult.Unsupported(resolution)
+    }
+
+    /**
+     * Result of checking whether a type is supported as a property value type
+     * in the configuration cache.
+     */
+    sealed interface CheckResult {
+        /** The type is supported — no action needed. */
+        object Supported : CheckResult
+
+        /** The type is unsupported — [resolution] describes what to use instead. */
+        class Unsupported(val resolution: String) : CheckResult
+    }
+}

--- a/platforms/core-configuration/bean-serialization-services/src/test/kotlin/org/gradle/internal/serialize/beans/services/UnsupportedPropertyValueTypesTest.kt
+++ b/platforms/core-configuration/bean-serialization-services/src/test/kotlin/org/gradle/internal/serialize/beans/services/UnsupportedPropertyValueTypesTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.beans.services
+
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [UnsupportedPropertyValueTypes] — verifies that the unsupported type list
+ * is correctly checked, including subtype detection, property-kind-specific resolutions,
+ * and the [UnsupportedPropertyValueTypes.CheckResult] sealed interface.
+ */
+class UnsupportedPropertyValueTypesTest {
+    @Test
+    fun `check returns Supported for String`() {
+        assertTrue(
+            UnsupportedPropertyValueTypes.check(String::class.java, Property::class.java)
+                is UnsupportedPropertyValueTypes.CheckResult.Supported
+        )
+    }
+
+    @Test
+    fun `check returns Unsupported for Configuration`() {
+        val result = UnsupportedPropertyValueTypes.check(Configuration::class.java, Property::class.java)
+        assertTrue(result is UnsupportedPropertyValueTypes.CheckResult.Unsupported)
+        assertEquals(
+            "Use a @InputFiles ConfigurableFileCollection instead.",
+            (result as UnsupportedPropertyValueTypes.CheckResult.Unsupported).resolution
+        )
+    }
+
+    @Test
+    fun `check returns Unsupported for SourceDirectorySet`() {
+        val result = UnsupportedPropertyValueTypes.check(SourceDirectorySet::class.java, Property::class.java)
+        assertTrue(result is UnsupportedPropertyValueTypes.CheckResult.Unsupported)
+        assertEquals(
+            "Use a @InputFiles ConfigurableFileCollection instead.",
+            (result as UnsupportedPropertyValueTypes.CheckResult.Unsupported).resolution
+        )
+    }
+
+    @Test
+    fun `subtypes of unsupported types are also unsupported`() {
+        val result = UnsupportedPropertyValueTypes.check(TestConfigurationSubtype::class.java, Property::class.java)
+        assertTrue(result is UnsupportedPropertyValueTypes.CheckResult.Unsupported)
+    }
+
+    @Test
+    fun `MapProperty kind gets restructuring advice`() {
+        val result = UnsupportedPropertyValueTypes.check(Configuration::class.java, MapProperty::class.java)
+        assertTrue(result is UnsupportedPropertyValueTypes.CheckResult.Unsupported)
+        assertEquals(
+            "Avoid using Configuration as a MapProperty key or value.",
+            (result as UnsupportedPropertyValueTypes.CheckResult.Unsupported).resolution
+        )
+    }
+
+    @Test
+    fun `ListProperty kind gets standard advice`() {
+        val result = UnsupportedPropertyValueTypes.check(Configuration::class.java, ListProperty::class.java)
+        assertTrue(result is UnsupportedPropertyValueTypes.CheckResult.Unsupported)
+        assertEquals(
+            "Use a @InputFiles ConfigurableFileCollection instead.",
+            (result as UnsupportedPropertyValueTypes.CheckResult.Unsupported).resolution
+        )
+    }
+
+    @Test
+    fun `SetProperty kind gets standard advice`() {
+        val result = UnsupportedPropertyValueTypes.check(Configuration::class.java, SetProperty::class.java)
+        assertTrue(result is UnsupportedPropertyValueTypes.CheckResult.Unsupported)
+        assertEquals(
+            "Use a @InputFiles ConfigurableFileCollection instead.",
+            (result as UnsupportedPropertyValueTypes.CheckResult.Unsupported).resolution
+        )
+    }
+
+    private interface TestConfigurationSubtype : Configuration
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGradlePropertiesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGradlePropertiesIntegrationTest.groovy
@@ -738,7 +738,7 @@ class ConfigurationCacheGradlePropertiesIntegrationTest extends AbstractConfigur
         assertHasUnsupportedPropertyValueType(Property, Configuration, "printFiles", "BrokenPrintTask")
 
         where:
-        annotation << ["@Input", "@Internal"]
+        annotation << ["@Input", "@Internal", "@InputFiles", "@Classpath"]
     }
 
     def "reports sensible error when concrete task has concrete Property of Configuration"() {
@@ -797,7 +797,7 @@ class ConfigurationCacheGradlePropertiesIntegrationTest extends AbstractConfigur
         assertHasUnsupportedPropertyValueType(Property, SourceDirectorySet, "sdsTask", "SdsTask")
 
         where:
-        annotation << ["@Input", "@Internal"]
+        annotation << ["@Input", "@Internal", "@InputFiles", "@Classpath"]
     }
 
     def "reports sensible error task indirectly holds a Property of unsupported type"() {
@@ -860,28 +860,34 @@ class ConfigurationCacheGradlePropertiesIntegrationTest extends AbstractConfigur
                 @Internal
                 abstract Property<Configuration> getFirst()
 
-                @Internal
+                @Input
                 abstract Property<Configuration> getSecond()
 
-                @Input
+                @InputFiles
                 abstract Property<Configuration> getThird()
+
+                @Classpath
+                abstract Property<Configuration> getFourth()
 
                 @TaskAction
                 void run() {
                     println "First: " + first.get().name
                     println "Second: " + second.get().name
                     println "Third: " + third.get().name
+                    println "Fourth: " + fourth.get().name
                 }
             }
 
             configurations.create('confA')
             configurations.create('confB')
             configurations.create('confC')
+            configurations.create('confD')
 
             tasks.register("multiConf", MultiConfTask) {
                 first.set(configurations.getByName('confA'))
                 second.set(configurations.getByName('confB'))
                 third.set(configurations.getByName('confC'))
+                fourth.set(configurations.getByName('confD'))
             }
         """
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGradlePropertiesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheGradlePropertiesIntegrationTest.groovy
@@ -16,6 +16,12 @@
 
 package org.gradle.internal.cc.impl
 
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.internal.cc.impl.fixtures.GradlePropertiesIncludedBuildFixture
 import org.gradle.internal.cc.impl.fixtures.SystemPropertiesCompositeBuildFixture
@@ -26,7 +32,6 @@ import static org.gradle.initialization.properties.GradlePropertiesLoader.ENV_PR
 import static org.gradle.initialization.properties.GradlePropertiesLoader.SYSTEM_PROJECT_PROPERTIES_PREFIX
 
 class ConfigurationCacheGradlePropertiesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
-
     def configurationCache = newConfigurationCacheFixture()
 
     def "invalidates cache when set of Gradle property defining system properties changes"() {
@@ -705,5 +710,369 @@ class ConfigurationCacheGradlePropertiesIntegrationTest extends AbstractConfigur
         configurationCache.assertStateLoaded()
         outputContains "Bar: one"
         // Must be cache miss
+    }
+
+    def "reports sensible error when task has #annotation Property of Configuration"() {
+        buildFile << """
+            abstract class BrokenPrintTask extends DefaultTask {
+                $annotation
+                abstract Property<Configuration> getConf()
+
+                @TaskAction
+                void run() {
+                    println "Files: = " + conf.get().files
+                }
+            }
+
+            configurations.create('myConf')
+
+            tasks.register("printFiles", BrokenPrintTask) {
+                conf.set(configurations.getByName('myConf'))
+            }
+        """
+
+        when:
+        configurationCacheFails "printFiles"
+
+        then:
+        assertHasUnsupportedPropertyValueType(Property, Configuration, "printFiles", "BrokenPrintTask")
+
+        where:
+        annotation << ["@Input", "@Internal"]
+    }
+
+    def "reports sensible error when concrete task has concrete Property of Configuration"() {
+        buildFile << """
+            import javax.inject.Inject
+
+            class ConcreteConfTask extends DefaultTask {
+                final Property<Configuration> conf
+
+                @Inject
+                ConcreteConfTask(ObjectFactory objects) {
+                    conf = objects.property(Configuration)
+                }
+
+                @TaskAction
+                void run() {
+                    println "Conf: " + conf.get().name
+                }
+            }
+
+            configurations.create('myConf')
+
+            tasks.register("concreteConf", ConcreteConfTask) {
+                conf.set(configurations.getByName('myConf'))
+            }
+        """
+
+        when:
+        configurationCacheFails "concreteConf"
+
+        then:
+        assertHasUnsupportedPropertyValueType(Property, Configuration, "concreteConf", "ConcreteConfTask")
+    }
+
+    def "reports sensible error when task has #annotation Property of SourceDirectorySet"() {
+        buildFile << """
+            abstract class SdsTask extends DefaultTask {
+                $annotation
+                abstract Property<SourceDirectorySet> getSds()
+
+                @TaskAction
+                void run() {
+                    println "SDS: " + sds.get().name
+                }
+            }
+
+            tasks.register("sdsTask", SdsTask) {
+                sds.set(objects.sourceDirectorySet('sources', 'source files'))
+            }
+        """
+
+        when:
+        configurationCacheFails "sdsTask"
+
+        then:
+        assertHasUnsupportedPropertyValueType(Property, SourceDirectorySet, "sdsTask", "SdsTask")
+
+        where:
+        annotation << ["@Input", "@Internal"]
+    }
+
+    def "reports sensible error task indirectly holds a Property of unsupported type"() {
+        buildFile << """
+            abstract class ConfHolder {
+                @Internal
+                abstract Property<Configuration> getConf()
+            }
+
+            abstract class BeanHolderTask extends DefaultTask {
+                @Nested
+                abstract ConfHolder getHolder()
+
+                @TaskAction
+                void run() {
+                    println "Conf: " + holder.conf.get().name
+                }
+            }
+
+            configurations.create('myConf')
+
+            tasks.register("beanHolder", BeanHolderTask) {
+                holder.conf.set(configurations.getByName('myConf'))
+            }
+        """
+
+        when:
+        configurationCacheFails "beanHolder"
+
+        then:
+        assertHasUnsupportedPropertyValueType(Property, Configuration, "beanHolder", "BeanHolderTask")
+    }
+
+    def "reports sensible error when Property of unsupported type is captured without custom task"() {
+        buildFile << """
+            interface ConfHolder {
+                Property<Configuration> getConf()
+            }
+
+            def holder = objects.newInstance(ConfHolder)
+            holder.conf.set(configurations.create('myConf'))
+
+            tasks.named("tasks") {
+                doLast {
+                    println "Conf: " + holder.conf.get().name
+                }
+            }
+        """
+
+        when:
+        configurationCacheFails "tasks"
+
+        then:
+        assertHasUnsupportedPropertyValueType(Property, Configuration, "tasks", "TaskReportTask")
+    }
+
+    def "reports error only once when multiple properties of same unsupported type exist"() {
+        buildFile << """
+            abstract class MultiConfTask extends DefaultTask {
+                @Internal
+                abstract Property<Configuration> getFirst()
+
+                @Internal
+                abstract Property<Configuration> getSecond()
+
+                @Input
+                abstract Property<Configuration> getThird()
+
+                @TaskAction
+                void run() {
+                    println "First: " + first.get().name
+                    println "Second: " + second.get().name
+                    println "Third: " + third.get().name
+                }
+            }
+
+            configurations.create('confA')
+            configurations.create('confB')
+            configurations.create('confC')
+
+            tasks.register("multiConf", MultiConfTask) {
+                first.set(configurations.getByName('confA'))
+                second.set(configurations.getByName('confB'))
+                third.set(configurations.getByName('confC'))
+            }
+        """
+
+        when:
+        configurationCacheFails "multiConf"
+
+        then:
+        assertHasUnsupportedPropertyValueType(Property, Configuration, "multiConf", "MultiConfTask")
+    }
+
+    def "unset Property of unsupported type does not cause an error"() {
+        // An unset abstract managed property's backing field is null (lazy initialization never triggered).
+        // The codec framework writes a null marker directly, so PropertyCodec is never invoked
+        // and the unsupported type check does not fire.
+        buildFile << """
+            abstract class UnsetConfTask extends DefaultTask {
+                @Internal
+                abstract Property<Configuration> getConf()
+
+                @TaskAction
+                void run() {
+                    println "Present: " + conf.isPresent()
+                }
+            }
+
+            tasks.register("unsetConf", UnsetConfTask)
+        """
+
+        when:
+        configurationCacheRun "unsetConf"
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains "Present: false"
+    }
+
+    def "following resolution advice fixes Property of #typeName"() {
+        def buildScript = { String propertyDeclaration, String wiring ->
+            """
+            abstract class PrintFiles extends DefaultTask {
+                ${propertyDeclaration}
+
+                @TaskAction
+                void run() {
+                    println "Files: " + inputFiles.files*.name
+                }
+            }
+
+            ${sourceSetup}
+
+            tasks.register("printFiles", PrintFiles) {
+                ${wiring}
+            }
+            """
+        }
+
+        given: "a broken build using Property<$typeName>"
+        buildFile << buildScript(
+            "@Internal abstract Property<${typeName}> getInputFiles()",
+            "inputFiles.set(${sourceExpression})"
+        )
+
+        when: "configuration cache store fails"
+        configurationCacheFails "printFiles"
+
+        then: "error identifies the problem and suggests a fix"
+        assertHasUnsupportedPropertyValueType(Property, unsupportedType, "printFiles", "PrintFiles")
+
+        when: "the property type is changed following the resolution advice"
+        buildFile.text = buildScript(
+            "@InputFiles abstract ConfigurableFileCollection getInputFiles()",
+            "inputFiles.from(${sourceExpression})"
+        )
+
+        and: "configuration cache stores successfully"
+        configurationCacheRun "printFiles"
+
+        then:
+        configurationCache.assertStateStored()
+
+        when: "configuration cache loads successfully"
+        configurationCacheRun "printFiles"
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        where:
+        typeName             | unsupportedType    | sourceSetup                                                                                    | sourceExpression
+        "Configuration"      | Configuration      | "configurations.create('myConf')"                                                              | "configurations.getByName('myConf')"
+        "SourceDirectorySet" | SourceDirectorySet | "def sds = objects.sourceDirectorySet('sources', 'source files')\nsds.srcDir('src/main/java')" | "sds"
+    }
+
+    // region Collection Properties with unsupported element types
+    def "reports sensible error when task has #propertyKind.simpleName of unsupported #typeSimpleName"() {
+        buildFile << buildScript
+
+        when:
+        configurationCacheFails taskName
+
+        then:
+        assertHasUnsupportedPropertyValueType(propertyKind, unsupportedType, taskName, taskType)
+
+        where:
+        propertyKind | unsupportedType | typeSimpleName  | taskName         | taskType            | buildScript
+        ListProperty | Configuration   | "Configuration" | "listConfTask"   | "ListConfTask"      | listPropertyBuildScript()
+        SetProperty  | Configuration   | "Configuration" | "setConfTask"    | "SetConfTask"       | setPropertyBuildScript()
+        MapProperty  | Configuration   | "Configuration" | "mapConfTask"    | "MapConfTask"       | mapPropertyValueBuildScript()
+        MapProperty  | Configuration   | "Configuration" | "mapKeyConfTask" | "MapKeyConfTask"    | mapPropertyKeyBuildScript()
+    }
+
+    private static String listPropertyBuildScript() {
+        """
+            abstract class ListConfTask extends DefaultTask {
+                @Internal
+                abstract ListProperty<Configuration> getConfs()
+
+                @TaskAction
+                void run() { println "Confs: " + confs.get()*.name }
+            }
+
+            configurations.create('myConf')
+
+            tasks.register("listConfTask", ListConfTask) {
+                confs.add(configurations.getByName('myConf'))
+            }
+        """
+    }
+
+    private static String setPropertyBuildScript() {
+        """
+            abstract class SetConfTask extends DefaultTask {
+                @Internal
+                abstract SetProperty<Configuration> getConfs()
+
+                @TaskAction
+                void run() { println "Confs: " + confs.get()*.name }
+            }
+
+            configurations.create('myConf')
+
+            tasks.register("setConfTask", SetConfTask) {
+                confs.add(configurations.getByName('myConf'))
+            }
+        """
+    }
+
+    private static String mapPropertyValueBuildScript() {
+        """
+            abstract class MapConfTask extends DefaultTask {
+                @Internal
+                abstract MapProperty<String, Configuration> getConfs()
+
+                @TaskAction
+                void run() { println "Confs: " + confs.get() }
+            }
+
+            configurations.create('myConf')
+
+            tasks.register("mapConfTask", MapConfTask) {
+                confs.put("main", configurations.getByName('myConf'))
+            }
+        """
+    }
+
+    private static String mapPropertyKeyBuildScript() {
+        """
+            abstract class MapKeyConfTask extends DefaultTask {
+                @Internal
+                abstract MapProperty<Configuration, String> getConfs()
+
+                @TaskAction
+                void run() { println "Confs: " + confs.get() }
+            }
+
+            configurations.create('myConf')
+
+            tasks.register("mapKeyConfTask", MapKeyConfTask) {
+                confs.put(configurations.getByName('myConf'), "main")
+            }
+        """
+    }
+    // endregion Collection Properties with unsupported element types
+
+    private void assertHasUnsupportedPropertyValueType(Class<?> propertyKind, Class<?> unsupportedType, String taskPath, String taskType) {
+        failure.assertHasCause(
+            "Cannot serialize ${propertyKind.simpleName}<${unsupportedType.simpleName}> in task :${taskPath} of type ${taskType}.  The value type of this property (${unsupportedType.name}) is not supported with the configuration cache."
+        )
+        if (MapProperty.isAssignableFrom(propertyKind)) {
+            failure.assertHasResolution("Avoid using ${unsupportedType.simpleName} as a MapProperty key or value.")
+        } else {
+            failure.assertHasResolution("Use a @InputFiles ConfigurableFileCollection instead.")
+        }
     }
 }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
@@ -36,7 +36,11 @@ import org.gradle.api.internal.provider.PropertyFactory
 import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.api.internal.provider.ValueSupplier
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
@@ -47,6 +51,8 @@ import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.cc.base.serialize.IsolateOwners
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.extensions.core.serviceOf
+import org.gradle.internal.reflect.UnsupportedPropertyValueException
+import org.gradle.internal.serialize.beans.services.UnsupportedPropertyValueTypes
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.file.PathToFileResolver
 import org.gradle.internal.flow.services.BuildWorkResultProvider
@@ -385,6 +391,29 @@ abstract class AbstractPropertyCodec<P : AbstractProperty<*, *>>(
 }
 
 
+/**
+ * Throws [UnsupportedPropertyValueException] if [valueType] is not supported
+ * by the configuration cache as a property value type.
+ */
+private fun IsolateContext.rejectUnsupportedPropertyValueType(propertyKind: Class<*>, valueType: Class<*>) {
+    val result = UnsupportedPropertyValueTypes.check(valueType, propertyKind)
+    if (result is UnsupportedPropertyValueTypes.CheckResult.Supported) return
+
+    val unsupported = result as UnsupportedPropertyValueTypes.CheckResult.Unsupported
+
+    val taskDescription = trace.sequence
+        .filterIsInstance<PropertyTrace.Task>()
+        .firstOrNull()
+        ?.let { "task ${it.path} of type ${it.type.simpleName}" }
+        ?: trace.toString()
+
+    throw UnsupportedPropertyValueException(
+        "Cannot serialize ${propertyKind.simpleName}<${valueType.simpleName}> in $taskDescription.  The value type of this property (${valueType.name}) is not supported with the configuration cache.",
+        listOf(unsupported.resolution)
+    )
+}
+
+
 class PropertyCodec(
     private val propertyFactory: PropertyFactory,
     providerCodec: FixedValueReplacingProviderCodec
@@ -392,7 +421,9 @@ class PropertyCodec(
 
     override suspend fun WriteContext.encodeThis(value: DefaultProperty<*>) {
         encodePreservingIdentityOf(value) {
-            writeClass(value.type)
+            val type = value.type
+            rejectUnsupportedPropertyValueType(Property::class.java, type)
+            writeClass(type)
             providerCodec.run { encodeProvider(value.provider) }
         }
     }
@@ -455,6 +486,7 @@ class ListPropertyCodec(
 ) : AbstractPropertyCodec<DefaultListProperty<*>>(providerCodec){
 
     override suspend fun WriteContext.encodeThis(value: DefaultListProperty<*>) {
+        rejectUnsupportedPropertyValueType(ListProperty::class.java, value.elementType)
         writeClass(value.elementType)
         providerCodec.run { encodeValue(value.calculateExecutionTimeValue()) }
     }
@@ -475,6 +507,7 @@ class SetPropertyCodec(
 ) : AbstractPropertyCodec<DefaultSetProperty<*>>(providerCodec) {
 
     override suspend fun WriteContext.encodeThis(value: DefaultSetProperty<*>) {
+        rejectUnsupportedPropertyValueType(SetProperty::class.java, value.elementType)
         writeClass(value.elementType)
         providerCodec.run { encodeValue(value.calculateExecutionTimeValue()) }
     }
@@ -495,6 +528,8 @@ class MapPropertyCodec(
 ) : AbstractPropertyCodec<DefaultMapProperty<*, *>>(providerCodec) {
 
     override suspend fun WriteContext.encodeThis(value: DefaultMapProperty<*, *>) {
+        rejectUnsupportedPropertyValueType(MapProperty::class.java, value.keyType)
+        rejectUnsupportedPropertyValueType(MapProperty::class.java, value.valueType)
         writeClass(value.keyType)
         writeClass(value.valueType)
         providerCodec.run { encodeValue(value.calculateExecutionTimeValue()) }

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/UnsupportedPropertyValueException.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/UnsupportedPropertyValueException.java
@@ -17,13 +17,31 @@
 package org.gradle.internal.reflect;
 
 import org.gradle.internal.exceptions.Contextual;
+import org.gradle.internal.exceptions.ResolutionProvider;
+import org.jspecify.annotations.NonNull;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Thrown when a property is set to an unsupported value.
  */
 @Contextual
-public class UnsupportedPropertyValueException extends RuntimeException {
+public final class UnsupportedPropertyValueException extends RuntimeException implements ResolutionProvider {
+    private final List<String> resolutions;
+
+    public UnsupportedPropertyValueException(String message, List<String> resolutions) {
+        super(message);
+        this.resolutions = Collections.unmodifiableList(resolutions);
+    }
+
     public UnsupportedPropertyValueException(String message, Throwable cause) {
         super(message, cause);
+        this.resolutions = Collections.emptyList();
+    }
+
+    @NonNull
+    @Override
+    public List<String> getResolutions() {
+        return resolutions;
     }
 }


### PR DESCRIPTION
Using types like Configuration or SourceDirectorySet as a value type
for a Property causes confusing type-mismatch errors during cache
loading. This change introduces a check during serialization to fail
fast with a clear diagnostic message and resolution suggestion.

Fixes https://github.com/gradle/gradle/issues/19122.