### PR TITLE
Fix issue with excluding test by class

### DIFF
--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestDefinitionProcessor.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestDefinitionProcessor.java
@@ -175,7 +175,7 @@ public final class JUnitPlatformTestDefinitionProcessor extends AbstractJUnitTes
             // Conservative: any declared class (even non-test inner classes) is treated as a
             // potential nested test class, so we keep the selector to let JUnit Platform discover
             // nested tests. The post-discovery filter handles any extra class that slips through.
-            return matcher().matchesExcludeClass(klass.getName()) && klass.getDeclaredClasses().length == 0;
+            return matcher().matchesExcludeClassExactly(klass.getName()) && klass.getDeclaredClasses().length == 0;
         }
 
         private TestSelectionMatcher matcher() {

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestDefinitionProcessor.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestDefinitionProcessor.java
@@ -129,6 +129,8 @@ public final class JUnitPlatformTestDefinitionProcessor extends AbstractJUnitTes
         private final JUnitPlatformSpec spec;
         private final IdGenerator<?> idGenerator;
         private final Clock clock;
+        @Nullable
+        private TestSelectionMatcher cachedMatcher;
 
         CollectThenExecuteTestDefinitionConsumer(TestResultProcessor resultProcessor, BackwardsCompatibleLauncherSession launcherSession, ClassLoader junitClassLoader, JUnitPlatformSpec spec, IdGenerator<?> idGenerator, Clock clock) {
             this.resultProcessor = resultProcessor;
@@ -170,10 +172,18 @@ public final class JUnitPlatformTestDefinitionProcessor extends AbstractJUnitTes
             if (filterSpec.getExcludedTests().isEmpty()) {
                 return false;
             }
-            TestSelectionMatcher matcher = new TestSelectionMatcher(filterSpec);
-            return matcher.matchesExcludeClass(klass.getName()) && klass.getDeclaredClasses().length == 0;
+            // Conservative: any declared class (even non-test inner classes) is treated as a
+            // potential nested test class, so we keep the selector to let JUnit Platform discover
+            // nested tests. The post-discovery filter handles any extra class that slips through.
+            return matcher().matchesExcludeClass(klass.getName()) && klass.getDeclaredClasses().length == 0;
         }
 
+        private TestSelectionMatcher matcher() {
+            if (cachedMatcher == null) {
+                cachedMatcher = new TestSelectionMatcher(spec.getFilter());
+            }
+            return cachedMatcher;
+        }
 
         private void executeDirectory(DirectoryBasedTestDefinition testDefinition) {
             selectors.add(DiscoverySelectors.selectDirectory(testDefinition.getTestDefinitionsDir()));

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestDefinitionProcessor.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestDefinitionProcessor.java
@@ -155,7 +155,23 @@ public final class JUnitPlatformTestDefinitionProcessor extends AbstractJUnitTes
             if (isInnerClass(klass) || (supportsVintageTests() && isNestedClassInsideEnclosedRunner(klass))) {
                 return;
             }
+            if (isExcludedAndHasNoNestedClasses(klass)) {
+                // Class is explicitly excluded by name and has no nested classes that would
+                // need it as a discovery root. Skip registering as a selector so that
+                // engine-level test generation (e.g. ArchUnit's field-based tests) does not
+                // bypass the exclude filter. See issue #37539.
+                return;
+            }
             selectors.add(DiscoverySelectors.selectClass(klass));
+        }
+
+        private boolean isExcludedAndHasNoNestedClasses(Class<?> klass) {
+            TestFilterSpec filterSpec = spec.getFilter();
+            if (filterSpec.getExcludedTests().isEmpty()) {
+                return false;
+            }
+            TestSelectionMatcher matcher = new TestSelectionMatcher(filterSpec);
+            return matcher.matchesExcludeClass(klass.getName()) && klass.getDeclaredClasses().length == 0;
         }
 
 

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/filters/ClassMethodNameFilter.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/filters/ClassMethodNameFilter.java
@@ -83,8 +83,8 @@ public final class ClassMethodNameFilter implements PostDiscoveryFilter {
     private boolean shouldRun(TestDescriptor descriptor, boolean checkingParent, ClassSource classSource) {
         String className = classSource.getClassName();
         if (matcher.matchesExcludeClass(className)) {
-            // This class exactly matches an exclude pattern (not merely a fuzzy may-match).
-            // Don't let children-recursion re-include the container. Ancestors that are
+            // This class exactly matches an exclude pattern.
+            // Return immediately to prevent children from re-including the container. Ancestors that are
             // themselves included by pattern (e.g. a test suite) are handled by classMatch.
             return false;
         }

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/filters/ClassMethodNameFilter.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/filters/ClassMethodNameFilter.java
@@ -139,6 +139,9 @@ public final class ClassMethodNameFilter implements PostDiscoveryFilter {
     private boolean classMatch(TestDescriptor descriptor) {
         TestDescriptor current = descriptor;
         String methodName = null;
+        // Records the lowest-level class in the chain that matches an exclude pattern.
+        // Used to block re-inclusion via the walk-up only for enclosing-class ancestors;
+        // unrelated ancestors (e.g. test suites) can still re-include.
         String excludedClassName = null;
         while (true) {
             Optional<TestDescriptor> parent = current.getParent();
@@ -152,9 +155,11 @@ public final class ClassMethodNameFilter implements PostDiscoveryFilter {
                 if (excludedClassName == null && matcher.matchesExcludeTest(name, methodName)) {
                     excludedClassName = name;
                 }
-                boolean encloseExclude = excludedClassName != null
+                // True when this ancestor is an enclosing class of the excluded class
+                // (same class, or a $-parent), as opposed to an unrelated ancestor.
+                boolean ancestorEnclosesExclude = excludedClassName != null
                     && (excludedClassName.equals(name) || excludedClassName.startsWith(name + "$"));
-                if (!encloseExclude && matcher.matchesIncludeTest(name, methodName)) {
+                if (!ancestorEnclosesExclude && matcher.matchesIncludeTest(name, methodName)) {
                     return true;
                 }
             }

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/filters/ClassMethodNameFilter.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/filters/ClassMethodNameFilter.java
@@ -73,7 +73,7 @@ public final class ClassMethodNameFilter implements PostDiscoveryFilter {
         while (current != null) {
             Optional<String> enclosingClassName = className(current);
             if (enclosingClassName.isPresent()) {
-                return !matcher.matchesExcludeClass(enclosingClassName.get());
+                return !matcher.matchesExcludeClassExactly(enclosingClassName.get());
             }
             current = current.getParent().orElse(null);
         }
@@ -82,7 +82,7 @@ public final class ClassMethodNameFilter implements PostDiscoveryFilter {
 
     private boolean shouldRun(TestDescriptor descriptor, boolean checkingParent, ClassSource classSource) {
         String className = classSource.getClassName();
-        if (matcher.matchesExcludeClass(className)) {
+        if (matcher.matchesExcludeClassExactly(className)) {
             // This class exactly matches an exclude pattern.
             // Return immediately to prevent children from re-including the container. Ancestors that are
             // themselves included by pattern (e.g. a test suite) are handled by classMatch.

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/filters/ClassMethodNameFilter.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/filters/ClassMethodNameFilter.java
@@ -54,24 +54,40 @@ public final class ClassMethodNameFilter implements PostDiscoveryFilter {
 
     private boolean shouldRun(TestDescriptor descriptor, boolean checkingParent) {
         Optional<TestSource> source = descriptor.getSource();
-        if (!source.isPresent()) {
-            return true;
+        if (source.isPresent()) {
+            TestSource testSource = source.get();
+            if (testSource instanceof MethodSource) {
+                return shouldRun(descriptor, (MethodSource) testSource);
+            }
+            if (testSource instanceof ClassSource) {
+                return shouldRun(descriptor, checkingParent, (ClassSource) testSource);
+            }
         }
 
-        TestSource testSource = source.get();
-        if (testSource instanceof MethodSource) {
-            return shouldRun(descriptor, (MethodSource) testSource);
+        // Source is absent or of a custom type (e.g. ArchUnit field-based tests).
+        // Walk up to the first ancestor with a class source and honor its exclude status:
+        // if that enclosing class exactly matches an exclude pattern, this descriptor is also
+        // excluded (as a member of the class). Otherwise default to included (original behavior
+        // preserved — the filter's status quo for custom sources is inclusive).
+        TestDescriptor current = descriptor.getParent().orElse(null);
+        while (current != null) {
+            Optional<String> enclosingClassName = className(current);
+            if (enclosingClassName.isPresent()) {
+                return !matcher.matchesExcludeClass(enclosingClassName.get());
+            }
+            current = current.getParent().orElse(null);
         }
-
-        if (testSource instanceof ClassSource) {
-            return shouldRun(descriptor, checkingParent, (ClassSource) testSource);
-        }
-
-        Optional<TestDescriptor> parent = descriptor.getParent();
-        return parent.isPresent() && shouldRun(parent.get(), true);
+        return true;
     }
 
     private boolean shouldRun(TestDescriptor descriptor, boolean checkingParent, ClassSource classSource) {
+        String className = classSource.getClassName();
+        if (matcher.matchesExcludeClass(className)) {
+            // This class exactly matches an exclude pattern (not merely a fuzzy may-match).
+            // Don't let children-recursion re-include the container. Ancestors that are
+            // themselves included by pattern (e.g. a test suite) are handled by classMatch.
+            return false;
+        }
         Set<? extends TestDescriptor> children = descriptor.getChildren();
         if (!checkingParent) {
             for (TestDescriptor child : children) {
@@ -81,7 +97,6 @@ public final class ClassMethodNameFilter implements PostDiscoveryFilter {
             }
         }
         if (children.isEmpty()) {
-            String className = classSource.getClassName();
             return matcher.matchesTest(className, null)
                 || matcher.matchesTest(className, descriptor.getLegacyReportingName());
         }

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/filters/ClassMethodNameFilter.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/filters/ClassMethodNameFilter.java
@@ -101,20 +101,45 @@ public final class ClassMethodNameFilter implements PostDiscoveryFilter {
             .isPresent();
     }
 
+    /**
+     * Walks up the descriptor chain looking for an ancestor class whose name matches an include
+     * pattern. An ancestor-level include may re-include a descendant, but an exclude on a nested
+     * class must not be bypassed by walking up to its enclosing class.
+     *
+     * <p>An ancestor is an <em>enclosing class</em> of the excluded class when the excluded
+     * class's fully qualified name starts with the ancestor's name followed by {@code $}
+     * (e.g. {@code SampleTest} encloses {@code SampleTest$NestedTestClass}). Re-inclusion
+     * via an enclosing ancestor is forbidden. Re-inclusion via an unrelated ancestor
+     * (e.g. a JUnit Platform suite that references a separate excluded class) is allowed.
+     *
+     * <p>This asymmetry is intentional:
+     * <ul>
+     *   <li>{@code --tests Parent} should pull in tests from {@code Parent$Nested} transitively.</li>
+     *   <li>{@code excludeTest("Parent$Nested", null)} must not be bypassed because the
+     *       enclosing class {@code Parent} happens not to match the exclude.</li>
+     *   <li>{@code excludeTestsMatching("Foo")} excludes standalone {@code Foo} tests, but
+     *       should still allow {@code Foo} tests to run when wrapped in an unrelated suite.</li>
+     * </ul>
+     */
     private boolean classMatch(TestDescriptor descriptor) {
         TestDescriptor current = descriptor;
         String methodName = null;
+        String excludedClassName = null;
         while (true) {
-
             Optional<TestDescriptor> parent = current.getParent();
             if (!parent.isPresent()) {
                 break;
             }
 
-            // If the current descriptor is a class, check if it matches the test selection criteria
             Optional<String> className = className(current);
             if (className.isPresent()) {
-                if (matcher.matchesTest(className.get(), methodName)) {
+                String name = className.get();
+                if (excludedClassName == null && matcher.matchesExcludeTest(name, methodName)) {
+                    excludedClassName = name;
+                }
+                boolean encloseExclude = excludedClassName != null
+                    && (excludedClassName.equals(name) || excludedClassName.startsWith(name + "$"));
+                if (!encloseExclude && matcher.matchesIncludeTest(name, methodName)) {
                     return true;
                 }
             }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterFilteringIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterFilteringIntegrationTest.groovy
@@ -40,43 +40,7 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
             }
         """
 
-        file("src/test/java/SampleTest.java") << """
-            import static org.junit.jupiter.api.Assertions.fail;
-
-            import org.junit.jupiter.api.Nested;
-            import org.junit.jupiter.api.Test;
-            import org.junit.jupiter.params.ParameterizedTest;
-            import org.junit.jupiter.params.provider.ValueSource;
-
-            public class SampleTest {
-                @Test
-                public void regularTest() {
-                    fail();
-                }
-
-                @Nested
-                public class NestedTestClass {
-                    @Nested
-                    public class SubNestedTestClass {
-                        @Test
-                        public void subNestedTest() {
-                            fail();
-                        }
-
-                        @ParameterizedTest
-                        @ValueSource(strings = { "racecar", "radar", "able was I ere I saw elba" })
-                        public void palindromes(String candidate) {
-                            fail();
-                        }
-                    }
-
-                    @Test
-                    public void nestedTest() {
-                      fail();
-                    }
-                }
-            }
-        """
+        file("src/test/java/SampleTest.java") << sampleClassWithNestedTests
         file("src/test/java/TestSomethingTest.java") << """
             import static org.junit.jupiter.api.Assertions.fail;
 
@@ -105,10 +69,10 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
         fails "test", "--tests", commandLineFilter
 
         then:
-        assertExpectedTestsAndCounts(expectedTests as Map<String, Integer>)
+        assertExpectedTestsAndCounts(expectedTestsAndCounts as Map<String, Integer>)
 
         where:
-        commandLineFilter                                 | withConfiguredFilters | expectedTests
+        commandLineFilter                                 | withConfiguredFilters | expectedTestsAndCounts
         'SampleTest'                                      | false                 | ['SampleTest': 1, 'SampleTest$NestedTestClass': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
         'SampleTest'                                      | true                  | ['SampleTest': 1, 'SampleTest$NestedTestClass': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
         'SampleTest$NestedTestClass'                      | false                 | ['SampleTest$NestedTestClass': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
@@ -132,7 +96,35 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
             }
         """
 
-        file("src/test/java/SampleTest.java") << """
+        file("src/test/java/SampleTest.java") << sampleClassWithNestedTests
+
+        when:
+        fails "test"
+
+        then:
+        result.assertTaskExecuted(":test")
+        assertExpectedTestsAndCounts(expectedTestsAndCounts as Map<String, Integer>)
+
+        where:
+        excludeFilter                                       | expectedTestsAndCounts
+        'SampleTest'                                        | ['SampleTest$NestedTestClass': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
+        'SampleTest$NestedTestClass'                        | ['SampleTest': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
+        'SampleTest$NestedTestClass$SubNestedTestClass'     | ['SampleTest': 1, 'SampleTest$NestedTestClass': 1]
+        'SampleTest*'                                       | [:]
+    }
+
+    private void assertExpectedTestsAndCounts(Map<String, Integer> expectedTestsAndCounts) {
+        Map<String, Integer> executedClasses = file("build/executed-classes.txt").readLines().collectEntries { it.split(' ', 2).with { [(it[0]): it[1] as Integer] } }
+        def executedClassNames = executedClasses.keySet()
+        def expectedClassNames = expectedTestsAndCounts.keySet()
+        assert executedClassNames == expectedClassNames
+        expectedTestsAndCounts.each { className, expectedCount ->
+            assert executedClasses[className] == expectedCount
+        }
+    }
+
+    private static String getSampleClassWithNestedTests() {
+        return """
             import static org.junit.jupiter.api.Assertions.fail;
 
             import org.junit.jupiter.api.Nested;
@@ -169,30 +161,6 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
                 }
             }
         """
-
-        when:
-        fails "test"
-
-        then:
-        result.assertTaskExecuted(":test")
-        assertExpectedTestsAndCounts(expectedTestsAndCounts as Map<String, Integer>)
-
-        where:
-        excludeFilter                                       | expectedTestsAndCounts
-        'SampleTest'                                        | ['SampleTest$NestedTestClass': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
-        'SampleTest$NestedTestClass'                        | ['SampleTest': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
-        'SampleTest$NestedTestClass$SubNestedTestClass'     | ['SampleTest': 1, 'SampleTest$NestedTestClass': 1]
-        'SampleTest*'                                       | [:]
-    }
-
-    private void assertExpectedTestsAndCounts(Map<String, Integer> expectedTestsAndCounts) {
-        Map<String, Integer> executedClasses = file("build/executed-classes.txt").readLines().collectEntries { it.split(' ', 2).with { [(it[0]): it[1] as Integer] } }
-        def executedClassNames = executedClasses.keySet()
-        def expectedClassNames = expectedTestsAndCounts.keySet()
-        assert executedClassNames == expectedClassNames
-        expectedTestsAndCounts.each { className, expectedCount ->
-            assert executedClasses[className] == expectedCount
-        }
     }
 
     private static String getTestClassAndCountListener() {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterFilteringIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterFilteringIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.testing.junit.jupiter
 
-import org.gradle.api.internal.tasks.testing.report.generic.GenericTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.AbstractTestFilteringIntegrationTest
@@ -33,11 +32,14 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
             dependencies {
                 testImplementation 'org.junit.jupiter:junit-jupiter:${MultiVersionIntegrationSpec.version}'
             }
+
+            ${testClassAndCountListener}
+
             test {
                 ${maybeConfigureFilters(withConfiguredFilters)}
             }
         """
-\
+
         file("src/test/java/SampleTest.java") << """
             import static org.junit.jupiter.api.Assertions.fail;
 
@@ -103,18 +105,16 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
         fails "test", "--tests", commandLineFilter
 
         then:
-        def testResult = resultsFor()
-        testResult.assertAtLeastTestPathsExecuted(expectedTests as String[])
-        assertExpectedTestCounts(testResult, expectedTests)
+        assertExpectedTestsAndCounts(expectedTests as Map<String, Integer>)
 
         where:
         commandLineFilter                                 | withConfiguredFilters | expectedTests
-        'SampleTest'                                      | false                 | [':SampleTest', ':SampleTest:SampleTest$NestedTestClass', ':SampleTest:SampleTest$NestedTestClass:SampleTest$NestedTestClass$SubNestedTestClass']
-        'SampleTest'                                      | true                  | [':SampleTest', ':SampleTest:SampleTest$NestedTestClass', ':SampleTest:SampleTest$NestedTestClass:SampleTest$NestedTestClass$SubNestedTestClass']
-        'SampleTest$NestedTestClass'                      | false                 | [':SampleTest:SampleTest$NestedTestClass', ':SampleTest:SampleTest$NestedTestClass:SampleTest$NestedTestClass$SubNestedTestClass']
-        'SampleTest$NestedTestClass'                      | true                  | [':SampleTest:SampleTest$NestedTestClass', ':SampleTest:SampleTest$NestedTestClass:SampleTest$NestedTestClass$SubNestedTestClass']
-        'SampleTest$NestedTestClass$SubNestedTestClass'   | false                 | [':SampleTest:SampleTest$NestedTestClass:SampleTest$NestedTestClass$SubNestedTestClass']
-        'SampleTest$NestedTestClass$SubNestedTestClass'   | true                  | [':SampleTest:SampleTest$NestedTestClass:SampleTest$NestedTestClass$SubNestedTestClass']
+        'SampleTest'                                      | false                 | ['SampleTest': 1, 'SampleTest$NestedTestClass': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
+        'SampleTest'                                      | true                  | ['SampleTest': 1, 'SampleTest$NestedTestClass': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
+        'SampleTest$NestedTestClass'                      | false                 | ['SampleTest$NestedTestClass': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
+        'SampleTest$NestedTestClass'                      | true                  | ['SampleTest$NestedTestClass': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
+        'SampleTest$NestedTestClass$SubNestedTestClass'   | false                 | ['SampleTest$NestedTestClass$SubNestedTestClass': 4]
+        'SampleTest$NestedTestClass$SubNestedTestClass'   | true                  | ['SampleTest$NestedTestClass$SubNestedTestClass': 4]
     }
 
     @Issue("https://github.com/gradle/gradle/issues/31304")
@@ -124,8 +124,11 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
             dependencies {
                 testImplementation 'org.junit.jupiter:junit-jupiter:${MultiVersionIntegrationSpec.version}'
             }
+
+            ${testClassAndCountListener}
+
             test {
-                filter.excludeTest("${excludeFilter}", null)
+                filter.excludeTest("${excludeFilter.replace('$', '\\$')}", null)
             }
         """
 
@@ -172,29 +175,54 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
 
         then:
         result.assertTaskExecuted(":test")
-        def testResult = resultsFor()
-        assertExpectedTestCounts(testResult, expectedTests)
+        assertExpectedTestsAndCounts(expectedTestsAndCounts as Map<String, Integer>)
 
         where:
-        excludeFilter                                       | expectedTests
-        'SampleTest'                                        | [':SampleTest:SampleTest$NestedTestClass', ':SampleTest:SampleTest$NestedTestClass:SampleTest$NestedTestClass$SubNestedTestClass']
-        'SampleTest\\$NestedTestClass'                      | [':SampleTest', ':SampleTest$NestedTestClass:SampleTest$NestedTestClass$SubNestedTestClass']
-        'SampleTest\\$NestedTestClass\\$SubNestedTestClass' | [':SampleTest', ':SampleTest:SampleTest$NestedTestClass']
-        'SampleTest*'                                       | []
+        excludeFilter                                       | expectedTestsAndCounts
+        'SampleTest'                                        | ['SampleTest$NestedTestClass': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
+        'SampleTest$NestedTestClass'                        | ['SampleTest': 1, 'SampleTest$NestedTestClass$SubNestedTestClass': 4]
+        'SampleTest$NestedTestClass$SubNestedTestClass'     | ['SampleTest': 1, 'SampleTest$NestedTestClass': 1]
+        'SampleTest*'                                       | [:]
     }
 
-    void assertExpectedTestCounts(GenericTestExecutionResult testExecutionResult, List<String> expectedTests) {
-        if (expectedTests.contains('SampleTest')) {
-            testExecutionResult.testPath('SampleTest').onlyRoot().assertChildCount(1, 0)
+    private void assertExpectedTestsAndCounts(Map<String, Integer> expectedTestsAndCounts) {
+        Map<String, Integer> executedClasses = file("build/executed-classes.txt").readLines().collectEntries { it.split(' ', 2).with { [(it[0]): it[1] as Integer] } }
+        def executedClassNames = executedClasses.keySet()
+        def expectedClassNames = expectedTestsAndCounts.keySet()
+        assert executedClassNames == expectedClassNames
+        expectedTestsAndCounts.each { className, expectedCount ->
+            assert executedClasses[className] == expectedCount
         }
+    }
 
-        if (expectedTests.contains('SampleTest$NestedTestClass')) {
-            testExecutionResult.testPath('SampleTest$NestedTestClass').onlyRoot().assertChildCount(1, 0)
-        }
+    private static String getTestClassAndCountListener() {
+        return """
+            def classListener = new TestListener() {
+                def executedClasses = [:].withDefault { 0 }
 
-        if (expectedTests.contains('SampleTest$NestedTestClass$SubNestedTestClass')) {
-            testExecutionResult.testPath('SampleTest$NestedTestClass$SubNestedTestClass').onlyRoot().assertChildCount(4, 0)
-        }
+                @Override
+                void beforeSuite(TestDescriptor descriptor) { }
+
+                @Override
+                void afterSuite(TestDescriptor descriptor, TestResult result) { }
+
+                @Override
+                void beforeTest(TestDescriptor descriptor) { }
+
+                @Override
+                void afterTest(TestDescriptor descriptor, TestResult result) {
+                    if (descriptor.className) {
+                        executedClasses[descriptor.className]++
+                    }
+                }
+            }
+
+            gradle.buildFinished {
+                project.layout.buildDirectory.file("executed-classes.txt").get().asFile.text = classListener.executedClasses.collect { k, v -> "\${k} \${v}" }.join("\\n")
+            }
+
+            test.addTestListener(classListener)
+        """
     }
 
     String maybeConfigureFilters(boolean withConfiguredFilters) {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterFilteringIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterFilteringIntegrationTest.groovy
@@ -165,8 +165,21 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
 
     private static String getTestClassAndCountListener() {
         return """
-            def classListener = new TestListener() {
+            abstract class TestClassCounter implements BuildService<org.gradle.api.services.BuildServiceParameters.None> {
                 def executedClasses = [:].withDefault { 0 }
+
+                Map<String, Integer> getExecutedClasses() {
+                    return executedClasses
+                }
+            }
+
+            class TestClassListener implements TestListener {
+                private Provider<TestClassCounter> testClassCounter
+
+                @Inject
+                public TestClassListener(Provider<TestClassCounter> testClassCounter) {
+                    this.testClassCounter = testClassCounter
+                }
 
                 @Override
                 void beforeSuite(TestDescriptor descriptor) { }
@@ -180,16 +193,27 @@ class JUnitJupiterFilteringIntegrationTest extends AbstractTestFilteringIntegrat
                 @Override
                 void afterTest(TestDescriptor descriptor, TestResult result) {
                     if (descriptor.className) {
-                        executedClasses[descriptor.className]++
+                        testClassCounter.get().executedClasses[descriptor.className]++
                     }
                 }
             }
 
-            gradle.buildFinished {
-                project.layout.buildDirectory.file("executed-classes.txt").get().asFile.text = classListener.executedClasses.collect { k, v -> "\${k} \${v}" }.join("\\n")
+            def testClassCounterService = project.getGradle().getSharedServices().registerIfAbsent("testClassCounter", TestClassCounter)
+
+            test {
+                usesService(testClassCounterService)
+                test.addTestListener(new TestClassListener(testClassCounterService))
             }
 
-            test.addTestListener(classListener)
+            def writeTestCounts = tasks.register("writeTestCounts") {
+                def outputFile = project.layout.buildDirectory.file("executed-classes.txt")
+                usesService(testClassCounterService)
+                doLast {
+                    outputFile.get().asFile.text = testClassCounterService.get().executedClasses.collect { k, v -> "\${k} \${v}" }.join("\\n")
+                }
+            }
+
+            test.finalizedBy(writeTestCounts)
         """
     }
 

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
@@ -37,13 +37,12 @@ import static org.apache.commons.lang3.StringUtils.substringAfterLast;
  *       class possibly contribute tests that match the includes? Used to prune scanning; false
  *       positives are acceptable, false negatives are not.</li>
  *   <li><strong>Combined test-level check</strong> ({@link #matchesTest(String, String)}) — the
- *       AND of {@link #matchesIncludeTest(String, String)} and the negation of
+ *       result of {@link #matchesIncludeTest(String, String)} ANDed with the negation of
  *       {@link #matchesExcludeTest(String, String)}. What most callers want for a leaf test.</li>
  *   <li><strong>Separated include / exclude queries</strong>
  *       ({@link #matchesIncludeTest(String, String)} / {@link #matchesExcludeTest(String, String)}
  *       / {@link #matchesExcludeClass(String)}) — lets callers reason about include and exclude
- *       semantics independently. Needed by walkers that must distinguish "excluded at this
- *       descriptor" from "include matched via a non-excluded ancestor".</li>
+ *       semantics independently.</li>
  * </ul>
  *
  * <p>Pattern interpretation:
@@ -77,8 +76,8 @@ class ClassTestSelectionMatcher {
     }
 
     /**
-     * Returns true if the given (className, methodName) pair matches the include patterns and is not excluded by the
-     * exclude patterns.
+     * {@return true if the given (className, methodName) pair matches the include patterns and is not excluded by the
+     * exclude patterns}
      */
     public boolean matchesTest(String className, @Nullable String methodName) {
         return matchesIncludeTest(className, methodName) && !matchesExcludeTest(className, methodName);
@@ -152,8 +151,7 @@ class ClassTestSelectionMatcher {
      *
      * <p>Unlike {@link #matchesExcludeTest(String, String)}, this does <em>not</em> consult
      * the fuzzy {@code mayMatchClass} heuristic: pattern {@code Parent} does not match
-     * class {@code Parent$Nested} here. Used by callers that need a definitive
-     * "is this class excluded?" answer rather than a "might this class match?" hint.</p>
+     * class {@code Parent$Nested} here.</p>
      */
     public boolean matchesExcludeClass(String className) {
         for (ClassTestPattern pattern : buildScriptExcludePatterns) {

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
@@ -29,17 +29,34 @@ import static org.apache.commons.lang3.StringUtils.splitPreserveAllTokens;
 import static org.apache.commons.lang3.StringUtils.substringAfterLast;
 
 /**
- * This class has two responsibilities:
+ * Class-and-method pattern matcher used by {@link TestSelectionMatcher}.
  *
+ * <p>Separates three kinds of queries:
  * <ul>
- * <li>Judge whether a test class might be included. For example, class 'org.gradle.Test' can't
- * be included by pattern 'org.apache.Test'
- * <li>Judge whether a test method is matched exactly.
+ *   <li><strong>Permissive scan-time check</strong> ({@link #mayIncludeClass(String)}) — may this
+ *       class possibly contribute tests that match the includes? Used to prune scanning; false
+ *       positives are acceptable, false negatives are not.</li>
+ *   <li><strong>Combined test-level check</strong> ({@link #matchesTest(String, String)}) — the
+ *       AND of {@link #matchesIncludeTest(String, String)} and the negation of
+ *       {@link #matchesExcludeTest(String, String)}. What most callers want for a leaf test.</li>
+ *   <li><strong>Separated include / exclude queries</strong>
+ *       ({@link #matchesIncludeTest(String, String)} / {@link #matchesExcludeTest(String, String)}
+ *       / {@link #matchesExcludeClass(String)}) — lets callers reason about include and exclude
+ *       semantics independently. Needed by walkers that must distinguish "excluded at this
+ *       descriptor" from "include matched via a non-excluded ancestor".</li>
  * </ul>
  *
- * In both cases, if the pattern starts with an upper-case letter, it will be used to match
- * the simple class name;
- * otherwise, it will be used to match the fully qualified class name.
+ * <p>Pattern interpretation:
+ * <ul>
+ *   <li>A pattern that starts with an upper-case letter matches the simple class name.</li>
+ *   <li>Otherwise, it matches the fully qualified class name.</li>
+ *   <li>{@link #matchesExcludeTest(String, String)} applies a fuzzy {@code mayMatchClass}
+ *       heuristic at the class level (when method name is null), so callers that iterate
+ *       into individual methods can still find exact exclude matches without giving up the
+ *       entire class prematurely.</li>
+ *   <li>{@link #matchesExcludeClass(String)} does <em>not</em> apply the fuzzy heuristic —
+ *       pattern {@code Parent} matches {@code Parent} but not {@code Parent$Nested}.</li>
+ * </ul>
  */
 @NullMarked
 class ClassTestSelectionMatcher {

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
@@ -76,13 +76,16 @@ class ClassTestSelectionMatcher {
             .collect(Collectors.toList());
     }
 
-
+    /**
+     * Returns true if the given (className, methodName) pair matches the include patterns and is not excluded by the
+     * exclude patterns.
+     */
     public boolean matchesTest(String className, @Nullable String methodName) {
         return matchesIncludeTest(className, methodName) && !matchesExcludeTest(className, methodName);
     }
 
     /**
-     * Returns true iff the given (className, methodName) pair matches the include patterns.
+     * Returns true if the given (className, methodName) pair matches the include patterns.
      *
      * <p>The result is the conjunction of the build-script include patterns and the command-line
      * include patterns. An empty include set is treated as "everything matches" (vacuously true).
@@ -94,7 +97,7 @@ class ClassTestSelectionMatcher {
     }
 
     /**
-     * Returns true iff the given (className, methodName) pair matches any exclude pattern.
+     * Returns true if the given (className, methodName) pair matches any exclude pattern.
      *
      * <p>An empty exclude set returns false. Include patterns are not consulted.</p>
      */
@@ -145,7 +148,7 @@ class ClassTestSelectionMatcher {
     }
 
     /**
-     * Returns true iff the class name exactly matches an exclude pattern's class component.
+     * Returns true if the class name exactly matches an exclude pattern's class component.
      *
      * <p>Unlike {@link #matchesExcludeTest(String, String)}, this does <em>not</em> consult
      * the fuzzy {@code mayMatchClass} heuristic: pattern {@code Parent} does not match

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
@@ -41,7 +41,7 @@ import static org.apache.commons.lang3.StringUtils.substringAfterLast;
  *       {@link #matchesExcludeTest(String, String)}. What most callers want for a leaf test.</li>
  *   <li><strong>Separated include / exclude queries</strong>
  *       ({@link #matchesIncludeTest(String, String)} / {@link #matchesExcludeTest(String, String)}
- *       / {@link #matchesExcludeClass(String)}) — lets callers reason about include and exclude
+ *       / {@link #matchesExcludeClassExactly(String)}) — lets callers reason about include and exclude
  *       semantics independently.</li>
  * </ul>
  *
@@ -52,7 +52,7 @@ import static org.apache.commons.lang3.StringUtils.substringAfterLast;
  *   <li>{@link #matchesExcludeTest(String, String)} applies a heuristic at the class level when
  *       method name is null, so callers that have multiple ways to match against method names
  *       don't prematurly "accept" the test when one of the ways does not match any excludes.</li>
- *   <li>{@link #matchesExcludeClass(String)} does <em>not</em> apply the fuzzy heuristic —
+ *   <li>{@link #matchesExcludeClassExactly(String)} does <em>not</em> apply the fuzzy heuristic —
  *       pattern {@code Parent} matches {@code Parent} but not {@code Parent$Nested}.</li>
  * </ul>
  */
@@ -157,7 +157,7 @@ class ClassTestSelectionMatcher {
      * the fuzzy {@code mayMatchClass} heuristic: pattern {@code Parent} does not match
      * class {@code Parent$Nested} here.</p>
      */
-    public boolean matchesExcludeClass(String className) {
+    public boolean matchesExcludeClassExactly(String className) {
         for (ClassTestPattern pattern : buildScriptExcludePatterns) {
             if (pattern.matchesClass(className)) {
                 return true;

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
@@ -49,10 +49,9 @@ import static org.apache.commons.lang3.StringUtils.substringAfterLast;
  * <ul>
  *   <li>A pattern that starts with an upper-case letter matches the simple class name.</li>
  *   <li>Otherwise, it matches the fully qualified class name.</li>
- *   <li>{@link #matchesExcludeTest(String, String)} applies a fuzzy {@code mayMatchClass}
- *       heuristic at the class level (when method name is null), so callers that iterate
- *       into individual methods can still find exact exclude matches without giving up the
- *       entire class prematurely.</li>
+ *   <li>{@link #matchesExcludeTest(String, String)} applies a heuristic at the class level when
+ *       method name is null, so callers that have multiple ways to match against method names
+ *       don't prematurly "accept" the test when one of the ways does not match any excludes.</li>
  *   <li>{@link #matchesExcludeClass(String)} does <em>not</em> apply the fuzzy heuristic —
  *       pattern {@code Parent} matches {@code Parent} but not {@code Parent$Nested}.</li>
  * </ul>
@@ -97,6 +96,11 @@ class ClassTestSelectionMatcher {
 
     /**
      * Returns true if the given (className, methodName) pair matches any exclude pattern.
+     *
+     * When methodName is null, this may still return true, even if the className matches any
+     * exclude patterns that include a method name.  This is to allow callers that have multiple
+     * ways to match method names to avoid "accepting" the test when one of the ways does not
+     * match any excludes.
      *
      * <p>An empty exclude set returns false. Include patterns are not consulted.</p>
      */

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
@@ -127,6 +127,23 @@ class ClassTestSelectionMatcher {
         return matchesClassAndMethod(buildScriptExcludePatterns, className, methodName);
     }
 
+    /**
+     * Returns true iff the class name exactly matches an exclude pattern's class component.
+     *
+     * <p>Unlike {@link #matchesExcludeTest(String, String)}, this does <em>not</em> consult
+     * the fuzzy {@code mayMatchClass} heuristic: pattern {@code Parent} does not match
+     * class {@code Parent$Nested} here. Used by callers that need a definitive
+     * "is this class excluded?" answer rather than a "might this class match?" hint.</p>
+     */
+    public boolean matchesExcludeClass(String className) {
+        for (ClassTestPattern pattern : buildScriptExcludePatterns) {
+            if (pattern.matchesClass(className)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private boolean matchesClassAndMethod(List<ClassTestPattern> patterns, String className, @Nullable String methodName) {
         for (ClassTestPattern pattern : patterns) {
             if (pattern.matchesClassAndMethod(className, methodName)) {

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
@@ -61,9 +61,28 @@ class ClassTestSelectionMatcher {
 
 
     public boolean matchesTest(String className, @Nullable String methodName) {
+        return matchesIncludeTest(className, methodName) && !matchesExcludeTest(className, methodName);
+    }
+
+    /**
+     * Returns true iff the given (className, methodName) pair matches the include patterns.
+     *
+     * <p>The result is the conjunction of the build-script include patterns and the command-line
+     * include patterns. An empty include set is treated as "everything matches" (vacuously true).
+     * Exclude patterns are <strong>not</strong> consulted.</p>
+     */
+    public boolean matchesIncludeTest(String className, @Nullable String methodName) {
         return matchesPattern(buildScriptIncludePatterns, className, methodName)
-            && matchesPattern(commandLineIncludePatterns, className, methodName)
-            && !matchesExcludePattern(className, methodName);
+            && matchesPattern(commandLineIncludePatterns, className, methodName);
+    }
+
+    /**
+     * Returns true iff the given (className, methodName) pair matches any exclude pattern.
+     *
+     * <p>An empty exclude set returns false. Include patterns are not consulted.</p>
+     */
+    public boolean matchesExcludeTest(String className, @Nullable String methodName) {
+        return matchesExcludePattern(className, methodName);
     }
 
     public boolean mayIncludeClass(String fullQualifiedClassName) {

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/ClassTestSelectionMatcher.java
@@ -87,8 +87,7 @@ class ClassTestSelectionMatcher {
 
     public boolean mayIncludeClass(String fullQualifiedClassName) {
         return mayIncludeClass(buildScriptIncludePatterns, fullQualifiedClassName)
-            && mayIncludeClass(commandLineIncludePatterns, fullQualifiedClassName)
-            && !mayExcludeClass(fullQualifiedClassName);
+            && mayIncludeClass(commandLineIncludePatterns, fullQualifiedClassName);
     }
 
     private boolean mayIncludeClass(List<ClassTestPattern> includePatterns, String fullQualifiedName) {
@@ -96,22 +95,6 @@ class ClassTestSelectionMatcher {
             return true;
         }
         return mayMatchClass(includePatterns, fullQualifiedName);
-    }
-
-    public boolean mayExcludeClass(String fullQualifiedName) {
-        if (buildScriptExcludePatterns.isEmpty()) {
-            return false;
-        }
-        return matchesClass(buildScriptExcludePatterns, fullQualifiedName);
-    }
-
-    private boolean matchesClass(List<ClassTestPattern> patterns, String fullQualifiedName) {
-        for (ClassTestPattern pattern : patterns) {
-            if (pattern.matchesClass(fullQualifiedName)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private boolean mayMatchClass(List<ClassTestPattern> patterns, String fullQualifiedName) {

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -101,6 +101,17 @@ public class TestSelectionMatcher {
     }
 
     /**
+     * Returns true iff the given class name exactly matches an exclude pattern's class component.
+     * Unlike {@link #matchesExcludeTest(String, String)}, this does <em>not</em> apply the fuzzy
+     * {@code mayMatchClass} heuristic.
+     *
+     * @see ClassTestSelectionMatcher#matchesExcludeClass(String)
+     */
+    public boolean matchesExcludeClass(String className) {
+        return classTestSelectionMatcher.matchesExcludeClass(className);
+    }
+
+    /**
      * Returns true if the given fully qualified class name may be included in test execution. This is more optimistic than {@link #matchesTest(String, String)}
      * because some classes may still be excluded later for other reasons.
      *

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -110,7 +110,7 @@ public class TestSelectionMatcher {
     }
 
     /**
-     * Returns true iff the given class name exactly matches an exclude pattern's class component.
+     * Returns true if the given class name exactly matches an exclude pattern's class component.
      * Unlike {@link #matchesExcludeTest(String, String)}, this does <em>not</em> apply the fuzzy
      * {@code mayMatchClass} heuristic.
      *

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -24,22 +24,31 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- * This class has three public APIs:
+ * Entry point for matching test descriptors against include and exclude patterns.
  *
+ * <p>Provides the following queries:
  * <ul>
- * <li>Judge whether a test class might be matched.
- * <li>Judge whether a test class or class+method is definitely matched.
- * <li>Judge whether a test file is definitely matched for resource-based tests.
+ *   <li>{@link #mayIncludeClass(String)} — may a class be included (permissive scan-time check)?</li>
+ *   <li>{@link #matchesTest(String, String)} — does a (class, method) pair match includes and not
+ *       match excludes? Equivalent to {@code matchesIncludeTest && !matchesExcludeTest}.</li>
+ *   <li>{@link #matchesIncludeTest(String, String)} — does a (class, method) match the include
+ *       patterns alone? Empty include sets are treated as vacuously true.</li>
+ *   <li>{@link #matchesExcludeTest(String, String)} — does a (class, method) match any exclude
+ *       pattern? Uses a fuzzy heuristic at the class level (no method) so callers that iterate
+ *       into individual methods can still find exact exclude matches.</li>
+ *   <li>{@link #matchesExcludeClass(String)} — exact variant: only returns true when the class
+ *       name is directly matched by an exclude pattern's class component. Unlike the fuzzy
+ *       {@code matchesExcludeTest}, pattern {@code Parent} does <em>not</em> match nested class
+ *       {@code Parent$Nested} here.</li>
+ *   <li>{@link #matchesFile(java.io.File)} — does a resource-based test file match?</li>
  * </ul>
  *
- * For example, class 'org.gradle.Test' can't be matched by pattern 'org.apache.Test', so
+ * <p>For example, class 'org.gradle.Test' can't be matched by pattern 'org.apache.Test', so
  * {@link #mayIncludeClass(String)} will return false when given 'org.gradle.Test'.
  *
- * In all cases, if the pattern starts with an uppercase letter, matching is performed on the
+ * <p>In all cases, if the pattern starts with an uppercase letter, matching is performed on the
  * simple name of the test. For classes, this is the class name. For resource files, this is
- * the file name without an extension.
- *
- * Otherwise, the pattern will be used to match the fully qualified name of the test.
+ * the file name without an extension. Otherwise, the pattern matches the fully qualified name.
  *
  * @see ClassTestSelectionMatcher
  * @see FileTestSelectionMatcher

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -82,6 +82,25 @@ public class TestSelectionMatcher {
     }
 
     /**
+     * Returns true if the given class and method matches the include patterns (build-script and command-line).
+     * Exclude patterns are <strong>not</strong> consulted.
+     *
+     * @see ClassTestSelectionMatcher#matchesIncludeTest(String, String)
+     */
+    public boolean matchesIncludeTest(String className, @Nullable String methodName) {
+        return classTestSelectionMatcher.matchesIncludeTest(className, methodName);
+    }
+
+    /**
+     * Returns true if the given class and method matches any exclude pattern. Include patterns are not consulted.
+     *
+     * @see ClassTestSelectionMatcher#matchesExcludeTest(String, String)
+     */
+    public boolean matchesExcludeTest(String className, @Nullable String methodName) {
+        return classTestSelectionMatcher.matchesExcludeTest(className, methodName);
+    }
+
+    /**
      * Returns true if the given fully qualified class name may be included in test execution. This is more optimistic than {@link #matchesTest(String, String)}
      * because some classes may still be excluded later for other reasons.
      *

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -97,10 +97,10 @@ public class TestSelectionMatcher {
      * Unlike {@link #matchesExcludeTest(String, String)}, this does <em>not</em> apply the fuzzy
      * {@code mayMatchClass} heuristic.
      *
-     * @see ClassTestSelectionMatcher#matchesExcludeClass(String)
+     * @see ClassTestSelectionMatcher#matchesExcludeClassExactly(String)
      */
-    public boolean matchesExcludeClass(String className) {
-        return classTestSelectionMatcher.matchesExcludeClass(className);
+    public boolean matchesExcludeClassExactly(String className) {
+        return classTestSelectionMatcher.matchesExcludeClassExactly(className);
     }
 
     /**

--- a/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/platforms/software/testing-base-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -26,23 +26,6 @@ import java.util.Collections;
 /**
  * Entry point for matching test descriptors against include and exclude patterns.
  *
- * <p>Provides the following queries:
- * <ul>
- *   <li>{@link #mayIncludeClass(String)} — may a class be included (permissive scan-time check)?</li>
- *   <li>{@link #matchesTest(String, String)} — does a (class, method) pair match includes and not
- *       match excludes? Equivalent to {@code matchesIncludeTest && !matchesExcludeTest}.</li>
- *   <li>{@link #matchesIncludeTest(String, String)} — does a (class, method) match the include
- *       patterns alone? Empty include sets are treated as vacuously true.</li>
- *   <li>{@link #matchesExcludeTest(String, String)} — does a (class, method) match any exclude
- *       pattern? Uses a fuzzy heuristic at the class level (no method) so callers that iterate
- *       into individual methods can still find exact exclude matches.</li>
- *   <li>{@link #matchesExcludeClass(String)} — exact variant: only returns true when the class
- *       name is directly matched by an exclude pattern's class component. Unlike the fuzzy
- *       {@code matchesExcludeTest}, pattern {@code Parent} does <em>not</em> match nested class
- *       {@code Parent$Nested} here.</li>
- *   <li>{@link #matchesFile(java.io.File)} — does a resource-based test file match?</li>
- * </ul>
- *
  * <p>For example, class 'org.gradle.Test' can't be matched by pattern 'org.apache.Test', so
  * {@link #mayIncludeClass(String)} will return false when given 'org.gradle.Test'.
  *
@@ -91,7 +74,7 @@ public class TestSelectionMatcher {
     }
 
     /**
-     * Returns true if the given class and method matches the include patterns (build-script and command-line).
+     * Returns true if the given class and method matches the include patterns.
      * Exclude patterns are <strong>not</strong> consulted.
      *
      * @see ClassTestSelectionMatcher#matchesIncludeTest(String, String)

--- a/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -24,318 +24,286 @@ class TestSelectionMatcherTest extends Specification {
 
     def "knows if test matches class"() {
         expect:
-        matcher(input, [], []).matchesTest(className, methodName) == match
-        matcher([], [], input).matchesTest(className, methodName) == match
+        assertMatchesTest(pattern, patternMatches, patternDoesNotMatch)
 
         where:
-        input                    | className                 | methodName            | match
-        ["FooTest"]              | "FooTest"                 | "whatever"            | true
-        ["FooTest"]              | "fooTest"                 | "whatever"            | false
-
-        ["com.foo.FooTest"]      | "com.foo.FooTest"         | "x"                   | true
-        ["com.foo.FooTest"]      | "FooTest"                 | "x"                   | false
-        ["com.foo.FooTest"]      | "com_foo_FooTest"         | "x"                   | false
-
-        ["com.foo.FooTest.*"]    | "com.foo.FooTest"         | "aaa"                 | true
-        ["com.foo.FooTest.*"]    | "com.foo.FooTest"         | "bbb"                 | true
-        ["com.foo.FooTest.*"]    | "com.foo.FooTestx"        | "bbb"                 | false
-
-        ["*.FooTest.*"]          | "com.foo.FooTest"         | "aaa"                 | true
-        ["*.FooTest.*"]          | "com.bar.FooTest"         | "aaa"                 | true
-        ["*.FooTest.*"]          | "FooTest"                 | "aaa"                 | false
-
-        ["com*FooTest"]          | "com.foo.FooTest"         | "aaa"                 | true
-        ["com*FooTest"]          | "com.FooTest"             | "bbb"                 | true
-        ["com*FooTest"]          | "FooTest"                 | "bbb"                 | false
-
-        ["*.foo.*"]              | "com.foo.FooTest"         | "aaaa"                | true
-        ["*.foo.*"]              | "com.foo.bar.BarTest"     | "aaaa"                | true
-        ["*.foo.*"]              | "foo.Test"                | "aaaa"                | false
-        ["*.foo.*"]              | "fooTest"                 | "aaaa"                | false
-        ["*.foo.*"]              | "foo"                     | "aaaa"                | false
+        // patternMatches and patternDoesNotMatch entries are [className, methodName] tuples
+        pattern               | patternMatches                                                 | patternDoesNotMatch
+        ["FooTest"]           | [["FooTest", "whatever"]]                                      | [["fooTest", "whatever"]]
+        ["com.foo.FooTest"]   | [["com.foo.FooTest", "x"]]                                     | [["FooTest", "x"], ["com_foo_FooTest", "x"]]
+        ["com.foo.FooTest.*"] | [["com.foo.FooTest", "aaa"], ["com.foo.FooTest", "bbb"]]       | [["com.foo.FooTestx", "bbb"]]
+        ["*.FooTest.*"]       | [["com.foo.FooTest", "aaa"], ["com.bar.FooTest", "aaa"]]       | [["FooTest", "aaa"]]
+        ["com*FooTest"]       | [["com.foo.FooTest", "aaa"], ["com.FooTest", "bbb"]]           | [["FooTest", "bbb"]]
+        ["*.foo.*"]           | [["com.foo.FooTest", "aaaa"], ["com.foo.bar.BarTest", "aaaa"]] | [["foo.Test", "aaaa"], ["fooTest", "aaaa"], ["foo", "aaaa"]]
     }
 
     def "knows if excluded test matches class"() {
         expect:
-        matcher([], input, []).matchesTest(className, methodName) == match
+        for (pair in patternMatches) {
+            def (className, methodName) = pair
+            assert !matcher([], pattern, []).matchesTest(className, methodName) : "excludedTests=$pattern expected to match [$className, $methodName]"
+        }
+        for (pair in patternDoesNotMatch) {
+            def (className, methodName) = pair
+            assert matcher([], pattern, []).matchesTest(className, methodName) : "excludedTests=$pattern expected NOT to match [$className, $methodName]"
+        }
 
         where:
-        input                    | className                 | methodName            | match
-        ["FooTest"]              | "FooTest"                 | "whatever"            | false
-        ["FooTest"]              | "fooTest"                 | "whatever"            | true
-
-        ["com.foo.FooTest"]      | "com.foo.FooTest"         | "x"                   | false
-        ["com.foo.FooTest"]      | "FooTest"                 | "x"                   | true
-        ["com.foo.FooTest"]      | "com_foo_FooTest"         | "x"                   | true
-
-        ["com.foo.FooTest.*"]    | "com.foo.FooTest"         | "aaa"                 | false
-        ["com.foo.FooTest.*"]    | "com.foo.FooTest"         | "bbb"                 | false
-        ["com.foo.FooTest.*"]    | "com.foo.FooTestx"        | "bbb"                 | true
-
-        ["*.FooTest.*"]          | "com.foo.FooTest"         | "aaa"                 | false
-        ["*.FooTest.*"]          | "com.bar.FooTest"         | "aaa"                 | false
-        ["*.FooTest.*"]          | "FooTest"                 | "aaa"                 | true
-
-        ["com*FooTest"]          | "com.foo.FooTest"         | "aaa"                 | false
-        ["com*FooTest"]          | "com.FooTest"             | "bbb"                 | false
-        ["com*FooTest"]          | "FooTest"                 | "bbb"                 | true
-
-        ["*.foo.*"]              | "com.foo.FooTest"         | "aaaa"                | false
-        ["*.foo.*"]              | "com.foo.bar.BarTest"     | "aaaa"                | false
-        ["*.foo.*"]              | "foo.Test"                | "aaaa"                | true
-        ["*.foo.*"]              | "fooTest"                 | "aaaa"                | true
-        ["*.foo.*"]              | "foo"                     | "aaaa"                | true
+        // patternMatches and patternDoesNotMatch entries are [className, methodName] tuples
+        pattern               | patternMatches                                                 | patternDoesNotMatch
+        ["FooTest"]           | [["FooTest", "whatever"]]                                      | [["fooTest", "whatever"]]
+        ["com.foo.FooTest"]   | [["com.foo.FooTest", "x"]]                                     | [["FooTest", "x"], ["com_foo_FooTest", "x"]]
+        ["com.foo.FooTest.*"] | [["com.foo.FooTest", "aaa"], ["com.foo.FooTest", "bbb"]]       | [["com.foo.FooTestx", "bbb"]]
+        ["*.FooTest.*"]       | [["com.foo.FooTest", "aaa"], ["com.bar.FooTest", "aaa"]]       | [["FooTest", "aaa"]]
+        ["com*FooTest"]       | [["com.foo.FooTest", "aaa"], ["com.FooTest", "bbb"]]           | [["FooTest", "bbb"]]
+        ["*.foo.*"]           | [["com.foo.FooTest", "aaaa"], ["com.foo.bar.BarTest", "aaaa"]] | [["foo.Test", "aaaa"], ["fooTest", "aaaa"], ["foo", "aaaa"]]
     }
 
     def "knows if test matches"() {
         expect:
-        matcher(input, [], []).matchesTest(className, methodName) == match
-        matcher([], [], input).matchesTest(className, methodName) == match
+        assertMatchesTest(pattern, patternMatches, patternDoesNotMatch)
 
         where:
-        input                    | className                 | methodName            | match
-        ["FooTest.test"]         | "FooTest"                 | "test"                | true
-        ["FooTest.test"]         | "Footest"                 | "test"                | false
-        ["FooTest.test"]         | "FooTest"                 | "TEST"                | false
-        ["FooTest.test"]         | "com.foo.FooTest"         | "test"                | true
-        ["FooTest.test"]         | "Foo.test"                | ""                    | false
-
-        ["FooTest.*slow*"]       | "FooTest"                 | "slowUiTest"          | true
-        ["FooTest.*slow*"]       | "FooTest"                 | "veryslowtest"        | true
-        ["FooTest.*slow*"]       | "FooTest.SubTest"         | "slow"                | false
-        ["FooTest.*slow*"]       | "FooTest"                 | "a slow test"         | true
-        ["FooTest.*slow*"]       | "FooTest"                 | "aslow"               | true
-        ["FooTest.*slow*"]       | "com.foo.FooTest"         | "slowUiTest"          | true
-        ["FooTest.*slow*"]       | "FooTest"                 | "verySlowTest"        | false
-
-        ["com.FooTest***slow*"]  | "com.FooTest"             | "slowMethod"          | true
-        ["com.FooTest***slow*"]  | "com.FooTest2"            | "aslow"               | true
-        ["com.FooTest***slow*"]  | "com.FooTest.OtherTest"   | "slow"                | true
-        ["com.FooTest***slow*"]  | "FooTest"                 | "slowMethod"          | false
+        // patternMatches and patternDoesNotMatch entries are [className, methodName] tuples
+        pattern                 | patternMatches                                                                                                                                                              | patternDoesNotMatch
+        ["FooTest.test"]        | [["FooTest", "test"], ["com.foo.FooTest", "test"]]                                                                                                                          | [["Footest", "test"], ["FooTest", "TEST"], ["Foo.test", ""]]
+        ["FooTest.*slow*"]      | [["FooTest", "slowUiTest"], ["FooTest", "veryslowtest"], ["FooTest", "a slow test"], ["FooTest", "aslow"], ["com.foo.FooTest", "slowUiTest"]]                               | [["FooTest.SubTest", "slow"], ["FooTest", "verySlowTest"]]
+        ["com.FooTest***slow*"] | [["com.FooTest", "slowMethod"], ["com.FooTest2", "aslow"], ["com.FooTest.OtherTest", "slow"]]                                                                               | [["FooTest", "slowMethod"]]
     }
 
     def "matches any of input"() {
         expect:
-        matcher(input, [], []).matchesTest(className, methodName) == match
-        matcher([], [], input).matchesTest(className, methodName) == match
+        assertMatchesTest(pattern, patternMatches, patternDoesNotMatch)
 
         where:
-        input                               | className                 | methodName            | match
-        ["FooTest.test", "FooTest.bar"]     | "FooTest"                 | "test"                | true
-        ["FooTest.test", "FooTest.bar"]     | "FooTest"                 | "bar"                 | true
-        ["FooTest.test", "FooTest.bar"]     | "FooTest"                 | "baz"                 | false
-        ["FooTest.test", "FooTest.bar"]     | "Footest"                 | "test"                | false
-
-        ["FooTest.test", "BarTest.*"]       | "FooTest"                 | "test"                | true
-        ["FooTest.test", "BarTest.*"]       | "BarTest"                 | "xxxx"                | true
-        ["FooTest.test", "BarTest.*"]       | "FooTest"                 | "xxxx"                | false
-
-        ["FooTest.test", "FooTest.*fast*"]  | "FooTest"                 | "test"                | true
-        ["FooTest.test", "FooTest.*fast*"]  | "FooTest"                 | "fast"                | true
-        ["FooTest.test", "FooTest.*fast*"]  | "FooTest"                 | "a fast test"         | true
-        ["FooTest.test", "FooTest.*fast*"]  | "FooTest"                 | "xxxx"                | false
-
-        ["FooTest", "*BarTest"]             | "FooTest"                 | "test"                | true
-        ["FooTest", "*BarTest"]             | "FooTest"                 | "xxxx"                | true
-        ["FooTest", "*BarTest"]             | "BarTest"                 | "xxxx"                | true
-        ["FooTest", "*BarTest"]             | "com.foo.BarTest"         | "xxxx"                | true
-        ["FooTest", "*BarTest"]             | "com.foo.FooTest"         | "xxxx"                | true
+        // patternMatches and patternDoesNotMatch entries are [className, methodName] tuples
+        pattern                            | patternMatches                                                                                                                    | patternDoesNotMatch
+        ["FooTest.test", "FooTest.bar"]    | [["FooTest", "test"], ["FooTest", "bar"]]                                                                                         | [["FooTest", "baz"], ["Footest", "test"]]
+        ["FooTest.test", "BarTest.*"]      | [["FooTest", "test"], ["BarTest", "xxxx"]]                                                                                        | [["FooTest", "xxxx"]]
+        ["FooTest.test", "FooTest.*fast*"] | [["FooTest", "test"], ["FooTest", "fast"], ["FooTest", "a fast test"]]                                                            | [["FooTest", "xxxx"]]
+        ["FooTest", "*BarTest"]            | [["FooTest", "test"], ["FooTest", "xxxx"], ["BarTest", "xxxx"], ["com.foo.BarTest", "xxxx"], ["com.foo.FooTest", "xxxx"]]         | [["BazTest", "xxxx"]]
     }
 
-    def "regexp chars are handled"() {
+    def "globbing is handled"() {
         expect:
-        matcher(input, [], []).matchesTest(className, methodName) == match
-        matcher([], [], input).matchesTest(className, methodName) == match
+        assertMatchesTest(pattern, patternMatches, patternDoesNotMatch)
 
         where:
-        input                               | className                 | methodName            | match
-        ["*Foo+Bar*"]                       | "Foo+Bar"                 | "test"                | true
-        ["*Foo+Bar*"]                       | "Foo+Bar"                 | "xxxx"                | true
-        ["*Foo+Bar*"]                       | "com.Foo+Bar"             | "xxxx"                | true
-        ["*Foo+Bar*"]                       | "FooBar"                  | "xxxx"                | false
+        // patternMatches and patternDoesNotMatch entries are [className, methodName] tuples
+        pattern        | patternMatches                                                                                    | patternDoesNotMatch
+        ["*Foo+Bar*"]  | [["Foo+Bar", "test"], ["Foo+Bar", "xxxx"], ["com.Foo+Bar", "xxxx"], ["com.Foo+BarBaz", "xxxx"]]   | [["FooBar", "xxxx"], ["Foo+bar", "xxxx"]]
+        ["*Foo*Bar"]   | [["FooSomethingBar", "test"], ["Foo---Bar", "test"], ["com.Foo-Bar", "xxxx"], ["FooBar", "xxxx"]] | [["Foobar", "xxxx"], ["FooBaar", "xxxx"]]
     }
 
     def "handles null test method"() {
         expect:
-        matcher(input, [], []).matchesTest(className, methodName) == match
-        matcher([], [], input).matchesTest(className, methodName) == match
+        assertMatchesTest(pattern, patternMatches, patternDoesNotMatch)
 
         where:
-        input                               | className                 | methodName            | match
-        ["FooTest"]                         | "FooTest"                 | null                  | true
-        ["FooTest*"]                        | "FooTest"                 | null                  | true
-
-        ["FooTest.*"]                       | "FooTest"                 | null                  | false
-        ["FooTest"]                         | "OtherTest"               | null                  | false
-        ["FooTest.test"]                    | "FooTest"                 | null                  | false
-        ["FooTest.null"]                    | "FooTest"                 | null                  | false
+        // patternMatches and patternDoesNotMatch entries are [className, methodName] tuples
+        pattern           | patternMatches          | patternDoesNotMatch
+        ["FooTest"]       | [["FooTest", null]]     | [["OtherTest", null]]
+        ["FooTest*"]      | [["FooTest", null]]     | [["OtherTest", null]]
+        ["FooTest.*"]     | [["FooTest", "test"]]   | [["FooTest", null]]
+        ["FooTest.test"]  | [["FooTest", "test"]]   | [["FooTest", null]]
+        ["FooTest.null"]  | []                      | [["FooTest", null]]
     }
 
     def "script includes and command line includes both have to match"() {
         expect:
-        matcher(input, [], inputCommandLine).matchesTest(className, methodName) == match
+        for (pair in matches) {
+            def (className, methodName) = pair
+            assert matcher(buildScript, [], inputCommandLine).matchesTest(className, methodName) : "input=$buildScript, inputCommandLine=$inputCommandLine expected to match [$className, $methodName]"
+        }
+        for (pair in doesNotMatch) {
+            def (className, methodName) = pair
+            assert !matcher(buildScript, [], inputCommandLine).matchesTest(className, methodName) : "input=$buildScript, inputCommandLine=$inputCommandLine expected NOT to match [$className, $methodName]"
+        }
 
         where:
-        input               | inputCommandLine | className  | methodName | match
-        ["FooTest", "Bar" ] | []               | "FooTest"  | "whatever" | true
-        ["FooTest"]         | ["Bar"]          | "FooTest"  | "whatever" | false
+        // matches and doesNotMatch entries are [className, methodName] tuples
+        buildScript         | inputCommandLine | matches                                        | doesNotMatch
+        ["FooTest", "Bar"]  | []               | [["FooTest", "whatever"], ["Bar", "whatever"]] | [["Baz", "whatever"]]
+        ["FooTest"]         | ["Bar"]          | []                                             | [["FooTest", "whatever"], ["Bar", "whatever"]]
+        ["FooTest"]         | ["FooTest"]      | [["FooTest", "whatever"]]                      | [["Bar", "whatever"]]
     }
 
-    def 'can exclude as many classes as possible'() {
+    def 'can exclude as many classes as possible with mayIncludeClass'() {
         expect:
-        matcher(input, [], []).mayIncludeClass(fullQualifiedName) == maybeMatch
-        matcher([], [], input).mayIncludeClass(fullQualifiedName) == maybeMatch
+        for (fqn in patternMatches) {
+            assert matcher(pattern, [], []).mayIncludeClass(fqn) : "includedTests=$pattern expected to possibly include $fqn"
+            assert matcher([], [], pattern).mayIncludeClass(fqn) : "includedTestsCommandLine=$pattern expected to possibly include $fqn"
+        }
+        for (fqn in patternDoesNotMatch) {
+            assert !matcher(pattern, [], []).mayIncludeClass(fqn) : "includedTests=$pattern expected NOT to possibly include $fqn"
+            assert !matcher([], [], pattern).mayIncludeClass(fqn) : "includedTestsCommandLine=$pattern expected NOT to possibly include $fqn"
+        }
 
         where:
-        input                             | fullQualifiedName    | maybeMatch
-        ['.']                             | 'FooTest'            | false
-        ['.FooTest.']                     | 'FooTest'            | false
-        ['FooTest']                       | 'FooTest'            | true
-        ['FooTest']                       | 'org.gradle.FooTest' | true
-        ['FooTest']                       | 'org.foo.FooTest'    | true
-        ['FooTest']                       | 'BarTest'            | false
-        ['FooTest']                       | 'org.gradle.BarTest' | false
-        ['FooTest.testMethod']            | 'FooTest'            | true
-        ['FooTest.testMethod']            | 'BarTest'            | false
-        ['FooTest.testMethod']            | 'org.gradle.FooTest' | true
-        ['FooTest.testMethod']            | 'org.gradle.BarTest' | false
-        ['org.gradle.FooTest.testMethod'] | 'FooTest'            | false
-        ['org.gradle.FooTest.testMethod'] | 'org.gradle.FooTest' | true
-        ['org.gradle.FooTest.testMethod'] | 'org.gradle.BarTest' | false
-        ['org.foo.FooTest.testMethod']    | 'org.gradle.FooTest' | false
-        ['org.foo.FooTest']               | 'org.gradle.FooTest' | false
+        pattern                           | patternMatches                                                             | patternDoesNotMatch
+        ['.']                             | []                                                                         | ['FooTest']
+        ['.FooTest.']                     | []                                                                         | ['FooTest']
+        ['FooTest']                       | ['FooTest', 'org.gradle.FooTest', 'org.foo.FooTest']                       | ['BarTest', 'org.gradle.BarTest']
+        ['FooTest.testMethod']            | ['FooTest', 'org.gradle.FooTest']                                          | ['BarTest', 'org.gradle.BarTest']
+        ['org.gradle.FooTest.testMethod'] | ['org.gradle.FooTest']                                                     | ['FooTest', 'org.gradle.BarTest']
+        ['org.foo.FooTest.testMethod']    | []                                                                         | ['org.gradle.FooTest']
+        ['org.foo.FooTest']               | []                                                                         | ['org.gradle.FooTest']
 
-        ['*FooTest*']                     | 'org.gradle.FooTest' | true
-        ['*FooTest*']                     | 'aaa'                | true
-        ['*FooTest']                      | 'org.gradle.FooTest' | true
-        ['*FooTest']                      | 'FooTest'            | true
-        ['*FooTest']                      | 'org.gradle.BarTest' | true // org.gradle.BarTest.testFooTest
+        ['*FooTest*']                     | ['org.gradle.FooTest', 'aaa']                                              | []
+        ['*FooTest']                      | ['org.gradle.FooTest', 'FooTest', 'org.gradle.BarTest' /* .testFooTest */] | []
 
-        ['or*']                           | 'org.gradle.FooTest' | true
-        ['org*']                          | 'org.gradle.FooTest' | true
-        ['org.*']                         | 'org.gradle.FooTest' | true
-        ['org.g*']                        | 'org.gradle.FooTest' | true
-        ['org*']                          | 'FooTest'            | false
-        ['org.*']                         | 'com.gradle.FooTest' | false
-        ['org*']                          | 'com.gradle.FooTest' | false
-        ['org.*']                         | 'com.gradle.FooTest' | false
-        ['org.g*']                        | 'com.gradle.FooTest' | false
-        ['FooTest*']                      | 'FooTest'            | true
-        ['FooTest*']                      | 'org.gradle.FooTest' | true
-        ['FooTest*']                      | 'BarTest'            | false
-        ['FooTest*']                      | 'org.gradle.BarTest' | false
-        ['org.gradle.FooTest*']           | 'org.gradle.BarTest' | false
-        ['FooTest.testMethod*']           | 'FooTest'            | true
-        ['FooTest.testMethod*']           | 'org.gradle.FooTest' | true
-        ['org.foo.FooTest*']              | 'FooTest'            | false
-        ['org.foo.FooTest*']              | 'org.gradle.FooTest' | false
-        ['org.foo.*FooTest*']             | 'org.gradle.FooTest' | false
-        ['org.foo.*FooTest*']             | 'org.foo.BarTest'    | true // org.foo.BarTest.testFooTest
+        ['or*']                           | ['org.gradle.FooTest']                                                     | []
+        ['org*']                          | ['org.gradle.FooTest']                                                     | ['FooTest', 'com.gradle.FooTest']
+        ['org.*']                         | ['org.gradle.FooTest']                                                     | ['com.gradle.FooTest']
+        ['org.g*']                        | ['org.gradle.FooTest']                                                     | ['com.gradle.FooTest']
+        ['FooTest*']                      | ['FooTest', 'org.gradle.FooTest']                                          | ['BarTest', 'org.gradle.BarTest']
+        ['org.gradle.FooTest*']           | []                                                                         | ['org.gradle.BarTest']
+        ['FooTest.testMethod*']           | ['FooTest', 'org.gradle.FooTest']                                          | []
+        ['org.foo.FooTest*']              | []                                                                         | ['FooTest', 'org.gradle.FooTest']
+        ['org.foo.*FooTest*']             | ['org.foo.BarTest' /* .testFooTest */]                                     | ['org.gradle.FooTest']
 
-        ['Foo']                           | 'FooTest'            | false
-        ['org.gradle.Foo']                | 'org.gradle.FooTest' | false
-        ['org.gradle.Foo.*']              | 'org.gradle.FooTest' | false
+        ['Foo']                           | []                                                                         | ['FooTest']
+        ['org.gradle.Foo']                | []                                                                         | ['org.gradle.FooTest']
+        ['org.gradle.Foo.*']              | []                                                                         | ['org.gradle.FooTest']
 
-        ['org.gradle.Foo$Bar.*test']      | 'Foo'                | false
-        ['org.gradle.Foo$Bar.*test']      | 'org.Foo'            | false
-        ['org.gradle.Foo$Bar.*test']      | 'org.gradle.Foo'     | true
-        ['Enclosing$Nested.test']         | "Enclosing"          | true
-        ['org.gradle.Foo$1$2.test']       | "org.gradle.Foo"     | true
+        ['org.gradle.Foo$Bar.*test']      | ['org.gradle.Foo']                                                         | ['Foo', 'org.Foo']
+        ['Enclosing$Nested.test']         | ['Enclosing']                                                              | []
+        ['org.gradle.Foo$1$2.test']       | ['org.gradle.Foo']                                                         | []
     }
 
-    def 'can use multiple patterns'() {
+    def 'can use multiple patterns with mayIncludeClass'() {
         expect:
-        matcher(pattern1, [], pattern2).mayIncludeClass(fullQualifiedName) == maybeMatch
+        for (fqn in matches) {
+            assert matcher(pattern1, [], pattern2).mayIncludeClass(fqn) : "pattern1=$pattern1, pattern2=$pattern2 expected to possibly include $fqn"
+        }
+        for (fqn in doesNotMatch) {
+            assert !matcher(pattern1, [], pattern2).mayIncludeClass(fqn) : "pattern1=$pattern1, pattern2=$pattern2 expected NOT to possibly include $fqn"
+        }
 
         where:
-        pattern1                | pattern2                        | fullQualifiedName     | maybeMatch
-        ['']                    | ['com.my.Test.test[first.com]'] | 'com.my.Test'         | true
-        ['FooTest*']            | ['FooTest']                     | 'FooTest'             | true
-        ['FooTest*']            | ['BarTest*']                    | 'FooTest'             | false
-        ['FooTest*']            | ['BarTest*']                    | 'FooBarTest'          | false
-        []                      | []                              | 'anything'            | true
-        ['org.gradle.FooTest*'] | ['org.gradle.BarTest*']         | 'org.gradle.FooTest'  | false
-        ['org.gradle.FooTest*'] | ['*org.gradle.BarTest*']        | 'org.gradle.FooTest'  | true
+        pattern1                | pattern2                        | matches                | doesNotMatch
+        []                      | []                              | ['anything']           | []
+        ['']                    | ['com.my.Test.test[first.com]'] | ['com.my.Test']        | []
+        ['FooTest*']            | ['FooTest']                     | ['FooTest']            | []
+        ['FooTest*']            | ['BarTest*']                    | []                     | ['FooTest', 'FooBarTest']
+        ['org.gradle.FooTest*'] | ['org.gradle.BarTest*']         | []                     | ['org.gradle.FooTest']
+        ['org.gradle.FooTest*'] | ['*org.gradle.BarTest*']        | ['org.gradle.FooTest'] | []
     }
 
     def "matchesIncludeTest ignores exclude patterns"() {
         expect:
-        matcher(includes, excludes, []).matchesIncludeTest(className, methodName) == match
+        for (pair in matches) {
+            def (className, methodName) = pair
+            assert matcher(includes, excludes, []).matchesIncludeTest(className, methodName) : "includes=$includes, excludes=$excludes expected to match [$className, $methodName]"
+        }
+        for (pair in doesNotMatch) {
+            def (className, methodName) = pair
+            assert !matcher(includes, excludes, []).matchesIncludeTest(className, methodName) : "includes=$includes, excludes=$excludes expected NOT to match [$className, $methodName]"
+        }
 
         where:
-        includes           | excludes           | className         | methodName       | match
-        []                 | ["FooTest"]        | "FooTest"         | "aaa"            | true
-        ["FooTest"]        | ["FooTest"]        | "FooTest"         | "aaa"            | true
-        ["FooTest"]        | ["FooTest"]        | "FooTest"         | null             | true
-        ["FooTest.aaa"]    | ["FooTest"]        | "FooTest"         | "aaa"            | true
-        ["FooTest.aaa"]    | ["FooTest"]        | "FooTest"         | "bbb"            | false
-        ["FooTest"]        | ["FooTest.aaa"]    | "FooTest"         | "aaa"            | true
+        // matches and doesNotMatch entries are [className, methodName] tuples
+        includes         | excludes        | matches                                                     | doesNotMatch
+        []               | ["FooTest"]     | [["FooTest", "aaa"]]                                        | []
+        ["FooTest"]      | ["FooTest"]     | [["FooTest", null], ["FooTest", "aaa"], ["FooTest", "bbb"]] | [["BarTest", "aaa"]]
+        ["FooTest.aaa"]  | ["FooTest"]     | [["FooTest", "aaa"]]                                        | [["FooTest", null], ["FooTest", "bbb"], ["BarTest", "aaa"]]
+        ["FooTest"]      | ["FooTest.aaa"] | [["FooTest", null], ["FooTest", "aaa"], ["FooTest", "bbb"]] | [["BarTest", "aaa"]]
     }
 
     def "matchesIncludeTest returns the AND of build-script and command-line includes"() {
         expect:
-        matcher(buildScript, [], commandLine).matchesIncludeTest(className, null) == match
+        for (className in matches) {
+            assert matcher(buildScript, [], commandLine).matchesIncludeTest(className, null) : "buildScript=$buildScript, commandLine=$commandLine expected to match $className"
+        }
+        for (className in doesNotMatch) {
+            assert !matcher(buildScript, [], commandLine).matchesIncludeTest(className, null) : "buildScript=$buildScript, commandLine=$commandLine expected NOT to match $className"
+        }
 
         where:
-        buildScript        | commandLine       | className         | match
-        []                 | []                | "FooTest"         | true
-        ["FooTest"]        | []                | "FooTest"         | true
-        []                 | ["FooTest"]       | "FooTest"         | true
-        ["FooTest"]        | ["FooTest"]       | "FooTest"         | true
-        ["FooTest"]        | ["BarTest"]       | "FooTest"         | false
-        ["FooTest"]        | ["BarTest"]       | "BarTest"         | false
+        buildScript  | commandLine  | matches      | doesNotMatch
+        []           | []           | ["FooTest"]  | []
+        ["FooTest"]  | []           | ["FooTest"]  | ["BarTest"]
+        []           | ["FooTest"]  | ["FooTest"]  | ["BarTest"]
+        ["FooTest"]  | ["FooTest"]  | ["FooTest"]  | ["BarTest"]
+        ["FooTest"]  | ["BarTest"]  | []           | ["FooTest", "BarTest"]
     }
 
     def "matchesExcludeTest correctly matches on exclude patterns"() {
         expect:
-        matcher([], excludes, []).matchesExcludeTest(className, methodName) == match
+        for (pair in patternMatches) {
+            def (className, methodName) = pair
+            assert matcher([], pattern, []).matchesExcludeTest(className, methodName) : "excludedTests=$pattern expected to match [$className, $methodName]"
+        }
+        for (pair in patternDoesNotMatch) {
+            def (className, methodName) = pair
+            assert !matcher([], pattern, []).matchesExcludeTest(className, methodName) : "excludedTests=$pattern expected NOT to match [$className, $methodName]"
+        }
 
         where:
-        excludes                   | className                        | methodName         | match
-        []                         | "FooTest"                        | null               | false
-        ["FooTest"]                | "FooTest"                        | null               | true
-        ["FooTest"]                | "BarTest"                        | null               | false
-        ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
-        ["FooTest.doThing"]        | "FooTest"                        | "doOther"          | false
+        // patternMatches and patternDoesNotMatch entries are [className, methodName] tuples
+        pattern             | patternMatches                              | patternDoesNotMatch
+        []                  | []                                          | [["FooTest", null], ["FooTest", "doThing"], ["BarTest", null], ["BarTest", "doThing"]]
+        ["FooTest"]         | [["FooTest", null], ["FooTest", "doThing"]] | [["BarTest", null], ["BarTest", "doThing"]]
+        // Note that ["FooTest", null] matches because of multiple ways to match on method patterns - see ClassTestSelectionMatcher.matchesExcludeTest()
+        ["FooTest.doThing"] | [["FooTest", null], ["FooTest", "doThing"]] | [["FooTest", "doOther"], ["BarTest", null], ["BarTest", "doThing"]]
     }
 
     def "matchesExcludeTest ignores include patterns"() {
         expect:
-        matcher(includes, excludes, []).matchesExcludeTest(className, methodName) == match
+        for (pair in matches) {
+            def (className, methodName) = pair
+            assert matcher(includes, excludes, []).matchesExcludeTest(className, methodName) : "includes=$includes, excludes=$excludes expected to match [$className, $methodName]"
+        }
+        for (pair in doesNotMatch) {
+            def (className, methodName) = pair
+            assert !matcher(includes, excludes, []).matchesExcludeTest(className, methodName) : "includes=$includes, excludes=$excludes expected NOT to match [$className, $methodName]"
+        }
 
         where:
-        includes           | excludes                   | className                        | methodName         | match
-        ["BarTest"]        | ["FooTest"]                | "FooTest"                        | null               | true
-        ["FooTest"]        | ["FooTest"]                | "FooTest"                        | null               | true
-        ["BarTest"]        | ["FooTest"]                | "BarTest"                        | null               | false
-        ["BarTest"]        | ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
-        ["BarTest"]        | ["FooTest.doThing"]        | "FooTest"                        | "doOther"          | false
-        ["FooTest"]        | ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
-        ["FooTest.doThing"]| ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
+        // matches and doesNotMatch entries are [className, methodName] tuples
+        includes            | excludes            | matches                                     | doesNotMatch
+        ["BarTest"]         | ["FooTest"]         | [["FooTest", null], ["FooTest", "doThing"]] | [["BarTest", null], ["BarTest", "doThing"]]
+        ["FooTest"]         | ["FooTest"]         | [["FooTest", null], ["FooTest", "doThing"]] | [["BarTest", null], ["BarTest", "doThing"]]
+        // Note that ["FooTest", null] matches because of multiple ways to match on method patterns - see ClassTestSelectionMatcher.matchesExcludeTest()
+        ["BarTest"]         | ["FooTest.doThing"] | [["FooTest", null], ["FooTest", "doThing"]] | [["FooTest", "doOther"], ["BarTest", null], ["BarTest", "doThing"]]
+        ["FooTest"]         | ["FooTest.doThing"] | [["FooTest", null], ["FooTest", "doThing"]] | [["FooTest", "doOther"], ["BarTest", null], ["BarTest", "doThing"]]
+        ["FooTest.doThing"] | ["FooTest.doThing"] | [["FooTest", null], ["FooTest", "doThing"]] | [["FooTest", "doOther"], ["BarTest", null], ["BarTest", "doThing"]]
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37539")
     def "matchesExcludeClass is exact and does not treat parent pattern as matching nested class"() {
         expect:
-        matcher([], [excludePattern], []).matchesExcludeClassExactly(className) == match
+        for (className in patternMatches) {
+            assert matcher([], [pattern], []).matchesExcludeClassExactly(className) : "excludedTests=[$pattern] expected to match exactly $className"
+        }
+        for (className in patternDoesNotMatch) {
+            assert !matcher([], [pattern], []).matchesExcludeClassExactly(className) : "excludedTests=[$pattern] expected NOT to match exactly $className"
+        }
 
         where:
-        excludePattern                                    | className                                         | match
-        "SampleTest"                                      | "SampleTest"                                      | true
-        "SampleTest"                                      | "SampleTest\$NestedTestClass"                     | false
-        "SampleTest"                                      | "SampleTest\$NestedTestClass\$SubNestedTestClass" | false
-        "SampleTest\$NestedTestClass"                     | "SampleTest"                                      | false
-        "SampleTest\$NestedTestClass"                     | "SampleTest\$NestedTestClass"                     | true
-        "SampleTest\$NestedTestClass"                     | "SampleTest\$NestedTestClass\$SubNestedTestClass" | false
-        "SampleTest\$NestedTestClass\$SubNestedTestClass" | "SampleTest"                                      | false
-        "SampleTest\$NestedTestClass\$SubNestedTestClass" | "SampleTest\$NestedTestClass"                     | false
-        "SampleTest\$NestedTestClass\$SubNestedTestClass" | "SampleTest\$NestedTestClass\$SubNestedTestClass" | true
-        "SampleTest*"                                     | "SampleTest"                                      | true
-        "SampleTest*"                                     | "SampleTest\$NestedTestClass"                     | true
-        "SampleTest*"                                     | "SampleTest\$NestedTestClass\$SubNestedTestClass" | true
+        pattern                                           | patternMatches                                                                                   | patternDoesNotMatch
+        "SampleTest"                                      | ["SampleTest"]                                                                                   | ["SampleTest\$NestedTestClass", "SampleTest\$NestedTestClass\$SubNestedTestClass"]
+        "SampleTest\$NestedTestClass"                     | ["SampleTest\$NestedTestClass"]                                                                  | ["SampleTest", "SampleTest\$NestedTestClass\$SubNestedTestClass"]
+        "SampleTest\$NestedTestClass\$SubNestedTestClass" | ["SampleTest\$NestedTestClass\$SubNestedTestClass"]                                              | ["SampleTest", "SampleTest\$NestedTestClass"]
+        "SampleTest*"                                     | ["SampleTest", "SampleTest\$NestedTestClass", "SampleTest\$NestedTestClass\$SubNestedTestClass"] | ["NotSampleTest", "NotSampleTest\$NestedTestClass"]
     }
 
     def matcher(Collection<String> includedTests, Collection<String> excludedTests, Collection<String> includedTestsCommandLine) {
         return new TestSelectionMatcher(new TestFilterSpec(includedTests as Set, excludedTests as Set, includedTestsCommandLine as Set))
+    }
+
+    private void assertMatchesTest(List<String> pattern,
+                                   List<List<String>> patternMatches,
+                                   List<List<String>> patternDoesNotMatch) {
+        for (pair in patternMatches) {
+            def (className, methodName) = pair
+            assert matcher(pattern, [], []).matchesTest(className, methodName) : "includedTests=$pattern expected to match [$className, $methodName]"
+            assert matcher([], [], pattern).matchesTest(className, methodName) : "includedTestsCommandLine=$pattern expected to match [$className, $methodName]"
+        }
+        for (pair in patternDoesNotMatch) {
+            def (className, methodName) = pair
+            assert !matcher(pattern, [], []).matchesTest(className, methodName) : "includedTests=$pattern expected NOT to match [$className, $methodName]"
+            assert !matcher([], [], pattern).matchesTest(className, methodName) : "includedTestsCommandLine=$pattern expected NOT to match [$className, $methodName]"
+        }
     }
 }

--- a/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing.filter
 
 
+import spock.lang.Issue
 import spock.lang.Specification
 
 class TestSelectionMatcherTest extends Specification {
@@ -255,6 +256,50 @@ class TestSelectionMatcherTest extends Specification {
         []                      | []                              | 'anything'            | true
         ['org.gradle.FooTest*'] | ['org.gradle.BarTest*']         | 'org.gradle.FooTest'  | false
         ['org.gradle.FooTest*'] | ['*org.gradle.BarTest*']        | 'org.gradle.FooTest'  | true
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37539")
+    def "matchesIncludeTest ignores exclude patterns"() {
+        expect:
+        matcher(includes, excludes, []).matchesIncludeTest(className, methodName) == match
+
+        where:
+        includes           | excludes           | className         | methodName       | match
+        []                 | []                 | "FooTest"         | "aaa"            | true
+        []                 | ["FooTest"]        | "FooTest"         | "aaa"            | true
+        ["FooTest"]        | []                 | "FooTest"         | "aaa"            | true
+        ["FooTest"]        | ["FooTest"]        | "FooTest"         | "aaa"            | true
+        ["FooTest"]        | []                 | "BarTest"         | "aaa"            | false
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37539")
+    def "matchesIncludeTest combines build-script and command-line includes"() {
+        expect:
+        matcher(buildScript, [], commandLine).matchesIncludeTest(className, null) == match
+
+        where:
+        buildScript        | commandLine       | className         | match
+        []                 | []                | "FooTest"         | true
+        ["FooTest"]        | []                | "FooTest"         | true
+        []                 | ["FooTest"]       | "FooTest"         | true
+        ["FooTest"]        | ["FooTest"]       | "FooTest"         | true
+        ["FooTest"]        | ["BarTest"]       | "FooTest"         | false
+        ["FooTest"]        | ["BarTest"]       | "BarTest"         | false
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37539")
+    def "matchesExcludeTest ignores include patterns"() {
+        expect:
+        matcher(includes, excludes, []).matchesExcludeTest(className, methodName) == match
+
+        where:
+        includes           | excludes                   | className                        | methodName         | match
+        []                 | []                         | "FooTest"                        | null               | false
+        []                 | ["FooTest"]                | "FooTest"                        | null               | true
+        ["BarTest"]        | ["FooTest"]                | "FooTest"                        | null               | true
+        []                 | ["FooTest"]                | "BarTest"                        | null               | false
+        []                 | ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
+        []                 | ["FooTest.doThing"]        | "FooTest"                        | "doOther"          | false
     }
 
     def matcher(Collection<String> includedTests, Collection<String> excludedTests, Collection<String> includedTestsCommandLine) {

--- a/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -302,6 +302,23 @@ class TestSelectionMatcherTest extends Specification {
         []                 | ["FooTest.doThing"]        | "FooTest"                        | "doOther"          | false
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/37539")
+    def "matchesExcludeClass is exact and does not treat parent pattern as matching nested class"() {
+        expect:
+        matcher([], [excludePattern], []).matchesExcludeClass(className) == match
+
+        where:
+        excludePattern                                 | className                                        | match
+        "SampleTest"                                   | "SampleTest"                                     | true
+        "SampleTest"                                   | "SampleTest\$NestedTestClass"                    | false
+        "SampleTest"                                   | "SampleTest\$NestedTestClass\$SubNestedTestClass" | false
+        "SampleTest\$NestedTestClass"                  | "SampleTest"                                     | false
+        "SampleTest\$NestedTestClass"                  | "SampleTest\$NestedTestClass"                    | true
+        "SampleTest\$NestedTestClass"                  | "SampleTest\$NestedTestClass\$SubNestedTestClass" | false
+        "SampleTest*"                                  | "SampleTest"                                     | true
+        "SampleTest*"                                  | "SampleTest\$NestedTestClass"                    | true
+    }
+
     def matcher(Collection<String> includedTests, Collection<String> excludedTests, Collection<String> includedTestsCommandLine) {
         return new TestSelectionMatcher(new TestFilterSpec(includedTests as Set, excludedTests as Set, includedTestsCommandLine as Set))
     }

--- a/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -305,7 +305,7 @@ class TestSelectionMatcherTest extends Specification {
     @Issue("https://github.com/gradle/gradle/issues/37539")
     def "matchesExcludeClass is exact and does not treat parent pattern as matching nested class"() {
         expect:
-        matcher([], [excludePattern], []).matchesExcludeClass(className) == match
+        matcher([], [excludePattern], []).matchesExcludeClassExactly(className) == match
 
         where:
         excludePattern                                    | className                                         | match

--- a/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -264,14 +264,15 @@ class TestSelectionMatcherTest extends Specification {
 
         where:
         includes           | excludes           | className         | methodName       | match
-        []                 | []                 | "FooTest"         | "aaa"            | true
         []                 | ["FooTest"]        | "FooTest"         | "aaa"            | true
-        ["FooTest"]        | []                 | "FooTest"         | "aaa"            | true
         ["FooTest"]        | ["FooTest"]        | "FooTest"         | "aaa"            | true
-        ["FooTest"]        | []                 | "BarTest"         | "aaa"            | false
+        ["FooTest"]        | ["FooTest"]        | "FooTest"         | null             | true
+        ["FooTest.aaa"]    | ["FooTest"]        | "FooTest"         | "aaa"            | true
+        ["FooTest.aaa"]    | ["FooTest"]        | "FooTest"         | "bbb"            | false
+        ["FooTest"]        | ["FooTest.aaa"]    | "FooTest"         | "aaa"            | true
     }
 
-    def "matchesIncludeTest combines build-script and command-line includes"() {
+    def "matchesIncludeTest returns the AND of build-script and command-line includes"() {
         expect:
         matcher(buildScript, [], commandLine).matchesIncludeTest(className, null) == match
 
@@ -285,21 +286,32 @@ class TestSelectionMatcherTest extends Specification {
         ["FooTest"]        | ["BarTest"]       | "BarTest"         | false
     }
 
+    def "matchesExcludeTest correctly matches on exclude patterns"() {
+        expect:
+        matcher([], excludes, []).matchesExcludeTest(className, methodName) == match
+
+        where:
+        excludes                   | className                        | methodName         | match
+        []                         | "FooTest"                        | null               | false
+        ["FooTest"]                | "FooTest"                        | null               | true
+        ["FooTest"]                | "BarTest"                        | null               | false
+        ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
+        ["FooTest.doThing"]        | "FooTest"                        | "doOther"          | false
+    }
+
     def "matchesExcludeTest ignores include patterns"() {
         expect:
         matcher(includes, excludes, []).matchesExcludeTest(className, methodName) == match
 
         where:
         includes           | excludes                   | className                        | methodName         | match
-        []                 | []                         | "FooTest"                        | null               | false
-        []                 | ["FooTest"]                | "FooTest"                        | null               | true
         ["BarTest"]        | ["FooTest"]                | "FooTest"                        | null               | true
-        []                 | ["FooTest"]                | "BarTest"                        | null               | false
+        ["FooTest"]        | ["FooTest"]                | "FooTest"                        | null               | true
         ["BarTest"]        | ["FooTest"]                | "BarTest"                        | null               | false
-        []                 | ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
         ["BarTest"]        | ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
-        []                 | ["FooTest.doThing"]        | "FooTest"                        | "doOther"          | false
         ["BarTest"]        | ["FooTest.doThing"]        | "FooTest"                        | "doOther"          | false
+        ["FooTest"]        | ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
+        ["FooTest.doThing"]| ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37539")

--- a/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/platforms/software/testing-base-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -258,7 +258,6 @@ class TestSelectionMatcherTest extends Specification {
         ['org.gradle.FooTest*'] | ['*org.gradle.BarTest*']        | 'org.gradle.FooTest'  | true
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/37539")
     def "matchesIncludeTest ignores exclude patterns"() {
         expect:
         matcher(includes, excludes, []).matchesIncludeTest(className, methodName) == match
@@ -272,7 +271,6 @@ class TestSelectionMatcherTest extends Specification {
         ["FooTest"]        | []                 | "BarTest"         | "aaa"            | false
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/37539")
     def "matchesIncludeTest combines build-script and command-line includes"() {
         expect:
         matcher(buildScript, [], commandLine).matchesIncludeTest(className, null) == match
@@ -287,7 +285,6 @@ class TestSelectionMatcherTest extends Specification {
         ["FooTest"]        | ["BarTest"]       | "BarTest"         | false
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/37539")
     def "matchesExcludeTest ignores include patterns"() {
         expect:
         matcher(includes, excludes, []).matchesExcludeTest(className, methodName) == match
@@ -298,8 +295,11 @@ class TestSelectionMatcherTest extends Specification {
         []                 | ["FooTest"]                | "FooTest"                        | null               | true
         ["BarTest"]        | ["FooTest"]                | "FooTest"                        | null               | true
         []                 | ["FooTest"]                | "BarTest"                        | null               | false
+        ["BarTest"]        | ["FooTest"]                | "BarTest"                        | null               | false
         []                 | ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
+        ["BarTest"]        | ["FooTest.doThing"]        | "FooTest"                        | "doThing"          | true
         []                 | ["FooTest.doThing"]        | "FooTest"                        | "doOther"          | false
+        ["BarTest"]        | ["FooTest.doThing"]        | "FooTest"                        | "doOther"          | false
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37539")
@@ -308,15 +308,19 @@ class TestSelectionMatcherTest extends Specification {
         matcher([], [excludePattern], []).matchesExcludeClass(className) == match
 
         where:
-        excludePattern                                 | className                                        | match
-        "SampleTest"                                   | "SampleTest"                                     | true
-        "SampleTest"                                   | "SampleTest\$NestedTestClass"                    | false
-        "SampleTest"                                   | "SampleTest\$NestedTestClass\$SubNestedTestClass" | false
-        "SampleTest\$NestedTestClass"                  | "SampleTest"                                     | false
-        "SampleTest\$NestedTestClass"                  | "SampleTest\$NestedTestClass"                    | true
-        "SampleTest\$NestedTestClass"                  | "SampleTest\$NestedTestClass\$SubNestedTestClass" | false
-        "SampleTest*"                                  | "SampleTest"                                     | true
-        "SampleTest*"                                  | "SampleTest\$NestedTestClass"                    | true
+        excludePattern                                    | className                                         | match
+        "SampleTest"                                      | "SampleTest"                                      | true
+        "SampleTest"                                      | "SampleTest\$NestedTestClass"                     | false
+        "SampleTest"                                      | "SampleTest\$NestedTestClass\$SubNestedTestClass" | false
+        "SampleTest\$NestedTestClass"                     | "SampleTest"                                      | false
+        "SampleTest\$NestedTestClass"                     | "SampleTest\$NestedTestClass"                     | true
+        "SampleTest\$NestedTestClass"                     | "SampleTest\$NestedTestClass\$SubNestedTestClass" | false
+        "SampleTest\$NestedTestClass\$SubNestedTestClass" | "SampleTest"                                      | false
+        "SampleTest\$NestedTestClass\$SubNestedTestClass" | "SampleTest\$NestedTestClass"                     | false
+        "SampleTest\$NestedTestClass\$SubNestedTestClass" | "SampleTest\$NestedTestClass\$SubNestedTestClass" | true
+        "SampleTest*"                                     | "SampleTest"                                      | true
+        "SampleTest*"                                     | "SampleTest\$NestedTestClass"                     | true
+        "SampleTest*"                                     | "SampleTest\$NestedTestClass\$SubNestedTestClass" | true
     }
 
     def matcher(Collection<String> includedTests, Collection<String> excludedTests, Collection<String> includedTestsCommandLine) {


### PR DESCRIPTION
Calling filter.excludeTest("SampleTest", null) didn't just exclude `SampleTest` — it also silently excluded all of its `@Nested` children.  Compounding this, the test that should have caught this regression was broken in such a way that it continued to pass even though the behavior was wrong. 
                                                                                                                                                                                                                 
Three interacting bugs were responsible:                                                                                                                          
   
- Scan-time over-pruning. Excluded outer classes were dropped before JUnit Platform discovery. Because JUnit Platform discovers `@Nested` children through their outer class as a selector, dropping the outer left no way to reach the nested tests.
- Ancestor walk-up re-inclusion. The post-discovery filter's walk up the descriptor chain treated any non-excluded ancestor as sufficient to include a test, so a nested  class exclude could be bypassed by its non-excluded enclosing class.                                                                                                      
- Fuzzy exclude matching. The exclude-match heuristic treated a pattern like SampleTest$NestedTestClass as also matching SampleTest.  This was accidentally patching over the walk-up bug in some cases.                                   
                                                            
Fixing any single bug in isolation moves the failures around, so a correct fix involved fixing all three together.                                                           
                                                            
The following fixes were made:
- The test that should have caught this regression was rewritten to be more resilient.                                                                                                                                                                    
- Stopped pruning excluded classes at scan time that have nested classes. Excluded outer classes remain available as discovery selectors; filtering moves to post-discovery where it can be correct.  
- Rewrote the walk-up so that an exclude on a nested class is never bypassed by its enclosing class, while unrelated ancestors may still re-include.                                                                                                                                                         
- Added an exact-match exclude query distinct from the existing fuzzy heuristic. The exact query is used where a definitive "this class is excluded" answer is required; the fuzzy one is retained for the JUnit 4 filter, which relies on it to drill into individual methods.                                                                    

Fixes #37539 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
