### PR TITLE
Inspect Kotlin delegates for unsupported types usage

### DIFF
--- a/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/BeanPropertyWriter.kt
+++ b/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/BeanPropertyWriter.kt
@@ -19,11 +19,14 @@ package org.gradle.internal.serialize.beans.services
 import com.google.common.primitives.Primitives.wrap
 import org.gradle.api.internal.IConventionAware
 import org.gradle.internal.configuration.problems.PropertyKind
+import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.extensions.stdlib.uncheckedCast
+import org.gradle.internal.reflect.UnsupportedTypeException
 import org.gradle.internal.serialize.graph.BeanStateWriter
 import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.reportUnsupportedFieldType
 import org.gradle.internal.serialize.graph.withDebugFrame
+import org.gradle.internal.serialize.graph.withPropertyTrace
 import org.gradle.internal.serialize.graph.writePropertyValue
 import java.lang.reflect.Field
 
@@ -50,9 +53,105 @@ class BeanPropertyWriter(
             relevantField.unsupportedFieldType?.let {
                 reportUnsupportedFieldType(it, "serialize", fieldName, fieldValue)
             }
+            if (relevantField.unsupportedFieldType == null) {
+                checkKotlinDelegateForUnsupportedValue(field, fieldName, fieldValue)
+            }
             withDebugFrame({ field.debugFrameName() }) {
                 writePropertyValue(PropertyKind.Field, fieldName, fieldValue)
             }
+        }
+    }
+
+    /**
+     * Inspects the value of a Kotlin property delegate field for unsupported types.
+     *
+     * Kotlin `by`-delegates (e.g. `by lazy { … }`) create a backing field whose
+     * declared type is the delegate class, hiding the actual value type from
+     * [unsupportedFieldTypeFor].  This method looks inside the delegate and
+     * reports a configuration cache error when the wrapped value is an
+     * unsupported type (such as [org.gradle.api.artifacts.Configuration]).
+     *
+     * Only reports when the Kotlin property type (the getter return type) is itself
+     * an unsupported type.  When the user explicitly narrows the property type to
+     * a safe supertype (e.g. `val x: FileCollection by lazy { … }`), the
+     * round-trip through serialization succeeds and no error is reported.
+     *
+     * The error is routed through [onError] so that it appears in the failure
+     * cause chain (for `assertHasCause`) and in the CC problems report.
+     */
+    private
+    suspend fun WriteContext.checkKotlinDelegateForUnsupportedValue(field: Field, fieldName: String, fieldValue: Any?) {
+        if (!KotlinDelegateInspector.isKotlinDelegate(fieldValue)) return
+        val delegateValue = KotlinDelegateInspector.extractValue(fieldValue!!) ?: return
+        val unsupportedType = unsupportedFieldDeclaredTypes.firstOrNull { it.java.isInstance(delegateValue) } ?: return
+        if (isKotlinPropertyTypeUnsupported(field)) {
+            reportUnsupportedKotlinDelegateType(field, fieldName, fieldValue, unsupportedType)
+        }
+    }
+
+    /**
+     * Reports a configuration cache error for a Kotlin delegate whose result type
+     * is unsupported.  The error is routed through [onError] so that it appears
+     * in both the failure cause chain and the CC problems report.
+     */
+    private
+    suspend fun WriteContext.reportUnsupportedKotlinDelegateType(
+        field: Field,
+        fieldName: String,
+        delegate: Any,
+        unsupportedType: kotlin.reflect.KClass<*>
+    ) {
+        val delegateKind = KotlinDelegateInspector.delegateKindName(delegate)
+        val propertyName = field.name.removeSuffix("\$delegate")
+        val taskDescription = trace.sequence
+            .filterIsInstance<PropertyTrace.Task>()
+            .firstOrNull()
+            ?.let { "task ${it.path} of type ${it.type.simpleName}" }
+            ?: trace.toString()
+
+        val exception = UnsupportedTypeException(
+            "Cannot serialize $delegateKind delegate returning ${unsupportedType.simpleName} in $taskDescription." +
+                "  The result type of this delegate (${unsupportedType.qualifiedName}) is not supported with the configuration cache.",
+            listOf("Declare the property type explicitly as a supported type (e.g., val $propertyName: FileCollection by $delegateKind { ... }).")
+        )
+        withPropertyTrace(PropertyKind.Field, fieldName) {
+            onError(exception) {
+                text("failed to serialize value of ")
+                reference(trace.toString())
+            }
+        }
+    }
+
+    /**
+     * Checks whether the Kotlin property backed by [delegateField] has a return type
+     * that is an unsupported configuration cache type.
+     *
+     * Kotlin compiles `val x by delegate` into a field named `x$delegate` and a
+     * getter `getX()`.  This method finds the getter and checks its return type.
+     *
+     * @throws DelegateInspectionException if the getter cannot be found for a `$delegate` field
+     */
+    internal
+    fun isKotlinPropertyTypeUnsupported(delegateField: Field): Boolean {
+        val propertyName = delegateField.name.removeSuffix("\$delegate")
+        if (propertyName == delegateField.name) {
+            throw DelegateInspectionException(
+                "Field '${delegateField.name}' on ${delegateField.declaringClass.name} " +
+                    "does not follow the Kotlin delegate naming convention (<name>\$delegate)."
+            )
+        }
+
+        val getterName = "get${propertyName.replaceFirstChar { it.uppercase() }}"
+        return try {
+            val returnType = delegateField.declaringClass.getMethod(getterName).returnType
+            unsupportedFieldDeclaredTypes.any { it.java.isAssignableFrom(returnType) }
+        } catch (e: NoSuchMethodException) {
+            throw DelegateInspectionException(
+                "Could not find getter '$getterName()' on ${delegateField.declaringClass.name} " +
+                    "for delegate field '${delegateField.name}'. " +
+                    "Available methods: ${delegateField.declaringClass.methods.map { it.name }.sorted().distinct().joinToString(", ")}",
+                e
+            )
         }
     }
 

--- a/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/KotlinDelegateInspector.kt
+++ b/platforms/core-configuration/bean-serialization-services/src/main/kotlin/org/gradle/internal/serialize/beans/services/KotlinDelegateInspector.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.beans.services
+
+import kotlin.properties.ReadOnlyProperty
+import kotlin.properties.ReadWriteProperty
+
+
+/**
+ * Extracts the current value from Kotlin property delegates so that it can be
+ * inspected for unsupported types before configuration cache serialization.
+ *
+ * Kotlin `by`-delegates create a backing field whose *declared* type is the
+ * delegate class (e.g. `Lazy`), hiding the actual value type from the
+ * field-level check in [unsupportedFieldTypeFor].  This inspector looks
+ * *inside* recognised delegate wrappers to retrieve the wrapped value.
+ *
+ * Currently supports:
+ * - [Lazy] (`by lazy { … }`) — the most common delegate in Gradle tasks
+ * - [ReadWriteProperty] subclasses (`Delegates.observable`, `Delegates.vetoable`,
+ *   `Delegates.notNull`) — via reflective access to the conventional `value` field
+ * - [ReadOnlyProperty] subclasses — same reflective fallback
+ */
+internal object KotlinDelegateInspector {
+    /**
+     * Extracts the current value held by a Kotlin property delegate.
+     *
+     * Callers must guard with [isKotlinDelegate] before calling this method.
+     *
+     * @return the wrapped value, or `null` when the delegate has not yet been
+     *   initialised (e.g. un-evaluated `lazy`) or holds a null value.
+     *
+     * @throws DelegateInspectionException if [delegate] is not a recognised delegate type,
+     *   or if a recognised delegate type cannot be reflectively inspected
+     */
+    fun extractValue(delegate: Any): Any? = when (delegate) {
+        is Lazy<*> -> extractFromLazy(delegate)
+        is ReadWriteProperty<*, *> -> extractViaValueField(delegate)
+        is ReadOnlyProperty<*, *> -> extractViaValueField(delegate)
+        else -> throw DelegateInspectionException(
+            "Not a recognised Kotlin property delegate: ${delegate::class.java.name}. " +
+                "Callers must guard with isKotlinDelegate() before calling extractValue()."
+        )
+    }
+
+    /**
+     * Returns `true` when [value] is a recognised Kotlin property delegate type.
+     */
+    fun isKotlinDelegate(value: Any?): Boolean = when (value) {
+        is Lazy<*> -> true
+        is ReadWriteProperty<*, *> -> true
+        is ReadOnlyProperty<*, *> -> true
+        else -> false
+    }
+
+    /**
+     * Returns a human-readable label for the delegate kind, used in diagnostic messages.
+     *
+     * @throws DelegateInspectionException if [delegate] is not a recognised delegate type;
+     *   callers must guard with [isKotlinDelegate] first.
+     */
+    fun delegateKindName(delegate: Any): String = when (delegate) {
+        is Lazy<*> -> "lazy"
+        is ReadWriteProperty<*, *> -> "observable/vetoable"
+        is ReadOnlyProperty<*, *> -> "delegate"
+        else -> throw DelegateInspectionException(
+            "Not a recognised Kotlin property delegate: ${delegate::class.java.name}. " +
+                "Callers must guard with isKotlinDelegate() before calling delegateKindName()."
+        )
+    }
+
+    private fun extractFromLazy(delegate: Lazy<*>): Any? =
+        if (delegate.isInitialized()) delegate.value else null
+
+    /**
+     * Reflective fallback for delegates that store their value in a field named `value`.
+     * This covers [kotlin.properties.ObservableProperty] (`Delegates.observable` / `vetoable`)
+     * and the internal `NotNullVar` (`Delegates.notNull`).
+     *
+     * Walks the class hierarchy because the `value` field is typically declared in a
+     * superclass (e.g. `ObservableProperty`) while the runtime instance may be an
+     * anonymous subclass created by factory methods like [kotlin.properties.Delegates.observable].
+     *
+     * @throws DelegateInspectionException if the delegate's value cannot be reflectively accessed
+     */
+    private fun extractViaValueField(delegate: Any): Any? {
+        val delegateClass = delegate.javaClass
+        val field = findValueFieldInHierarchy(delegateClass)
+            ?: throw DelegateInspectionException(
+                "Could not find 'value' field in delegate of type ${delegateClass.name}. " +
+                    "Available fields: ${describeFieldsOf(delegateClass)}"
+            )
+        try {
+            field.isAccessible = true
+            return field.get(delegate)
+        } catch (e: Exception) {
+            throw DelegateInspectionException(
+                "Could not read 'value' field (declared in ${field.declaringClass.name}) " +
+                    "from delegate of type ${delegateClass.name}.",
+                e
+            )
+        }
+    }
+
+    private fun findValueFieldInHierarchy(clazz: Class<*>): java.lang.reflect.Field? {
+        var current: Class<*>? = clazz
+        while (current != null && current != Any::class.java) {
+            try {
+                return current.getDeclaredField("value")
+            } catch (_: NoSuchFieldException) {
+                current = current.superclass
+            }
+        }
+        return null
+    }
+
+    private fun describeFieldsOf(clazz: Class<*>): String =
+        generateSequence(clazz) { it.superclass }
+            .takeWhile { it != Any::class.java }
+            .flatMap { c -> c.declaredFields.map { "${c.simpleName}.${it.name}: ${it.type.simpleName}" } }
+            .joinToString(", ")
+            .ifEmpty { "(none)" }
+}
+
+
+/**
+ * Thrown when a Kotlin property delegate cannot be inspected, either because
+ * it is not a recognised delegate type or because reflective access failed.
+ */
+internal class DelegateInspectionException(
+    message: String,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)

--- a/platforms/core-configuration/bean-serialization-services/src/test/kotlin/org/gradle/internal/serialize/beans/services/BeanPropertyWriterTest.kt
+++ b/platforms/core-configuration/bean-serialization-services/src/test/kotlin/org/gradle/internal/serialize/beans/services/BeanPropertyWriterTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.beans.services
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+
+/**
+ * Tests for the Kotlin delegate inspection methods on [BeanPropertyWriter].
+ *
+ * These are unit tests for the pure-logic helpers; end-to-end integration tests
+ * for the full serialization path live in `ConfigurationCacheUnsupportedTypesIntegrationTest`.
+ */
+class BeanPropertyWriterTest {
+    // region isKotlinPropertyTypeUnsupported
+    @Test
+    fun `returns true when getter returns Configuration`() {
+        val field = BeanWithConfigurationDelegate::class.java.getDeclaredField("conf\$delegate")
+        val writer = BeanPropertyWriter(BeanWithConfigurationDelegate::class.java)
+        assertTrue(writer.isKotlinPropertyTypeUnsupported(field))
+    }
+
+    @Test
+    fun `returns false when getter returns FileCollection`() {
+        val field = BeanWithFileCollectionDelegate::class.java.getDeclaredField("files\$delegate")
+        val writer = BeanPropertyWriter(BeanWithFileCollectionDelegate::class.java)
+        assertFalse(writer.isKotlinPropertyTypeUnsupported(field))
+    }
+
+    @Test
+    fun `returns false when getter returns String`() {
+        val field = BeanWithStringDelegate::class.java.getDeclaredField("name\$delegate")
+        val writer = BeanPropertyWriter(BeanWithStringDelegate::class.java)
+        assertFalse(writer.isKotlinPropertyTypeUnsupported(field))
+    }
+
+    @Test(expected = DelegateInspectionException::class)
+    fun `throws when field does not follow delegate naming convention`() {
+        val field = BeanWithPlainField::class.java.getDeclaredField("notADelegate")
+        val writer = BeanPropertyWriter(BeanWithPlainField::class.java)
+        writer.isKotlinPropertyTypeUnsupported(field)
+    }
+
+    @Test(expected = DelegateInspectionException::class)
+    fun `throws when getter cannot be found for delegate field`() {
+        // A private val produces a $delegate field but a private getter,
+        // so Class.getMethod (public-only) cannot find it.
+        val field = BeanWithPrivateDelegate::class.java.getDeclaredField("hidden\$delegate")
+        val writer = BeanPropertyWriter(BeanWithPrivateDelegate::class.java)
+        writer.isKotlinPropertyTypeUnsupported(field)
+    }
+    // endregion isKotlinPropertyTypeUnsupported
+
+    // region test fixtures
+    @Suppress("unused")
+    private class BeanWithConfigurationDelegate {
+        val conf by lazy<org.gradle.api.artifacts.Configuration> {
+            throw UnsupportedOperationException("not called in test")
+        }
+    }
+
+    @Suppress("unused")
+    private class BeanWithFileCollectionDelegate {
+        val files by lazy<org.gradle.api.file.FileCollection> {
+            throw UnsupportedOperationException("not called in test")
+        }
+    }
+
+    @Suppress("unused")
+    private class BeanWithStringDelegate {
+        val name by lazy { "hello" }
+    }
+
+    @Suppress("unused")
+    private class BeanWithPlainField {
+        @JvmField
+        val notADelegate: String = "plain"
+    }
+
+    @Suppress("unused")
+    private class BeanWithPrivateDelegate {
+        private val hidden by lazy { "invisible getter" }
+    }
+    // endregion test fixtures
+}

--- a/platforms/core-configuration/bean-serialization-services/src/test/kotlin/org/gradle/internal/serialize/beans/services/KotlinDelegateInspectorTest.kt
+++ b/platforms/core-configuration/bean-serialization-services/src/test/kotlin/org/gradle/internal/serialize/beans/services/KotlinDelegateInspectorTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize.beans.services
+
+import kotlin.properties.Delegates
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KotlinDelegateInspectorTest {
+    // region extractValue
+    @Test
+    fun `extractValue extracts value from initialized lazy`() {
+        val delegate = lazy { "computed" }
+        delegate.value // force evaluation
+        assertEquals("computed", KotlinDelegateInspector.extractValue(delegate))
+    }
+
+    @Test
+    fun `extractValue returns null for uninitialized lazy`() {
+        val delegate = lazy { "not yet" }
+        assertNull(KotlinDelegateInspector.extractValue(delegate))
+    }
+
+    @Test
+    fun `extractValue returns null for initialized lazy holding null`() {
+        val delegate = lazy<String?> { null }
+        delegate.value // force evaluation
+        assertNull(KotlinDelegateInspector.extractValue(delegate))
+    }
+
+    @Test
+    fun `extractValue extracts value from observable delegate`() {
+        val delegate = Delegates.observable("initial") { _, _, _ -> }
+        assertEquals("initial", KotlinDelegateInspector.extractValue(delegate))
+    }
+
+    @Test
+    fun `extractValue extracts value from vetoable delegate`() {
+        val delegate = Delegates.vetoable("guarded") { _, _, _ -> true }
+        assertEquals("guarded", KotlinDelegateInspector.extractValue(delegate))
+    }
+
+    @Test
+    fun `extractValue returns null from notNull delegate before assignment`() {
+        val delegate = Delegates.notNull<String>()
+        assertNull(KotlinDelegateInspector.extractValue(delegate))
+    }
+
+    @Test(expected = DelegateInspectionException::class)
+    fun `extractValue throws for non-delegate object`() {
+        KotlinDelegateInspector.extractValue("not a delegate")
+    }
+
+    @Test(expected = DelegateInspectionException::class)
+    fun `extractValue throws for ReadOnlyProperty delegate without value field`() {
+        val delegate = object : ReadOnlyProperty<Any?, String> {
+            override fun getValue(thisRef: Any?, property: KProperty<*>) = "hello"
+        }
+        KotlinDelegateInspector.extractValue(delegate)
+    }
+    // endregion extractValue
+
+    // region isKotlinDelegate
+    @Test
+    fun `isKotlinDelegate returns true for Lazy`() {
+        assertTrue(KotlinDelegateInspector.isKotlinDelegate(lazy { }))
+    }
+
+    @Test
+    fun `isKotlinDelegate returns true for observable`() {
+        assertTrue(KotlinDelegateInspector.isKotlinDelegate(Delegates.observable("x") { _, _, _ -> }))
+    }
+
+    @Test
+    fun `isKotlinDelegate returns true for vetoable`() {
+        assertTrue(KotlinDelegateInspector.isKotlinDelegate(Delegates.vetoable("x") { _, _, _ -> true }))
+    }
+
+    @Test
+    fun `isKotlinDelegate returns false for plain objects`() {
+        assertFalse(KotlinDelegateInspector.isKotlinDelegate("not a delegate"))
+    }
+
+    @Test
+    fun `isKotlinDelegate returns false for null`() {
+        assertFalse(KotlinDelegateInspector.isKotlinDelegate(null))
+    }
+
+    // endregion isKotlinDelegate
+
+    // region delegateKindName
+    @Test
+    fun `delegateKindName returns lazy for Lazy`() {
+        assertEquals("lazy", KotlinDelegateInspector.delegateKindName(lazy { }))
+    }
+
+    @Test
+    fun `delegateKindName returns observable-vetoable for observable`() {
+        val delegate = Delegates.observable("x") { _, _, _ -> }
+        assertEquals("observable/vetoable", KotlinDelegateInspector.delegateKindName(delegate))
+    }
+
+    @Test
+    fun `delegateKindName returns observable-vetoable for vetoable`() {
+        val delegate = Delegates.vetoable("x") { _, _, _ -> true }
+        assertEquals("observable/vetoable", KotlinDelegateInspector.delegateKindName(delegate))
+    }
+
+    @Test(expected = DelegateInspectionException::class)
+    fun `delegateKindName throws for unrecognized types`() {
+        KotlinDelegateInspector.delegateKindName("not a delegate")
+    }
+    // endregion delegateKindName
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
@@ -94,9 +94,11 @@ import org.gradle.initialization.DefaultSettings
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.locking.DefaultDependencyLockingHandler
 import org.gradle.invocation.DefaultGradle
+import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.JdkVersionTestPreconditions
 
+import spock.lang.Issue
 import spock.lang.Shared
 
 import java.util.concurrent.Executor
@@ -544,5 +546,160 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
         DefaultLegacyConfiguration     | Configuration      | "project.configurations.create('some')"     | "project.configurations.getByName('some')"           | 'file collection'
         DefaultResolvableConfiguration | Configuration      | "project.configurations.resolvable('some')" | "project.configurations.getByName('some')"           | 'file collection'
         DefaultSourceDirectorySet      | SourceDirectorySet | ""                                          | "project.objects.sourceDirectorySet('some', 'more')" | 'file tree'
+    }
+
+    @Requires(JdkVersionTestPreconditions.KotlinSupportedJdk)
+    @Issue("https://github.com/gradle/gradle/issues/16177")
+    def "reports when Kotlin #delegateKind delegate wraps an unsupported type, when the type is implicit (#configSource)"() {
+        given:
+        file("buildSrc/settings.gradle.kts").text = ""
+        file("buildSrc/build.gradle.kts").text = """
+            plugins { `kotlin-dsl` }
+            ${mavenCentralRepository(GradleDsl.KOTLIN)}
+        """
+        file("buildSrc/src/main/kotlin/BrokenTask.kt").text = """
+            import org.gradle.api.DefaultTask
+            import org.gradle.api.tasks.Internal
+            import org.gradle.api.tasks.TaskAction
+            import kotlin.properties.Delegates
+
+            open class BrokenTask : DefaultTask() {
+                $delegateDeclaration
+
+                @TaskAction
+                fun run() {
+                    println("task executed")
+                }
+            }
+        """.stripIndent()
+        buildFile << """
+            tasks.register("broken", BrokenTask) {
+                println("configured classPath type: " + classPath.class.name)
+            }
+        """
+
+        when:
+        configurationCacheFails "broken"
+
+        then: "CC detects the unsupported type inside the delegate with a clear cause and resolution"
+        failure.assertHasCause(
+            "Cannot serialize $delegateLabel delegate returning Configuration in task :broken of type BrokenTask." +
+            "  The result type of this delegate (org.gradle.api.artifacts.Configuration) is not supported with the configuration cache."
+        )
+        failure.assertHasResolution("Declare the property type explicitly as a supported type (e.g., val classPath: FileCollection by $delegateLabel { ... }).")
+
+        where:
+        delegateKind | configSource | delegateLabel         | delegateDeclaration
+        "lazy"       | "detached"   | "lazy"                | '@get:Internal val classPath by lazy { project.configurations.detachedConfiguration() }'
+        "lazy"       | "created"    | "lazy"                | '@get:Internal val classPath by lazy { project.configurations.create("myConf") }'
+        "observable" | "detached"   | "observable/vetoable" | '@get:Internal var classPath by Delegates.observable(project.configurations.detachedConfiguration()) { _, _, _ -> }'
+        "observable" | "created"    | "observable/vetoable" | '@get:Internal var classPath by Delegates.observable(project.configurations.create("myConf")) { _, _, _ -> }'
+        "vetoable"   | "detached"   | "observable/vetoable" | '@get:Internal var classPath by Delegates.vetoable(project.configurations.detachedConfiguration()) { _, _, _ -> true }'
+        "vetoable"   | "created"    | "observable/vetoable" | '@get:Internal var classPath by Delegates.vetoable(project.configurations.create("myConf")) { _, _, _ -> true }'
+    }
+
+    @Requires(JdkVersionTestPreconditions.KotlinSupportedJdk)
+    @Issue("https://github.com/gradle/gradle/issues/16177")
+    def "Kotlin #delegateKind delegate with explicit FileCollection type works with configuration cache (#configSource)"() {
+        given:
+        file("buildSrc/settings.gradle.kts").text = ""
+        file("buildSrc/build.gradle.kts").text = """
+            plugins { `kotlin-dsl` }
+            ${mavenCentralRepository(GradleDsl.KOTLIN)}
+        """
+        file("buildSrc/src/main/kotlin/WorkingTask.kt").text = """
+            import org.gradle.api.DefaultTask
+            import org.gradle.api.file.FileCollection
+            import org.gradle.api.tasks.Internal
+            import org.gradle.api.tasks.TaskAction
+            import kotlin.properties.Delegates
+
+            open class WorkingTask : DefaultTask() {
+                $delegateDeclaration
+
+                @TaskAction
+                fun run() {
+                    println("classPath files: " + classPath.files)
+                }
+            }
+        """.stripIndent()
+        buildFile << """
+            tasks.register("working", WorkingTask) {
+                println("configured classPath type: " + classPath.class.name)
+            }
+        """
+
+        when: "first run stores to configuration cache"
+        configurationCacheRun "working"
+
+        then:
+        outputContains("classPath files: []")
+
+        when: "second run loads from cache and succeeds"
+        configurationCacheRun "working"
+
+        then: "no error because FileCollection checkcast succeeds"
+        outputContains("classPath files: []")
+
+        where:
+        delegateKind | configSource   | delegateDeclaration
+        "lazy"       | "detached"     | '@get:Internal val classPath: FileCollection by lazy { project.configurations.detachedConfiguration() }'
+        "lazy"       | "created"      | '@get:Internal val classPath: FileCollection by lazy { project.configurations.create("myConf") }'
+        "observable" | "detached"     | '@get:Internal var classPath: FileCollection by Delegates.observable(project.configurations.detachedConfiguration()) { _, _, _ -> }'
+        "observable" | "created"      | '@get:Internal var classPath: FileCollection by Delegates.observable(project.configurations.create("myConf")) { _, _, _ -> }'
+        "vetoable"   | "detached"     | '@get:Internal var classPath: FileCollection by Delegates.vetoable(project.configurations.detachedConfiguration()) { _, _, _ -> true }'
+        "vetoable"   | "created"      | '@get:Internal var classPath: FileCollection by Delegates.vetoable(project.configurations.create("myConf")) { _, _, _ -> true }'
+    }
+
+    @Requires(JdkVersionTestPreconditions.KotlinSupportedJdk)
+    @Issue("https://github.com/gradle/gradle/issues/16177")
+    def "Kotlin #delegateKind fails sensibly with explicit Configuration type with configuration cache (#configSource)"() {
+        given:
+        file("buildSrc/settings.gradle.kts").text = ""
+        file("buildSrc/build.gradle.kts").text = """
+            plugins { `kotlin-dsl` }
+            ${mavenCentralRepository(GradleDsl.KOTLIN)}
+        """
+        file("buildSrc/src/main/kotlin/FailingTask.kt").text = """
+            import org.gradle.api.DefaultTask
+            import org.gradle.api.artifacts.Configuration
+            import org.gradle.api.file.FileCollection
+            import org.gradle.api.tasks.Internal
+            import org.gradle.api.tasks.TaskAction
+            import kotlin.properties.Delegates
+
+            open class FailingTask : DefaultTask() {
+                $delegateDeclaration
+
+                @TaskAction
+                fun run() {
+                    println("classPath files: " + classPath.files)
+                }
+            }
+        """.stripIndent()
+        buildFile << """
+            tasks.register("failing", FailingTask) {
+                println("configured classPath type: " + classPath.class.name)
+            }
+        """
+
+        when:
+        configurationCacheFails "failing"
+
+        then:
+        failure.assertHasCause(
+            "Cannot serialize $delegateLabel delegate returning Configuration in task :failing of type FailingTask." +
+            "  The result type of this delegate (org.gradle.api.artifacts.Configuration) is not supported with the configuration cache."
+        )
+        failure.assertHasResolution("Declare the property type explicitly as a supported type (e.g., val classPath: FileCollection by $delegateLabel { ... }).")
+
+        where:
+        delegateKind | configSource | delegateLabel         | delegateDeclaration
+        "lazy"       | "detached"   | "lazy"                | '@get:Internal val classPath: Configuration by lazy { project.configurations.detachedConfiguration() }'
+        "lazy"       | "created"    | "lazy"                | '@get:Internal val classPath: Configuration by lazy { project.configurations.create("myConf") }'
+        "observable" | "detached"   | "observable/vetoable" | '@get:Internal var classPath: Configuration by Delegates.observable(project.configurations.detachedConfiguration()) { _, _, _ -> }'
+        "observable" | "created"    | "observable/vetoable" | '@get:Internal var classPath: Configuration by Delegates.observable(project.configurations.create("myConf")) { _, _, _ -> }'
+        "vetoable"   | "detached"   | "observable/vetoable" | '@get:Internal var classPath: Configuration by Delegates.vetoable(project.configurations.detachedConfiguration()) { _, _, _ -> true }'
+        "vetoable"   | "created"    | "observable/vetoable" | '@get:Internal var classPath: Configuration by Delegates.vetoable(project.configurations.create("myConf")) { _, _, _ -> true }'
     }
 }

--- a/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
+++ b/platforms/core-configuration/core-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/core/ProviderCodecs.kt
@@ -51,7 +51,7 @@ import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.cc.base.serialize.IsolateOwners
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.extensions.core.serviceOf
-import org.gradle.internal.reflect.UnsupportedPropertyValueException
+import org.gradle.internal.reflect.UnsupportedTypeException
 import org.gradle.internal.serialize.beans.services.UnsupportedPropertyValueTypes
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.file.PathToFileResolver
@@ -392,7 +392,7 @@ abstract class AbstractPropertyCodec<P : AbstractProperty<*, *>>(
 
 
 /**
- * Throws [UnsupportedPropertyValueException] if [valueType] is not supported
+ * Throws [UnsupportedTypeException] if [valueType] is not supported
  * by the configuration cache as a property value type.
  */
 private fun IsolateContext.rejectUnsupportedPropertyValueType(propertyKind: Class<*>, valueType: Class<*>) {
@@ -407,7 +407,7 @@ private fun IsolateContext.rejectUnsupportedPropertyValueType(propertyKind: Clas
         ?.let { "task ${it.path} of type ${it.type.simpleName}" }
         ?: trace.toString()
 
-    throw UnsupportedPropertyValueException(
+    throw UnsupportedTypeException(
         "Cannot serialize ${propertyKind.simpleName}<${valueType.simpleName}> in $taskDescription.  The value type of this property (${valueType.name}) is not supported with the configuration cache.",
         listOf(unsupported.resolution)
     )

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/manage/schema/extract/ManagedProxyClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/model/internal/manage/schema/extract/ManagedProxyClassGenerator.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.Types.TypeVisitResult;
 import org.gradle.internal.reflect.Types.TypeVisitor;
-import org.gradle.internal.reflect.UnsupportedPropertyValueException;
+import org.gradle.internal.reflect.UnsupportedTypeException;
 import org.gradle.internal.typeconversion.TypeConversionException;
 import org.gradle.internal.typeconversion.TypeConverter;
 import org.gradle.model.internal.asm.AsmClassGenerator;
@@ -996,8 +996,8 @@ public class ManagedProxyClassGenerator extends AbstractProxyClassGenerator {
 
     // Called from generated code on failure to convert the supplied value for a property to the property type
     @SuppressWarnings("unused")
-    public static void propertyValueConvertFailure(Class<?> viewType, String propertyName, Object value, TypeConversionException failure) throws UnsupportedPropertyValueException {
-        throw new UnsupportedPropertyValueException(String.format("Cannot set property: %s for class: %s to value: %s.", propertyName, viewType.getName(), value), failure);
+    public static void propertyValueConvertFailure(Class<?> viewType, String propertyName, Object value, TypeConversionException failure) throws UnsupportedTypeException {
+        throw new UnsupportedTypeException(String.format("Cannot set property: %s for class: %s to value: %s.", propertyName, viewType.getName(), value), failure);
     }
 
     public interface GeneratedView {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/model/internal/manage/schema/extract/ManagedProxyClassGeneratorTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/model/internal/manage/schema/extract/ManagedProxyClassGeneratorTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.model.internal.manage.schema.extract
 import com.google.common.base.Optional
 import groovy.test.NotYetImplemented
 import org.gradle.api.internal.file.FileResolver
-import org.gradle.internal.reflect.UnsupportedPropertyValueException
+import org.gradle.internal.reflect.UnsupportedTypeException
 import org.gradle.internal.typeconversion.DefaultTypeConverter
 import org.gradle.internal.typeconversion.TypeConversionException
 import org.gradle.model.Managed
@@ -445,7 +445,7 @@ class ManagedProxyClassGeneratorTest extends ProjectRegistrySpec {
         impl.value = "not-a-number"
 
         then:
-        def e = thrown(UnsupportedPropertyValueException)
+        def e = thrown(UnsupportedTypeException)
         e.message == "Cannot set property: value for class: ${SomeType.name} to value: not-a-number."
         e.cause instanceof TypeConversionException
 
@@ -513,7 +513,7 @@ class ManagedProxyClassGeneratorTest extends ProjectRegistrySpec {
         impl.value "not-a-number"
 
         then:
-        def e = thrown(UnsupportedPropertyValueException)
+        def e = thrown(UnsupportedTypeException)
         e.message == "Cannot set property: value for class: ${SomeType.name} to value: not-a-number."
         e.cause instanceof TypeConversionException
 

--- a/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/UnsupportedTypeException.java
+++ b/platforms/core-configuration/model-reflect/src/main/java/org/gradle/internal/reflect/UnsupportedTypeException.java
@@ -23,18 +23,20 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Thrown when a property is set to an unsupported value.
+ * Thrown when a type is not supported in a given context — for example, when a
+ * property value type or Kotlin delegate result type cannot survive a
+ * configuration cache serialization round-trip.
  */
 @Contextual
-public final class UnsupportedPropertyValueException extends RuntimeException implements ResolutionProvider {
+public final class UnsupportedTypeException extends RuntimeException implements ResolutionProvider {
     private final List<String> resolutions;
 
-    public UnsupportedPropertyValueException(String message, List<String> resolutions) {
+    public UnsupportedTypeException(String message, List<String> resolutions) {
         super(message);
         this.resolutions = Collections.unmodifiableList(resolutions);
     }
 
-    public UnsupportedPropertyValueException(String message, Throwable cause) {
+    public UnsupportedTypeException(String message, Throwable cause) {
         super(message, cause);
         this.resolutions = Collections.emptyList();
     }


### PR DESCRIPTION
> [!NOTE]
> Merge https://github.com/gradle/gradle/pull/37466 first.

Using types like Configuration or SourceDirectorySet as a value type
for a Property causes confusing type-mismatch errors during cache
loading. This change introduces a check during serialization to fail
fast with a clear diagnostic message and resolution suggestion.

Fixes:
- https://github.com/gradle/gradle/issues/16177