### PR TITLE
Interrupt dispatch thread in WorkerAction.stop() to unblock blocking work actions

### DIFF
--- a/platforms/core-execution/request-handler-worker/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
+++ b/platforms/core-execution/request-handler-worker/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
@@ -57,6 +57,10 @@ public class WorkerAction implements Action<WorkerProcessContext>, Serializable,
     private InstantiatorFactory instantiatorFactory;
     private transient Exception failure;
 
+    private final Object runningThreadLock = new Object();
+    private transient Thread runningThread;
+    private transient boolean stopped;
+
     public WorkerAction(Class<?> workerImplementation) {
         this.workerImplementationName = workerImplementation.getName();
     }
@@ -113,6 +117,12 @@ public class WorkerAction implements Action<WorkerProcessContext>, Serializable,
 
     @Override
     public void stop() {
+        synchronized (runningThreadLock) {
+            stopped = true;
+            if (runningThread != null) {
+                runningThread.interrupt();
+            }
+        }
         completed.countDown();
         CurrentBuildOperationRef.instance().clear();
     }
@@ -136,32 +146,43 @@ public class WorkerAction implements Action<WorkerProcessContext>, Serializable,
     @Override
     public void run(Request request) {
         if (failure != null) {
-            // Ignore
             return;
         }
-        CurrentBuildOperationRef.instance().with(request.getBuildOperation(), () -> {
-            try {
-                Object result;
-                try {
-                    // We want to use the responder as the logging protocol object here because log messages from the
-                    // action will have the build operation associated.  By using the responder, we ensure that all
-                    // messages arrive on the same incoming queue in the build process and the completed message will only
-                    // arrive after all log messages have been processed.
-                    result = workerLogEventListener.withWorkerLoggingProtocol(responder, () -> implementation.run(request.getArg()));
-                } catch (Throwable failure) {
-                    if (failure instanceof NoClassDefFoundError) {
-                        // Assume an infrastructure problem
-                        responder.infrastructureFailed(failure);
-                    } else {
-                        responder.failed(failure);
-                    }
-                    return;
-                }
-                responder.completed(result);
-            } catch (Throwable t) {
-                responder.infrastructureFailed(t);
+        synchronized (runningThreadLock) {
+            runningThread = Thread.currentThread();
+            if (stopped) {
+                runningThread.interrupt();
             }
-        });
+        }
+        try {
+            CurrentBuildOperationRef.instance().with(request.getBuildOperation(), () -> {
+                try {
+                    Object result;
+                    try {
+                        // We want to use the responder as the logging protocol object here because log messages from the
+                        // action will have the build operation associated.  By using the responder, we ensure that all
+                        // messages arrive on the same incoming queue in the build process and the completed message will only
+                        // arrive after all log messages have been processed.
+                        result = workerLogEventListener.withWorkerLoggingProtocol(responder, () -> implementation.run(request.getArg()));
+                    } catch (Throwable failure) {
+                        if (failure instanceof NoClassDefFoundError) {
+                            // Assume an infrastructure problem
+                            responder.infrastructureFailed(failure);
+                        } else {
+                            responder.failed(failure);
+                        }
+                        return;
+                    }
+                    responder.completed(result);
+                } catch (Throwable t) {
+                    responder.infrastructureFailed(t);
+                }
+            });
+        } finally {
+            synchronized (runningThreadLock) {
+                runningThread = null;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Problem

`WorkerAction.stop()` signalled the main execute thread via `completed.countDown()` but never interrupted the dispatch thread that is actually running the work action. With `process` isolation, the worker JVM cannot exit while that non-daemon dispatch thread is alive. So `DefaultWorkerProcess.waitForStop()` blocks for the full duration of any blocking call inside the work action (e.g. `new CountDownLatch(1).await(90, TimeUnit.SECONDS)`).

This caused `TaskTimeoutIntegrationTest`'s `"timeout stops long running work items with process isolation"` to hang — 100 process-isolated workers each blocking for 90s, and the cleanup in `StopSessionScopedWorkers.beforeComplete()` trying to stop them all gracefully — far exceeding the test's 60-second `@IntegrationTestTimeout`.

## Fix

Track the dispatch thread in `runningThread` (guarded by `runningThreadLock`).

- `stop()` now sets `stopped = true` and calls `runningThread.interrupt()` if the thread is set, causing any interruptible blocking call in the work action (e.g. `CountDownLatch.await()`, `Thread.sleep()`) to throw `InterruptedException` and exit promptly.
- `run()` sets `runningThread = Thread.currentThread()` before executing the action and clears it in a `finally` block.
- `run()` also checks `stopped` after setting `runningThread` to handle the race where `stop()` ran before `run()` had a chance to set the field.

## Evidence

- Failing test: `TaskTimeoutIntegrationTest > timeout stops long running work items with process isolation`
- Root method: `WorkerAction.stop()` — missing `runningThread.interrupt()` call
- With the fix, interrupting the dispatch thread causes the blocking `CountDownLatch.await()` to throw `InterruptedException`, the worker JVM exits, `waitForStop()` returns immediately, and cleanup completes well within the timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)