### PR TITLE
Enrich file visitor with file size info

### DIFF
--- a/docs/superpowers/plans/2026-04-16-file-visitor-length.md
+++ b/docs/superpowers/plans/2026-04-16-file-visitor-length.md
@@ -1,0 +1,258 @@
+# File Visitor Length Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `getLength()` to `FilePropertyVisitor.VisitState` so the DV plugin can retrieve file sizes when traversing resolved artifacts via the snapshot build operations.
+
+**Architecture:** Single new method on the existing `VisitState` interface, implemented in `BaseFilePropertyVisitState` by extracting the length from `RegularFileSnapshot.getMetadata()` during the snapshot tree walk. The `DirectoryVisitState` inner class throws `UnsupportedOperationException`, matching the existing pattern for `getHashBytes()`.
+
+**Tech Stack:** Java, Groovy (tests), Spock framework
+
+**Spec:** `docs/superpowers/specs/2026-04-16-file-visitor-length-design.md`
+
+---
+
+### Task 1: Add `getLength()` to the `FilePropertyVisitor.VisitState` interface
+
+**Files:**
+- Modify: `platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/FilePropertyVisitor.java:84-125`
+
+- [ ] **Step 1: Add the `getLength()` method to the `VisitState` interface**
+
+In `FilePropertyVisitor.java`, add the new method after `getHashBytes()` (after line 124):
+
+```java
+        /**
+         * Returns the length in bytes of the last visited file.
+         * <p>
+         * Must not be called when the last visited location was a directory.
+         *
+         * @since 9.2
+         */
+        long getLength();
+```
+
+- [ ] **Step 2: Update the `file()` Javadoc to mention `getLength()`**
+
+In `FilePropertyVisitor.java`, update the Javadoc for `file(VisitState)` (lines 56-60) from:
+
+```java
+    /**
+     * Called when visiting a non-directory file.
+     * <p>
+     * {@link VisitState#getName()}, {@link VisitState#getPath()} and {@link VisitState#getHashBytes()} may be called during.
+     */
+```
+
+to:
+
+```java
+    /**
+     * Called when visiting a non-directory file.
+     * <p>
+     * {@link VisitState#getName()}, {@link VisitState#getPath()}, {@link VisitState#getHashBytes()} and {@link VisitState#getLength()} may be called during.
+     */
+```
+
+---
+
+### Task 2: Update `InputFilePropertyVisitor.file()` Javadoc
+
+**Files:**
+- Modify: `platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java:129-134`
+
+- [ ] **Step 1: Update the `file()` Javadoc in `InputFilePropertyVisitor`**
+
+In `SnapshotTaskInputsBuildOperationType.java`, update the Javadoc for `InputFilePropertyVisitor.file(VisitState)` (lines 129-134) from:
+
+```java
+            /**
+             * Called when visiting a non-directory file.
+             * <p>
+             * {@link VisitState#getName()}, {@link VisitState#getPath()} and {@link VisitState#getHashBytes()} may be called during.
+             */
+```
+
+to:
+
+```java
+            /**
+             * Called when visiting a non-directory file.
+             * <p>
+             * {@link VisitState#getName()}, {@link VisitState#getPath()}, {@link VisitState#getHashBytes()} and {@link VisitState#getLength()} may be called during.
+             */
+```
+
+---
+
+### Task 3: Implement `getLength()` in `BaseFilePropertyVisitState`
+
+**Files:**
+- Modify: `subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java:37-212`
+
+- [ ] **Step 1: Add the `RegularFileSnapshot` import**
+
+Add this import after the existing `DirectorySnapshot` import (line 24):
+
+```java
+import org.gradle.internal.snapshot.RegularFileSnapshot;
+```
+
+- [ ] **Step 2: Add the `length` field**
+
+Add `long length;` after the `int depth;` field (after line 47):
+
+```java
+    long length;
+```
+
+- [ ] **Step 3: Implement `getLength()`**
+
+Add the `getLength()` override after the existing `getHashBytes()` method (after line 93):
+
+```java
+    @Override
+    public long getLength() {
+        return length;
+    }
+```
+
+- [ ] **Step 4: Populate the `length` field in `visitEntry()`**
+
+In the `visitEntry()` method, after line 131 (`this.hash = fingerprint.getNormalizedContentHash();`), add:
+
+```java
+        this.length = snapshot instanceof RegularFileSnapshot
+            ? ((RegularFileSnapshot) snapshot).getMetadata().getLength()
+            : 0;
+```
+
+- [ ] **Step 5: Add `getLength()` to `DirectoryVisitState`**
+
+In the `DirectoryVisitState` inner class, add a `getLength()` override after the `getHashBytes()` method (after line 195). This follows the same pattern as `getHashBytes()`:
+
+```java
+        @Override
+        public long getLength() {
+            throw new UnsupportedOperationException("Cannot query length for directories");
+        }
+```
+
+- [ ] **Step 6: Verify compilation**
+
+Run:
+```bash
+./gradlew :core:compileJava :enterprise-operations:compileJava
+```
+
+Expected: BUILD SUCCESSFUL
+
+---
+
+### Task 4: Write test for `getLength()` in the visitor
+
+**Files:**
+- Modify: `subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/tasks/AbstractSnapshotInputsBuildOperationResultTest.groovy:39-241`
+
+- [ ] **Step 1: Add the `RegularFileSnapshot` import**
+
+Add this import to `AbstractSnapshotInputsBuildOperationResultTest.groovy` (after the existing snapshot import on line 29):
+
+```groovy
+import org.gradle.internal.snapshot.RegularFileSnapshot
+```
+
+- [ ] **Step 2: Write the test method**
+
+Add the following test method at the end of the class (before the closing `}`):
+
+```groovy
+    @Requires(OsTestPreconditions.NotWindows)
+    def "file visitor provides file length"() {
+        given:
+        def visitor = createMockVisitor()
+        def inputFileProperty = Mock(InputFilePropertySpec) {
+            getDirectorySensitivity() >> IGNORE_DIRECTORIES
+            getLineEndingNormalization() >> NORMALIZE_LINE_ENDINGS
+            getNormalizer() >> InputNormalizer.ABSOLUTE_PATH
+            getPropertyName() >> 'foo'
+        }
+        def fileOneSnapshot = new RegularFileSnapshot(
+            '/foo/one.txt', 'one.txt',
+            TestHashCodes.hashCodeFrom(123),
+            file(0, 1024, DIRECT)
+        )
+        def fileTwoSnapshot = new RegularFileSnapshot(
+            '/foo/sub/two.txt', 'two.txt',
+            TestHashCodes.hashCodeFrom(234),
+            file(0, 2048, DIRECT)
+        )
+        def snapshots = directory('/foo', [
+            fileOneSnapshot,
+            directory('/foo/sub', [
+                fileTwoSnapshot
+            ])
+        ])
+        def beforeExecutionState = Mock(BeforeExecutionState) {
+            getInputFileProperties() >> ImmutableSortedMap.of('foo',
+                Mock(CurrentFileCollectionFingerprint) {
+                    getHash() >> TestHashCodes.hashCodeFrom(345)
+                    getFingerprints() >> [
+                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(123)),
+                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(234)),
+                    ]
+                    getSnapshot() >> snapshots
+                }
+            )
+        }
+        def cachingState = CachingState.enabled(Mock(BuildCacheKey), beforeExecutionState)
+        def buildOpResult = createSnapshotInputsBuildOperationResult(
+            cachingState,
+            [inputFileProperty] as Set
+        )
+
+        when:
+        buildOpResult.visitInputFileProperties(visitor)
+
+        then:
+        1 * visitor.file { it.path == '/foo/one.txt' && it.length == 1024 }
+
+        then:
+        1 * visitor.file { it.path == '/foo/sub/two.txt' && it.length == 2048 }
+    }
+```
+
+Note: this test creates `RegularFileSnapshot` instances directly with known lengths (1024 and 2048 bytes) instead of using the `regularFile()` helper, which uses random lengths.
+
+- [ ] **Step 3: Run the tests**
+
+Run:
+```bash
+./gradlew :core:test --tests '*SnapshotTaskInputsBuildOperationResultTest' :dependency-management:test --tests '*SnapshotTransformInputsBuildOperationResultTest'
+```
+
+Expected: both test classes pass (the new `"file visitor provides file length"` test runs in both concrete subclasses).
+
+---
+
+### Task 5: Commit
+
+- [ ] **Step 1: Commit all changes**
+
+```bash
+git add \
+  platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/FilePropertyVisitor.java \
+  platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java \
+  subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java \
+  subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/tasks/AbstractSnapshotInputsBuildOperationResultTest.groovy
+
+git commit -m "Add getLength() to FilePropertyVisitor.VisitState
+
+Enrich the file property visitor with file size information so that
+consumers (e.g. the DV plugin) can retrieve file lengths when
+traversing resolved artifacts via SnapshotTaskInputsBuildOperationType
+and SnapshotTransformInputsBuildOperationType.
+
+The length is extracted from RegularFileSnapshot metadata during the
+snapshot tree walk in BaseFilePropertyVisitState.visitEntry()."
+```

--- a/docs/superpowers/specs/2026-04-16-file-visitor-length-design.md
+++ b/docs/superpowers/specs/2026-04-16-file-visitor-length-design.md
@@ -1,0 +1,85 @@
+# Enrich FilePropertyVisitor with File Size Information
+
+**Date:** 2026-04-16
+**Status:** Approved
+
+## Problem
+
+The DV plugin uses `SnapshotTaskInputsBuildOperationType` and `SnapshotTransformInputsBuildOperationType` to get a list of resolved artifacts. The result provides a `FilePropertyVisitor` that allows traversing found files. The DV plugin is interested in regular files on the top level (just below a root, not inside a directory). Currently, `FilePropertyVisitor.VisitState` exposes the file name, path, and content hash, but not the file size.
+
+The file size is available internally in `RegularFileSnapshot.getMetadata().getLength()`, and is already present at the point where the visit state is populated (`BaseFilePropertyVisitState.visitEntry()`), but is not wired through to the public API.
+
+## Approach
+
+Add `getLength()` directly to `FilePropertyVisitor.VisitState`. This is the simplest option with a single new method, no new types, and minimal code change. It is consistent with `getHashBytes()` being on the same interface.
+
+Alternatives considered:
+- **Default method with sentinel (-1):** Misleading because the default would not actually be returned on old Gradle at runtime (throws `NoSuchMethodError` instead). Creates a false sense of graceful degradation.
+- **New sub-interface (`FileVisitState extends VisitState`):** Adds interface complexity for a single field. The `instanceof` check triggers `NoClassDefFoundError` on old Gradle, so the type-level distinction doesn't provide practical benefit over a direct method addition.
+
+## API Change
+
+Add to `FilePropertyVisitor.VisitState` (in `platforms/enterprise/enterprise-operations`):
+
+```java
+/**
+ * Returns the length in bytes of the last visited file.
+ * <p>
+ * Must not be called when the last visited location was a directory.
+ *
+ * @since 9.x
+ */
+long getLength();
+```
+
+This mirrors the contract of `getHashBytes()` -- only valid during `file()` visits, not during directory visits.
+
+Update the Javadoc on `FilePropertyVisitor.file(VisitState)` to list `getLength()` among the callable methods.
+
+Update the Javadoc on `SnapshotTaskInputsBuildOperationType.Result.InputFilePropertyVisitor.file(VisitState)` similarly, since its `VisitState` inherits from `FilePropertyVisitor.VisitState`.
+
+## Implementation
+
+All changes are in `BaseFilePropertyVisitState` (in `subprojects/core`), the shared base for both the task and transform visitor state implementations:
+
+1. Add a `long length` field alongside the existing `path`, `name`, `hash` fields.
+2. In `visitEntry()`, after setting `path`/`name`/`hash`, extract the length:
+   ```java
+   this.length = snapshot instanceof RegularFileSnapshot
+       ? ((RegularFileSnapshot) snapshot).getMetadata().getLength()
+       : 0;
+   ```
+   Directories are filtered out at the top of `visitEntry()`. Non-directory snapshots that reach this point are expected to be `RegularFileSnapshot` instances, but `MissingFileSnapshot` is also a leaf type that passes the directory filter, so the `instanceof` guard is added for safety.
+3. Implement `getLength()` returning the `length` field.
+4. In `DirectoryVisitState` (nested class), implement `getLength()` throwing `UnsupportedOperationException`, following the same pattern as `getHashBytes()`.
+
+No changes needed to `FilePropertyVisitState` or `SnapshotTaskInputsResultFilePropertyVisitState` -- they delegate to `BaseFilePropertyVisitState` which handles everything.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/FilePropertyVisitor.java` | Add `getLength()` to `VisitState`; update `file()` Javadoc |
+| `platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java` | Update `InputFilePropertyVisitor.file()` Javadoc |
+| `subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java` | Add `length` field, `getLength()` impl, populate in `visitEntry()`, add to `DirectoryVisitState` |
+
+## Backward Compatibility
+
+Backward compatibility is required in both directions.
+
+**Old DV plugin + New Gradle:** The old plugin never calls `getLength()`. The method exists but is unused. No breakage.
+
+**New DV plugin + Old Gradle:** Calling `state.getLength()` throws `NoSuchMethodError` at runtime because old Gradle's `VisitState` interface does not have the method. The DV plugin must guard against this:
+
+```java
+// DV plugin side (illustrative, not part of this change)
+try {
+    long length = state.getLength();
+} catch (NoSuchMethodError e) {
+    long length = new File(state.getPath()).length();
+}
+```
+
+## Testing
+
+Add or extend an existing integration test in the `SnapshotTaskInputsBuildOperationType` test suite to verify that `getLength()` returns the correct file size during `file()` visits.

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -129,7 +129,7 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
             /**
              * Called when visiting a non-directory file.
              * <p>
-             * {@link VisitState#getName()}, {@link VisitState#getPath()} and {@link VisitState#getHashBytes()} may be called during.
+             * {@link VisitState#getName()}, {@link VisitState#getPath()}, {@link VisitState#getHashBytes()} and {@link VisitState#getLength()} may be called during.
              */
             void file(VisitState state);
 

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/FilePropertyVisitor.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/operations/execution/FilePropertyVisitor.java
@@ -56,7 +56,7 @@ public interface FilePropertyVisitor {
     /**
      * Called when visiting a non-directory file.
      * <p>
-     * {@link VisitState#getName()}, {@link VisitState#getPath()} and {@link VisitState#getHashBytes()} may be called during.
+     * {@link VisitState#getName()}, {@link VisitState#getPath()}, {@link VisitState#getHashBytes()} and {@link VisitState#getLength()} may be called during.
      */
     void file(VisitState state);
 
@@ -122,5 +122,14 @@ public interface FilePropertyVisitor {
          * Must not be called when the last visited location was a directory.
          */
         byte[] getHashBytes();
+
+        /**
+         * Returns the length in bytes of the last visited file.
+         * <p>
+         * Must not be called when the last visited location was a directory.
+         *
+         * @since 9.6
+         */
+        long getLength();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseFilePropertyVisitState.java
@@ -24,6 +24,7 @@ import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.DirectorySnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshotHierarchyVisitor;
+import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
 import org.gradle.operations.execution.FilePropertyVisitor;
 import org.jspecify.annotations.NullMarked;
@@ -45,6 +46,7 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
     String path;
     HashCode hash;
     int depth;
+    long length;
 
     protected BaseFilePropertyVisitState(Map<String, InputFilePropertySpec> propertySpecsByName) {
         this.propertySpecsByName = propertySpecsByName;
@@ -93,10 +95,16 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
     }
 
     @Override
+    public long getLength() {
+        return length;
+    }
+
+    @Override
     public void enterDirectory(DirectorySnapshot physicalSnapshot) {
         this.path = physicalSnapshot.getAbsolutePath();
         this.name = physicalSnapshot.getName();
         this.hash = null;
+        this.length = 0;
 
         if (depth++ == 0) {
             preRoot();
@@ -129,6 +137,9 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
         this.path = snapshot.getAbsolutePath();
         this.name = snapshot.getName();
         this.hash = fingerprint.getNormalizedContentHash();
+        this.length = snapshot instanceof RegularFileSnapshot
+            ? ((RegularFileSnapshot) snapshot).getMetadata().getLength()
+            : 0;
 
         boolean isRoot = depth == 0;
         if (isRoot) {
@@ -192,6 +203,11 @@ public abstract class BaseFilePropertyVisitState implements FilePropertyVisitor.
         @Override
         public byte[] getHashBytes() {
             throw new UnsupportedOperationException("Cannot query hash for directories");
+        }
+
+        @Override
+        public long getLength() {
+            throw new UnsupportedOperationException("Cannot query length for directories");
         }
 
         @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/tasks/AbstractSnapshotInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/tasks/AbstractSnapshotInputsBuildOperationResultTest.groovy
@@ -26,12 +26,15 @@ import org.gradle.internal.file.FileType
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
 import org.gradle.internal.hash.TestHashCodes
+import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.internal.snapshot.TestSnapshotFixture
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.OsTestPreconditions
 
 import spock.lang.Specification
 
+import static org.gradle.internal.file.FileMetadata.AccessType.DIRECT
+import static org.gradle.internal.file.impl.DefaultFileMetadata.file
 import static org.gradle.internal.fingerprint.DirectorySensitivity.DEFAULT
 import static org.gradle.internal.fingerprint.DirectorySensitivity.IGNORE_DIRECTORIES
 import static org.gradle.internal.fingerprint.LineEndingSensitivity.NORMALIZE_LINE_ENDINGS
@@ -237,5 +240,59 @@ abstract class AbstractSnapshotInputsBuildOperationResultTest<RESULT extends Bas
 
         and:
         0 * visitor._
+    }
+
+    @Requires(OsTestPreconditions.NotWindows)
+    def "file visitor provides file length"() {
+        given:
+        def visitor = createMockVisitor()
+        def inputFileProperty = Mock(InputFilePropertySpec) {
+            getDirectorySensitivity() >> IGNORE_DIRECTORIES
+            getLineEndingNormalization() >> NORMALIZE_LINE_ENDINGS
+            getNormalizer() >> InputNormalizer.ABSOLUTE_PATH
+            getPropertyName() >> 'foo'
+        }
+        def fileOneSnapshot = new RegularFileSnapshot(
+            '/foo/one.txt', 'one.txt',
+            TestHashCodes.hashCodeFrom(123),
+            file(0, 1024, DIRECT)
+        )
+        def fileTwoSnapshot = new RegularFileSnapshot(
+            '/foo/sub/two.txt', 'two.txt',
+            TestHashCodes.hashCodeFrom(234),
+            file(0, 2048, DIRECT)
+        )
+        def snapshots = directory('/foo', [
+            fileOneSnapshot,
+            directory('/foo/sub', [
+                fileTwoSnapshot
+            ])
+        ])
+        def beforeExecutionState = Mock(BeforeExecutionState) {
+            getInputFileProperties() >> ImmutableSortedMap.of('foo',
+                Mock(CurrentFileCollectionFingerprint) {
+                    getHash() >> TestHashCodes.hashCodeFrom(345)
+                    getFingerprints() >> [
+                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(123)),
+                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(234)),
+                    ]
+                    getSnapshot() >> snapshots
+                }
+            )
+        }
+        def cachingState = CachingState.enabled(Mock(BuildCacheKey), beforeExecutionState)
+        def buildOpResult = createSnapshotInputsBuildOperationResult(
+            cachingState,
+            [inputFileProperty] as Set
+        )
+
+        when:
+        buildOpResult.visitInputFileProperties(visitor)
+
+        then:
+        1 * visitor.file { it.path == '/foo/one.txt' && it.length == 1024 }
+
+        and:
+        1 * visitor.file { it.path == '/foo/sub/two.txt' && it.length == 2048 }
     }
 }


### PR DESCRIPTION
This pull request adds file size reporting to the file property visitor API, enabling consumers (such as the DV plugin) to retrieve the length of files when traversing resolved artifacts in Gradle's snapshot-based build operations.

The change is very small and shouldn't have any measurable impact on the performance.
