### PR TITLE
Send the warning about no env vars due to uninitialized native infrastructure to the client

### DIFF
--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
@@ -47,6 +47,7 @@ import org.gradle.launcher.daemon.server.api.HandleReportStatus;
 import org.gradle.launcher.daemon.server.api.HandleStop;
 import org.gradle.launcher.daemon.server.exec.CleanUpVirtualFileSystemAfterBuild;
 import org.gradle.launcher.daemon.server.exec.DaemonCommandExecuter;
+import org.gradle.launcher.daemon.server.exec.ApplyClientEnvironmentVariables;
 import org.gradle.launcher.daemon.server.exec.EstablishBuildEnvironment;
 import org.gradle.launcher.daemon.server.exec.ExecuteBuild;
 import org.gradle.launcher.daemon.server.exec.ForwardClientInput;
@@ -170,6 +171,7 @@ public class DaemonServices implements ServiceRegistrationProvider {
             new StartBuildOrRespondWithBusy(daemonDiagnostics), // from this point down, the daemon is 'busy'
             new EstablishBuildEnvironment(processEnvironment),
             new LogToClient(loggingManager, daemonDiagnostics), // from this point down, logging is sent back to the client
+            new ApplyClientEnvironmentVariables(processEnvironment),
             new LogAndCheckHealth(healthStats, healthCheck, runningStats),
             new ForwardClientInput(inputReader, eventDispatch),
             new RequestStopIfSingleUsedDaemon(),

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ApplyClientEnvironmentVariables.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ApplyClientEnvironmentVariables.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.launcher.daemon.server.exec;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.internal.nativeintegration.EnvironmentModificationResult;
+import org.gradle.internal.nativeintegration.ProcessEnvironment;
+import org.gradle.launcher.daemon.protocol.Build;
+import org.gradle.launcher.daemon.server.api.DaemonCommandExecution;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Applies the environment variables specified by the client to the daemon JVM, and restores the
+ * previous values when the build finishes.
+ *
+ * <p>This action runs <em>after</em> {@link LogToClient} so that the warning logged when the daemon
+ * cannot mutate its process environment (typically because the native integration is unavailable, e.g.
+ * when {@code ~/.gradle/native/} is on a {@code noexec} filesystem) is forwarded to the client and
+ * surfaces in the build's standard output rather than being buried in the daemon log.</p>
+ *
+ * <p>Sibling action {@link EstablishBuildEnvironment} handles system properties and the working
+ * directory and runs <em>before</em> {@code LogToClient} so that properties such as
+ * {@link LogToClient#DISABLE_OUTPUT} are visible to {@code LogToClient} when it decides whether to
+ * forward output.</p>
+ */
+@NullMarked
+public class ApplyClientEnvironmentVariables extends BuildCommandOnly {
+    private static final Logger DEFAULT_LOGGER = Logging.getLogger(ApplyClientEnvironmentVariables.class);
+
+    private final ProcessEnvironment processEnvironment;
+    private final Logger logger;
+
+    public ApplyClientEnvironmentVariables(ProcessEnvironment processEnvironment) {
+        this(processEnvironment, DEFAULT_LOGGER);
+    }
+
+    @VisibleForTesting
+    ApplyClientEnvironmentVariables(ProcessEnvironment processEnvironment, Logger logger) {
+        this.processEnvironment = processEnvironment;
+        this.logger = logger;
+    }
+
+    @Override
+    protected void doBuild(DaemonCommandExecution execution, Build build) {
+        Map<String, String> originalEnv = new HashMap<>(System.getenv());
+
+        // Log only the variable names and not their values. Environment variables often contain sensitive data that should not be leaked to log files.
+        logger.debug("Configuring env variables: {}", build.getParameters().getEnvVariables().keySet());
+
+        EnvironmentModificationResult setEnvironmentResult = processEnvironment.maybeSetEnvironment(build.getParameters().getEnvVariables());
+        if (!setEnvironmentResult.isSuccess()) {
+            logger.warn("Warning: Unable to set daemon's environment variables to match the client because: "
+                + System.getProperty("line.separator") + "  "
+                + setEnvironmentResult
+                + System.getProperty("line.separator") + "  "
+                + "If the daemon was started with a significantly different environment from the client, and your build "
+                + System.getProperty("line.separator") + "  "
+                + "relies on environment variables, you may experience unexpected behavior.");
+        }
+
+        try {
+            execution.proceed();
+        } finally {
+            processEnvironment.maybeSetEnvironment(originalEnv);
+        }
+    }
+}

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
@@ -15,26 +15,30 @@
  */
 package org.gradle.launcher.daemon.server.exec;
 
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
-import org.gradle.internal.nativeintegration.EnvironmentModificationResult;
 import org.gradle.launcher.daemon.protocol.Build;
 import org.gradle.launcher.daemon.server.api.DaemonCommandExecution;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
 /**
- * Aims to make the local environment the same as the client's environment.
+ * Applies the system properties and process directory specified by the client to the daemon JVM,
+ * and restores the previous values when the build finishes.
+ *
+ * <p>This action is intentionally placed before {@link LogToClient} in the daemon command chain so
+ * that system properties such as {@link LogToClient#DISABLE_OUTPUT} are visible to {@code LogToClient}
+ * when it decides whether to forward output to the client.</p>
+ *
+ * <p>Applying client-supplied environment variables is the responsibility of {@link ApplyClientEnvironmentVariables},
+ * which runs <em>after</em> {@code LogToClient} so that any warning emitted on environment-modification
+ * failure (e.g. when the native integration is unavailable on a {@code noexec} filesystem) reaches the client.</p>
  */
 public class EstablishBuildEnvironment extends BuildCommandOnly {
-    private final static Logger LOGGER = Logging.getLogger(EstablishBuildEnvironment.class);
 
     private final ProcessEnvironment processEnvironment;
 
@@ -46,7 +50,6 @@ public class EstablishBuildEnvironment extends BuildCommandOnly {
     protected void doBuild(DaemonCommandExecution execution, Build build) {
         Properties originalSystemProperties = new Properties();
         originalSystemProperties.putAll(System.getProperties());
-        Map<String, String> originalEnv = new HashMap<String, String>(System.getenv());
         File originalProcessDir = FileUtils.canonicalize(new File("."));
 
         for (Map.Entry<String, String> entry : build.getParameters().getSystemProperties().entrySet()) {
@@ -62,19 +65,6 @@ public class EstablishBuildEnvironment extends BuildCommandOnly {
             System.setProperty(entry.getKey(), entry.getValue());
         }
 
-        // Log only the variable names and not their values. Environment variables often contain sensitive data that should not be leaked to log files.
-        LOGGER.debug("Configuring env variables: {}", build.getParameters().getEnvVariables().keySet());
-
-        EnvironmentModificationResult setEnvironmentResult = processEnvironment.maybeSetEnvironment(build.getParameters().getEnvVariables());
-        if(!setEnvironmentResult.isSuccess()) {
-            LOGGER.warn("Warning: Unable able to set daemon's environment variables to match the client because: "
-                + System.getProperty("line.separator") + "  "
-                + setEnvironmentResult
-                + System.getProperty("line.separator") + "  "
-                + "If the daemon was started with a significantly different environment from the client, and your build "
-                + System.getProperty("line.separator") + "  "
-                + "relies on environment variables, you may experience unexpected behavior.");
-        }
         processEnvironment.maybeSetProcessDir(build.getParameters().getCurrentDir());
 
         // Capture and restore this in case the build code calls Locale.setDefault()
@@ -84,7 +74,6 @@ public class EstablishBuildEnvironment extends BuildCommandOnly {
             execution.proceed();
         } finally {
             System.setProperties(originalSystemProperties);
-            processEnvironment.maybeSetEnvironment(originalEnv);
             processEnvironment.maybeSetProcessDir(originalProcessDir);
             Locale.setDefault(locale);
         }

--- a/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/exec/ApplyClientEnvironmentVariablesTest.groovy
+++ b/platforms/core-runtime/launcher/src/test/groovy/org/gradle/launcher/daemon/server/exec/ApplyClientEnvironmentVariablesTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.daemon.server.exec
+
+import org.gradle.api.logging.Logger
+import org.gradle.internal.nativeintegration.EnvironmentModificationResult
+import org.gradle.internal.nativeintegration.ProcessEnvironment
+import org.gradle.launcher.daemon.protocol.Build
+import org.gradle.launcher.daemon.server.api.DaemonCommandExecution
+import org.gradle.launcher.exec.BuildActionParameters
+import spock.lang.Specification
+
+class ApplyClientEnvironmentVariablesTest extends Specification {
+
+    def execution = Mock(DaemonCommandExecution)
+    def build = Mock(Build)
+    def parameters = Mock(BuildActionParameters)
+    def processEnvironment = Mock(ProcessEnvironment)
+    def logger = Mock(Logger)
+    def action = new ApplyClientEnvironmentVariables(processEnvironment, logger)
+
+    def setup() {
+        build.parameters >> parameters
+        parameters.envVariables >> [FOO: "BAR"]
+    }
+
+    def "logs WARN when daemon cannot mutate its environment"() {
+        given:
+        processEnvironment.maybeSetEnvironment(_) >> EnvironmentModificationResult.UNSUPPORTED_ENVIRONMENT
+
+        when:
+        action.doBuild(execution, build)
+
+        then:
+        1 * logger.warn({ String message ->
+            message.contains("Unable to set daemon's environment variables")
+        })
+    }
+
+    def "does not log WARN when daemon successfully applies the environment"() {
+        given:
+        processEnvironment.maybeSetEnvironment(_) >> EnvironmentModificationResult.SUCCESS
+
+        when:
+        action.doBuild(execution, build)
+
+        then:
+        0 * logger.warn(_)
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r960/EnvironmentVariablesUnsupportedEnvironmentCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r960/EnvironmentVariablesUnsupportedEnvironmentCrossVersionSpec.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r960
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.tooling.ProjectConnection
+import spock.lang.Issue
+
+@TargetGradleVersion(">=9.6.0")
+class EnvironmentVariablesUnsupportedEnvironmentCrossVersionSpec extends ToolingApiSpecification {
+
+    TestFile userHome
+
+    def setup() {
+        toolingApi.requireDaemons()
+        userHome = toolingApi.requireIsolatedUserHome()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37366")
+    def "warning about dropped environment variables reaches the TAPI client when daemon cannot mutate its environment"() {
+        given:
+        buildFile << """
+            task touchProject {
+                doLast {
+                    println("OK")
+                }
+            }
+        """
+
+        /**
+         * Warmup build: let a daemon extract native-platform libraries to the isolated user home.
+         * Once extracted, each library's .lock file holds an "extraction complete" marker byte.
+         */
+        withConnection { ProjectConnection connection -> connection.newBuild().forTasks("help").run()}
+
+        /**
+         * Workaround for https://github.com/gradle/gradle/issues/28203, simply corrupt the native libs
+         * so they cannot be loaded.
+         */
+        corruptNativeLibraries(userHome.file("native"))
+
+        when:
+        /*
+         * Pass -Xmx that is part of the daemon compatibility check so the second build
+         * spawns a fresh daemon instead of reusing the warmup daemon with loaded native libs.
+         * Cannot kill the daemon via the test fixture here: it will lead to a flaky clash on startup.
+         */
+        withConnection { ProjectConnection connection ->
+            connection.newBuild()
+                .setJvmArguments("-Xmx256m")
+                .setEnvironmentVariables(["FOO": "BAR"])
+                .forTasks("touchProject")
+                .run()
+        }
+
+        then:
+        stdout.toString().contains(
+            "Warning: Unable to set daemon's environment variables to match the client because: \n" +
+            "  There is no native integration with this operating environment.\n" +
+            "  If the daemon was started with a significantly different environment from the client, and your build \n" +
+            "  relies on environment variables, you may experience unexpected behavior."
+        )
+    }
+
+    private static void corruptNativeLibraries(File nativeDir) {
+        assert nativeDir.directory: "Expected native dir to exist after warmup: $nativeDir"
+        nativeDir.eachFileRecurse { File file ->
+            if (file.directory) {
+                return
+            }
+            if (file.name.endsWith(".lock")) {
+                return // preserve the "extraction complete" marker
+            }
+            if (file.path.contains(File.separator + "jansi" + File.separator)) {
+                return // Jansi has its own loading path and is not required for the daemon's Native.init
+            }
+            file.bytes = new byte[0]
+        }
+    }
+}

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r960/EnvironmentVariablesUnsupportedEnvironmentCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r960/EnvironmentVariablesUnsupportedEnvironmentCrossVersionSpec.groovy
@@ -19,10 +19,14 @@ package org.gradle.integtests.tooling.r960
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.OsTestPreconditions
 import org.gradle.tooling.ProjectConnection
 import spock.lang.Issue
 
 @TargetGradleVersion(">=9.6.0")
+// The test uses a workaround overwriting the native lib files on disk, which are locked on Windows while the daemon that loaded them is alive
+@Requires(OsTestPreconditions.NotWindows)
 class EnvironmentVariablesUnsupportedEnvironmentCrossVersionSpec extends ToolingApiSpecification {
 
     TestFile userHome


### PR DESCRIPTION
Fixes:
* https://github.com/gradle/gradle/issues/37366

Related:
* Workaround was needed for https://github.com/gradle/gradle/issues/28203 in the test