### PR TITLE
Upgrade Dokka from 2.0.0 to 2.2.0

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/KotlinDslReference.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/KotlinDslReference.java
@@ -30,8 +30,8 @@ public abstract class KotlinDslReference {
     public abstract DirectoryProperty getRenderedDocumentation();
 
     /**
-     * The Dokka version to use instead the default one Dokkatoo is configured with.
-     * Will use the Dokkatoo default, if not specified.
+     * The Dokka version to use instead of the default one the Dokka Gradle Plugin is configured with.
+     * Will use the Dokka default, if not specified.
      */
     public abstract Property<String> getDokkaVersionOverride();
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,8 +34,16 @@ systemProp.dependency.analysis.test.analysis=false
 # Informs BuildCommitDistribution task that the current commit can be built with CC enabled
 buildCommitDistribution.gradleModeCompatibility=CC
 
+# Dokka 2.2.0 DGPv2 is the default, but the plugin still looks up these properties dynamically.
+# Setting them here avoids cross-project property lookups that break isolated projects.
+# https://github.com/Kotlin/dokka/issues/4488
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+org.jetbrains.dokka.experimental.gradle.pluginMode.nowarn=true
+org.jetbrains.dokka.experimental.tryK2=true
+org.jetbrains.dokka.experimental.tryK2.noWarn=true
+org.jetbrains.dokka.experimental.tryK2.nowarn=true
+org.jetbrains.dokka.internal.enableWorkaroundKT80551=true
 
 # workaround until the Shadow plugin fixes IP violation in the develocity integration area
 # https://github.com/GradleUp/shadow/issues/1835

--- a/gradle/dependency-management/build.versions.toml
+++ b/gradle/dependency-management/build.versions.toml
@@ -21,7 +21,7 @@ detektPlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", ve
 develocityConventions = { module = "io.github.gradle.develocity-conventions-plugin:io.github.gradle.develocity-conventions-plugin.gradle.plugin", version = "0.14.1" }
 develocityPlugin = { module = "com.gradle.develocity:com.gradle.develocity.gradle.plugin", version.ref = "develocity" }
 docbook = { module = "net.sf.docbook:docbook-xsl", version = "1.75.2" }
-dokkaPlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.0.0" }
+dokkaPlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.2.0" }
 errorProne = { module = "com.google.errorprone:error_prone_core", version.ref = "errorProne" }
 errorPronePlugin = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version = "4.1.0" }
 flexmark = { module = "com.vladsch.flexmark:flexmark-all", version = "0.34.60" } # Higher versions tested are either incompatible (0.62.2) or bring additional unwanted dependencies (0.36.8)

--- a/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/testing/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -39,7 +39,7 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getDistributionSizeMiB() {
-        return 230
+        return 231
     }
 
     @Requires(TestEnvironmentPreconditions.StableGroovy) // cannot link to public javadocs of Groovy snapshots like https://docs.groovy-lang.org/docs/groovy-4.0.5-SNAPSHOT/html/gapi/


### PR DESCRIPTION
Bump the Dokka Gradle Plugin used to generate the Kotlin DSL Reference to 2.2.0 to pick up K2 analysis fixes, HTML output refinements, and compatibility improvements.

DGPv2 and K2 analysis are the default since Dokka 2.1.0, so the corresponding opt-in properties are no longer strictly required. However, Dokka 2.2.0 still looks them up dynamically at plugin application time, which conflicts with isolated projects. Keep the existing properties and add the missing variants (nowarn casing, tryK2 family, internal.enableWorkaroundKT80551) so the lookups resolve locally in each project rather than falling through to the parent. See https://github.com/Kotlin/dokka/issues/4488

Also fix a stale "Dokkatoo" reference in KotlinDslReference Javadoc.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
