### PR TITLE
Fix flaky ToolingApiLoggingCrossVersionSpec

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -178,8 +178,8 @@ project.logger.debug("debug logging");
         // Must replace both build result formats for cross compat
         return output
             .replaceAll(/Unable to list file systems to check whether they can be watched.*\n/, '')
-            .replaceFirst(/Parallel Configuration Cache is an incubating feature.\n/, '')
-            .replaceFirst(/Support for .* was deprecated.*\n/, '')
+            .replaceAll(/Parallel Configuration Cache is an incubating feature.\n/, '')
+            .replaceAll(/Support for .* was deprecated.*\n/, '')
             .replaceFirst(/ in [ \dms]+/, " in 0ms")
             .replaceFirst("Total time: .+ secs", "Total time: 0 secs")
             .replaceFirst(/(?s)To honour the JVM settings for this build a (new JVM|single-use Daemon process) will be forked.+will be stopped at the end of the build (stopping after processing)?\n/, "")


### PR DESCRIPTION
## Problem

`ToolingApiLoggingCrossVersionSpec` (m8) has been failing intermittently on CI since April 11, 2026 — roughly 11 days after the test was introduced. Develocity data shows 147 failures of `:tooling-api:embeddedCrossVersionTest` over 30 days, concentrated on the `Quick Java26 Adoptium Linux Amd64` configuration.

Root cause: CI runs Java 26. For older Gradle distributions (5.x–7.x) that don't support Java 26, `ToolingApi.getJvmOverride()` supplies a Java 17 JVM for both the TAPI connection and the `NoDaemonGradleExecuter` command-line run. Those old Gradle versions emit **multiple** deprecation warnings of the form `"Support for running Gradle with Java 17 was deprecated..."` — one per build script evaluated.

The `normaliseOutput()` method used `replaceFirst` for this pattern, which strips only the first occurrence. When the TAPI output and command-line output contained different numbers of such warnings, the equality assertion `normaliseOutput(out) == normaliseOutput(commandLineOutput)` failed.

## Fix

Change `replaceFirst` to `replaceAll` for both the deprecation warning pattern and the Parallel Configuration Cache incubating notice, so all occurrences are stripped before comparison.

## Evidence

- Failure rate: 147 `:tooling-api:embeddedCrossVersionTest` failures over 30 days
- Platform: Linux (Java 26 Adoptium)
- Representative error: output mismatch on `normaliseOutput(out) == normaliseOutput(commandLineOutput)` with extra `"Support for running Gradle with Java 17 was deprecated"` lines in one of the two outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)