### PR TITLE
Update Kotlin DSL embedded compiler architecture statement

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dsl-apis/kotlin_dsl.adoc
@@ -29,7 +29,7 @@ TIP: If you are interested in migrating an existing Gradle build to the Kotlin D
 [[kotdsl:prerequisites]]
 == Prerequisites
 
-* The embedded Kotlin compiler works on Linux, macOS, Windows, Cygwin, FreeBSD, and Solaris on x86-64 architectures.
+* The embedded Kotlin compiler works on Linux, macOS, Windows, Cygwin, FreeBSD, and Solaris. For the most up-to-date information on supported architectures, consult the link:{kotlin-reference}[Kotlin documentation].
 * Familiarity with Kotlin syntax and basic language features is recommended.
 Refer to the link:{kotlin-reference}[Kotlin documentation] and link:https://kotlinlang.org/docs/tutorials/koans.html[Kotlin Koans] to learn the basics.
 * Using the <<plugins_intermediate.adoc#sec:plugins_block,`plugins {}`>> block to declare Gradle plugins is highly recommended as it significantly improves the editing experience.


### PR DESCRIPTION
Good day

This PR updates the Kotlin DSL documentation to remove the outdated statement that the embedded Kotlin compiler only works on x86-64 architectures.

## Changes

- Removed the outdated "on x86-64 architectures" limitation from the embedded Kotlin compiler description
- Added a reference to the Kotlin documentation for up-to-date architecture information

## Issue

Fixes #37017 - The previous statement was 8 years old and no longer accurate. The embedded Kotlin compiler now supports additional architectures beyond x86-64.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof