### PR TITLE
Enable groupArtifactsByBuild for parallel tests (TeamCity 2025.11 default)

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/DocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/DocsTest.kt
@@ -76,6 +76,7 @@ class DocsTest(
             features {
                 parallelTests {
                     this.numberOfBatches = parallelizationMethod.numberOfBatches
+                    groupArtifactsByBuild = true
                 }
             }
         }

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -90,6 +90,7 @@ fun BaseGradleBuildType.tcParallelTests(numberOfBatches: Int) {
         features {
             parallelTests {
                 this.numberOfBatches = numberOfBatches
+                groupArtifactsByBuild = true
             }
         }
     }


### PR DESCRIPTION
- Adds `groupArtifactsByBuild = true` to all `parallelTests` feature blocks in `GradleBuildConfigurationDefaults.kt` and `DocsTest.kt`
- Makes the new TeamCity 2025.11 default explicit in the DSL config