### PR TITLE
Prune DCL schema building failures

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/DefaultAnalysisSchema.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/analysis/DefaultAnalysisSchema.kt
@@ -46,6 +46,7 @@ import org.gradle.declarative.dsl.schema.UnsafeNonAbstractMember
 import org.gradle.declarative.dsl.schema.UnsafeNonInterfaceType
 import org.gradle.declarative.dsl.schema.VarargParameter
 import org.gradle.internal.declarativedsl.language.DataTypeInternal
+import kotlin.reflect.KClass
 
 @Serializable
 @SerialName("analysisSchema")
@@ -448,6 +449,8 @@ data class DefaultProjectFeatureAccessorIdentifier(
 @Serializable
 data class DefaultFqName(override val packageName: String, override val simpleName: String) : FqName {
     companion object {
+        fun of(kClass: KClass<*>) = parse(kClass.java.canonicalName.orEmpty())
+
         fun parse(fqNameString: String): FqName {
             val parts = fqNameString.split(".")
             return DefaultFqName(parts.dropLast(1).joinToString("."), parts.last())

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/DataSchemaBuilder.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/DataSchemaBuilder.kt
@@ -50,6 +50,7 @@ import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.Discovered
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass.DiscoveryTag.ProjectFeatureDefinition
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass.DiscoveryTag.Supertype
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.collections.mutableSetOf
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
@@ -65,8 +66,8 @@ import kotlin.reflect.typeOf
 interface SchemaBuildingHost {
     val topLevelReceiverClass: KClass<*>
 
-    val typeFailures: Iterable<SchemaResult.Failure>
-    fun recordTypeFailure(failure: SchemaResult.Failure)
+    val typeFailures: Map<FqName, Set<SchemaResult.Failure>>
+    fun recordTypeDiscoveryFailure(inTypeByName: FqName, failure: SchemaResult.Failure)
 
     fun recordClaimedMember(kClass: KClass<*>, member: SupportedCallable)
     fun recordMemberWithFailure(kClass: KClass<*>, member: SupportedCallable, failure: SchemaResult.Failure)
@@ -189,12 +190,12 @@ class DefaultSchemaBuildingHost(override val topLevelReceiverClass: KClass<*>) :
     private val claimedMembers = mutableMapOf<KClass<*>, MutableSet<SupportedCallable>>()
     private val failedMembers = mutableMapOf<KClass<*>, MutableMap<SupportedCallable, MutableList<SchemaResult.Failure>>>()
 
-    private val mutableTypeFailures = mutableListOf<SchemaResult.Failure>()
+    private val mutableTypeFailures = mutableMapOf<FqName, MutableSet<SchemaResult.Failure>>()
 
-    override val typeFailures: Iterable<SchemaResult.Failure> get() = mutableTypeFailures.toList()
+    override val typeFailures: Map<FqName, Set<SchemaResult.Failure>> get() = mutableTypeFailures.toMap()
 
-    override fun recordTypeFailure(failure: SchemaResult.Failure) {
-        mutableTypeFailures += failure
+    override fun recordTypeDiscoveryFailure(inTypeByName: FqName, failure: SchemaResult.Failure) {
+        mutableTypeFailures.getOrPut(inTypeByName) { mutableSetOf() } += failure
     }
 
     override fun recordClaimedMember(kClass: KClass<*>, member: SupportedCallable) {
@@ -437,7 +438,7 @@ class DataSchemaBuilder(
         preIndex: PreIndex,
         schema: DefaultAnalysisSchema,
     ): List<SchemaResult.Failure> = buildSet {
-        addAll(host.typeFailures)
+        addAll(host.typeFailures.values.flatten())
 
         addAll(checkDiscoveredTypeForIllegalHiddenTypeUsages(host, preIndex.allDiscoveredTypes))
 
@@ -590,11 +591,13 @@ class DataSchemaBuilder(
                 if (add(type)) {
                     val discoveriesToVisitNext = typeDiscovery.getClassesToVisitFrom(typeDiscoveryServices, type)
 
-                    allTypeDiscoveries.addAll(discoveriesToVisitNext.filterIsInstance<SchemaResult.Result<DiscoveredClass>>().map { it.result })
-                    discoveriesToVisitNext.filterIsInstance<SchemaResult.Failure>().forEach(host::recordTypeFailure)
+                    allTypeDiscoveries.addAll(discoveriesToVisitNext.filterIsInstance<ExtractedType>().map { it.result })
+                    discoveriesToVisitNext.filterIsInstance<TypeDiscoveryFailure>().forEach { failure ->
+                        host.recordTypeDiscoveryFailure(failure.metadata, failure.failure)
+                    }
 
                     discoveriesToVisitNext.forEach {
-                        if (it is SchemaResult.Result && !it.result.isHidden) {
+                        if (it is ExtractedType && !it.result.isHidden) {
                             visit(it.result.kClass)
                         }
                     }

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/DataSchemaBuilder.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/DataSchemaBuilder.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.declarativedsl.schemaBuilder
 
-import org.gradle.declarative.dsl.evaluation.SchemaBuildingFailure
 import org.gradle.declarative.dsl.schema.AnalysisSchema
 import org.gradle.declarative.dsl.schema.DataClass
 import org.gradle.declarative.dsl.schema.DataConstructor
@@ -163,6 +162,8 @@ object SchemaBuildingTags {
                 featureNames.joinToString { "'$it'" } + if (pluginId != null) " (plugin '${pluginId}')" else ""
             }
     )
+
+    fun erroneousTypes(typeNames: Set<String>) = TagContextElement("types that are only used in other erroneous types: ${typeNames.joinToString(limit = 3) { "'$it'" }}")
 }
 
 inline fun <R> SchemaBuildingHost.inContextOf(contextElement: SchemaBuildingContextElement, doBuildSchema: () -> R): R =
@@ -426,9 +427,10 @@ class DataSchemaBuilder(
 
         validateSchemaInvariants(host, schema)
 
+        val allFailures = collectSchemaBuildingFailures(host, preIndex, schema)
         schemaBuildingFailureReporter.report(
             schema,
-            collectSchemaBuildingFailures(host, preIndex, schema).values.flatten().map { it.asReportableFailure() }
+            pruneSchemaBuildingFailures(host, preIndex.allDiscoveredTypes, allFailures).map { it.asReportableFailure() }
         )
 
         return schema
@@ -439,8 +441,14 @@ class DataSchemaBuilder(
         preIndex: PreIndex,
         schema: DefaultAnalysisSchema,
     ): Map<FqName, Set<SchemaResult.Failure>> = buildMap<FqName, MutableSet<SchemaResult.Failure>> {
-        fun addAll(fqName: FqName, failures: Iterable<SchemaResult.Failure>) { getOrPut(fqName) { mutableSetOf() } += failures }
-        fun add(fqName: FqName, failure: SchemaResult.Failure) { getOrPut(fqName) { mutableSetOf() } += failure }
+        fun addAll(fqName: FqName, failures: Iterable<SchemaResult.Failure>) {
+            if (failures.any())
+                getOrPut(fqName) { mutableSetOf() } += failures
+        }
+
+        fun add(fqName: FqName, failure: SchemaResult.Failure) {
+            getOrPut(fqName) { mutableSetOf() } += failure
+        }
 
         host.typeFailures.forEach { (name, failures) -> addAll(name, failures) }
 
@@ -448,7 +456,7 @@ class DataSchemaBuilder(
             addAll(DefaultFqName.of(kClass), failures)
         }
 
-        checkSafeTypeRequirements(schema, host).forEach { name, failures ->
+        checkSafeTypeRequirements(schema, host).forEach { (name, failures) ->
             addAll(name, failures)
         }
 
@@ -648,7 +656,7 @@ class DataSchemaBuilder(
 
                 val illegalUsages = discoveries.filterNot { it.isHidden }
                     .map { it.discoveryTag }
-                    .filter { it !is Supertype || it.ofType != kClass } // Filter out the self-appearance in the type hierarchy
+                    .filter { it !is Supertype || it.fromClass != kClass } // Filter out the self-appearance in the type hierarchy
 
                 listOf(host.schemaBuildingFailure(SchemaBuildingIssue.HiddenTypeUsedInDeclaration(kClass, hiddenBecause, illegalUsages)))
             } else emptyList()

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/DataSchemaBuilder.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/DataSchemaBuilder.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.declarativedsl.schemaBuilder
 
+import org.gradle.declarative.dsl.evaluation.SchemaBuildingFailure
 import org.gradle.declarative.dsl.schema.AnalysisSchema
 import org.gradle.declarative.dsl.schema.DataClass
 import org.gradle.declarative.dsl.schema.DataConstructor
@@ -427,7 +428,7 @@ class DataSchemaBuilder(
 
         schemaBuildingFailureReporter.report(
             schema,
-            collectSchemaBuildingFailures(host, preIndex, schema).map { it.asReportableFailure() }
+            collectSchemaBuildingFailures(host, preIndex, schema).values.flatten().map { it.asReportableFailure() }
         )
 
         return schema
@@ -437,12 +438,19 @@ class DataSchemaBuilder(
         host: SchemaBuildingHost,
         preIndex: PreIndex,
         schema: DefaultAnalysisSchema,
-    ): List<SchemaResult.Failure> = buildSet {
-        addAll(host.typeFailures.values.flatten())
+    ): Map<FqName, Set<SchemaResult.Failure>> = buildMap<FqName, MutableSet<SchemaResult.Failure>> {
+        fun addAll(fqName: FqName, failures: Iterable<SchemaResult.Failure>) { getOrPut(fqName) { mutableSetOf() } += failures }
+        fun add(fqName: FqName, failure: SchemaResult.Failure) { getOrPut(fqName) { mutableSetOf() } += failure }
 
-        addAll(checkDiscoveredTypeForIllegalHiddenTypeUsages(host, preIndex.allDiscoveredTypes))
+        host.typeFailures.forEach { (name, failures) -> addAll(name, failures) }
 
-        addAll(checkSafeTypeRequirements(schema, host))
+        checkDiscoveredTypeForIllegalHiddenTypeUsages(host, preIndex.allDiscoveredTypes).forEach { (kClass, failures) ->
+            addAll(DefaultFqName.of(kClass), failures)
+        }
+
+        checkSafeTypeRequirements(schema, host).forEach { name, failures ->
+            addAll(name, failures)
+        }
 
         preIndex.types.forEach { type ->
             if (schema.dataClassTypesByFqName[type.fqName] == null) {
@@ -454,14 +462,14 @@ class DataSchemaBuilder(
             host.classMembers(type).run {
                 membersBySupertype.values.flatten().forEach { member ->
                     if (member is ExtractionResult.Failure) {
-                        add(member.failure)
+                        add(DefaultFqName.of(type), member.failure)
                     }
                 }
                 declarativeMembers.forEach { potentiallyDeclarative ->
                     if (host.isUnusedMember(type, potentiallyDeclarative)) {
                         host.inContextOfModelClass(type) {
                             host.inContextOfModelMember(potentiallyDeclarative.kCallable) {
-                                add(host.schemaBuildingFailure(SchemaBuildingIssue.UnrecognizedMember()))
+                                add(DefaultFqName.of(type), host.schemaBuildingFailure(SchemaBuildingIssue.UnrecognizedMember()))
                             }
                         }
                     }
@@ -469,10 +477,10 @@ class DataSchemaBuilder(
             }
 
             host.membersWithFailures(type).forEach { (_, failures) ->
-                addAll(failures)
+                addAll(DefaultFqName.of(type), failures)
             }
         }
-    }.toList()
+    }
 
     private fun validateSchemaInvariants(host: SchemaBuildingHost, schema: AnalysisSchema) {
         checkAllTypesInScope(host, schema)
@@ -632,8 +640,8 @@ class DataSchemaBuilder(
     private fun checkDiscoveredTypeForIllegalHiddenTypeUsages(
         host: SchemaBuildingHost,
         allDiscoveries: Set<DiscoveredClass>
-    ): List<SchemaResult.Failure> =
-        allDiscoveries.groupBy { it.kClass }.entries.mapNotNull { (kClass, discoveries) ->
+    ): Map<KClass<*>, List<SchemaResult.Failure>> =
+        allDiscoveries.groupBy { it.kClass }.mapValues { (kClass, discoveries) ->
             if (!isIgnoredInVisibilityChecks(kClass) && discoveries.any { it.isHidden } && discoveries.any { !it.isHidden }) {
                 val hiddenBecause = discoveries.filter { it.isHidden }
                     .map { it.discoveryTag }
@@ -642,8 +650,8 @@ class DataSchemaBuilder(
                     .map { it.discoveryTag }
                     .filter { it !is Supertype || it.ofType != kClass } // Filter out the self-appearance in the type hierarchy
 
-                host.schemaBuildingFailure(SchemaBuildingIssue.HiddenTypeUsedInDeclaration(kClass, hiddenBecause, illegalUsages))
-            } else null
+                listOf(host.schemaBuildingFailure(SchemaBuildingIssue.HiddenTypeUsedInDeclaration(kClass, hiddenBecause, illegalUsages)))
+            } else emptyList()
         }
 
     /**

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/DefinitionSafetyChecks.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/DefinitionSafetyChecks.kt
@@ -22,6 +22,7 @@ import com.google.common.graph.Graphs
 import com.google.common.graph.Traverser
 import org.gradle.declarative.dsl.schema.AnalysisSchema
 import org.gradle.declarative.dsl.schema.DataClass
+import org.gradle.declarative.dsl.schema.FqName
 import org.gradle.declarative.dsl.schema.FunctionSemantics
 import org.gradle.declarative.dsl.schema.ProjectFeatureOrigin
 import org.gradle.declarative.dsl.schema.SchemaMemberFunction
@@ -32,7 +33,7 @@ import org.gradle.internal.declarativedsl.schemaBuilder.SchemaBuildingContextEle
 internal fun checkSafeTypeRequirements(
     schema: AnalysisSchema,
     host: SchemaBuildingHost
-): List<SchemaResult.Failure> = buildList {
+): Map<FqName, List<SchemaResult.Failure>> {
     val safeFeatureDefinitionsByDefinitionClass = schema.dataClassTypesByFqName.values
         .filterIsInstance<DataClass>()
         .filter { type -> type.metadata.any { it is ProjectFeatureOrigin && it.isSafeDefinition } }
@@ -55,7 +56,9 @@ internal fun checkSafeTypeRequirements(
 
     val usedIn = Graphs.transpose(reachabilityViaMembers)
 
-    safelyUsedClasses.forEach { reportUnsafeDeclarationsInSafelyUsedClass(host, it, usedIn) }
+    return safelyUsedClasses.associateWith {
+        buildList { reportUnsafeDeclarationsInSafelyUsedClass(host, it, usedIn) }
+    }.mapKeys { it.key.name }
 }
 
 internal fun ignoreSafeUsageOfUnsafeClass(classQualifiedName: String) = classQualifiedName.startsWith("org.gradle.api.")

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/FailuresPruning.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/FailuresPruning.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.declarativedsl.schemaBuilder
+
+import com.google.common.graph.GraphBuilder
+import com.google.common.graph.MutableGraph
+import com.google.common.graph.Traverser
+import org.gradle.declarative.dsl.schema.FqName
+import org.gradle.internal.declarativedsl.analysis.DefaultFqName
+import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass.DiscoveryTag.FromClassDiscoveryTag
+import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass.DiscoveryTag.ProjectFeatureDefinition
+import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass.DiscoveryTag.Special
+
+/**
+ * Filters out schema building failures reported in the types that are only used in other types having at least one failure.
+ *
+ * @return A list of failures only in the types that are used from the correct types
+ *   with an additional [org.gradle.declarative.dsl.evaluation.SchemaIssue.MoreFailuresInErroneousTypes] failure aggregating
+ *   the failures filtered out, if any.
+ */
+fun pruneSchemaBuildingFailures(
+    host: SchemaBuildingHost,
+    allTypeDiscoveries: Iterable<TypeDiscovery.DiscoveredClass>,
+    allFailures: Map<FqName, Iterable<SchemaResult.Failure>>
+): List<SchemaResult.Failure> {
+    if (allFailures.isEmpty())
+        return emptyList()
+
+    val usageFromCorrectTypesGraph = getUsageFromCorrectTypesGraph(allTypeDiscoveries, allFailures)
+
+    val reachabilitySource = allTypeDiscoveries.filter { it.isReachabilitySource() }
+        .mapTo(mutableSetOf(DefaultFqName.of(host.topLevelReceiverClass))) { DefaultFqName.of(it.kClass) }
+
+    val typesReachableViaCorrectTypes = Traverser.forGraph(usageFromCorrectTypesGraph).breadthFirst(reachabilitySource).toSet()
+
+    val otherErroneousTypeNames = allFailures.keys - typesReachableViaCorrectTypes
+
+    return allFailures.filterKeys { it in typesReachableViaCorrectTypes }.values.flatten() +
+        if (otherErroneousTypeNames.isNotEmpty()) {
+            aggregateOmittedFailures(host, otherErroneousTypeNames, allFailures, typesReachableViaCorrectTypes)
+        } else emptyList()
+}
+
+private fun getUsageFromCorrectTypesGraph(
+    allTypeDiscoveries: Iterable<TypeDiscovery.DiscoveredClass>,
+    allFailures: Map<FqName, Iterable<SchemaResult.Failure>>
+): MutableGraph<FqName> = GraphBuilder.directed().build<FqName>().apply {
+    allTypeDiscoveries.forEach { typeDiscovery ->
+        val to = DefaultFqName.of(typeDiscovery.kClass)
+            .also(::addNode)
+
+        if (typeDiscovery.discoveryTag is FromClassDiscoveryTag) {
+            val from = DefaultFqName.of(typeDiscovery.discoveryTag.fromClass)
+                .also(::addNode)
+            if (from !in allFailures && to != from) {
+                putEdge(from, to)
+            }
+        }
+    }
+}
+
+private fun aggregateOmittedFailures(
+    host: SchemaBuildingHost,
+    otherErroneousTypeNames: Set<FqName>,
+    allFailures: Map<FqName, Iterable<SchemaResult.Failure>>,
+    typesReachableViaCorrectTypes: Set<FqName>
+): List<SchemaResult.Failure> = host.inIsolatedContext {
+    val otherErroneousTypeNameStrings = otherErroneousTypeNames.mapTo(mutableSetOf()) { it.qualifiedName }
+    listOf(
+        host.withTag(SchemaBuildingTags.erroneousTypes(otherErroneousTypeNameStrings)) {
+            host.schemaBuildingFailure(
+                SchemaBuildingIssue.MoreFailuresInErroneousTypes(
+                    otherErroneousTypeNameStrings,
+                    allFailures.filterKeys { it !in typesReachableViaCorrectTypes }.values.flatMap { it.map(SchemaResult.Failure::asReportableFailure) }
+                )
+            )
+        }
+    )
+}
+
+private fun TypeDiscovery.DiscoveredClass.isReachabilitySource() =
+    when (discoveryTag) {
+        is ProjectFeatureDefinition,
+        is Special -> true
+
+        else -> false
+    }

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/FailuresPruning.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/FailuresPruning.kt
@@ -86,7 +86,7 @@ private fun aggregateOmittedFailures(
 ): List<SchemaResult.Failure> = host.inIsolatedContext {
     val otherErroneousTypeNameStrings = otherErroneousTypeNames.mapTo(mutableSetOf()) { it.qualifiedName }
     listOf(
-        host.withTag(SchemaBuildingTags.erroneousTypes(otherErroneousTypeNameStrings)) {
+        host.withTag(SchemaBuildingTags.erroneousTypes(otherErroneousTypeNameStrings.toSortedSet())) {
             host.schemaBuildingFailure(
                 SchemaBuildingIssue.MoreFailuresInErroneousTypes(
                     otherErroneousTypeNameStrings,

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/FailuresPruning.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/FailuresPruning.kt
@@ -59,6 +59,11 @@ private fun getUsageFromCorrectTypesGraph(
     allTypeDiscoveries: Iterable<TypeDiscovery.DiscoveredClass>,
     allFailures: Map<FqName, Iterable<SchemaResult.Failure>>
 ): MutableGraph<FqName> = GraphBuilder.directed().build<FqName>().apply {
+    /**
+     * A feature definition type is never _accidentally_ added into a schema, so we still want error reports for all types directly referenced from the feature definition.
+     */
+    val featureDefinitions = allTypeDiscoveries.filter { it.discoveryTag is ProjectFeatureDefinition }.mapTo(mutableSetOf()) { DefaultFqName.of(it.kClass) }
+
     allTypeDiscoveries.forEach { typeDiscovery ->
         val to = DefaultFqName.of(typeDiscovery.kClass)
             .also(::addNode)
@@ -66,7 +71,7 @@ private fun getUsageFromCorrectTypesGraph(
         if (typeDiscovery.discoveryTag is FromClassDiscoveryTag) {
             val from = DefaultFqName.of(typeDiscovery.discoveryTag.fromClass)
                 .also(::addNode)
-            if (from !in allFailures && to != from) {
+            if ((from in featureDefinitions || from !in allFailures) && to != from) {
                 putEdge(from, to)
             }
         }

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/MemberTypeDiscovery.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/MemberTypeDiscovery.kt
@@ -26,7 +26,7 @@ class FunctionLambdaTypeDiscovery(
      * Collect everything that potentially looks like types configured by the lambdas.
      * TODO: this may be excessive
      */
-    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<DiscoveredClass>> =
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
         typeDiscoveryServices.host.classMembers(kClass).declarativeMembers
             .filter { it.kind == MemberKind.FUNCTION }
             .flatMapTo(mutableSetOf()) { fn ->
@@ -35,7 +35,7 @@ class FunctionLambdaTypeDiscovery(
                     ?.asSupported(typeDiscoveryServices.host)
                     ?.let {
                         if (it is SchemaResult.Result)
-                            DiscoveredClass.classesOf(it.result, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable)).map(::schemaResult)
+                            DiscoveredClass.classesOf(it.result, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable))
                         else emptyList()
                     }
                     ?: emptyList()
@@ -46,10 +46,10 @@ class FunctionReturnTypeDiscovery : TypeDiscovery {
     /**
      * Collects everything that restricted functions mention as return values.
      */
-    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<DiscoveredClass>> =
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
         typeDiscoveryServices.host.classMembers(kClass).declarativeMembers
             .flatMapTo(mutableSetOf()) { fn ->
-                DiscoveredClass.classesOf(fn.returnType, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable)).map(::schemaResult)
+                DiscoveredClass.classesOf(fn.returnType, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable))
             }
 }
 
@@ -57,11 +57,11 @@ class FunctionParameterTypeDiscovery : TypeDiscovery {
     /**
      * Collects everything that restricted functions mention as return values.
      */
-    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<DiscoveredClass>> =
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
         typeDiscoveryServices.host.classMembers(kClass).declarativeMembers
             .flatMapTo(mutableSetOf()) { fn ->
                 fn.parameters.flatMap {
-                    DiscoveredClass.classesOf(it.type, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable)).map(::schemaResult)
+                    DiscoveredClass.classesOf(it.type, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable))
                 }
             }
 }

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/MemberTypeDiscovery.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/MemberTypeDiscovery.kt
@@ -35,7 +35,7 @@ class FunctionLambdaTypeDiscovery(
                     ?.asSupported(typeDiscoveryServices.host)
                     ?.let {
                         if (it is SchemaResult.Result)
-                            DiscoveredClass.classesOf(it.result, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable))
+                            DiscoveredClass.classesOf(it.result, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable, kClass))
                         else emptyList()
                     }
                     ?: emptyList()
@@ -49,7 +49,7 @@ class FunctionReturnTypeDiscovery : TypeDiscovery {
     override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
         typeDiscoveryServices.host.classMembers(kClass).declarativeMembers
             .flatMapTo(mutableSetOf()) { fn ->
-                DiscoveredClass.classesOf(fn.returnType, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable))
+                DiscoveredClass.classesOf(fn.returnType, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable, kClass))
             }
 }
 
@@ -61,7 +61,7 @@ class FunctionParameterTypeDiscovery : TypeDiscovery {
         typeDiscoveryServices.host.classMembers(kClass).declarativeMembers
             .flatMapTo(mutableSetOf()) { fn ->
                 fn.parameters.flatMap {
-                    DiscoveredClass.classesOf(it.type, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable))
+                    DiscoveredClass.classesOf(it.type, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable, kClass))
                 }
             }
 }

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/MemberTypeDiscovery.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/MemberTypeDiscovery.kt
@@ -42,7 +42,7 @@ class FunctionLambdaTypeDiscovery(
                 }
 }
 
-class FunctionReturnTypeDiscovery : TypeDiscovery {
+class FunctionReturnTypeDiscovery(private val typeFilter: (KClass<*>) -> Boolean) : TypeDiscovery {
     /**
      * Collects everything that restricted functions mention as return values.
      */
@@ -50,7 +50,7 @@ class FunctionReturnTypeDiscovery : TypeDiscovery {
         typeDiscoveryServices.host.classMembers(kClass).declarativeMembers
             .flatMapTo(mutableSetOf()) { fn ->
                 DiscoveredClass.classesOf(fn.returnType, DiscoveredClass.DiscoveryTag.UsedInMember(fn.kCallable, kClass))
-            }
+            }.filter { it !is ExtractionResult.Extracted || typeFilter(it.result.kClass) }
 }
 
 class FunctionParameterTypeDiscovery : TypeDiscovery {

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/SchemaResult.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/SchemaResult.kt
@@ -163,6 +163,11 @@ sealed interface SchemaBuildingIssue {
         override val usedInSafeFeatures: List<ProjectFeatureOrigin>,
         override val unsafeApiCause: UnsafeSchemaItem
     ) : SchemaBuildingIssue, SchemaIssue.UnsafeDeclarationInSafeFeatureApi
+
+    class MoreFailuresInErroneousTypes(
+        override val typeNames: Set<String>,
+        override val issues: List<SchemaBuildingFailure>
+    ) : SchemaIssue.MoreFailuresInErroneousTypes
 }
 
 object SchemaFailureMessageFormatter {
@@ -212,6 +217,7 @@ object SchemaFailureMessageFormatter {
                 is UnsafeBecauseHasNonPublicMembers -> ": non-public member${if (cause.memberNames.size > 1) "s" else ""} ${cause.memberNames.joinToString(limit = 3) { "'$it'" }}"
                 else -> ""
             }
+            is SchemaBuildingIssue.MoreFailuresInErroneousTypes -> "More failures that are not reported now"
             else -> "Schema issue: $schemaIssue"
         }
 
@@ -219,9 +225,9 @@ object SchemaFailureMessageFormatter {
 
 private fun discoveryTagDescription(tag: DiscoveryTag, violatingClass: KClass<*>): String = when (tag) {
     is ContainerElement -> "as the element of a container '${tag.containerMember}'"
-    is PropertyType -> "as the property type of '${tag.kClass.qualifiedName}.${tag.propertyName}'"
-    is Supertype -> if (tag.ofType == violatingClass && tag.isHidden) "type '${violatingClass.qualifiedName}' is annotated as hidden" else
-        "in the supertypes of '${tag.ofType.qualifiedName}'"
+    is PropertyType -> "as the property type of '${tag.fromClass.qualifiedName}.${tag.propertyName}'"
+    is Supertype -> if (tag.fromClass == violatingClass && tag.isHidden) "type '${violatingClass.qualifiedName}' is annotated as hidden" else
+        "in the supertypes of '${tag.fromClass.qualifiedName}'"
 
     is UsedInMember -> "referenced from member '${tag.member}'"
     is DiscoveryTag.ProjectFeatureDefinition -> "definition of project feature '${tag.featureData.featureName}'"

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/SchemaResult.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/SchemaResult.kt
@@ -213,8 +213,8 @@ object SchemaFailureMessageFormatter {
                 is UnsafeInjectProperty -> ": injected service property"
                 is UnsafeJavaBeanProperty -> ": unsafe property"
                 is UnsafeNonPureFunction -> ": function relying on side effects or custom implementation"
-                is UnsafeBecauseHasHiddenMembers -> ": hidden member${if (cause.memberNames.size > 1) "s" else ""} ${cause.memberNames.joinToString(limit = 3) { "'$it'" }}"
-                is UnsafeBecauseHasNonPublicMembers -> ": non-public member${if (cause.memberNames.size > 1) "s" else ""} ${cause.memberNames.joinToString(limit = 3) { "'$it'" }}"
+                is UnsafeBecauseHasHiddenMembers -> ": hidden member${if (cause.memberNames.size > 1) "s" else ""} ${cause.memberNames.sorted().joinToString(limit = 3) { "'$it'" }}"
+                is UnsafeBecauseHasNonPublicMembers -> ": non-public member${if (cause.memberNames.size > 1) "s" else ""} ${cause.memberNames.sorted().joinToString(limit = 3) { "'$it'" }}"
                 else -> ""
             }
             is SchemaBuildingIssue.MoreFailuresInErroneousTypes -> "More failures that are not reported now"

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/SupertypeDiscovery.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/SupertypeDiscovery.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.declarativedsl.schemaBuilder
 
+import org.gradle.internal.declarativedsl.analysis.DefaultFqName
 import kotlin.reflect.KClass
 
 /**
@@ -25,23 +26,25 @@ import kotlin.reflect.KClass
 class SupertypeDiscovery(
     val isBuildModelType: (KClass<*>) -> Boolean = { false }
 ) : TypeDiscovery {
-    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<TypeDiscovery.DiscoveredClass>> =
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
         withAllPotentiallyDeclarativeSupertypes(typeDiscoveryServices.host, kClass)
-            .filter { it !is SchemaResult.Result || !isBuildModelType(it.result.kClass) }
+            .filter { it !is ExtractionResult.Extracted || !isBuildModelType(it.result.kClass) }
 }
 
-internal fun withAllPotentiallyDeclarativeSupertypes(host: SchemaBuildingHost, kClass: KClass<*>): Iterable<SchemaResult<TypeDiscovery.DiscoveredClass>> =
+internal fun withAllPotentiallyDeclarativeSupertypes(host: SchemaBuildingHost, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
     host.declarativeSupertypesHierarchy(kClass).flatMap { result ->
         when (result) {
             is MaybeDeclarativeClassInHierarchy.VisibleSuperclassInHierarchy, is MaybeDeclarativeClassInHierarchy.HiddenSuperclassInHierarchy -> {
                 val isHidden = result is MaybeDeclarativeClassInHierarchy.HiddenSuperclassInHierarchy
                 val tag = TypeDiscovery.DiscoveredClass.DiscoveryTag.Supertype(kClass, isHidden = isHidden)
 
-                listOf(schemaResult(TypeDiscovery.DiscoveredClass(result.superClass, tag))) +
-                    if (!isHidden) result.typeVariableAssignments.values.flatMap { TypeDiscovery.DiscoveredClass.classesOf(it, tag).map(::schemaResult) }
-                    else emptyList()
+                listOf(
+                    TypeDiscovery.DiscoveredClass(result.superClass, tag).extracted()
+                ) + if (!isHidden)
+                    result.typeVariableAssignments.values.flatMap { TypeDiscovery.DiscoveredClass.classesOf(it, tag) }
+                else emptyList()
             }
 
-            is MaybeDeclarativeClassInHierarchy.NonDeclarativeSuperclassInHierarchy -> listOf(result.reason)
+            is MaybeDeclarativeClassInHierarchy.NonDeclarativeSuperclassInHierarchy -> listOf(ExtractionResult.Failure(result.reason, DefaultFqName.of(result.superClass)))
         }
     }

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/TypeDiscovery.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/TypeDiscovery.kt
@@ -54,18 +54,22 @@ interface TypeDiscovery {
             get() = discoveryTag.isHidden
 
         sealed interface DiscoveryTag {
+            sealed interface FromClassDiscoveryTag : DiscoveryTag {
+                val fromClass: KClass<*>
+            }
+
             val isHidden: Boolean
 
-            data class Supertype(val ofType: KClass<*>, override val isHidden: Boolean) : DiscoveryTag
-            data class ContainerElement(val containerMember: KCallable<*>) : DiscoveryTag {
+            data class Supertype(override val fromClass: KClass<*>, override val isHidden: Boolean) : FromClassDiscoveryTag
+            data class ContainerElement(override val fromClass: KClass<*>, val containerMember: KCallable<*>) : FromClassDiscoveryTag {
                 override val isHidden = false
             }
 
-            data class UsedInMember(val member: KCallable<*>) : DiscoveryTag {
+            data class UsedInMember(val member: KCallable<*>, override val fromClass: KClass<*>) : FromClassDiscoveryTag {
                 override val isHidden = false
             }
 
-            data class PropertyType(val kClass: KClass<*>, val propertyName: String) : DiscoveryTag {
+            data class PropertyType(override val fromClass: KClass<*>, val propertyName: String) : FromClassDiscoveryTag {
                 override val isHidden = false
             }
 

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/TypeDiscovery.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/TypeDiscovery.kt
@@ -16,18 +16,30 @@
 
 package org.gradle.internal.declarativedsl.schemaBuilder
 
+import org.gradle.declarative.dsl.schema.FqName
 import org.gradle.declarative.dsl.schema.ProjectFeatureOrigin
+import org.gradle.internal.declarativedsl.analysis.DefaultFqName
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 
+/**
+ * A type discovery result is either a [DiscoveredClass] tag or a failure, in either case accompanied by an [FqName] of the type
+ * being discovered.
+ */
+typealias TypeDiscoveryResult = ExtractionResult<DiscoveredClass, FqName>
+typealias ExtractedType = ExtractionResult.Extracted<DiscoveredClass, FqName>
+typealias TypeDiscoveryFailure = ExtractionResult.Failure<FqName>
+
+fun DiscoveredClass.extracted(): ExtractedType =
+    ExtractedType(this, DefaultFqName.of(kClass))
 
 interface TypeDiscovery {
     /**
      * Given a [kClass] that is included in the schema, produces [DiscoveredClass] entries for other classes reachable from the [kClass] that should be
      * considered for inclusionn into the schema. The returned [DiscoveredClass] entries might have non-unique [DiscoveredClass.kClass] values.
      */
-    fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<DiscoveredClass>>
+    fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult>
 
     interface TypeDiscoveryServices {
         val host: SchemaBuildingHost
@@ -67,7 +79,7 @@ interface TypeDiscovery {
         }
 
         companion object {
-            fun classesOf(kType: SupportedTypeProjection.SupportedType, discoveryTag: DiscoveryTag): Iterable<DiscoveredClass> =
+            fun classesOf(kType: SupportedTypeProjection.SupportedType, discoveryTag: DiscoveryTag): Iterable<TypeDiscoveryResult> =
                 buildSet {
                     fun visitType(type: SupportedTypeProjection.SupportedType) { // safe to recurse without the visited set: the types are deconstructed to smaller types
                         (type.classifier as? KClass<*>)?.let(::add)
@@ -80,26 +92,27 @@ interface TypeDiscovery {
                         }
                     }
                     visitType(kType)
-                }.map { DiscoveredClass(it, discoveryTag) }
+                }.map { ExtractionResult.Extracted(DiscoveredClass(it, discoveryTag), DefaultFqName.parse(it.qualifiedName.orEmpty())) }
         }
     }
 
     companion object {
         val none = object : TypeDiscovery {
-            override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<DiscoveredClass>> = emptyList()
+            override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> = emptyList()
         }
     }
 }
 
 
 class CompositeTypeDiscovery(internal val implementations: Iterable<TypeDiscovery>) : TypeDiscovery {
-    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<DiscoveredClass>> =
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
         implementations.flatMap { it.getClassesToVisitFrom(typeDiscoveryServices, kClass) }
 }
 
 class FilteringTypeDiscovery(private val delegate: TypeDiscovery, val typeFilter: (KClass<*>) -> Boolean) : TypeDiscovery {
-    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<DiscoveredClass>> =
-        if (typeFilter(kClass)) delegate.getClassesToVisitFrom(typeDiscoveryServices, kClass).filter { it !is SchemaResult.Result || typeFilter(it.result.kClass) } else emptyList()
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
+        if (typeFilter(kClass)) delegate.getClassesToVisitFrom(typeDiscoveryServices, kClass)
+            .filter { it !is ExtractionResult.Extracted || typeFilter(it.result.kClass) } else emptyList()
 }
 
 

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/schemaFromTypes.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/schemaBuilder/schemaFromTypes.kt
@@ -48,7 +48,7 @@ fun basicFunctionExtractor(configureLambdas: ConfigureLambdaHandler): CompositeF
 
 fun basicTypeDiscovery(configureLambdas: ConfigureLambdaHandler) = CompositeTypeDiscovery(listOf(
     FunctionLambdaTypeDiscovery(configureLambdas),
-    FunctionReturnTypeDiscovery(),
+    FunctionReturnTypeDiscovery { true },
     FunctionParameterTypeDiscovery(),
     SupertypeDiscovery()
 ))

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/schemaBuidler/SchemaSupertypeMemberVisibilityTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/schemaBuidler/SchemaSupertypeMemberVisibilityTest.kt
@@ -60,10 +60,10 @@ class SchemaSupertypeMemberVisibilityTest {
             |Multiple failures in building the declarative schema:
             |
             |* Conflicting annotations: @VisibleInDefinition and @HiddenInDefinition are present
-            |  in class 'org.gradle.internal.declarativedsl.schemaBuidler.VisibleHidden'
-            |
-            |* Conflicting annotations: @VisibleInDefinition and @HiddenInDefinition are present
             |  in class 'org.gradle.internal.declarativedsl.schemaBuidler.AnotherVisibleHiddenSub'
+            |
+            |* More failures that are not reported now
+            |  in types that are only used in other erroneous types: 'org.gradle.internal.declarativedsl.schemaBuidler.VisibleHidden'
             """.trimMargin(),
             error.message
         )

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/schemaBuidler/SchemeExtractionErrorTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/schemaBuidler/SchemeExtractionErrorTest.kt
@@ -130,12 +130,9 @@ class SchemeExtractionErrorTest {
                     |Multiple failures in building the declarative schema:
                     |
                     |* Conflicting annotations: @VisibleInDefinition and @HiddenInDefinition are present
-                    |  in class 'org.gradle.internal.declarativedsl.schemaBuidler.SchemeExtractionErrorTest.VisibleAndHidden'
-                    |
-                    |* Conflicting annotations: @VisibleInDefinition and @HiddenInDefinition are present
                     |  in member 'var org.gradle.internal.declarativedsl.schemaBuidler.SchemeExtractionErrorTest.MultipleInvalidMembers.s: kotlin.String'
                     |  in class 'org.gradle.internal.declarativedsl.schemaBuidler.SchemeExtractionErrorTest.MultipleInvalidMembers'
-                |
+                    |
                     |* Illegal 'IN' variance
                     |  in type argument 'in kotlin.String'
                     |  in parameter 'x'
@@ -145,6 +142,9 @@ class SchemeExtractionErrorTest {
                     |* Unsupported property declaration: nullable read-only property
                     |  in member 'val org.gradle.internal.declarativedsl.schemaBuidler.SchemeExtractionErrorTest.MultipleInvalidMembers.y: kotlin.Int?'
                     |  in class 'org.gradle.internal.declarativedsl.schemaBuidler.SchemeExtractionErrorTest.MultipleInvalidMembers'
+                    |
+                    |* More failures that are not reported now
+                    |  in types that are only used in other erroneous types: 'org.gradle.internal.declarativedsl.schemaBuidler.SchemeExtractionErrorTest.VisibleAndHidden'
                     """.trimMargin(),
                     message
                 )

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/schemaBuiler/TypeDiscoveryTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/schemaBuiler/TypeDiscoveryTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.declarativedsl.schemaBuidler
+package org.gradle.internal.declarativedsl.schemaBuiler
 
 import org.gradle.internal.declarativedsl.schemaBuilder.schemaFromTypes
 import org.gradle.internal.declarativedsl.schemaUtils.findTypeFor

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
@@ -491,6 +491,70 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         }
     }
 
+    def 'failures in erroneous definition type and its referenced erroneous type are both reported'() {
+        given:
+        PluginBuilder pluginBuilder = withProjectFeature()
+        pluginBuilder.prepareToExecute()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        pluginBuilder.file("src/main/java/org/gradle/test/ReferencedType.java") << """
+            package org.gradle.test;
+            import org.gradle.api.provider.Property;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+            public interface ReferencedType {
+                Property<String> getValue();
+                @HiddenInDefinition
+                Property<String> getHiddenInReferenced();
+            }
+        """
+
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+                "Property<String> getHiddenProp();\n" +
+                "@org.gradle.api.tasks.Nested\n" +
+                "ReferencedType getReferenced();"
+        )
+
+        expect:
+        fails().assertHasErrorOutput(
+            "Unsafe declaration in safe definition: hidden member 'getHiddenInReferenced'\n" +
+                "      in schema type 'org.gradle.test.ReferencedType'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+        )
+        fails().assertHasErrorOutput(
+            "Unsafe declaration in safe definition: hidden member 'getHiddenProp'\n" +
+                "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+        )
+
+        verifyAll(receivedProblem(0)) {
+            fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"
+            details == "Unsafe declaration in safe definition: hidden member 'getHiddenInReferenced'\n" +
+                "  in schema type 'org.gradle.test.ReferencedType'\n" +
+                "  in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+            solutions == [
+                "Remove the hidden members.",
+                "Declare the corresponding features as having unsafe definitions.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+        verifyAll(receivedProblem(1)) {
+            fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"
+            details == "Unsafe declaration in safe definition: hidden member 'getHiddenProp'\n" +
+                "  in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "  in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+            solutions == [
+                "Remove the hidden members.",
+                "Declare the corresponding features as having unsafe definitions.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+    }
+
     private void addDefinitionMembers(String definitionFileName, String members) {
         file("plugins/src/main/java/org/gradle/test/${definitionFileName}"). replace(
             "Property<String> getText();",

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
@@ -171,6 +171,46 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         }
     }
 
+    def 'unsafe hidden members message is truncated when more than three are present'() {
+        given:
+        PluginBuilder pluginBuilder = withProjectFeature()
+        pluginBuilder.prepareToExecute()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+                "Property<String> getHiddenA();\n" +
+                "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+                "Property<String> getHiddenB();\n" +
+                "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+                "Property<String> getHiddenC();\n" +
+                "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+                "Property<String> getHiddenD();"
+        )
+
+        expect:
+        fails().assertHasErrorOutput(
+            "Unsafe declaration in safe definition: hidden members 'getHiddenA', 'getHiddenB', 'getHiddenC', ...\n" +
+                "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+        )
+
+        verifyAll(receivedProblem(0)) {
+            fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"
+            details == "Unsafe declaration in safe definition: hidden members 'getHiddenA', 'getHiddenB', 'getHiddenC', ...\n" +
+                "  in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "  in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+            solutions == [
+                "Remove the hidden members.",
+                "Declare the corresponding features as having unsafe definitions.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+    }
+
     def 'unsafe non-public member in safe definition is reported'() {
         given:
         PluginBuilder pluginBuilder = withProjectFeature()
@@ -491,6 +531,74 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         }
     }
 
+    def 'erroneous type names in aggregated failures message are truncated when more than three are present'() {
+        given:
+        PluginBuilder pluginBuilder = withProjectFeature()
+        pluginBuilder.prepareToExecute()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        ["A", "B", "C", "D"].each { suffix ->
+            pluginBuilder.file("src/main/java/org/gradle/test/IndirectType${suffix}.java") << """
+                package org.gradle.test;
+                import org.gradle.api.provider.Property;
+                import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+                public interface IndirectType${suffix} {
+                    Property<String> getValue();
+                    @HiddenInDefinition
+                    Property<String> getHiddenIn${suffix}();
+                }
+            """
+        }
+
+        pluginBuilder.file("src/main/java/org/gradle/test/TypeWithIssues.java") << """
+            package org.gradle.test;
+            import org.gradle.api.provider.Property;
+            import org.gradle.api.tasks.Nested;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+            public interface TypeWithIssues {
+                Property<String> getValue();
+
+                @HiddenInDefinition
+                Property<String> getHidden();
+
+                @Nested IndirectTypeA getIndirectA();
+                @Nested IndirectTypeB getIndirectB();
+                @Nested IndirectTypeC getIndirectC();
+                @Nested IndirectTypeD getIndirectD();
+            }
+        """
+
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.api.tasks.Nested\n" +
+                "TypeWithIssues getTypeWithIssues();"
+        )
+
+        expect:
+        fails().assertHasErrorOutput(
+            "More failures that are not reported now\n" +
+                "      in types that are only used in other erroneous types: 'org.gradle.test.IndirectTypeA', 'org.gradle.test.IndirectTypeB', 'org.gradle.test.IndirectTypeC', ..."
+        )
+
+        verifyAll(receivedProblem(0)) {
+            fqid == "scripts:dcl-schema:more-failures-in-erroneous-types"
+            details == "More failures that are not reported now\n" +
+                "  in types that are only used in other erroneous types: 'org.gradle.test.IndirectTypeA', 'org.gradle.test.IndirectTypeB', 'org.gradle.test.IndirectTypeC', ..."
+            solutions == [
+                "Fix the other issues first and run the build with the updated plugin to see the details.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+        verifyAll(receivedProblem(1)) {
+            fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"
+            details == "Unsafe declaration in safe definition: hidden member 'getHidden'\n" +
+                "  in schema type 'org.gradle.test.TypeWithIssues'\n" +
+                "  in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+        }
+    }
+
     def 'failures in erroneous definition type and its referenced erroneous type are both reported'() {
         given:
         PluginBuilder pluginBuilder = withProjectFeature()
@@ -528,6 +636,7 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
                 "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
                 "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
         )
+        fails().assertNotOutput("More failures that are not reported now")
 
         verifyAll(receivedProblem(0)) {
             fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
@@ -554,6 +554,70 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         }
     }
 
+    def 'failures in erroneous definition type and its referenced erroneous type are both reported'() {
+        given:
+        PluginBuilder pluginBuilder = withProjectFeature()
+        pluginBuilder.prepareToExecute()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        pluginBuilder.file("src/main/java/org/gradle/test/ReferencedType.java") << """
+            package org.gradle.test;
+            import org.gradle.api.provider.Property;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+            public interface ReferencedType {
+                Property<String> getValue();
+                @HiddenInDefinition
+                Property<String> getHiddenInReferenced();
+            }
+        """
+
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+                "Property<String> getHiddenProp();\n" +
+                "@org.gradle.api.tasks.Nested\n" +
+                "ReferencedType getReferenced();"
+        )
+
+        expect:
+        fails().assertHasErrorOutput(
+            "Unsafe declaration in safe definition: hidden member 'getHiddenInReferenced'\n" +
+                "      in schema type 'org.gradle.test.ReferencedType'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+        )
+        fails().assertHasErrorOutput(
+            "Unsafe declaration in safe definition: hidden member 'getHiddenProp'\n" +
+                "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+        )
+
+        verifyAll(receivedProblem(0)) {
+            fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"
+            details == "Unsafe declaration in safe definition: hidden member 'getHiddenInReferenced'\n" +
+                "  in schema type 'org.gradle.test.ReferencedType'\n" +
+                "  in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+            solutions == [
+                "Remove the hidden members.",
+                "Declare the corresponding features as having unsafe definitions.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+        verifyAll(receivedProblem(1)) {
+            fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"
+            details == "Unsafe declaration in safe definition: hidden member 'getHiddenProp'\n" +
+                "  in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "  in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+            solutions == [
+                "Remove the hidden members.",
+                "Declare the corresponding features as having unsafe definitions.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+    }
+
     private PluginBuilder withProjectFeature() {
         return testScenario {
             def type = projectType("testProjectType") {

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
@@ -33,10 +33,9 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         def settings = file("settings.gradle.dcl")
         settings << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "java.util.Map<String, String> myMap();\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "java.util.Map<String, String> myMap();\n" +
                 "java.util.Map<String, String> anotherMap();\n" +
                 "Property<? extends CharSequence> getWildcard();"
         )
@@ -120,8 +119,8 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         expect:
         fails().assertHasErrorOutput(
             "Unsafe declaration in safe definition: non-interface type\n" +
-            "      in schema type 'org.gradle.test.FeatureDefinition.Fizz'\n" +
-            "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+                "      in schema type 'org.gradle.test.FeatureDefinition.Fizz'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
         )
 
         verifyAll(receivedProblem(0)) {
@@ -145,18 +144,17 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
                 "Property<String> getHiddenProp();"
         )
 
         expect:
         fails().assertHasErrorOutput(
             "Unsafe declaration in safe definition: hidden member 'getHiddenProp'\n" +
-            "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
-            "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+                "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
         )
 
         verifyAll(receivedProblem(0)) {
@@ -180,9 +178,9 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\nprivate String nonPublicMember() { return \"\"; }"
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "private String nonPublicMember() { return \"\"; }"
         )
 
         expect:
@@ -215,10 +213,9 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "String getPlainText();\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "String getPlainText();\n" +
                 "void setPlainText(String value);"
         )
 
@@ -251,10 +248,9 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "default String getDefaultValue() { return \"default\"; }"
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "default String getDefaultValue() { return \"default\"; }"
         )
 
         expect:
@@ -286,19 +282,18 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "@org.gradle.declarative.dsl.model.annotations.Adding\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.declarative.dsl.model.annotations.Adding\n" +
                 "Fizz addFizz();"
         )
 
         expect:
         fails().assertHasErrorOutput(
             "Unsafe declaration in safe definition: function relying on side effects or custom implementation\n" +
-            "      in schema function 'addFizz(): Fizz'\n" +
-            "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
-            "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+                "      in schema function 'addFizz(): Fizz'\n" +
+                "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
         )
 
         verifyAll(receivedProblem(0)) {
@@ -324,10 +319,9 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "@javax.inject.Inject\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@javax.inject.Inject\n" +
                 "Fizz getInjectedFizz();"
         )
 
@@ -376,25 +370,22 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
             }
         """
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "@org.gradle.api.tasks.Nested\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.api.tasks.Nested\n" +
                 "SharedType getShared();"
         )
 
-        file("plugins/src/main/java/org/gradle/test/AnotherFeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "@org.gradle.api.tasks.Nested\n" +
+        addDefinitionMembers("AnotherFeatureDefinition.java",
+            "@org.gradle.api.tasks.Nested\n" +
                 "SharedType getShared();"
         )
 
         expect:
         fails().assertHasErrorOutput(
             "Unsafe declaration in safe definition: hidden member 'getHiddenProp'\n" +
-            "      in schema type 'org.gradle.test.SharedType'\n" +
-            "      in safe feature definitions of 'feature', 'anotherFeature' (plugin 'com.example.test-software-ecosystem')"
+                "      in schema type 'org.gradle.test.SharedType'\n" +
+                "      in safe feature definitions of 'feature', 'anotherFeature' (plugin 'com.example.test-software-ecosystem')"
         )
 
         verifyAll(receivedProblem(0)) {
@@ -409,5 +400,101 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
                 "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
             ]
         }
+    }
+
+    def 'failures in types only used in other erroneous types are aggregated'() {
+        given:
+        PluginBuilder pluginBuilder = withProjectFeature()
+        pluginBuilder.prepareToExecute()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        pluginBuilder.file("src/main/java/org/gradle/test/IndirectType.java") << """
+            package org.gradle.test;
+            import org.gradle.api.provider.Property;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+            public interface IndirectType {
+                Property<String> getValue();
+                @HiddenInDefinition
+                Property<String> getAlsoHidden();
+            }
+        """
+
+        pluginBuilder.file("src/main/java/org/gradle/test/AnotherIndirectType.java") << """
+            package org.gradle.test;
+            import org.gradle.api.provider.Property;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+            public interface AnotherIndirectType {
+                Property<String> getValue();
+                @HiddenInDefinition
+                Property<String> getYetAnotherHidden();
+            }
+        """
+
+        pluginBuilder.file("src/main/java/org/gradle/test/TypeWithIssues.java") << """
+            package org.gradle.test;
+            import org.gradle.api.provider.Property;
+            import org.gradle.api.tasks.Nested;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+            public interface TypeWithIssues {
+                Property<String> getValue();
+
+                @HiddenInDefinition
+                Property<String> getHidden();
+
+                @Nested
+                AnotherIndirectType getAnotherIndirect();
+
+                @Nested
+                IndirectType getIndirect();
+            }
+        """
+
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.api.tasks.Nested\n" +
+                "TypeWithIssues getTypeWithIssues();"
+        )
+
+        expect:
+        fails().assertHasErrorOutput(
+            "Unsafe declaration in safe definition: hidden member 'getHidden'\n" +
+                "      in schema type 'org.gradle.test.TypeWithIssues'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+        )
+        fails().assertHasErrorOutput(
+            "More failures that are not reported now\n" +
+                "      in types that are only used in other erroneous types: 'org.gradle.test.AnotherIndirectType', 'org.gradle.test.IndirectType'"
+        )
+
+        verifyAll(receivedProblem(0)) {
+            fqid == "scripts:dcl-schema:more-failures-in-erroneous-types"
+            details == "More failures that are not reported now\n" +
+                "  in types that are only used in other erroneous types: 'org.gradle.test.AnotherIndirectType', 'org.gradle.test.IndirectType'"
+            solutions == [
+                "Fix the other issues first and run the build with the updated plugin to see the details.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+        verifyAll(receivedProblem(1)) {
+            fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"
+            details == "Unsafe declaration in safe definition: hidden member 'getHidden'\n" +
+                "  in schema type 'org.gradle.test.TypeWithIssues'\n" +
+                "  in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+            solutions == [
+                "Remove the hidden members.",
+                "Declare the corresponding features as having unsafe definitions.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+    }
+
+    private void addDefinitionMembers(String definitionFileName, String members) {
+        file("plugins/src/main/java/org/gradle/test/${definitionFileName}"). replace(
+            "Property<String> getText();",
+            "Property<String> getText();\n" + members
+        )
     }
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
@@ -35,10 +35,9 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         def settings = file("settings.gradle.dcl")
         settings << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "java.util.Map<String, String> myMap();\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "java.util.Map<String, String> myMap();\n" +
                 "java.util.Map<String, String> anotherMap();\n" +
                 "Property<? extends CharSequence> getWildcard();"
         )
@@ -143,8 +142,8 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         expect:
         fails().assertHasErrorOutput(
             "Unsafe declaration in safe definition: non-interface type\n" +
-            "      in schema type 'org.gradle.test.FeatureDefinition.Fizz'\n" +
-            "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+                "      in schema type 'org.gradle.test.FeatureDefinition.Fizz'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
         )
 
         verifyAll(receivedProblem(0)) {
@@ -168,18 +167,17 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
                 "Property<String> getHiddenProp();"
         )
 
         expect:
         fails().assertHasErrorOutput(
             "Unsafe declaration in safe definition: hidden member 'getHiddenProp'\n" +
-            "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
-            "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+                "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
         )
 
         verifyAll(receivedProblem(0)) {
@@ -203,9 +201,9 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\nprivate String nonPublicMember() { return \"\"; }"
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "private String nonPublicMember() { return \"\"; }"
         )
 
         expect:
@@ -238,10 +236,9 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "String getPlainText();\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "String getPlainText();\n" +
                 "void setPlainText(String value);"
         )
 
@@ -274,10 +271,9 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "default String getDefaultValue() { return \"default\"; }"
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "default String getDefaultValue() { return \"default\"; }"
         )
 
         expect:
@@ -309,19 +305,18 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "@org.gradle.declarative.dsl.model.annotations.Adding\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.declarative.dsl.model.annotations.Adding\n" +
                 "Fizz addFizz();"
         )
 
         expect:
         fails().assertHasErrorOutput(
             "Unsafe declaration in safe definition: function relying on side effects or custom implementation\n" +
-            "      in schema function 'addFizz(): Fizz'\n" +
-            "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
-            "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+                "      in schema function 'addFizz(): Fizz'\n" +
+                "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
         )
 
         verifyAll(receivedProblem(0)) {
@@ -347,10 +342,9 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
-        file("plugins/src/main/java/org/gradle/test/FeatureDefinition.java").replace(
-            "Property<String> getText();",
-            "Property<String> getText();\n" +
-                "@javax.inject.Inject\n" +
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@javax.inject.Inject\n" +
                 "Fizz getInjectedFizz();"
         )
 
@@ -436,6 +430,20 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
 
         file("settings.gradle.dcl") << pluginsFromIncludedBuild
 
+        pluginBuilder.file("src/main/java/org/gradle/test/SharedType.java") << """
+            package org.gradle.test;
+
+            import org.gradle.api.provider.Property;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+
+            public interface SharedType {
+                Property<String> getValue();
+
+                @HiddenInDefinition
+                Property<String> getHiddenProp();
+            }
+        """
+
         expect:
         fails().assertHasErrorOutput(
             "Unsafe declaration in safe definition: hidden member 'getHiddenProp'\n" +
@@ -448,6 +456,95 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
             details == "Unsafe declaration in safe definition: hidden member 'getHiddenProp'\n" +
                 "  in schema type 'org.gradle.test.Shared'\n" +
                 "  in safe feature definitions of 'feature', 'anotherFeature' (plugin 'com.example.test-software-ecosystem')"
+            solutions == [
+                "Remove the hidden members.",
+                "Declare the corresponding features as having unsafe definitions.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+    }
+
+    def 'failures in types only used in other erroneous types are aggregated'() {
+        given:
+        PluginBuilder pluginBuilder = withProjectFeature()
+        pluginBuilder.prepareToExecute()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        pluginBuilder.file("src/main/java/org/gradle/test/IndirectType.java") << """
+            package org.gradle.test;
+            import org.gradle.api.provider.Property;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+            public interface IndirectType {
+                Property<String> getValue();
+                @HiddenInDefinition
+                Property<String> getAlsoHidden();
+            }
+        """
+
+        pluginBuilder.file("src/main/java/org/gradle/test/AnotherIndirectType.java") << """
+            package org.gradle.test;
+            import org.gradle.api.provider.Property;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+            public interface AnotherIndirectType {
+                Property<String> getValue();
+                @HiddenInDefinition
+                Property<String> getYetAnotherHidden();
+            }
+        """
+
+        pluginBuilder.file("src/main/java/org/gradle/test/TypeWithIssues.java") << """
+            package org.gradle.test;
+            import org.gradle.api.provider.Property;
+            import org.gradle.api.tasks.Nested;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+            public interface TypeWithIssues {
+                Property<String> getValue();
+
+                @HiddenInDefinition
+                Property<String> getHidden();
+
+                @Nested
+                AnotherIndirectType getAnotherIndirect();
+
+                @Nested
+                IndirectType getIndirect();
+            }
+        """
+
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.api.tasks.Nested\n" +
+                "TypeWithIssues getTypeWithIssues();"
+        )
+
+        expect:
+        fails().assertHasErrorOutput(
+            "Unsafe declaration in safe definition: hidden member 'getHidden'\n" +
+                "      in schema type 'org.gradle.test.TypeWithIssues'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+        )
+        fails().assertHasErrorOutput(
+            "More failures that are not reported now\n" +
+                "      in types that are only used in other erroneous types: 'org.gradle.test.AnotherIndirectType', 'org.gradle.test.IndirectType'"
+        )
+
+        verifyAll(receivedProblem(0)) {
+            fqid == "scripts:dcl-schema:more-failures-in-erroneous-types"
+            details == "More failures that are not reported now\n" +
+                "  in types that are only used in other erroneous types: 'org.gradle.test.AnotherIndirectType', 'org.gradle.test.IndirectType'"
+            solutions == [
+                "Fix the other issues first and run the build with the updated plugin to see the details.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+        verifyAll(receivedProblem(1)) {
+            fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"
+            details == "Unsafe declaration in safe definition: hidden member 'getHidden'\n" +
+                "  in schema type 'org.gradle.test.TypeWithIssues'\n" +
+                "  in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
             solutions == [
                 "Remove the hidden members.",
                 "Declare the corresponding features as having unsafe definitions.",
@@ -490,4 +587,10 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         }
     }
 
+    private void addDefinitionMembers(String definitionFileName, String members) {
+        file("plugins/src/main/java/org/gradle/test/${definitionFileName}"). replace(
+            "Property<String> getText();",
+            "Property<String> getText();\n" + members
+        )
+    }
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/schema/SchemaBuildingFailureReportingIntegrationTest.groovy
@@ -194,6 +194,46 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         }
     }
 
+    def 'unsafe hidden members message is truncated when more than three are present'() {
+        given:
+        PluginBuilder pluginBuilder = withProjectFeature()
+        pluginBuilder.prepareToExecute()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+                "Property<String> getHiddenA();\n" +
+                "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+                "Property<String> getHiddenB();\n" +
+                "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+                "Property<String> getHiddenC();\n" +
+                "@org.gradle.declarative.dsl.model.annotations.HiddenInDefinition\n" +
+                "Property<String> getHiddenD();"
+        )
+
+        expect:
+        fails().assertHasErrorOutput(
+            "Unsafe declaration in safe definition: hidden members 'getHiddenA', 'getHiddenB', 'getHiddenC', ...\n" +
+                "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+        )
+
+        verifyAll(receivedProblem(0)) {
+            fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"
+            details == "Unsafe declaration in safe definition: hidden members 'getHiddenA', 'getHiddenB', 'getHiddenC', ...\n" +
+                "  in schema type 'org.gradle.test.FeatureDefinition'\n" +
+                "  in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+            solutions == [
+                "Remove the hidden members.",
+                "Declare the corresponding features as having unsafe definitions.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+    }
+
     def 'unsafe non-public member in safe definition is reported'() {
         given:
         PluginBuilder pluginBuilder = withProjectFeature()
@@ -554,6 +594,74 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
         }
     }
 
+    def 'erroneous type names in aggregated failures message are truncated when more than three are present'() {
+        given:
+        PluginBuilder pluginBuilder = withProjectFeature()
+        pluginBuilder.prepareToExecute()
+
+        file("settings.gradle.dcl") << pluginsFromIncludedBuild
+
+        ["A", "B", "C", "D"].each { suffix ->
+            pluginBuilder.file("src/main/java/org/gradle/test/IndirectType${suffix}.java") << """
+                package org.gradle.test;
+                import org.gradle.api.provider.Property;
+                import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+                public interface IndirectType${suffix} {
+                    Property<String> getValue();
+                    @HiddenInDefinition
+                    Property<String> getHiddenIn${suffix}();
+                }
+            """
+        }
+
+        pluginBuilder.file("src/main/java/org/gradle/test/TypeWithIssues.java") << """
+            package org.gradle.test;
+            import org.gradle.api.provider.Property;
+            import org.gradle.api.tasks.Nested;
+            import org.gradle.declarative.dsl.model.annotations.HiddenInDefinition;
+            public interface TypeWithIssues {
+                Property<String> getValue();
+
+                @HiddenInDefinition
+                Property<String> getHidden();
+
+                @Nested IndirectTypeA getIndirectA();
+                @Nested IndirectTypeB getIndirectB();
+                @Nested IndirectTypeC getIndirectC();
+                @Nested IndirectTypeD getIndirectD();
+            }
+        """
+
+        addDefinitionMembers(
+            "FeatureDefinition.java",
+            "@org.gradle.api.tasks.Nested\n" +
+                "TypeWithIssues getTypeWithIssues();"
+        )
+
+        expect:
+        fails().assertHasErrorOutput(
+            "More failures that are not reported now\n" +
+                "      in types that are only used in other erroneous types: 'org.gradle.test.IndirectTypeA', 'org.gradle.test.IndirectTypeB', 'org.gradle.test.IndirectTypeC', ..."
+        )
+
+        verifyAll(receivedProblem(0)) {
+            fqid == "scripts:dcl-schema:more-failures-in-erroneous-types"
+            details == "More failures that are not reported now\n" +
+                "  in types that are only used in other erroneous types: 'org.gradle.test.IndirectTypeA', 'org.gradle.test.IndirectTypeB', 'org.gradle.test.IndirectTypeC', ..."
+            solutions == [
+                "Fix the other issues first and run the build with the updated plugin to see the details.",
+                "Remove the violating declaration or make it non-public in an unsafe definition.",
+                "In an unsafe definition, annotate the violating declaration as @HiddenInDefinition to exclude it from the Declarative schema.",
+            ]
+        }
+        verifyAll(receivedProblem(1)) {
+            fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"
+            details == "Unsafe declaration in safe definition: hidden member 'getHidden'\n" +
+                "  in schema type 'org.gradle.test.TypeWithIssues'\n" +
+                "  in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
+        }
+    }
+
     def 'failures in erroneous definition type and its referenced erroneous type are both reported'() {
         given:
         PluginBuilder pluginBuilder = withProjectFeature()
@@ -591,6 +699,7 @@ class SchemaBuildingFailureReportingIntegrationTest extends AbstractIntegrationS
                 "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
                 "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')"
         )
+        fails().assertNotOutput("More failures that are not reported now")
 
         verifyAll(receivedProblem(0)) {
             fqid == "scripts:dcl-schema:unsafe-because-has-hidden-members"

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/GradlePropertyApiAnalysisSchemaComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/GradlePropertyApiAnalysisSchemaComponent.kt
@@ -32,16 +32,15 @@ import org.gradle.internal.declarativedsl.schemaBuilder.PropertyExtractionMetada
 import org.gradle.internal.declarativedsl.schemaBuilder.PropertyExtractionResult
 import org.gradle.internal.declarativedsl.schemaBuilder.PropertyExtractor
 import org.gradle.internal.declarativedsl.schemaBuilder.SchemaBuildingHost
-import org.gradle.internal.declarativedsl.schemaBuilder.SchemaResult
 import org.gradle.internal.declarativedsl.schemaBuilder.SupportedTypeProjection
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass.DiscoveryTag.PropertyType
+import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscoveryResult
 import org.gradle.internal.declarativedsl.schemaBuilder.annotationsWithGetters
 import org.gradle.internal.declarativedsl.schemaBuilder.asSupported
 import org.gradle.internal.declarativedsl.schemaBuilder.inContextOfModelMember
 import org.gradle.internal.declarativedsl.schemaBuilder.orFailWith
 import org.gradle.internal.declarativedsl.schemaBuilder.returnTypeRef
-import org.gradle.internal.declarativedsl.schemaBuilder.schemaResult
 import java.util.Locale
 import kotlin.reflect.KClass
 import kotlin.reflect.KClassifier
@@ -137,13 +136,13 @@ class GradlePropertyApiPropertyExtractor : PropertyExtractor {
 
 private
 class PropertyReturnTypeDiscovery : TypeDiscovery {
-    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<TypeDiscovery.DiscoveredClass>> =
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
         typeDiscoveryServices.propertyExtractor.extractProperties(typeDiscoveryServices.host, kClass).flatMap { extractionResult ->
             when (extractionResult) {
                 is ExtractionResult.Extracted<DataProperty, PropertyExtractionMetadata> ->
                     extractionResult.metadata.originalType?.let { originalType ->
                         propertyValueType(typeDiscoveryServices.host, originalType)
-                            .let { propertyValueType -> TypeDiscovery.DiscoveredClass.classesOf(propertyValueType, PropertyType(kClass, extractionResult.result.name)).map(::schemaResult) }
+                            .let { propertyValueType -> TypeDiscovery.DiscoveredClass.classesOf(propertyValueType, PropertyType(kClass, extractionResult.result.name)) }
                     } ?: emptyList()
 
                 is ExtractionResult.Failure -> emptyList()

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/MinimalSchemaBuildingComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/MinimalSchemaBuildingComponent.kt
@@ -18,7 +18,6 @@ package org.gradle.internal.declarativedsl.common
 
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.artifacts.dsl.DependencyCollector
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.internal.declarativedsl.dependencycollectors.DependencyCollectorFunctionExtractorAndRuntimeResolver
 import org.gradle.internal.declarativedsl.evaluationSchema.AnalysisSchemaComponent
@@ -55,8 +54,18 @@ class MinimalSchemaBuildingComponent : AnalysisSchemaComponent {
     override fun typeDiscovery(): List<TypeDiscovery> = listOf(
         FunctionLambdaTypeDiscovery(gradleConfigureLambdas),
         FunctionParameterTypeDiscovery(),
-        FunctionReturnTypeDiscovery { it != Property::class } // not interested in bringing `Property` to the schema from functions returning it, it only produces noise in failure reports
+        FunctionReturnTypeDiscovery(::isSemanticUsageOfType)
     )
+}
+
+/**
+ * To make schema building issues less noisy, it makes sense to not track usages of classes where they only
+ * wrap the type that is semantically used.
+ */
+private fun isSemanticUsageOfType(usedClass: KClass<*>) = when {
+    usedClass.isSubclassOf(Provider::class) -> false
+    usedClass == NamedDomainObjectContainer::class -> false // NDOC subtypes might be custom types with semantics
+    else -> true
 }
 
 private fun isValidNestedGradleModelType(type: SupportedTypeProjection.SupportedType): Boolean =

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/MinimalSchemaBuildingComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/common/MinimalSchemaBuildingComponent.kt
@@ -18,6 +18,7 @@ package org.gradle.internal.declarativedsl.common
 
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.artifacts.dsl.DependencyCollector
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.internal.declarativedsl.dependencycollectors.DependencyCollectorFunctionExtractorAndRuntimeResolver
 import org.gradle.internal.declarativedsl.evaluationSchema.AnalysisSchemaComponent
@@ -54,7 +55,7 @@ class MinimalSchemaBuildingComponent : AnalysisSchemaComponent {
     override fun typeDiscovery(): List<TypeDiscovery> = listOf(
         FunctionLambdaTypeDiscovery(gradleConfigureLambdas),
         FunctionParameterTypeDiscovery(),
-        FunctionReturnTypeDiscovery()
+        FunctionReturnTypeDiscovery { it != Property::class } // not interested in bringing `Property` to the schema from functions returning it, it only produces noise in failure reports
     )
 }
 

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluationSchema/FixedTypeDiscovery.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/evaluationSchema/FixedTypeDiscovery.kt
@@ -16,9 +16,9 @@
 
 package org.gradle.internal.declarativedsl.evaluationSchema
 
-import org.gradle.internal.declarativedsl.schemaBuilder.SchemaResult
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery
-import org.gradle.internal.declarativedsl.schemaBuilder.schemaResult
+import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscoveryResult
+import org.gradle.internal.declarativedsl.schemaBuilder.extracted
 import kotlin.reflect.KClass
 
 
@@ -28,10 +28,10 @@ import kotlin.reflect.KClass
  */
 internal
 class FixedTypeDiscovery(private val keyClass: KClass<*>?, private val discoverClasses: List<TypeDiscovery.DiscoveredClass>) : TypeDiscovery {
-    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<TypeDiscovery.DiscoveredClass>> =
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
         when (kClass) {
-            keyClass -> discoverClasses.map(::schemaResult)
-            typeDiscoveryServices.host.topLevelReceiverClass -> if (keyClass == null) discoverClasses.map(::schemaResult) else emptyList()
+            keyClass -> discoverClasses.map { it.extracted() }
+            typeDiscoveryServices.host.topLevelReceiverClass -> if (keyClass == null) discoverClasses.map { it.extracted() } else emptyList()
             else -> emptyList()
         }
 }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/ndoc/ContainersSchemaComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/ndoc/ContainersSchemaComponent.kt
@@ -64,6 +64,7 @@ import org.gradle.internal.declarativedsl.schemaBuilder.SupportedTypeProjection
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass.DiscoveryTag
+import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscoveryResult
 import org.gradle.internal.declarativedsl.schemaBuilder.asSupported
 import org.gradle.internal.declarativedsl.schemaBuilder.flatMap
 import org.gradle.internal.declarativedsl.schemaBuilder.inContextOfModelClass
@@ -159,16 +160,16 @@ internal class ContainersSchemaComponent : AnalysisSchemaComponent, ObjectConver
 
     override fun typeDiscovery(): List<TypeDiscovery> = listOf(
         object : TypeDiscovery {
-            override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<DiscoveredClass>> =
+            override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> =
                 typeDiscoveryServices.host.inContextOfModelClass(kClass) {
                     containerProperties(typeDiscoveryServices.host, kClass).values.flatMap { propertyResult ->
                         when (propertyResult) {
-                            is SchemaResult.Failure -> listOf(propertyResult)
+                            is SchemaResult.Failure -> listOf(ExtractionResult.of(propertyResult, DefaultFqName.of(kClass)))
                             is SchemaResult.Result -> {
                                 listOfNotNull(
                                     // discover the element type, only if the declared container type is not NDOC<T>; otherwise, it will be discovered from the signature
                                     (propertyResult.result.containerType.takeIf { it.classifier != NamedDomainObjectContainer::class })
-                                        ?.let { DiscoveredClass.classesOf(it, DiscoveryTag.ContainerElement(propertyResult.result.originDeclaration.kCallable)).map(::schemaResult) }
+                                        ?.let { DiscoveredClass.classesOf(it, DiscoveryTag.ContainerElement(propertyResult.result.originDeclaration.kCallable)) }
                                 ).flatten()
                             }
                         }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/ndoc/ContainersSchemaComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/ndoc/ContainersSchemaComponent.kt
@@ -169,7 +169,7 @@ internal class ContainersSchemaComponent : AnalysisSchemaComponent, ObjectConver
                                 listOfNotNull(
                                     // discover the element type, only if the declared container type is not NDOC<T>; otherwise, it will be discovered from the signature
                                     (propertyResult.result.containerType.takeIf { it.classifier != NamedDomainObjectContainer::class })
-                                        ?.let { DiscoveredClass.classesOf(it, DiscoveryTag.ContainerElement(propertyResult.result.originDeclaration.kCallable)) }
+                                        ?.let { DiscoveredClass.classesOf(it, DiscoveryTag.ContainerElement(kClass, propertyResult.result.originDeclaration.kCallable)) }
                                 ).flatten()
                             }
                         }

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/TypesafeProjectAccessorsComponent.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/project/TypesafeProjectAccessorsComponent.kt
@@ -32,10 +32,10 @@ import org.gradle.internal.declarativedsl.schemaBuilder.MemberKind
 import org.gradle.internal.declarativedsl.schemaBuilder.PropertyExtractionResult
 import org.gradle.internal.declarativedsl.schemaBuilder.PropertyExtractor
 import org.gradle.internal.declarativedsl.schemaBuilder.SchemaBuildingHost
-import org.gradle.internal.declarativedsl.schemaBuilder.SchemaResult
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery
 import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscovery.DiscoveredClass.DiscoveryTag.Special
-import org.gradle.internal.declarativedsl.schemaBuilder.schemaResult
+import org.gradle.internal.declarativedsl.schemaBuilder.TypeDiscoveryResult
+import org.gradle.internal.declarativedsl.schemaBuilder.extracted
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 
@@ -105,10 +105,10 @@ class ProjectPropertyAccessorRuntimeResolver : RuntimePropertyResolver {
 
 private
 class TypesafeProjectAccessorTypeDiscovery : TypeDiscovery {
-    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<SchemaResult<TypeDiscovery.DiscoveredClass>> {
+    override fun getClassesToVisitFrom(typeDiscoveryServices: TypeDiscovery.TypeDiscoveryServices, kClass: KClass<*>): Iterable<TypeDiscoveryResult> {
         return if (kClass.isGeneratedAccessors()) {
             allClassesReachableFromGetters(typeDiscoveryServices.host, kClass).map {
-                schemaResult(TypeDiscovery.DiscoveredClass(it, Special("type-safe project accessor")))
+                TypeDiscovery.DiscoveredClass(it, Special("type-safe project accessor")).extracted()
             }
         } else {
             emptyList()

--- a/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/SchemaBuildingFailureProblems.kt
+++ b/platforms/core-configuration/declarative-dsl-provider/src/main/kotlin/org/gradle/internal/declarativedsl/provider/SchemaBuildingFailureProblems.kt
@@ -74,6 +74,7 @@ private object ProblemIds {
     val SCHEMA_UNSAFE_NON_PURE_FUNCTION = create("unsafe-non-pure-function", "Unsafe non-pure function in safe feature API", group)
     val SCHEMA_UNSAFE_BECAUSE_HAS_HIDDEN_MEMBERS = create("unsafe-because-has-hidden-members", "Unsafe hidden members in safe feature API", group)
     val SCHEMA_UNSAFE_BECAUSE_HAS_NON_PUBLIC_MEMBERS = create("unsafe-because-has-non-public-members", "Non-public members in safe feature API", group)
+    val SCHEMA_MORE_FAILURES_IN_ERRONEOUS_TYPES = create("more-failures-in-erroneous-types", "More failures in types that are only used in other erroneous types", group)
 }
 
 @Suppress("CyclomaticComplexMethod")
@@ -102,6 +103,7 @@ internal fun schemaBuildingFailureProblemId(failure: SchemaBuildingFailure): Pro
         is UnsafeBecauseHasNonPublicMembers -> ProblemIds.SCHEMA_UNSAFE_BECAUSE_HAS_NON_PUBLIC_MEMBERS
         else -> ProblemIds.SCHEMA_BUILDING_FAILURE
     }
+    is SchemaIssue.MoreFailuresInErroneousTypes -> ProblemIds.SCHEMA_MORE_FAILURES_IN_ERRONEOUS_TYPES
     else -> ProblemIds.SCHEMA_BUILDING_FAILURE
 }
 
@@ -175,6 +177,10 @@ internal fun ProblemSpec.solutionFor(failure: SchemaBuildingFailure) {
                 else -> Unit
             }
             solution("Declare the corresponding features as having unsafe definitions.")
+        }
+
+        is SchemaIssue.MoreFailuresInErroneousTypes -> {
+            solution("Fix the other issues first and run the build with the updated plugin to see the details.")
         }
 
         is SchemaIssue.NonClassifiableType,

--- a/platforms/core-configuration/declarative-dsl-tooling-models/src/main/kotlin/org/gradle/declarative/dsl/evaluation/SchemaIssue.kt
+++ b/platforms/core-configuration/declarative-dsl-tooling-models/src/main/kotlin/org/gradle/declarative/dsl/evaluation/SchemaIssue.kt
@@ -36,7 +36,8 @@ import java.io.Serializable
     SchemaIssue.NonClassifiableType::class,
     SchemaIssue.UnitAddingFunctionWithLambda::class,
     SchemaIssue.UnrecognizedMember::class,
-    SchemaIssue.UnsafeDeclarationInSafeFeatureApi::class
+    SchemaIssue.UnsafeDeclarationInSafeFeatureApi::class,
+    SchemaIssue.MoreFailuresInErroneousTypes::class
 ])
 interface SchemaIssue : Serializable {
     interface DeclarationBothHiddenAndVisible : SchemaIssue
@@ -92,5 +93,10 @@ interface SchemaIssue : Serializable {
     interface UnsafeDeclarationInSafeFeatureApi : SchemaIssue {
         val usedInSafeFeatures: List<ProjectFeatureOrigin>
         val unsafeApiCause: UnsafeSchemaItem
+    }
+
+    interface MoreFailuresInErroneousTypes : SchemaIssue {
+        val typeNames: Set<String>
+        val issues: List<SchemaBuildingFailure>
     }
 }

--- a/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/ProjectFeatureSafetyIntegrationTest.groovy
+++ b/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/ProjectFeatureSafetyIntegrationTest.groovy
@@ -133,10 +133,6 @@ class ProjectFeatureSafetyIntegrationTest extends AbstractIntegrationSpec implem
         failure.assertHasErrorOutput(
             "    Unsafe declaration in safe definition: injected service property\n" +
                 "      in schema property 'objects: ObjectFactory'\n" +
-                "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
-                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')\n" +
-                "    Unsafe declaration in safe definition: injected service property\n" +
-                "      in schema property 'objects: ObjectFactory'\n" +
                 "      in schema type 'org.gradle.test.FeatureDefinition.Fizz'\n" +
                 "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')\n"
         )

--- a/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/ProjectFeatureSafetyIntegrationTest.groovy
+++ b/platforms/core-configuration/project-features/src/integTest/groovy/org/gradle/features/ProjectFeatureSafetyIntegrationTest.groovy
@@ -278,10 +278,6 @@ class ProjectFeatureSafetyIntegrationTest extends AbstractIntegrationSpec implem
         failure.assertHasErrorOutput(
             "    Unsafe declaration in safe definition: injected service property\n" +
                 "      in schema property 'objects: ObjectFactory'\n" +
-                "      in schema type 'org.gradle.test.FeatureDefinition'\n" +
-                "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')\n" +
-                "    Unsafe declaration in safe definition: injected service property\n" +
-                "      in schema property 'objects: ObjectFactory'\n" +
                 "      in schema type 'org.gradle.test.FeatureDefinition.Fizz'\n" +
                 "      in safe feature definition of 'feature' (plugin 'com.example.test-software-ecosystem')\n"
         )

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/problems/KnownProblemIds.groovy
@@ -199,6 +199,7 @@ class KnownProblemIds {
         'scripts:dcl-schema:unsafe-non-pure-function': ['.*'],
         'scripts:dcl-schema:unsafe-because-has-hidden-members': ['.*'],
         'scripts:dcl-schema:unsafe-because-has-non-public-members': ['.*'],
+        'scripts:dcl-schema:more-failures-in-erroneous-types': ['.*'],
 
         // integration test problems
         'deprecation:some-indirect-deprecation': ['Some indirect deprecation has been deprecated.'],


### PR DESCRIPTION
Report only the DCL schema building failures occurring in types that are used
from non-erroneous types. If a type is only used in other erroneous types,
omit failures in it, but report a summary that says that such failures are also
present.

Fixes:
* https://github.com/gradle/gradle/issues/37365