### PR TITLE
Deprecate calling Task methods at execution time

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeModelControllerServices.kt
@@ -114,6 +114,7 @@ object BuildTreeModelControllerServices : ServiceRegistrationProvider {
         }
 
         add(InstrumentedExecutionAccessListenerRegistry::class.java)
+        add(ExecutionAccessChecker::class.java, ConfigurationTimeBarrierBasedExecutionAccessChecker::class.java)
 
         if (modelParameters.isVintage) {
             // region ALL MODES
@@ -124,7 +125,6 @@ object BuildTreeModelControllerServices : ServiceRegistrationProvider {
             add(ProjectScopedScriptResolution::class.java, ProjectScopedScriptResolution.NO_OP)
             add(ConfigurationCacheInputsListener::class.java, PromoInputsListener::class.java)
             add(BuildTreeModelSideEffectExecutor::class.java, DefaultBuildTreeModelSideEffectExecutor::class.java)
-            add(ExecutionAccessChecker::class.java, ConfigurationTimeBarrierBasedExecutionAccessChecker::class.java)
             // endregion
 
             // region VT-only
@@ -143,7 +143,6 @@ object BuildTreeModelControllerServices : ServiceRegistrationProvider {
                 ConfigurationCacheBuildTreeModelSideEffectExecutor::class.java,
                 ConfigurationCacheBuildTreeModelSideEffectExecutor::class.java
             )
-            add(ExecutionAccessChecker::class.java, ConfigurationTimeBarrierBasedExecutionAccessChecker::class.java)
             // endregion
 
             // region CC and IP

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/BuildTreeModelControllerServices.kt
@@ -113,6 +113,8 @@ object BuildTreeModelControllerServices : ServiceRegistrationProvider {
             else -> add(ProblemsListener::class.java, IgnoringProblemsListener)
         }
 
+        add(InstrumentedExecutionAccessListenerRegistry::class.java)
+
         if (modelParameters.isVintage) {
             // region ALL MODES
             add(Environment::class.java, DefaultEnvironment::class.java)
@@ -122,7 +124,7 @@ object BuildTreeModelControllerServices : ServiceRegistrationProvider {
             add(ProjectScopedScriptResolution::class.java, ProjectScopedScriptResolution.NO_OP)
             add(ConfigurationCacheInputsListener::class.java, PromoInputsListener::class.java)
             add(BuildTreeModelSideEffectExecutor::class.java, DefaultBuildTreeModelSideEffectExecutor::class.java)
-            add(ExecutionAccessChecker::class.java, DefaultExecutionAccessChecker::class.java)
+            add(ExecutionAccessChecker::class.java, ConfigurationTimeBarrierBasedExecutionAccessChecker::class.java)
             // endregion
 
             // region VT-only
@@ -149,7 +151,6 @@ object BuildTreeModelControllerServices : ServiceRegistrationProvider {
             add(ConfigurationCacheKey::class.java)
             add(ConfigurationCacheClassLoaderScopeRegistryListener::class.java)
             add(BuildTreeConfigurationCache::class.java, DefaultConfigurationCache::class.java)
-            add(InstrumentedExecutionAccessListenerRegistry::class.java)
             add(DefaultDeferredRootBuildGradle::class.java)
             add(
                 ConfigurationCacheInputFileChecker.Host::class.java,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationTimeBarrierBasedExecutionAccessChecker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ConfigurationTimeBarrierBasedExecutionAccessChecker.kt
@@ -40,10 +40,3 @@ class ConfigurationTimeBarrierBasedExecutionAccessChecker(
     fun shouldReportExecutionTimeAccess(): Boolean =
         !configurationTimeBarrier.isAtConfigurationTime
 }
-
-
-internal
-class DefaultExecutionAccessChecker : ExecutionAccessChecker {
-
-    override fun disallowedAtExecutionInjectedServiceAccessed(injectedServiceType: Class<*>, getterName: String, consumer: String) = Unit
-}

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
@@ -72,9 +72,7 @@ class DeprecatedFeaturesListener(
     }
 
     override fun onTaskDependenciesAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (buildModelParameters.isConfigurationCache) {
-            throwUnsupported("Invocation of $invocationDescription at execution time")
-        } else if (shouldNagFor(task, runningTask, ignoreStable = true)) {
+        if (shouldNagFor(task, runningTask, ignoreStable = true)) {
             nagUserAbout("Invocation of $invocationDescription at execution time", 9, "task_dependencies")
         }
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
@@ -57,35 +57,35 @@ class DeprecatedFeaturesListener(
                 DeprecationLogger.deprecateMethod(Gradle::class.java, "useLogger(Object)")
                     .willBeRemovedInGradle10()
                     .withUpgradeGuideSection(8, "deprecated_use_logger")
-                    .nagUser();
+                    .nagUser()
             }
             shouldNagAbout(listener) -> {
                 nagUserAbout("Listener registration using $invocationDescription()", 7, "task_execution_events")
-            }
+            } // TODO: this is now the only call site for these "shouldNag.." methods where the ignoreStable flag is not TRUE; probably we should change this too
         }
     }
 
     override fun onProjectAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (shouldNagFor(task, runningTask, ignoreStable = true)) {
+        if (shouldNagFor(task, runningTask)) {
             nagUserAbout("Invocation of $invocationDescription at execution time", 7, "task_project")
         }
     }
 
     override fun onTaskDependenciesAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (shouldNagFor(task, runningTask, ignoreStable = true)) {
+        if (shouldNagFor(task, runningTask)) {
             nagUserAbout("Invocation of $invocationDescription at execution time", 9, "task_dependencies")
         }
     }
 
     override fun onConventionAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (shouldNagFor(task, runningTask, ignoreStable = true)) {
+        if (shouldNagFor(task, runningTask)) {
             nagUserAbout("Invocation of $invocationDescription at execution time", 9, "task_extensions")
         }
     }
 
     override fun disallowedAtExecutionInjectedServiceAccessed(injectedServiceType: Class<*>, getterName: String, consumer: String) {
-        if (shouldNag()) {
-            throwUnsupported("Invocation of $injectedServiceType at execution time")
+        if (shouldNag(ignoreStable = true)) {
+            nagUserAbout("Reading injected service of type ${injectedServiceType.simpleName} at execution time", 9, "injected_service_types_at_execution")
         }
     }
 
@@ -99,8 +99,8 @@ class DeprecatedFeaturesListener(
     }
 
     private
-    fun shouldNagFor(task: TaskInternal, runningTask: TaskInternal?, ignoreStable: Boolean = false) =
-        shouldNag(ignoreStable) && shouldReportInContext(task, runningTask)
+    fun shouldNagFor(task: TaskInternal, runningTask: TaskInternal?) =
+        shouldNag(true) && shouldReportInContext(task, runningTask)
 
     private
     fun shouldNag(ignoreStable: Boolean = false): Boolean =
@@ -117,10 +117,6 @@ class DeprecatedFeaturesListener(
     private
     fun shouldReportInContext(task: TaskInternal, runningTask: TaskInternal?) =
         runningTask == null || task === runningTask
-
-    private
-    fun throwUnsupported(reason: String): Nothing =
-        throw UnsupportedOperationException("$reason is unsupported with the STABLE_CONFIGURATION_CACHE feature preview.")
 }
 
 /**

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
@@ -78,8 +78,8 @@ class DeprecatedFeaturesListener(
     }
 
     override fun onConventionAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (shouldNagFor(task, runningTask)) {
-            nagUserAbout("Invocation of $invocationDescription at execution time", 8, "task_convention")
+        if (shouldNagFor(task, runningTask, ignoreStable = true)) {
+            nagUserAbout("Invocation of $invocationDescription at execution time", 9, "task_extensions")
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
@@ -77,14 +77,14 @@ class DeprecatedFeaturesListener(
         }
     }
 
-    override fun onConventionAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
+    override fun onTaskExtensionAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
         if (shouldNagFor(task, runningTask)) {
             nagUserAbout("Invocation of $invocationDescription at execution time", 9, "task_extensions")
         }
     }
 
     override fun disallowedAtExecutionInjectedServiceAccessed(injectedServiceType: Class<*>, getterName: String, consumer: String) {
-        if (shouldNag(ignoreStable = true)) {
+        if (shouldNag()) {
             nagUserAbout("Reading injected service of type ${injectedServiceType.simpleName} at execution time", 9, "injected_service_types_at_execution")
         }
     }
@@ -100,15 +100,15 @@ class DeprecatedFeaturesListener(
 
     private
     fun shouldNagFor(task: TaskInternal, runningTask: TaskInternal?) =
-        shouldNag(true) && shouldReportInContext(task, runningTask)
+        shouldNag() && shouldReportInContext(task, runningTask)
 
     private
-    fun shouldNag(ignoreStable: Boolean = false): Boolean =
-        // TODO:configuration-cache - this listener shouldn't be registered when cc is enabled
-        !buildModelParameters.isConfigurationCache && (ignoreStable || featureFlags.isEnabled(STABLE_CONFIGURATION_CACHE))
+    fun shouldNag(): Boolean =
+        !buildModelParameters.isConfigurationCache
 
     private
-    fun shouldNagAbout(listener: Any): Boolean = shouldNag() && !isSupportedListener(listener)
+    fun shouldNagAbout(listener: Any): Boolean =
+        !buildModelParameters.isConfigurationCache && featureFlags.isEnabled(STABLE_CONFIGURATION_CACHE) && !isSupportedListener(listener)
 
     /**
      * Only nag about tasks that are actually executing, but not tasks that are configured by the executing tasks.

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/DeprecatedFeaturesListener.kt
@@ -72,8 +72,10 @@ class DeprecatedFeaturesListener(
     }
 
     override fun onTaskDependenciesAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (shouldNagFor(task, runningTask)) {
+        if (buildModelParameters.isConfigurationCache) {
             throwUnsupported("Invocation of $invocationDescription at execution time")
+        } else if (shouldNagFor(task, runningTask, ignoreStable = true)) {
+            nagUserAbout("Invocation of $invocationDescription at execution time", 9, "task_dependencies")
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/TaskExecutionAccessCheckers.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/TaskExecutionAccessCheckers.kt
@@ -56,7 +56,7 @@ abstract class AbstractTaskProjectAccessChecker(
 
     override fun notifyConventionAccess(task: TaskInternal, invocationDescription: String) {
         if (shouldReportExecutionTimeAccess(task)) {
-            broadcaster.onConventionAccess(invocationDescription, task, currentTask())
+            broadcaster.onTaskExtensionAccess(invocationDescription, task, currentTask())
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/TaskExecutionAccessCheckers.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/TaskExecutionAccessCheckers.kt
@@ -54,7 +54,7 @@ abstract class AbstractTaskProjectAccessChecker(
         }
     }
 
-    override fun notifyConventionAccess(task: TaskInternal, invocationDescription: String) {
+    override fun notifyTaskExtensionsAccess(task: TaskInternal, invocationDescription: String) {
         if (shouldReportExecutionTimeAccess(task)) {
             broadcaster.onTaskExtensionAccess(invocationDescription, task, currentTask())
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/Workarounds.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/Workarounds.kt
@@ -60,7 +60,7 @@ object Workarounds {
             }
         }
 
-    fun canAccessConventions(from: String, area: String) =
+    fun canAccessTaskExtensions(from: String, area: String) =
         withWorkaroundsFor(area) {
             from.startsWith("com.android.build.gradle.tasks.factory.AndroidUnitTest") || callStackHasElement {
                 isBuildScanPlugin(className)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -27,7 +27,7 @@ import org.gradle.api.internal.provider.ConfigurationTimeBarrier
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
 import org.gradle.execution.ExecutionAccessListener
 import org.gradle.internal.cc.impl.InputTrackingState
-import org.gradle.internal.cc.impl.Workarounds.canAccessConventions
+import org.gradle.internal.cc.impl.Workarounds.canAccessTaskExtensions
 import org.gradle.internal.cc.impl.isSupportedListener
 import org.gradle.internal.configuration.problems.DocumentationSection
 import org.gradle.internal.configuration.problems.DocumentationSection.RequirementsBuildListeners
@@ -74,7 +74,7 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     }
 
     override fun onTaskExtensionAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (canAccessConventions(task.javaClass.name, invocationDescription)) {
+        if (canAccessTaskExtensions(task.javaClass.name, invocationDescription)) {
             return
         }
         onTaskExecutionAccessProblem(invocationDescription, task, runningTask)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/initialization/ConfigurationCacheProblemsListener.kt
@@ -73,7 +73,7 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
         onTaskExecutionAccessProblem(invocationDescription, task, runningTask)
     }
 
-    override fun onConventionAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
+    override fun onTaskExtensionAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
         if (canAccessConventions(task.javaClass.name, invocationDescription)) {
             return
         }

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -209,6 +209,22 @@ This is another step towards moving users away from idioms that are incompatible
 
 Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, configuration cache documentation>> for alternatives that are compatible with the configuration cache.
 
+[[injected_service_types_at_execution]]
+==== Accessing injected `Project` or `Gradle` services from a task action
+
+Reading an injected service of type link:{javadocPath}/org/gradle/api/Project.html[Project] or link:{javadocPath}/org/gradle/api/invocation/Gradle.html[Gradle] from a task action at execution time is now deprecated and will be made an error in Gradle 10.
+
+These services can still be read during configuration time.
+
+The deprecation is only issued if the configuration cache is **not** enabled.
+When the configuration cache is enabled, such accesses are reported as configuration cache problems instead.
+
+This restriction was originally enforced only when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled.
+That feature flag no longer controls this deprecation.
+This is another step towards moving users away from idioms that are incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release.
+
+Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, configuration cache documentation>> for alternatives that are compatible with the configuration cache.
+
 [[deprecate_build_needed_build_dependents_tasks]]
 ==== Deprecation of `buildNeeded` and `buildDependents` tasks
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -185,10 +185,6 @@ These methods can still be used during configuration time.
 
 The deprecation is only issued if the Configuration Cache is **not** enabled.
 When the Configuration Cache is enabled, calls to these methods are reported as Configuration Cache problems instead.
-
-The deprecation of `Task.getTaskDependencies()` was originally introduced in <<upgrading_version_7.adoc#task_dependencies, Gradle 7.4>> but was only issued when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled.
-That feature flag no longer controls this deprecation.
-The other methods listed above are newly deprecated in this version.
 This is another step towards moving users away from idioms that are incompatible with the Configuration Cache, which will become the only mode supported by Gradle in a future release.
 For example:
 
@@ -223,9 +219,6 @@ This method can still be used during configuration time.
 
 The deprecation is only issued if the Configuration Cache is **not** enabled.
 When the Configuration Cache is enabled, calls to this method are reported as Configuration Cache problems instead.
-
-This deprecation was originally introduced in <<upgrading_version_8.adoc#task_convention, Gradle 8.2>> but was only issued when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled.
-That feature flag no longer controls this deprecation.
 This is another step towards moving users away from idioms that are incompatible with the Configuration Cache, which will become the only mode supported by Gradle in a future release.
 
 For example:
@@ -259,9 +252,6 @@ These services can still be read during configuration time.
 
 The deprecation is only issued if the Configuration Cache is **not** enabled.
 When the Configuration Cache is enabled, such accesses are reported as Configuration Cache problems instead.
-
-This restriction was originally enforced only when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled.
-That feature flag no longer controls this deprecation.
 This is another step towards moving users away from idioms that are incompatible with the Configuration Cache, which will become the only mode supported by Gradle in a future release.
 
 For example:

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -193,6 +193,22 @@ This is another step towards moving users away from idioms that are incompatible
 
 Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, configuration cache documentation>> for alternatives that are compatible with the configuration cache.
 
+[[task_extensions]]
+==== Accessing extensions from a task action
+
+Calling link:{javadocPath}/org/gradle/api/Task.html#getExtensions--[Task.getExtensions()] from a task action at execution time is now deprecated and will be made an error in Gradle 10.
+
+This method can still be used during configuration time.
+
+The deprecation is only issued if the configuration cache is **not** enabled.
+When the configuration cache is enabled, calls to this method are reported as configuration cache problems instead.
+
+This deprecation was originally introduced in <<upgrading_version_8.adoc#task_convention, Gradle 8.2>> but was only issued when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled.
+That feature flag no longer controls this deprecation.
+This is another step towards moving users away from idioms that are incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release.
+
+Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, configuration cache documentation>> for alternatives that are compatible with the configuration cache.
+
 [[deprecate_build_needed_build_dependents_tasks]]
 ==== Deprecation of `buildNeeded` and `buildDependents` tasks
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -173,57 +173,132 @@ implementation.getDependencies().add(dependency);
 [[task_dependencies]]
 ==== Accessing task dependency relationships from a task action
 
-Calling the following methods from a task action at execution time is now deprecated and will be made an error in Gradle 10:
+Calling the following methods from a task action at execution time is now deprecated and will become an error in Gradle 10:
 
-- link:{javadocPath}/org/gradle/api/Task.html#getTaskDependencies--[Task.getTaskDependencies()]
-- link:{javadocPath}/org/gradle/api/Task.html#getDependsOn--[Task.getDependsOn()]
-- link:{javadocPath}/org/gradle/api/Task.html#getMustRunAfter--[Task.getMustRunAfter()]
-- link:{javadocPath}/org/gradle/api/Task.html#getFinalizedBy--[Task.getFinalizedBy()]
-- link:{javadocPath}/org/gradle/api/Task.html#getShouldRunAfter--[Task.getShouldRunAfter()]
+- link:{javadocPath}/org/gradle/api/Task.html#getTaskDependencies--[`Task.getTaskDependencies()`]
+- link:{javadocPath}/org/gradle/api/Task.html#getDependsOn--[`Task.getDependsOn()`]
+- link:{javadocPath}/org/gradle/api/Task.html#getMustRunAfter--[`Task.getMustRunAfter()`]
+- link:{javadocPath}/org/gradle/api/Task.html#getFinalizedBy--[`Task.getFinalizedBy()`]
+- link:{javadocPath}/org/gradle/api/Task.html#getShouldRunAfter--[`Task.getShouldRunAfter()`]
 
 These methods can still be used during configuration time.
 
-The deprecation is only issued if the configuration cache is **not** enabled.
-When the configuration cache is enabled, calls to these methods are reported as configuration cache problems instead.
+The deprecation is only issued if the Configuration Cache is **not** enabled.
+When the Configuration Cache is enabled, calls to these methods are reported as Configuration Cache problems instead.
 
 The deprecation of `Task.getTaskDependencies()` was originally introduced in <<upgrading_version_7.adoc#task_dependencies, Gradle 7.4>> but was only issued when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled.
 That feature flag no longer controls this deprecation.
 The other methods listed above are newly deprecated in this version.
-This is another step towards moving users away from idioms that are incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release.
+This is another step towards moving users away from idioms that are incompatible with the Configuration Cache, which will become the only mode supported by Gradle in a future release.
+For example:
 
-Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, configuration cache documentation>> for alternatives that are compatible with the configuration cache.
+[source,kotlin]
+----
+// Deprecated: inspecting dependencies from within the task action
+tasks.register("report") {
+    dependsOn("compileJava")
+    doLast {
+        taskDependencies.getDependencies(this).forEach { println(it.name) }
+    }
+}
+
+// Recommended: capture what you need at configuration time
+tasks.register("report") {
+    dependsOn("compileJava")
+    val dependencyNames = dependsOn.filterIsInstance<Task>().map { it.name }
+    doLast {
+        dependencyNames.forEach { println(it) }
+    }
+}
+----
+
+Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, Configuration Cache documentation>> for alternatives that are compatible with the Configuration Cache.
 
 [[task_extensions]]
 ==== Accessing extensions from a task action
 
-Calling link:{javadocPath}/org/gradle/api/Task.html#getExtensions--[Task.getExtensions()] from a task action at execution time is now deprecated and will be made an error in Gradle 10.
+Calling link:{javadocPath}/org/gradle/api/Task.html#getExtensions--[`Task.getExtensions()`] from a task action at execution time is now deprecated and will become an error in Gradle 10.
 
 This method can still be used during configuration time.
 
-The deprecation is only issued if the configuration cache is **not** enabled.
-When the configuration cache is enabled, calls to this method are reported as configuration cache problems instead.
+The deprecation is only issued if the Configuration Cache is **not** enabled.
+When the Configuration Cache is enabled, calls to this method are reported as Configuration Cache problems instead.
 
 This deprecation was originally introduced in <<upgrading_version_8.adoc#task_convention, Gradle 8.2>> but was only issued when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled.
 That feature flag no longer controls this deprecation.
-This is another step towards moving users away from idioms that are incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release.
+This is another step towards moving users away from idioms that are incompatible with the Configuration Cache, which will become the only mode supported by Gradle in a future release.
 
-Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, configuration cache documentation>> for alternatives that are compatible with the configuration cache.
+For example:
+[source,kotlin]
+----
+// Deprecated: reading the extension from within the task action
+tasks.register("greet") {
+    doLast {
+        val ext = extensions.getByType<GreetingExtension>()
+        println(ext.message.get())
+    }
+}
+
+// Recommended: capture the value at configuration time
+tasks.register("greet") {
+    val message = extensions.getByType<GreetingExtension>().message
+    doLast {
+        println(message.get())
+    }
+}
+----
+
+Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, Configuration Cache documentation>> for alternatives that are compatible with the configuration cache.
 
 [[injected_service_types_at_execution]]
 ==== Accessing injected `Project` or `Gradle` services from a task action
 
-Reading an injected service of type link:{javadocPath}/org/gradle/api/Project.html[Project] or link:{javadocPath}/org/gradle/api/invocation/Gradle.html[Gradle] from a task action at execution time is now deprecated and will be made an error in Gradle 10.
+Reading an injected service of type link:{javadocPath}/org/gradle/api/Project.html[`Project`] or link:{javadocPath}/org/gradle/api/invocation/Gradle.html[`Gradle`] from a task action at execution time is now deprecated and will become an error in Gradle 10.
 
 These services can still be read during configuration time.
 
-The deprecation is only issued if the configuration cache is **not** enabled.
-When the configuration cache is enabled, such accesses are reported as configuration cache problems instead.
+The deprecation is only issued if the Configuration Cache is **not** enabled.
+When the Configuration Cache is enabled, such accesses are reported as Configuration Cache problems instead.
 
 This restriction was originally enforced only when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled.
 That feature flag no longer controls this deprecation.
-This is another step towards moving users away from idioms that are incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release.
+This is another step towards moving users away from idioms that are incompatible with the Configuration Cache, which will become the only mode supported by Gradle in a future release.
 
-Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, configuration cache documentation>> for alternatives that are compatible with the configuration cache.
+For example:
+
+[source,kotlin]
+----
+// Deprecated: reading from the injected Project at execution time
+abstract class PrintVersionTask : DefaultTask() {
+    @get:Inject
+    abstract val project: Project
+
+    @TaskAction
+    fun run() {
+        println("Building ${project.name} version ${project.version}")
+    }
+}
+
+// Recommended: declare the values you need as task inputs
+abstract class PrintVersionTask : DefaultTask() {
+    @get:Input
+    abstract val projectName: Property<String>
+
+    @get:Input
+    abstract val projectVersion: Property<String>
+
+    @TaskAction
+    fun run() {
+        println("Building ${projectName.get()} version ${projectVersion.get()}")
+    }
+}
+
+tasks.register<PrintVersionTask>("printVersion") {
+    projectName.set(project.name)
+    projectVersion.set(project.version.toString())
+}
+----
+Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, Configuration Cache documentation>> for alternatives that are compatible with the Configuration Cache.
 
 [[deprecate_build_needed_build_dependents_tasks]]
 ==== Deprecation of `buildNeeded` and `buildDependents` tasks

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -171,18 +171,27 @@ implementation.getDependencies().add(dependency);
 ----
 
 [[task_dependencies]]
-==== Calling `Task.getTaskDependencies()` from a task action
+==== Accessing task dependency relationships from a task action
 
-Calling link:{javadocPath}/org/gradle/api/Task.html#getTaskDependencies--[Task.getTaskDependencies()] from a task action at execution time is now deprecated and will be made an error in Gradle 10.
-This method can still be used during configuration time.
+Calling the following methods from a task action at execution time is now deprecated and will be made an error in Gradle 10:
+
+- link:{javadocPath}/org/gradle/api/Task.html#getTaskDependencies--[Task.getTaskDependencies()]
+- link:{javadocPath}/org/gradle/api/Task.html#getDependsOn--[Task.getDependsOn()]
+- link:{javadocPath}/org/gradle/api/Task.html#getMustRunAfter--[Task.getMustRunAfter()]
+- link:{javadocPath}/org/gradle/api/Task.html#getFinalizedBy--[Task.getFinalizedBy()]
+- link:{javadocPath}/org/gradle/api/Task.html#getShouldRunAfter--[Task.getShouldRunAfter()]
+
+These methods can still be used during configuration time.
 
 The deprecation is only issued if the configuration cache is **not** enabled.
-When the configuration cache is enabled, calls to link:{javadocPath}/org/gradle/api/Task.html#getTaskDependencies--[Task.getTaskDependencies()] are reported as configuration cache problems instead.
+When the configuration cache is enabled, calls to these methods are reported as configuration cache problems instead.
 
-This deprecation was originally introduced in <<upgrading_version_7.adoc#task_dependencies, Gradle 7.4>> but was only issued when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled. That feature flag no longer controls this deprecation.
+The deprecation of `Task.getTaskDependencies()` was originally introduced in <<upgrading_version_7.adoc#task_dependencies, Gradle 7.4>> but was only issued when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled.
+That feature flag no longer controls this deprecation.
+The other methods listed above are newly deprecated in this version.
 This is another step towards moving users away from idioms that are incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release.
 
-Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, configuration cache documentation>> for alternatives to invoking `Task.getTaskDependencies()` at execution time that are compatible with the configuration cache.
+Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, configuration cache documentation>> for alternatives that are compatible with the configuration cache.
 
 [[deprecate_build_needed_build_dependents_tasks]]
 ==== Deprecation of `buildNeeded` and `buildDependents` tasks

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -170,6 +170,20 @@ ProjectDependency dependency = project.getDependencyFactory().createProjectDepen
 implementation.getDependencies().add(dependency);
 ----
 
+[[task_dependencies]]
+==== Calling `Task.getTaskDependencies()` from a task action
+
+Calling link:{javadocPath}/org/gradle/api/Task.html#getTaskDependencies--[Task.getTaskDependencies()] from a task action at execution time is now deprecated and will be made an error in Gradle 10.
+This method can still be used during configuration time.
+
+The deprecation is only issued if the configuration cache is **not** enabled.
+When the configuration cache is enabled, calls to link:{javadocPath}/org/gradle/api/Task.html#getTaskDependencies--[Task.getTaskDependencies()] are reported as configuration cache problems instead.
+
+This deprecation was originally introduced in <<upgrading_version_7.adoc#task_dependencies, Gradle 7.4>> but was only issued when the <<configuration_cache_enabling.adoc#config_cache:stable,`STABLE_CONFIGURATION_CACHE`>> feature flag was enabled. That feature flag no longer controls this deprecation.
+This is another step towards moving users away from idioms that are incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release.
+
+Please refer to the <<configuration_cache_requirements.adoc#config_cache:requirements:use_project_during_execution, configuration cache documentation>> for alternatives to invoking `Task.getTaskDependencies()` at execution time that are compatible with the configuration cache.
+
 [[deprecate_build_needed_build_dependents_tasks]]
 ==== Deprecation of `buildNeeded` and `buildDependents` tasks
 

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeBinariesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeBinariesIntegrationTest.groovy
@@ -37,13 +37,13 @@ class NativeBinariesIntegrationTest extends AbstractInstalledToolChainIntegratio
     def "skips building executable binary with no source"() {
         given:
         buildFile << """
-apply plugin: "cpp"
-model {
-    components {
-        main(NativeExecutableSpec)
-    }
-}
-"""
+            apply plugin: "cpp"
+            model {
+                components {
+                    main(NativeExecutableSpec)
+                }
+            }
+            """.stripIndent()
 
         when:
         succeeds "mainExecutable"
@@ -58,26 +58,26 @@ model {
 
         and:
         buildFile << """
-import org.gradle.nativeplatform.platform.internal.NativePlatforms
-
-apply plugin: 'c'
-
-model {
-    platforms {
-        unknown {
-            architecture "unknown"
-        }
-    }
-}
-model {
-    components {
-        main(NativeExecutableSpec) {
-            targetPlatform "unknown"
-            targetPlatform "${NativePlatformsTestFixture.defaultPlatformName}"
-        }
-    }
-}
-"""
+            import org.gradle.nativeplatform.platform.internal.NativePlatforms
+            
+            apply plugin: 'c'
+            
+            model {
+                platforms {
+                    unknown {
+                        architecture "unknown"
+                    }
+                }
+            }
+            model {
+                components {
+                    main(NativeExecutableSpec) {
+                        targetPlatform "unknown"
+                        targetPlatform "${NativePlatformsTestFixture.defaultPlatformName}"
+                    }
+                }
+            }
+            """.stripIndent()
         when:
         succeeds "assemble"
 
@@ -93,30 +93,35 @@ model {
     @ToBeFixedForConfigurationCache
     def "assemble task produces sensible error when there are no buildable binaries"() {
         buildFile << """
-apply plugin: 'c'
-
-model {
-    platforms {
-        unknown {
-            architecture "unknown"
-        }
-    }
-}
-model {
-    components {
-        main(NativeExecutableSpec) {
-            targetPlatform "unknown"
-        }
-        hello(NativeLibrarySpec) {
-            targetPlatform "unknown"
-        }
-        another(NativeLibrarySpec) {
-            binaries.all { buildable = false }
-        }
-    }
-}
-"""
+            apply plugin: 'c'
+            
+            model {
+                platforms {
+                    unknown {
+                        architecture "unknown"
+                    }
+                }
+            }
+            model {
+                components {
+                    main(NativeExecutableSpec) {
+                        targetPlatform "unknown"
+                    }
+                    hello(NativeLibrarySpec) {
+                        targetPlatform "unknown"
+                    }
+                    another(NativeLibrarySpec) {
+                        binaries.all { buildable = false }
+                    }
+                }
+            }
+            """.stripIndent()
         when:
+        executer.expectDocumentedDeprecationWarning(
+            "Invocation of Task.taskDependencies at execution time has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
         fails "assemble"
 
         then:
@@ -144,26 +149,26 @@ model {
 
         when:
         buildFile << """
-apply plugin: "c"
-apply plugin: "cpp"
-
-model {
-    components {
-        main(NativeExecutableSpec) {
-            sources {
-                c {
-                    source.srcDir "src/test/c"
-                    exportedHeaders.srcDir "src/test/headers"
-                }
-                cpp {
-                    source.srcDir "src/test/cpp"
-                    exportedHeaders.srcDir "src/test/headers"
+            apply plugin: "c"
+            apply plugin: "cpp"
+            
+            model {
+                components {
+                    main(NativeExecutableSpec) {
+                        sources {
+                            c {
+                                source.srcDir "src/test/c"
+                                exportedHeaders.srcDir "src/test/headers"
+                            }
+                            cpp {
+                                source.srcDir "src/test/cpp"
+                                exportedHeaders.srcDir "src/test/headers"
+                            }
+                        }
+                    }
                 }
             }
-        }
-    }
-}
-"""
+            """.stripIndent()
 
         then:
         succeeds "mainExecutable"
@@ -178,31 +183,31 @@ model {
 
         when:
         buildFile << """
-apply plugin: "c"
-apply plugin: "cpp"
-
-model {
-    components {
-        main(NativeExecutableSpec)
-        all {
-            binaries {
-                all {
-                    sources {
-                        testCpp(CppSourceSet) {
-                            source.srcDir "src/test/cpp"
-                            exportedHeaders.srcDir "src/test/headers"
-                        }
-                        testC(CSourceSet) {
-                            source.srcDir "src/test/c"
-                            exportedHeaders.srcDir "src/test/headers"
+            apply plugin: "c"
+            apply plugin: "cpp"
+            
+            model {
+                components {
+                    main(NativeExecutableSpec)
+                    all {
+                        binaries {
+                            all {
+                                sources {
+                                    testCpp(CppSourceSet) {
+                                        source.srcDir "src/test/cpp"
+                                        exportedHeaders.srcDir "src/test/headers"
+                                    }
+                                    testC(CSourceSet) {
+                                        source.srcDir "src/test/c"
+                                        exportedHeaders.srcDir "src/test/headers"
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
-        }
-    }
-}
-"""
+            """.stripIndent()
 
         then:
         succeeds "mainExecutable"
@@ -218,13 +223,13 @@ model {
     def "build fails when link executable fails"() {
         given:
         buildFile << """
-apply plugin: "cpp"
-model {
-    components {
-        main(NativeExecutableSpec)
-    }
-}
-"""
+            apply plugin: "cpp"
+            model {
+                components {
+                    main(NativeExecutableSpec)
+                }
+            }
+            """.stripIndent()
 
         and:
         file("src", "main", "cpp", "helloworld.cpp") << """
@@ -242,25 +247,25 @@ model {
     def "build fails when link library fails"() {
         given:
         buildFile << """
-apply plugin: "cpp"
-model {
-    components {
-        main(NativeLibrarySpec)
-    }
-}
-"""
+            apply plugin: "cpp"
+            model {
+                components {
+                    main(NativeLibrarySpec)
+                }
+            }
+            """.stripIndent()
 
         and:
         file("src/main/cpp/hello1.cpp") << """
             void hello() {
             }
-"""
+            """.stripIndent()
 
         and:
         file("src/main/cpp/hello2.cpp") << """
             void hello() {
             }
-"""
+            """.stripIndent()
 
         when:
         fails "mainSharedLibrary"
@@ -275,25 +280,24 @@ model {
     def "build fails when create static library fails"() {
         given:
         buildFile << """
-apply plugin: "cpp"
-model {
-    components {
-        main(NativeLibrarySpec)
-    }
-    binaries {
-        withType(StaticLibraryBinarySpec) {
-            staticLibArchiver.args "not_a_file"
-        }
-    }
-}
-
-        """
+            apply plugin: "cpp"
+            model {
+                components {
+                    main(NativeLibrarySpec)
+                }
+                binaries {
+                    withType(StaticLibraryBinarySpec) {
+                        staticLibArchiver.args "not_a_file"
+                    }
+                }
+            }
+            """.stripIndent()
 
         and:
         file("src/main/cpp/hello.cpp") << """
             void hello() {
             }
-"""
+            """.stripIndent()
 
         when:
         fails "mainStaticLibrary"
@@ -308,29 +312,29 @@ model {
     @Requires(TestEnvironmentPreconditions.CanInstallExecutable)
     def "installed executable receives command-line parameters"() {
         buildFile << """
-apply plugin: 'c'
-
-model {
-    components {
-        echo(NativeExecutableSpec)
-    }
-}
-"""
+            apply plugin: 'c'
+            
+            model {
+                components {
+                    echo(NativeExecutableSpec)
+                }
+            }
+            """.stripIndent()
         file("src/echo/c/main.c") << """
-// Simple hello world app
-#include <stdio.h>
-
-// Print the command line args
-int main (int argc, char *argv[]) {
-    int i;
-
-    for (i = 1; i < argc; i++) {
-        printf("[%s] ", argv[i]);
-    }
-    printf("\\n");
-    return 0;
-}
-"""
+            // Simple hello world app
+            #include <stdio.h>
+            
+            // Print the command line args
+            int main (int argc, char *argv[]) {
+                int i;
+            
+                for (i = 1; i < argc; i++) {
+                    printf("[%s] ", argv[i]);
+                }
+                printf("\\n");
+                return 0;
+            }
+            """.stripIndent()
 
         when:
         succeeds "installEchoExecutable"
@@ -360,7 +364,7 @@ int main (int argc, char *argv[]) {
                     lib(NativeLibrarySpec)
                 }
             }
-"""
+            """.stripIndent()
         when:
         succeeds "model"
 

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeBinariesIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeBinariesIntegrationTest.groovy
@@ -117,11 +117,7 @@ class NativeBinariesIntegrationTest extends AbstractInstalledToolChainIntegratio
             }
             """.stripIndent()
         when:
-        executer.expectDocumentedDeprecationWarning(
-            "Invocation of Task.taskDependencies at execution time has been deprecated. " +
-            "This will fail with an error in Gradle 10. " +
-            "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
+        expectTaskGetTaskDependenciesDeprecations()
         fails "assemble"
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/BinariesLifecycleTaskIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/BinariesLifecycleTaskIntegrationTest.groovy
@@ -66,6 +66,11 @@ class BinariesLifecycleTaskIntegrationTest extends AbstractIntegrationSpec {
         withStandaloneBinaries("ignoreMe")
 
         when:
+        executer.expectDocumentedDeprecationWarning(
+            "Invocation of Task.taskDependencies at execution time has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
         fails "assemble"
 
         then:
@@ -101,6 +106,11 @@ class BinariesLifecycleTaskIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning(
+            "Invocation of Task.taskDependencies at execution time has been deprecated. " +
+            "This will fail with an error in Gradle 10. " +
+            "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
         run "assemble"
 
         then:

--- a/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/BinariesLifecycleTaskIntegrationTest.groovy
+++ b/platforms/software/platform-base/src/integTest/groovy/org/gradle/language/base/BinariesLifecycleTaskIntegrationTest.groovy
@@ -17,11 +17,12 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.internal.logging.text.DiagnosticsVisitor
 
 @UnsupportedWithConfigurationCache(because = "software model")
-class BinariesLifecycleTaskIntegrationTest extends AbstractIntegrationSpec {
+class BinariesLifecycleTaskIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     def setup() {
         settingsFile << """rootProject.name = 'assemble-binary'"""
         buildFile << """
@@ -66,11 +67,7 @@ class BinariesLifecycleTaskIntegrationTest extends AbstractIntegrationSpec {
         withStandaloneBinaries("ignoreMe")
 
         when:
-        executer.expectDocumentedDeprecationWarning(
-            "Invocation of Task.taskDependencies at execution time has been deprecated. " +
-            "This will fail with an error in Gradle 10. " +
-            "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
+        expectTaskGetTaskDependenciesDeprecations()
         fails "assemble"
 
         then:
@@ -106,11 +103,7 @@ class BinariesLifecycleTaskIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning(
-            "Invocation of Task.taskDependencies at execution time has been deprecated. " +
-            "This will fail with an error in Gradle 10. " +
-            "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
+        expectTaskGetTaskDependenciesDeprecations()
         run "assemble"
 
         then:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -618,7 +618,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     @Internal
     @Override
     public ExtensionContainer getExtensions() {
-        notifyConventionAccess("Task.extensions");
+        notifyTaskExtensionsAccess("Task.extensions");
         assertDynamicObject();
         return extensibleDynamicObject.getExtensions();
     }
@@ -1088,8 +1088,8 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         return getBuildServiceRegistry().getSharedResources(taskRequiredServices.getElements());
     }
 
-    private void notifyConventionAccess(String invocationDescription) {
-        taskExecutionAccessChecker.notifyConventionAccess(this, invocationDescription);
+    private void notifyTaskExtensionsAccess(String invocationDescription) {
+        taskExecutionAccessChecker.notifyTaskExtensionsAccess(this, invocationDescription);
     }
 
     private BuildServiceRegistryInternal getBuildServiceRegistry() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionAccessChecker.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionAccessChecker.java
@@ -27,5 +27,5 @@ import org.gradle.internal.service.scopes.ServiceScope;
 public interface TaskExecutionAccessChecker {
     void notifyProjectAccess(TaskInternal task);
     void notifyTaskDependenciesAccess(TaskInternal task, String invocationDescription);
-    void notifyConventionAccess(TaskInternal task, String invocationDescription);
+    void notifyTaskExtensionsAccess(TaskInternal task, String invocationDescription);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecutionAccessListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecutionAccessListener.java
@@ -36,8 +36,8 @@ public interface TaskExecutionAccessListener {
     void onTaskDependenciesAccess(String invocationDescription, TaskInternal task, @Nullable TaskInternal runningTask);
 
     /**
-     * Called when accessing the convention object during task execution.
+     * Called when accessing task extensions during task execution.
      */
-    void onConventionAccess(String invocationDescription, TaskInternal task, @Nullable TaskInternal runningTask);
+    void onTaskExtensionAccess(String invocationDescription, TaskInternal task, @Nullable TaskInternal runningTask);
 
 }

--- a/testing/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryForwardCompatibilityCrossVersionSpec.groovy
+++ b/testing/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryForwardCompatibilityCrossVersionSpec.groovy
@@ -41,6 +41,11 @@ class TaskSubclassingBinaryForwardCompatibilityCrossVersionSpec extends Abstract
 
         expect:
         version previous withTasks 'assemble' inDirectory(file("producer")) run()
-        version current requireDaemon() requireIsolatedDaemons() withTasks 't' run()
+        version current requireDaemon() requireIsolatedDaemons() withTasks 't' expectDocumentedDeprecationWarning(
+            "Invocation of Task.taskDependencies at execution time has been deprecated. " +
+                "This will fail with an error in Gradle 10. " +
+                "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies"
+        ) run()
     }
 }

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
@@ -18,17 +18,13 @@ package org.gradle.integtests
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.StableConfigurationCacheDeprecations
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
-class TaskActionIntegrationTest extends AbstractIntegrationSpec {
+class TaskActionIntegrationTest extends AbstractIntegrationSpec implements StableConfigurationCacheDeprecations {
     // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
     @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
     def "nags when task action uses Task.project"() {
-        if (featureFlag) {
-            settingsFile """
-                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-            """
-        }
         buildFile """
             task broken {
                 doLast {
@@ -38,24 +34,16 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_project")
+        expectTaskGetProjectDeprecations()
         succeeds("broken")
 
         then:
         noExceptionThrown()
-
-        where:
-        featureFlag << [true, false]
     }
 
     // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
     @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
     def "nags when task action uses #accessor"() {
-        if (featureFlag) {
-            settingsFile """
-                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-            """
-        }
         buildFile """
             task broken {
                 doLast {
@@ -72,25 +60,18 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
         noExceptionThrown()
 
         where:
-        [featureFlag, accessor, deprecatedProperty] << [true, false].collectMany { flag ->
-            [
+        [accessor, deprecatedProperty] << [
                 ["getTaskDependencies()", "taskDependencies"],
-                ["getDependsOn()",        "dependsOn"],
-                ["getMustRunAfter()",     "mustRunAfter"],
-                ["getFinalizedBy()",      "finalizedBy"],
-                ["getShouldRunAfter()",   "shouldRunAfter"],
-            ].collect { [flag] + it }
-        }
+                ["getDependsOn()", "dependsOn"],
+                ["getMustRunAfter()", "mustRunAfter"],
+                ["getFinalizedBy()", "finalizedBy"],
+                ["getShouldRunAfter()", "shouldRunAfter"],
+        ]
     }
 
     // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
     @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
-    def "nags when task action uses Task.getExtensions() (featureFlag=#featureFlag)"() {
-        if (featureFlag) {
-            settingsFile """
-                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-            """
-        }
+    def "nags when task action uses Task.getExtensions()"() {
         buildFile """
             task broken {
                 doLast {
@@ -100,24 +81,16 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("Invocation of Task.extensions at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_extensions")
+        expectTaskGetExtensionsDeprecations()
         succeeds("broken")
 
         then:
         noExceptionThrown()
-
-        where:
-        featureFlag << [true, false]
     }
 
     // When configuration cache is enabled, this is tested in ConfigurationCacheUnsupportedTypesIntegrationTest
     @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
-    def "nags when task action accesses injected #serviceType service (featureFlag=#featureFlag)"() {
-        if (featureFlag) {
-            settingsFile """
-                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-            """
-        }
+    def "nags when task action accesses injected #serviceType service"() {
         buildFile """
             abstract class Foo extends DefaultTask {
                 @javax.inject.Inject
@@ -140,13 +113,12 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
         noExceptionThrown()
 
         where:
-        [featureFlag, serviceType] << [true, false].collectMany { flag ->
+        serviceType <<
             [
                 "org.gradle.api.Project",
                 "org.gradle.api.internal.project.ProjectInternal",
                 "org.gradle.api.invocation.Gradle",
                 "org.gradle.api.internal.GradleInternal",
-            ].collect { [flag, it] }
-        }
+            ]
     }
 }

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 class TaskActionIntegrationTest extends AbstractIntegrationSpec {
+    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
     @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
     def "nags when task action uses Task.project"() {
         if (featureFlag) {
@@ -47,11 +48,14 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
         featureFlag << [true, false]
     }
 
+    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
     @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
-    def "fails when task action uses Task.taskDependencies and feature preview is enabled"() {
-        settingsFile """
-            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-        """
+    def "nags when task action uses Task.taskDependencies"() {
+        if (featureFlag) {
+            settingsFile """
+                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+            """
+        }
         buildFile """
             task broken {
                 doLast {
@@ -61,9 +65,13 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        fails("broken")
+        executer.expectDocumentedDeprecationWarning("Invocation of Task.taskDependencies at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
+        succeeds("broken")
 
         then:
-        failureHasCause("Invocation of Task.taskDependencies at execution time is unsupported with the STABLE_CONFIGURATION_CACHE feature preview.")
+        noExceptionThrown()
+
+        where:
+        featureFlag << [true, false]
     }
 }

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
@@ -50,7 +50,7 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
 
     // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
     @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
-    def "nags when task action uses Task.taskDependencies"() {
+    def "nags when task action uses #accessor"() {
         if (featureFlag) {
             settingsFile """
                 enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
@@ -59,127 +59,27 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
         buildFile """
             task broken {
                 doLast {
-                    taskDependencies
+                    ${accessor}
                 }
             }
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("Invocation of Task.taskDependencies at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
+        executer.expectDocumentedDeprecationWarning("Invocation of Task.${deprecatedProperty} at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
         succeeds("broken")
 
         then:
         noExceptionThrown()
 
         where:
-        featureFlag << [true, false]
-    }
-
-    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
-    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
-    def "nags when task action uses Task.dependsOn"() {
-        if (featureFlag) {
-            settingsFile """
-                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-            """
+        [featureFlag, accessor, deprecatedProperty] << [true, false].collectMany { flag ->
+            [
+                ["getTaskDependencies()", "taskDependencies"],
+                ["getDependsOn()",        "dependsOn"],
+                ["getMustRunAfter()",     "mustRunAfter"],
+                ["getFinalizedBy()",      "finalizedBy"],
+                ["getShouldRunAfter()",   "shouldRunAfter"],
+            ].collect { [flag] + it }
         }
-        buildFile """
-            task broken {
-                doLast {
-                    getDependsOn()
-                }
-            }
-        """
-
-        when:
-        executer.expectDocumentedDeprecationWarning("Invocation of Task.dependsOn at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
-        succeeds("broken")
-
-        then:
-        noExceptionThrown()
-
-        where:
-        featureFlag << [true, false]
-    }
-
-    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
-    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
-    def "nags when task action uses Task.mustRunAfter"() {
-        if (featureFlag) {
-            settingsFile """
-                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-            """
-        }
-        buildFile """
-            task broken {
-                doLast {
-                    getMustRunAfter()
-                }
-            }
-        """
-
-        when:
-        executer.expectDocumentedDeprecationWarning("Invocation of Task.mustRunAfter at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
-        succeeds("broken")
-
-        then:
-        noExceptionThrown()
-
-        where:
-        featureFlag << [true, false]
-    }
-
-    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
-    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
-    def "nags when task action uses Task.finalizedBy"() {
-        if (featureFlag) {
-            settingsFile """
-                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-            """
-        }
-        buildFile """
-            task broken {
-                doLast {
-                    getFinalizedBy()
-                }
-            }
-        """
-
-        when:
-        executer.expectDocumentedDeprecationWarning("Invocation of Task.finalizedBy at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
-        succeeds("broken")
-
-        then:
-        noExceptionThrown()
-
-        where:
-        featureFlag << [true, false]
-    }
-
-    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
-    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
-    def "nags when task action uses Task.shouldRunAfter"() {
-        if (featureFlag) {
-            settingsFile """
-                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
-            """
-        }
-        buildFile """
-            task broken {
-                doLast {
-                    getShouldRunAfter()
-                }
-            }
-        """
-
-        when:
-        executer.expectDocumentedDeprecationWarning("Invocation of Task.shouldRunAfter at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
-        succeeds("broken")
-
-        then:
-        noExceptionThrown()
-
-        where:
-        featureFlag << [true, false]
     }
 }

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
@@ -109,4 +109,44 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
         where:
         featureFlag << [true, false]
     }
+
+    // When configuration cache is enabled, this is tested in ConfigurationCacheUnsupportedTypesIntegrationTest
+    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
+    def "nags when task action accesses injected #serviceType service (featureFlag=#featureFlag)"() {
+        if (featureFlag) {
+            settingsFile """
+                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+            """
+        }
+        buildFile """
+            abstract class Foo extends DefaultTask {
+                @javax.inject.Inject
+                abstract ${serviceType} getInjected()
+
+                @TaskAction
+                void action() {
+                    println(getInjected())
+                }
+            }
+
+            tasks.register('foo', Foo)
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Reading injected service of type ${serviceType.tokenize('.').last()} at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#injected_service_types_at_execution")
+        succeeds("foo")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        [featureFlag, serviceType] << [true, false].collectMany { flag ->
+            [
+                "org.gradle.api.Project",
+                "org.gradle.api.internal.project.ProjectInternal",
+                "org.gradle.api.invocation.Gradle",
+                "org.gradle.api.internal.GradleInternal",
+            ].collect { [flag, it] }
+        }
+    }
 }

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
@@ -74,4 +74,112 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
         where:
         featureFlag << [true, false]
     }
+
+    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
+    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
+    def "nags when task action uses Task.dependsOn"() {
+        if (featureFlag) {
+            settingsFile """
+                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+            """
+        }
+        buildFile """
+            task broken {
+                doLast {
+                    getDependsOn()
+                }
+            }
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Invocation of Task.dependsOn at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
+        succeeds("broken")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        featureFlag << [true, false]
+    }
+
+    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
+    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
+    def "nags when task action uses Task.mustRunAfter"() {
+        if (featureFlag) {
+            settingsFile """
+                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+            """
+        }
+        buildFile """
+            task broken {
+                doLast {
+                    getMustRunAfter()
+                }
+            }
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Invocation of Task.mustRunAfter at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
+        succeeds("broken")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        featureFlag << [true, false]
+    }
+
+    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
+    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
+    def "nags when task action uses Task.finalizedBy"() {
+        if (featureFlag) {
+            settingsFile """
+                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+            """
+        }
+        buildFile """
+            task broken {
+                doLast {
+                    getFinalizedBy()
+                }
+            }
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Invocation of Task.finalizedBy at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
+        succeeds("broken")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        featureFlag << [true, false]
+    }
+
+    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
+    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
+    def "nags when task action uses Task.shouldRunAfter"() {
+        if (featureFlag) {
+            settingsFile """
+                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+            """
+        }
+        buildFile """
+            task broken {
+                doLast {
+                    getShouldRunAfter()
+                }
+            }
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Invocation of Task.shouldRunAfter at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
+        succeeds("broken")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        featureFlag << [true, false]
+    }
 }

--- a/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
@@ -82,4 +82,31 @@ class TaskActionIntegrationTest extends AbstractIntegrationSpec {
             ].collect { [flag] + it }
         }
     }
+
+    // When configuration cache is enabled, this is tested in ConfigurationCacheTaskExecutionIntegrationTest
+    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
+    def "nags when task action uses Task.getExtensions() (featureFlag=#featureFlag)"() {
+        if (featureFlag) {
+            settingsFile """
+                enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+            """
+        }
+        buildFile """
+            task broken {
+                doLast {
+                    extensions
+                }
+            }
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Invocation of Task.extensions at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_extensions")
+        succeeds("broken")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        featureFlag << [true, false]
+    }
 }

--- a/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/StableConfigurationCacheDeprecations.groovy
+++ b/testing/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/StableConfigurationCacheDeprecations.groovy
@@ -35,4 +35,26 @@ trait StableConfigurationCacheDeprecations {
             }
         }
     }
+
+    void expectTaskGetTaskDependenciesDeprecations(int count = 1) {
+        if (GradleContextualExecuter.notConfigCache) {
+            count.times {
+                executer.expectDocumentedDeprecationWarning("Invocation of Task.taskDependencies at execution time has been deprecated. " +
+                        "This will fail with an error in Gradle 10. " +
+                        "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
+                        "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_dependencies")
+            }
+        }
+    }
+
+    void expectTaskGetExtensionsDeprecations(int count = 1) {
+        if (GradleContextualExecuter.notConfigCache) {
+            count.times {
+                executer.expectDocumentedDeprecationWarning("Invocation of Task.extensions at execution time has been deprecated. " +
+                        "This will fail with an error in Gradle 10. " +
+                        "This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. " +
+                        "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_extensions")
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes:
* https://github.com/gradle/gradle/issues/31141
* https://github.com/gradle/gradle/issues/31142
* https://github.com/gradle/gradle/issues/31143

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
