### PR TITLE
Make kotlin version upgrades keep the latest minor

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateKotlinVersions.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateKotlinVersions.kt
@@ -70,37 +70,43 @@ abstract class UpdateKotlinVersions : AbstractVersionsUpdateTask() {
             require(minimumSupported in allVersions) {
                 "Minimum supported '$minimumSupported' was not found in available versions: $allVersions"
             }
+
+            val minimumSupportedVersion = VersionNumber.parse(minimumSupported)
             val versionsByMinor = allVersions
-                .groupBy { it.take(3) } // e.g. 1.9
-                .toSortedMap()
-            val latests = buildList {
-                versionsByMinor.entries.forEachIndexed { idx, entry ->
-                    val versionsOfMinor = entry.value.sortedByDescending { VersionNumber.parse(it) }
-                    if (idx < versionsByMinor.size - 1) {
-                        // Latest of the previous minor
-                        add(versionsOfMinor.first())
-                    } else {
-                        // Current minor
+                .map { VersionNumber.parse(it) }
+                .filter { it >= minimumSupportedVersion }
+                .sortedDescending()
+                .groupBy { it.major to it.minor }
+                .toSortedMap(compareBy({ it.first }, { it.second }))
+            val currentMinor = versionsByMinor.lastKey()
+
+            return buildList {
+                versionsByMinor.forEach { (minor, versionsOfMinor) ->
+                    if (minor == currentMinor) {
+                        // Current minor: from the newest patch down, emit the best version per patch.
+                        // VersionNumber's natural ordering covers it: stable (null) > RC3 > RC2 > RC > Beta5 > ... > Beta1 > Beta.
                         val versionsByPatch = versionsOfMinor
-                            .groupBy { it.take(5) } // e.g. 1.9.2(x)
+                            .groupBy { it.micro }
                             .toSortedMap()
-                        for (key in versionsByPatch.keys.reversed()) {
-                            val versionsOfPatch = versionsByPatch.getValue(key)
-                            if (versionsOfPatch.any { !it.contains("-") }) {
-                                add(versionsOfPatch.first { !it.contains("-") })
-                                break
-                            }
-                            if (versionsOfPatch.any { it.contains("-RC") }) {
-                                add(versionsOfPatch.firstOrNull { it.contains("-RC") })
-                            } else if (versionsOfPatch.any { it.contains("-Beta") }) {
-                                add(versionsOfPatch.firstOrNull { it.contains("-Beta") })
+                        for (patch in versionsByPatch.keys.reversed()) {
+                            val best = versionsByPatch.getValue(patch).first()
+                            add(best)
+                            if (best.qualifier == null) break
+                        }
+                    } else {
+                        // Not current minor: just take the latest stable and (if exists) the latest RC/Beta if it's newer than the stable.
+                        val latestStable = versionsOfMinor.firstOrNull { it.qualifier == null }
+                        if (latestStable != null) {
+                            add(latestStable)
+                            val latest = versionsOfMinor.first()
+                            if (latest != latestStable) {
+                                add(latest)
                             }
                         }
                     }
                 }
-                add(minimumSupported)
-            }.filterNotNull().distinct().sorted()
-            return latests.subList(latests.indexOf(minimumSupported), latests.size)
+                add(minimumSupportedVersion)
+            }.distinct().sorted().map { it.toString() }
         }
     }
 }

--- a/build-logic/build-update-utils/src/test/groovy/gradlebuild/buildutils/tasks/UpdateKotlinVersionsTest.groovy
+++ b/build-logic/build-update-utils/src/test/groovy/gradlebuild/buildutils/tasks/UpdateKotlinVersionsTest.groovy
@@ -98,4 +98,70 @@ class UpdateKotlinVersionsTest extends Specification {
         def ex = thrown(IllegalArgumentException)
         ex.message == "Minimum supported '1.9.10' was not found in available versions: [2.0.0, 2.0.0-RC1, 2.0.0-Beta1]"
     }
+
+    def "previous minor keeps its latest stable alongside a newer RC"() {
+        // Regression test: before the fix, when a newer minor published its first pre-release
+        // (e.g. 2.4.0-Beta1), the previous minor's selection switched from the per-patch logic to
+        // "pick the top-sorted version", letting a -RC for the next patch (2.3.21-RC) displace the
+        // last stable (2.3.20). That caused `latestStable` to fall back from 2.3.20 to 2.2.21 and
+        // broke AGP alpha07 smoke tests.
+        given:
+        def allVersions = [
+            "2.4.0-Beta1",
+            "2.3.21-RC",
+            "2.3.20", "2.3.20-RC3", "2.3.20-Beta2",
+            "2.3.10", "2.3.10-RC",
+            "2.3.0", "2.3.0-RC", "2.3.0-Beta1",
+            "2.2.21", "2.2.21-RC",
+            "2.1.21",
+            "2.0.21", "2.0.0",
+        ]
+
+        when:
+        def selected = UpdateKotlinVersions.selectVersionsFrom("2.0.0", allVersions)
+
+        then:
+        selected == ["2.0.0", "2.0.21", "2.1.21", "2.2.21", "2.3.20", "2.3.21-RC", "2.4.0-Beta1"]
+    }
+
+    def "previous minor with no stable patch is dropped"() {
+        // If a minor never shipped a stable, we don't want to leave orphan pre-releases pinned
+        // in the test matrix — they would stick around forever. Skip the minor entirely in that
+        // case; the current minor's pre-release still covers upcoming Kotlin.
+        given:
+        def allVersions = [
+            "2.4.0-Beta1",
+            "2.3.0-RC2", "2.3.0-RC", "2.3.0-Beta1",
+            "2.2.21",
+            "2.1.21",
+            "2.0.21", "2.0.0",
+        ]
+
+        when:
+        def selected = UpdateKotlinVersions.selectVersionsFrom("2.0.0", allVersions)
+
+        then:
+        selected == ["2.0.0", "2.0.21", "2.1.21", "2.2.21", "2.4.0-Beta1"]
+    }
+
+    def "two-digit patch numbers in the current minor do not collide"() {
+        // Regression test: the old algorithm grouped patches by `String.take(5)`, so "2.3.20" and
+        // "2.3.21-RC" hashed to the same bucket "2.3.2" and the RC was silently swallowed. The
+        // refactored algorithm groups by the parsed `micro` integer so adjacent two-digit patches
+        // stay distinct.
+        given:
+        def allVersions = [
+            "2.3.21-RC",
+            "2.3.20",
+            "2.3.10",
+            "2.3.0",
+            "2.2.21", "2.1.21", "2.0.21", "2.0.0",
+        ]
+
+        when:
+        def selected = UpdateKotlinVersions.selectVersionsFrom("2.0.0", allVersions)
+
+        then:
+        selected == ["2.0.0", "2.0.21", "2.1.21", "2.2.21", "2.3.20", "2.3.21-RC"]
+    }
 }

--- a/gradle/dependency-management/kotlin-versions.properties
+++ b/gradle/dependency-management/kotlin-versions.properties
@@ -1,2 +1,2 @@
 # Generated - Update by running `./gradlew updateKotlinVersions`
-latests=2.0.0,2.0.21,2.1.21,2.2.21,2.3.21-RC,2.4.0-Beta1
+latests=2.0.0,2.0.21,2.1.21,2.2.21,2.3.20,2.3.21-RC,2.4.0-Beta1


### PR DESCRIPTION
Our Kotlin version selection algorithm have a peculiar behavior: if for a given minor version (e.g, `2.3.X` line) a new RC is introduced, than it will overtake the previous stable version.

E.g.
```diff
-latests=2.0.0,2.0.21,2.1.21,2.2.21,2.3.20,2.3.21-RC1,2.4.0-Beta1
+latests=2.0.0,2.0.21,2.1.21,2.2.21,2.3.20,2.3.20,2.4.0-Beta1
``` 

### New behavior

- RCs and Alphas in their minor-group doesn't supersede their stable counterpart: they will be listed instead _alongside_ the stable
- A new filtering is added, which will drop an older minor version if there is no stable release present for it (e.g., 2.3 is the new one, and for 2.2 there is only `2.2.1-RC1`, `2.2.1-RC2`...) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build tool versions (AGP 9.1.1, 9.2.0-rc01) and Kotlin version catalog entries
  * Advanced nightly build metadata to AGP 9.3.0-dev
* **Tests**
  * Enhanced test coverage for version selection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->