### PR TITLE
Skip lint error stacktrace in Android lint smoke test

### DIFF
--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidProjectSmokeTest.groovy
@@ -100,6 +100,7 @@ class AndroidProjectLintSmokeTest extends AndroidProjectSmokeTest {
         // Use --continue so that a deterministic set of tasks runs when some tasks fail
         runner.withArguments(runner.arguments + "--continue")
         def result = runner
+            .ignoreStackTraces("Android Lint may log stack traces when computing SARIF quick-fix edits fails")
             .deprecations(AndroidProjectDeprecations) {
                 expectMultiStringNotationDeprecation(agpVersion)
                 expectProjectDependencyNotationDeprecation()
@@ -117,6 +118,7 @@ class AndroidProjectLintSmokeTest extends AndroidProjectSmokeTest {
             checkoutDir, agpVersion, "app:lint", "-Dandroid.lintWarningsAsErrors=true"
         )
         result = runner.withArguments(runner.arguments + "--continue")
+                .ignoreStackTraces("Android Lint may log stack traces when computing SARIF quick-fix edits fails")
                 .deprecations(AndroidProjectDeprecations) {}
                 .buildAndFail()
 


### PR DESCRIPTION
### Context

Since AGP 9.0.1, we saw such a stacktrace in Android lint smoke test:

```
Couldn't compute fix edits for null
java.lang.StringIndexOutOfBoundsException: begin 131, end 143, length 0
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4606)
        ....
	at java.base/java.lang.Thread.run(Thread.java:840)
```

Ignoring the stacktrace doesn't affect the test result.
