### PR TITLE
Fix test ordering for same-named methods in TestNG factory tests

### DIFF
--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModelResultsProvider.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/TestTreeModelResultsProvider.java
@@ -91,7 +91,8 @@ public final class TestTreeModelResultsProvider implements TestResultsProvider {
     }
 
     private static final Comparator<PerRootInfo> PER_ROOT_INFO_BY_START_TIME =
-        Comparator.comparing(leaf -> leaf.getResults().get(0).getStartTime());
+        Comparator.comparingLong((PerRootInfo leaf) -> leaf.getResults().get(0).getStartTime())
+                  .thenComparingLong(PerRootInfo::getId);
 
     private static Map<Long, ClassNode> createClasses(TestTreeModel root) {
         Map<org.gradle.util.Path, TestTreeModel> parentOfPath = buildParentOfPathMap(root);


### PR DESCRIPTION
## Problem

`SamplesJavaTestingIntegrationTest.can use the groupByInstances option with TestNG tests` has been failing intermittently. The assertion:

```groovy
xmlResults.testcase.@name*.text() == ["test1", "test2", "test1", "test2"]
```

was producing `["test1", "test1", "test2", "test2"]` instead.

**Root cause:** Commit 64426b7acf0 switched `AbstractTestTask` to the new `JunitXmlTestReportGenerator` backed by `TestTreeModelResultsProvider`. This provider groups test methods by name in a tree — so both `TestFactory[data1].test1()` and `TestFactory[data2].test1()` share the same `:test1` tree node.

When re-emitting leaves for the XML writer, they are sorted by `getStartTime()`. For trivially fast test methods that all complete within the same millisecond, the sort is a no-op, leaving them in depth-first insertion order: `[test1, test1, test2, test2]` — the non-`groupByInstances` pattern.

## Fix

Add `getId()` as a tiebreaker to `PER_ROOT_INFO_BY_START_TIME`. The `PerRootInfo.id` is assigned from the `SerializableTestResultStore` serialization sequence, which matches execution/completion order. When start times are equal, secondary sorting by ID restores the correct groupByInstances ordering: `[test1, test2, test1, test2]`.

## Evidence

- Build: https://builds.gradle.org/buildConfiguration/Gradle_Release_Check_IsolatedProjects_21_bucket4/111473014
- Failure: `xmlResults.testcase.@name*.text()` was `[test1, test1, test2, test2]` instead of `[test1, test2, test1, test2]`
- Execution stdout confirms `groupByInstances` was working correctly (data2's tests ran together before data1's), but the XML writer lost the ordering
- Root change: 64426b7acf0
