### PR TITLE
Prevent library.jansi.path from leaking across JVMs

### DIFF
--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/jansi/JansiBootPathConfigurer.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/jansi/JansiBootPathConfigurer.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.nativeintegration.jansi;
 
 import org.apache.commons.io.IOUtils;
+import org.fusesource.jansi.internal.JansiLoader;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.nativeintegration.NativeIntegrationException;
 
@@ -26,16 +27,23 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class JansiBootPathConfigurer {
-    private static final String JANSI_LIBRARY_PATH_SYS_PROP = "library.jansi.path";
+    static final String JANSI_LIBRARY_PATH_SYS_PROP = "library.jansi.path";
     private final JansiStorageLocator locator = new JansiStorageLocator();
 
     /**
      * Attempts to find the Jansi library and copies it to a specified folder.
-     * The copy operation happens only once. Sets the Jansi-related system property.
+     * The copy operation happens only once. Temporarily sets the Jansi-related
+     * system property so that {@link JansiLoader} finds the pre-extracted native
+     * library, eagerly initializes Jansi, then restores the previous property value.
      *
-     * This hackery is to prevent Jansi from creating a shared lib in a tmp dir which is deleted when
+     * <p>This hackery is to prevent Jansi from creating a shared lib in a tmp dir which is deleted when
      * the Java process finishes. To avoid performance impacts caused by Jansi's default behavior the
-     * library is proactively extracted into a known directory and reused by subsequent invocations.
+     * library is proactively extracted into a known directory and reused by subsequent invocations.</p>
+     *
+     * <p>The property is restored after initialization to prevent it from leaking to other Jansi
+     * versions sharing this JVM. This matters when Gradle is loaded as a Tooling API provider
+     * inside an IDE's JVM: the IDE may bundle a different Jansi version that would read the
+     * stale property and attempt to load an incompatible native library, causing a JNI crash.</p>
      *
      * @param storageDir where to store the Jansi library
      */
@@ -57,7 +65,17 @@ public class JansiBootPathConfigurer {
                 }
             }
 
-            System.setProperty(JANSI_LIBRARY_PATH_SYS_PROP, libFile.getParent());
+            String prev = System.getProperty(JANSI_LIBRARY_PATH_SYS_PROP);
+            try {
+                System.setProperty(JANSI_LIBRARY_PATH_SYS_PROP, libFile.getParent());
+                JansiLoader.initialize();
+            } finally {
+                if (prev == null) {
+                    System.clearProperty(JANSI_LIBRARY_PATH_SYS_PROP);
+                } else {
+                    System.setProperty(JANSI_LIBRARY_PATH_SYS_PROP, prev);
+                }
+            }
         }
     }
 

--- a/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/jansi/JansiBootPathConfigurerTest.groovy
+++ b/platforms/core-runtime/native/src/test/groovy/org/gradle/internal/nativeintegration/jansi/JansiBootPathConfigurerTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.nativeintegration.jansi
+
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+import static org.gradle.internal.nativeintegration.jansi.JansiBootPathConfigurer.JANSI_LIBRARY_PATH_SYS_PROP
+
+class JansiBootPathConfigurerTest extends Specification {
+
+    @Rule
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+
+    def configurer = new JansiBootPathConfigurer()
+
+    String originalJansiPath
+
+    def setup() {
+        originalJansiPath = System.getProperty(JANSI_LIBRARY_PATH_SYS_PROP)
+    }
+
+    def cleanup() {
+        if (originalJansiPath == null) {
+            System.clearProperty(JANSI_LIBRARY_PATH_SYS_PROP)
+        } else {
+            System.setProperty(JANSI_LIBRARY_PATH_SYS_PROP, originalJansiPath)
+        }
+    }
+
+    def "does not leak library.jansi.path system property after configure"() {
+        given:
+        System.clearProperty(JANSI_LIBRARY_PATH_SYS_PROP)
+
+        when:
+        configurer.configure(tmpDir.testDirectory)
+
+        then:
+        System.getProperty(JANSI_LIBRARY_PATH_SYS_PROP) == null
+    }
+
+    def "restores previous library.jansi.path value after configure"() {
+        given:
+        def previousValue = "/some/previous/jansi/path"
+        System.setProperty(JANSI_LIBRARY_PATH_SYS_PROP, previousValue)
+
+        when:
+        configurer.configure(tmpDir.testDirectory)
+
+        then:
+        System.getProperty(JANSI_LIBRARY_PATH_SYS_PROP) == previousValue
+    }
+}

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoader.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoader.java
@@ -102,8 +102,40 @@ public class DefaultToolingImplementationLoader implements ToolingImplementation
         }
     }
 
+    /**
+     * The system property that Jansi uses to locate pre-extracted native libraries.
+     * Old Gradle provider versions set this JVM-global property during {@code configure()},
+     * pointing to their bundled native library. We must restore it after the call to prevent
+     * it from poisoning any other Jansi version in this JVM (e.g. the IDE's own Jansi).
+     */
+    private static final String JANSI_LIBRARY_PATH_SYS_PROP = "library.jansi.path";
+
+    /**
+     * Serializes the snapshot/configure/restore of {@link #JANSI_LIBRARY_PATH_SYS_PROP}.
+     * Multiple {@link org.gradle.tooling.GradleConnector} instances (e.g. one per IDE project)
+     * can call {@link #createConnection} concurrently; without this lock one thread could
+     * snapshot the stale value written by another thread's provider.
+     */
+    private static final Object JANSI_PATH_LOCK = new Object();
+
     private ConsumerConnection createConnection(AbstractConsumerConnection adaptedConnection, ConnectionParameters connectionParameters) {
-        adaptedConnection.configure(connectionParameters);
+        // Save and restore library.jansi.path around the provider's configure() call.
+        // Old provider versions (e.g. Gradle 7.6) set this JVM-global property to point to
+        // their bundled jansi 1.x native library path. If left set, it causes jansi 2.x in
+        // the same JVM (e.g. the IDE's own jansi) to load an incompatible native library,
+        // resulting in a JNI crash.
+        synchronized (JANSI_PATH_LOCK) {
+            String prevJansiPath = System.getProperty(JANSI_LIBRARY_PATH_SYS_PROP);
+            try {
+                adaptedConnection.configure(connectionParameters);
+            } finally {
+                if (prevJansiPath == null) {
+                    System.clearProperty(JANSI_LIBRARY_PATH_SYS_PROP);
+                } else {
+                    System.setProperty(JANSI_LIBRARY_PATH_SYS_PROP, prevJansiPath);
+                }
+            }
+        }
         VersionDetails versionDetails = adaptedConnection.getVersionDetails();
         return new ParameterValidatingConsumerConnection(versionDetails, adaptedConnection);
     }

--- a/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoaderTest.groovy
+++ b/platforms/ide/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoaderTest.groovy
@@ -136,6 +136,59 @@ class DefaultToolingImplementationLoaderTest extends Specification {
         expect:
         loader.create(distribution, loggerFactory, progressListener, connectionParameters, cancellationToken) instanceof NoToolingApiConnection
     }
+
+    def "cleans up library.jansi.path set by old provider during configure"() {
+        given:
+        distribution.getToolingImplementationClasspath(loggerFactory, progressListener, connectionParameters, cancellationToken) >> DefaultClassPath.of(
+            getToolingApiResourcesDir(TestConnectionThatSetsJansiPath.class),
+            ClasspathUtil.getClasspathForClass(TestConnection.class),
+            ClasspathUtil.getClasspathForClass(ActorFactory.class),
+            ClasspathUtil.getClasspathForClass(Logger.class),
+            ClasspathUtil.getClasspathForClass(GroovyObject.class),
+            ClasspathUtil.getClasspathForClass(GradleVersion.class))
+        def prevJansiPath = System.getProperty("library.jansi.path")
+
+        when:
+        System.clearProperty("library.jansi.path")
+        loader.create(distribution, loggerFactory, progressListener, connectionParameters, cancellationToken)
+
+        then:
+        System.getProperty("library.jansi.path") == null
+
+        cleanup:
+        if (prevJansiPath == null) {
+            System.clearProperty("library.jansi.path")
+        } else {
+            System.setProperty("library.jansi.path", prevJansiPath)
+        }
+    }
+
+    def "restores previous library.jansi.path value after old provider sets it"() {
+        given:
+        distribution.getToolingImplementationClasspath(loggerFactory, progressListener, connectionParameters, cancellationToken) >> DefaultClassPath.of(
+            getToolingApiResourcesDir(TestConnectionThatSetsJansiPath.class),
+            ClasspathUtil.getClasspathForClass(TestConnection.class),
+            ClasspathUtil.getClasspathForClass(ActorFactory.class),
+            ClasspathUtil.getClasspathForClass(Logger.class),
+            ClasspathUtil.getClasspathForClass(GroovyObject.class),
+            ClasspathUtil.getClasspathForClass(GradleVersion.class))
+        def prevJansiPath = System.getProperty("library.jansi.path")
+        def existingValue = "/ide/own/jansi/path"
+
+        when:
+        System.setProperty("library.jansi.path", existingValue)
+        loader.create(distribution, loggerFactory, progressListener, connectionParameters, cancellationToken)
+
+        then:
+        System.getProperty("library.jansi.path") == existingValue
+
+        cleanup:
+        if (prevJansiPath == null) {
+            System.clearProperty("library.jansi.path")
+        } else {
+            System.setProperty("library.jansi.path", prevJansiPath)
+        }
+    }
 }
 
 class TestMetaData implements ConnectionMetaDataVersion1 {
@@ -253,5 +306,16 @@ class TestR10M3Connection implements ConnectionVersion4 {
 
     ConnectionMetaDataVersion1 getMetaData() {
         return new TestMetaData('1.0-milestone-3')
+    }
+}
+
+/**
+ * Simulates an old Gradle provider that sets library.jansi.path during configure(),
+ * as Gradle versions before the fix did via NativeServices/JansiBootPathConfigurer.
+ */
+class TestConnectionThatSetsJansiPath extends TestConnection {
+    void configure(org.gradle.tooling.internal.protocol.ConnectionParameters parameters) {
+        super.configure(parameters)
+        System.setProperty("library.jansi.path", "/stale/jansi/1.18/native/path")
     }
 }


### PR DESCRIPTION
## Summary

When an IDE (e.g. IntelliJ IDEA) uses Tooling API 9.x to connect to an old Gradle project (e.g. Gradle 7.6), the cross-version compatibility layer loads the old provider's JARs into the IDE's JVM. The old provider's `NativeServices` / `JansiBootPathConfigurer` sets the JVM-global system property `library.jansi.path` to point at Gradle's pre-extracted jansi **1.18** native directory. After `configure()` returns, this stale value remains set. When the IDE's own jansi **2.x** later reads the property, it attempts to load the 1.18 native library with 2.x JNI bindings, causing a **JVM crash**.

### Root cause

`JansiBootPathConfigurer.configure()` calls `System.setProperty("library.jansi.path", ...)` to tell jansi where to find the pre-extracted native library (avoiding extraction to a potentially noexec-mounted tmpdir). This property is JVM-global and was never cleaned up after use.

### Fix

**Provider side (`JansiBootPathConfigurer`):** The property is now set temporarily — save the previous value, set the path, eagerly call `JansiLoader.initialize()` to load the native library, then restore the previous value in a `finally` block. Once jansi's internal `loaded` flag is set, the property is no longer consulted, so clearing it is safe. This prevents future Gradle versions from leaking the property when loaded as TAPI providers.

**Consumer side (`DefaultToolingImplementationLoader`):** Save and restore `library.jansi.path` around the provider's `configure()` call. This is the defense-in-depth fix that protects against **old** provider versions (e.g. Gradle 7.6) whose code cannot be changed.

## Test plan

- [ ] `JansiBootPathConfigurerTest` — verifies the property is not leaked after `configure()` and that a pre-existing value is restored
- [ ] `DefaultToolingImplementationLoaderTest` — two new tests using a mock connection that simulates an old provider setting the property; verifies cleanup when no prior value exists and restoration when one does
- [ ] Existing `JansiStorageLocatorTest`, `JansiLibraryFactoryIntegrationTest`, and `JansiEndUserIntegrationTest` still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced Jansi library path management to properly restore system state after initialization, ensuring the native library path property is only temporarily set during configuration and restored to its previous state afterward.

## Tests
* Added comprehensive test coverage for system property cleanup in Jansi initialization and tooling connection creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->