### PR TITLE
Upgrade TeamCity DSL to 2025.11; enable groupArtifactsByBuild for parallel tests

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -3,7 +3,7 @@ import jetbrains.buildServer.configs.kotlin.project
 import jetbrains.buildServer.configs.kotlin.version
 import projects.GradleBuildToolRootProject
 
-version = "2023.11"
+version = "2025.11"
 
 /*
 

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -17,6 +17,7 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task:
         if (splitNumber > 1) {
             parallelTests {
                 numberOfBatches = splitNumber
+                groupArtifactsByBuild = true
             }
         }
     }


### PR DESCRIPTION
- Bumps `settings.kts` version from `2023.11` to `2025.11`
- Adds `groupArtifactsByBuild = true` to `SmokeTests.kt` parallel tests feature block