### PR TITLE
Add missed compilation classpath to KotlinDSL project model

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslIntegrationTest.groovy
@@ -51,9 +51,206 @@ class IsolatedProjectsToolingApiKotlinDslIntegrationTest extends AbstractIsolate
             modelsCreated(":", KotlinDslScriptsModel)
             modelsCreated(":a", [isolatedScriptsModel])
         }
-
         checkKotlinDslScriptsModel(model, originalModel)
 
+        when:
+        withIsolatedProjects()
+        fetchModel(KotlinDslScriptsModel)
+
+        then:
+        fixture.assertModelLoaded()
+    }
+
+    def "can fetch KotlinDslScripts model for build with convention plugin from #buildLogicLocation"() {
+        withBuildScriptIn(buildLogicLocation, """
+            plugins {
+                `kotlin-dsl`
+            }
+
+            $repositoriesBlock
+        """)
+        withFile("$buildLogicLocation/src/main/kotlin/my-convention.gradle.kts", """
+            plugins {
+                `java-library`
+            }
+        """)
+
+        withSettings("""
+            $pluginManagementBlock
+            rootProject.name = "root"
+            include("a")
+        """)
+        withBuildScript()
+        withBuildScriptIn("a", """
+            plugins {
+                id("my-convention")
+            }
+        """)
+
+        when:
+        def originalModel = fetchModel(KotlinDslScriptsModel)
+
+        then:
+        fixture.assertNoConfigurationCache()
+
+        when:
+        withIsolatedProjects()
+        def model = fetchModel(KotlinDslScriptsModel)
+
+        then:
+        fixture.assertModelStored {
+            projectConfigured(":$buildLogicLocation")
+            modelsCreated(":", KotlinDslScriptsModel)
+            modelsCreated(":a", [isolatedScriptsModel])
+        }
+        checkKotlinDslScriptsModel(model, originalModel)
+
+        when:
+        withIsolatedProjects()
+        fetchModel(KotlinDslScriptsModel)
+
+        then:
+        fixture.assertModelLoaded()
+
+        where:
+        buildLogicLocation | pluginManagementBlock
+        "buildSrc"         | ""
+        "build-logic"      | """pluginManagement { includeBuild("build-logic") }"""
+    }
+
+    def "can fetch KotlinDslScripts model for build with Kotlin extension from #buildLogicLocation"() {
+        withBuildScriptIn(buildLogicLocation, """
+            plugins {
+                `kotlin-dsl`
+            }
+            group = "org.test"
+
+            $repositoriesBlock
+        """)
+        withFile("$buildLogicLocation/src/main/kotlin/extensions.kt", """
+            import org.gradle.api.Project
+            fun Project.foo() {}
+        """)
+
+        withSettings("""
+            $settingsBlock
+            rootProject.name = "root"
+            include("a")
+        """)
+        withBuildScript()
+        withBuildScriptIn("a", """
+            $buildscriptBlock
+            foo()
+        """)
+
+        when:
+        def originalModel = fetchModel(KotlinDslScriptsModel)
+
+        then:
+        fixture.assertNoConfigurationCache()
+
+        when:
+        withIsolatedProjects()
+        def model = fetchModel(KotlinDslScriptsModel)
+
+        then:
+        fixture.assertModelStored {
+            projectConfigured(":$buildLogicLocation")
+            modelsCreated(":", KotlinDslScriptsModel)
+            modelsCreated(":a", [isolatedScriptsModel])
+        }
+        checkKotlinDslScriptsModel(model, originalModel)
+
+        when:
+        withIsolatedProjects()
+        fetchModel(KotlinDslScriptsModel)
+
+        then:
+        fixture.assertModelLoaded()
+
+        where:
+        buildLogicLocation | settingsBlock                     | buildscriptBlock
+        "buildSrc"         | ""                                | ""
+        "build-logic"      | """includeBuild("build-logic")""" | """buildscript { dependencies { classpath("org.test:build-logic") } }"""
+    }
+
+    def "can fetch KotlinDslScripts model for build with build-logic using Kotlin extension from included build"() {
+        withBuildScriptIn("included", """
+            plugins {
+                `kotlin-dsl`
+            }
+            group = "org.test"
+
+            $repositoriesBlock
+        """)
+        withFile("included/src/main/kotlin/extensions.kt", """
+            import org.gradle.api.Project
+            fun Project.foo() {}
+        """)
+        withSettingsIn("build-logic", """
+            includeBuild("../included")
+        """)
+        withBuildScriptIn("build-logic", """
+            plugins {
+                `kotlin-dsl`
+            }
+            $repositoriesBlock
+
+            gradlePlugin {
+                plugins {
+                    register("my-convention") {
+                        implementationClass = "MyConventionPlugin"
+                    }
+                }
+            }
+
+            dependencies {
+                implementation("org.test:included")
+            }
+        """)
+        withFile("build-logic/src/main/kotlin/MyConventionPlugin.kt", """
+            import org.gradle.api.Plugin
+            import org.gradle.api.Project
+            import foo
+
+            class MyConventionPlugin: Plugin<Project> {
+                override fun apply(target: Project) {
+                    target.foo()
+                }
+            }
+        """)
+
+        withSettings("""
+            pluginManagement {
+                includeBuild("build-logic")
+            }
+            rootProject.name = "root"
+            include("a")
+        """)
+        withBuildScript()
+        withBuildScriptIn("a", """
+            plugins {
+                id("my-convention")
+            }
+        """)
+
+        when:
+        def originalModel = fetchModel(KotlinDslScriptsModel)
+
+        then:
+        fixture.assertNoConfigurationCache()
+
+        when:
+        withIsolatedProjects()
+        def model = fetchModel(KotlinDslScriptsModel)
+
+        then:
+        fixture.assertModelStored {
+            projectsConfigured(":build-logic", ":included")
+            modelsCreated(":", KotlinDslScriptsModel)
+            modelsCreated(":a", [isolatedScriptsModel])
+        }
+        checkKotlinDslScriptsModel(model, originalModel)
 
         when:
         withIsolatedProjects()

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt
@@ -297,7 +297,7 @@ object IsolatedScriptsModelBuilder : ToolingModelBuilder {
 
 private
 fun isolatedScriptsModelFor(project: ProjectInternal): IsolatedScriptsModel {
-    val models = buildList {
+    val models = mutableListOf<IntermediateScriptModel>().apply {
         addNotNull(buildScriptModelFor(project))
         addAll(precompiledScriptModelsFor(project))
     }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt
@@ -187,7 +187,7 @@ fun IntermediateToolingModelProvider.getIsolatedModels(requester: ProjectState, 
 
 private
 fun buildOutputModel(base: ScriptModelBase, model: IntermediateScriptModel): StandardKotlinDslScriptModel {
-    val classPath = base.scriptPaths.bin + model.localClassPath
+    val classPath = model.localClassPath
     val gradleKotlinDslJar = classPath.filter(::isGradleKotlinDslJar)
     val sourcePath = gradleKotlinDslJar + base.scriptPaths.src + model.localSourcePath
     val implicitImports = base.implicitImports + model.localImplicitImports
@@ -297,13 +297,8 @@ object IsolatedScriptsModelBuilder : ToolingModelBuilder {
 
 private
 fun isolatedScriptsModelFor(project: ProjectInternal): IsolatedScriptsModel {
-    // TODO:isolated compute own classpaths
-    val additionalClassPath = ClassPath.EMPTY
-    val additionalSourcePath = ClassPath.EMPTY
-    val models = mutableListOf<IntermediateScriptModel>().apply {
-        buildScriptModelFor(project, additionalClassPath, additionalSourcePath)?.let {
-            add(it)
-        }
+    val models = buildList {
+        addNotNull(buildScriptModelFor(project))
         addAll(precompiledScriptModelsFor(project))
     }
     return IsolatedScriptsModel(models)
@@ -311,12 +306,7 @@ fun isolatedScriptsModelFor(project: ProjectInternal): IsolatedScriptsModel {
 
 
 private
-fun buildScriptModelFor(
-    project: ProjectInternal,
-    localClassPath: ClassPath,
-    localSourcePath: ClassPath
-): IntermediateScriptModel? {
-
+fun buildScriptModelFor(project: ProjectInternal): IntermediateScriptModel? {
     val buildScript = project.discoverBuildScript()
         ?: return null
 
@@ -327,10 +317,12 @@ fun buildScriptModelFor(
         project.accessorsClassPathOf(compilationClassPath)
     } ?: AccessorsClassPath.empty
 
+    val classpathSources = sourcePathFor(listOf(project.buildscript))
+
     return IntermediateScriptModel(
         scriptFile = buildScript,
-        localClassPath = localClassPath + accessorsClassPath.bin,
-        localSourcePath = localSourcePath + accessorsClassPath.src,
+        localClassPath = compilationClassPath + accessorsClassPath.bin,
+        localSourcePath = classpathSources + accessorsClassPath.src,
     )
 }
 


### PR DESCRIPTION
Fixes #36697 
This PR is adding missed compilation classpath to KotlinDSL projects models built in IP mode. 
Project model building for KotlinDSL with IP: https://github.com/gradle/gradle/blob/dc2206026547c2c4bcac0646dc7ded5037c5235f/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt#L313-L335

There we compute `compilationClassPath`, pass it for generating `accessorsClassPath`, and then throw it away. `AccessorsClassPath` _doesn't include_ `compilationClassPath`. `localClassPath` is being passed to this method [is always empty](https://github.com/gradle/gradle/blob/dc2206026547c2c4bcac0646dc7ded5037c5235f/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt#L300-L302).

Vintage project script model building confirms that:
https://github.com/gradle/gradle/blob/7ce1e6f06a90013471dd3286cf1aa1cb9149b840/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt#L221-L232

[This test](https://github.com/gradle/gradle/blob/32e6e2174420f42405c80d09e8e9e28facb58462/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsToolingApiKotlinDslIntegrationTest.groovy#L26) aimed to exercise parity in between IP vs Vintage KotlinDSL model building, however that classpath gap 
slipped in due to simplicity of the build-under-test. To exercise this we need more complex classloading structure with included builds. This PR extends this coverage greatly.

There is a related TODO: https://github.com/gradle/gradle/blob/87eb49c6f8f776f7e039ae9a68a5e93d5e8eaee5/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/IsolatedProjectsSafeKotlinDslScriptsModelBuilder.kt#L333-L334 which we may want to address. It is reproducible, but in a bit weird setup - when the source of precompiled plugins is a root build. In all others scenarios it seems like the fix in the PR overlaps this precompiled plugins classpath, according to the added tests.
### Context

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for Kotlin DSL scripts model with isolated projects, including scenarios with convention plugins, Kotlin extensions, and multi-level build compositions.

* **Chores**
  * Optimized internal classpath and sourcepath handling in Kotlin DSL tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->