### PR TITLE
Surface resolved external artifacts via enriched and synthetic build operations

### DIFF
--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/DefaultResolvableArtifactCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/DefaultResolvableArtifactCodec.kt
@@ -16,18 +16,28 @@
 
 package org.gradle.internal.serialize.codecs.dm
 
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultResolvableArtifact
+import org.gradle.api.internal.artifacts.DownloadArtifactBuildOperationType
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentIdentifierSerializer
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.IvyArtifactNameSerializer
 import org.gradle.api.internal.tasks.TaskDependencyContainer
+import org.gradle.internal.Describables
+import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
+import org.gradle.internal.model.CalculatedValueContainerFactory
+import org.gradle.internal.operations.BuildOperationContext
+import org.gradle.internal.operations.BuildOperationDescriptor
+import org.gradle.internal.operations.BuildOperationRunner
+import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
 import org.gradle.internal.serialize.graph.readFile
+import org.gradle.internal.serialize.graph.serviceOf
 import org.gradle.internal.serialize.graph.writeFile
-import org.gradle.internal.Describables
-import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
-import org.gradle.internal.model.CalculatedValueContainerFactory
+
+import java.io.File
 
 
 class DefaultResolvableArtifactCodec(
@@ -38,7 +48,9 @@ class DefaultResolvableArtifactCodec(
 
     override suspend fun WriteContext.encode(value: DefaultResolvableArtifact) {
         // Write the source artifact
-        writeFile(value.file)
+        val file = value.file
+        writeFile(file)
+        writeLong(file.length())
         IvyArtifactNameSerializer.INSTANCE.write(this, value.artifactName)
         // TODO - preserve the artifact id implementation instead of unpacking the component id
         componentIdSerializer.write(this, value.id.componentIdentifier)
@@ -47,9 +59,48 @@ class DefaultResolvableArtifactCodec(
 
     override suspend fun ReadContext.decode(): DefaultResolvableArtifact {
         val file = readFile()
+        val fileSize = readLong()
         val artifactName = IvyArtifactNameSerializer.INSTANCE.read(this)
         val componentId = componentIdSerializer.read(this)
         val artifactId = ComponentFileArtifactIdentifier(componentId, file.name)
+        if (componentId is ModuleComponentIdentifier) {
+            emitReplayOperation(artifactId, file, fileSize)
+        }
         return DefaultResolvableArtifact(null, artifactName, artifactId, TaskDependencyContainer.EMPTY, calculatedValueContainerFactory.create(Describables.of(artifactId), file), calculatedValueContainerFactory)
+    }
+
+    private
+    fun ReadContext.emitReplayOperation(artifactId: ComponentArtifactIdentifier, file: File, fileSize: Long) {
+        val buildOperationRunner = isolate.owner.serviceOf<BuildOperationRunner>()
+        buildOperationRunner.run(ReplayDownloadArtifactOperation(artifactId, file, fileSize))
+    }
+
+    /**
+     * Emits a [DownloadArtifactBuildOperationType] synthetically during Configuration Cache replay.
+     *
+     * On CC hit the original resolution pipeline is skipped, so neither [DownloadArtifactBuildOperationType]
+     * nor any [org.gradle.internal.resource.ExternalResourceReadBuildOperationType] /
+     * [org.gradle.internal.resource.ExternalResourceAlreadyPresentBuildOperationType] is emitted for the
+     * artifact. This synthetic emission surfaces the resolved artifact to build operation consumers
+     * (e.g. the Develocity plugin) with the same path/size payload. The absence of a child
+     * [org.gradle.internal.resource.ExternalResourceReadBuildOperationType] signals that no download
+     * occurred — on CC replay, every artifact is cache-resolved by definition.
+     */
+    private
+    class ReplayDownloadArtifactOperation(
+        private val artifactId: ComponentArtifactIdentifier,
+        private val file: File,
+        private val fileSize: Long
+    ) : RunnableBuildOperation {
+        override fun run(context: BuildOperationContext) {
+            context.setResult(DownloadArtifactBuildOperationType.ResultImpl(file.absolutePath, fileSize))
+        }
+
+        override fun description(): BuildOperationDescriptor.Builder {
+            val displayName = artifactId.displayName
+            return BuildOperationDescriptor
+                .displayName("Resolve $displayName")
+                .details(DownloadArtifactBuildOperationType.DetailsImpl(displayName))
+        }
     }
 }

--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/DefaultResolvableArtifactCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/DefaultResolvableArtifactCodec.kt
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultResolvableArtifact
 import org.gradle.api.internal.artifacts.DownloadArtifactBuildOperationType
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.FileStoreAndIndexProvider
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentIdentifierSerializer
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.IvyArtifactNameSerializer
 import org.gradle.api.internal.tasks.TaskDependencyContainer
@@ -65,9 +66,24 @@ class DefaultResolvableArtifactCodec(
         val componentId = componentIdSerializer.read(this)
         val artifactId = ComponentFileArtifactIdentifier(componentId, file.name)
         if (componentId is ModuleComponentIdentifier) {
+            markAccessedInArtifactCache(file)
             emitReplayOperation(artifactId, file, fileSize)
         }
         return DefaultResolvableArtifact(null, artifactName, artifactId, TaskDependencyContainer.EMPTY, calculatedValueContainerFactory.create(Describables.of(artifactId), file), calculatedValueContainerFactory)
+    }
+
+    /**
+     * Mark a CC-replayed artifact file as accessed in the Gradle user home artifact cache journal.
+     *
+     * Without this, LRU cache cleanup would not see the file as in-use and could evict it despite
+     * it being actively used by builds that consistently hit the Configuration Cache. On CC miss,
+     * this bookkeeping is done by `AbstractCachedIndex.lookup()`; on CC hit the resolution pipeline
+     * is bypassed, leaving the journal un-updated.
+     */
+    private
+    fun ReadContext.markAccessedInArtifactCache(file: File) {
+        val fileStoreProvider = isolate.owner.serviceOf<FileStoreAndIndexProvider>()
+        fileStoreProvider.artifactIdentifierFileStore.fileAccessTracker.markAccessed(file)
     }
 
     private

--- a/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/DefaultResolvableArtifactCodec.kt
+++ b/platforms/core-configuration/dependency-management-serialization-codecs/src/main/kotlin/org/gradle/internal/serialize/codecs/dm/DefaultResolvableArtifactCodec.kt
@@ -30,6 +30,7 @@ import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationDescriptor
 import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.operations.RunnableBuildOperation
+import org.gradle.internal.resource.ExternalResourceAlreadyPresentBuildOperationType
 import org.gradle.internal.serialize.graph.Codec
 import org.gradle.internal.serialize.graph.ReadContext
 import org.gradle.internal.serialize.graph.WriteContext
@@ -72,27 +73,33 @@ class DefaultResolvableArtifactCodec(
     private
     fun ReadContext.emitReplayOperation(artifactId: ComponentArtifactIdentifier, file: File, fileSize: Long) {
         val buildOperationRunner = isolate.owner.serviceOf<BuildOperationRunner>()
-        buildOperationRunner.run(ReplayDownloadArtifactOperation(artifactId, file, fileSize))
+        buildOperationRunner.run(ReplayDownloadArtifactOperation(artifactId, file, fileSize, buildOperationRunner))
     }
 
     /**
-     * Emits a [DownloadArtifactBuildOperationType] synthetically during Configuration Cache replay.
+     * Emits a [DownloadArtifactBuildOperationType] synthetically during Configuration Cache replay,
+     * with a nested [ExternalResourceAlreadyPresentBuildOperationType] child that signals the artifact
+     * was served from the local cache (by definition on CC hit). The child carries the same
+     * file path and size payload as would fire during a CC-miss cache-hit resolution.
      *
-     * On CC hit the original resolution pipeline is skipped, so neither [DownloadArtifactBuildOperationType]
-     * nor any [org.gradle.internal.resource.ExternalResourceReadBuildOperationType] /
-     * [org.gradle.internal.resource.ExternalResourceAlreadyPresentBuildOperationType] is emitted for the
-     * artifact. This synthetic emission surfaces the resolved artifact to build operation consumers
-     * (e.g. the Develocity plugin) with the same path/size payload. The absence of a child
-     * [org.gradle.internal.resource.ExternalResourceReadBuildOperationType] signals that no download
-     * occurred — on CC replay, every artifact is cache-resolved by definition.
+     * Consumers see a consistent parent-child structure on both CC miss and CC hit:
+     *   DownloadArtifactBuildOperationType
+     *     └── ExternalResourceAlreadyPresentBuildOperationType   (cache-resolved)
+     *
+     * The child's `location` is empty because the original request URI is not persisted in the
+     * configuration cache — consumers that need it should correlate via the artifact identifier
+     * on the parent op. Replay for related module metadata files (POM, `.module`) is intentionally
+     * not included here and is tracked as a follow-up.
      */
     private
     class ReplayDownloadArtifactOperation(
         private val artifactId: ComponentArtifactIdentifier,
         private val file: File,
-        private val fileSize: Long
+        private val fileSize: Long,
+        private val buildOperationRunner: BuildOperationRunner
     ) : RunnableBuildOperation {
         override fun run(context: BuildOperationContext) {
+            buildOperationRunner.run(ReplayAlreadyPresentOperation(file, fileSize))
             context.setResult(DownloadArtifactBuildOperationType.ResultImpl(file.absolutePath, fileSize))
         }
 
@@ -102,5 +109,36 @@ class DefaultResolvableArtifactCodec(
                 .displayName("Resolve $displayName")
                 .details(DownloadArtifactBuildOperationType.DetailsImpl(displayName))
         }
+    }
+
+    private
+    class ReplayAlreadyPresentOperation(
+        private val file: File,
+        private val fileSize: Long
+    ) : RunnableBuildOperation {
+        override fun run(context: BuildOperationContext) {
+            context.setResult(ReplayAlreadyPresentResult(file.absolutePath, fileSize))
+        }
+
+        override fun description(): BuildOperationDescriptor.Builder {
+            return BuildOperationDescriptor
+                .displayName("Cache hit for " + file.absolutePath)
+                .details(ReplayAlreadyPresentDetails)
+        }
+    }
+
+    private
+    object ReplayAlreadyPresentDetails : ExternalResourceAlreadyPresentBuildOperationType.Details {
+        // Original request URI is not persisted in the Configuration Cache.
+        override fun getLocation(): String = ""
+    }
+
+    private
+    class ReplayAlreadyPresentResult(
+        private val resolvedFilePath: String,
+        private val fileSize: Long
+    ) : ExternalResourceAlreadyPresentBuildOperationType.Result {
+        override fun getResolvedFilePath(): String = resolvedFilePath
+        override fun getFileSize(): Long = fileSize
     }
 }

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/resource/ExternalResourceAlreadyPresentBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/resource/ExternalResourceAlreadyPresentBuildOperationType.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource;
+
+import org.gradle.internal.operations.BuildOperationType;
+
+/**
+ * An external resource request that was satisfied entirely from the local dependency cache,
+ * without contacting the remote repository.
+ * <p>
+ * Sibling to {@link ExternalResourceReadBuildOperationType}: for a given resource request,
+ * exactly one of the two operations is emitted — {@code ExternalResourceRead} when the content
+ * was fetched over the wire, {@code ExternalResourceAlreadyPresent} when it was served from
+ * the local cache.
+ *
+ * @since 9.6
+ */
+public final class ExternalResourceAlreadyPresentBuildOperationType implements BuildOperationType<ExternalResourceAlreadyPresentBuildOperationType.Details, ExternalResourceAlreadyPresentBuildOperationType.Result> {
+
+    public interface Details {
+
+        /**
+         * The location of the resource that was served from the local cache.
+         * A valid URI.
+         */
+        String getLocation();
+
+    }
+
+    public interface Result {
+
+        /**
+         * The absolute filesystem path of the cached resource file.
+         */
+        String getResolvedFilePath();
+
+        /**
+         * The size of the cached resource file in bytes.
+         */
+        long getFileSize();
+
+    }
+
+    private ExternalResourceAlreadyPresentBuildOperationType() {
+    }
+
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
@@ -407,9 +407,16 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         replayedOps[0].details.artifactIdentifier == 'impl-1.3.jar (org.utils:impl:1.3)'
         replayedOps[0].result.resolvedFilePath.endsWith('impl-1.3.jar')
         replayedOps[0].result.fileSize == m.artifact.file.length()
-        // On CC hit no network or cache-lookup happens, so no Read/AlreadyPresent children fire.
+        // On CC hit, no network read happens at all.
         buildOperations.all(ExternalResourceReadBuildOperationType).isEmpty()
-        buildOperations.all(ExternalResourceAlreadyPresentBuildOperationType).isEmpty()
+        // A synthetic ExternalResourceAlreadyPresent child is emitted, so consumers see a consistent
+        // parent-child structure on both CC miss and CC hit. The location is empty because the
+        // original request URI is not persisted in CC state.
+        def replayedAlreadyPresentOps = buildOperations.all(ExternalResourceAlreadyPresentBuildOperationType)
+        replayedAlreadyPresentOps.size() == 1
+        replayedAlreadyPresentOps[0].details.location == ''
+        replayedAlreadyPresentOps[0].result.resolvedFilePath.endsWith('impl-1.3.jar')
+        replayedAlreadyPresentOps[0].result.fileSize == m.artifact.file.length()
     }
 
     def "emits events for an artifact once per build"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.DownloadArtifactBuildOperationType
 import org.gradle.api.internal.artifacts.ResolveArtifactsBuildOperationType
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.internal.resource.ExternalResourceAlreadyPresentBuildOperationType
 import org.gradle.internal.resource.ExternalResourceListBuildOperationType
 import org.gradle.internal.resource.ExternalResourceReadBuildOperationType
 import org.gradle.internal.resource.ExternalResourceReadMetadataBuildOperationType
@@ -101,6 +102,58 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         where:
         chunked << [true, false]
+    }
+
+    def "emits ExternalResourceAlreadyPresent events when artifacts are served from the local cache"() {
+        given:
+        def m = mavenHttpRepo.module("org.utils", "impl", '1.3')
+            .allowAll()
+            .publish()
+
+        buildFile << """
+            repositories {
+                maven { url = "${mavenHttpRepo.uri}" }
+            }
+
+            configurations {
+                base { canBeResolved = false; canBeConsumed = false }
+                path { extendsFrom(base) }
+            }
+
+            dependencies {
+                base "org.utils:impl:1.3"
+            }
+
+            println configurations.path.files
+        """
+
+        when:
+        // First invocation: nothing cached yet, artifacts are downloaded
+        run "help"
+
+        then:
+        buildOperations.all(ExternalResourceAlreadyPresentBuildOperationType).size() == 0
+
+        when:
+        // Second invocation without --refresh-dependencies: cache is still valid
+        // and the resource accessor returns from cache without any network traffic.
+        run "help"
+
+        then:
+        buildOperations.all(ExternalResourceReadBuildOperationType).size() == 0
+        buildOperations.all(ExternalResourceReadMetadataBuildOperationType).size() == 0
+
+        def alreadyPresentOps = buildOperations.all(ExternalResourceAlreadyPresentBuildOperationType)
+        alreadyPresentOps.size() == 2
+        alreadyPresentOps*.details*.location as Set == [m.pom.uri.toString(), m.artifact.uri.toString()] as Set
+        alreadyPresentOps.find { it.details.location == m.artifact.uri.toString() }.with {
+            it.result.resolvedFilePath.endsWith('impl-1.3.jar')
+            it.result.fileSize == m.artifact.file.length()
+        }
+        alreadyPresentOps.find { it.details.location == m.pom.uri.toString() }.with {
+            it.result.resolvedFilePath.endsWith('impl-1.3.pom')
+            it.result.fileSize == m.pom.file.length()
+        }
     }
 
     def "emits events for missing resources"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
@@ -77,6 +77,8 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
         artifactOps[0].details.artifactIdentifier == 'impl-1.3.jar (org.utils:impl:1.3)'
+        artifactOps[0].result.resolvedFilePath.endsWith('impl-1.3.jar')
+        artifactOps[0].result.fileSize == m.artifact.file.length()
 
         when:
         executer.withArguments("--refresh-dependencies")
@@ -94,6 +96,8 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1
         artifactOps2[0].details.artifactIdentifier == 'impl-1.3.jar (org.utils:impl:1.3)'
+        artifactOps2[0].result.resolvedFilePath.endsWith('impl-1.3.jar')
+        artifactOps2[0].result.fileSize == m.artifact.file.length()
 
         where:
         chunked << [true, false]

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
@@ -355,6 +355,63 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         artifactOps2[0].details.artifactIdentifier == 'impl-1.3.jar (org.utils:impl:1.3)'
     }
 
+    def "emits DownloadArtifactBuildOperationType synthetically on configuration cache hit"() {
+        given:
+        def m = mavenHttpRepo.module("org.utils", "impl", '1.3')
+            .allowAll()
+            .publish()
+
+        buildFile << """
+            repositories {
+                maven { url = "${mavenHttpRepo.uri}" }
+            }
+
+            configurations {
+                base { canBeResolved = false; canBeConsumed = false }
+                path { extendsFrom(base) }
+            }
+
+            dependencies {
+                base "org.utils:impl:1.3"
+            }
+
+            tasks.register('consume') {
+                def files = configurations.path
+                doLast {
+                    files.each { println it }
+                }
+            }
+        """
+
+        when:
+        // First run: configuration cache miss, dependency is resolved normally.
+        executer.withArgument("--configuration-cache")
+        run "consume"
+
+        then:
+        def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
+        artifactOps.size() == 1
+        artifactOps[0].details.artifactIdentifier == 'impl-1.3.jar (org.utils:impl:1.3)'
+        artifactOps[0].result.resolvedFilePath.endsWith('impl-1.3.jar')
+        artifactOps[0].result.fileSize == m.artifact.file.length()
+
+        when:
+        // Second run: configuration cache HIT. The original resolution pipeline is skipped but
+        // the synthetic build operation is emitted during artifact deserialization.
+        executer.withArgument("--configuration-cache")
+        run "consume"
+
+        then:
+        def replayedOps = buildOperations.all(DownloadArtifactBuildOperationType)
+        replayedOps.size() == 1
+        replayedOps[0].details.artifactIdentifier == 'impl-1.3.jar (org.utils:impl:1.3)'
+        replayedOps[0].result.resolvedFilePath.endsWith('impl-1.3.jar')
+        replayedOps[0].result.fileSize == m.artifact.file.length()
+        // On CC hit no network or cache-lookup happens, so no Read/AlreadyPresent children fire.
+        buildOperations.all(ExternalResourceReadBuildOperationType).isEmpty()
+        buildOperations.all(ExternalResourceAlreadyPresentBuildOperationType).isEmpty()
+    }
+
     def "emits events for an artifact once per build"() {
         given:
         def m = mavenHttpRepo.module("org.utils", "impl", '1.3')

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DownloadArtifactBuildOperationType.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DownloadArtifactBuildOperationType.java
@@ -33,7 +33,22 @@ public final class DownloadArtifactBuildOperationType implements BuildOperationT
 
     }
 
+    @UsedByScanPlugin
     public interface Result {
+
+        /**
+         * The absolute filesystem path of the resolved artifact file.
+         *
+         * @since 9.6
+         */
+        String getResolvedFilePath();
+
+        /**
+         * The size of the resolved artifact file in bytes.
+         *
+         * @since 9.6
+         */
+        long getFileSize();
 
     }
 
@@ -52,8 +67,27 @@ public final class DownloadArtifactBuildOperationType implements BuildOperationT
 
     }
 
-    public final static Result RESULT = new Result() {
-    };
+    public static class ResultImpl implements Result {
+
+        private final String resolvedFilePath;
+        private final long fileSize;
+
+        public ResultImpl(String resolvedFilePath, long fileSize) {
+            this.resolvedFilePath = resolvedFilePath;
+            this.fileSize = fileSize;
+        }
+
+        @Override
+        public String getResolvedFilePath() {
+            return resolvedFilePath;
+        }
+
+        @Override
+        public long getFileSize() {
+            return fileSize;
+        }
+
+    }
 
     private DownloadArtifactBuildOperationType() {
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -34,6 +34,7 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.resolve.resolver.ComponentArtifactResolver;
 import org.jspecify.annotations.Nullable;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -206,7 +207,8 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
         @Override
         public void run(BuildOperationContext context) {
             artifact.getFileSource().finalizeIfNotAlready();
-            context.setResult(DownloadArtifactBuildOperationType.RESULT);
+            File file = artifact.getFileSource().get();
+            context.setResult(new DownloadArtifactBuildOperationType.ResultImpl(file.getAbsolutePath(), file.length()));
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
@@ -27,7 +27,12 @@ import org.gradle.internal.UncheckedException;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hashing;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.resource.ExternalResource;
+import org.gradle.internal.resource.ExternalResourceAlreadyPresentBuildOperationType;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.ExternalResourceReadResult;
 import org.gradle.internal.resource.ExternalResourceRepository;
@@ -46,6 +51,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExternalResourceAccessor {
@@ -61,8 +67,9 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
     private final ProducerGuard<ExternalResourceName> producerGuard;
     private final FileResourceRepository fileResourceRepository;
     private final ChecksumService checksumService;
+    private final @Nullable BuildOperationRunner buildOperationRunner;
 
-    public DefaultCacheAwareExternalResourceAccessor(ExternalResourceRepository delegate, CachedExternalResourceIndex<String> cachedExternalResourceIndex, BuildCommencedTimeProvider timeProvider, TemporaryFileProvider temporaryFileProvider, ArtifactCacheLockingAccessCoordinator cacheAccessCoordinator, ExternalResourceCachePolicy externalResourceCachePolicy, ProducerGuard<ExternalResourceName> producerGuard, FileResourceRepository fileResourceRepository, ChecksumService checksumService) {
+    public DefaultCacheAwareExternalResourceAccessor(ExternalResourceRepository delegate, CachedExternalResourceIndex<String> cachedExternalResourceIndex, BuildCommencedTimeProvider timeProvider, TemporaryFileProvider temporaryFileProvider, ArtifactCacheLockingAccessCoordinator cacheAccessCoordinator, ExternalResourceCachePolicy externalResourceCachePolicy, ProducerGuard<ExternalResourceName> producerGuard, FileResourceRepository fileResourceRepository, ChecksumService checksumService, @Nullable BuildOperationRunner buildOperationRunner) {
         this.delegate = delegate;
         this.cachedExternalResourceIndex = cachedExternalResourceIndex;
         this.timeProvider = timeProvider;
@@ -72,6 +79,7 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
         this.producerGuard = producerGuard;
         this.fileResourceRepository = fileResourceRepository;
         this.checksumService = checksumService;
+        this.buildOperationRunner = buildOperationRunner;
     }
 
     @Nullable
@@ -88,6 +96,7 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
 
             // We might be able to use a cached/locally available version
             if (cached != null && !externalResourceCachePolicy.mustRefreshExternalResource(getAgeMillis(timeProvider, cached))) {
+                emitAlreadyPresent(location.getUri(), cached.getCachedFile());
                 return fileResourceRepository.resource(cached.getCachedFile(), location.getUri(), cached.getExternalResourceMetaData());
             }
 
@@ -111,6 +120,7 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
                     LOGGER.info("Cached resource {} is up-to-date (lastModified: {}).", location, cached.getExternalLastModified());
                     // Update the cache entry in the index: this resets the age of the cached entry to zero
                     cachedExternalResourceIndex.store(location.toString(), cached.getCachedFile(), cached.getExternalResourceMetaData());
+                    emitAlreadyPresent(location.getUri(), cached.getCachedFile());
                     return fileResourceRepository.resource(cached.getCachedFile(), location.getUri(), cached.getExternalResourceMetaData());
                 }
             }
@@ -209,5 +219,77 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
 
     private long getAgeMillis(BuildCommencedTimeProvider timeProvider, CachedExternalResource cached) {
         return timeProvider.getCurrentTime() - cached.getCachedAt();
+    }
+
+    private void emitAlreadyPresent(URI location, File cachedFile) {
+        if (buildOperationRunner == null) {
+            return;
+        }
+        buildOperationRunner.run(new AlreadyPresentOperation(location, cachedFile));
+    }
+
+    private static class AlreadyPresentOperation implements RunnableBuildOperation {
+        private final URI location;
+        private final File cachedFile;
+
+        AlreadyPresentOperation(URI location, File cachedFile) {
+            this.location = location;
+            this.cachedFile = cachedFile;
+        }
+
+        @Override
+        public void run(BuildOperationContext context) {
+            context.setResult(new AlreadyPresentResult(cachedFile.getAbsolutePath(), cachedFile.length()));
+        }
+
+        @Override
+        public BuildOperationDescriptor.Builder description() {
+            return BuildOperationDescriptor
+                .displayName("Cache hit for " + location)
+                .details(new AlreadyPresentDetails(location.toString()));
+        }
+    }
+
+    private static class AlreadyPresentDetails implements ExternalResourceAlreadyPresentBuildOperationType.Details {
+        private final String location;
+
+        AlreadyPresentDetails(String location) {
+            this.location = location;
+        }
+
+        @Override
+        public String getLocation() {
+            return location;
+        }
+
+        @Override
+        public String toString() {
+            return "ExternalResourceAlreadyPresentBuildOperationType.Details{location=" + location + '}';
+        }
+    }
+
+    private static class AlreadyPresentResult implements ExternalResourceAlreadyPresentBuildOperationType.Result {
+        private final String resolvedFilePath;
+        private final long fileSize;
+
+        AlreadyPresentResult(String resolvedFilePath, long fileSize) {
+            this.resolvedFilePath = resolvedFilePath;
+            this.fileSize = fileSize;
+        }
+
+        @Override
+        public String getResolvedFilePath() {
+            return resolvedFilePath;
+        }
+
+        @Override
+        public long getFileSize() {
+            return fileSize;
+        }
+
+        @Override
+        public String toString() {
+            return "ExternalResourceAlreadyPresentBuildOperationType.Result{resolvedFilePath=" + resolvedFilePath + ", fileSize=" + fileSize + '}';
+        }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/transport/ResourceConnectorRepositoryTransport.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/transport/ResourceConnectorRepositoryTransport.java
@@ -55,7 +55,7 @@ public class ResourceConnectorRepositoryTransport extends AbstractRepositoryTran
         ProgressLoggingExternalResourceAccessor loggingAccessor = new ProgressLoggingExternalResourceAccessor(connector, buildOperationRunner);
         ProgressLoggingExternalResourceLister loggingLister = new ProgressLoggingExternalResourceLister(connector, buildOperationRunner);
         repository = new DefaultExternalResourceRepository(name, loggingAccessor, loggingUploader, loggingLister);
-        resourceAccessor = new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, cacheAccessCoordinator, cachePolicy, producerGuard, fileResourceRepository, checksumService);
+        resourceAccessor = new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, cacheAccessCoordinator, cachePolicy, producerGuard, fileResourceRepository, checksumService, buildOperationRunner);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileTransport.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileTransport.java
@@ -43,7 +43,9 @@ public class FileTransport extends AbstractRepositoryTransport {
         super(name);
         this.repository = repository;
         ExternalResourceCachePolicy cachePolicy = new DefaultExternalResourceCachePolicy();
-        resourceAccessor = new FileCacheAwareExternalResourceAccessor(new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, cacheAccessCoordinator, cachePolicy, producerGuard, repository, checksumService));
+        // Local file:// repositories never emit an AlreadyPresent build operation because their resources are not cached
+        // from the network; passing a null BuildOperationRunner disables the emission.
+        resourceAccessor = new FileCacheAwareExternalResourceAccessor(new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, cacheAccessCoordinator, cachePolicy, producerGuard, repository, checksumService, null));
     }
 
     @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
@@ -62,7 +62,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
             supplier.get()
         }
     }
-    final cache = new DefaultCacheAwareExternalResourceAccessor(repository, index, timeProvider, temporaryFileProvider, cacheAccessCoordinator, cachePolicy, producerGuard, fileRepository, TestUtil.checksumService)
+    final cache = new DefaultCacheAwareExternalResourceAccessor(repository, index, timeProvider, temporaryFileProvider, cacheAccessCoordinator, cachePolicy, producerGuard, fileRepository, TestUtil.checksumService, null)
 
     def "returns null when the request resource is not cached and does not exist in the remote repository"() {
         def location = new ExternalResourceName("thing")


### PR DESCRIPTION
## Summary

Introduces a build-operation-based view of resolved external dependency artifacts (CC-miss and CC-hit builds), so  Develocity plugin can replace the heuristic-based task-input-snapshot scraping currently used to identify dependency artifacts.

## Commits

1. **Enrich `DownloadArtifactBuildOperationType.Result` with file path and size** — adds `getResolvedFilePath()` + `getFileSize()` to the existing op so consumers no longer need a separate `Files.length()` syscall.
2. **Add `ExternalResourceAlreadyPresentBuildOperationType` for cache-hit reads** — new op sibling to `ExternalResourceReadBuildOperationType`, emitted from `DefaultCacheAwareExternalResourceAccessor` when a resource is served from the local cache. Together, the two ops tell consumers whether an external resource (JAR, POM, `.module`) was downloaded or cache-hit. Threads `BuildOperationRunner` through `ResourceConnectorRepositoryTransport`; `FileTransport` opts out (local `file://` repos never emit the op).
3. **Replay `DownloadArtifactBuildOperationType` on configuration cache hit** — extends `DefaultResolvableArtifactCodec` to persist the artifact's file size and, on decode, synthetically fire `DownloadArtifactBuildOperationType` for external module artifacts via the build operation runner resolved from the isolate owner. Closes the primary gap noted in the proposal: _"these build operations are not emitted on a Configuration Cache (CC) hit"_.
4. **Emit `ExternalResourceAlreadyPresent` child on configuration cache replay** — adds a nested `ExternalResourceAlreadyPresent` child to the synthetic parent, so the parent-child hierarchy is consistent on both CC miss and CC hit. The child's `location` is empty because the original request URI is not persisted in CC state.
5. **Fix: mark dependency artifact files as accessed on Configuration Cache hit** — re-establishes `FileAccessTracker.markAccessed()` bookkeeping during CC replay. Without it, LRU cache cleanup could silently prune module cache entries that are actively used by CC-hit builds (latent bug).

## Build-operation hierarchy after this PR

CC miss (task input path):
```
DownloadArtifactBuildOperationType                       (enriched: path, size)
  ├── ExternalResourceReadBuildOperationType             (downloaded)
  └── ExternalResourceAlreadyPresentBuildOperationType   (cache-hit — new)
```

CC hit (task input path):
```
DownloadArtifactBuildOperationType                       (synthetic, enriched)
  └── ExternalResourceAlreadyPresentBuildOperationType   (synthetic, empty location)
```

## Scope intentionally deferred (follow-up work)

Two items from the original design are not in this PR; each would significantly expand the change and is worth a separate focused review:

- **Transform-input build operation (`DownloadTransformInputBuildOperationType`) and role-in-CC**. Wiring the new op through `AbstractTransformedArtifactSet` → `CalculateArtifacts` → `TransformingAsyncArtifactListener` requires threading `BuildOperationRunner` through many constructors and touching every caller that builds a transformed artifact set. Transform inputs are currently observable via `DownloadArtifactBuildOperationType` (on CC miss, through `DefaultResolvableArtifact` finalization) and via the synthetic op on CC hit — the distinction from task inputs is not surfaced yet.
- **Metadata file replay on CC hit (`*.pom`, `*.module`)**. On CC miss these are visible via `ExternalResourceAlreadyPresent`; on CC hit the resolution pipeline is skipped so metadata access doesn't re-occur and isn't replayed. Fixing this needs a dedicated access-tracker service plus new CC state plumbing — a meaningful chunk of infrastructure.

## Test plan

- [ ] `:dependency-management:integTest --tests "*DependencyDownloadBuildOperationsIntegrationTest*"` covers: enriched `DownloadArtifactBuildOperationType` Result (existing test extended); `ExternalResourceAlreadyPresent` firing for cache-hit JAR/POM (new test); synthetic replay on CC hit including child op (new test).
- [ ] `:dependency-management:test --tests "*DefaultCacheAwareExternalResourceAccessorTest*"` — existing unit test updated for new constructor param.
- [ ] Manual: run a sample build twice with `--configuration-cache` against a remote repo; verify `DownloadArtifactBuildOperationType` fires on both runs with matching `resolvedFilePath` / `fileSize`, and that `ExternalResourceRead` fires only on the first run.
- [ ] Manual: confirm LRU cleanup behavior — touch an artifact via a CC-hit build, verify `~/.gradle/caches/modules-2/files-2.1/.../<file>` access time journal entry is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)