### PR TITLE
Deprecate accessing Task passed to task dependency closure

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -30,7 +30,6 @@ import org.gradle.internal.typeconversion.UnsupportedNotationException;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-import java.lang.reflect.Proxy;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -114,9 +113,18 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 ((TaskDependencyContainer) dependency).visitDependencies(context);
             } else if (dependency instanceof Closure) {
                 Closure closure = (Closure) dependency;
-                Task task = context.getTask();
-                Object taskProxy = wrapTaskWithDeprecatingProxy(task);
-                Object closureResult = closure.call(taskProxy);
+                Object closureResult;
+                try {
+                    closureResult = closure.call(new Object[]{ null });
+                } catch (NullPointerException e) {
+                    DeprecationLogger.deprecateAction("Accessing tasks provided to task dependency closures")
+                        .willBecomeAnErrorInGradle10()
+                        .withUpgradeGuideSection(9, "task_in_task_dependency_closure")
+                        .nagUser();
+                    Task task = context.getTask();
+                    closureResult = closure.call(task);
+                }
+
                 if (closureResult != null) {
                     queue.addFirst(closureResult);
                 }
@@ -165,39 +173,11 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 formats.add("A TaskDependency instance");
                 formats.add("A Provider that represents a task output");
                 formats.add("A Provider instance that returns any of these types");
-                formats.add("A Closure instance that returns any of these types");
                 formats.add("A Callable instance that returns any of these types");
                 formats.add("An Iterable, Collection, Map or array instance that contains any of these types");
                 throw new UnsupportedNotationException(dependency, String.format("Cannot convert %s to a task.", dependency), null, formats);
             }
         }
-    }
-
-    private static Object wrapTaskWithDeprecatingProxy(@Nullable Task task) {
-        if (task == null) {
-            return null;
-        }
-        return Proxy.newProxyInstance(
-            task.getClass().getClassLoader(),
-            task.getClass().getInterfaces(),
-            (proxy, method, args) -> {
-                if ("getMetaClass".equals(method.getName()) && method.getParameterCount() == 0) {
-                    // Return a MetaClass for the proxy's own class, not the delegate's.
-                    // Groovy's invokedynamic call site asks for the MetaClass to determine
-                    // the argument type. If we delegate to the real task, Groovy will fail
-                    // due to the type mismatch.
-                    return org.codehaus.groovy.runtime.InvokerHelper.getMetaClass(proxy.getClass());
-                }
-
-                DeprecationLogger.deprecateAction("Accessing tasks provided to task dependency closures")
-                    .withContext("Cannot call method '" + method.getName() + "' on task passed to task dependency closure.")
-                    .willBecomeAnErrorInGradle10()
-                    .withUpgradeGuideSection(9, "task_in_task_dependency_closure")
-                    .nagUser();
-
-                return method.invoke(task, args);
-            }
-        );
     }
 
     private static void addAllFirst(Deque<Object> queue, Object[] items) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -173,6 +173,7 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 formats.add("A TaskDependency instance");
                 formats.add("A Provider that represents a task output");
                 formats.add("A Provider instance that returns any of these types");
+                formats.add("A Closure instance that returns any of these types");
                 formats.add("A Callable instance that returns any of these types");
                 formats.add("An Iterable, Collection, Map or array instance that contains any of these types");
                 throw new UnsupportedNotationException(dependency, String.format("Cannot convert %s to a task.", dependency), null, formats);

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -25,10 +25,12 @@ import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.internal.provider.ValueSupplier;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Cast;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.typeconversion.UnsupportedNotationException;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import java.lang.reflect.Proxy;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -112,7 +114,9 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 ((TaskDependencyContainer) dependency).visitDependencies(context);
             } else if (dependency instanceof Closure) {
                 Closure closure = (Closure) dependency;
-                Object closureResult = closure.call(context.getTask());
+                Task task = context.getTask();
+                Object taskProxy = wrapTaskWithDeprecatingProxy(task);
+                Object closureResult = closure.call(taskProxy);
                 if (closureResult != null) {
                     queue.addFirst(closureResult);
                 }
@@ -167,6 +171,33 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 throw new UnsupportedNotationException(dependency, String.format("Cannot convert %s to a task.", dependency), null, formats);
             }
         }
+    }
+
+    private static Object wrapTaskWithDeprecatingProxy(@Nullable Task task) {
+        if (task == null) {
+            return null;
+        }
+        return Proxy.newProxyInstance(
+            task.getClass().getClassLoader(),
+            task.getClass().getInterfaces(),
+            (proxy, method, args) -> {
+                if ("getMetaClass".equals(method.getName()) && method.getParameterCount() == 0) {
+                    // Return a MetaClass for the proxy's own class, not the delegate's.
+                    // Groovy's invokedynamic call site asks for the MetaClass to determine
+                    // the argument type. If we delegate to the real task, Groovy will fail
+                    // due to the type mismatch.
+                    return org.codehaus.groovy.runtime.InvokerHelper.getMetaClass(proxy.getClass());
+                }
+
+                DeprecationLogger.deprecateAction("Accessing tasks provided to task dependency closures")
+                    .withContext("Cannot call method '" + method.getName() + "' on task passed to task dependency closure.")
+                    .willBecomeAnErrorInGradle10()
+                    .withUpgradeGuideSection(9, "task_in_task_dependency_closure")
+                    .nagUser();
+
+                return method.invoke(task, args);
+            }
+        );
     }
 
     private static void addAllFirst(Deque<Object> queue, Object[] items) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -115,7 +115,7 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                 Closure closure = (Closure) dependency;
                 Object closureResult;
                 try {
-                    closureResult = closure.call(new Object[]{ null });
+                    closureResult = closure.call(new Object[]{null});
                 } catch (NullPointerException e) {
                     DeprecationLogger.deprecateAction("Accessing tasks provided to task dependency closures")
                         .willBecomeAnErrorInGradle10()

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
@@ -82,14 +82,15 @@ class DefaultTaskDependencyTest extends Specification {
 
     @ExpectDeprecation("Accessing tasks provided to task dependency closures has been deprecated")
     def "can depend on a closure"() {
+        Closure closure = Mock(Closure)
         when:
-        dependency.add({ Task suppliedTask ->
-            assert suppliedTask == task
-            otherTask
-        })
+        dependency.add(closure)
+        def result = dependency.getDependencies(task)
 
         then:
-        dependency.getDependencies(task) == toSet(otherTask)
+        result == toSet(otherTask)
+        1 * closure.call(new Object[] { null }) >> { arg -> throw new NullPointerException() }
+        1 * closure.call(task) >> { arg -> task }
     }
 
     def "can depend on a closure that returns null"() {
@@ -224,7 +225,6 @@ The following types/formats are supported:
   - A TaskDependency instance
   - A Provider that represents a task output
   - A Provider instance that returns any of these types
-  - A Closure instance that returns any of these types
   - A Callable instance that returns any of these types
   - An Iterable, Collection, Map or array instance that contains any of these types''')
     }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
@@ -225,6 +225,7 @@ The following types/formats are supported:
   - A TaskDependency instance
   - A Provider that represents a task output
   - A Provider instance that returns any of these types
+  - A Closure instance that returns any of these types
   - A Callable instance that returns any of these types
   - An Iterable, Collection, Map or array instance that contains any of these types''')
     }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskDependencyTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.provider.ValueSupplier
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.internal.typeconversion.UnsupportedNotationException
+import org.gradle.test.fixtures.ExpectDeprecation
 import org.gradle.util.Path
 import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
@@ -79,6 +80,7 @@ class DefaultTaskDependencyTest extends Specification {
         dependency.getDependencies(task) == toSet(otherTask)
     }
 
+    @ExpectDeprecation("Accessing tasks provided to task dependency closures has been deprecated")
     def "can depend on a closure"() {
         when:
         dependency.add({ Task suppliedTask ->

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -107,13 +107,13 @@ def foo = tasks.register("foo")
 // The below usages of dependsOn access the Task object provided as a parameter.
 tasks.register("bar") {
     dependsOn { task ->
-        task.toString()
+        task.getName()
         foo
     }
 }
 tasks.register("baz") {
     dependsOn {
-        it.toString()
+        it.getName()
         foo
     }
 }

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -106,6 +106,7 @@ The following code will not be permitted starting in Gradle 10:
 def foo = tasks.register("foo")
 
 // The below usages of dependsOn access the Task object provided as a parameter.
+// This is deprecated behavior.
 tasks.register("bar") {
     dependsOn { task ->
         task.getName()

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -93,6 +93,39 @@ Problem severity can no longer be set explicitly when creating a new instance.
 Instead, it is determined by the reporting method: `ProblemReporter.report()` produces warnings and `ProblemReporter.throwing()` produces errors.
 Calling `.severity()` on `ProblemSpec` is now a no-op and will be removed in Gradle 10.0.
 
+[[task_in_task_dependency_closure]]
+==== Accessing Task in dependsOn Closure
+
+Accessing a task provided to closures passed to the link:{javadocPath}/org/gradle/api/Task.html#dependsOn(java.lang.Object...)[Task.dependsOn] method has been deprecated.
+Starting in Gradle 10.0, Gradle will no longer provide the Task as an argument to closures passed to the Task.dependsOn method.
+
+The following code will not be permitted starting in Gradle 10.0
+[source,groovy]
+----
+def foo = tasks.register("foo")
+
+// The below usages of dependsOn access the Task object provided as a parameter.
+tasks.register("bar") {
+    dependsOn { task ->
+        task.toString()
+        foo
+    }
+}
+tasks.register("baz") {
+    dependsOn {
+        it.toString()
+        foo
+    }
+}
+
+// Build logic may continue to pass closures to dependsOn without accessing the provided Task.
+tasks.register("okay") {
+    dependsOn {
+        foo
+    }
+}
+----
+
 [[deprecated_get_properties]]
 ==== Deprecation of `getProperties()`
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -94,12 +94,13 @@ Instead, it is determined by the reporting method: `ProblemReporter.report()` pr
 Calling `.severity()` on `ProblemSpec` is now a no-op and will be removed in Gradle 10.0.
 
 [[task_in_task_dependency_closure]]
-==== Accessing Task in dependsOn Closure
+==== Accessing Task in `dependsOn` Closure
 
-Accessing a task provided to closures passed to the link:{javadocPath}/org/gradle/api/Task.html#dependsOn(java.lang.Object...)[Task.dependsOn] method has been deprecated.
-Starting in Gradle 10.0, Gradle will no longer provide the Task as an argument to closures passed to the Task.dependsOn method.
+Accessing a task provided to closures passed to the link:{javadocPath}/org/gradle/api/Task.html#dependsOn(java.lang.Object...)[`Task.dependsOn`] method has been deprecated.
+Starting in Gradle 10, Gradle will no longer provide the `Task` as an argument to closures passed to the `Task.dependsOn` method.
 
-The following code will not be permitted starting in Gradle 10.0
+The following code will not be permitted starting in Gradle 10:
+
 [source,groovy]
 ----
 def foo = tasks.register("foo")

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -114,6 +114,10 @@ import java.util.Set;
  * <li>A {@code Callable}. The {@code call()} method may return any of the types listed here. Its return value is
  * recursively converted to tasks. A {@code null} return value is treated as an empty collection.</li>
  *
+ * <li>A Groovy {@code Closure} or Kotlin function.
+ * The closure or function may return any of the types listed here. Its return value is
+ * recursively converted to tasks. A {@code null} return value is treated as an empty collection.</li>
+ *
  * <li>Anything else is treated as an error.</li>
  *
  * </ul>

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -114,10 +114,6 @@ import java.util.Set;
  * <li>A {@code Callable}. The {@code call()} method may return any of the types listed here. Its return value is
  * recursively converted to tasks. A {@code null} return value is treated as an empty collection.</li>
  *
- * <li>A Groovy {@code Closure} or Kotlin function. The closure may take a {@code Task} as parameter.
- * The closure or function may return any of the types listed here. Its return value is
- * recursively converted to tasks. A {@code null} return value is treated as an empty collection.</li>
- *
  * <li>Anything else is treated as an error.</li>
  *
  * </ul>

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
@@ -335,7 +335,6 @@ The following types/formats are supported:
   - A TaskDependency instance
   - A Provider that represents a task output
   - A Provider instance that returns any of these types
-  - A Closure instance that returns any of these types
   - A Callable instance that returns any of these types
   - An Iterable, Collection, Map or array instance that contains any of these types""")
 
@@ -368,7 +367,6 @@ The following types/formats are supported:
   - A TaskDependency instance
   - A Provider that represents a task output
   - A Provider instance that returns any of these types
-  - A Closure instance that returns any of these types
   - A Callable instance that returns any of these types
   - An Iterable, Collection, Map or array instance that contains any of these types""")
 
@@ -408,7 +406,6 @@ The following types/formats are supported:
   - A TaskDependency instance
   - A Provider that represents a task output
   - A Provider instance that returns any of these types
-  - A Closure instance that returns any of these types
   - A Callable instance that returns any of these types
   - An Iterable, Collection, Map or array instance that contains any of these types""")
 
@@ -442,7 +439,6 @@ The following types/formats are supported:
   - A TaskDependency instance
   - A Provider that represents a task output
   - A Provider instance that returns any of these types
-  - A Closure instance that returns any of these types
   - A Callable instance that returns any of these types
   - An Iterable, Collection, Map or array instance that contains any of these types""")
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
@@ -335,6 +335,7 @@ The following types/formats are supported:
   - A TaskDependency instance
   - A Provider that represents a task output
   - A Provider instance that returns any of these types
+  - A Closure instance that returns any of these types
   - A Callable instance that returns any of these types
   - An Iterable, Collection, Map or array instance that contains any of these types""")
 
@@ -367,6 +368,7 @@ The following types/formats are supported:
   - A TaskDependency instance
   - A Provider that represents a task output
   - A Provider instance that returns any of these types
+  - A Closure instance that returns any of these types
   - A Callable instance that returns any of these types
   - An Iterable, Collection, Map or array instance that contains any of these types""")
 
@@ -406,6 +408,7 @@ The following types/formats are supported:
   - A TaskDependency instance
   - A Provider that represents a task output
   - A Provider instance that returns any of these types
+  - A Closure instance that returns any of these types
   - A Callable instance that returns any of these types
   - An Iterable, Collection, Map or array instance that contains any of these types""")
 
@@ -439,6 +442,7 @@ The following types/formats are supported:
   - A TaskDependency instance
   - A Provider that represents a task output
   - A Provider instance that returns any of these types
+  - A Closure instance that returns any of these types
   - A Callable instance that returns any of these types
   - An Iterable, Collection, Map or array instance that contains any of these types""")
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyIntegrationTest.groovy
@@ -40,4 +40,54 @@ class TaskDependencyIntegrationTest extends AbstractIntegrationSpec {
         'removeAll([])' | _
         'retainAll([])' | _
     }
+
+    def "can use a closure as a task dependency"() {
+        buildFile << """
+            def bar = tasks.register("bar")
+            tasks.register("foo") {
+                dependsOn {
+                    bar
+                }
+            }
+        """
+
+        when:
+        succeeds("foo")
+
+        then:
+        executed(":bar")
+    }
+
+    def "accessing task provided to task dependency closure is deprecated"() {
+        buildFile << """
+            def bar = tasks.register("bar")
+            tasks.register("foo") {
+                dependsOn { task ->
+                    task.toString()
+                    bar
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Accessing tasks provided to task dependency closures has been deprecated. This will fail with an error in Gradle 10. Cannot call method 'toString' on task passed to task dependency closure. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_in_task_dependency_closure")
+        succeeds("foo")
+    }
+
+    def "accessing task provided to task dependency closure using it is deprecated"() {
+        buildFile << """
+            def bar = tasks.register("bar")
+            tasks.register("foo") {
+                dependsOn {
+                    it.toString()
+                    bar
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Accessing tasks provided to task dependency closures has been deprecated. This will fail with an error in Gradle 10. Cannot call method 'toString' on task passed to task dependency closure. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_in_task_dependency_closure")
+        succeeds("foo")
+    }
+
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyIntegrationTest.groovy
@@ -63,14 +63,14 @@ class TaskDependencyIntegrationTest extends AbstractIntegrationSpec {
             def bar = tasks.register("bar")
             tasks.register("foo") {
                 dependsOn { task ->
-                    task.toString()
+                    task.getName()
                     bar
                 }
             }
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Accessing tasks provided to task dependency closures has been deprecated. This will fail with an error in Gradle 10. Cannot call method 'toString' on task passed to task dependency closure. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_in_task_dependency_closure")
+        executer.expectDocumentedDeprecationWarning("Accessing tasks provided to task dependency closures has been deprecated. This will fail with an error in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_in_task_dependency_closure")
         succeeds("foo")
     }
 
@@ -79,15 +79,71 @@ class TaskDependencyIntegrationTest extends AbstractIntegrationSpec {
             def bar = tasks.register("bar")
             tasks.register("foo") {
                 dependsOn {
-                    it.toString()
+                    it.getName()
                     bar
                 }
             }
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Accessing tasks provided to task dependency closures has been deprecated. This will fail with an error in Gradle 10. Cannot call method 'toString' on task passed to task dependency closure. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_in_task_dependency_closure")
+        executer.expectDocumentedDeprecationWarning("Accessing tasks provided to task dependency closures has been deprecated. This will fail with an error in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#task_in_task_dependency_closure")
         succeeds("foo")
+    }
+
+    def "cannot pass a Java Function to dependsOn"() {
+        buildFile << """
+            def bar = tasks.register("bar")
+            tasks.register("foo") {
+                java.util.function.Function<Task, Object> function = { task ->
+                    task.getName()
+                    bar
+                }
+                dependsOn(function)
+            }
+        """
+
+        when:
+        fails("foo")
+
+        then:
+        failure.assertHasDescription("Could not determine the dependencies of task ':foo'")
+    }
+
+    def "cannot pass a Kotlin Function to dependsOn"() {
+        buildKotlinFile << """
+            val bar = tasks.register("bar")
+            tasks.register("foo") {
+                val function: (Task) -> Any = { task ->
+                    task.getName()
+                    bar
+                }
+                dependsOn(function)
+            }
+        """
+
+        when:
+        fails("foo")
+
+        then:
+        failure.assertHasDescription("Could not determine the dependencies of task ':foo'")
+    }
+
+    def "cannot pass a Kotlin closure to dependsOn"() {
+        buildKotlinFile << """
+            val bar = tasks.register("bar")
+            tasks.register("foo") {
+                dependsOn({ task: Task ->
+                    task.getName()
+                    bar
+                })
+            }
+        """
+
+        when:
+        fails("foo")
+
+        then:
+        failure.assertHasDescription("Could not determine the dependencies of task ':foo'")
     }
 
 }


### PR DESCRIPTION
This way, starting in Gradle 10, we can avoid wiring the Task through the whole task dependency resolution chain, permitting us to begin to 'un taskify' the work graph traversal logic


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
