### PR TITLE
Warm up AndroidHome for configCacheSmokeTest

### DIFF
--- a/testing/smoke-test/build.gradle.kts
+++ b/testing/smoke-test/build.gradle.kts
@@ -157,6 +157,8 @@ tasks {
         description = "Runs Smoke tests with the configuration cache"
         systemProperty("org.gradle.integtest.executer", "configCache")
         configureForSmokeTest(excludes = listOf(gradleBuildTestPattern, androidProjectTestPattern))
+
+        dependsOn("androidHomeWarmup")
     }
 
     register<SmokeTest>("gradleBuildSmokeTest") {


### PR DESCRIPTION
In https://github.com/gradle/gradle/pull/35816 we warm up AndroidHome for several test tasks, but not `configCacheSmokeTest`. Now it's failing in:

- https://ge.gradle.org/s/strgrlpppcwok/tests/overview?failure-group=aaaaaaaabfz5s
- https://ge.gradle.org/s/j3osrjbzt37tk/tests/overview?failure-group=aaaaaaaabfz5s