### PR TITLE
Strip `JVM *_OPTIONS` stderr echoes from execution results

### DIFF
--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
@@ -40,6 +40,14 @@ public class LogContent {
     // see org.gradle.internal.logging.console.StyledTextOutputBackedRenderer.ISO_8601_DATE_TIME_FORMAT
     private final static Pattern DEBUG_PREFIX = Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}[-+]\\d{4} \\[\\w+] \\[.+?] ");
 
+    /**
+     * Lines the JVM prints to stderr when {@code JAVA_TOOL_OPTIONS}, {@code JDK_JAVA_OPTIONS}, or
+     * {@code _JAVA_OPTIONS} are set. Not part of Gradle output; stripping avoids flaky assertions in CI.
+     */
+    private static final Pattern JVM_ENV_OPTIONS_ECHO_LINE = Pattern.compile(
+        "^Picked up (JAVA_TOOL_OPTIONS|JDK_JAVA_OPTIONS|_JAVA_OPTIONS):.*"
+    );
+
     private final ImmutableList<String> lines;
     private final boolean definitelyNoDebugPrefix;
     private final boolean definitelyNoAnsiChars;
@@ -193,6 +201,26 @@ public class LogContent {
             }
         }
         return new LogContent(ImmutableList.copyOf(result), true, definitelyNoAnsiChars);
+    }
+
+    /**
+     * Removes lines emitted by the JVM when {@code JAVA_TOOL_OPTIONS}, {@code JDK_JAVA_OPTIONS}, or
+     * {@code _JAVA_OPTIONS} are set in the environment.
+     */
+    public LogContent removeJvmEnvironmentOptionEchoLines() {
+        Builder<String> kept = ImmutableList.builder();
+        int removed = 0;
+        for (String line : lines) {
+            if (JVM_ENV_OPTIONS_ECHO_LINE.matcher(line).matches()) {
+                removed++;
+            } else {
+                kept.add(line);
+            }
+        }
+        if (removed == 0) {
+            return this;
+        }
+        return new LogContent(kept.build(), definitelyNoDebugPrefix, definitelyNoAnsiChars);
     }
 
     /**

--- a/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/testing/internal-distribution-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -108,7 +108,7 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
      */
     protected OutputScrapingExecutionResult(LogContent output, LogContent error, boolean includeBuildSrc) {
         this.output = output;
-        this.error = error;
+        this.error = error.removeJvmEnvironmentOptionEchoLines();
         this.includeBuildSrc = includeBuildSrc;
 
         // Split out up the output into main content and post build content

--- a/testing/internal-distribution-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
+++ b/testing/internal-distribution-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
@@ -52,6 +52,27 @@ class OutputScrapingExecutionResultTest extends AbstractExecutionResultTest {
         result.error == error
     }
 
+    def "strips JVM environment options echo lines from error output"() {
+        def output = """
+message
+
+BUILD SUCCESSFUL in 12s
+"""
+        def errorOut = """Picked up JAVA_TOOL_OPTIONS: -Dfoo=bar
+real stderr line
+Picked up JDK_JAVA_OPTIONS: -Dbaz
+another line
+Picked up _JAVA_OPTIONS: -Dqux
+"""
+        when:
+        def result = OutputScrapingExecutionResult.from(output, errorOut)
+
+        then:
+        result.error == """real stderr line
+another line
+"""
+    }
+
     def "finds stack traces when present"() {
         expect:
         STACK_TRACE_ELEMENT.matcher(line).matches()


### PR DESCRIPTION
JDK prints lines such as "Picked up JAVA_TOOL_OPTIONS:" to stderr when those environment variables are set. CI often injects them, which made command-line stderr differ from Tooling API captures in cross-version tests.

We now drops those lines, and OutputScrapingExecutionResult applies this when wrapping process stderr so integration tests see stable error output. A unit test covers the stripping behavior.

See also https://github.com/gradle/bt-dev-prod-infrastructure/pull/300