### PR TITLE
Dependency verification keyring cleanup

### DIFF
--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -167,6 +167,7 @@ public class BuildActionSerializer {
             encoder.writeString(startParameter.getDependencyVerificationMode().name());
             encoder.writeBoolean(startParameter.isRefreshKeys());
             encoder.writeBoolean(startParameter.isExportKeys());
+            encoder.writeBoolean(startParameter.isPruneKeys());
             encoder.writeString(startParameter.getWelcomeMessageConfiguration().getWelcomeMessageDisplayMode().name());
             encoder.writeBoolean(startParameter.isPropertyUpgradeReportEnabled());
             encoder.writeBoolean(startParameter.isProblemReportGenerationEnabled());
@@ -271,6 +272,7 @@ public class BuildActionSerializer {
             startParameter.setDependencyVerificationMode(DependencyVerificationMode.valueOf(decoder.readString()));
             startParameter.setRefreshKeys(decoder.readBoolean());
             startParameter.setExportKeys(decoder.readBoolean());
+            startParameter.setPruneKeys(decoder.readBoolean());
             startParameter.setWelcomeMessageConfiguration(new WelcomeMessageConfiguration(WelcomeMessageDisplayMode.valueOf(decoder.readString())));
             startParameter.setPropertyUpgradeReportEnabled(decoder.readBoolean());
             startParameter.enableProblemReportGeneration(decoder.readBoolean());

--- a/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/platforms/core-runtime/daemon-messaging/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -166,6 +166,7 @@ public class BuildActionSerializer {
             encoder.writeString(startParameter.getDependencyVerificationMode().name());
             encoder.writeBoolean(startParameter.isRefreshKeys());
             encoder.writeBoolean(startParameter.isExportKeys());
+            encoder.writeBoolean(startParameter.isPruneKeys());
             encoder.writeString(startParameter.getWelcomeMessageConfiguration().getWelcomeMessageDisplayMode().name());
             encoder.writeBoolean(startParameter.isPropertyUpgradeReportEnabled());
             encoder.writeBoolean(startParameter.isProblemReportGenerationEnabled());
@@ -269,6 +270,7 @@ public class BuildActionSerializer {
             startParameter.setDependencyVerificationMode(DependencyVerificationMode.valueOf(decoder.readString()));
             startParameter.setRefreshKeys(decoder.readBoolean());
             startParameter.setExportKeys(decoder.readBoolean());
+            startParameter.setPruneKeys(decoder.readBoolean());
             startParameter.setWelcomeMessageConfiguration(new WelcomeMessageConfiguration(WelcomeMessageDisplayMode.valueOf(decoder.readString())));
             startParameter.setPropertyUpgradeReportEnabled(decoder.readBoolean());
             startParameter.enableProblemReportGeneration(decoder.readBoolean());

--- a/platforms/core-runtime/launcher/src/testFixtures/groovy/org/gradle/launcher/cli/HelpFixture.groovy
+++ b/platforms/core-runtime/launcher/src/testFixtures/groovy/org/gradle/launcher/cli/HelpFixture.groovy
@@ -84,6 +84,7 @@ Performance:
 Security:
   --dependency-verification, -F      Configures the dependency verification mode. Supported values are 'strict', 'lenient', or 'off'.
   --export-keys                      Exports the public keys used for dependency verification.
+  --prune-keys                       Prunes the dependency verification keyring files so they only contain keys referenced by the verification metadata file.
   --refresh-keys                     Refreshes the public keys used for dependency verification.
   --update-locks                     Performs a partial update of the dependency lock. Allows passed-in module notations to change version. [incubating]
   --write-locks                      Persists dependency resolution for locked configurations. Ignores existing locking information if it exists.

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
@@ -1004,7 +1004,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * the final keyring excludes orphaned keys instead of merging with them.
      *
      * @return true if keyrings should be pruned
-     * @since 9.6.0
+     * @since 9.7.0
      */
     @Incubating
     public boolean isPruneKeys() {
@@ -1021,7 +1021,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * the final keyring excludes orphaned keys instead of merging with them.
      *
      * @param pruneKeys set to true if keyrings should be pruned
-     * @since 9.6.0
+     * @since 9.7.0
      */
     @Incubating
     public void setPruneKeys(boolean pruneKeys) {

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/StartParameter.java
@@ -104,6 +104,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private DependencyVerificationMode verificationMode = DependencyVerificationMode.STRICT;
     private boolean refreshKeys;
     private boolean exportKeys;
+    private boolean pruneKeys;
     private WelcomeMessageConfiguration welcomeMessageConfiguration = new WelcomeMessageConfiguration(WelcomeMessageDisplayMode.ONCE);
 
     /**
@@ -303,6 +304,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.verificationMode = verificationMode;
         p.refreshKeys = refreshKeys;
         p.exportKeys = exportKeys;
+        p.pruneKeys = pruneKeys;
         p.welcomeMessageConfiguration = welcomeMessageConfiguration;
         p.dryRun = dryRun;
         p.taskGraph = taskGraph;
@@ -783,6 +785,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
             + ", verificationMode=" + verificationMode
             + ", refreshKeys=" + refreshKeys
             + ", exportKeys=" + exportKeys
+            + ", pruneKeys=" + pruneKeys
             + ", welcomeMessageConfiguration=" + welcomeMessageConfiguration
             + '}';
     }
@@ -989,6 +992,40 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     public void setExportKeys(boolean exportKeys) {
         this.exportKeys = exportKeys;
+    }
+
+    /**
+     * If true, the dependency verification keyring files are pruned so that they only
+     * contain keys that are still referenced by the current {@code verification-metadata.xml}.
+     *
+     * When used alone, no dependency resolution is performed and no key servers are
+     * contacted: the keyring files are filtered in place. When combined with
+     * {@link #setWriteDependencyVerifications(List)} or {@link #setExportKeys(boolean)},
+     * the final keyring excludes orphaned keys instead of merging with them.
+     *
+     * @return true if keyrings should be pruned
+     * @since 9.6.0
+     */
+    @Incubating
+    public boolean isPruneKeys() {
+        return pruneKeys;
+    }
+
+    /**
+     * If true, the dependency verification keyring files are pruned so that they only
+     * contain keys that are still referenced by the current {@code verification-metadata.xml}.
+     *
+     * When used alone, no dependency resolution is performed and no key servers are
+     * contacted: the keyring files are filtered in place. When combined with
+     * {@link #setWriteDependencyVerifications(List)} or {@link #setExportKeys(boolean)},
+     * the final keyring excludes orphaned keys instead of merging with them.
+     *
+     * @param pruneKeys set to true if keyrings should be pruned
+     * @since 9.6.0
+     */
+    @Incubating
+    public void setPruneKeys(boolean pruneKeys) {
+        this.pruneKeys = pruneKeys;
     }
 
     /**

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -74,6 +74,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         new DependencyLockingUpdateOption(),
         new RefreshKeysOption(),
         new ExportKeysOption(),
+        new PruneKeysOption(),
         new ConfigurationCacheProblemsOption(),
         new ConfigurationCacheOption(),
         new ConfigurationCacheIgnoreInputsDuringStore(),
@@ -641,6 +642,26 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         @Override
         public void applyTo(StartParameterInternal settings, Origin origin) {
             settings.setExportKeys(true);
+        }
+
+        @Override
+        protected OptionCategory getCategory() {
+            return OptionCategory.SECURITY;
+        }
+    }
+
+    public static class PruneKeysOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
+
+        public static final String LONG_OPTION = "prune-keys";
+
+        public PruneKeysOption() {
+            super(null,
+                CommandLineOptionConfiguration.create(LONG_OPTION, "Prunes the dependency verification keyring files so they only contain keys referenced by the verification metadata file."));
+        }
+
+        @Override
+        public void applyTo(StartParameterInternal settings, Origin origin) {
+            settings.setPruneKeys(true);
         }
 
         @Override

--- a/platforms/core-runtime/start-parameter/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/platforms/core-runtime/start-parameter/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -74,6 +74,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         new DependencyLockingUpdateOption(),
         new RefreshKeysOption(),
         new ExportKeysOption(),
+        new PruneKeysOption(),
         new ConfigurationCacheProblemsOption(),
         new ConfigurationCacheOption(),
         new ConfigurationCacheIgnoreInputsDuringStore(),
@@ -640,6 +641,26 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         @Override
         public void applyTo(StartParameterInternal settings, Origin origin) {
             settings.setExportKeys(true);
+        }
+
+        @Override
+        protected OptionCategory getCategory() {
+            return OptionCategory.SECURITY;
+        }
+    }
+
+    public static class PruneKeysOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
+
+        public static final String LONG_OPTION = "prune-keys";
+
+        public PruneKeysOption() {
+            super(null,
+                CommandLineOptionConfiguration.create(LONG_OPTION, "Prunes the dependency verification keyring files so they only contain keys referenced by the verification metadata file."));
+        }
+
+        @Override
+        public void applyTo(StartParameterInternal settings, Origin origin) {
+            settings.setPruneKeys(true);
         }
 
         @Override

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
@@ -827,6 +827,9 @@ Refresh the public keys used for dependency verification.
 `--export-keys`::
 Exports the public keys used for dependency verification.
 
+`--prune-keys`::
+Prunes the dependency verification keyring files so they only contain keys referenced by the verification metadata file.
+
 [[sec:environment_options]]
 == Environment options
 

--- a/platforms/documentation/docs/src/docs/userguide/securing-builds/dependency_verification.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/securing-builds/dependency_verification.adoc
@@ -985,6 +985,32 @@ $ ./gradlew --export-keys
 
 NOTE: This command will not report verification errors, only export keys.
 
+==== Pruning Unused Keys
+
+When you manually remove trusted keys from `verification-metadata.xml`, the public keys they point to stay behind in `verification-keyring.keys` and `verification-keyring.gpg`.
+Running `--export-keys` merges any newly referenced keys in but does not remove orphaned entries, and regenerating the whole keyring depends on key servers that are frequently rate-limited.
+
+Use `--prune-keys` to drop unreferenced keys from the keyring in place, without contacting key servers:
+
+[source,bash]
+----
+$ ./gradlew help --prune-keys
+----
+
+This reads the on-disk keyring, keeps only the rings whose long-ID or fingerprint is still referenced by `verification-metadata.xml` (signing subkeys are treated as part of their ring), and rewrites the keyring file(s) in whichever format is declared by `<keyring-format>` — both formats are rewritten when no format is declared.
+Referenced keys that are not present in the keyring produce a `WARN` pointing at `--export-keys` as the recovery command.
+
+`--prune-keys` can be combined with `--export-keys` or `--write-verification-metadata` — in that case the keyring is written normally and then filtered against the freshly built verifier.
+Under `--dry-run`, pruned output is written to `verification-keyring.dryrun.keys` / `.dryrun.gpg` and the originals are left untouched.
+
+[WARNING]
+====
+Before running `--prune-keys`, commit or back up the existing keyring files.
+If a key is dropped by mistake, recover with `./gradlew help --export-keys`, which re-downloads keys referenced by `verification-metadata.xml` from the configured key servers.
+====
+
+NOTE: `--prune-keys` only touches the root build's `gradle/verification-keyring.*`. Included builds with their own verification metadata must be pruned separately.
+
 [[committing_keyring_files]]
 ==== Committing Keyring Files
 

--- a/platforms/documentation/docs/src/docs/userguide/securing-builds/dependency_verification.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/securing-builds/dependency_verification.adoc
@@ -993,6 +993,32 @@ $ ./gradlew --export-keys
 
 NOTE: This command will not report verification errors, only export keys.
 
+==== Pruning Unused Keys
+
+When you manually remove trusted keys from `verification-metadata.xml`, the public keys they point to stay behind in `verification-keyring.keys` and `verification-keyring.gpg`.
+Running `--export-keys` merges any newly referenced keys in but does not remove orphaned entries, and regenerating the whole keyring depends on key servers that are frequently rate-limited.
+
+Use `--prune-keys` to drop unreferenced keys from the keyring in place, without contacting key servers:
+
+[source,bash]
+----
+$ ./gradlew help --prune-keys
+----
+
+This reads the on-disk keyring, keeps only the rings whose long-ID or fingerprint is still referenced by `verification-metadata.xml` (signing subkeys are treated as part of their ring), and rewrites the keyring file(s) in whichever format is declared by `<keyring-format>` — both formats are rewritten when no format is declared.
+Referenced keys that are not present in the keyring produce a `WARN` pointing at `--export-keys` as the recovery command.
+
+`--prune-keys` can be combined with `--export-keys` or `--write-verification-metadata` — in that case the keyring is written normally and then filtered against the freshly built verifier.
+Under `--dry-run`, pruned output is written to `verification-keyring.dryrun.keys` / `.dryrun.gpg` and the originals are left untouched.
+
+[WARNING]
+====
+Before running `--prune-keys`, commit or back up the existing keyring files.
+If a key is dropped by mistake, recover with `./gradlew help --export-keys`, which re-downloads keys referenced by `verification-metadata.xml` from the configured key servers.
+====
+
+NOTE: `--prune-keys` only touches the root build's `gradle/verification-keyring.*`. Included builds with their own verification metadata must be pruned separately.
+
 ==== Committing Keyring Files
 
 It's a good idea to commit the keyring file to version control (as long as you trust your VCS).

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -668,6 +668,70 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         !prunedAscii.any { Fingerprint.of(it.publicKey) == orphanId }
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/37275")
+    def "--prune-keys is a no-op when keyring already matches the metadata"() {
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+        }
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature {
+                signAsciiArmored(it)
+            }
+        }
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        and: "seed keyring with exactly the referenced trusted key"
+        serveValidKey()
+        writeVerificationMetadata()
+        succeeds ":help", "--export-keys"
+
+        def seededAscii = file("gradle/verification-keyring.keys")
+        def seededBinary = file("gradle/verification-keyring.gpg")
+        def asciiBefore = seededAscii.bytes
+        def binaryBefore = seededBinary.bytes
+        SecuritySupport.loadKeyRingFile(seededAscii).size() == 1
+
+        when:
+        succeeds ":help", "--prune-keys"
+
+        then:
+        outputContains("Keyring is up to date")
+        seededAscii.bytes == asciiBefore
+        seededBinary.bytes == binaryBefore
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37275")
+    def "--prune-keys fails fast when verification metadata is missing"() {
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature {
+                signAsciiArmored(it)
+            }
+        }
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        and: "no gradle/verification-metadata.xml exists"
+        assert !file("gradle/verification-metadata.xml").exists()
+
+        when:
+        fails ":help", "--prune-keys"
+
+        then:
+        failure.assertHasDescription("Cannot run --prune-keys: no dependency verification metadata file at")
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/23607")
     def "verification-keyring.keys contains only necessary data"() {
         def keyring = newKeyRing()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.resolve.verification
 
+import org.bouncycastle.openpgp.PGPPublicKey
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.security.fixtures.SigningFixtures
 import org.gradle.security.internal.Fingerprint
@@ -603,17 +604,12 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
 
         then:
         outputContains("Exported 1 keys to")
-        def exportedKeyRingAscii = file("gradle/verification-keyring.keys")
-        exportedKeyRingAscii.exists()
-        def keyringsAscii = SecuritySupport.loadKeyRingFile(exportedKeyRingAscii)
-        keyringsAscii.size() == 1
-        keyringsAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+        assertKeyringContainsOnly("gradle/verification-keyring.keys", SigningFixtures.validPublicKey)
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37275")
     def "--prune-keys drops orphaned keys from keyrings"() {
         def orphan = newKeyRing()
-        def orphanId = Fingerprint.of(orphan.publicKey)
         createMetadataFile {
             keyServer(keyServerFixture.uri)
         }
@@ -637,10 +633,8 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         writeVerificationMetadata()
         succeeds ":help", "--export-keys"
 
-        def seededBinary = file("gradle/verification-keyring.gpg")
-        def seededAscii = file("gradle/verification-keyring.keys")
-        SecuritySupport.loadKeyRingFile(seededBinary).size() == 2
-        SecuritySupport.loadKeyRingFile(seededAscii).size() == 2
+        assertKeyringSize("gradle/verification-keyring.gpg", 2)
+        assertKeyringSize("gradle/verification-keyring.keys", 2)
 
         and: "user manually prunes the orphan from verification-metadata.xml"
         replaceMetadataFile {
@@ -652,20 +646,8 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         succeeds ":help", "--prune-keys"
 
         then:
-        def prunedBinary = SecuritySupport.loadKeyRingFile(file("gradle/verification-keyring.gpg"))
-        prunedBinary.size() == 1
-        prunedBinary.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
-        !prunedBinary.find { it.publicKey.keyID == orphan.publicKey.keyID }
-
-        and:
-        def prunedAscii = SecuritySupport.loadKeyRingFile(file("gradle/verification-keyring.keys"))
-        prunedAscii.size() == 1
-        prunedAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
-        !prunedAscii.find { it.publicKey.keyID == orphan.publicKey.keyID }
-
-        and: "orphanId appears in no keyring"
-        !prunedBinary.any { Fingerprint.of(it.publicKey) == orphanId }
-        !prunedAscii.any { Fingerprint.of(it.publicKey) == orphanId }
+        assertKeyringContainsOnly("gradle/verification-keyring.gpg", SigningFixtures.validPublicKey)
+        assertKeyringContainsOnly("gradle/verification-keyring.keys", SigningFixtures.validPublicKey)
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37275")
@@ -692,11 +674,12 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         writeVerificationMetadata()
         succeeds ":help", "--export-keys"
 
+        assertKeyringSize("gradle/verification-keyring.keys", 1)
+        assertKeyringSize("gradle/verification-keyring.gpg", 1)
         def seededAscii = file("gradle/verification-keyring.keys")
         def seededBinary = file("gradle/verification-keyring.gpg")
         def asciiBefore = seededAscii.bytes
         def binaryBefore = seededBinary.bytes
-        SecuritySupport.loadKeyRingFile(seededAscii).size() == 1
 
         when:
         succeeds ":help", "--prune-keys"
@@ -733,11 +716,13 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         writeVerificationMetadata()
         succeeds ":help", "--export-keys"
 
+        assertKeyringSize("gradle/verification-keyring.gpg", 2)
+        assertKeyringSize("gradle/verification-keyring.keys", 2)
+
         def seededBinary = file("gradle/verification-keyring.gpg")
         def seededAscii = file("gradle/verification-keyring.keys")
         def asciiBefore = seededAscii.bytes
         def binaryBefore = seededBinary.bytes
-        SecuritySupport.loadKeyRingFile(seededBinary).size() == 2
 
         and: "user manually prunes the orphan from verification-metadata.xml"
         replaceMetadataFile {
@@ -757,14 +742,8 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         seededBinary.bytes == binaryBefore
 
         and: "dryrun files reflect the pruned keyring"
-        def dryrunAscii = file("gradle/verification-keyring.dryrun.keys")
-        def dryrunBinary = file("gradle/verification-keyring.dryrun.gpg")
-        dryrunAscii.exists()
-        dryrunBinary.exists()
-        def prunedAscii = SecuritySupport.loadKeyRingFile(dryrunAscii)
-        prunedAscii.size() == 1
-        prunedAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
-        !prunedAscii.find { it.publicKey.keyID == orphan.publicKey.keyID }
+        assertKeyringContainsOnly("gradle/verification-keyring.dryrun.keys", SigningFixtures.validPublicKey)
+        assertKeyringContainsOnly("gradle/verification-keyring.dryrun.gpg", SigningFixtures.validPublicKey)
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37275")
@@ -803,9 +782,7 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         succeeds ":help", "--prune-keys", "--offline"
 
         then:
-        def prunedAscii = SecuritySupport.loadKeyRingFile(file("gradle/verification-keyring.keys"))
-        prunedAscii.size() == 1
-        prunedAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+        assertKeyringContainsOnly("gradle/verification-keyring.keys", SigningFixtures.validPublicKey)
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37275")
@@ -833,7 +810,7 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         keyServerFixture.registerPublicKey(orphan.publicKey)
         writeVerificationMetadata()
         succeeds ":help", "--export-keys"
-        SecuritySupport.loadKeyRingFile(file("gradle/verification-keyring.keys")).size() == 2
+        assertKeyringSize("gradle/verification-keyring.keys", 2)
 
         and: "user manually prunes the orphan from verification-metadata.xml"
         replaceMetadataFile {
@@ -845,9 +822,7 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         succeeds ":help", "--export-keys", "--prune-keys"
 
         then:
-        def prunedAscii = SecuritySupport.loadKeyRingFile(file("gradle/verification-keyring.keys"))
-        prunedAscii.size() == 1
-        prunedAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+        assertKeyringContainsOnly("gradle/verification-keyring.keys", SigningFixtures.validPublicKey)
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37275")
@@ -876,11 +851,11 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         writeVerificationMetadata()
         succeeds ":help", "--export-keys"
 
-        def asciiFile = file("gradle/verification-keyring.keys")
+        assertKeyringSize("gradle/verification-keyring.keys", 2)
+        assertKeyringSize("gradle/verification-keyring.gpg", 2)
+
         def binaryFile = file("gradle/verification-keyring.gpg")
         def binaryBefore = binaryFile.bytes
-        SecuritySupport.loadKeyRingFile(asciiFile).size() == 2
-        SecuritySupport.loadKeyRingFile(binaryFile).size() == 2
 
         and: "user drops the orphan and pins the keyring format to armored"
         replaceMetadataFile {
@@ -893,9 +868,7 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         succeeds ":help", "--prune-keys"
 
         then: "armored file is pruned"
-        def prunedAscii = SecuritySupport.loadKeyRingFile(asciiFile)
-        prunedAscii.size() == 1
-        prunedAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+        assertKeyringContainsOnly("gradle/verification-keyring.keys", SigningFixtures.validPublicKey)
 
         and: "binary file is byte-for-byte untouched"
         binaryFile.bytes == binaryBefore
@@ -927,11 +900,11 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         writeVerificationMetadata()
         succeeds ":help", "--export-keys"
 
+        assertKeyringSize("gradle/verification-keyring.keys", 2)
+        assertKeyringSize("gradle/verification-keyring.gpg", 2)
+
         def asciiFile = file("gradle/verification-keyring.keys")
-        def binaryFile = file("gradle/verification-keyring.gpg")
         def asciiBefore = asciiFile.bytes
-        SecuritySupport.loadKeyRingFile(asciiFile).size() == 2
-        SecuritySupport.loadKeyRingFile(binaryFile).size() == 2
 
         and: "user drops the orphan and pins the keyring format to binary"
         replaceMetadataFile {
@@ -944,9 +917,7 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         succeeds ":help", "--prune-keys"
 
         then: "binary file is pruned"
-        def prunedBinary = SecuritySupport.loadKeyRingFile(binaryFile)
-        prunedBinary.size() == 1
-        prunedBinary.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+        assertKeyringContainsOnly("gradle/verification-keyring.gpg", SigningFixtures.validPublicKey)
 
         and: "armored file is byte-for-byte untouched"
         asciiFile.bytes == asciiBefore
@@ -1310,5 +1281,15 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         exportedKeyRingAscii.exists()
         def keyringsAscii = SecuritySupport.loadKeyRingFile(exportedKeyRingAscii)
         keyringsAscii.size() == 3
+    }
+
+    private void assertKeyringContainsOnly(String keyringPath, PGPPublicKey expectedKey) {
+        def keyrings = SecuritySupport.loadKeyRingFile(file(keyringPath))
+        assert keyrings.size() == 1
+        assert keyrings.find { it.publicKey.keyID == expectedKey.keyID }
+    }
+
+    private void assertKeyringSize(String keyringPath, int expectedSize) {
+        assert SecuritySupport.loadKeyRingFile(file(keyringPath)).size() == expectedSize
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -708,6 +708,107 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37275")
+    def "--prune-keys --dry-run writes to dryrun files and leaves originals untouched"() {
+        def orphan = newKeyRing()
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+        }
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature {
+                orphan.sign(it, [(SigningFixtures.validSecretKey): SigningFixtures.validPassword])
+            }
+        }
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        and: "seed keyring with both the trusted key and an orphan"
+        serveValidKey()
+        keyServerFixture.registerPublicKey(orphan.publicKey)
+        writeVerificationMetadata()
+        succeeds ":help", "--export-keys"
+
+        def seededBinary = file("gradle/verification-keyring.gpg")
+        def seededAscii = file("gradle/verification-keyring.keys")
+        def asciiBefore = seededAscii.bytes
+        def binaryBefore = seededBinary.bytes
+        SecuritySupport.loadKeyRingFile(seededBinary).size() == 2
+
+        and: "user manually prunes the orphan from verification-metadata.xml"
+        replaceMetadataFile {
+            keyServer(keyServerFixture.uri)
+            addTrustedKey("org:foo:1.0", SigningFixtures.validPublicKeyHexString)
+        }
+
+        and: "stale dryrun files from a previous run are present"
+        file("gradle/verification-keyring.dryrun.keys") << "trash"
+        file("gradle/verification-keyring.dryrun.gpg") << "trash"
+
+        when:
+        succeeds ":help", "--prune-keys", "--dry-run"
+
+        then: "originals are untouched"
+        seededAscii.bytes == asciiBefore
+        seededBinary.bytes == binaryBefore
+
+        and: "dryrun files reflect the pruned keyring"
+        def dryrunAscii = file("gradle/verification-keyring.dryrun.keys")
+        def dryrunBinary = file("gradle/verification-keyring.dryrun.gpg")
+        dryrunAscii.exists()
+        dryrunBinary.exists()
+        def prunedAscii = SecuritySupport.loadKeyRingFile(dryrunAscii)
+        prunedAscii.size() == 1
+        prunedAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+        !prunedAscii.find { it.publicKey.keyID == orphan.publicKey.keyID }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37275")
+    def "--prune-keys --offline succeeds without contacting key servers"() {
+        def orphan = newKeyRing()
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+        }
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature {
+                orphan.sign(it, [(SigningFixtures.validSecretKey): SigningFixtures.validPassword])
+            }
+        }
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        and: "seed keyring with trusted key + orphan"
+        serveValidKey()
+        keyServerFixture.registerPublicKey(orphan.publicKey)
+        writeVerificationMetadata()
+        succeeds ":help", "--export-keys"
+
+        and: "user manually prunes the orphan from verification-metadata.xml"
+        replaceMetadataFile {
+            keyServer(keyServerFixture.uri)
+            addTrustedKey("org:foo:1.0", SigningFixtures.validPublicKeyHexString)
+        }
+
+        when: "--offline plus prune-keys proves no keyserver traffic is required"
+        succeeds ":help", "--prune-keys", "--offline"
+
+        then:
+        def prunedAscii = SecuritySupport.loadKeyRingFile(file("gradle/verification-keyring.keys"))
+        prunedAscii.size() == 1
+        prunedAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37275")
     def "--prune-keys fails fast when verification metadata is missing"() {
         given:
         javaLibrary()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -809,6 +809,48 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37275")
+    def "--prune-keys combined with --export-keys drops unreferenced existing keys"() {
+        def orphan = newKeyRing()
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+        }
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature {
+                orphan.sign(it, [(SigningFixtures.validSecretKey): SigningFixtures.validPassword])
+            }
+        }
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        and: "seed keyring with trusted key + orphan via --export-keys"
+        serveValidKey()
+        keyServerFixture.registerPublicKey(orphan.publicKey)
+        writeVerificationMetadata()
+        succeeds ":help", "--export-keys"
+        SecuritySupport.loadKeyRingFile(file("gradle/verification-keyring.keys")).size() == 2
+
+        and: "user manually prunes the orphan from verification-metadata.xml"
+        replaceMetadataFile {
+            keyServer(keyServerFixture.uri)
+            addTrustedKey("org:foo:1.0", SigningFixtures.validPublicKeyHexString)
+        }
+
+        when:
+        succeeds ":help", "--export-keys", "--prune-keys"
+
+        then:
+        def prunedAscii = SecuritySupport.loadKeyRingFile(file("gradle/verification-keyring.keys"))
+        prunedAscii.size() == 1
+        prunedAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37275")
     def "--prune-keys fails fast when verification metadata is missing"() {
         given:
         javaLibrary()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -851,6 +851,108 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
     }
 
     @Issue("https://github.com/gradle/gradle/issues/37275")
+    def "--prune-keys honors keyring-format=armored and leaves the binary file untouched"() {
+        def orphan = newKeyRing()
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+        }
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature {
+                orphan.sign(it, [(SigningFixtures.validSecretKey): SigningFixtures.validPassword])
+            }
+        }
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        and: "seed both keyring files with trusted + orphan (no format declared yet)"
+        serveValidKey()
+        keyServerFixture.registerPublicKey(orphan.publicKey)
+        writeVerificationMetadata()
+        succeeds ":help", "--export-keys"
+
+        def asciiFile = file("gradle/verification-keyring.keys")
+        def binaryFile = file("gradle/verification-keyring.gpg")
+        def binaryBefore = binaryFile.bytes
+        SecuritySupport.loadKeyRingFile(asciiFile).size() == 2
+        SecuritySupport.loadKeyRingFile(binaryFile).size() == 2
+
+        and: "user drops the orphan and pins the keyring format to armored"
+        replaceMetadataFile {
+            keyServer(keyServerFixture.uri)
+            keyRingFormat("armored")
+            addTrustedKey("org:foo:1.0", SigningFixtures.validPublicKeyHexString)
+        }
+
+        when:
+        succeeds ":help", "--prune-keys"
+
+        then: "armored file is pruned"
+        def prunedAscii = SecuritySupport.loadKeyRingFile(asciiFile)
+        prunedAscii.size() == 1
+        prunedAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+
+        and: "binary file is byte-for-byte untouched"
+        binaryFile.bytes == binaryBefore
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37275")
+    def "--prune-keys honors keyring-format=binary and leaves the armored file untouched"() {
+        def orphan = newKeyRing()
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+        }
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature {
+                orphan.sign(it, [(SigningFixtures.validSecretKey): SigningFixtures.validPassword])
+            }
+        }
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        and: "seed both keyring files with trusted + orphan (no format declared yet)"
+        serveValidKey()
+        keyServerFixture.registerPublicKey(orphan.publicKey)
+        writeVerificationMetadata()
+        succeeds ":help", "--export-keys"
+
+        def asciiFile = file("gradle/verification-keyring.keys")
+        def binaryFile = file("gradle/verification-keyring.gpg")
+        def asciiBefore = asciiFile.bytes
+        SecuritySupport.loadKeyRingFile(asciiFile).size() == 2
+        SecuritySupport.loadKeyRingFile(binaryFile).size() == 2
+
+        and: "user drops the orphan and pins the keyring format to binary"
+        replaceMetadataFile {
+            keyServer(keyServerFixture.uri)
+            keyRingFormat("binary")
+            addTrustedKey("org:foo:1.0", SigningFixtures.validPublicKeyHexString)
+        }
+
+        when:
+        succeeds ":help", "--prune-keys"
+
+        then: "binary file is pruned"
+        def prunedBinary = SecuritySupport.loadKeyRingFile(binaryFile)
+        prunedBinary.size() == 1
+        prunedBinary.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+
+        and: "armored file is byte-for-byte untouched"
+        asciiFile.bytes == asciiBefore
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37275")
     def "--prune-keys fails fast when verification metadata is missing"() {
         given:
         javaLibrary()

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -610,6 +610,64 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         keyringsAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/37275")
+    def "--prune-keys drops orphaned keys from keyrings"() {
+        def orphan = newKeyRing()
+        def orphanId = Fingerprint.of(orphan.publicKey)
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+        }
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature {
+                orphan.sign(it, [(SigningFixtures.validSecretKey): SigningFixtures.validPassword])
+            }
+        }
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        and: "seed keyring with both the trusted key and an orphan"
+        serveValidKey()
+        keyServerFixture.registerPublicKey(orphan.publicKey)
+        writeVerificationMetadata()
+        succeeds ":help", "--export-keys"
+
+        def seededBinary = file("gradle/verification-keyring.gpg")
+        def seededAscii = file("gradle/verification-keyring.keys")
+        SecuritySupport.loadKeyRingFile(seededBinary).size() == 2
+        SecuritySupport.loadKeyRingFile(seededAscii).size() == 2
+
+        and: "user manually prunes the orphan from verification-metadata.xml"
+        replaceMetadataFile {
+            keyServer(keyServerFixture.uri)
+            addTrustedKey("org:foo:1.0", SigningFixtures.validPublicKeyHexString)
+        }
+
+        when:
+        succeeds ":help", "--prune-keys"
+
+        then:
+        def prunedBinary = SecuritySupport.loadKeyRingFile(file("gradle/verification-keyring.gpg"))
+        prunedBinary.size() == 1
+        prunedBinary.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+        !prunedBinary.find { it.publicKey.keyID == orphan.publicKey.keyID }
+
+        and:
+        def prunedAscii = SecuritySupport.loadKeyRingFile(file("gradle/verification-keyring.keys"))
+        prunedAscii.size() == 1
+        prunedAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+        !prunedAscii.find { it.publicKey.keyID == orphan.publicKey.keyID }
+
+        and: "orphanId appears in no keyring"
+        !prunedBinary.any { Fingerprint.of(it.publicKey) == orphanId }
+        !prunedAscii.any { Fingerprint.of(it.publicKey) == orphanId }
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/23607")
     def "verification-keyring.keys contains only necessary data"() {
         def keyring = newKeyRing()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -89,8 +89,8 @@ public class StartParameterResolutionOverride {
         File verificationsFile = DependencyVerificationOverride.dependencyVerificationsFile(gradleDir);
         fileResourceListener.fileObserved(verificationsFile);
 
-        if (!checksums.isEmpty() || startParameter.isExportKeys()) {
-            return new WriteDependencyVerificationFile(verificationsFile, buildOperationExecutor, checksums, checksumService, signatureVerificationServiceFactory, startParameter.isDryRun(), startParameter.isExportKeys());
+        if (!checksums.isEmpty() || startParameter.isExportKeys() || startParameter.isPruneKeys()) {
+            return new WriteDependencyVerificationFile(verificationsFile, buildOperationExecutor, checksums, checksumService, signatureVerificationServiceFactory, startParameter.isDryRun(), startParameter.isExportKeys(), startParameter.isPruneKeys());
         }
 
         if (!verificationsFile.exists() ||

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -311,7 +311,10 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
      */
     private void pruneKeyRings(DependencyVerifier verifier, BuildTreeDefinedKeys existingKeyring) throws IOException {
         Set<String> referencedKeys = collectReferencedKeys(verifier);
-        List<PGPPublicKeyRing> existing = loadExistingKeyRing(existingKeyring);
+        // Always read the real on-disk keyring, even in dry-run mode — the `.dryrun.*` files are
+        // cleaned up by maybeCleanupDryRunFiles() in the constructor, so there is nothing to read
+        // from them, and loading an empty list would effectively prune everything.
+        List<PGPPublicKeyRing> existing = loadKeyRingFromDisk(existingKeyring.getEffectiveKeyringsFile());
         List<PGPPublicKeyRing> kept = new java.util.ArrayList<>(existing.size());
         for (PGPPublicKeyRing ring : existing) {
             if (isReferenced(ring, referencedKeys)) {
@@ -752,11 +755,14 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     }
 
     private List<PGPPublicKeyRing> loadExistingKeyRing(BuildTreeDefinedKeys keyrings) throws IOException {
-        File effectiveFile = mayBeDryRunFile(keyrings.getEffectiveKeyringsFile());
-        if (!effectiveFile.exists()) {
+        return loadKeyRingFromDisk(mayBeDryRunFile(keyrings.getEffectiveKeyringsFile()));
+    }
+
+    private static List<PGPPublicKeyRing> loadKeyRingFromDisk(File file) throws IOException {
+        if (!file.exists()) {
             return Collections.emptyList();
         }
-        List<PGPPublicKeyRing> existingRings = SecuritySupport.loadKeyRingFile(effectiveFile);
+        List<PGPPublicKeyRing> existingRings = SecuritySupport.loadKeyRingFile(file);
         LOGGER.info("Existing keyring file contains {} keyrings", existingRings.size());
         return existingRings;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -73,6 +73,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -315,7 +316,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         // cleaned up by maybeCleanupDryRunFiles() in the constructor, so there is nothing to read
         // from them, and loading an empty list would effectively prune everything.
         List<PGPPublicKeyRing> existing = loadKeyRingFromDisk(existingKeyring.getEffectiveKeyringsFile());
-        List<PGPPublicKeyRing> kept = new java.util.ArrayList<>(existing.size());
+        List<PGPPublicKeyRing> kept = new ArrayList<>(existing.size());
         for (PGPPublicKeyRing ring : existing) {
             if (isReferenced(ring, referencedKeys)) {
                 kept.add(ring);
@@ -329,21 +330,11 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
             LOGGER.warn("The following keys are referenced by the verification metadata but are not present in the keyring: {}. Run with --export-keys to download them.", missing);
         }
 
-        DependencyVerificationConfiguration.KeyringFormat format = verifier.getConfiguration().getKeyringFormat();
         File asciiArmoredFile = mayBeDryRunFile(existingKeyring.getAsciiKeyringsFile());
         File keyringFile = mayBeDryRunFile(existingKeyring.getBinaryKeyringsFile());
 
         int dropped = existing.size() - kept.size();
-        if (format == null) {
-            writeAsciiArmoredKeyRingFile(asciiArmoredFile, kept);
-            writeBinaryKeyringFile(keyringFile, kept);
-        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.ARMORED)) {
-            writeAsciiArmoredKeyRingFile(asciiArmoredFile, kept);
-        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.BINARY)) {
-            writeBinaryKeyringFile(keyringFile, kept);
-        } else {
-            throw new IllegalArgumentException("Unknown keyring format " + format);
-        }
+        writeKeyRingFiles(verifier.getConfiguration().getKeyringFormat(), asciiArmoredFile, keyringFile, kept);
 
         if (dropped == 0) {
             LOGGER.lifecycle("Keyring is up to date — no unreferenced keys to prune ({} kept)", kept.size());
@@ -663,18 +654,14 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         File asciiArmoredFile = mayBeDryRunFile(existingKeyring.getAsciiKeyringsFile());
         File keyringFile = mayBeDryRunFile(existingKeyring.getBinaryKeyringsFile());
 
+        writeKeyRingFiles(keyringFormat, asciiArmoredFile, keyringFile, allKeyRings);
+
         if (keyringFormat == null) {
-            writeAsciiArmoredKeyRingFile(asciiArmoredFile, allKeyRings);
-            writeBinaryKeyringFile(keyringFile, allKeyRings);
             LOGGER.lifecycle("Exported {} keys to {} and {}", allKeyRings.size(), keyringFile, asciiArmoredFile);
         } else if (keyringFormat.equals(DependencyVerificationConfiguration.KeyringFormat.ARMORED)) {
-            writeAsciiArmoredKeyRingFile(asciiArmoredFile, allKeyRings);
             LOGGER.lifecycle("Exported {} keys to {}", allKeyRings.size(), asciiArmoredFile);
-        } else if (keyringFormat.equals(DependencyVerificationConfiguration.KeyringFormat.BINARY)) {
-            writeBinaryKeyringFile(keyringFile, allKeyRings);
-            LOGGER.lifecycle("Exported {} keys to {}", allKeyRings.size(), keyringFile);
         } else {
-            throw new IllegalArgumentException("Unknown keyring format " + keyringFormat);
+            LOGGER.lifecycle("Exported {} keys to {}", allKeyRings.size(), keyringFile);
         }
     }
 
@@ -688,6 +675,24 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
             }
         });
         return seenKeyIds.values();
+    }
+
+    private void writeKeyRingFiles(
+        DependencyVerificationConfiguration.@Nullable KeyringFormat format,
+        File asciiFile,
+        File binaryFile,
+        Collection<PGPPublicKeyRing> rings
+    ) throws IOException {
+        if (format == null) {
+            writeAsciiArmoredKeyRingFile(asciiFile, rings);
+            writeBinaryKeyringFile(binaryFile, rings);
+        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.ARMORED)) {
+            writeAsciiArmoredKeyRingFile(asciiFile, rings);
+        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.BINARY)) {
+            writeBinaryKeyringFile(binaryFile, rings);
+        } else {
+            throw new IllegalArgumentException("Unknown keyring format " + format);
+        }
     }
 
     private void writeAsciiArmoredKeyRingFile(File ascii, Collection<PGPPublicKeyRing> allKeyRings) throws IOException {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -22,6 +22,7 @@ import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -113,6 +114,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     private final boolean isDryRun;
     private final boolean generatePgpInfo;
     private final boolean isExportKeyring;
+    private final boolean isPruneKeys;
 
     private boolean hasMissingSignatures = false;
     private boolean hasMissingKeys = false;
@@ -125,7 +127,8 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         ChecksumService checksumService,
         SignatureVerificationServiceFactory signatureVerificationServiceFactory,
         boolean isDryRun,
-        boolean exportKeyRing
+        boolean exportKeyRing,
+        boolean pruneKeys
     ) {
         this.buildOperationExecutor = buildOperationExecutor;
         this.checksums = checksums;
@@ -135,6 +138,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         this.isDryRun = isDryRun;
         this.generatePgpInfo = checksums.contains(PGP);
         this.isExportKeyring = exportKeyRing;
+        this.isPruneKeys = pruneKeys;
         maybeCleanupDryRunFiles();
     }
 
@@ -177,11 +181,15 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         return new DependencyVerifyingModuleComponentRepository(original, this, generatePgpInfo);
     }
 
+    private boolean isPruneKeysOnly() {
+        return isPruneKeys && !isExportKeyring && !isWriteVerificationFile();
+    }
+
     private void maybeCleanupDryRunFiles() {
         if (isDryRun) {
             boolean removed = false;
             removed |= mayBeDryRunFile(verificationFile).delete() || removed;
-            if (isExportKeyring) {
+            if (isExportKeyring || isPruneKeys) {
                 BuildTreeDefinedKeys existingKeyring = new BuildTreeDefinedKeys(verificationFile.getParentFile(), verificationsBuilder.getKeyringFormat());
                 removed |= mayBeDryRunFile(existingKeyring.getAsciiKeyringsFile()).delete();
                 removed |= mayBeDryRunFile(existingKeyring.getBinaryKeyringsFile()).delete();
@@ -195,7 +203,20 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     @Override
     public void buildFinished(GradleInternal gradle) {
         ensureOutputDirCreated();
+        if (isPruneKeysOnly() && !verificationFile.exists()) {
+            throw new InvalidUserDataException("Cannot run --prune-keys: no dependency verification metadata file at " + verificationFile);
+        }
         maybeReadExistingFile();
+        if (isPruneKeysOnly()) {
+            BuildTreeDefinedKeys existingKeyring = new BuildTreeDefinedKeys(verificationFile.getParentFile(), verificationsBuilder.getKeyringFormat());
+            try {
+                DependencyVerifier verifier = verificationsBuilder.build();
+                pruneKeyRings(verifier, existingKeyring);
+            } catch (IOException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
+            return;
+        }
         // when we generate the verification file, we intentionally ignore if the "use key servers" flag is false
         // because otherwise it forces the user to remove the option in the XML file, generate, then switch it back.
         boolean offline = gradle.getStartParameter().isOffline();
@@ -251,29 +272,110 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     }
 
     private void exportKeys(SignatureVerificationService signatureVerificationService, DependencyVerifier verifier, BuildTreeDefinedKeys existingKeyring) throws IOException {
-        Set<String> keysToExport = new HashSet<>();
-        verifier.getConfiguration()
-            .getTrustedKeys()
-            .stream()
-            .map(DependencyVerificationConfiguration.TrustedKey::getKeyId)
-            .forEach(keysToExport::add);
-        verifier.getConfiguration()
-            .getIgnoredKeys()
-            .stream()
-            .map(IgnoredKey::getKeyId)
-            .forEach(keysToExport::add);
-        verifier.getVerificationMetadata()
-            .stream()
-            .flatMap(md -> md.getArtifactVerifications().stream())
-            .flatMap(avm -> Stream.concat(avm.getTrustedPgpKeys().stream(), avm.getIgnoredPgpKeys().stream().map(IgnoredKey::getKeyId)))
-            .forEach(keysToExport::add);
+        Set<String> keysToExport = collectReferencedKeys(verifier);
 
         exportKeyRingCollection(
             signatureVerificationService.getPublicKeyService(),
             existingKeyring,
             keysToExport,
-            verifier.getConfiguration().getKeyringFormat()
+            verifier.getConfiguration().getKeyringFormat(),
+            isPruneKeys
         );
+    }
+
+    private static Set<String> collectReferencedKeys(DependencyVerifier verifier) {
+        Set<String> referenced = new HashSet<>();
+        verifier.getConfiguration()
+            .getTrustedKeys()
+            .stream()
+            .map(DependencyVerificationConfiguration.TrustedKey::getKeyId)
+            .forEach(referenced::add);
+        verifier.getConfiguration()
+            .getIgnoredKeys()
+            .stream()
+            .map(IgnoredKey::getKeyId)
+            .forEach(referenced::add);
+        verifier.getVerificationMetadata()
+            .stream()
+            .flatMap(md -> md.getArtifactVerifications().stream())
+            .flatMap(avm -> Stream.concat(avm.getTrustedPgpKeys().stream(), avm.getIgnoredPgpKeys().stream().map(IgnoredKey::getKeyId)))
+            .forEach(referenced::add);
+        return referenced;
+    }
+
+    /**
+     * Prunes the dependency verification keyring files so they only contain keys referenced by the
+     * current {@link DependencyVerifier}. Does not contact any key server and does not go through
+     * the {@link SignatureVerificationService}: the keyring files are loaded from disk, filtered
+     * in memory, and written back.
+     */
+    private void pruneKeyRings(DependencyVerifier verifier, BuildTreeDefinedKeys existingKeyring) throws IOException {
+        Set<String> referencedKeys = collectReferencedKeys(verifier);
+        List<PGPPublicKeyRing> existing = loadExistingKeyRing(existingKeyring);
+        List<PGPPublicKeyRing> kept = new java.util.ArrayList<>(existing.size());
+        for (PGPPublicKeyRing ring : existing) {
+            if (isReferenced(ring, referencedKeys)) {
+                kept.add(ring);
+            }
+        }
+
+        Set<String> presentInKept = keysPresentIn(kept);
+        Set<String> missing = new HashSet<>(referencedKeys);
+        missing.removeAll(presentInKept);
+        if (!missing.isEmpty()) {
+            LOGGER.warn("The following keys are referenced by the verification metadata but are not present in the keyring: {}. Run with --export-keys to download them.", missing);
+        }
+
+        DependencyVerificationConfiguration.KeyringFormat format = verifier.getConfiguration().getKeyringFormat();
+        File asciiArmoredFile = mayBeDryRunFile(existingKeyring.getAsciiKeyringsFile());
+        File keyringFile = mayBeDryRunFile(existingKeyring.getBinaryKeyringsFile());
+
+        int dropped = existing.size() - kept.size();
+        if (format == null) {
+            writeAsciiArmoredKeyRingFile(asciiArmoredFile, kept);
+            writeBinaryKeyringFile(keyringFile, kept);
+        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.ARMORED)) {
+            writeAsciiArmoredKeyRingFile(asciiArmoredFile, kept);
+        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.BINARY)) {
+            writeBinaryKeyringFile(keyringFile, kept);
+        } else {
+            throw new IllegalArgumentException("Unknown keyring format " + format);
+        }
+
+        if (dropped == 0) {
+            LOGGER.lifecycle("Keyring is up to date — no unreferenced keys to prune ({} kept)", kept.size());
+        } else {
+            LOGGER.lifecycle("Pruned {} unreferenced key(s) from the keyring, {} key(s) kept. If a key was pruned by mistake, run with --export-keys to re-download it.", dropped, kept.size());
+        }
+    }
+
+    static boolean isReferenced(PGPPublicKeyRing ring, Set<String> referencedKeys) {
+        // Precondition: entries in referencedKeys are upper-case hex (16-char long ID or 40-char fingerprint).
+        // TrustedKey / IgnoredKey normalise input to upper-case at construction time; callers must pass such values.
+        Iterator<PGPPublicKey> it = ring.getPublicKeys();
+        while (it.hasNext()) {
+            PGPPublicKey pk = it.next();
+            if (referencedKeys.contains(SecuritySupport.toLongIdHexString(pk.getKeyID()).toUpperCase(Locale.ROOT))) {
+                return true;
+            }
+            if (referencedKeys.contains(Fingerprint.of(pk).toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<String> keysPresentIn(Collection<PGPPublicKeyRing> rings) {
+        Set<String> present = new HashSet<>();
+        for (PGPPublicKeyRing ring : rings) {
+            Iterator<PGPPublicKey> it = ring.getPublicKeys();
+            while (it.hasNext()) {
+                PGPPublicKey pk = it.next();
+                present.add(SecuritySupport.toLongIdHexString(pk.getKeyID()).toUpperCase(Locale.ROOT));
+                present.add(Fingerprint.of(pk).toString());
+            }
+        }
+        return present;
     }
 
     private void maybeReadExistingFile() {
@@ -533,7 +635,8 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         PublicKeyService publicKeyService,
         BuildTreeDefinedKeys existingKeyring,
         Set<String> publicKeys,
-        DependencyVerificationConfiguration.@Nullable KeyringFormat keyringFormat
+        DependencyVerificationConfiguration.@Nullable KeyringFormat keyringFormat,
+        boolean pruneKeys
     ) throws IOException {
         List<PGPPublicKeyRing> existingRings = loadExistingKeyRing(existingKeyring);
         PGPPublicKeyRingListBuilder builder = new PGPPublicKeyRingListBuilder();
@@ -549,7 +652,10 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
             .stream()
             .filter(keyring -> PGPUtils.getSize(keyring) != 0);
 
-        Collection<PGPPublicKeyRing> allKeyRings = uniqueKeyRings(Stream.concat(keysSeenInVerifier, existingRings.stream()));
+        Stream<PGPPublicKeyRing> retainedExisting = pruneKeys
+            ? existingRings.stream().filter(ring -> isReferenced(ring, publicKeys))
+            : existingRings.stream();
+        Collection<PGPPublicKeyRing> allKeyRings = uniqueKeyRings(Stream.concat(keysSeenInVerifier, retainedExisting));
 
         File asciiArmoredFile = mayBeDryRunFile(existingKeyring.getAsciiKeyringsFile());
         File keyringFile = mayBeDryRunFile(existingKeyring.getBinaryKeyringsFile());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -313,7 +313,10 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
      */
     private void pruneKeyRings(DependencyVerifier verifier, BuildTreeDefinedKeys existingKeyring) throws IOException {
         Set<String> referencedKeys = collectReferencedKeys(verifier);
-        List<PGPPublicKeyRing> existing = loadExistingKeyRing(existingKeyring);
+        // Always read the real on-disk keyring, even in dry-run mode — the `.dryrun.*` files are
+        // cleaned up by maybeCleanupDryRunFiles() in the constructor, so there is nothing to read
+        // from them, and loading an empty list would effectively prune everything.
+        List<PGPPublicKeyRing> existing = loadKeyRingFromDisk(existingKeyring.getEffectiveKeyringsFile());
         List<PGPPublicKeyRing> kept = new java.util.ArrayList<>(existing.size());
         for (PGPPublicKeyRing ring : existing) {
             if (isReferenced(ring, referencedKeys)) {
@@ -754,11 +757,14 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     }
 
     private List<PGPPublicKeyRing> loadExistingKeyRing(BuildTreeDefinedKeys keyrings) throws IOException {
-        File effectiveFile = mayBeDryRunFile(keyrings.getEffectiveKeyringsFile());
-        if (!effectiveFile.exists()) {
+        return loadKeyRingFromDisk(mayBeDryRunFile(keyrings.getEffectiveKeyringsFile()));
+    }
+
+    private static List<PGPPublicKeyRing> loadKeyRingFromDisk(File file) throws IOException {
+        if (!file.exists()) {
             return Collections.emptyList();
         }
-        List<PGPPublicKeyRing> existingRings = SecuritySupport.loadKeyRingFile(effectiveFile);
+        List<PGPPublicKeyRing> existingRings = SecuritySupport.loadKeyRingFile(file);
         LOGGER.info("Existing keyring file contains {} keyrings", existingRings.size());
         return existingRings;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -22,6 +22,7 @@ import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
@@ -115,6 +116,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     private final boolean isDryRun;
     private final boolean generatePgpInfo;
     private final boolean isExportKeyring;
+    private final boolean isPruneKeys;
 
     private boolean hasMissingSignatures = false;
     private boolean hasMissingKeys = false;
@@ -127,7 +129,8 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         ChecksumService checksumService,
         SignatureVerificationServiceFactory signatureVerificationServiceFactory,
         boolean isDryRun,
-        boolean exportKeyRing
+        boolean exportKeyRing,
+        boolean pruneKeys
     ) {
         this.buildOperationExecutor = buildOperationExecutor;
         this.checksums = checksums;
@@ -137,6 +140,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         this.isDryRun = isDryRun;
         this.generatePgpInfo = checksums.contains(PGP);
         this.isExportKeyring = exportKeyRing;
+        this.isPruneKeys = pruneKeys;
         maybeCleanupDryRunFiles();
     }
 
@@ -179,11 +183,15 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         return new DependencyVerifyingModuleComponentRepository(original, this, generatePgpInfo);
     }
 
+    private boolean isPruneKeysOnly() {
+        return isPruneKeys && !isExportKeyring && !isWriteVerificationFile();
+    }
+
     private void maybeCleanupDryRunFiles() {
         if (isDryRun) {
             boolean removed = false;
             removed |= mayBeDryRunFile(verificationFile).delete() || removed;
-            if (isExportKeyring) {
+            if (isExportKeyring || isPruneKeys) {
                 BuildTreeDefinedKeys existingKeyring = new BuildTreeDefinedKeys(verificationFile.getParentFile(), verificationsBuilder.getKeyringFormat());
                 removed |= mayBeDryRunFile(existingKeyring.getAsciiKeyringsFile()).delete();
                 removed |= mayBeDryRunFile(existingKeyring.getBinaryKeyringsFile()).delete();
@@ -197,7 +205,20 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     @Override
     public void buildFinished(GradleInternal gradle) {
         ensureOutputDirCreated();
+        if (isPruneKeysOnly() && !verificationFile.exists()) {
+            throw new InvalidUserDataException("Cannot run --prune-keys: no dependency verification metadata file at " + verificationFile);
+        }
         maybeReadExistingFile();
+        if (isPruneKeysOnly()) {
+            BuildTreeDefinedKeys existingKeyring = new BuildTreeDefinedKeys(verificationFile.getParentFile(), verificationsBuilder.getKeyringFormat());
+            try {
+                DependencyVerifier verifier = verificationsBuilder.build();
+                pruneKeyRings(verifier, existingKeyring);
+            } catch (IOException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
+            return;
+        }
         // when we generate the verification file, we intentionally ignore if the "use key servers" flag is false
         // because otherwise it forces the user to remove the option in the XML file, generate, then switch it back.
         boolean offline = gradle.getStartParameter().isOffline();
@@ -253,29 +274,110 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     }
 
     private void exportKeys(SignatureVerificationService signatureVerificationService, DependencyVerifier verifier, BuildTreeDefinedKeys existingKeyring) throws IOException {
-        Set<String> keysToExport = new HashSet<>();
-        verifier.getConfiguration()
-            .getTrustedKeys()
-            .stream()
-            .map(DependencyVerificationConfiguration.TrustedKey::getKeyId)
-            .forEach(keysToExport::add);
-        verifier.getConfiguration()
-            .getIgnoredKeys()
-            .stream()
-            .map(IgnoredKey::getKeyId)
-            .forEach(keysToExport::add);
-        verifier.getVerificationMetadata()
-            .stream()
-            .flatMap(md -> md.getArtifactVerifications().stream())
-            .flatMap(avm -> Stream.concat(avm.getTrustedPgpKeys().stream(), avm.getIgnoredPgpKeys().stream().map(IgnoredKey::getKeyId)))
-            .forEach(keysToExport::add);
+        Set<String> keysToExport = collectReferencedKeys(verifier);
 
         exportKeyRingCollection(
             signatureVerificationService.getPublicKeyService(),
             existingKeyring,
             keysToExport,
-            verifier.getConfiguration().getKeyringFormat()
+            verifier.getConfiguration().getKeyringFormat(),
+            isPruneKeys
         );
+    }
+
+    private static Set<String> collectReferencedKeys(DependencyVerifier verifier) {
+        Set<String> referenced = new HashSet<>();
+        verifier.getConfiguration()
+            .getTrustedKeys()
+            .stream()
+            .map(DependencyVerificationConfiguration.TrustedKey::getKeyId)
+            .forEach(referenced::add);
+        verifier.getConfiguration()
+            .getIgnoredKeys()
+            .stream()
+            .map(IgnoredKey::getKeyId)
+            .forEach(referenced::add);
+        verifier.getVerificationMetadata()
+            .stream()
+            .flatMap(md -> md.getArtifactVerifications().stream())
+            .flatMap(avm -> Stream.concat(avm.getTrustedPgpKeys().stream(), avm.getIgnoredPgpKeys().stream().map(IgnoredKey::getKeyId)))
+            .forEach(referenced::add);
+        return referenced;
+    }
+
+    /**
+     * Prunes the dependency verification keyring files so they only contain keys referenced by the
+     * current {@link DependencyVerifier}. Does not contact any key server and does not go through
+     * the {@link SignatureVerificationService}: the keyring files are loaded from disk, filtered
+     * in memory, and written back.
+     */
+    private void pruneKeyRings(DependencyVerifier verifier, BuildTreeDefinedKeys existingKeyring) throws IOException {
+        Set<String> referencedKeys = collectReferencedKeys(verifier);
+        List<PGPPublicKeyRing> existing = loadExistingKeyRing(existingKeyring);
+        List<PGPPublicKeyRing> kept = new java.util.ArrayList<>(existing.size());
+        for (PGPPublicKeyRing ring : existing) {
+            if (isReferenced(ring, referencedKeys)) {
+                kept.add(ring);
+            }
+        }
+
+        Set<String> presentInKept = keysPresentIn(kept);
+        Set<String> missing = new HashSet<>(referencedKeys);
+        missing.removeAll(presentInKept);
+        if (!missing.isEmpty()) {
+            LOGGER.warn("The following keys are referenced by the verification metadata but are not present in the keyring: {}. Run with --export-keys to download them.", missing);
+        }
+
+        DependencyVerificationConfiguration.KeyringFormat format = verifier.getConfiguration().getKeyringFormat();
+        File asciiArmoredFile = mayBeDryRunFile(existingKeyring.getAsciiKeyringsFile());
+        File keyringFile = mayBeDryRunFile(existingKeyring.getBinaryKeyringsFile());
+
+        int dropped = existing.size() - kept.size();
+        if (format == null) {
+            writeAsciiArmoredKeyRingFile(asciiArmoredFile, kept);
+            writeBinaryKeyringFile(keyringFile, kept);
+        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.ARMORED)) {
+            writeAsciiArmoredKeyRingFile(asciiArmoredFile, kept);
+        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.BINARY)) {
+            writeBinaryKeyringFile(keyringFile, kept);
+        } else {
+            throw new IllegalArgumentException("Unknown keyring format " + format);
+        }
+
+        if (dropped == 0) {
+            LOGGER.lifecycle("Keyring is up to date — no unreferenced keys to prune ({} kept)", kept.size());
+        } else {
+            LOGGER.lifecycle("Pruned {} unreferenced key(s) from the keyring, {} key(s) kept. If a key was pruned by mistake, run with --export-keys to re-download it.", dropped, kept.size());
+        }
+    }
+
+    static boolean isReferenced(PGPPublicKeyRing ring, Set<String> referencedKeys) {
+        // Precondition: entries in referencedKeys are upper-case hex (16-char long ID or 40-char fingerprint).
+        // TrustedKey / IgnoredKey normalise input to upper-case at construction time; callers must pass such values.
+        Iterator<PGPPublicKey> it = ring.getPublicKeys();
+        while (it.hasNext()) {
+            PGPPublicKey pk = it.next();
+            if (referencedKeys.contains(SecuritySupport.toLongIdHexString(pk.getKeyID()).toUpperCase(Locale.ROOT))) {
+                return true;
+            }
+            if (referencedKeys.contains(Fingerprint.of(pk).toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<String> keysPresentIn(Collection<PGPPublicKeyRing> rings) {
+        Set<String> present = new HashSet<>();
+        for (PGPPublicKeyRing ring : rings) {
+            Iterator<PGPPublicKey> it = ring.getPublicKeys();
+            while (it.hasNext()) {
+                PGPPublicKey pk = it.next();
+                present.add(SecuritySupport.toLongIdHexString(pk.getKeyID()).toUpperCase(Locale.ROOT));
+                present.add(Fingerprint.of(pk).toString());
+            }
+        }
+        return present;
     }
 
     private void maybeReadExistingFile() {
@@ -535,7 +637,8 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         PublicKeyService publicKeyService,
         BuildTreeDefinedKeys existingKeyring,
         Set<String> publicKeys,
-        DependencyVerificationConfiguration.@Nullable KeyringFormat keyringFormat
+        DependencyVerificationConfiguration.@Nullable KeyringFormat keyringFormat,
+        boolean pruneKeys
     ) throws IOException {
         List<PGPPublicKeyRing> existingRings = loadExistingKeyRing(existingKeyring);
         PGPPublicKeyRingListBuilder builder = new PGPPublicKeyRingListBuilder();
@@ -551,7 +654,10 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
             .stream()
             .filter(keyring -> PGPUtils.getSize(keyring) != 0);
 
-        Collection<PGPPublicKeyRing> allKeyRings = uniqueKeyRings(Stream.concat(keysSeenInVerifier, existingRings.stream()));
+        Stream<PGPPublicKeyRing> retainedExisting = pruneKeys
+            ? existingRings.stream().filter(ring -> isReferenced(ring, publicKeys))
+            : existingRings.stream();
+        Collection<PGPPublicKeyRing> allKeyRings = uniqueKeyRings(Stream.concat(keysSeenInVerifier, retainedExisting));
 
         File asciiArmoredFile = mayBeDryRunFile(existingKeyring.getAsciiKeyringsFile());
         File keyringFile = mayBeDryRunFile(existingKeyring.getBinaryKeyringsFile());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -75,6 +75,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -317,7 +318,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         // cleaned up by maybeCleanupDryRunFiles() in the constructor, so there is nothing to read
         // from them, and loading an empty list would effectively prune everything.
         List<PGPPublicKeyRing> existing = loadKeyRingFromDisk(existingKeyring.getEffectiveKeyringsFile());
-        List<PGPPublicKeyRing> kept = new java.util.ArrayList<>(existing.size());
+        List<PGPPublicKeyRing> kept = new ArrayList<>(existing.size());
         for (PGPPublicKeyRing ring : existing) {
             if (isReferenced(ring, referencedKeys)) {
                 kept.add(ring);
@@ -331,21 +332,11 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
             LOGGER.warn("The following keys are referenced by the verification metadata but are not present in the keyring: {}. Run with --export-keys to download them.", missing);
         }
 
-        DependencyVerificationConfiguration.KeyringFormat format = verifier.getConfiguration().getKeyringFormat();
         File asciiArmoredFile = mayBeDryRunFile(existingKeyring.getAsciiKeyringsFile());
         File keyringFile = mayBeDryRunFile(existingKeyring.getBinaryKeyringsFile());
 
         int dropped = existing.size() - kept.size();
-        if (format == null) {
-            writeAsciiArmoredKeyRingFile(asciiArmoredFile, kept);
-            writeBinaryKeyringFile(keyringFile, kept);
-        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.ARMORED)) {
-            writeAsciiArmoredKeyRingFile(asciiArmoredFile, kept);
-        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.BINARY)) {
-            writeBinaryKeyringFile(keyringFile, kept);
-        } else {
-            throw new IllegalArgumentException("Unknown keyring format " + format);
-        }
+        writeKeyRingFiles(verifier.getConfiguration().getKeyringFormat(), asciiArmoredFile, keyringFile, kept);
 
         if (dropped == 0) {
             LOGGER.lifecycle("Keyring is up to date — no unreferenced keys to prune ({} kept)", kept.size());
@@ -665,18 +656,14 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         File asciiArmoredFile = mayBeDryRunFile(existingKeyring.getAsciiKeyringsFile());
         File keyringFile = mayBeDryRunFile(existingKeyring.getBinaryKeyringsFile());
 
+        writeKeyRingFiles(keyringFormat, asciiArmoredFile, keyringFile, allKeyRings);
+
         if (keyringFormat == null) {
-            writeAsciiArmoredKeyRingFile(asciiArmoredFile, allKeyRings);
-            writeBinaryKeyringFile(keyringFile, allKeyRings);
             LOGGER.lifecycle("Exported {} keys to {} and {}", allKeyRings.size(), keyringFile, asciiArmoredFile);
         } else if (keyringFormat.equals(DependencyVerificationConfiguration.KeyringFormat.ARMORED)) {
-            writeAsciiArmoredKeyRingFile(asciiArmoredFile, allKeyRings);
             LOGGER.lifecycle("Exported {} keys to {}", allKeyRings.size(), asciiArmoredFile);
-        } else if (keyringFormat.equals(DependencyVerificationConfiguration.KeyringFormat.BINARY)) {
-            writeBinaryKeyringFile(keyringFile, allKeyRings);
-            LOGGER.lifecycle("Exported {} keys to {}", allKeyRings.size(), keyringFile);
         } else {
-            throw new IllegalArgumentException("Unknown keyring format " + keyringFormat);
+            LOGGER.lifecycle("Exported {} keys to {}", allKeyRings.size(), keyringFile);
         }
     }
 
@@ -690,6 +677,24 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
             }
         });
         return seenKeyIds.values();
+    }
+
+    private void writeKeyRingFiles(
+        DependencyVerificationConfiguration.@Nullable KeyringFormat format,
+        File asciiFile,
+        File binaryFile,
+        Collection<PGPPublicKeyRing> rings
+    ) throws IOException {
+        if (format == null) {
+            writeAsciiArmoredKeyRingFile(asciiFile, rings);
+            writeBinaryKeyringFile(binaryFile, rings);
+        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.ARMORED)) {
+            writeAsciiArmoredKeyRingFile(asciiFile, rings);
+        } else if (format.equals(DependencyVerificationConfiguration.KeyringFormat.BINARY)) {
+            writeBinaryKeyringFile(binaryFile, rings);
+        } else {
+            throw new IllegalArgumentException("Unknown keyring format " + format);
+        }
     }
 
     private void writeAsciiArmoredKeyRingFile(File ascii, Collection<PGPPublicKeyRing> allKeyRings) throws IOException {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFileIsReferencedTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFileIsReferencedTest.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.writer
+
+import org.bouncycastle.bcpg.HashAlgorithmTags
+import org.bouncycastle.bcpg.PublicKeyAlgorithmTags
+import org.bouncycastle.bcpg.sig.KeyFlags
+import org.bouncycastle.crypto.generators.RSAKeyPairGenerator
+import org.bouncycastle.crypto.params.RSAKeyGenerationParameters
+import org.bouncycastle.openpgp.PGPKeyRingGenerator
+import org.bouncycastle.openpgp.PGPPublicKey
+import org.bouncycastle.openpgp.PGPPublicKeyRing
+import org.bouncycastle.openpgp.PGPSignatureSubpacketGenerator
+import org.bouncycastle.openpgp.operator.bc.BcPBESecretKeyEncryptorBuilder
+import org.bouncycastle.openpgp.operator.bc.BcPGPContentSignerBuilder
+import org.bouncycastle.openpgp.operator.bc.BcPGPDigestCalculatorProvider
+import org.bouncycastle.openpgp.operator.bc.BcPGPKeyPair
+import org.gradle.security.internal.Fingerprint
+import org.gradle.security.internal.SecuritySupport
+import spock.lang.Specification
+
+import java.security.SecureRandom
+
+import static java.util.Collections.emptySet
+import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.writer.WriteDependencyVerificationFile.isReferenced
+
+class WriteDependencyVerificationFileIsReferencedTest extends Specification {
+
+    // Generate a fresh keyring with master + encryption subkey, the common shape of keys this
+    // code path is meant to handle (whole-ring preservation when a subkey is referenced).
+    PGPPublicKeyRing ring = generateRingWithSubkey()
+
+    PGPPublicKey master = ring.publicKeys.findAll { it.masterKey }.first()
+    PGPPublicKey subkey = ring.publicKeys.findAll { !it.masterKey }.first()
+
+    def "empty reference set matches nothing"() {
+        expect:
+        !isReferenced(ring, emptySet())
+    }
+
+    def "matches on master long id"() {
+        expect:
+        isReferenced(ring, [SecuritySupport.toLongIdHexString(master.keyID).toUpperCase(Locale.ROOT)] as Set)
+    }
+
+    def "matches on master fingerprint"() {
+        expect:
+        isReferenced(ring, [Fingerprint.of(master).toString()] as Set)
+    }
+
+    def "matches on subkey long id — preserves the whole ring"() {
+        expect:
+        isReferenced(ring, [SecuritySupport.toLongIdHexString(subkey.keyID).toUpperCase(Locale.ROOT)] as Set)
+    }
+
+    def "matches on subkey fingerprint — preserves the whole ring"() {
+        expect:
+        isReferenced(ring, [Fingerprint.of(subkey).toString()] as Set)
+    }
+
+    def "does not match on unrelated key id"() {
+        expect:
+        !isReferenced(ring, ['DEADBEEFDEADBEEF'] as Set)
+    }
+
+    def "is case-sensitive — lower-case key id does not match upper-case reference"() {
+        // Callers are expected to uppercase their hex, per the contract at the call sites.
+        given:
+        def lower = SecuritySupport.toLongIdHexString(master.keyID).toLowerCase(Locale.ROOT)
+        expect:
+        !isReferenced(ring, [lower] as Set)
+    }
+
+    private static PGPPublicKeyRing generateRingWithSubkey() {
+        def date = new Date()
+        def rsa = new RSAKeyPairGenerator()
+        rsa.init(new RSAKeyGenerationParameters(0x10001G, new SecureRandom(), 1024, 12))
+        def signingKeyPair = new BcPGPKeyPair(PGPPublicKey.RSA_SIGN, rsa.generateKeyPair(), date)
+        def encryptionKeyPair = new BcPGPKeyPair(PGPPublicKey.RSA_ENCRYPT, rsa.generateKeyPair(), date)
+
+        def signingSubpackets = new PGPSignatureSubpacketGenerator()
+        signingSubpackets.setKeyFlags(false, KeyFlags.SIGN_DATA | KeyFlags.CERTIFY_OTHER)
+
+        def encryptionSubpackets = new PGPSignatureSubpacketGenerator()
+        encryptionSubpackets.setKeyFlags(false, KeyFlags.ENCRYPT_COMMS | KeyFlags.ENCRYPT_STORAGE)
+
+        def generator = new PGPKeyRingGenerator(
+            PGPPublicKey.RSA_SIGN,
+            signingKeyPair,
+            "test-user@gradle.com",
+            new BcPGPDigestCalculatorProvider().get(HashAlgorithmTags.SHA1),
+            signingSubpackets.generate(),
+            null,
+            new BcPGPContentSignerBuilder(PGPPublicKey.RSA_SIGN, HashAlgorithmTags.SHA512),
+            new BcPBESecretKeyEncryptorBuilder(PublicKeyAlgorithmTags.RSA_GENERAL).build("secret".toCharArray())
+        )
+        generator.addSubKey(encryptionKeyPair, encryptionSubpackets.generate(), null)
+        generator.generatePublicKeyRing()
+    }
+}


### PR DESCRIPTION
This adds a `--prune-keys` CLI flag that causes Gradle to remove keys from the saved keyrings if they are not part of the dependency verification metadata.

Fixes #37275
