### PR TITLE
Scope KTS model-default accessors to their binding type

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultProjectSchemaProvider.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultProjectSchemaProvider.kt
@@ -42,8 +42,14 @@ import org.gradle.kotlin.dsl.accessors.SchemaType
 import org.gradle.kotlin.dsl.accessors.ProjectFeatureEntry
 import org.gradle.kotlin.dsl.accessors.TypedProjectSchema
 import org.gradle.kotlin.dsl.accessors.isDclEnabledForScriptTarget
+import org.gradle.kotlin.dsl.provider.plugins.schema.TypeProjection
+import org.gradle.kotlin.dsl.provider.plugins.schema.TypeProjectionKind
+import org.gradle.kotlin.dsl.provider.plugins.schema.parameterizedTypeOfRawGenericClass
 import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.features.binding.Definition
+import org.gradle.features.binding.TargetTypeInformation
 import org.gradle.features.internal.binding.ProjectFeatureDeclarations
+import org.gradle.features.internal.binding.ProjectFeatureImplementation
 import java.lang.reflect.Modifier
 import kotlin.reflect.KVisibility
 
@@ -110,8 +116,14 @@ internal class DefaultProjectSchemaProvider(
             }
             if (target is Settings) {
                 val projectFeatureDeclarations = target.serviceOf<ProjectFeatureDeclarations>()
-                accessibleContainerSchema(projectFeatureDeclarations.schema).forEach { schema ->
-                    buildModelDefaults.add(ProjectSchemaEntry(typeOfModelDefaults, schema.name, schema.publicType))
+                projectFeatureDeclarations.projectFeatureImplementations.forEach { (name, impls) ->
+                    if (!isPublic(name)) return@forEach
+                    impls.forEach { impl ->
+                        val receiver = receiverTypeForDefaults(impl)
+                        buildModelDefaults.add(
+                            ProjectSchemaEntry(receiver, name, TypeOf.typeOf(impl.definitionPublicType as Class<*>))
+                        )
+                    }
                 }
             }
             if (target is NamedDomainObjectContainer<*>) {
@@ -306,6 +318,26 @@ val typeOfTaskContainer = typeOf<TaskContainer>()
 
 private
 val typeOfModelDefaults = typeOf<SharedModelDefaults>()
+
+
+private
+fun receiverTypeForDefaults(impl: ProjectFeatureImplementation<*, *>): TypeOf<*> =
+    when (val target = impl.targetDefinitionType) {
+        is TargetTypeInformation.DefinitionTargetTypeInformation<*> ->
+            if (target.definitionType == Project::class.java) typeOfModelDefaults
+            else TypeOf.typeOf(target.definitionType as Class<*>)
+
+        is TargetTypeInformation.BuildModelTargetTypeInformation<*> ->
+            // Definition<out U> — matches exactly the set of definitions whose
+            // build model is assignable to U, which is the same rule
+            // TargetTypeInformationChecks.isValidBindingType applies at runtime.
+            parameterizedTypeOfRawGenericClass(
+                listOf(TypeProjection(target.buildModelType, TypeProjectionKind.OUT)),
+                Definition::class.java
+            )
+
+        else -> error("Unknown TargetTypeInformation subclass: $target — receiver type for defaults accessor cannot be determined")
+    }
 
 
 internal

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/KotlinDslDclSchemaCollector.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/KotlinDslDclSchemaCollector.kt
@@ -39,11 +39,11 @@ import org.gradle.internal.service.scopes.ServiceScope
 import org.gradle.kotlin.dsl.accessors.ContainerElementFactoryEntry
 import org.gradle.kotlin.dsl.accessors.NestedModelEntry
 import org.gradle.kotlin.dsl.accessors.ProjectFeatureEntry
+import org.gradle.kotlin.dsl.provider.plugins.schema.TypeProjection
+import org.gradle.kotlin.dsl.provider.plugins.schema.TypeProjectionKind
+import org.gradle.kotlin.dsl.provider.plugins.schema.parameterizedTypeOfRawGenericClass
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.features.internal.binding.ProjectFeatureDeclarations
-import java.lang.reflect.ParameterizedType
-import java.lang.reflect.Type
-import java.lang.reflect.WildcardType
 
 data class KotlinDslDclSchema(
     val containerElementFactories: List<ContainerElementFactoryEntry<TypeOf<*>>>,
@@ -192,36 +192,4 @@ internal class DefaultKotlinDslDclSchemaCollector : KotlinDslDclSchemaCollector 
             }
         }.flatten()
 
-    /**
-     * Workaround: The [TypeOf] infrastructure handles parameterized types specially.
-     * Passing the raw [Class] obtained from the class loader to [TypeOf.parameterizedTypeOf] would not work.
-     * We need to provide a [ParameterizedType] instance.
-     */
-    private fun parameterizedTypeOfRawGenericClass(typeArgs: List<TypeProjection>, loadedClass: Class<*>): TypeOf<Any> =
-        TypeOf.typeOf(object : ParameterizedType {
-            override fun getActualTypeArguments(): Array<Type> = typeArgs.map { (clazz, projection) ->
-                when (projection) {
-                    TypeProjectionKind.NONE -> clazz
-                    TypeProjectionKind.OUT -> object : WildcardType {
-                        override fun getUpperBounds(): Array<out Type> = arrayOf(clazz)
-                        override fun getLowerBounds() = emptyArray<Type>()
-                    }
-                    TypeProjectionKind.IN -> object : WildcardType {
-                        override fun getUpperBounds(): Array<out Type> = emptyArray()
-                        override fun getLowerBounds() = arrayOf(clazz)
-                    }
-                }
-            }.toTypedArray<Type>()
-            override fun getRawType(): Type = loadedClass
-
-            /** [Class.getNestHost] is @since 11, cannot use it; but we are fine with no owner type here. */
-            /** [Class.getNestHost] is @since 11, cannot use it; but we are fine with no owner type here. */
-            override fun getOwnerType() = null
-        })
-
-    private data class TypeProjection(val clazz: Class<*>, val projection: TypeProjectionKind = TypeProjectionKind.NONE)
-
-    private enum class TypeProjectionKind {
-        NONE, OUT, IN
-    }
 }

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/schema/ParameterizedTypeSupport.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/schema/ParameterizedTypeSupport.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.provider.plugins.schema
+
+import org.gradle.api.reflect.TypeOf
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.lang.reflect.WildcardType
+
+
+internal data class TypeProjection(val clazz: Class<*>, val projection: TypeProjectionKind = TypeProjectionKind.NONE)
+
+
+internal enum class TypeProjectionKind {
+    NONE, OUT, IN
+}
+
+
+/**
+ * Workaround: The [TypeOf] infrastructure handles parameterized types specially.
+ * Passing the raw [Class] obtained from the class loader to [TypeOf.parameterizedTypeOf] would not work.
+ * We need to provide a [ParameterizedType] instance.
+ */
+internal fun parameterizedTypeOfRawGenericClass(typeArgs: List<TypeProjection>, loadedClass: Class<*>): TypeOf<Any> =
+    TypeOf.typeOf(object : ParameterizedType {
+        override fun getActualTypeArguments(): Array<Type> = typeArgs.map { (clazz, projection) ->
+            when (projection) {
+                TypeProjectionKind.NONE -> clazz
+                TypeProjectionKind.OUT -> object : WildcardType {
+                    override fun getUpperBounds(): Array<out Type> = arrayOf(clazz)
+                    override fun getLowerBounds() = emptyArray<Type>()
+                }
+                TypeProjectionKind.IN -> object : WildcardType {
+                    override fun getUpperBounds(): Array<out Type> = emptyArray()
+                    override fun getLowerBounds() = arrayOf(clazz)
+                }
+            }
+        }.toTypedArray<Type>()
+
+        override fun getRawType(): Type = loadedClass
+
+        override fun getOwnerType() = null
+    })

--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/DclModelDefaultsScopingIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/dcl/DclModelDefaultsScopingIntegrationTest.kt
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.dcl
+
+import org.gradle.features.annotations.BindsProjectFeature
+import org.gradle.features.annotations.BindsProjectType
+import org.gradle.features.annotations.RegistersProjectFeatures
+import org.gradle.features.binding.BuildModel
+import org.gradle.features.binding.Definition
+import org.gradle.features.binding.ProjectFeatureApplicationContext
+import org.gradle.features.binding.ProjectFeatureApplyAction
+import org.gradle.features.binding.ProjectFeatureBindingBuilder
+import org.gradle.features.binding.ProjectFeatureBinding
+import org.gradle.features.binding.ProjectTypeApplyAction
+import org.gradle.features.binding.ProjectTypeBindingBuilder
+import org.gradle.features.binding.ProjectTypeBinding
+import org.gradle.kotlin.dsl.accessors.DCL_ENABLED_PROPERTY_NAME
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.junit.Test
+
+class DclModelDefaultsScopingIntegrationTest : AbstractKotlinIntegrationTest() {
+
+    @Test
+    fun `feature accessor is not available at the top level of defaults`() {
+        withPluginsWithTwoProjectTypesAndFeatures()
+        enableDclInGradleProperties()
+
+        withSettingsContent(
+            """
+            defaults {
+                onlyForFirst {}
+            }
+            """.trimIndent()
+        )
+
+        buildAndFail("help").apply {
+            assertHasErrorOutput("Script compilation error:")
+            assertHasErrorOutput("onlyForFirst {}")
+            assertHasErrorOutput("Unresolved reference")
+        }
+    }
+
+    @Test
+    fun `definition bound feature accessor is not available inside an unrelated project type block`() {
+        withPluginsWithTwoProjectTypesAndFeatures()
+        enableDclInGradleProperties()
+
+        withSettingsContent(
+            """
+            defaults {
+                secondProjectType {
+                    onlyForFirst {}
+                }
+            }
+            """.trimIndent()
+        )
+
+        buildAndFail("help").apply {
+            assertHasErrorOutput("Script compilation error:")
+            assertHasErrorOutput("onlyForFirst {}")
+            assertHasErrorOutput("receiver type mismatch")
+        }
+    }
+
+    @Test
+    fun `build-model bound feature accessor is available on the project type with the matching build model`() {
+        withPluginsWithTwoProjectTypesAndFeatures()
+        enableDclInGradleProperties()
+
+        withSettingsContent(
+            """
+            defaults {
+                secondProjectType {
+                    onlyForSecondBuildModel {}
+                }
+            }
+            """.trimIndent()
+        )
+
+        build("help")
+    }
+
+    @Test
+    fun `build-model bound feature accessor is not available on a project type with a different build model`() {
+        withPluginsWithTwoProjectTypesAndFeatures()
+        enableDclInGradleProperties()
+
+        withSettingsContent(
+            """
+            defaults {
+                firstProjectType {
+                    onlyForSecondBuildModel {}
+                }
+            }
+            """.trimIndent()
+        )
+
+        buildAndFail("help").apply {
+            assertHasErrorOutput("Script compilation error:")
+            assertHasErrorOutput("onlyForSecondBuildModel {}")
+            assertHasErrorOutput("receiver type mismatch")
+        }
+    }
+
+    @Test
+    fun `definition bound feature accessor is available inside the project type it binds to`() {
+        withPluginsWithTwoProjectTypesAndFeatures()
+        enableDclInGradleProperties()
+
+        withSettingsContent(
+            """
+            defaults {
+                firstProjectType {
+                    onlyForFirst {}
+                }
+            }
+            """.trimIndent()
+        )
+
+        build("help")
+    }
+
+    private fun withPluginsWithTwoProjectTypesAndFeatures() {
+        withFile(
+            "build-logic/build.gradle.kts",
+            """
+                plugins {
+                    id("java-gradle-plugin")
+                    `kotlin-dsl`
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                gradlePlugin {
+                    plugins {
+                        create("firstPlugin") {
+                            id = "com.example.firstPlugin"
+                            implementationClass = "com.example.FirstPlugin"
+                        }
+                        create("secondPlugin") {
+                            id = "com.example.secondPlugin"
+                            implementationClass = "com.example.SecondPlugin"
+                        }
+                        create("myEcosystemPlugin") {
+                            id = "com.example.myEcosystemPlugin"
+                            implementationClass = "com.example.MyEcosystemPlugin"
+                        }
+                    }
+                }
+            """.trimIndent()
+        )
+
+        withFile(
+            "build-logic/src/main/kotlin/FirstPlugin.kt",
+            """
+                package com.example
+
+                import org.gradle.api.Plugin
+                import org.gradle.api.Project
+                import ${BindsProjectType::class.qualifiedName}
+                import ${BindsProjectFeature::class.qualifiedName}
+                import ${BuildModel::class.qualifiedName}
+                import ${Definition::class.qualifiedName}
+                import ${ProjectFeatureApplicationContext::class.qualifiedName}
+                import ${ProjectFeatureApplyAction::class.qualifiedName}
+                import ${ProjectFeatureBinding::class.qualifiedName}
+                import ${ProjectFeatureBindingBuilder::class.qualifiedName}
+                import ${ProjectTypeApplyAction::class.qualifiedName}
+                import ${ProjectTypeBinding::class.qualifiedName}
+                import ${ProjectTypeBindingBuilder::class.qualifiedName}
+
+                interface FirstBuildModel : BuildModel
+                interface FirstDefinition : ${Definition::class.simpleName}<FirstBuildModel>
+
+                interface OnlyForFirstBuildModel : BuildModel
+                interface OnlyForFirstDefinition : ${Definition::class.simpleName}<OnlyForFirstBuildModel>
+
+                class FirstProjectTypeApplyAction : ${ProjectTypeApplyAction::class.simpleName}<FirstDefinition, FirstBuildModel> {
+                    override fun apply(
+                        context: ProjectFeatureApplicationContext,
+                        definition: FirstDefinition,
+                        buildModel: FirstBuildModel
+                    ) {}
+                }
+
+                class OnlyForFirstApplyAction : ${ProjectFeatureApplyAction::class.simpleName}<OnlyForFirstDefinition, OnlyForFirstBuildModel, FirstDefinition> {
+                    override fun apply(
+                        context: ProjectFeatureApplicationContext,
+                        definition: OnlyForFirstDefinition,
+                        buildModel: OnlyForFirstBuildModel,
+                        parentDefinition: FirstDefinition
+                    ) {}
+                }
+
+                @${BindsProjectType::class.simpleName}(FirstPlugin.Binding::class)
+                @${BindsProjectFeature::class.simpleName}(FirstPlugin.FeatureBinding::class)
+                abstract class FirstPlugin : Plugin<Project> {
+
+                    override fun apply(project: Project) = Unit
+
+                    class Binding : ${ProjectTypeBinding::class.simpleName} {
+                        override fun bind(builder: ProjectTypeBindingBuilder) {
+                            builder.bindProjectType(
+                                "firstProjectType",
+                                FirstDefinition::class.java,
+                                FirstProjectTypeApplyAction::class.java
+                            )
+                        }
+                    }
+
+                    class FeatureBinding : ${ProjectFeatureBinding::class.simpleName} {
+                        override fun bind(builder: ProjectFeatureBindingBuilder) {
+                            builder.bindProjectFeatureToDefinition(
+                                "onlyForFirst",
+                                OnlyForFirstDefinition::class.java,
+                                FirstDefinition::class.java,
+                                OnlyForFirstApplyAction::class.java
+                            )
+                        }
+                    }
+                }
+            """.trimIndent()
+        )
+
+        withFile(
+            "build-logic/src/main/kotlin/SecondPlugin.kt",
+            """
+                package com.example
+
+                import org.gradle.api.Plugin
+                import org.gradle.api.Project
+                import ${BindsProjectFeature::class.qualifiedName}
+                import ${BindsProjectType::class.qualifiedName}
+                import ${BuildModel::class.qualifiedName}
+                import ${Definition::class.qualifiedName}
+                import ${ProjectFeatureApplicationContext::class.qualifiedName}
+                import ${ProjectFeatureApplyAction::class.qualifiedName}
+                import ${ProjectFeatureBinding::class.qualifiedName}
+                import ${ProjectFeatureBindingBuilder::class.qualifiedName}
+                import ${ProjectTypeApplyAction::class.qualifiedName}
+                import ${ProjectTypeBinding::class.qualifiedName}
+                import ${ProjectTypeBindingBuilder::class.qualifiedName}
+
+                interface SecondBuildModel : BuildModel
+                interface SecondDefinition : ${Definition::class.simpleName}<SecondBuildModel>
+
+                interface OnlyForSecondBuildModelBuildModel : BuildModel
+                interface OnlyForSecondBuildModelDefinition : ${Definition::class.simpleName}<OnlyForSecondBuildModelBuildModel>
+
+                class SecondProjectTypeApplyAction : ${ProjectTypeApplyAction::class.simpleName}<SecondDefinition, SecondBuildModel> {
+                    override fun apply(context: ProjectFeatureApplicationContext, definition: SecondDefinition, buildModel: SecondBuildModel) {}
+                }
+
+                class OnlyForSecondBuildModelApplyAction : ${ProjectFeatureApplyAction::class.simpleName}<OnlyForSecondBuildModelDefinition, OnlyForSecondBuildModelBuildModel, Definition<SecondBuildModel>> {
+                    override fun apply(
+                        context: ProjectFeatureApplicationContext,
+                        definition: OnlyForSecondBuildModelDefinition,
+                        buildModel: OnlyForSecondBuildModelBuildModel,
+                        parentDefinition: Definition<SecondBuildModel>
+                    ) {}
+                }
+
+                @${BindsProjectType::class.simpleName}(SecondPlugin.Binding::class)
+                @${BindsProjectFeature::class.simpleName}(SecondPlugin.FeatureBinding::class)
+                abstract class SecondPlugin : Plugin<Project> {
+
+                    override fun apply(project: Project) = Unit
+
+                    class Binding : ${ProjectTypeBinding::class.simpleName} {
+                        override fun bind(builder: ProjectTypeBindingBuilder) {
+                            builder.bindProjectType(
+                                "secondProjectType",
+                                SecondDefinition::class.java,
+                                SecondProjectTypeApplyAction::class.java
+                            )
+                        }
+                    }
+
+                    class FeatureBinding : ${ProjectFeatureBinding::class.simpleName} {
+                        override fun bind(builder: ProjectFeatureBindingBuilder) {
+                            builder.bindProjectFeatureToBuildModel(
+                                "onlyForSecondBuildModel",
+                                OnlyForSecondBuildModelDefinition::class.java,
+                                SecondBuildModel::class.java,
+                                OnlyForSecondBuildModelApplyAction::class.java
+                            )
+                        }
+                    }
+                }
+            """.trimIndent()
+        )
+
+        withFile(
+            "build-logic/src/main/kotlin/MyEcosystemPlugin.kt",
+            """
+                package com.example
+
+                import org.gradle.api.Plugin
+                import org.gradle.api.initialization.Settings
+                import ${RegistersProjectFeatures::class.qualifiedName}
+
+                @${RegistersProjectFeatures::class.simpleName}(FirstPlugin::class, SecondPlugin::class)
+                class MyEcosystemPlugin : Plugin<Settings> {
+                    override fun apply(settings: Settings) = Unit
+                }
+            """.trimIndent()
+        )
+    }
+
+    private fun withSettingsContent(content: String) {
+        withFile(
+            "settings.gradle.kts",
+            """
+            pluginManagement {
+                includeBuild("build-logic")
+            }
+
+            plugins {
+                id("com.example.myEcosystemPlugin")
+            }
+
+            $content
+            """.trimIndent()
+        )
+    }
+
+    private fun enableDclInGradleProperties() =
+        withFile("gradle.properties").appendText("\n$DCL_ENABLED_PROPERTY_NAME=true\n")
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.accessors
 import org.gradle.api.Action
 import org.gradle.api.Incubating
 import org.gradle.api.Project
+import org.gradle.api.initialization.SharedModelDefaults
 import org.gradle.api.internal.DynamicObjectAware
 import org.gradle.api.reflect.TypeOf
 import org.gradle.internal.deprecation.ConfigurationDeprecationType
@@ -1112,10 +1113,12 @@ fun fragmentsForModelDefault(
     val className = internalNameForAccessorClassOf(accessorSpec)
     val (accessibleReceiverType, name, modelType) = accessorSpec
     val projectFeatureName = name.kotlinIdentifier
-    val receiverType = accessibleReceiverType.type.kmType
+    val (kotlinReceiverType, jvmReceiverType) = accessibleTypesFor(accessibleReceiverType)
     val (kotlinPublicType, jvmPublicType) = accessibleTypesFor(modelType)
     val deprecation = accessor.spec.type.deprecation()
     val optIns = accessor.spec.type.requiredOptIns()
+
+    val isTopLevelReceiver = accessibleReceiverType.type.value.concreteClass == SharedModelDefaults::class.java
 
     return className to sequenceOf(
         AccessorFragment(
@@ -1124,17 +1127,29 @@ fun fragmentsForModelDefault(
                 publicStaticMethod(signature) {
                     maybeWithDeprecation(deprecation)
                     maybeWithOptInRequirement(optIns)
-                    ALOAD(0)
-                    LDC(projectFeatureName)
-                    LDC(jvmPublicType)
-                    ALOAD(1)
-                    INVOKEINTERFACE(GradleTypeName.modeDefaults, "add", "(Ljava/lang/String;Ljava/lang/Class;Lorg/gradle/api/Action;)V")
-                    RETURN()
+                    if (isTopLevelReceiver) {
+                        ALOAD(0)
+                        LDC(projectFeatureName)
+                        LDC(jvmPublicType)
+                        ALOAD(1)
+                        INVOKEINTERFACE(GradleTypeName.modeDefaults, "add", "(Ljava/lang/String;Ljava/lang/Class;Lorg/gradle/api/Action;)V")
+                        RETURN()
+                    } else {
+                        ALOAD(0)
+                        CHECKCAST(DynamicObjectAware::class.internalName)
+                        LDC(projectFeatureName)
+                        ALOAD(1)
+                        invokeRuntime(
+                            "applyProjectFeature",
+                            "(L${DynamicObjectAware::class.internalName};L${String::class.internalName};L${Action::class.internalName};)V"
+                        )
+                        RETURN()
+                    }
                 }
             },
             metadata = {
                 kmPackage.functions += newFunctionOf(
-                    receiverType = receiverType,
+                    receiverType = kotlinReceiverType,
                     returnType = KotlinType.unit,
                     name = projectFeatureName,
                     valueParameters = listOf(
@@ -1150,7 +1165,7 @@ fun fragmentsForModelDefault(
             },
             signature = JvmMethodSignature(
                 name.kotlinIdentifier,
-                "(Lorg/gradle/api/initialization/SharedModelDefaults;Lorg/gradle/api/Action;)V"
+                "(L$jvmReceiverType;Lorg/gradle/api/Action;)V"
             )
         )
     )

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.kotlin.dsl.accessors
 
+import org.gradle.api.initialization.SharedModelDefaults
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.support.unsafeLazy
 import org.gradle.util.internal.TextUtil
@@ -334,36 +335,63 @@ fun inaccessibleExistingContainerElementAccessorFor(containerType: String, name:
 
 internal
 fun modelDefaultAccessor(spec: TypedAccessorSpec): String = spec.run {
+    val receiverKotlinType = receiver.type.kotlinString
+    val isTopLevelReceiver = receiver.type.value.concreteClass == SharedModelDefaults::class.java
     when (type) {
-        is TypeAccessibility.Accessible -> accessibleModelDefaultAccessorFor(name, type.type.kotlinString, type.deprecation(), type.optInRequirements)
-        is TypeAccessibility.Inaccessible -> inaccessibleModelDefaultAccessorFor(name, type)
+        is TypeAccessibility.Accessible -> accessibleModelDefaultAccessorFor(
+            receiverKotlinType,
+            isTopLevelReceiver,
+            name,
+            type.type.kotlinString,
+            type.deprecation(),
+            type.optInRequirements
+        )
+        is TypeAccessibility.Inaccessible -> inaccessibleModelDefaultAccessorFor(receiverKotlinType, isTopLevelReceiver, name, type)
     }
 }
 
 
 private
-fun accessibleModelDefaultAccessorFor(name: AccessorNameSpec, type: String, deprecation: Deprecated?, optIns: List<AnnotationRepresentation>): String = name.run {
+fun accessibleModelDefaultAccessorFor(
+    receiverType: String,
+    isTopLevelReceiver: Boolean,
+    name: AccessorNameSpec,
+    type: String,
+    deprecation: Deprecated?,
+    optIns: List<AnnotationRepresentation>
+): String = name.run {
     val annotations = """${maybeDeprecationAnnotations(deprecation)}${maybeOptInAnnotationSource(optIns)}"""
+    val body =
+        if (isTopLevelReceiver) """add("$stringLiteral", $type, configure)"""
+        else """applyProjectFeature(this, "$stringLiteral", configure)"""
     """
     |        /**
-    |         * Adds model defaults for the [$original][$name] project type.
+    |         * Adds model defaults for the [$original][$type] project feature.
     |         */
-    |        ${annotations}fun SharedModelDefaults.`$kotlinIdentifier`(configure: Action<$type>): Unit =
-    |            add("$stringLiteral", $type, configure)
+    |        ${annotations}fun $receiverType.`$kotlinIdentifier`(configure: Action<$type>): Unit =
+    |            $body
     """.trimMargin()
 }
 
 
 private
-fun inaccessibleModelDefaultAccessorFor(name: AccessorNameSpec, typeAccess: TypeAccessibility.Inaccessible): String = name.run {
+fun inaccessibleModelDefaultAccessorFor(
+    receiverType: String,
+    isTopLevelReceiver: Boolean,
+    name: AccessorNameSpec,
+    typeAccess: TypeAccessibility.Inaccessible
+): String = name.run {
+    val body =
+        if (isTopLevelReceiver) """add("$stringLiteral", KotlinType.Any, configure)"""
+        else """applyProjectFeature(this, "$stringLiteral", configure)"""
     """
         /**
-         * Adds model defaults for the `$original` project type.
+         * Adds model defaults for the `$original` project feature.
          *
          * ${documentInaccessibilityReasons(name, typeAccess)}
          */
-        fun SharedModelDefaults.`$kotlinIdentifier`(configure: Action<Any>): Unit =
-            add("$stringLiteral", KotlinType.Any, configure)
+        fun $receiverType.`$kotlinIdentifier`(configure: Action<Any>): Unit =
+            $body
 
     """
 }

--- a/platforms/core-configuration/kotlin-dsl/src/test/resources/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors-expected-output.txt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/resources/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors-expected-output.txt
@@ -376,8 +376,8 @@
 
 
     /**
-     * Adds model defaults for the [projectType][AccessorNameSpec(original=projectType)] project type.
+     * Adds model defaults for the [projectType][org.gradle.kotlin.dsl.accessors.tasks.PrintAccessorsTest.TestProjectType] project feature.
      */
-    fun SharedModelDefaults.`projectType`(configure: Action<org.gradle.kotlin.dsl.accessors.tasks.PrintAccessorsTest.TestProjectType>): Unit =
+    fun org.gradle.api.initialization.SharedModelDefaults.`projectType`(configure: Action<org.gradle.kotlin.dsl.accessors.tasks.PrintAccessorsTest.TestProjectType>): Unit =
         add("projectType", org.gradle.kotlin.dsl.accessors.tasks.PrintAccessorsTest.TestProjectType, configure)
 


### PR DESCRIPTION
Feature accessors generated inside `defaults { }` in settings.gradle.kts were emitted as extensions on `SharedModelDefaults`, so they resolved inside every project-type block regardless of binding. Now each accessor's receiver is chosen from the feature's `TargetTypeInformation`: the owning definition class for definition-bound features and `Definition<out U>` for build-model-bound features, with features bound to `Project` keeping `SharedModelDefaults` so the outer project-type accessor still stores the action. Scoped accessors dispatch through the existing `applyProjectFeature` runtime helper when replayed against a real definition at project-configuration time.

Fixes #36411

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
