### PR TITLE
Upgrade TeamCity DSL to 2025.11; enable groupArtifactsByBuild for parallel tests

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -3,7 +3,7 @@ import jetbrains.buildServer.configs.kotlin.project
 import jetbrains.buildServer.configs.kotlin.version
 import projects.GradleBuildToolRootProject
 
-version = "2025.07"
+version = "2025.11"
 
 /*
 

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -90,6 +90,7 @@ fun BaseGradleBuildType.tcParallelTests(numberOfBatches: Int) {
         features {
             parallelTests {
                 this.numberOfBatches = numberOfBatches
+                groupArtifactsByBuild = true
             }
         }
     }


### PR DESCRIPTION
- Bumps `settings.kts` version from `2025.07` to `2025.11`
- Adds `groupArtifactsByBuild = true` to `GradleBuildConfigurationDefaults.kt` parallel tests feature block