### PR TITLE
Barebones support for starting Gradle on z/OS without compromise

### DIFF
--- a/platforms/core-execution/worker-main/src/main/java/org/gradle/process/internal/worker/GradleWorkerMain.java
+++ b/platforms/core-execution/worker-main/src/main/java/org/gradle/process/internal/worker/GradleWorkerMain.java
@@ -19,7 +19,10 @@ package org.gradle.process.internal.worker;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.stream.EncodedStream;
 
+import java.io.BufferedInputStream;
 import java.io.DataInputStream;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -32,7 +35,7 @@ import java.util.concurrent.Callable;
  */
 public class GradleWorkerMain {
     public void run() throws Exception {
-        DataInputStream instr = new DataInputStream(new EncodedStream.EncodedInput(System.in));
+        DataInputStream instr = new DataInputStream(new EncodedStream.EncodedInput(new BufferedInputStream(new FileInputStream(FileDescriptor.in))));
 
         // Read shared packages
         int sharedPackagesCount = instr.readInt();

--- a/platforms/core-execution/worker-main/src/main/java/org/gradle/process/internal/worker/child/BootstrapSecurityManager.java
+++ b/platforms/core-execution/worker-main/src/main/java/org/gradle/process/internal/worker/child/BootstrapSecurityManager.java
@@ -19,8 +19,11 @@ package org.gradle.process.internal.worker.child;
 import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.gradle.internal.stream.EncodedStream;
 
+import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -69,7 +72,7 @@ public class BootstrapSecurityManager extends SecurityManager {
             Method addUrlMethod = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
             addUrlMethod.setAccessible(true);
 
-            DataInputStream inputStream = new DataInputStream(new EncodedStream.EncodedInput(System.in));
+            DataInputStream inputStream = new DataInputStream(new EncodedStream.EncodedInput(new BufferedInputStream(new FileInputStream(FileDescriptor.in))));
             int count = inputStream.readInt();
             StringBuilder classpathStr = new StringBuilder();
             for (int i = 0; i < count; i++) {

--- a/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonStartupCommunication.java
+++ b/platforms/core-runtime/daemon-protocol/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonStartupCommunication.java
@@ -38,18 +38,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 public class DaemonStartupCommunication {
 
     private static final Logger LOGGER = Logging.getLogger(DaemonStartupCommunication.class);
 
-    @SuppressWarnings("DefaultCharset")
     public void printDaemonStarted(PrintStream target, Long pid, String uid, Address address, File daemonLog) {
 
         // Encode as ascii
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         try {
-            byteArrayOutputStream.write(daemonGreeting().getBytes());
+            byteArrayOutputStream.write(daemonGreeting().getBytes(StandardCharsets.UTF_8));
             OutputStream outputStream = new EncodedStream.EncodedOutput(byteArrayOutputStream);
             FlushableEncoder encoder = new OutputStreamBackedEncoder(outputStream);
             encoder.writeNullableString(pid == null ? null : pid.toString());
@@ -60,7 +61,11 @@ public class DaemonStartupCommunication {
         } catch (IOException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
-        target.println(byteArrayOutputStream.toString());
+        try {
+            target.println(byteArrayOutputStream.toString("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
 
         //ibm vm 1.6 + windows XP gotchas:
         //we need to print something else to the stream after we print the daemon greeting.
@@ -69,7 +74,6 @@ public class DaemonStartupCommunication {
         //btw. the ibm vm+winXP also has some issues detecting closed streams by the child but we handle this problem differently.
     }
 
-    @SuppressWarnings("DefaultCharset")
     public DaemonStartupInfo readDiagnostics(String message) {
         //Assuming the message has correct format. Not bullet proof, but seems to work ok for now.
         if (!message.startsWith(daemonGreeting())) {
@@ -77,7 +81,7 @@ public class DaemonStartupCommunication {
         }
         try {
             String encoded = message.substring(daemonGreeting().length()).trim();
-            InputStream inputStream = new EncodedStream.EncodedInput(new ByteArrayInputStream(encoded.getBytes()));
+            InputStream inputStream = new EncodedStream.EncodedInput(new ByteArrayInputStream(encoded.getBytes(StandardCharsets.UTF_8)));
             Decoder decoder = new InputStreamBackedDecoder(inputStream);
             String pidString = decoder.readNullableString();
             String uid = decoder.readString();

--- a/platforms/core-runtime/daemon-server/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
+++ b/platforms/core-runtime/daemon-server/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
@@ -48,8 +48,11 @@ import org.gradle.launcher.daemon.server.expiry.DaemonExpirationStrategy;
 import org.gradle.process.internal.shutdown.ShutdownHooks;
 
 import java.io.ByteArrayInputStream;
+import java.io.BufferedInputStream;
 import java.io.EOFException;
 import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -80,7 +83,9 @@ public class DaemonMain extends EntryPoint {
         DaemonServerConfiguration parameters;
 
         try {
-            KryoBackedDecoder decoder = new KryoBackedDecoder(new EncodedStream.EncodedInput(System.in));
+            // Don't use System.in, IBM JVMs on some platforms (namely z/OS) will try to auto-convert the data in System.in between
+            // codepages incorrectly.
+            KryoBackedDecoder decoder = new KryoBackedDecoder(new EncodedStream.EncodedInput(new BufferedInputStream(new FileInputStream(FileDescriptor.in))));
             gradleHomeDir = new File(decoder.readString());
             parameters = readDaemonServerConfiguration(decoder);
         } catch (EOFException e) {

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/continuous/ContinuousBuildActionExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/continuous/ContinuousBuildActionExecutor.java
@@ -47,6 +47,9 @@ import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.internal.watch.vfs.FileChangeListeners;
 import org.gradle.util.internal.DisconnectableInputStream;
 
+import java.io.BufferedInputStream;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.util.function.Supplier;
 
 public class ContinuousBuildActionExecutor implements BuildSessionActionExecutor {
@@ -119,7 +122,7 @@ public class ContinuousBuildActionExecutor implements BuildSessionActionExecutor
         final CancellableOperationManager cancellableOperationManager;
         if (requestContext.isInteractiveConsole()) {
             if (!(System.in instanceof DisconnectableInputStream)) {
-                System.setIn(new DisconnectableInputStream(System.in));
+                System.setIn(new DisconnectableInputStream(new BufferedInputStream(new FileInputStream(FileDescriptor.in))));
             }
             DisconnectableInputStream inputStream = (DisconnectableInputStream) System.in;
             cancellableOperationManager = new DefaultCancellableOperationManager(executorFactory.create("Cancel signal monitor"), inputStream, cancellationToken);

--- a/platforms/core-runtime/native/src/main/java/org/gradle/platform/OperatingSystem.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/platform/OperatingSystem.java
@@ -25,5 +25,5 @@ import org.gradle.api.Incubating;
  */
 @Incubating
 public enum OperatingSystem {
-    LINUX, UNIX, WINDOWS, MAC_OS, SOLARIS, FREE_BSD
+    LINUX, UNIX, WINDOWS, MAC_OS, SOLARIS, FREE_BSD, ZOS
 }

--- a/platforms/core-runtime/native/src/main/java/org/gradle/platform/internal/CurrentBuildPlatform.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/platform/internal/CurrentBuildPlatform.java
@@ -84,6 +84,8 @@ public class CurrentBuildPlatform {
             return OperatingSystem.SOLARIS;
         } else if (org.gradle.internal.os.OperatingSystem.FREE_BSD == operatingSystem) {
             return OperatingSystem.FREE_BSD;
+        } else if (org.gradle.internal.os.OperatingSystem.ZOS == operatingSystem) {
+            return OperatingSystem.ZOS;
         } else {
             throw new GradleException("Unhandled operating system: " + operatingSystem.getName());
         }

--- a/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/os/OperatingSystem.java
+++ b/platforms/core-runtime/stdlib-java-extensions/src/main/java/org/gradle/internal/os/OperatingSystem.java
@@ -33,6 +33,7 @@ public abstract class OperatingSystem {
     public static final Solaris SOLARIS = new Solaris();
     public static final Linux LINUX = new Linux();
     public static final FreeBSD FREE_BSD = new FreeBSD();
+    public static final ZOs ZOS = new ZOs();
     public static final Unix UNIX = new Unix();
     private static @Nullable OperatingSystem currentOs;
     private final String toStringValue;
@@ -69,6 +70,8 @@ public abstract class OperatingSystem {
             return LINUX;
         } else if (osName.contains("freebsd")) {
             return FREE_BSD;
+        } else if (osName.contains("z/os")) {
+            return ZOS;
         } else {
             // Not strictly true
             return UNIX;
@@ -102,6 +105,10 @@ public abstract class OperatingSystem {
     }
 
     public boolean isLinux() {
+        return false;
+    }
+
+    public boolean isZOs() {
         return false;
     }
 
@@ -437,6 +444,28 @@ public abstract class OperatingSystem {
                 return "x86";
             }
             return super.getArch();
+        }
+    }
+
+    static class ZOs extends Unix {
+        @Override
+        public boolean isZOs() {
+            return true;
+        }
+
+        @Override
+        public String getFamilyName() {
+            return "zos";
+        }
+
+        @Override
+        public String getOsPrefix() {
+            return "zos";
+        }
+
+        @Override
+        public String getLinkLibrarySuffix() {
+            return ".x";
         }
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
#24498 

### Context

IBM Java can perform implicit conversion of process stdin/stdout/stderr streams which interferes with the daemon bootstrap by causing the parent and daemon processes to disagree about the character encoding needed for the initial handshake message. Furthermore, there's inconsistency about the character set used to encode this handshake message which can lead to even more disagreement between the two processes.

This is especially problematic on z/OS where the standard stream conversion is to/from EBCDIC codepages, but the daemon process always starts with `file.encoding=UTF-8`. Users on z/OS have historically resorted to forcing  `-Dfile.encoding=UTF-8 -Dconsole.encoding=UTF-8` but this is not a long term solution.

With this change, a user on z/OS can use gradle without forcing the encodings. I've managed to verify this on the z/OS machine I have access to and can build a simple Java project. I've unsuccessfully tried to get gradle itself to build on z/OS, but the user ID I have access to has a too low ulimit for file handles to be able to actually compile all the plugins needed... the daemon starts at least!

This fix works by directly accessing the file descriptor for `stdin` rather than using `System.in`, which will have been wrapped in some sort of `FilterInputStream` in IBM JVMs.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
