### PR TITLE
Fix double "report"

### DIFF
--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationWorkAction.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationWorkAction.kt
@@ -41,7 +41,7 @@ abstract class IncubatingApiReportAggregationWorkAction : WorkAction<IncubatingA
             }
         }
         generateHtmlReport(byCategory)
-        LOGGER.lifecycle("Generated incubating html report report to file://${parameters.htmlReportFile.get().asFile.absolutePath}")
+        LOGGER.lifecycle("Generated incubating html report to file://${parameters.htmlReportFile.get().asFile.absolutePath}")
 
         generateCsvReport(byCategory)
         LOGGER.lifecycle("Generated incubating csv report to file://${parameters.csvReportFile.get().asFile.absolutePath}")


### PR DESCRIPTION
This fixes #37583 by removing the double word "report" in `build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportAggregationWorkAction.kt`

### Contributor Checklist
- [x ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [ x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
