### PR TITLE
Update supported architectures for Kotlin embedded compiler

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
@@ -29,7 +29,7 @@ TIP: If you are interested in migrating an existing Gradle build to the Kotlin D
 [[kotdsl:prerequisites]]
 == Prerequisites
 
-* The embedded Kotlin compiler works on Linux, macOS, Windows, Cygwin, FreeBSD, and Solaris on x86-64 architectures.
+* The embedded Kotlin compiler works on Linux, macOS, Windows, Cygwin, FreeBSD, and Solaris on x86-64, arm64, and arm32 architectures.
 * Familiarity with Kotlin syntax and basic language features is recommended.
 Refer to the link:{kotlin-reference}[Kotlin documentation] and link:https://kotlinlang.org/docs/tutorials/koans.html[Kotlin Koans] to learn the basics.
 * Using the <<plugins_intermediate.adoc#sec:plugins_block,`plugins {}`>> block to declare Gradle plugins is highly recommended as it significantly improves the editing experience.


### PR DESCRIPTION
Good day,

I noticed that the documentation in `platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc` still states that the Kotlin embedded compiler only works on x86-64 architectures. However, looking at the codebase, I can see that Gradle actually supports arm64 (aarch64) and arm32 architectures as well.

This PR updates the documentation to reflect the current state:
- Before: `on x86-64 architectures`
- After: `on x86-64, arm64, and arm32 architectures`

Reference: https://github.com/gradle/gradle/issues/37017

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof