### PR TITLE
Prepare for ArtifactGraph feature

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSet.java
@@ -22,6 +22,9 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
  * Instances are retained during the lifetime of a build, so should avoid retaining unnecessary state.
  */
 public interface ArtifactSet {
+
+    ArtifactSet EMPTY = (consumerServices, spec) -> ResolvedArtifactSet.EMPTY;
+
     /**
      * Selects the artifacts of this set that meet the given criteria.
      * Implementation should be eager where possible, so that selection happens
@@ -31,4 +34,5 @@ public interface ArtifactSet {
         ArtifactSelectionServices consumerServices,
         ArtifactSelectionSpec spec
     );
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/CompositeArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/CompositeArtifactSet.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
+
+import com.google.common.collect.ImmutableList;
+
+public class CompositeArtifactSet implements ArtifactSet {
+
+    private final ImmutableList<ArtifactSet> artifactSets;
+
+    private CompositeArtifactSet(ImmutableList<ArtifactSet> artifactSets) {
+        this.artifactSets = artifactSets;
+    }
+
+    public static ArtifactSet of(ImmutableList<ArtifactSet> sets) {
+        if (sets.isEmpty()) {
+            return EMPTY;
+        }
+        if (sets.size() == 1) {
+            return sets.get(0);
+        }
+        return new CompositeArtifactSet(sets);
+    }
+
+    @Override
+    public ResolvedArtifactSet select(
+        ArtifactSelectionServices consumerServices,
+        ArtifactSelectionSpec spec
+    ) {
+        ImmutableList.Builder<ResolvedArtifactSet> builder = ImmutableList.builder();
+        for (ArtifactSet artifactSet : artifactSets) {
+            builder.add(artifactSet.select(consumerServices, spec));
+        }
+        return CompositeResolvedArtifactSet.of(builder.build());
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/CompositeResolvedArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/CompositeResolvedArtifactSet.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
+import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
@@ -24,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 
 public class CompositeResolvedArtifactSet implements ResolvedArtifactSet {
+
     private final List<ResolvedArtifactSet> sets;
 
     private CompositeResolvedArtifactSet(List<ResolvedArtifactSet> sets) {
@@ -33,17 +35,32 @@ public class CompositeResolvedArtifactSet implements ResolvedArtifactSet {
     public static ResolvedArtifactSet of(Collection<? extends ResolvedArtifactSet> sets) {
         List<ResolvedArtifactSet> filtered = new ArrayList<>(sets.size());
         for (ResolvedArtifactSet set : sets) {
-            if (set != ResolvedArtifactSet.EMPTY) {
+            if (set instanceof CompositeResolvedArtifactSet composite) {
+                filtered.addAll(composite.sets);
+            } else if (set != ResolvedArtifactSet.EMPTY) {
                 filtered.add(set);
             }
         }
+
         if (filtered.isEmpty()) {
             return EMPTY;
         }
+
         if (filtered.size() == 1) {
             return filtered.get(0);
         }
+
         return new CompositeResolvedArtifactSet(filtered);
+    }
+
+    public static ResolvedArtifactSet reverse(ResolvedArtifactSet artifacts) {
+        if (artifacts == EMPTY) {
+            return artifacts;
+        } else if (artifacts instanceof CompositeResolvedArtifactSet composite) {
+            return new CompositeResolvedArtifactSet(Lists.reverse(composite.sets));
+        } else {
+            return artifacts;
+        }
     }
 
     @Override
@@ -73,4 +90,5 @@ public class CompositeResolvedArtifactSet implements ResolvedArtifactSet {
             set.visitDependencies(context);
         }
     }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultResolvedArtifactsBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultResolvedArtifactsBuilder.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
-import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,20 +34,10 @@ public class DefaultResolvedArtifactsBuilder implements DependencyArtifactsVisit
     }
 
     @Override
-    public void visitArtifacts(DependencyGraphNode from, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifacts) {
-        collectArtifacts(artifactSetId, artifacts);
-    }
-
-    @Override
-    public void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts) {
-        // Don't collect build dependencies if not required
+    public void visitArtifacts(DependencyGraphNode from, int artifactSetId, ArtifactSet artifacts) {
         if (!buildProjectDependencies) {
             artifacts = new NoBuildDependenciesArtifactSet(artifacts);
         }
-        collectArtifacts(artifactSetId, artifacts);
-    }
-
-    private void collectArtifacts(int artifactSetId, ArtifactSet artifacts) {
         // Collect artifact sets in a list, using the id of the set as its index in the list
         assert artifactSetsById.size() >= artifactSetId;
         if (artifactSetsById.size() == artifactSetId) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResults.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResults.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ResolutionStrategy;
 
 import java.util.ArrayList;
@@ -58,11 +57,11 @@ public class DefaultVisitedArtifactResults implements VisitedArtifactResults {
 
         DefaultSelectedArtifactResults(ResolutionStrategy.SortOrder sortOrder, List<ResolvedArtifactSet> resolvedArtifactsById) {
             this.resolvedArtifactsById = resolvedArtifactsById;
+            ResolvedArtifactSet artifacts = CompositeResolvedArtifactSet.of(resolvedArtifactsById);
             if (sortOrder == ResolutionStrategy.SortOrder.DEPENDENCY_FIRST) {
-                this.allArtifacts = CompositeResolvedArtifactSet.of(Lists.reverse(resolvedArtifactsById));
-            } else {
-                this.allArtifacts = CompositeResolvedArtifactSet.of(resolvedArtifactsById);
+                artifacts = CompositeResolvedArtifactSet.reverse(artifacts);
             }
+            this.allArtifacts = artifacts;
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DependencyArtifactsVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DependencyArtifactsVisitor.java
@@ -18,29 +18,29 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
-import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 
 public interface DependencyArtifactsVisitor {
+
     /**
      * Visits a node in the graph. All nodes are visited prior to visiting the edges
      */
     default void visitNode(DependencyGraphNode node) {}
 
     /**
-     * Visits the artifacts introduced by a particular edge in the graph. Called for every edge in the graph.
+     * Visits the edges in the graph. Called for every edge in the graph.
      * The nodes are visited in consumer-first order.
      */
-    default void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts) {}
+    default void visitEdge(DependencyGraphNode from, DependencyGraphNode to) {}
 
     /**
-     * Visits the artifacts introduce by a particular node in the graph. Called *zero or more* times for each node.
-     * Currently local files are treated differently to other dependencies.
+     * Visits the artifacts introduced by a particular node in the graph. Called once for each node.
      * The nodes are visited in consumer-first order
      */
-    default void visitArtifacts(DependencyGraphNode from, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifactSet) {}
+    default void visitArtifacts(DependencyGraphNode from, int artifactSetId, ArtifactSet artifactSet) {}
 
     /**
      * Completes visiting.
      */
     default void finishArtifacts(RootGraphNode root) {}
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.capability.CapabilitySelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
@@ -29,6 +30,7 @@ import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantGraphResolveState;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Set;
@@ -65,62 +67,70 @@ public class ResolvedArtifactsGraphVisitor implements DependencyGraphVisitor {
 
     @Override
     public void visitEdges(DependencyGraphNode node) {
-        boolean hasTransitiveIncomingEdge = visitNonFileEdges(node);
+        boolean hasTransitiveIncomingEdge = false;
+        ImmutableList.Builder<ArtifactSet> builder = null;
+        ArtifactSet implicitArtifactSet = ArtifactSet.EMPTY;
+
+        for (DependencyGraphEdge edge : node.getIncomingEdges()) {
+            hasTransitiveIncomingEdge |= edge.isTransitive();
+
+            if (!edge.isConstraint()) {
+                artifactResults.visitEdge(edge.getFrom(), node);
+
+                ArtifactSet adhocArtifacts = maybeGetAdhocArtifacts(node, edge);
+                if (adhocArtifacts != null) {
+                    // The artifacts for this node were modified by the dependency.
+                    // Do not use the implicit artifact set.
+                    if (builder == null) {
+                        builder = ImmutableList.builder();
+                    }
+                    builder.add(adhocArtifacts);
+                } else if (implicitArtifactSet == ArtifactSet.EMPTY) {
+                    // We have not visited the implicit artifacts yet.
+                    // Since the dependency does not modify the artifacts, we can use the same
+                    // artifact set as other dependencies that do not modify the artifacts. We call
+                    // this the implicit artifact set.
+                    implicitArtifactSet = artifactSetCache.getImplicitVariant(node.getOwner().getResolveState(), node.getResolveState());
+                }
+            }
+        }
 
         if (node.isRoot() || hasTransitiveIncomingEdge) {
             // Since file dependencies are not modeled as actual edges, we need to verify
             // there are edges to this node that would follow this file dependency.
             for (LocalFileDependencyMetadata fileDependency : node.getOutgoingFileEdges()) {
-                int id = nextId++;
-                artifactResults.visitArtifacts(node, fileDependency, id, new FileDependencyArtifactSet(fileDependency, node.getId(), artifactTypeRegistry, calculatedValueContainerFactory));
-            }
-        }
-    }
-
-    /**
-     * Visit all the non-file edges for the given node.
-     *
-     * @return true if there is a transitive incoming edge.
-     */
-    private boolean visitNonFileEdges(DependencyGraphNode node) {
-        boolean hasTransitiveIncomingEdge = false;
-
-        int implicitArtifactSetId = -1;
-        ArtifactSet implicitArtifactSet = null;
-
-        for (DependencyGraphEdge edge : node.getIncomingEdges()) {
-            hasTransitiveIncomingEdge |= edge.isTransitive();
-
-            if (edge.contributesArtifacts()) {
-                if (maybeVisitAdhocEdge(node, edge)) {
-                    // The artifacts for this node were modified by the dependency.
-                    // Do not use the implicit artifact set.
-                    continue;
+                if (builder == null) {
+                    builder = ImmutableList.builder();
                 }
-
-                // Since the dependency does not modify the artifacts, we can use the same
-                // artifact set as other dependencies that do not modify the artifacts. We call
-                // this the implicit artifact set.
-                if (implicitArtifactSet == null) {
-                    // We have not visited the implicit artifacts yet.
-                    implicitArtifactSetId = nextId++;
-                    implicitArtifactSet = artifactSetCache.getImplicitVariant(node.getOwner().getResolveState(), node.getResolveState());
-                }
-
-                artifactResults.visitArtifacts(edge.getFrom(), node, implicitArtifactSetId, implicitArtifactSet);
+                builder.add(new FileDependencyArtifactSet(fileDependency, node.getId(), artifactTypeRegistry, calculatedValueContainerFactory));
             }
         }
 
-        return hasTransitiveIncomingEdge;
+        int id = nextId++;
+        ArtifactSet nodeArtifacts = implicitArtifactSet;
+        if (builder != null) {
+            if (implicitArtifactSet != ArtifactSet.EMPTY) {
+                ImmutableList<ArtifactSet> extraArtifactSets = builder.build();
+                nodeArtifacts = CompositeArtifactSet.of(ImmutableList.<ArtifactSet>builderWithExpectedSize(extraArtifactSets.size() + 1)
+                    .add(implicitArtifactSet)
+                    .addAll(extraArtifactSets)
+                    .build()
+                );
+            } else {
+                nodeArtifacts = CompositeArtifactSet.of(builder.build());
+            }
+        }
+        artifactResults.visitArtifacts(node, id, nodeArtifacts);
     }
 
     /**
-     * Process the given edge, and if it modifies the artifacts, visit the artifacts.
+     * Process the given edge, and if it modifies the artifacts, return the artifact set representing
+     * those modified artifacts.
      *
-     * @return true if this edge modifies the artifacts, meaning it is adhoc, and should
-     * not also contribute to the implicit artifact set.
+     * @return The adhoc artifact set if this edge modifies the artifacts, or null if this edge
+     * is non-adhoc and should instead contribute the implicit artifact set.
      */
-    private boolean maybeVisitAdhocEdge(DependencyGraphNode node, DependencyGraphEdge dependency) {
+    private static @Nullable ArtifactSet maybeGetAdhocArtifacts(DependencyGraphNode node, DependencyGraphEdge dependency) {
         ComponentGraphResolveState component = node.getOwner().getResolveState();
         VariantGraphResolveState variant = node.getResolveState();
 
@@ -135,18 +145,15 @@ public class ResolvedArtifactsGraphVisitor implements DependencyGraphVisitor {
             capabilitySelectors.isEmpty() &&
             !exclusions.mayExcludeArtifacts()
         ) {
-            return false;
+            return null;
         }
 
-        int id = nextId++;
-        VariantResolvingArtifactSet artifactSet = new VariantResolvingArtifactSet(component, variant, attributes, artifacts, exclusions, capabilitySelectors);
-        artifactResults.visitArtifacts(dependency.getFrom(), node, id, artifactSet);
-
-        return true;
+        return new VariantResolvingArtifactSet(component, variant, attributes, artifacts, exclusions, capabilitySelectors);
     }
 
     @Override
     public void finish(RootGraphNode root) {
         artifactResults.finishArtifacts(root);
     }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/CompositeDependencyArtifactsVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/CompositeDependencyArtifactsVisitor.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor;
-import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 
 import java.util.List;
 
@@ -37,16 +36,16 @@ public class CompositeDependencyArtifactsVisitor implements DependencyArtifactsV
     }
 
     @Override
-    public void visitArtifacts(DependencyGraphNode from, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifactSet) {
+    public void visitArtifacts(DependencyGraphNode from, int artifactSetId, ArtifactSet artifactSet) {
         for (DependencyArtifactsVisitor visitor : visitors) {
-            visitor.visitArtifacts(from, fileDependency, artifactSetId, artifactSet);
+            visitor.visitArtifacts(from, artifactSetId, artifactSet);
         }
     }
 
     @Override
-    public void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts) {
+    public void visitEdge(DependencyGraphNode from, DependencyGraphNode to) {
         for (DependencyArtifactsVisitor visitor : visitors) {
-            visitor.visitArtifacts(from, to, artifactSetId, artifacts);
+            visitor.visitEdge(from, to);
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
@@ -37,8 +37,6 @@ public interface DependencyGraphEdge extends ResolvedGraphDependency {
 
     ExcludeSpec getExclusions();
 
-    boolean contributesArtifacts();
-
     DependencyMetadata getDependencyMetadata();
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -408,11 +408,6 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     @Override
-    public boolean contributesArtifacts() {
-        return !isConstraint;
-    }
-
-    @Override
     public ComponentSelector getRequested() {
         return resolveState.desugarSelector(dependencyState.getRequested());
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/TransientConfigurationResultsBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/TransientConfigurationResultsBuilder.java
@@ -35,7 +35,6 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.cache.internal.BinaryStore;
 import org.gradle.cache.internal.Store;
-import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.time.Time;
@@ -93,7 +92,7 @@ public class TransientConfigurationResultsBuilder implements DependencyArtifacts
         });
 
         for (DependencyGraphEdge dependency : node.getIncomingEdges()) {
-            if (dependency.getFrom().isRoot()) {
+            if (dependency.getFrom().isRoot() && !dependency.isConstraint()) {
                 firstLevelDependency(node.getNodeId());
             }
         }
@@ -116,17 +115,16 @@ public class TransientConfigurationResultsBuilder implements DependencyArtifacts
     }
 
     @Override
-    public void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts) {
+    public void visitEdge(DependencyGraphNode from, DependencyGraphNode to) {
         binaryStore.write(encoder -> {
             encoder.writeByte(EDGE);
             encoder.writeSmallLong(from.getNodeId());
             encoder.writeSmallLong(to.getNodeId());
-            encoder.writeSmallInt(artifactSetId);
         });
     }
 
     @Override
-    public void visitArtifacts(DependencyGraphNode from, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifactSet) {
+    public void visitArtifacts(DependencyGraphNode from, int artifactSetId, ArtifactSet artifactSet) {
         binaryStore.write(encoder -> {
             encoder.writeByte(NODE_ARTIFACTS);
             encoder.writeSmallLong(from.getNodeId());
@@ -199,8 +197,6 @@ public class TransientConfigurationResultsBuilder implements DependencyArtifacts
                             throw new IllegalStateException(String.format("Unexpected child dependency id %s. Seen ids: %s", childId, allDependencies.keySet()));
                         }
                         parent.addChild(child);
-                        artifacts = artifactResults.getArtifactsWithId(decoder.readSmallInt());
-                        child.addParentSpecificArtifacts(parent, artifacts);
                         break;
                     case NODE_ARTIFACTS:
                         id = decoder.readSmallLong();

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -99,19 +99,8 @@ class ResolveTestFixture {
                 def configuration = configurations.${configurationName}
 
                 it.outputFile = file("\${buildDir}/last-graph.txt")
-                it.rootComponent = configuration.incoming.resolutionResult.rootComponent
-                it.files.from(configuration)
 
-                it.incomingFiles = configuration.incoming.files
-                it.incomingArtifacts = configuration.incoming.artifacts
-
-                it.artifactViewFiles = configuration.incoming.artifactView { }.files
-                it.artifactViewArtifacts = configuration.incoming.artifactView { }.artifacts
-
-                it.lenientArtifactViewFiles = configuration.incoming.artifactView { it.lenient = true }.files
-                it.lenientArtifactViewArtifacts = configuration.incoming.artifactView { it.lenient = true }.artifacts
-
-                it.inputs.files configuration
+                configureFrom(configuration)
             }
         """
     }
@@ -147,8 +136,63 @@ class ResolveTestFixture {
                 @Internal
                 ArtifactCollection lenientArtifactViewArtifacts
 
+                @Internal
+                abstract Property<String> getConfigurationCacheUnsafeLines()
+
                 GenerateGraphTask() {
                     outputs.upToDateWhen { false }
+                }
+
+                def configureFrom(Configuration configuration) {
+                    rootComponent = configuration.incoming.resolutionResult.rootComponent
+                    files.from(configuration)
+
+                    incomingFiles = configuration.incoming.files
+                    incomingArtifacts = configuration.incoming.artifacts
+
+                    artifactViewFiles = configuration.incoming.artifactView { }.files
+                    artifactViewArtifacts = configuration.incoming.artifactView { }.artifacts
+
+                    lenientArtifactViewFiles = configuration.incoming.artifactView { it.lenient = true }.files
+                    lenientArtifactViewArtifacts = configuration.incoming.artifactView { it.lenient = true }.artifacts
+
+                    inputs.files configuration
+
+                    configurationCacheUnsafeLines.set(project.provider {
+                        def stringWriter = new StringWriter()
+                        def pw = new PrintWriter(stringWriter)
+
+                        try {
+                            // ResolvedConfiguration
+                            configuration.resolvedConfiguration.firstLevelModuleDependencies.each {
+                                pw.println("first-level:[${it.moduleGroup}:${it.moduleName}:${it.moduleVersion}]")
+                            }
+                            visitNodes("resolved", configuration.resolvedConfiguration.firstLevelModuleDependencies, pw, new HashSet<>())
+                            configuration.resolvedConfiguration.resolvedArtifacts.each {
+                                pw.println("artifact:[${it.moduleVersion.id}][${it.name}:${it.classifier}:${it.extension}:${it.type}] (${it.id.componentIdentifier.displayName})")
+                            }
+                            configuration.resolvedConfiguration.resolvedArtifacts.each {
+                                writeFile("file-artifact-resolved-config", pw, it.file)
+                            }
+
+                            // LenientConfiguration
+                            configuration.resolvedConfiguration.lenientConfiguration.firstLevelModuleDependencies.each {
+                                pw.println("lenient-first-level:[${it.moduleGroup}:${it.moduleName}:${it.moduleVersion}]")
+                            }
+                            visitNodes("lenient", configuration.resolvedConfiguration.lenientConfiguration.firstLevelModuleDependencies, pw, new HashSet<>())
+                            configuration.resolvedConfiguration.lenientConfiguration.artifacts.each {
+                                pw.println("lenient-artifact:[${it.moduleVersion.id}][${it.name}:${it.classifier}:${it.extension}:${it.type}] (${it.id.componentIdentifier.displayName})")
+                            }
+                            configuration.resolvedConfiguration.lenientConfiguration.artifacts.each {
+                                writeFile("file-artifact-lenient-config", pw, it.file)
+                            }
+                        } catch (Exception ignored) {
+                            // We will emit the failure later when the the fields on the task are read.
+                        }
+
+                        pw.flush()
+                        stringWriter.toString()
+                    })
                 }
 
                 @TaskAction
@@ -226,6 +270,22 @@ class ResolveTestFixture {
                         lenientArtifactViewArtifacts.artifactFiles.each {
                             writeFile("lenient-artifact-view-artifact-file", writer, it)
                         }
+
+                        // ResolvedConfiguration and LenientConfiguration (captured during configuration)
+                        writer.print(configurationCacheUnsafeLines.get())
+                    }
+                }
+
+                protected void visitNodes(String prefix, Collection<ResolvedDependency> nodes, PrintWriter writer, Set<ResolvedDependency> visited) {
+                    for (ResolvedDependency node : nodes) {
+                        if (!visited.add(node)) {
+                            continue
+                        }
+                        writer.println(prefix + "-resolved-dependency:[${node.moduleGroup}:${node.moduleName}:${node.moduleVersion}]")
+                        for (ResolvedDependency child : node.children) {
+                            writer.println(prefix + "-resolved-dependency-edge:[${node.moduleGroup}:${node.moduleName}:${node.moduleVersion}]->[${child.moduleGroup}:${child.moduleName}:${child.moduleVersion}]")
+                        }
+                        visitNodes(prefix, node.children, writer, visited)
                     }
                 }
 
@@ -419,6 +479,53 @@ class ResolveTestFixture {
 
         actualFiles = findLines(configDetails, 'lenient-artifact-view-artifact-file')
         compare("artifactView.artifacts.artifactFiles (lenient)", actualFiles, expectedFiles)
+
+        // ResolvedConfiguration and LenientConfiguration checks
+        def expectedFirstLevel = root.deps.findAll { !it.constraint }.collect { d ->
+            "[${d.selected.moduleVersionId}]"
+        } as Set
+
+        def actualFirstLevel = findLines(configDetails, 'first-level') as Set
+        compare("first level dependencies", actualFirstLevel, expectedFirstLevel)
+
+        actualFirstLevel = findLines(configDetails, 'lenient-first-level') as Set
+        compare("lenient first level dependencies", actualFirstLevel, expectedFirstLevel)
+
+        def expectedResolvedDependencies = graph.nodesWithoutRoot.collect { "[${it.moduleVersionId}]".toString() } - graph.virtualConfigurations.collect { "[${it}]".toString() } as Set
+
+        def actualResolvedDeps = findLines(configDetails, 'resolved-resolved-dependency') as Set
+        compare("resolved dependencies in graph", actualResolvedDeps, expectedResolvedDependencies)
+
+        def expectedResolvedEdges = graph.edges
+            .findAll { !it.constraint && it.from != root }
+            .collect { "[${it.from.moduleVersionId}]->[${it.selected.moduleVersionId}]" } as Set
+
+        def actualResolvedEdges = findLines(configDetails, 'resolved-resolved-dependency-edge')
+            .findAll() { !it.contains("[${root.moduleVersionId}]->[") } as Set
+        compare("resolved dependency edges", actualResolvedEdges, expectedResolvedEdges)
+
+        def actualLenientResolvedDeps = findLines(configDetails, 'lenient-resolved-dependency') as Set
+        compare("lenient resolved dependencies in graph", actualLenientResolvedDeps, expectedResolvedDependencies)
+
+        def actualLenientResolvedEdges = findLines(configDetails, 'lenient-resolved-dependency-edge')
+            .findAll() { !it.contains("[${root.moduleVersionId}]->[") } as Set
+        compare("lenient resolved dependency edges", actualLenientResolvedEdges, expectedResolvedEdges)
+
+        def expectedLegacyArtifacts = graph.artifactNodes.collect { "[${it.moduleVersionId}][${it.legacyArtifactName}] (${it.componentId})" }
+
+        actualArtifacts = findLines(configDetails, 'artifact')
+        compare("artifacts", actualArtifacts, expectedLegacyArtifacts)
+
+        actualArtifacts = findLines(configDetails, 'lenient-artifact')
+        compare("lenient artifacts", actualArtifacts, expectedLegacyArtifacts)
+
+        def expectedArtifactOnlyFiles = graph.artifactNodes.collect { it.fileName }
+
+        actualFiles = findLines(configDetails, 'file-artifact-resolved-config')
+        compare("resolved configuration artifact files", actualFiles, expectedArtifactOnlyFiles)
+
+        actualFiles = findLines(configDetails, 'file-artifact-lenient-config')
+        compare("lenient configuration artifact files", actualFiles, expectedArtifactOnlyFiles)
     }
 
     List<String> findLines(List<String> lines, String prefix) {


### PR DESCRIPTION
Update artifact resolution to produce exactly one artifact set per node in the graph, simplifying the model for storing "artifact graph" data. 

Additionally, we restore `ResolveTestFixture` support for `ResolvedConfiguration` and `LenientConfiguration`, which was removed in a prior commit, as this test coverage is important for verifying the correctness of these changes.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
