### PR TITLE
Make all None parameters behave identically

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheValueSourceIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheValueSourceIntegrationTest.groovy
@@ -24,6 +24,36 @@ import spock.lang.Issue
 
 class ConfigurationCacheValueSourceIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
+    @Issue("https://github.com/gradle/gradle/issues/30182")
+    def "value source without parameters can access None parameters"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+
+        buildFile("""
+            import org.gradle.api.provider.*
+
+            abstract class GreetValueSource implements ValueSource<String, ValueSourceParameters.None> {
+                String obtain() {
+                    println("Parameters: " + getParameters())
+                    return "Hello!"
+                }
+            }
+
+            def greetValueSource = providers.of(GreetValueSource) {}
+            tasks.register("greet") {
+                doLast { println greetValueSource.get() }
+            }
+        """)
+
+        when:
+        configurationCacheRun "greet"
+
+        then:
+        configurationCache.assertStateStored()
+        output.contains("Parameters: org.gradle.api.provider.ValueSourceParameters\$None@")
+        output.contains("Hello!")
+    }
+
     def "value source without parameters can be used as task input"() {
         given:
         def configurationCache = newConfigurationCacheFixture()

--- a/platforms/core-configuration/core-flow-services-api/src/main/java/org/gradle/api/flow/FlowParameters.java
+++ b/platforms/core-configuration/core-flow-services-api/src/main/java/org/gradle/api/flow/FlowParameters.java
@@ -40,7 +40,7 @@ public interface FlowParameters {
     /**
      * Used for {@link FlowAction dataflow actions} without parameters.
      *
-     * <p>When {@link None} is used as parameters, calling {@link FlowActionSpec#getParameters()} throws an exception.</p>
+     * <p>When {@link None} is used as parameters, calling {@link FlowActionSpec#getParameters()} returns the {@link #INSTANCE singleton}.</p>
      *
      * @since 8.1
      */

--- a/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/BuildFlowScope.kt
+++ b/platforms/core-configuration/flow-services/src/main/kotlin/org/gradle/internal/flow/services/BuildFlowScope.kt
@@ -94,7 +94,8 @@ open class BuildFlowScope @Inject internal constructor(
         IsolationScheme(
             FlowAction::class.java,
             FlowParameters::class.java,
-            FlowParameters.None::class.java
+            FlowParameters.None::class.java,
+            FlowParameters.None.INSTANCE
         )
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -57,7 +57,7 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
     private final ExecOperations execOperations;
     private final ValueListener valueListener;
     private final ComputationListener computationListener;
-    private final IsolationScheme<ValueSource, ValueSourceParameters> isolationScheme = new IsolationScheme<>(ValueSource.class, ValueSourceParameters.class, ValueSourceParameters.None.class);
+    private final IsolationScheme<ValueSource, ValueSourceParameters> isolationScheme = new IsolationScheme<>(ValueSource.class, ValueSourceParameters.class, ValueSourceParameters.None.class, ValueSourceParameters.None.INSTANCE);
     private final InstanceGenerator paramsInstantiator;
     private final InstanceGenerator specInstantiator;
 
@@ -129,6 +129,8 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
                 registration.add(ExecOperations.class, execOperations);
                 if (isolatedParameters != null) {
                     registration.add(parametersType, isolatedParameters);
+                } else {
+                    registration.add(ValueSourceParameters.None.class, ValueSourceParameters.None.INSTANCE);
                 }
             })
             .build();

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
@@ -40,11 +40,13 @@ import java.util.Collection;
 public class IsolationScheme<INTERFACE, PARAMS> implements TypeParameterInspection<INTERFACE, PARAMS> {
     private final Class<INTERFACE> interfaceType;
     private final Class<? extends PARAMS> noParamsType;
+    private final PARAMS noParamsInstance;
     private final TypeParameterInspection<INTERFACE, PARAMS> typeParameterInspection;
 
-    public IsolationScheme(Class<INTERFACE> interfaceType, Class<PARAMS> paramsType, Class<? extends PARAMS> noParamsType) {
+    public IsolationScheme(Class<INTERFACE> interfaceType, Class<PARAMS> paramsType, Class<? extends PARAMS> noParamsType, PARAMS noParamsInstance) {
         this.interfaceType = interfaceType;
         this.noParamsType = noParamsType;
+        this.noParamsInstance = noParamsInstance;
         this.typeParameterInspection = new DefaultTypeParameterInspection<>(interfaceType, paramsType, noParamsType);
     }
 
@@ -88,12 +90,13 @@ public class IsolationScheme<INTERFACE, PARAMS> implements TypeParameterInspecti
         ServiceLookup allServices,
         Collection<? extends Class<?>> additionalAllowedServices
     ) {
-        return new ServicesForIsolatedObject(interfaceType, noParamsType, params, allServices, additionalAllowedServices);
+        return new ServicesForIsolatedObject(interfaceType, noParamsType, noParamsInstance, params, allServices, additionalAllowedServices);
     }
 
     private static class ServicesForIsolatedObject implements ServiceLookup {
         private final Class<?> interfaceType;
         private final Class<?> noParamsType;
+        private final Object noParamsInstance;
         private final Collection<? extends Class<?>> additionalAllowedServices;
         private final ServiceLookup allServices;
         private final @Nullable Object params;
@@ -101,12 +104,14 @@ public class IsolationScheme<INTERFACE, PARAMS> implements TypeParameterInspecti
         public ServicesForIsolatedObject(
             Class<?> interfaceType,
             Class<?> noParamsType,
+            Object noParamsInstance,
             @Nullable Object params,
             ServiceLookup allServices,
             Collection<? extends Class<?>> additionalAllowedServices
         ) {
             this.interfaceType = interfaceType;
             this.noParamsType = noParamsType;
+            this.noParamsInstance = noParamsInstance;
             this.additionalAllowedServices = additionalAllowedServices;
             this.allServices = allServices;
             this.params = params;
@@ -121,7 +126,7 @@ public class IsolationScheme<INTERFACE, PARAMS> implements TypeParameterInspecti
                     return params;
                 }
                 if (serviceClass.isAssignableFrom(noParamsType)) {
-                    throw new ServiceLookupException(String.format("Cannot query the parameters of an instance of %s that takes no parameters.", interfaceType.getSimpleName()));
+                    return noParamsInstance;
                 }
                 if (serviceClass.isAssignableFrom(ExecOperations.class)) {
                     return allServices.find(ExecOperations.class);

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/isolated/IsolationSchemeTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/internal/isolated/IsolationSchemeTest.groovy
@@ -21,13 +21,12 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.service.ServiceLookup
-import org.gradle.internal.service.ServiceLookupException
 import org.gradle.internal.service.UnknownServiceException
 import org.gradle.process.ExecOperations
 import spock.lang.Specification
 
 class IsolationSchemeTest extends Specification {
-    def scheme = new IsolationScheme(SomeAction, SomeParams, Nothing)
+    def scheme = new IsolationScheme(SomeAction, SomeParams, Nothing, Nothing.INSTANCE)
 
     def "can extract parameters type"() {
         expect:
@@ -147,31 +146,32 @@ class IsolationSchemeTest extends Specification {
         result2.is(params)
     }
 
-    def "cannot query parameters when parameters are null"() {
+    def "returns None instance when parameters are null"() {
         def allServices = Mock(ServiceLookup)
 
         def injectedServices = scheme.servicesForImplementation(null, allServices, [])
 
         when:
-        injectedServices.find(SomeParams)
+        def result = injectedServices.find(SomeParams)
 
         then:
-        def e = thrown(ServiceLookupException)
-        e.message == "Cannot query the parameters of an instance of SomeAction that takes no parameters."
+        result.is(Nothing.INSTANCE)
 
         when:
-        injectedServices.get(SomeParams)
+        def result2 = injectedServices.get(SomeParams)
 
         then:
-        def e2 = thrown(ServiceLookupException)
-        e2.message == "Cannot query the parameters of an instance of SomeAction that takes no parameters."
+        result2.is(Nothing.INSTANCE)
+        result2.is(result)
     }
 }
 
 interface SomeParams {
 }
 
-interface Nothing extends SomeParams {}
+interface Nothing extends SomeParams {
+    Nothing INSTANCE = new Nothing() {}
+}
 
 interface SomeAction<P extends SomeParams> {
 }

--- a/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/WorkParameters.java
+++ b/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/WorkParameters.java
@@ -16,6 +16,8 @@
 
 package org.gradle.workers;
 
+import org.gradle.api.Incubating;
+
 /**
  * Marker interface for parameter objects to {@link WorkAction}s.
  *
@@ -36,11 +38,19 @@ public interface WorkParameters {
     /**
      * Used for work actions without parameters.
      *
-     * <p>When {@link None} is used as parameters, calling {@link WorkAction#getParameters()} throws an exception.</p>
+     * <p>When {@link None} is used as parameters, calling {@link WorkAction#getParameters()} returns the {@link #INSTANCE singleton}.</p>
      *
      * @since 5.6
      */
     final class None implements WorkParameters {
+        /**
+         * Singleton instance of {@link None}.
+         *
+         * @since 9.6.0
+         */
+        @Incubating
+        public static final None INSTANCE = new None();
+
         private None() {}
     }
 }

--- a/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/AbstractClassLoaderWorker.java
+++ b/platforms/core-execution/daemon-server-worker/src/main/java/org/gradle/workers/internal/AbstractClassLoaderWorker.java
@@ -40,7 +40,7 @@ public abstract class AbstractClassLoaderWorker implements RequestHandler<Transp
         this.worker = new DefaultWorkerServer(
             workServices,
             instantiatorFactory,
-            new IsolationScheme<>(Cast.uncheckedCast(WorkAction.class), WorkParameters.class, WorkParameters.None.class),
+            new IsolationScheme<>(Cast.uncheckedCast(WorkAction.class), WorkParameters.class, WorkParameters.None.class, WorkParameters.None.INSTANCE),
             Collections.singletonList(IsolatedAntBuilder.class));
     }
 

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -498,6 +498,26 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         isolationMode << ISOLATION_MODES
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/30182")
+    def "can access None parameters in a work action with isolation mode #isolationMode"() {
+        buildFile << """
+            ${noneParameterWorkAction('println "parameters: " + getParameters()')}
+
+            tasks.register("runWork", ParameterTask) {
+                isolationMode = ${isolationMode}
+            }
+        """
+
+        when:
+        succeeds("runWork")
+
+        then:
+        outputContains("parameters: org.gradle.workers.WorkParameters\$None@")
+
+        where:
+        isolationMode << ISOLATION_MODES
+    }
+
     String parameterWorkAction(String type, String action, boolean requiresSetter = false) {
         return """
             import org.gradle.workers.WorkAction

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -69,7 +69,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
     private final ClassLoaderStructureProvider classLoaderStructureProvider;
     private final ActionExecutionSpecFactory actionExecutionSpecFactory;
     private final Instantiator instantiator;
-    private final IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme = new IsolationScheme<>(Cast.uncheckedCast(WorkAction.class), WorkParameters.class, WorkParameters.None.class);
+    private final IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme = new IsolationScheme<>(Cast.uncheckedCast(WorkAction.class), WorkParameters.class, WorkParameters.None.class, WorkParameters.None.INSTANCE);
     private final CachedClasspathTransformer classpathTransformer;
     private final File baseDir;
     private final ProjectCacheDir projectCacheDir;

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
@@ -39,7 +39,7 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
     public NoIsolationWorkerFactory(BuildOperationRunner buildOperationRunner, InstantiatorFactory instantiatorFactory, ActionExecutionSpecFactory specFactory, ServiceRegistry internalServices) {
         this.buildOperationRunner = buildOperationRunner;
         this.specFactory = specFactory;
-        IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme = new IsolationScheme<>(Cast.uncheckedNonnullCast(WorkAction.class), WorkParameters.class, WorkParameters.None.class);
+        IsolationScheme<WorkAction<?>, WorkParameters> isolationScheme = new IsolationScheme<>(Cast.uncheckedNonnullCast(WorkAction.class), WorkParameters.class, WorkParameters.None.class, WorkParameters.None.INSTANCE);
         workerServer = new DefaultWorkerServer(internalServices, instantiatorFactory, isolationScheme, Collections.singleton(WorkerExecutor.class));
     }
 

--- a/platforms/jvm/plugins-jvm-test-suite/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
+++ b/platforms/jvm/plugins-jvm-test-suite/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
@@ -320,7 +320,7 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
         }
 
         private <T extends JvmTestToolchainParameters> JvmTestToolchain<T> create(Class<? extends JvmTestToolchain<T>> type) {
-            IsolationScheme<JvmTestToolchain<?>, JvmTestToolchainParameters> isolationScheme = new IsolationScheme<>(uncheckedCast(JvmTestToolchain.class), JvmTestToolchainParameters.class, JvmTestToolchainParameters.None.class);
+            IsolationScheme<JvmTestToolchain<?>, JvmTestToolchainParameters> isolationScheme = new IsolationScheme<>(uncheckedCast(JvmTestToolchain.class), JvmTestToolchainParameters.class, JvmTestToolchainParameters.None.class, JvmTestToolchainParameters.None.INSTANCE);
             Class<T> parametersType = isolationScheme.parameterTypeForOrNull(type);
             T parameters = parametersType == null ? null : objectFactory.newInstance(parametersType);
             ServiceLookup lookup = isolationScheme.servicesForImplementation(parameters, parentServices, Collections.singleton(DependencyFactory.class));

--- a/platforms/jvm/plugins-jvm-test-suite/src/main/java/org/gradle/api/testing/toolchains/internal/JvmTestToolchainParameters.java
+++ b/platforms/jvm/plugins-jvm-test-suite/src/main/java/org/gradle/api/testing/toolchains/internal/JvmTestToolchainParameters.java
@@ -26,5 +26,9 @@ public interface JvmTestToolchainParameters {
     /**
      * Marker interface for {@link JvmTestToolchain} implementations that do not require any configuration.
      */
-    final class None implements JvmTestToolchainParameters {}
+    final class None implements JvmTestToolchainParameters {
+        public static final None INSTANCE = new None();
+
+        private None() {}
+    }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -455,7 +455,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         )
     }
 
-    def "cannot query parameters for transform without parameters"() {
+    def "can query parameters for transform with None parameters"() {
         createDirs("a", "b", "c")
         settingsFile << """
             include 'a', 'b', 'c'
@@ -471,17 +471,14 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
 
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 void transform(TransformOutputs outputs) {
-                    println getParameters()
+                    println("Parameters: " + getParameters())
                 }
             }
         """
 
-        when:
-        fails(":a:resolve")
-
-        then:
-        failure.assertResolutionFailure(':a:resolver')
-        failure.assertHasCause("Cannot query the parameters of an instance of TransformAction that takes no parameters.")
+        expect:
+        succeeds(":a:resolve")
+        outputContains("Parameters: org.gradle.api.artifacts.transform.TransformParameters\$None@")
     }
 
     def "transform parameters type cannot use caching annotations"() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransform.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransform.java
@@ -413,7 +413,7 @@ public class DefaultTransform implements Transform {
 
     private TransformAction<?> newTransformAction(Provider<FileSystemLocation> inputArtifactProvider, TransformDependencies transformDependencies, @Nullable InputChanges inputChanges) {
         TransformParameters parameters = isolatedParameters.get().getIsolatedParameterObject().isolate();
-        ServiceLookup services = new IsolationScheme<>(TransformAction.class, TransformParameters.class, TransformParameters.None.class).servicesForImplementation(parameters, internalServices, Collections.emptySet());
+        ServiceLookup services = new IsolationScheme<>(TransformAction.class, TransformParameters.class, TransformParameters.None.class, TransformParameters.None.INSTANCE).servicesForImplementation(parameters, internalServices, Collections.emptySet());
         services = new TransformServiceLookup(inputArtifactProvider, requiresDependencies ? transformDependencies : null, inputChanges, services);
         return instanceFactory.newInstance(services);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -49,7 +49,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
     private final InstantiationScheme parametersInstantiationScheme;
     private final TransformRegistrationFactory registrationFactory;
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private final IsolationScheme<TransformAction<?>, TransformParameters> isolationScheme = new IsolationScheme<TransformAction<?>, TransformParameters>((Class)TransformAction.class, TransformParameters.class, TransformParameters.None.class);
+    private final IsolationScheme<TransformAction<?>, TransformParameters> isolationScheme = new IsolationScheme<TransformAction<?>, TransformParameters>((Class) TransformAction.class, TransformParameters.class, TransformParameters.None.class, TransformParameters.None.INSTANCE);
     private final DocumentationRegistry documentationRegistry;
 
     public DefaultVariantTransformRegistry(

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformParameters.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.artifacts.transform;
 
+import org.gradle.api.Incubating;
+
 /**
  * Marker interface for parameter objects to {@link TransformAction}s.
  *
@@ -41,11 +43,19 @@ public interface TransformParameters {
     /**
      * Used for {@link TransformAction}s without parameters.
      *
-     * <p>When {@link None} is used as parameters, calling {@link TransformAction#getParameters()} throws an exception.</p>
+     * <p>When {@link None} is used as parameters, calling {@link TransformAction#getParameters()} returns the {@link #INSTANCE singleton}.</p>
      *
      * @since 5.3
      */
     final class None implements TransformParameters {
+        /**
+         * Singleton instance of {@link None}.
+         *
+         * @since 9.6.0
+         */
+        @Incubating
+        public static final None INSTANCE = new None();
+
         private None() {}
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ValueSourceParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ValueSourceParameters.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.Incubating;
+
 /**
  * Marker interface for parameter objects to {@link ValueSource}s.
  *
@@ -37,6 +39,14 @@ public interface ValueSourceParameters {
      * @since 6.1
      */
     final class None implements ValueSourceParameters {
+        /**
+         * Singleton instance of {@link None}.
+         *
+         * @since 9.6.0
+         */
+        @Incubating
+        public static final None INSTANCE = new None();
+
         private None() {
         }
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/services/BuildServiceParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/services/BuildServiceParameters.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.services;
 
+import org.gradle.api.Incubating;
+
 /**
  * A set of parameters to be injected into a {@link BuildService} implementation.
  *
@@ -28,6 +30,14 @@ public interface BuildServiceParameters {
      * @since 6.1
      */
     final class None implements BuildServiceParameters {
+        /**
+         * Singleton instance of {@link None}.
+         *
+         * @since 9.6.0
+         */
+        @Incubating
+        public static final None INSTANCE = new None();
+
         private None() {
         }
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -1285,6 +1285,31 @@ Hello, subproject1
         outputContains("service: value is 2")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/30182")
+    def "service with no parameters can access None parameters"() {
+        buildFile << """
+            abstract class CountingService implements BuildService<${BuildServiceParameters.name}.None> {
+                CountingService() {
+                    println("service: parameters = " + getParameters())
+                }
+            }
+
+            def provider = gradle.sharedServices.registerIfAbsent("counter", CountingService) {}
+
+            task check {
+                doFirst {
+                    provider.get()
+                }
+            }
+        """
+
+        when:
+        run("check")
+
+        then:
+        outputContains("service: parameters = org.gradle.api.services.BuildServiceParameters\$None@")
+    }
+
     def "service can be registered without action"() {
         noParametersServiceImplementation()
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
@@ -69,7 +69,7 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
     private final IsolatableFactory isolatableFactory;
     private final SharedResourceLeaseRegistry leaseRegistry;
     private final IsolationScheme<BuildService<?>, BuildServiceParameters> isolationScheme = new IsolationScheme<>(
-        Cast.uncheckedCast(BuildService.class), BuildServiceParameters.class, BuildServiceParameters.None.class);
+        Cast.uncheckedCast(BuildService.class), BuildServiceParameters.class, BuildServiceParameters.None.class, BuildServiceParameters.None.INSTANCE);
     private final Instantiator paramsInstantiator;
     private final Instantiator specInstantiator;
     private final BuildServiceProvider.Listener listener;


### PR DESCRIPTION
Fixes #30182

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed behavior for work actions, transforms, value sources, build services, and flow actions with no parameters. `getParameters()` now returns a singleton instance instead of throwing an exception.

* **Tests**
  * Added integration tests validating that no-parameter actions can safely access their parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->