### PR TITLE
Introduce repositories report

### DIFF
--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
@@ -62,6 +62,14 @@ public abstract class HelpTasksPlugin implements Plugin<Project> {
     @Incubating
     public static final String ARTIFACT_TRANSFORMS_TASK = DiagnosticsTaskNames.ARTIFACT_TRANSFORMS_TASK;
 
+    /**
+     * The name of the repositories report task.
+     *
+     * @since 9.5
+     */
+    @Incubating
+    public static final String REPOSITORIES_TASK = DiagnosticsTaskNames.REPOSITORIES_TASK;
+
     public static final String MODEL_TASK = DiagnosticsTaskNames.MODEL_TASK;
 
 

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
@@ -65,7 +65,7 @@ public abstract class HelpTasksPlugin implements Plugin<Project> {
     /**
      * The name of the repositories report task.
      *
-     * @since 9.5
+     * @since 9.6.0
      */
     @Incubating
     public static final String REPOSITORIES_TASK = DiagnosticsTaskNames.REPOSITORIES_TASK;

--- a/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/DiagnosticsTaskNames.java
+++ b/platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/DiagnosticsTaskNames.java
@@ -86,6 +86,14 @@ public interface DiagnosticsTaskNames {
     String ARTIFACT_TRANSFORMS_TASK = "artifactTransforms";
 
     /**
+     * The name of the repositories report task.
+     *
+     * @since 9.5
+     */
+    @Incubating
+    String REPOSITORIES_TASK = "repositories";
+
+    /**
      * The name of the model report task.
      *
      * @since 8.13

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -1004,9 +1004,9 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         configurationCacheFails("ok", "-DPROP=12")
 
         then:
-        outputContains("Configuration cache entry discarded with 16 problems")
+        outputContains("Configuration cache entry discarded with 17 problems")
         problems.assertFailureHasProblems(failure) {
-            totalProblemsCount = 16
+            totalProblemsCount = 17
             withInput("Script 'script.gradle': system property 'PROP'")
             withProblem("Script 'script.gradle': line 4: registration of listener on 'Gradle.buildFinished' is unsupported")
         }

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -92,6 +92,63 @@ When `NO_COLOR` is set and non-empty, Gradle suppresses color output while prese
 
 See the [Environment variables](userguide/build_environment.html#sec:gradle_environment_variables) section in the Gradle User Manual for more information.
 
+#### Repositories report
+
+Gradle now provides a built-in `repositories` diagnostic task that shows a unified view of all [repository declarations](userguide/declaring_repositories_basics.html) across settings and projects.
+The report identifies where each repository is defined, what dependency types it serves, and flags duplicate declarations that could be centralized.
+It also performs lightweight reachability probes against remote URLs to detect unreachable or unauthorized repositories.
+
+Run `./gradlew repositories` to generate the report, or use `./gradlew repositories --project :app` to filter to a specific project:
+
+```text
+$ ./gradlew repositories
+
+--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1) *
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+MavenRepo (2) *
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':app' > repositories
+
+maven (3)
+    Location:   https://my.internal.repo/releases/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':app' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)
+
+project ':app' uses
+    - MavenRepo (2)
+    - maven (3)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(*) Identical repository declaration found in multiple locations.
+    Consider consolidating to settings.dependencyResolutionManagement.repositories
+    or settings.pluginManagement.repositories.
+    See https://docs.gradle.org/current/userguide/centralizing_repositories.html
+(ur) Unreachable — the URL could not be contacted.
+```
+
+See the [Declaring Repositories](userguide/declaring_repositories_basics.html#sec:listing-repositories) section in the Gradle User Manual for more information.
+
 ### Build authoring improvements
 Gradle provides [rich APIs](userguide/getting_started_dev.html) for build engineers and plugin authors, enabling the creation of custom, reusable build logic and better maintainability.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/centralizing_repositories.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/centralizing_repositories.adoc
@@ -19,6 +19,8 @@ Instead of declaring repositories in every subproject of your build or via an `a
 
 NOTE: Central declaration of repositories is an incubating feature.
 
+TIP: Use the `repositories` task to identify duplicate repository declarations across your build that could be consolidated into settings. See <<command_line_interface.adoc#sec:listing-repositories, Listing repositories>>.
+
 You can declare repositories that will be used by convention in every subproject in the `settings.gradle(.kts)` file:
 
 ====

--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/declaring_repositories_basics.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/declaring_repositories_basics.adoc
@@ -155,3 +155,5 @@ However, some plugins may be hosted in other repositories (public or private).
 To include these plugins, you need to specify additional repositories in your build script so Gradle knows where to search.
 
 Since declaring repositories depends on how the plugin is applied, refer to the <<plugins_intermediate.adoc#sec:custom_plugin_repositories,Custom Plugin Repositories>> for more details on configuring repositories for plugins from different sources.
+
+TIP: Use the `repositories` task to identify duplicate repository declarations across your build that could be consolidated into settings. See <<command_line_interface.adoc#sec:listing-repositories, Listing repositories>>.

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/command_line_interface.adoc
@@ -522,6 +522,93 @@ $ ./gradlew dependencyInsight --dependency [...] --configuration [...]
 
 The `--configuration` parameter restricts the report to a particular configuration such as `compileClasspath`.
 
+[[sec:listing-repositories]]
+=== Listing project repositories
+
+Gradle provides the built-in `repositories` task to display a unified view of all repository declarations across your build.
+The report covers repositories declared in settings (`pluginManagement`, `dependencyResolutionManagement`, `buildscript`) and in each project (`buildscript`, `repositories`):
+
+[source,bash]
+----
+$ ./gradlew repositories
+----
+[source,text]
+----
+--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1) *
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+maven (2)
+    Location:   https://my.internal.repo/releases/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':app' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)
+
+project ':app' uses
+    - MavenRepo (2)
+    - maven (3)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+----
+
+The report includes three sections:
+
+*All Repositories*::
+A globally-numbered list of every repository in the build, showing each repository's name, location URL, type (Maven, Ivy, flat directory), roles (what kinds of dependencies it serves), and where it was declared.
+
+*Repositories by Location*::
+Groups repositories by the settings or project that uses them, showing which repositories are available to each project during resolution.
+
+*Legend*::
+Explains any markers that appear in the report.
+
+==== Understanding output markers
+
+The report annotates repositories with the following markers:
+
+[cols="1,3"]
+|===
+| Marker | Meaning
+
+| `*`
+| Identical repository declaration found in multiple locations. Consider consolidating to `settings.dependencyResolutionManagement.repositories` or `settings.pluginManagement.repositories`.
+
+| `(ur)`
+| Unreachable — the URL could not be contacted (connection refused, DNS failure, timeout, or HTTP error).
+
+| `(ua)`
+| Unauthorized — the URL returned HTTP 401 or 403.
+
+| `(o)`
+| Displayed on the report heading when Gradle runs in `--offline` mode. No reachability checks are performed.
+|===
+
+==== Filtering to a specific project
+
+Use the `--project` option to narrow the report to repositories relevant to a single project:
+
+[source,bash]
+----
+$ ./gradlew repositories --project :app
+----
+
+This filters *All Repositories* to only the entries relevant to `:app` (plugin repositories, dependency resolution management repositories, and the project's own declarations) and shows only that project's block in *Repositories by Location*.
+
 [[sec:listing_properties]]
 === Listing project properties
 

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -342,7 +342,9 @@ abstract class ToolingApiSpecification extends Specification implements CommonTe
      * Returns the set of implicit task names expected for any project for the target Gradle version.
      */
     Set<String> getImplicitTasks() {
-        if (targetVersion >= GradleVersion.version("9.0")) {
+        if (targetVersion >= GradleVersion.version("9.6")) {
+            return ['artifactTransforms', 'buildEnvironment', 'dependencies', 'dependencyInsight', 'help', 'javaToolchains', 'projects', 'properties', 'repositories', 'tasks', 'outgoingVariants', 'resolvableConfigurations']
+        } else if (targetVersion >= GradleVersion.version("9.0")) {
             return ['artifactTransforms', 'buildEnvironment', 'dependencies', 'dependencyInsight', 'help', 'javaToolchains', 'projects', 'properties', 'tasks', 'outgoingVariants', 'resolvableConfigurations']
         } else if (targetVersion >= GradleVersion.version("8.13")) {
             return ['artifactTransforms', 'buildEnvironment', 'components', 'dependencies', 'dependencyInsight', 'dependentComponents', 'help', 'javaToolchains', 'projects', 'properties', 'tasks', 'model', 'outgoingVariants', 'resolvableConfigurations']

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
@@ -36,6 +36,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -187,7 +188,9 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
     private void addInclude(String group, @Nullable String moduleName, @Nullable String version, MatcherKind matcherKind) {
         assertMutable();
         if (includeSpecs == null) {
-            includeSpecs = new HashSet<>();
+            // LinkedHashSet preserves declaration order so describeIncludeRules() reports
+            // rules in the order the user declared them.
+            includeSpecs = new LinkedHashSet<>();
         }
         includeSpecs.add(new ContentSpec(matcherKind, group, moduleName, version, versionSelectorScheme, versionSelectors, true));
     }
@@ -243,7 +246,9 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
     private void addExclude(String group, @Nullable String moduleName, @Nullable String version, MatcherKind matcherKind) {
         assertMutable();
         if (excludeSpecs == null) {
-            excludeSpecs = new HashSet<>();
+            // LinkedHashSet preserves declaration order so describeExcludeRules() reports
+            // rules in the order the user declared them.
+            excludeSpecs = new LinkedHashSet<>();
         }
         excludeSpecs.add(new ContentSpec(matcherKind, group, moduleName, version, versionSelectorScheme, versionSelectors, false));
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
@@ -36,6 +36,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -314,6 +315,27 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
         this.excludeSpecs = excludeSpecs;
     }
 
+    @Override
+    public List<String> describeIncludeRules() {
+        return describeSpecs(includeSpecs);
+    }
+
+    @Override
+    public List<String> describeExcludeRules() {
+        return describeSpecs(excludeSpecs);
+    }
+
+    private static List<String> describeSpecs(@Nullable Set<ContentSpec> specs) {
+        if (specs == null || specs.isEmpty()) {
+            return ImmutableList.of();
+        }
+        ImmutableList.Builder<String> out = ImmutableList.builderWithExpectedSize(specs.size());
+        for (ContentSpec spec : specs) {
+            out.add(spec.describe());
+        }
+        return out.build();
+    }
+
     @Nullable
     @Override
     public Map<Attribute<Object>, Set<Object>> getRequiredAttributes() {
@@ -365,6 +387,40 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
         @Override
         public int hashCode() {
             return hashCode;
+        }
+
+        String describe() {
+            String prefix = inclusive ? "include" : "exclude";
+            if (module == null && version == null) {
+                // group-only
+                String methodName;
+                switch (matcherKind) {
+                    case SIMPLE:
+                        methodName = prefix + "Group";
+                        break;
+                    case SUB_GROUP:
+                        methodName = prefix + "GroupAndSubgroups";
+                        break;
+                    case REGEX:
+                        methodName = prefix + "GroupByRegex";
+                        break;
+                    default:
+                        throw new IllegalStateException("Unknown matcher kind: " + matcherKind);
+                }
+                return methodName + "(\"" + group + "\")";
+            }
+            if (version == null) {
+                // group+module
+                String methodName = matcherKind == MatcherKind.REGEX
+                    ? prefix + "ModuleByRegex"
+                    : prefix + "Module";
+                return methodName + "(\"" + group + "\", \"" + module + "\")";
+            }
+            // group+module+version
+            String versionMethod = matcherKind == MatcherKind.REGEX
+                ? prefix + "VersionByRegex"
+                : prefix + "Version";
+            return versionMethod + "(\"" + group + "\", \"" + module + "\", \"" + version + "\")";
         }
 
         SpecMatcher toMatcher() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/RepositoryContentDescriptorInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/RepositoryContentDescriptorInternal.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
 import org.gradle.api.attributes.Attribute;
 import org.jspecify.annotations.Nullable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,4 +45,27 @@ public interface RepositoryContentDescriptorInternal extends RepositoryContentDe
      */
     @Nullable
     Map<Attribute<Object>, Set<Object>> getRequiredAttributes();
+
+    /**
+     * Returns user-facing descriptions of include rules declared on this descriptor,
+     * for use by diagnostic reporting.
+     *
+     * <p>Each entry is a human-readable form such as
+     * {@code includeGroup("com.example")} or
+     * {@code includeVersion("g", "m", "1.0")}. Entries preserve declaration order.
+     *
+     * <p>Note: {@code includeModule(group, module)} and {@code includeModuleByRegex(groupRegex, moduleRegex)}
+     * store identically internally and are both rendered as {@code includeModuleByRegex(...)}.
+     *
+     * @return immutable list of rule descriptions, empty when none
+     */
+    List<String> describeIncludeRules();
+
+    /**
+     * Returns user-facing descriptions of exclude rules declared on this descriptor,
+     * for use by diagnostic reporting.
+     *
+     * @return immutable list of rule descriptions, empty when none
+     */
+    List<String> describeExcludeRules();
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorDescribeRulesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorDescribeRulesTest.groovy
@@ -54,16 +54,44 @@ class DefaultRepositoryContentDescriptorDescribeRulesTest extends Specification 
         descriptor.describeIncludeRules() == ['includeModuleByRegex("com\\\\.example.*", "lib.*")']
     }
 
-    def "describes excludeModuleByRegex distinctly from excludeModule"() {
+    def "describes excludeModuleByRegex distinctly from excludeModule, preserving declaration order"() {
         when:
         descriptor.excludeModule("a", "b")
         descriptor.excludeModuleByRegex("x\\\\..*", "y.*")
 
         then:
-        descriptor.describeExcludeRules() as Set == [
+        descriptor.describeExcludeRules() == [
             'excludeModule("a", "b")',
             'excludeModuleByRegex("x\\\\..*", "y.*")'
-        ] as Set
+        ]
+    }
+
+    def "preserves declaration order for include rules"() {
+        when:
+        descriptor.includeGroup("z.last")
+        descriptor.includeGroup("a.first")
+        descriptor.includeGroup("m.middle")
+
+        then:
+        descriptor.describeIncludeRules() == [
+            'includeGroup("z.last")',
+            'includeGroup("a.first")',
+            'includeGroup("m.middle")'
+        ]
+    }
+
+    def "preserves declaration order for exclude rules"() {
+        when:
+        descriptor.excludeGroup("z.last")
+        descriptor.excludeGroup("a.first")
+        descriptor.excludeGroup("m.middle")
+
+        then:
+        descriptor.describeExcludeRules() == [
+            'excludeGroup("z.last")',
+            'excludeGroup("a.first")',
+            'excludeGroup("m.middle")'
+        ]
     }
 
     def "includeModule renders identically to includeModuleByRegex because of internal storage"() {
@@ -91,7 +119,7 @@ class DefaultRepositoryContentDescriptorDescribeRulesTest extends Specification 
         descriptor.describeIncludeRules() == ['includeVersionByRegex("com\\\\.example.*", "lib.*", "1\\\\..*")']
     }
 
-    def "describes excludeGroup, excludeModule, excludeVersion"() {
+    def "describes excludeGroup, excludeModule, excludeVersion in declaration order"() {
         when:
         descriptor.excludeGroup("a")
         descriptor.excludeModule("b", "m")
@@ -99,11 +127,11 @@ class DefaultRepositoryContentDescriptorDescribeRulesTest extends Specification 
 
         then:
         descriptor.describeIncludeRules() == []
-        descriptor.describeExcludeRules() as Set == [
+        descriptor.describeExcludeRules() == [
             'excludeGroup("a")',
             'excludeModule("b", "m")',
             'excludeVersion("c", "m", "1.0")'
-        ] as Set
+        ]
     }
 
     def "returns empty lists when no rules declared"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorDescribeRulesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorDescribeRulesTest.groovy
@@ -6,6 +6,12 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.gradle.api.internal.artifacts.repositories
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorDescribeRulesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorDescribeRulesTest.groovy
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.internal.artifacts.repositories
+
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
+import spock.lang.Specification
+
+class DefaultRepositoryContentDescriptorDescribeRulesTest extends Specification {
+    def descriptor = new DefaultRepositoryContentDescriptor({ "test" }, new VersionParser())
+
+    def "describes includeGroup as includeGroup(\"g\")"() {
+        when:
+        descriptor.includeGroup("com.example")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeGroup("com.example")']
+        descriptor.describeExcludeRules() == []
+    }
+
+    def "describes includeGroupAndSubgroups"() {
+        when:
+        descriptor.includeGroupAndSubgroups("com.example")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeGroupAndSubgroups("com.example")']
+    }
+
+    def "describes includeGroupByRegex"() {
+        when:
+        descriptor.includeGroupByRegex("com\\\\.example.*")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeGroupByRegex("com\\\\.example.*")']
+    }
+
+    def "describes includeModuleByRegex"() {
+        when:
+        descriptor.includeModuleByRegex("com\\\\.example.*", "lib.*")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeModuleByRegex("com\\\\.example.*", "lib.*")']
+    }
+
+    def "describes excludeModuleByRegex distinctly from excludeModule"() {
+        when:
+        descriptor.excludeModule("a", "b")
+        descriptor.excludeModuleByRegex("x\\\\..*", "y.*")
+
+        then:
+        descriptor.describeExcludeRules() as Set == [
+            'excludeModule("a", "b")',
+            'excludeModuleByRegex("x\\\\..*", "y.*")'
+        ] as Set
+    }
+
+    def "includeModule renders identically to includeModuleByRegex because of internal storage"() {
+        when:
+        descriptor.includeModule("com.example", "lib")
+
+        then:
+        // Known ambiguity: includeModule stores as MatcherKind.REGEX, indistinguishable from includeModuleByRegex
+        descriptor.describeIncludeRules() == ['includeModuleByRegex("com.example", "lib")']
+    }
+
+    def "describes includeVersion"() {
+        when:
+        descriptor.includeVersion("com.example", "lib", "1.0")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeVersion("com.example", "lib", "1.0")']
+    }
+
+    def "describes includeVersionByRegex"() {
+        when:
+        descriptor.includeVersionByRegex("com\\\\.example.*", "lib.*", "1\\\\..*")
+
+        then:
+        descriptor.describeIncludeRules() == ['includeVersionByRegex("com\\\\.example.*", "lib.*", "1\\\\..*")']
+    }
+
+    def "describes excludeGroup, excludeModule, excludeVersion"() {
+        when:
+        descriptor.excludeGroup("a")
+        descriptor.excludeModule("b", "m")
+        descriptor.excludeVersion("c", "m", "1.0")
+
+        then:
+        descriptor.describeIncludeRules() == []
+        descriptor.describeExcludeRules() as Set == [
+            'excludeGroup("a")',
+            'excludeModule("b", "m")',
+            'excludeVersion("c", "m", "1.0")'
+        ] as Set
+    }
+
+    def "returns empty lists when no rules declared"() {
+        expect:
+        descriptor.describeIncludeRules() == []
+        descriptor.describeExcludeRules() == []
+    }
+}

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorDescribeRulesTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorDescribeRulesTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.repositories
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import spock.lang.Specification
 
+/** Tests for {@link DefaultRepositoryContentDescriptor} describe rules. */
 class DefaultRepositoryContentDescriptorDescribeRulesTest extends Specification {
     def descriptor = new DefaultRepositoryContentDescriptor({ "test" }, new VersionParser())
 

--- a/platforms/software/software-diagnostics/build.gradle.kts
+++ b/platforms/software/software-diagnostics/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.gson)
     implementation(libs.jatl)
+    implementation(libs.slf4jApi)
 
     implementationResources(variantOf(libs.jquery) { artifactType("js") })
 

--- a/platforms/software/software-diagnostics/build.gradle.kts
+++ b/platforms/software/software-diagnostics/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     api(libs.jspecify)
     api(libs.inject)
 
+    implementation(projects.credentialsApi)
     implementation(projects.functional)
     implementation(projects.loggingApi)
     implementation(projects.startParameter)

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -57,6 +57,7 @@ class ModelReportIntegrationTest extends AbstractIntegrationSpec {
                     prepareKotlinBuildScriptModel()
                     projects()
                     properties()
+                    repositories()
                     resovableVariants()
                     tasks()
                     wrapper()
@@ -390,6 +391,12 @@ model {
           | Type:   \torg.gradle.api.tasks.diagnostics.PropertyReportTask
           | Value:  \ttask ':properties\'
           | Creator: \tProject.<init>.tasks.properties()
+          | Rules:
+             ⤷ copyToTaskContainer
+    + repositories
+          | Type:   \torg.gradle.api.tasks.diagnostics.RepositoriesReportTask
+          | Value:  \ttask ':repositories\'
+          | Creator: \tProject.<init>.tasks.repositories()
           | Rules:
              ⤷ copyToTaskContainer
     + resolvableConfigurations

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
@@ -25,7 +25,6 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
-
     @Rule
     public final HttpServer server = new HttpServer()
 

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
@@ -6,6 +6,12 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.gradle.api.tasks.diagnostics
 
@@ -39,10 +45,10 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds ':repositories'
         outputContains('There are no repositories present.')
-        !result.output.contains('All Repositories')
-        !result.output.contains('Repositories by Location')
-        !result.output.contains('(none)')
-        !result.output.contains('Legend')
+        outputDoesNotContain('All Repositories')
+        outputDoesNotContain('Repositories by Location')
+        outputDoesNotContain('(none)')
+        outputDoesNotContain('Legend')
     }
 
     def "task reports a single mavenCentral repository in All Repositories"() {
@@ -146,8 +152,8 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         outputContains('Google')
         outputContains('Repositories by Location')
         outputContains("project ':app' uses")
-        !result.output.contains('settings uses')
-        !result.output.contains("project ':other'")
+        outputDoesNotContain('settings uses')
+        outputDoesNotContain("project ':other'")
     }
 
     def "--project with unknown project path fails with clear error"() {
@@ -210,7 +216,7 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds ':repositories'
-        !result.output.contains('Legend')
+        outputDoesNotContain('Legend')
     }
 
     def "reports authentication scheme class name"() {
@@ -253,8 +259,8 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         succeeds ':repositories'
         outputContains('Credentials: PRESENT')
         // ensure the actual credential values never leak
-        !result.output.contains('cred-username-xyzzy')
-        !result.output.contains('cred-password-xyzzy')
+        outputDoesNotContain('cred-username-xyzzy')
+        outputDoesNotContain('cred-password-xyzzy')
     }
 
     def "omits Credentials line when no credentials declared"() {
@@ -269,7 +275,7 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds ':repositories'
-        !result.output.contains('Credentials:')
+        outputDoesNotContain('Credentials:')
     }
 
     def "reports Secure: false when allowInsecureProtocol = true"() {
@@ -435,8 +441,8 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds ':repositories'
         outputContains('MavenRepo')
-        !result.output.contains('included.example.com')
-        !result.output.contains("project ':included' uses")
+        outputDoesNotContain('included.example.com')
+        outputDoesNotContain("project ':included' uses")
     }
 
     def "complex example reports properly"() {
@@ -556,13 +562,13 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         outputContains("project ':lib' uses")
         outputContains("project ':' uses")
         // Included build must NOT be descended
-        !result.output.contains('included.example.com')
-        !result.output.contains("project ':included'")
+        outputDoesNotContain('included.example.com')
+        outputDoesNotContain("project ':included'")
         // Ivy repo carried credentials — Credentials line should render
         outputContains('Credentials: PRESENT')
         // Credential values must never leak into the output
-        !result.output.contains('ivyUser')
-        !result.output.contains('ivyPass')
+        outputDoesNotContain('ivyUser')
+        outputDoesNotContain('ivyPass')
         // Legend present (mavenCentral declared in both DRM and :lib triggers duplicate marker)
         outputContains('Legend')
         outputContains('centralizing_repositories.html')
@@ -694,7 +700,7 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         outputContains("Defined in: project ':' > repositories")
         outputContains("Defined in: project ':app' > repositories")
         outputContains("Defined in: project ':lib' > repositories")
-        !result.output.contains("Defined in: settings >")
+        outputDoesNotContain("Defined in: settings >")
         // Each project's "uses" list should reference the repo.
         outputContains("project ':' uses")
         outputContains("project ':app' uses")
@@ -745,7 +751,7 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         outputContains('(ua)')
         outputContains('Legend')
         outputContains('(ua) Unauthorized')
-        !result.output.contains('(ur)')
+        outputDoesNotContain('(ur)')
     }
 
     def "reports (o) marker on All Repositories heading in offline mode"() {
@@ -764,8 +770,8 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         outputContains('Legend')
         outputContains('(o)  Running in offline mode')
         // Offline suppresses per-repo reachability markers.
-        !result.output.contains('(ur)')
-        !result.output.contains('(ua)')
+        outputDoesNotContain('(ur)')
+        outputDoesNotContain('(ua)')
     }
 
     def "no reachability markers when URL is reachable"() {
@@ -790,10 +796,10 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds ':repositories'
         outputContains('All Repositories')
-        !result.output.contains('(ur)')
-        !result.output.contains('(ua)')
-        !result.output.contains('(o)')
-        !result.output.contains('Legend')
+        outputDoesNotContain('(ur)')
+        outputDoesNotContain('(ua)')
+        outputDoesNotContain('(o)')
+        outputDoesNotContain('Legend')
     }
 
     def "repos declared via allprojects and subprojects are shown under each project"() {

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
@@ -24,6 +24,7 @@ import org.junit.Rule
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
+/** Tests for {@link org.gradle.api.tasks.diagnostics.RepositoriesReportTask}. */
 class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     public final HttpServer server = new HttpServer()
@@ -41,9 +42,11 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "task reports empty when no repositories declared"() {
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('There are no repositories present.')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""There are no repositories present.""")
         outputDoesNotContain('All Repositories')
         outputDoesNotContain('Repositories by Location')
         outputDoesNotContain('(none)')
@@ -58,14 +61,26 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('All Repositories')
-        outputContains('''MavenRepo (1)
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1)
     Location:   https://repo.maven.apache.org/maven2/
     Type:       MAVEN
     Roles:      PROJECT_DEPENDENCIES
-    Defined in: project ':' > repositories''')
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)""")
     }
 
     def "task reports settings pluginManagement repo under All Repositories with PLUGINS role"() {
@@ -79,10 +94,29 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
             rootProject.name = "myLib"
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('All Repositories')
-        outputContains('PLUGINS')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+Gradle Central Plugin Repository (1)
+    Location:   https://plugins.gradle.org/m2
+    Type:       MAVEN
+    Roles:      PLUGINS
+    Defined in: settings > pluginManagement.repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - Gradle Central Plugin Repository (1)
+
+project ':' uses
+    - Gradle Central Plugin Repository (1)""")
     }
 
     def "task reports settings.buildscript repo in All Repositories and under settings uses"() {
@@ -96,11 +130,26 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
             rootProject.name = "myLib"
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('All Repositories')
-        outputContains('SETTINGS_BUILDSCRIPT_DEPENDENCIES')
-        outputContains('settings uses')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1)
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      SETTINGS_BUILDSCRIPT_DEPENDENCIES
+    Defined in: settings > buildscript.repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - MavenRepo (1)""")
     }
 
     def "multi-project: PLUGINS and DRM repos appear under every project's reference list"() {
@@ -118,13 +167,45 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         """
         createDirs("app", "lib")
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains("project ':app' uses")
-        outputContains("project ':lib' uses")
-        // each project should reference at least the DRM and PLUGINS entries
-        result.output.count('- Gradle Central Plugin Repository') >= 2 ||
-            result.output.count('- MavenRepo') >= 2
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+Gradle Central Plugin Repository (1)
+    Location:   https://plugins.gradle.org/m2
+    Type:       MAVEN
+    Roles:      PLUGINS
+    Defined in: settings > pluginManagement.repositories
+
+MavenRepo (2)
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: settings > dependencyResolutionManagement.repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - Gradle Central Plugin Repository (1)
+    - MavenRepo (2)
+
+project ':' uses
+    - Gradle Central Plugin Repository (1)
+    - MavenRepo (2)
+
+project ':app' uses
+    - Gradle Central Plugin Repository (1)
+    - MavenRepo (2)
+
+project ':lib' uses
+    - Gradle Central Plugin Repository (1)
+    - MavenRepo (2)""")
     }
 
     def "--project filter limits Repositories by Location to the single project"() {
@@ -181,12 +262,44 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         file('app/build.gradle') << 'repositories { mavenCentral() }'
         file('lib/build.gradle') << 'repositories { mavenCentral() }'
 
-        expect:
+        when:
         succeeds ':repositories'
-        result.output.count('MavenRepo') >= 2
-        outputContains('*')
-        outputContains('Legend')
-        outputContains('Identical repository declaration')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1) *
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':app' > repositories
+
+MavenRepo (2) *
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':lib' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':app' uses
+    - MavenRepo (1)
+
+project ':lib' uses
+    - MavenRepo (2)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(*) Identical repository declaration found in multiple locations.
+    Consider consolidating to settings.dependencyResolutionManagement.repositories
+    or settings.pluginManagement.repositories.
+    See https://docs.gradle.org/current/userguide/centralizing_repositories.html""")
     }
 
     def "non-identical declarations do NOT trigger Legend"() {
@@ -404,7 +517,7 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         outputContains('MAVEN_LOCAL')
     }
 
-    def "project buildscript repo gets both PROJECT_LEGACY_PLUGINS and PROJECT_BUILDSCRIPT_DEPENDENCIES roles"() {
+    def "project buildscript repo gets PROJECT_BUILDSCRIPT_DEPENDENCIES role"() {
         given:
         buildFile.text = """
             buildscript {
@@ -414,9 +527,26 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('Roles:      PROJECT_LEGACY_PLUGINS, PROJECT_BUILDSCRIPT_DEPENDENCIES')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1)
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_BUILDSCRIPT_DEPENDENCIES
+    Defined in: project ':' > buildscript.repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)""")
     }
 
     def "does not list repositories from included builds"() {
@@ -437,9 +567,26 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('MavenRepo')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1)
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)""")
         outputDoesNotContain('included.example.com')
         outputDoesNotContain("project ':included' uses")
     }
@@ -550,10 +697,9 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         // Project-plugin-added repo: PROJECT_DEPENDENCIES, attributed to :app
         outputContains('https://project-plugin-repo.example.com/')
         outputContains("Defined in: project ':app' > repositories")
-        // All 5 RepositoryRole values appear
+        // All 4 RepositoryRole values appear
         outputContains('PLUGINS')
         outputContains('SETTINGS_BUILDSCRIPT_DEPENDENCIES')
-        outputContains('PROJECT_LEGACY_PLUGINS')
         outputContains('PROJECT_BUILDSCRIPT_DEPENDENCIES')
         outputContains('PROJECT_DEPENDENCIES')
         // Per-project reference blocks
@@ -763,12 +909,33 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories', '--offline'
-        outputContains('All Repositories (o)')
-        outputContains('Legend')
-        outputContains('(o)  Running in offline mode')
-        // Offline suppresses per-repo reachability markers.
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories (o)
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(o)  Running in offline mode \u2014 no reachability checks were performed.
+""")
         outputDoesNotContain('(ur)')
         outputDoesNotContain('(ua)')
     }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
@@ -24,7 +24,9 @@ import org.junit.Rule
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-/** Tests for {@link org.gradle.api.tasks.diagnostics.RepositoriesReportTask}. */
+/**
+ * Tests for {@link org.gradle.api.tasks.diagnostics.RepositoriesReportTask}.
+ */
 class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     public final HttpServer server = new HttpServer()
@@ -36,9 +38,11 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "task is registered under help group"() {
-        expect:
+        when:
         succeeds ':tasks', '--all'
-        outputContains('repositories -')
+
+        then:
+        result.assertOutputContains("repositories")
     }
 
     def "task reports empty when no repositories declared"() {
@@ -95,11 +99,11 @@ project ':' uses
         """
 
         when:
-        succeeds ':repositories'
+        succeeds ':repositories', '--offline'
 
         then:
         result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
-All Repositories
+All Repositories (o)
 --------------------------------------------------------
 
 Gradle Central Plugin Repository (1)
@@ -116,7 +120,13 @@ settings uses
     - Gradle Central Plugin Repository (1)
 
 project ':' uses
-    - Gradle Central Plugin Repository (1)""")
+    - Gradle Central Plugin Repository (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(o)  Running in offline mode \u2014 no reachability checks were performed.""")
     }
 
     def "task reports settings.buildscript repo in All Repositories and under settings uses"() {
@@ -168,11 +178,11 @@ settings uses
         createDirs("app", "lib")
 
         when:
-        succeeds ':repositories'
+        succeeds ':repositories', '--offline'
 
         then:
         result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
-All Repositories
+All Repositories (o)
 --------------------------------------------------------
 
 Gradle Central Plugin Repository (1)
@@ -205,7 +215,13 @@ project ':app' uses
 
 project ':lib' uses
     - Gradle Central Plugin Repository (1)
-    - MavenRepo (2)""")
+    - MavenRepo (2)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(o)  Running in offline mode \u2014 no reachability checks were performed.""")
     }
 
     def "--project filter limits Repositories by Location to the single project"() {
@@ -228,10 +244,29 @@ project ':lib' uses
         succeeds ':repositories', '--project', ':app'
 
         then:
-        outputContains('All Repositories')
-        outputContains('Google')
-        outputContains('Repositories by Location')
-        outputContains("project ':app' uses")
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+Gradle Central Plugin Repository (1)
+    Location:   https://plugins.gradle.org/m2
+    Type:       MAVEN
+    Roles:      PLUGINS
+    Defined in: settings > pluginManagement.repositories
+
+MavenRepo (2)
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: settings > dependencyResolutionManagement.repositories""")
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':app' uses
+    - Gradle Central Plugin Repository (1)
+    - MavenRepo (2)
+    - Google (3)""")
         outputDoesNotContain('settings uses')
         outputDoesNotContain("project ':other'")
     }
@@ -326,8 +361,36 @@ Legend
             }
         '''
 
-        expect:
+        when:
         succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Content:    includeGroup("com.example")
+    Defined in: project ':app' > repositories
+
+maven (2)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':lib' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':app' uses
+    - maven (1)
+
+project ':lib' uses
+    - maven (2)""")
         outputDoesNotContain('Legend')
     }
 
@@ -345,10 +408,33 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('Auth:')
-        outputContains('BasicAuthentication')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://corp.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Auth:       DefaultBasicAuthentication_Decorated
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
     }
 
     def "reports Credentials: PRESENT for repo with declared credentials"() {
@@ -367,9 +453,33 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('Credentials: PRESENT')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://corp.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Credentials: PRESENT
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
         // ensure the actual credential values never leak
         outputDoesNotContain('cred-username-xyzzy')
         outputDoesNotContain('cred-password-xyzzy')
@@ -385,8 +495,32 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://open.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
         outputDoesNotContain('Credentials:')
     }
 
@@ -401,9 +535,33 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('Secure:     false')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   http://legacy.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
     }
 
     def "renders content filter with include and onlyForConfigurations"() {
@@ -422,10 +580,27 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('Content:    includeGroup("com.example"), excludeModule("com.other", "bad")')
-        outputContains('onlyForConfigurations')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Content:    includeGroup("com.example"), excludeModule("com.other", "bad"), onlyForConfigurations([compile])
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
     }
 
     def "task is configuration-cache compatible"() {
@@ -440,6 +615,22 @@ Legend
         succeeds ':repositories', '--configuration-cache'
 
         then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1)
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)""")
         postBuildOutputContains('Configuration cache entry stored')
 
         when:
@@ -460,11 +651,20 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('FLAT_DIR')
-        outputContains('dirs:[')
-        outputContains('libs')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""    Type:       FLAT_DIR
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - flatDir (1)""")
     }
 
     def "reports Ivy repository"() {
@@ -477,10 +677,32 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('Location:   https://example.com/ivy/')
-        outputContains('Type:       IVY')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+ivy (1)
+    Location:   https://example.com/ivy/ (ur)
+    Type:       IVY
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - ivy (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
     }
 
     def "reports Ivy repository with content filter includeGroup"() {
@@ -496,12 +718,33 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('Type:       IVY')
-        outputContains('Location:   https://example.com/ivy/')
-        outputContains('Content:    includeGroup("com.example")')
-        outputContains("project ':' uses")
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+ivy (1)
+    Location:   https://example.com/ivy/ (ur)
+    Type:       IVY
+    Roles:      PROJECT_DEPENDENCIES
+    Content:    includeGroup("com.example")
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - ivy (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
     }
 
     def "reports mavenLocal repository with MAVEN_LOCAL type"() {
@@ -512,9 +755,20 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('MAVEN_LOCAL')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""    Type:       MAVEN_LOCAL
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenLocal (1)""")
     }
 
     def "project buildscript repo gets PROJECT_BUILDSCRIPT_DEPENDENCIES role"() {
@@ -670,54 +924,68 @@ project ':' uses
             }
         '''
 
-        expect:
-        succeeds ':repositories'
-        // Section headers
-        outputContains('All Repositories')
-        // Settings DRM repositories
-        outputContains('https://repo.maven.apache.org/maven2/')
-        outputContains('https://dl.google.com/dl/android/maven2/')
-        // Settings pluginManagement repository
-        outputContains('https://plugins.gradle.org/m2')
-        // Settings buildscript repository
-        outputContains('https://settings-buildscript.example.com/')
-        // Project buildscript repository (app)
-        outputContains('https://app-buildscript.example.com/')
-        // subprojects { } repository
-        outputContains('https://subprojects.example.com/')
-        // app's Ivy repository
-        outputContains('https://app-ivy.example.com/')
-        outputContains('Type:       IVY')
-        // lib's flatDir repository
-        outputContains('Type:       FLAT_DIR')
-        outputContains('dirs:[')
-        // Settings-plugin-added repo: PROJECT_DEPENDENCIES, attributed to settings DRM
-        outputContains('https://settings-plugin-drm.example.com/')
-        outputContains('Defined in: settings > dependencyResolutionManagement.repositories')
-        // Project-plugin-added repo: PROJECT_DEPENDENCIES, attributed to :app
-        outputContains('https://project-plugin-repo.example.com/')
-        outputContains("Defined in: project ':app' > repositories")
-        // All 4 RepositoryRole values appear
-        outputContains('PLUGINS')
-        outputContains('SETTINGS_BUILDSCRIPT_DEPENDENCIES')
-        outputContains('PROJECT_BUILDSCRIPT_DEPENDENCIES')
-        outputContains('PROJECT_DEPENDENCIES')
-        // Per-project reference blocks
-        outputContains("project ':app' uses")
-        outputContains("project ':lib' uses")
-        outputContains("project ':' uses")
+        when:
+        succeeds ':repositories', '--offline'
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""Gradle Central Plugin Repository (2)
+    Location:   https://plugins.gradle.org/m2
+    Type:       MAVEN
+    Roles:      PLUGINS
+    Defined in: settings > pluginManagement.repositories""")
+        result.groupedOutput.task(":repositories").assertOutputContains("""MavenRepo (4) *
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: settings > dependencyResolutionManagement.repositories""")
+        result.groupedOutput.task(":repositories").assertOutputContains("""ivy (9)
+    Location:   https://app-ivy.example.com/
+    Type:       IVY
+    Roles:      PROJECT_DEPENDENCIES
+    Credentials: PRESENT
+    Defined in: project ':app' > repositories""")
+        result.groupedOutput.task(":repositories").assertOutputContains("""settings uses
+    - maven (1)
+    - Gradle Central Plugin Repository (2)
+    - maven (3)
+    - MavenRepo (4)
+    - Google (5)
+
+project ':' uses
+    - Gradle Central Plugin Repository (2)
+    - maven (3)
+    - MavenRepo (4)
+    - Google (5)
+
+project ':app' uses
+    - Gradle Central Plugin Repository (2)
+    - maven (3)
+    - MavenRepo (4)
+    - Google (5)
+    - maven (6)
+    - maven (7)
+    - maven2 (8)
+    - ivy (9)
+
+project ':lib' uses
+    - Gradle Central Plugin Repository (2)
+    - maven (3)
+    - MavenRepo (4)
+    - Google (5)
+    - maven (10)
+    - MavenRepo (11)
+    - flatDir (12)""")
+        result.groupedOutput.task(":repositories").assertOutputContains("""(*) Identical repository declaration found in multiple locations.
+    Consider consolidating to settings.dependencyResolutionManagement.repositories
+    or settings.pluginManagement.repositories.
+    See https://docs.gradle.org/current/userguide/centralizing_repositories.html
+(o)  Running in offline mode \u2014 no reachability checks were performed.""")
         // Included build must NOT be descended
         outputDoesNotContain('included.example.com')
         outputDoesNotContain("project ':included'")
-        // Ivy repo carried credentials — Credentials line should render
-        outputContains('Credentials: PRESENT')
         // Credential values must never leak into the output
         outputDoesNotContain('ivyUser')
         outputDoesNotContain('ivyPass')
-        // Legend present (mavenCentral declared in both DRM and :lib triggers duplicate marker)
-        outputContains('Legend')
-        outputContains('centralizing_repositories.html')
-        outputContains('*')
     }
 
     def "project plugin adds repositories to its host project"() {
@@ -738,13 +1006,32 @@ project ':' uses
             apply from: 'project-repo-plugin.gradle'
         '''
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('All Repositories')
-        outputContains('https://project-plugin-repo.example.com/')
-        outputContains('Roles:      PROJECT_DEPENDENCIES')
-        outputContains("Defined in: project ':app' > repositories")
-        outputContains("project ':app' uses")
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://project-plugin-repo.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':app' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':app' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
     }
 
     def "settings plugin adds repositories via dependencyResolutionManagement"() {
@@ -766,16 +1053,41 @@ project ':' uses
         """
         createDirs("app", "lib")
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('All Repositories')
-        outputContains('https://settings-plugin-drm.example.com/')
-        outputContains('Roles:      PROJECT_DEPENDENCIES')
-        outputContains('Defined in: settings > dependencyResolutionManagement.repositories')
-        // The DRM repo should appear under every project's "uses" block.
-        outputContains("project ':' uses")
-        outputContains("project ':app' uses")
-        outputContains("project ':lib' uses")
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://settings-plugin-drm.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: settings > dependencyResolutionManagement.repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - maven (1)
+
+project ':' uses
+    - maven (1)
+
+project ':app' uses
+    - maven (1)
+
+project ':lib' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
     }
 
     def "both project plugin and settings plugin add repositories"() {
@@ -802,19 +1114,45 @@ project ':' uses
             apply from: 'project-repo-plugin.gradle'
         '''
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('All Repositories')
-        // Settings-plugin-added repo: PROJECT_DEPENDENCIES, declared in settings DRM
-        outputContains('https://settings-plugin-drm.example.com/')
-        outputContains('Defined in: settings > dependencyResolutionManagement.repositories')
-        // Project-plugin-added repo: PROJECT_DEPENDENCIES, declared in project ':app'
-        outputContains('https://project-plugin-repo.example.com/')
-        outputContains("Defined in: project ':app' > repositories")
-        // Both repos carry the PROJECT_DEPENDENCIES role
-        outputContains('Roles:      PROJECT_DEPENDENCIES')
-        // :app should reference both repos in its "uses" block
-        outputContains("project ':app' uses")
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://settings-plugin-drm.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: settings > dependencyResolutionManagement.repositories
+
+maven (2)
+    Location:   https://project-plugin-repo.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':app' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+settings uses
+    - maven (1)
+
+project ':' uses
+    - maven (1)
+
+project ':app' uses
+    - maven (1)
+    - maven (2)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
     }
 
     def "settings plugin adds repositories directly to each project"() {
@@ -836,20 +1174,55 @@ project ':' uses
         """
         createDirs("app", "lib")
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('All Repositories')
-        outputContains('https://settings-plugin-per-project.example.com/')
-        outputContains('Roles:      PROJECT_DEPENDENCIES')
-        // Repo is attributed to each project, not to settings.
-        outputContains("Defined in: project ':' > repositories")
-        outputContains("Defined in: project ':app' > repositories")
-        outputContains("Defined in: project ':lib' > repositories")
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1) *
+    Location:   https://settings-plugin-per-project.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+maven (2) *
+    Location:   https://settings-plugin-per-project.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':app' > repositories
+
+maven (3) *
+    Location:   https://settings-plugin-per-project.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':lib' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+project ':app' uses
+    - maven (2)
+
+project ':lib' uses
+    - maven (3)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(*) Identical repository declaration found in multiple locations.
+    Consider consolidating to settings.dependencyResolutionManagement.repositories
+    or settings.pluginManagement.repositories.
+    See https://docs.gradle.org/current/userguide/centralizing_repositories.html
+(ur) Unreachable \u2014 the URL could not be contacted.""")
         outputDoesNotContain("Defined in: settings >")
-        // Each project's "uses" list should reference the repo.
-        outputContains("project ':' uses")
-        outputContains("project ':app' uses")
-        outputContains("project ':lib' uses")
     }
 
     def "reports (ur) marker for unreachable URL"() {
@@ -865,11 +1238,33 @@ project ':' uses
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('(ur)')
-        outputContains('Legend')
-        outputContains('(ur) Unreachable')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   http://127.0.0.1:1/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ur) Unreachable \u2014 the URL could not be contacted.""")
     }
 
     def "reports (ua) marker for URL requiring authentication"() {
@@ -891,11 +1286,33 @@ project ':' uses
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('(ua)')
-        outputContains('Legend')
-        outputContains('(ua) Unauthorized')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   ${server.uri}/ (ua)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(ua) Unauthorized \u2014 the URL returned 401/403; credentials were not sent.""")
         outputDoesNotContain('(ur)')
     }
 
@@ -959,9 +1376,27 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('All Repositories')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   ${server.uri}/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
         outputDoesNotContain('(ur)')
         outputDoesNotContain('(ua)')
         outputDoesNotContain('(o)')
@@ -991,9 +1426,27 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('All Repositories')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   ${server.uri}/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Secure:     false
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
         outputDoesNotContain('(ur)')
         outputDoesNotContain('(ua)')
         outputDoesNotContain('(m)')
@@ -1013,9 +1466,27 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('notForConfigurations')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Content:    notForConfigurations([skipMe])
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
     }
 
     def "renders onlyForAttribute content filter branch"() {
@@ -1033,9 +1504,27 @@ Legend
             }
         """
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains('onlyForAttribute')
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+maven (1)
+    Location:   https://example.com/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Content:    onlyForAttribute(example-attr, [one, two])
+    Defined in: project ':' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - maven (1)""")
     }
 
     def "repos declared via allprojects and subprojects are shown under each project"() {
@@ -1061,19 +1550,67 @@ Legend
             }
         '''
 
-        expect:
+        when:
         succeeds ':repositories'
-        outputContains("All Repositories")
-        outputContains("Repositories by Location")
-        outputContains("project ':' uses")
-        outputContains("project ':app' uses")
-        outputContains("project ':lib' uses")
-        // mavenCentral applied by allprojects — visible to root and both subprojects
-        outputContains("https://repo.maven.apache.org/maven2/")
-        // sub.example.com applied only to subprojects
-        outputContains("https://sub.example.com/")
-        // Root has mavenCentral only; each subproject has both — so there should be
-        // at least 3 "- MavenRepo" reference lines across the per-project blocks.
-        result.output.count('- MavenRepo') >= 3
+
+        then:
+        result.groupedOutput.task(":repositories").assertOutputContains("""--------------------------------------------------------
+All Repositories
+--------------------------------------------------------
+
+MavenRepo (1) *
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories
+
+MavenRepo (2) *
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':app' > repositories
+
+maven (3) *
+    Location:   https://sub.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':app' > repositories
+
+MavenRepo (4) *
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':lib' > repositories
+
+maven (5) *
+    Location:   https://sub.example.com/ (ur)
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':lib' > repositories
+
+--------------------------------------------------------
+Repositories by Location
+--------------------------------------------------------
+
+project ':' uses
+    - MavenRepo (1)
+
+project ':app' uses
+    - MavenRepo (2)
+    - maven (3)
+
+project ':lib' uses
+    - MavenRepo (4)
+    - maven (5)
+
+--------------------------------------------------------
+Legend
+--------------------------------------------------------
+
+(*) Identical repository declaration found in multiple locations.
+    Consider consolidating to settings.dependencyResolutionManagement.repositories
+    or settings.pluginManagement.repositories.
+    See https://docs.gradle.org/current/userguide/centralizing_repositories.html
+(ur) Unreachable \u2014 the URL could not be contacted.""")
     }
 }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
@@ -802,6 +802,76 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         outputDoesNotContain('Legend')
     }
 
+    def "no reachability markers when server returns 405 on HEAD but 200 on GET (fallback classifies as REACHABLE)"() {
+        given:
+        server.addHandler(new AbstractHandler() {
+            @Override
+            void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+                if ("HEAD".equalsIgnoreCase(request.method)) {
+                    response.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED)
+                } else {
+                    response.setStatus(HttpServletResponse.SC_OK)
+                }
+                baseRequest.handled = true
+            }
+        })
+        server.start()
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("${server.uri}/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('All Repositories')
+        outputDoesNotContain('(ur)')
+        outputDoesNotContain('(ua)')
+        outputDoesNotContain('(m)')
+    }
+
+    def "renders notForConfigurations content filter branch"() {
+        given:
+        buildFile << """
+            configurations.create("skipMe")
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                    content {
+                        notForConfigurations("skipMe")
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('notForConfigurations')
+    }
+
+    def "renders onlyForAttribute content filter branch"() {
+        given:
+        buildFile << """
+            import org.gradle.api.attributes.Attribute
+            def attr = Attribute.of("example-attr", String)
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                    content {
+                        onlyForAttribute(attr, "one", "two")
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('onlyForAttribute')
+    }
+
     def "repos declared via allprojects and subprojects are shown under each project"() {
         given:
         settingsFile.text = """

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
@@ -42,7 +42,7 @@ class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
         succeeds ':tasks', '--all'
 
         then:
-        result.assertOutputContains("repositories")
+        outputContains("repositories")
     }
 
     def "task reports empty when no repositories declared"() {
@@ -1624,7 +1624,9 @@ Legend
      */
     private static String resolveReportedUrl(String mirrorKey, String originalUrl) {
         def env = System.getenv("REPO_MIRROR_URLS")
-        if (!env) return originalUrl
+        if (!env) {
+            return originalUrl
+        }
         def entries = env.split(',').collectEntries { it.split(':', 2) as List }
         entries[mirrorKey] ?: originalUrl
     }

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
@@ -1,0 +1,837 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics
+
+import org.eclipse.jetty.server.Request
+import org.eclipse.jetty.server.handler.AbstractHandler
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.server.http.HttpServer
+import org.junit.Rule
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class RepositoriesReportTaskIntegrationTest extends AbstractIntegrationSpec {
+
+    @Rule
+    public final HttpServer server = new HttpServer()
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = "myLib"
+        """
+    }
+
+    def "task is registered under help group"() {
+        expect:
+        succeeds ':tasks', '--all'
+        outputContains('repositories -')
+    }
+
+    def "task reports empty when no repositories declared"() {
+        expect:
+        succeeds ':repositories'
+        outputContains('There are no repositories present.')
+        !result.output.contains('All Repositories')
+        !result.output.contains('Repositories by Location')
+        !result.output.contains('(none)')
+        !result.output.contains('Legend')
+    }
+
+    def "task reports a single mavenCentral repository in All Repositories"() {
+        given:
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('All Repositories')
+        outputContains('''MavenRepo (1)
+    Location:   https://repo.maven.apache.org/maven2/
+    Type:       MAVEN
+    Roles:      PROJECT_DEPENDENCIES
+    Defined in: project ':' > repositories''')
+    }
+
+    def "task reports settings pluginManagement repo under All Repositories with PLUGINS role"() {
+        given:
+        settingsFile.text = """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                }
+            }
+            rootProject.name = "myLib"
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('All Repositories')
+        outputContains('PLUGINS')
+    }
+
+    def "task reports settings.buildscript repo in All Repositories and under settings uses"() {
+        given:
+        settingsFile.text = """
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            rootProject.name = "myLib"
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('All Repositories')
+        outputContains('SETTINGS_BUILDSCRIPT_DEPENDENCIES')
+        outputContains('settings uses')
+    }
+
+    def "multi-project: PLUGINS and DRM repos appear under every project's reference list"() {
+        given:
+        settingsFile.text = """
+            pluginManagement {
+                repositories { gradlePluginPortal() }
+            }
+            dependencyResolutionManagement {
+                repositories { mavenCentral() }
+            }
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+
+        expect:
+        succeeds ':repositories'
+        outputContains("project ':app' uses")
+        outputContains("project ':lib' uses")
+        // each project should reference at least the DRM and PLUGINS entries
+        result.output.count('- Gradle Central Plugin Repository') >= 2 ||
+            result.output.count('- MavenRepo') >= 2
+    }
+
+    def "--project filter limits Repositories by Location to the single project"() {
+        given:
+        settingsFile.text = """
+            pluginManagement {
+                repositories { gradlePluginPortal() }
+            }
+            dependencyResolutionManagement {
+                repositories { mavenCentral() }
+            }
+            rootProject.name = "myLib"
+            include ":app"
+            include ":other"
+        """
+        createDirs("app", "other")
+        file('app/build.gradle') << 'repositories { google() }'
+
+        when:
+        succeeds ':repositories', '--project', ':app'
+
+        then:
+        outputContains('All Repositories')
+        outputContains('Google')
+        outputContains('Repositories by Location')
+        outputContains("project ':app' uses")
+        !result.output.contains('settings uses')
+        !result.output.contains("project ':other'")
+    }
+
+    def "--project with unknown project path fails with clear error"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+        """
+        createDirs("app")
+
+        when:
+        fails ':repositories', '--project', ':nope'
+
+        then:
+        failure.assertHasCause("Project ':nope' not found")
+    }
+
+    def "identical declarations in multiple projects mark entries with star and render Legend"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+        file('app/build.gradle') << 'repositories { mavenCentral() }'
+        file('lib/build.gradle') << 'repositories { mavenCentral() }'
+
+        expect:
+        succeeds ':repositories'
+        result.output.count('MavenRepo') >= 2
+        outputContains('*')
+        outputContains('Legend')
+        outputContains('Identical repository declaration')
+    }
+
+    def "non-identical declarations do NOT trigger Legend"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+        file('app/build.gradle') << '''
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                    content { includeGroup("com.example") }
+                }
+            }
+        '''
+        file('lib/build.gradle') << '''
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                }
+            }
+        '''
+
+        expect:
+        succeeds ':repositories'
+        !result.output.contains('Legend')
+    }
+
+    def "reports authentication scheme class name"() {
+        given:
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("https://corp.example.com/")
+                    credentials(PasswordCredentials)
+                    authentication {
+                        basic(BasicAuthentication)
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('Auth:')
+        outputContains('BasicAuthentication')
+    }
+
+    def "reports Credentials: PRESENT for repo with declared credentials"() {
+        given:
+        // Use distinctive, non-substring credential values so leak detection is unambiguous —
+        // e.g. "user" would collide with the "/userguide/" links that appear in --warning-mode output.
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("https://corp.example.com/")
+                    credentials {
+                        username = "cred-username-xyzzy"
+                        password = "cred-password-xyzzy"
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('Credentials: PRESENT')
+        // ensure the actual credential values never leak
+        !result.output.contains('cred-username-xyzzy')
+        !result.output.contains('cred-password-xyzzy')
+    }
+
+    def "omits Credentials line when no credentials declared"() {
+        given:
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("https://open.example.com/")
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        !result.output.contains('Credentials:')
+    }
+
+    def "reports Secure: false when allowInsecureProtocol = true"() {
+        given:
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("http://legacy.example.com/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('Secure:     false')
+    }
+
+    def "renders content filter with include and onlyForConfigurations"() {
+        given:
+        buildFile << """
+            configurations.create("compile")
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                    content {
+                        includeGroup("com.example")
+                        excludeModule("com.other", "bad")
+                        onlyForConfigurations("compile")
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('Content:    includeGroup("com.example"), excludeModule("com.other", "bad")')
+        outputContains('onlyForConfigurations')
+    }
+
+    def "task is configuration-cache compatible"() {
+        given:
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+        """
+
+        when:
+        succeeds ':repositories', '--configuration-cache'
+
+        then:
+        postBuildOutputContains('Configuration cache entry stored')
+
+        when:
+        succeeds ':repositories', '--configuration-cache'
+
+        then:
+        postBuildOutputContains('Configuration cache entry reused')
+    }
+
+    def "reports FlatDir repository with dirs location"() {
+        given:
+        file('libs').mkdirs()
+        buildFile << """
+            repositories {
+                flatDir {
+                    dirs 'libs'
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('FLAT_DIR')
+        outputContains('dirs:[')
+        outputContains('libs')
+    }
+
+    def "reports Ivy repository"() {
+        given:
+        buildFile << """
+            repositories {
+                ivy {
+                    url = uri("https://example.com/ivy/")
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('Location:   https://example.com/ivy/')
+        outputContains('Type:       IVY')
+    }
+
+    def "reports Ivy repository with content filter includeGroup"() {
+        given:
+        buildFile << """
+            repositories {
+                ivy {
+                    url = uri("https://example.com/ivy/")
+                    content {
+                        includeGroup("com.example")
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('Type:       IVY')
+        outputContains('Location:   https://example.com/ivy/')
+        outputContains('Content:    includeGroup("com.example")')
+        outputContains("project ':' uses")
+    }
+
+    def "reports mavenLocal repository with MAVEN_LOCAL type"() {
+        given:
+        buildFile << """
+            repositories {
+                mavenLocal()
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('MAVEN_LOCAL')
+    }
+
+    def "project buildscript repo gets both PROJECT_LEGACY_PLUGINS and PROJECT_BUILDSCRIPT_DEPENDENCIES roles"() {
+        given:
+        buildFile.text = """
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('Roles:      PROJECT_LEGACY_PLUGINS, PROJECT_BUILDSCRIPT_DEPENDENCIES')
+    }
+
+    def "does not list repositories from included builds"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            includeBuild 'included'
+        """
+        file('included/settings.gradle') << "rootProject.name = 'included'"
+        file('included/build.gradle') << '''
+            repositories {
+                maven { url = uri("https://included.example.com/") }
+            }
+        '''
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('MavenRepo')
+        !result.output.contains('included.example.com')
+        !result.output.contains("project ':included' uses")
+    }
+
+    def "complex example reports properly"() {
+        given:
+        // Settings plugin: adds a repo via settings.dependencyResolutionManagement.
+        file('settings-plugin.gradle') << '''
+            dependencyResolutionManagement {
+                repositories {
+                    maven { url = uri("https://settings-plugin-drm.example.com/") }
+                }
+            }
+        '''
+        settingsFile.text = """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                }
+            }
+            buildscript {
+                repositories {
+                    maven { url = uri("https://settings-buildscript.example.com/") }
+                }
+            }
+            apply from: 'settings-plugin.gradle'
+            dependencyResolutionManagement {
+                repositories {
+                    mavenCentral()
+                    google()
+                }
+            }
+            rootProject.name = "myLib"
+            include ':app'
+            include ':lib'
+            includeBuild 'included'
+        """
+        createDirs('app', 'lib')
+        buildFile << '''
+            subprojects {
+                repositories {
+                    maven { url = uri("https://subprojects.example.com/") }
+                }
+            }
+        '''
+        // Project plugin: applied to :app, adds a repo to :app's own repositories container.
+        file('app/project-plugin.gradle') << '''
+            repositories {
+                maven { url = uri("https://project-plugin-repo.example.com/") }
+            }
+        '''
+        file('app/build.gradle') << '''
+            buildscript {
+                repositories {
+                    maven { url = uri("https://app-buildscript.example.com/") }
+                }
+            }
+            apply from: 'project-plugin.gradle'
+            repositories {
+                ivy {
+                    url = uri("https://app-ivy.example.com/")
+                    credentials {
+                        username = "ivyUser"
+                        password = "ivyPass"
+                    }
+                }
+            }
+        '''
+        file('lib/build.gradle') << '''
+            repositories {
+                mavenCentral()
+            }
+            repositories {
+                flatDir { dirs 'libs' }
+            }
+        '''
+        file('included/settings.gradle') << "rootProject.name = 'included'"
+        file('included/build.gradle') << '''
+            repositories {
+                maven { url = uri("https://included.example.com/") }
+            }
+        '''
+
+        expect:
+        succeeds ':repositories'
+        // Section headers
+        outputContains('All Repositories')
+        // Settings DRM repositories
+        outputContains('https://repo.maven.apache.org/maven2/')
+        outputContains('https://dl.google.com/dl/android/maven2/')
+        // Settings pluginManagement repository
+        outputContains('https://plugins.gradle.org/m2')
+        // Settings buildscript repository
+        outputContains('https://settings-buildscript.example.com/')
+        // Project buildscript repository (app)
+        outputContains('https://app-buildscript.example.com/')
+        // subprojects { } repository
+        outputContains('https://subprojects.example.com/')
+        // app's Ivy repository
+        outputContains('https://app-ivy.example.com/')
+        outputContains('Type:       IVY')
+        // lib's flatDir repository
+        outputContains('Type:       FLAT_DIR')
+        outputContains('dirs:[')
+        // Settings-plugin-added repo: PROJECT_DEPENDENCIES, attributed to settings DRM
+        outputContains('https://settings-plugin-drm.example.com/')
+        outputContains('Defined in: settings > dependencyResolutionManagement.repositories')
+        // Project-plugin-added repo: PROJECT_DEPENDENCIES, attributed to :app
+        outputContains('https://project-plugin-repo.example.com/')
+        outputContains("Defined in: project ':app' > repositories")
+        // All 5 RepositoryRole values appear
+        outputContains('PLUGINS')
+        outputContains('SETTINGS_BUILDSCRIPT_DEPENDENCIES')
+        outputContains('PROJECT_LEGACY_PLUGINS')
+        outputContains('PROJECT_BUILDSCRIPT_DEPENDENCIES')
+        outputContains('PROJECT_DEPENDENCIES')
+        // Per-project reference blocks
+        outputContains("project ':app' uses")
+        outputContains("project ':lib' uses")
+        outputContains("project ':' uses")
+        // Included build must NOT be descended
+        !result.output.contains('included.example.com')
+        !result.output.contains("project ':included'")
+        // Ivy repo carried credentials — Credentials line should render
+        outputContains('Credentials: PRESENT')
+        // Credential values must never leak into the output
+        !result.output.contains('ivyUser')
+        !result.output.contains('ivyPass')
+        // Legend present (mavenCentral declared in both DRM and :lib triggers duplicate marker)
+        outputContains('Legend')
+        outputContains('centralizing_repositories.html')
+        outputContains('*')
+    }
+
+    def "project plugin adds repositories to its host project"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+        """
+        createDirs("app")
+        // Script plugin acting as a project plugin: when applied to a project,
+        // it adds a repository to that project's `repositories` container.
+        file('app/project-repo-plugin.gradle') << '''
+            repositories {
+                maven { url = uri("https://project-plugin-repo.example.com/") }
+            }
+        '''
+        file('app/build.gradle') << '''
+            apply from: 'project-repo-plugin.gradle'
+        '''
+
+        expect:
+        succeeds ':repositories'
+        outputContains('All Repositories')
+        outputContains('https://project-plugin-repo.example.com/')
+        outputContains('Roles:      PROJECT_DEPENDENCIES')
+        outputContains("Defined in: project ':app' > repositories")
+        outputContains("project ':app' uses")
+    }
+
+    def "settings plugin adds repositories via dependencyResolutionManagement"() {
+        given:
+        // Script plugin acting as a settings plugin: when applied to settings,
+        // it adds a repository to settings.dependencyResolutionManagement.repositories.
+        file('settings-drm-plugin.gradle') << '''
+            dependencyResolutionManagement {
+                repositories {
+                    maven { url = uri("https://settings-plugin-drm.example.com/") }
+                }
+            }
+        '''
+        settingsFile.text = """
+            apply from: 'settings-drm-plugin.gradle'
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+
+        expect:
+        succeeds ':repositories'
+        outputContains('All Repositories')
+        outputContains('https://settings-plugin-drm.example.com/')
+        outputContains('Roles:      PROJECT_DEPENDENCIES')
+        outputContains('Defined in: settings > dependencyResolutionManagement.repositories')
+        // The DRM repo should appear under every project's "uses" block.
+        outputContains("project ':' uses")
+        outputContains("project ':app' uses")
+        outputContains("project ':lib' uses")
+    }
+
+    def "both project plugin and settings plugin add repositories"() {
+        given:
+        file('settings-drm-plugin.gradle') << '''
+            dependencyResolutionManagement {
+                repositories {
+                    maven { url = uri("https://settings-plugin-drm.example.com/") }
+                }
+            }
+        '''
+        settingsFile.text = """
+            apply from: 'settings-drm-plugin.gradle'
+            rootProject.name = "myLib"
+            include ":app"
+        """
+        createDirs("app")
+        file('app/project-repo-plugin.gradle') << '''
+            repositories {
+                maven { url = uri("https://project-plugin-repo.example.com/") }
+            }
+        '''
+        file('app/build.gradle') << '''
+            apply from: 'project-repo-plugin.gradle'
+        '''
+
+        expect:
+        succeeds ':repositories'
+        outputContains('All Repositories')
+        // Settings-plugin-added repo: PROJECT_DEPENDENCIES, declared in settings DRM
+        outputContains('https://settings-plugin-drm.example.com/')
+        outputContains('Defined in: settings > dependencyResolutionManagement.repositories')
+        // Project-plugin-added repo: PROJECT_DEPENDENCIES, declared in project ':app'
+        outputContains('https://project-plugin-repo.example.com/')
+        outputContains("Defined in: project ':app' > repositories")
+        // Both repos carry the PROJECT_DEPENDENCIES role
+        outputContains('Roles:      PROJECT_DEPENDENCIES')
+        // :app should reference both repos in its "uses" block
+        outputContains("project ':app' uses")
+    }
+
+    def "settings plugin adds repositories directly to each project"() {
+        given:
+        // Script plugin acting as a settings plugin that uses gradle.beforeProject
+        // to mutate each project's own `repositories` container.
+        file('settings-per-project-plugin.gradle') << '''
+            gradle.beforeProject { project ->
+                project.repositories {
+                    maven { url = uri("https://settings-plugin-per-project.example.com/") }
+                }
+            }
+        '''
+        settingsFile.text = """
+            apply from: 'settings-per-project-plugin.gradle'
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+
+        expect:
+        succeeds ':repositories'
+        outputContains('All Repositories')
+        outputContains('https://settings-plugin-per-project.example.com/')
+        outputContains('Roles:      PROJECT_DEPENDENCIES')
+        // Repo is attributed to each project, not to settings.
+        outputContains("Defined in: project ':' > repositories")
+        outputContains("Defined in: project ':app' > repositories")
+        outputContains("Defined in: project ':lib' > repositories")
+        !result.output.contains("Defined in: settings >")
+        // Each project's "uses" list should reference the repo.
+        outputContains("project ':' uses")
+        outputContains("project ':app' uses")
+        outputContains("project ':lib' uses")
+    }
+
+    def "reports (ur) marker for unreachable URL"() {
+        given:
+        // Port 1 is a reserved "tcpmux" port that virtually nothing listens on — a connect there
+        // will fail immediately with ECONNREFUSED, giving us a deterministic unreachable URL.
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("http://127.0.0.1:1/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('(ur)')
+        outputContains('Legend')
+        outputContains('(ur) Unreachable')
+    }
+
+    def "reports (ua) marker for URL requiring authentication"() {
+        given:
+        server.addHandler(new AbstractHandler() {
+            @Override
+            void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED)
+                baseRequest.handled = true
+            }
+        })
+        server.start()
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("${server.uri}/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('(ua)')
+        outputContains('Legend')
+        outputContains('(ua) Unauthorized')
+        !result.output.contains('(ur)')
+    }
+
+    def "reports (o) marker on All Repositories heading in offline mode"() {
+        given:
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("https://example.com/")
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories', '--offline'
+        outputContains('All Repositories (o)')
+        outputContains('Legend')
+        outputContains('(o)  Running in offline mode')
+        // Offline suppresses per-repo reachability markers.
+        !result.output.contains('(ur)')
+        !result.output.contains('(ua)')
+    }
+
+    def "no reachability markers when URL is reachable"() {
+        given:
+        server.addHandler(new AbstractHandler() {
+            @Override
+            void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+                response.setStatus(HttpServletResponse.SC_OK)
+                baseRequest.handled = true
+            }
+        })
+        server.start()
+        buildFile << """
+            repositories {
+                maven {
+                    url = uri("${server.uri}/")
+                    allowInsecureProtocol = true
+                }
+            }
+        """
+
+        expect:
+        succeeds ':repositories'
+        outputContains('All Repositories')
+        !result.output.contains('(ur)')
+        !result.output.contains('(ua)')
+        !result.output.contains('(o)')
+        !result.output.contains('Legend')
+    }
+
+    def "repos declared via allprojects and subprojects are shown under each project"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = "myLib"
+            include ":app"
+            include ":lib"
+        """
+        createDirs("app", "lib")
+        buildFile << '''
+            allprojects {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            subprojects {
+                repositories {
+                    maven {
+                        url = uri("https://sub.example.com/")
+                    }
+                }
+            }
+        '''
+
+        expect:
+        succeeds ':repositories'
+        outputContains("All Repositories")
+        outputContains("Repositories by Location")
+        outputContains("project ':' uses")
+        outputContains("project ':app' uses")
+        outputContains("project ':lib' uses")
+        // mavenCentral applied by allprojects — visible to root and both subprojects
+        outputContains("https://repo.maven.apache.org/maven2/")
+        // sub.example.com applied only to subprojects
+        outputContains("https://sub.example.com/")
+        // Root has mavenCentral only; each subproject has both — so there should be
+        // at least 3 "- MavenRepo" reference lines across the per-project blocks.
+        result.output.count('- MavenRepo') >= 3
+    }
+}

--- a/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
+++ b/platforms/software/software-diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/RepositoriesReportTaskIntegrationTest.groovy
@@ -107,7 +107,7 @@ All Repositories (o)
 --------------------------------------------------------
 
 Gradle Central Plugin Repository (1)
-    Location:   https://plugins.gradle.org/m2
+    Location:   ${pluginPortalUrl}
     Type:       MAVEN
     Roles:      PLUGINS
     Defined in: settings > pluginManagement.repositories
@@ -186,7 +186,7 @@ All Repositories (o)
 --------------------------------------------------------
 
 Gradle Central Plugin Repository (1)
-    Location:   https://plugins.gradle.org/m2
+    Location:   ${pluginPortalUrl}
     Type:       MAVEN
     Roles:      PLUGINS
     Defined in: settings > pluginManagement.repositories
@@ -249,7 +249,7 @@ All Repositories
 --------------------------------------------------------
 
 Gradle Central Plugin Repository (1)
-    Location:   https://plugins.gradle.org/m2
+    Location:   ${pluginPortalUrl}
     Type:       MAVEN
     Roles:      PLUGINS
     Defined in: settings > pluginManagement.repositories
@@ -929,7 +929,7 @@ project ':' uses
 
         then:
         result.groupedOutput.task(":repositories").assertOutputContains("""Gradle Central Plugin Repository (2)
-    Location:   https://plugins.gradle.org/m2
+    Location:   ${pluginPortalUrl}
     Type:       MAVEN
     Roles:      PLUGINS
     Defined in: settings > pluginManagement.repositories""")
@@ -1613,4 +1613,21 @@ Legend
     See https://docs.gradle.org/current/userguide/centralizing_repositories.html
 (ur) Unreachable \u2014 the URL could not be contacted.""")
     }
+
+    /**
+     * Returns the URL that the repositories report will print for the given canonical
+     * repository factory. On CI the URL is rewritten by {@code mirroring-init-script.gradle}
+     * based on the {@code REPO_MIRROR_URLS} env var; locally the original URL is used.
+     *
+     * @param mirrorKey one of "gradle-prod-plugins", "mavencentral", "google", "jcenter"
+     * @param originalUrl the canonical URL used when no mirror is configured
+     */
+    private static String resolveReportedUrl(String mirrorKey, String originalUrl) {
+        def env = System.getenv("REPO_MIRROR_URLS")
+        if (!env) return originalUrl
+        def entries = env.split(',').collectEntries { it.split(':', 2) as List }
+        entries[mirrorKey] ?: originalUrl
+    }
+
+    private pluginPortalUrl = resolveReportedUrl("gradle-prod-plugins", "https://plugins.gradle.org/m2")
 }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/SoftwareReportingTasksPlugin.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/SoftwareReportingTasksPlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.diagnostics.BuildEnvironmentReportTask;
 import org.gradle.api.tasks.diagnostics.DependencyInsightReportTask;
 import org.gradle.api.tasks.diagnostics.DependencyReportTask;
 import org.gradle.api.tasks.diagnostics.OutgoingVariantsReportTask;
+import org.gradle.api.tasks.diagnostics.RepositoriesReportTask;
 import org.gradle.api.tasks.diagnostics.ResolvableConfigurationsReportTask;
 import org.gradle.api.tasks.diagnostics.TaskReportTask;
 import org.jspecify.annotations.NullMarked;
@@ -67,6 +68,15 @@ public abstract class SoftwareReportingTasksPlugin implements Plugin<Project> {
             task.setDescription("Displays the Artifact Transforms that can be executed in " + projectName + ".");
             task.setGroup(HelpTasksPlugin.HELP_GROUP);
             task.setImpliesSubProjects(true);
+        });
+        boolean offline = project.getGradle().getStartParameter().isOffline();
+        tasks.register(HelpTasksPlugin.REPOSITORIES_TASK, RepositoriesReportTask.class, task -> {
+            task.setDescription("Displays the repositories available for dependency resolution.");
+            task.setGroup(HelpTasksPlugin.HELP_GROUP);
+            task.setImpliesSubProjects(true);
+            // Capture the offline flag at config time so the task action doesn't need to access
+            // Gradle.startParameter at execution time (which is CC-incompatible).
+            task.getOfflineMode().convention(offline);
         });
         tasks.withType(TaskReportTask.class).configureEach(task -> {
             task.getShowTypes().convention(false);

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/SoftwareReportingTasksPlugin.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/SoftwareReportingTasksPlugin.java
@@ -69,14 +69,13 @@ public abstract class SoftwareReportingTasksPlugin implements Plugin<Project> {
             task.setGroup(HelpTasksPlugin.HELP_GROUP);
             task.setImpliesSubProjects(true);
         });
-        boolean offline = project.getGradle().getStartParameter().isOffline();
         tasks.register(HelpTasksPlugin.REPOSITORIES_TASK, RepositoriesReportTask.class, task -> {
             task.setDescription("Displays the repositories available for dependency resolution.");
             task.setGroup(HelpTasksPlugin.HELP_GROUP);
             task.setImpliesSubProjects(true);
             // Capture the offline flag at config time so the task action doesn't need to access
             // Gradle.startParameter at execution time (which is CC-incompatible).
-            task.getOfflineMode().convention(offline);
+            task.getOfflineMode().convention(project.getGradle().getStartParameter().isOffline());
         });
         tasks.withType(TaskReportTask.class).configureEach(task -> {
             task.getShowTypes().convention(false);

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
@@ -177,7 +177,7 @@ public abstract class RepositoriesReportTask extends ConventionReportTask {
                 Set.of(RepositoryRole.PROJECT_DEPENDENCIES))
         );
 
-        TreeMap<Path, RepositoryReportProjectModel> projects = new TreeMap<>(RepositoryReportFullModel.pathComparator());
+        TreeMap<Path, RepositoryReportProjectModel> projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator());
         for (Project p : root.getAllprojects()) {
             ProjectInternal pi = (ProjectInternal) p;
             projects.put(pi.getProjectPath(),
@@ -193,7 +193,7 @@ public abstract class RepositoriesReportTask extends ConventionReportTask {
 
         List<ReportRepository> buildscriptRepos = convertRepos(
             project.getBuildscript().getRepositories(), factory, buildscriptSite,
-            Set.of(RepositoryRole.PROJECT_LEGACY_PLUGINS, RepositoryRole.PROJECT_BUILDSCRIPT_DEPENDENCIES),
+            Set.of(RepositoryRole.PROJECT_BUILDSCRIPT_DEPENDENCIES),
             project
         );
         List<ReportRepository> projectRepos = convertRepos(
@@ -233,7 +233,7 @@ public abstract class RepositoriesReportTask extends ConventionReportTask {
                     repo.getName(), context, site.getBlock(), repo.getClass().getName());
                 continue;
             }
-            out.add(factory.toReportRepository((AbstractArtifactRepository) repo, roles, site));
+            out.add(factory.buildReportRepository((AbstractArtifactRepository) repo, roles, site));
         }
         return ImmutableList.copyOf(out);
     }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.Incubating;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ArtifactRepositoryContainer;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.artifacts.repositories.AbstractArtifactRepository;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.diagnostics.internal.TextReportRenderer;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportFullModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportModelFactory;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportProjectModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportSettingsModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole;
+import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.ReachabilityStatus;
+import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.RepositoryReachabilityChecker;
+import org.gradle.api.tasks.diagnostics.internal.repositories.renderer.ConsoleRepositoriesReportRenderer;
+import org.gradle.api.tasks.diagnostics.internal.repositories.spec.RepositoriesReportSpec;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.internal.serialization.Cached;
+import org.gradle.util.Path;
+import org.gradle.work.DisableCachingByDefault;
+import org.jspecify.annotations.Nullable;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.PROJECT;
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.SETTINGS;
+
+/**
+ * Displays a unified view of every repository used by the build, across settings-level
+ * and project-level declaration sites, annotated with the kinds of dependencies each is allowed to serve.
+ *
+ * @since 9.5
+ */
+@Incubating
+@DisableCachingByDefault(because = "Produces only non-cacheable console output")
+public abstract class RepositoriesReportTask extends ConventionReportTask {
+
+    private final Cached<RepositoryReportFullModel> fullModel = Cached.of(this::buildFullModel);
+
+    @Inject
+    @Override
+    protected abstract StyledTextOutputFactory getTextOutputFactory();
+
+    private final TextReportRenderer textRenderer = new TextReportRenderer();
+
+    @Override
+    protected TextReportRenderer getRenderer() {
+        return textRenderer;
+    }
+
+    /**
+     * Limits the report to a single project path.
+     *
+     * @return property holding the project path to filter to
+     * @since 9.5
+     */
+    @Input
+    @Optional
+    @Option(option = "project", description = "Limits the report to a single project path")
+    public abstract Property<String> getProjectFilter();
+
+    @TaskAction
+    void report() {
+        RepositoryReportFullModel model = fullModel.get();
+        boolean offline = getOfflineMode().get();
+        Map<String, ReachabilityStatus> reachability;
+        if (offline) {
+            reachability = Collections.emptyMap();
+        } else {
+            reachability = new RepositoryReachabilityChecker().check(collectAllRepos(model), false);
+        }
+        RepositoriesReportSpec spec = new RepositoriesReportSpec(
+            getProjectFilter().getOrNull(),
+            offline,
+            reachability
+        );
+        ConsoleRepositoriesReportRenderer renderer = new ConsoleRepositoriesReportRenderer(spec);
+        StyledTextOutput out = getTextOutputFactory().create(getClass());
+        renderer.render(model, out);
+    }
+
+    /**
+     * Whether the build is running with {@code --offline}. Wired internally at registration time
+     * from {@code gradle.startParameter.isOffline()} so that we do not touch {@link Project}
+     * or the {@link org.gradle.api.invocation.Gradle Gradle} object at task-execution time
+     * (which is CC-incompatible).
+     *
+     * @since 9.5
+     */
+    @Internal
+    public abstract Property<Boolean> getOfflineMode();
+
+    private static List<ReportRepository> collectAllRepos(RepositoryReportFullModel model) {
+        List<ReportRepository> all = new ArrayList<>();
+        all.addAll(model.getSettings().getPluginManagementRepositories());
+        all.addAll(model.getSettings().getSettingsBuildscriptRepositories());
+        all.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
+        for (RepositoryReportProjectModel p : model.getProjectsByPath().values()) {
+            all.addAll(p.getBuildscriptRepositories());
+            all.addAll(p.getProjectRepositories());
+        }
+        return all;
+    }
+
+    private RepositoryReportFullModel buildFullModel() {
+        ProjectInternal root = (ProjectInternal) getProject().getRootProject();
+        SettingsInternal settings = root.getGradle().getSettings();
+        RepositoryReportModelFactory factory = new RepositoryReportModelFactory();
+
+        RepositoryReportSettingsModel settingsModel = new RepositoryReportSettingsModel(
+            convertSettingsRepos(settings.getPluginManagement().getRepositories(), factory,
+                new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories"),
+                Set.of(RepositoryRole.PLUGINS)),
+            convertSettingsRepos(settings.getBuildscript().getRepositories(), factory,
+                new RepositoryDeclarationSite(SETTINGS, null, "buildscript.repositories"),
+                Set.of(RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES)),
+            convertSettingsRepos(settings.getDependencyResolutionManagement().getRepositories(), factory,
+                new RepositoryDeclarationSite(SETTINGS, null, "dependencyResolutionManagement.repositories"),
+                Set.of(RepositoryRole.PROJECT_DEPENDENCIES))
+        );
+
+        TreeMap<Path, RepositoryReportProjectModel> projects = new TreeMap<>(RepositoryReportFullModel.pathComparator());
+        for (Project p : root.getAllprojects()) {
+            ProjectInternal pi = (ProjectInternal) p;
+            projects.put(pi.getProjectPath(),
+                buildProjectModel(pi, factory));
+        }
+
+        return new RepositoryReportFullModel(settingsModel, projects);
+    }
+
+    private RepositoryReportProjectModel buildProjectModel(ProjectInternal project, RepositoryReportModelFactory factory) {
+        RepositoryDeclarationSite buildscriptSite = new RepositoryDeclarationSite(PROJECT, project.getProjectPath(), "buildscript.repositories");
+        RepositoryDeclarationSite repositoriesSite = new RepositoryDeclarationSite(PROJECT, project.getProjectPath(), "repositories");
+
+        List<ReportRepository> buildscriptRepos = convertRepos(
+            project.getBuildscript().getRepositories(), factory, buildscriptSite,
+            Set.of(RepositoryRole.PROJECT_LEGACY_PLUGINS, RepositoryRole.PROJECT_BUILDSCRIPT_DEPENDENCIES),
+            project
+        );
+        List<ReportRepository> projectRepos = convertRepos(
+            project.getRepositories(), factory, repositoriesSite,
+            Set.of(RepositoryRole.PROJECT_DEPENDENCIES),
+            project
+        );
+        return new RepositoryReportProjectModel(
+            project.getProjectPath(),
+            project.getName(),
+            buildscriptRepos,
+            projectRepos
+        );
+    }
+
+    private List<ReportRepository> convertSettingsRepos(
+        ArtifactRepositoryContainer container,
+        RepositoryReportModelFactory factory,
+        RepositoryDeclarationSite site,
+        Set<RepositoryRole> roles
+    ) {
+        return convertRepos(container, factory, site, roles, null);
+    }
+
+    private List<ReportRepository> convertRepos(
+        ArtifactRepositoryContainer container,
+        RepositoryReportModelFactory factory,
+        RepositoryDeclarationSite site,
+        Set<RepositoryRole> roles,
+        @Nullable Project projectForLogging
+    ) {
+        List<ReportRepository> out = new ArrayList<>(container.size());
+        for (ArtifactRepository repo : container) {
+            if (!(repo instanceof AbstractArtifactRepository)) {
+                String context = projectForLogging != null ? "project " + projectForLogging : "settings";
+                getLogger().warn("Skipping repository '{}' in {} > {}: not an AbstractArtifactRepository (class={})",
+                    repo.getName(), context, site.getBlock(), repo.getClass().getName());
+                continue;
+            }
+            out.add(factory.toReportRepository((AbstractArtifactRepository) repo, roles, site));
+        }
+        return ImmutableList.copyOf(out);
+    }
+
+    @Internal
+    protected org.gradle.initialization.BuildClientMetaData getClientMetaDataInternal() {
+        return getClientMetaData();
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
@@ -63,12 +63,11 @@ import static org.gradle.api.tasks.diagnostics.internal.repositories.model.Repos
  * Displays a unified view of every repository used by the build, across settings-level
  * and project-level declaration sites, annotated with the kinds of dependencies each is allowed to serve.
  *
- * @since 9.5
+ * @since 9.6.0
  */
 @Incubating
 @DisableCachingByDefault(because = "Produces only non-cacheable console output")
 public abstract class RepositoriesReportTask extends ConventionReportTask {
-
     private final Cached<RepositoryReportFullModel> fullModel = Cached.of(this::buildFullModel);
 
     @Inject
@@ -86,7 +85,7 @@ public abstract class RepositoriesReportTask extends ConventionReportTask {
      * Limits the report to a single project path.
      *
      * @return property holding the project path to filter to
-     * @since 9.5
+     * @since 9.6.0
      */
     @Input
     @Optional
@@ -119,7 +118,7 @@ public abstract class RepositoriesReportTask extends ConventionReportTask {
      * or the {@link org.gradle.api.invocation.Gradle Gradle} object at task-execution time
      * (which is CC-incompatible).
      *
-     * @since 9.5
+     * @since 9.6.0
      */
     @Internal
     public abstract Property<Boolean> getOfflineMode();
@@ -212,10 +211,5 @@ public abstract class RepositoriesReportTask extends ConventionReportTask {
             out.add(factory.toReportRepository((AbstractArtifactRepository) repo, roles, site));
         }
         return ImmutableList.copyOf(out);
-    }
-
-    @Internal
-    protected org.gradle.initialization.BuildClientMetaData getClientMetaDataInternal() {
-        return getClientMetaData();
     }
 }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
@@ -148,8 +148,8 @@ public abstract class RepositoriesReportTask extends ConventionReportTask {
 
     private static List<ReportRepository> collectAllRepos(RepositoryReportFullModel model) {
         List<ReportRepository> all = new ArrayList<>();
-        all.addAll(model.getSettings().getPluginManagementRepositories());
         all.addAll(model.getSettings().getSettingsBuildscriptRepositories());
+        all.addAll(model.getSettings().getPluginManagementRepositories());
         all.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
         for (RepositoryReportProjectModel p : model.getProjectsByPath().values()) {
             all.addAll(p.getBuildscriptRepositories());
@@ -163,13 +163,15 @@ public abstract class RepositoriesReportTask extends ConventionReportTask {
         SettingsInternal settings = root.getGradle().getSettings();
         RepositoryReportModelFactory factory = new RepositoryReportModelFactory();
 
+        // Walk order matches Gradle's actual repo-search sequence during a build: the
+        // settings-script classpath is resolved first, then plugin resolution, then DRM/project deps.
         RepositoryReportSettingsModel settingsModel = new RepositoryReportSettingsModel(
-            convertSettingsRepos(settings.getPluginManagement().getRepositories(), factory,
-                new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories"),
-                Set.of(RepositoryRole.PLUGINS)),
             convertSettingsRepos(settings.getBuildscript().getRepositories(), factory,
                 new RepositoryDeclarationSite(SETTINGS, null, "buildscript.repositories"),
                 Set.of(RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES)),
+            convertSettingsRepos(settings.getPluginManagement().getRepositories(), factory,
+                new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories"),
+                Set.of(RepositoryRole.PLUGINS)),
             convertSettingsRepos(settings.getDependencyResolutionManagement().getRepositories(), factory,
                 new RepositoryDeclarationSite(SETTINGS, null, "dependencyResolutionManagement.repositories"),
                 Set.of(RepositoryRole.PROJECT_DEPENDENCIES))

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/RepositoriesReportTask.java
@@ -100,7 +100,15 @@ public abstract class RepositoriesReportTask extends ConventionReportTask {
         if (offline) {
             reachability = Collections.emptyMap();
         } else {
-            reachability = new RepositoryReachabilityChecker().check(collectAllRepos(model), false);
+            List<ReportRepository> all = collectAllRepos(model);
+            int probeCount = countProbeableLocations(all);
+            if (probeCount > 0) {
+                getLogger().lifecycle("Probing {} repository URL{}...", probeCount, probeCount == 1 ? "" : "s");
+            }
+            reachability = RepositoryReachabilityChecker.withDefaultTimeout().check(all, false);
+            if (probeCount > 0) {
+                getLogger().lifecycle("done.");
+            }
         }
         RepositoriesReportSpec spec = new RepositoriesReportSpec(
             getProjectFilter().getOrNull(),
@@ -110,6 +118,21 @@ public abstract class RepositoriesReportTask extends ConventionReportTask {
         ConsoleRepositoriesReportRenderer renderer = new ConsoleRepositoriesReportRenderer(spec);
         StyledTextOutput out = getTextOutputFactory().create(getClass());
         renderer.render(model, out);
+    }
+
+    private static int countProbeableLocations(List<ReportRepository> all) {
+        java.util.Set<String> uniqueProbeable = new java.util.LinkedHashSet<>();
+        for (ReportRepository r : all) {
+            if (r.getType() == org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType.MAVEN_LOCAL
+                || r.getType() == org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType.FLAT_DIR) {
+                continue;
+            }
+            String loc = r.getLocation();
+            if (loc.startsWith("http://") || loc.startsWith("https://")) {
+                uniqueProbeable.add(loc);
+            }
+        }
+        return uniqueProbeable.size();
     }
 
     /**

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportContentFilter.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportContentFilter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+@NullMarked
+public final class ReportContentFilter {
+    public static final ReportContentFilter EMPTY = new ReportContentFilter(
+        ImmutableList.of(), ImmutableList.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableMap.of()
+    );
+
+    private final List<String> includeRules;
+    private final List<String> excludeRules;
+    private final Set<String> onlyForConfigurations;
+    private final Set<String> notForConfigurations;
+    private final Map<String, Set<String>> onlyForAttributes;
+
+    public ReportContentFilter(
+        List<String> includeRules,
+        List<String> excludeRules,
+        Set<String> onlyForConfigurations,
+        Set<String> notForConfigurations,
+        Map<String, Set<String>> onlyForAttributes
+    ) {
+        this.includeRules = ImmutableList.copyOf(includeRules);
+        this.excludeRules = ImmutableList.copyOf(excludeRules);
+        this.onlyForConfigurations = ImmutableSet.copyOf(onlyForConfigurations);
+        this.notForConfigurations = ImmutableSet.copyOf(notForConfigurations);
+        ImmutableMap.Builder<String, Set<String>> b = ImmutableMap.builder();
+        for (Map.Entry<String, Set<String>> e : onlyForAttributes.entrySet()) {
+            b.put(e.getKey(), ImmutableSet.copyOf(e.getValue()));
+        }
+        this.onlyForAttributes = b.build();
+    }
+
+    public boolean isEmpty() {
+        return includeRules.isEmpty()
+            && excludeRules.isEmpty()
+            && onlyForConfigurations.isEmpty()
+            && notForConfigurations.isEmpty()
+            && onlyForAttributes.isEmpty();
+    }
+
+    public List<String> getIncludeRules() {
+        return includeRules;
+    }
+
+    public List<String> getExcludeRules() {
+        return excludeRules;
+    }
+
+    public Set<String> getOnlyForConfigurations() {
+        return onlyForConfigurations;
+    }
+
+    public Set<String> getNotForConfigurations() {
+        return notForConfigurations;
+    }
+
+    public Map<String, Set<String>> getOnlyForAttributes() {
+        return onlyForAttributes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ReportContentFilter)) return false;
+        ReportContentFilter that = (ReportContentFilter) o;
+        return includeRules.equals(that.includeRules)
+            && excludeRules.equals(that.excludeRules)
+            && onlyForConfigurations.equals(that.onlyForConfigurations)
+            && notForConfigurations.equals(that.notForConfigurations)
+            && onlyForAttributes.equals(that.onlyForAttributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(includeRules, excludeRules, onlyForConfigurations, notForConfigurations, onlyForAttributes);
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportContentFilter.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportContentFilter.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 
 import com.google.common.collect.ImmutableList;
@@ -79,8 +86,12 @@ public final class ReportContentFilter {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ReportContentFilter)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ReportContentFilter)) {
+            return false;
+        }
         ReportContentFilter that = (ReportContentFilter) o;
         return includeRules.equals(that.includeRules)
             && excludeRules.equals(that.excludeRules)

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportContentFilter.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportContentFilter.java
@@ -26,6 +26,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+/**
+ * Snapshot of a repository's content-filtering rules (include/exclude rules, configuration
+ * targeting, and attribute targeting) as resolved from
+ * {@code RepositoryContentDescriptorInternal} at model build time.
+ */
 @NullMarked
 public final class ReportContentFilter {
     public static final ReportContentFilter EMPTY = new ReportContentFilter(

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportRepository.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportRepository.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 
 import com.google.common.collect.ImmutableList;
@@ -51,15 +58,41 @@ public final class ReportRepository {
         this.declarationSite = Objects.requireNonNull(declarationSite);
     }
 
-    public String getName() { return name; }
-    public RepositoryType getType() { return type; }
-    public String getLocation() { return location; }
-    public boolean isSecure() { return secure; }
-    public List<String> getAuthSchemes() { return authSchemes; }
-    public boolean hasCredentials() { return hasCredentials; }
-    public ReportContentFilter getContentFilter() { return contentFilter; }
-    public Set<RepositoryRole> getRoles() { return roles; }
-    public RepositoryDeclarationSite getDeclarationSite() { return declarationSite; }
+    public String getName() {
+        return name;
+    }
+
+    public RepositoryType getType() {
+        return type;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public List<String> getAuthSchemes() {
+        return authSchemes;
+    }
+
+    public boolean hasCredentials() {
+        return hasCredentials;
+    }
+
+    public ReportContentFilter getContentFilter() {
+        return contentFilter;
+    }
+
+    public Set<RepositoryRole> getRoles() {
+        return roles;
+    }
+
+    public RepositoryDeclarationSite getDeclarationSite() {
+        return declarationSite;
+    }
 
     /**
      * Structural key for identifying "identical" repositories. Excludes roles
@@ -91,8 +124,12 @@ public final class ReportRepository {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof IdentityKey)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof IdentityKey)) {
+                return false;
+            }
             IdentityKey that = (IdentityKey) o;
             return secure == that.secure
                 && hasCredentials == that.hasCredentials

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportRepository.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportRepository.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@NullMarked
+public final class ReportRepository {
+    private final String name;
+    private final RepositoryType type;
+    private final String location;
+    private final boolean secure;
+    private final List<String> authSchemes;
+    private final boolean hasCredentials;
+    private final ReportContentFilter contentFilter;
+    private final Set<RepositoryRole> roles;
+    private final RepositoryDeclarationSite declarationSite;
+
+    public ReportRepository(
+        String name,
+        RepositoryType type,
+        String location,
+        boolean secure,
+        List<String> authSchemes,
+        boolean hasCredentials,
+        ReportContentFilter contentFilter,
+        Set<RepositoryRole> roles,
+        RepositoryDeclarationSite declarationSite
+    ) {
+        this.name = Objects.requireNonNull(name);
+        this.type = Objects.requireNonNull(type);
+        this.location = Objects.requireNonNull(location);
+        this.secure = secure;
+        this.authSchemes = ImmutableList.copyOf(authSchemes);
+        this.hasCredentials = hasCredentials;
+        this.contentFilter = Objects.requireNonNull(contentFilter);
+        this.roles = ImmutableSet.copyOf(roles);
+        this.declarationSite = Objects.requireNonNull(declarationSite);
+    }
+
+    public String getName() { return name; }
+    public RepositoryType getType() { return type; }
+    public String getLocation() { return location; }
+    public boolean isSecure() { return secure; }
+    public List<String> getAuthSchemes() { return authSchemes; }
+    public boolean hasCredentials() { return hasCredentials; }
+    public ReportContentFilter getContentFilter() { return contentFilter; }
+    public Set<RepositoryRole> getRoles() { return roles; }
+    public RepositoryDeclarationSite getDeclarationSite() { return declarationSite; }
+
+    /**
+     * Structural key for identifying "identical" repositories. Excludes roles
+     * and declarationSite — two entries with the same configuration but
+     * declared in different places compare equal by this key.
+     */
+    public IdentityKey identityKey() {
+        return new IdentityKey(name, type, location, secure, authSchemes, hasCredentials, contentFilter);
+    }
+
+    public static final class IdentityKey {
+        private final String name;
+        private final RepositoryType type;
+        private final String location;
+        private final boolean secure;
+        private final List<String> authSchemes;
+        private final boolean hasCredentials;
+        private final ReportContentFilter contentFilter;
+
+        IdentityKey(String name, RepositoryType type, String location, boolean secure, List<String> authSchemes, boolean hasCredentials, ReportContentFilter contentFilter) {
+            this.name = name;
+            this.type = type;
+            this.location = location;
+            this.secure = secure;
+            this.authSchemes = authSchemes;
+            this.hasCredentials = hasCredentials;
+            this.contentFilter = contentFilter;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof IdentityKey)) return false;
+            IdentityKey that = (IdentityKey) o;
+            return secure == that.secure
+                && hasCredentials == that.hasCredentials
+                && name.equals(that.name)
+                && type == that.type
+                && location.equals(that.location)
+                && authSchemes.equals(that.authSchemes)
+                && contentFilter.equals(that.contentFilter);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, type, location, secure, authSchemes, hasCredentials, contentFilter);
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportRepository.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportRepository.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * Immutable value object representing a single repository as it appears on the report.
  *
  * <p>Captures identity-forming attributes (name, type, location, auth/content) plus the
- * role(s) the repository plays and where it was declared. See {@link #identityKey()} for
+ * role(s) the repository plays and where it was declared. See {@link #getIdentityKey()} for
  * the structural key used by the renderer to detect duplicate declarations.
  */
 @NullMarked
@@ -42,6 +42,7 @@ public final class ReportRepository {
     private final ReportContentFilter contentFilter;
     private final Set<RepositoryRole> roles;
     private final RepositoryDeclarationSite declarationSite;
+    private final IdentityKey identityKey;
 
     public ReportRepository(
         String name,
@@ -63,6 +64,7 @@ public final class ReportRepository {
         this.contentFilter = Objects.requireNonNull(contentFilter);
         this.roles = ImmutableSet.copyOf(roles);
         this.declarationSite = Objects.requireNonNull(declarationSite);
+        this.identityKey = new IdentityKey(name, type, location, secure, this.authSchemes, hasCredentials, contentFilter);
     }
 
     public String getName() {
@@ -102,14 +104,17 @@ public final class ReportRepository {
     }
 
     /**
+     * Returns the identity key used to detect duplicate repository declarations.
+     */
+    public IdentityKey getIdentityKey() {
+        return identityKey;
+    }
+
+    /**
      * Structural key for identifying "identical" repositories. Excludes roles
      * and declarationSite — two entries with the same configuration but
      * declared in different places compare equal by this key.
      */
-    public IdentityKey identityKey() {
-        return new IdentityKey(name, type, location, secure, authSchemes, hasCredentials, contentFilter);
-    }
-
     public static final class IdentityKey {
         private final String name;
         private final RepositoryType type;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportRepository.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/ReportRepository.java
@@ -24,6 +24,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+/**
+ * Immutable value object representing a single repository as it appears on the report.
+ *
+ * <p>Captures identity-forming attributes (name, type, location, auth/content) plus the
+ * role(s) the repository plays and where it was declared. See {@link #identityKey()} for
+ * the structural key used by the renderer to detect duplicate declarations.
+ */
 @NullMarked
 public final class ReportRepository {
     private final String name;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryDeclarationSite.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryDeclarationSite.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+
+@NullMarked
+public final class RepositoryDeclarationSite {
+    public enum Scope { SETTINGS, PROJECT }
+
+    private final Scope scope;
+    private final @Nullable Path projectPath;
+    private final String block;
+
+    public RepositoryDeclarationSite(Scope scope, @Nullable Path projectPath, String block) {
+        this.scope = Objects.requireNonNull(scope);
+        this.projectPath = projectPath;
+        this.block = Objects.requireNonNull(block);
+        if (scope == Scope.PROJECT && projectPath == null) {
+            throw new IllegalArgumentException("PROJECT scope requires a non-null projectPath");
+        }
+        if (scope == Scope.SETTINGS && projectPath != null) {
+            throw new IllegalArgumentException("SETTINGS scope requires a null projectPath");
+        }
+    }
+
+    public Scope getScope() {
+        return scope;
+    }
+
+    public @Nullable Path getProjectPath() {
+        return projectPath;
+    }
+
+    public String getBlock() {
+        return block;
+    }
+
+    public String render() {
+        if (scope == Scope.SETTINGS) {
+            return "settings > " + block;
+        }
+        return "project '" + projectPath + "' > " + block;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RepositoryDeclarationSite)) return false;
+        RepositoryDeclarationSite that = (RepositoryDeclarationSite) o;
+        return scope == that.scope
+            && Objects.equals(projectPath, that.projectPath)
+            && block.equals(that.block);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scope, projectPath, block);
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryDeclarationSite.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryDeclarationSite.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 
 import org.gradle.util.Path;
@@ -56,8 +63,12 @@ public final class RepositoryDeclarationSite {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof RepositoryDeclarationSite)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RepositoryDeclarationSite)) {
+            return false;
+        }
         RepositoryDeclarationSite that = (RepositoryDeclarationSite) o;
         return scope == that.scope
             && Objects.equals(projectPath, that.projectPath)

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryDeclarationSite.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryDeclarationSite.java
@@ -22,8 +22,14 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
+/**
+ * Identifies where a repository was declared: either in a settings script block or in a
+ * specific project's buildscript/repositories block. The {@link #render()} method produces
+ * the human-readable "Defined in:" line shown on the report.
+ */
 @NullMarked
 public final class RepositoryDeclarationSite {
+    /** Scope of a declaration site. */
     public enum Scope { SETTINGS, PROJECT }
 
     private final Scope scope;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportFullModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportFullModel.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+@NullMarked
+public final class RepositoryReportFullModel {
+
+    private static final PathComparator PATH_COMPARATOR = new PathComparator();
+
+    private final RepositoryReportSettingsModel settings;
+    private final SortedMap<Path, RepositoryReportProjectModel> projectsByPath;
+
+    public RepositoryReportFullModel(
+        RepositoryReportSettingsModel settings,
+        SortedMap<Path, RepositoryReportProjectModel> projectsByPath
+    ) {
+        this.settings = settings;
+        // Use a plain TreeMap with a named Serializable Comparator rather than Guava's
+        // ImmutableSortedMap so the configuration-cache serializer can round-trip this field.
+        // TreeMap has a dedicated CC codec; a lambda-based Comparator would not survive CC
+        // because the synthetic lambda class is not resolvable from the Gradle runtime class loader
+        // during cache reuse.
+        TreeMap<Path, RepositoryReportProjectModel> copy = new TreeMap<>(PATH_COMPARATOR);
+        copy.putAll(projectsByPath);
+        this.projectsByPath = copy;
+    }
+
+    public RepositoryReportSettingsModel getSettings() { return settings; }
+    public SortedMap<Path, RepositoryReportProjectModel> getProjectsByPath() { return projectsByPath; }
+
+    public static Comparator<Path> pathComparator() {
+        return PATH_COMPARATOR;
+    }
+
+    private static final class PathComparator implements Comparator<Path>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public int compare(Path a, Path b) {
+            return a.asString().compareTo(b.asString());
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportFullModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportFullModel.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 
 import org.gradle.util.Path;
@@ -40,8 +47,13 @@ public final class RepositoryReportFullModel {
         this.projectsByPath = copy;
     }
 
-    public RepositoryReportSettingsModel getSettings() { return settings; }
-    public SortedMap<Path, RepositoryReportProjectModel> getProjectsByPath() { return projectsByPath; }
+    public RepositoryReportSettingsModel getSettings() {
+        return settings;
+    }
+
+    public SortedMap<Path, RepositoryReportProjectModel> getProjectsByPath() {
+        return projectsByPath;
+    }
 
     public static Comparator<Path> pathComparator() {
         return PATH_COMPARATOR;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportFullModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportFullModel.java
@@ -24,9 +24,13 @@ import java.util.Comparator;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+/**
+ * Aggregates the settings-level model and the per-project models into a single
+ * configuration-cache-serializable payload consumed by
+ * {@link org.gradle.api.tasks.diagnostics.internal.repositories.renderer.ConsoleRepositoriesReportRenderer}.
+ */
 @NullMarked
 public final class RepositoryReportFullModel {
-
     private static final PathComparator PATH_COMPARATOR = new PathComparator();
 
     private final RepositoryReportSettingsModel settings;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportFullModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportFullModel.java
@@ -36,6 +36,10 @@ public final class RepositoryReportFullModel {
     private final RepositoryReportSettingsModel settings;
     private final SortedMap<Path, RepositoryReportProjectModel> projectsByPath;
 
+    public static Comparator<Path> getPathComparator() {
+        return PATH_COMPARATOR;
+    }
+
     public RepositoryReportFullModel(
         RepositoryReportSettingsModel settings,
         SortedMap<Path, RepositoryReportProjectModel> projectsByPath
@@ -57,10 +61,6 @@ public final class RepositoryReportFullModel {
 
     public SortedMap<Path, RepositoryReportProjectModel> getProjectsByPath() {
         return projectsByPath;
-    }
-
-    public static Comparator<Path> pathComparator() {
-        return PATH_COMPARATOR;
     }
 
     private static final class PathComparator implements Comparator<Path>, Serializable {

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
@@ -43,8 +43,25 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+/**
+ * Builds the {@link ReportRepository} model for a single {@link AbstractArtifactRepository}.
+ *
+ * <p>All inspection is read-only: the factory never mutates the source repository, and it
+ * explicitly avoids reading credential values (only their presence is recorded).
+ */
 @NullMarked
 public final class RepositoryReportModelFactory {
+    /** Sentinel emitted by {@link #resolveLocation} when a URL-based repository has no URL set. */
+    private static final String NO_URL_SENTINEL = "<NO_URL>";
+
+    /**
+     * Builds a {@link ReportRepository} by inspecting the given Gradle repository.
+     *
+     * @param repo the Gradle repository being reported on
+     * @param roles the role(s) this repository plays in the build
+     * @param site where this repository was declared
+     * @return the immutable report model for this repository
+     */
     public ReportRepository toReportRepository(
         AbstractArtifactRepository repo,
         Set<RepositoryRole> roles,
@@ -52,7 +69,15 @@ public final class RepositoryReportModelFactory {
     ) {
         RepositoryType type = resolveType(repo);
         String location = resolveLocation(repo, type);
-        boolean secure = resolveSecure(repo, type);
+        boolean secure;
+        if (type == RepositoryType.FLAT_DIR || type == RepositoryType.CUSTOM) {
+            // FLAT_DIR has no URL and no insecure-protocol concept; CUSTOM repos have unknown
+            // semantics — treat both as secure inline so resolveSecure() can enforce its
+            // URL-based-only contract.
+            secure = true;
+        } else {
+            secure = resolveSecure(repo, type);
+        }
         List<String> authSchemes = resolveAuthSchemes(repo);
         boolean hasCredentials = resolveHasCredentials(repo);
         ReportContentFilter contentFilter = resolveContentFilter(repo);
@@ -86,41 +111,63 @@ public final class RepositoryReportModelFactory {
     private RepositoryType resolveType(ArtifactRepository repo) {
         if (repo instanceof DefaultMavenLocalArtifactRepository) {
             return RepositoryType.MAVEN_LOCAL;
-        }
-        if (repo instanceof MavenArtifactRepository) {
+        } else if (repo instanceof MavenArtifactRepository) {
             return RepositoryType.MAVEN;
-        }
-        if (repo instanceof IvyArtifactRepository) {
+        } else if (repo instanceof IvyArtifactRepository) {
             return RepositoryType.IVY;
-        }
-        if (repo instanceof FlatDirectoryArtifactRepository) {
+        } else if (repo instanceof FlatDirectoryArtifactRepository) {
             return RepositoryType.FLAT_DIR;
+        } else {
+            return RepositoryType.CUSTOM;
         }
-        throw new IllegalArgumentException("Unsupported repository type: " + repo.getClass().getName());
     }
 
     private String resolveLocation(ArtifactRepository repo, RepositoryType type) {
-        switch (type) {
-            case MAVEN:
-            case MAVEN_LOCAL:
-                return String.valueOf(((MavenArtifactRepository) repo).getUrl());
-            case IVY:
-                return String.valueOf(((IvyArtifactRepository) repo).getUrl());
-            case FLAT_DIR:
-                Set<File> dirs = ((FlatDirectoryArtifactRepository) repo).getDirs();
-                String joined = dirs.stream()
-                    .map(File::getAbsolutePath)
-                    .sorted()
-                    .collect(Collectors.joining(", "));
-                return "dirs:[" + joined + "]";
-            default:
-                throw new IllegalStateException("Unexpected type: " + type);
+        if (type == RepositoryType.MAVEN || type == RepositoryType.MAVEN_LOCAL) {
+            return mavenUrl((MavenArtifactRepository) repo);
+        } else if (type == RepositoryType.IVY) {
+            return ivyUrl((IvyArtifactRepository) repo);
+        } else if (type == RepositoryType.FLAT_DIR) {
+            Set<File> dirs = ((FlatDirectoryArtifactRepository) repo).getDirs();
+            String joined = dirs.stream()
+                .map(File::getAbsolutePath)
+                .sorted()
+                .collect(Collectors.joining(", "));
+            return "dirs:[" + joined + "]";
+        } else {
+            // CUSTOM — no URL-based accessor; surface the concrete subclass name so users
+            // can identify which third-party repository produced the entry.
+            return repo.getClass().getName();
         }
     }
 
+    private static String mavenUrl(MavenArtifactRepository repo) {
+        Object url = repo.getUrl();
+        return url == null ? NO_URL_SENTINEL : url.toString();
+    }
+
+    private static String ivyUrl(IvyArtifactRepository repo) {
+        Object url = repo.getUrl();
+        return url == null ? NO_URL_SENTINEL : url.toString();
+    }
+
+    /**
+     * Resolves the {@code secure} attribute for URL-based repositories.
+     *
+     * <p>This method must only be called with URL-based types ({@link RepositoryType#MAVEN},
+     * {@link RepositoryType#MAVEN_LOCAL}, or {@link RepositoryType#IVY}). Callers are
+     * responsible for setting {@code secure} inline for {@link RepositoryType#FLAT_DIR} and
+     * {@link RepositoryType#CUSTOM}, which have no URL to inspect.
+     *
+     * @param repo the repository being inspected
+     * @param type the previously resolved type
+     * @return {@code true} if the repository does not allow insecure protocols (or is not a
+     *     {@code UrlArtifactRepository}), {@code false} otherwise
+     * @throws IllegalArgumentException if called with a non-URL-based type
+     */
     private boolean resolveSecure(ArtifactRepository repo, RepositoryType type) {
-        if (type == RepositoryType.FLAT_DIR) {
-            return true;
+        if (type != RepositoryType.MAVEN && type != RepositoryType.MAVEN_LOCAL && type != RepositoryType.IVY) {
+            throw new IllegalArgumentException("resolveSecure must only be called for URL-based repository types; got: " + type);
         }
         if (repo instanceof UrlArtifactRepository) {
             return !((UrlArtifactRepository) repo).isAllowInsecureProtocol();

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 
 import com.google.common.collect.ImmutableList;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
@@ -45,7 +45,6 @@ import java.util.stream.Collectors;
 
 @NullMarked
 public final class RepositoryReportModelFactory {
-
     public ReportRepository toReportRepository(
         AbstractArtifactRepository repo,
         Set<RepositoryRole> roles,

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
@@ -62,7 +62,7 @@ public final class RepositoryReportModelFactory {
      * @param site where this repository was declared
      * @return the immutable report model for this repository
      */
-    public ReportRepository toReportRepository(
+    public ReportRepository buildReportRepository(
         AbstractArtifactRepository repo,
         Set<RepositoryRole> roles,
         RepositoryDeclarationSite site

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactory.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.artifacts.repositories.AuthenticationSupported;
+import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.artifacts.repositories.UrlArtifactRepository;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.authentication.Authentication;
+import org.gradle.api.internal.artifacts.repositories.AbstractArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.DefaultMavenLocalArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.RepositoryContentDescriptorInternal;
+import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal;
+import org.jspecify.annotations.NullMarked;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+@NullMarked
+public final class RepositoryReportModelFactory {
+
+    public ReportRepository toReportRepository(
+        AbstractArtifactRepository repo,
+        Set<RepositoryRole> roles,
+        RepositoryDeclarationSite site
+    ) {
+        RepositoryType type = resolveType(repo);
+        String location = resolveLocation(repo, type);
+        boolean secure = resolveSecure(repo, type);
+        List<String> authSchemes = resolveAuthSchemes(repo);
+        boolean hasCredentials = resolveHasCredentials(repo);
+        ReportContentFilter contentFilter = resolveContentFilter(repo);
+
+        return new ReportRepository(
+            repo.getName(),
+            type,
+            location,
+            secure,
+            authSchemes,
+            hasCredentials,
+            contentFilter,
+            roles,
+            site
+        );
+    }
+
+    /**
+     * Detects whether credentials were declared on the repository without ever reading their values.
+     * Uses the internal `AuthenticationSupportedInternal.getConfiguredCredentials()` `Property`
+     * and checks `isPresent()`: the property is only set when `credentials { ... }`,
+     * `credentials(SomeCredentials)`, or `setConfiguredCredentials(...)` has been invoked.
+     */
+    private boolean resolveHasCredentials(ArtifactRepository repo) {
+        if (!(repo instanceof AuthenticationSupportedInternal)) {
+            return false;
+        }
+        return ((AuthenticationSupportedInternal) repo).getConfiguredCredentials().isPresent();
+    }
+
+    private RepositoryType resolveType(ArtifactRepository repo) {
+        if (repo instanceof DefaultMavenLocalArtifactRepository) {
+            return RepositoryType.MAVEN_LOCAL;
+        }
+        if (repo instanceof MavenArtifactRepository) {
+            return RepositoryType.MAVEN;
+        }
+        if (repo instanceof IvyArtifactRepository) {
+            return RepositoryType.IVY;
+        }
+        if (repo instanceof FlatDirectoryArtifactRepository) {
+            return RepositoryType.FLAT_DIR;
+        }
+        throw new IllegalArgumentException("Unsupported repository type: " + repo.getClass().getName());
+    }
+
+    private String resolveLocation(ArtifactRepository repo, RepositoryType type) {
+        switch (type) {
+            case MAVEN:
+            case MAVEN_LOCAL:
+                return String.valueOf(((MavenArtifactRepository) repo).getUrl());
+            case IVY:
+                return String.valueOf(((IvyArtifactRepository) repo).getUrl());
+            case FLAT_DIR:
+                Set<File> dirs = ((FlatDirectoryArtifactRepository) repo).getDirs();
+                String joined = dirs.stream()
+                    .map(File::getAbsolutePath)
+                    .sorted()
+                    .collect(Collectors.joining(", "));
+                return "dirs:[" + joined + "]";
+            default:
+                throw new IllegalStateException("Unexpected type: " + type);
+        }
+    }
+
+    private boolean resolveSecure(ArtifactRepository repo, RepositoryType type) {
+        if (type == RepositoryType.FLAT_DIR) {
+            return true;
+        }
+        if (repo instanceof UrlArtifactRepository) {
+            return !((UrlArtifactRepository) repo).isAllowInsecureProtocol();
+        }
+        return true;
+    }
+
+    private List<String> resolveAuthSchemes(ArtifactRepository repo) {
+        if (!(repo instanceof AuthenticationSupported)) {
+            return ImmutableList.of();
+        }
+        Collection<Authentication> auths = ((AuthenticationSupported) repo).getAuthentication();
+        if (auths == null || auths.isEmpty()) {
+            return ImmutableList.of();
+        }
+        List<String> names = new ArrayList<>(auths.size());
+        for (Authentication a : auths) {
+            names.add(a.getClass().getSimpleName());
+        }
+        Collections.sort(names);
+        return ImmutableList.copyOf(names);
+    }
+
+    private ReportContentFilter resolveContentFilter(AbstractArtifactRepository repo) {
+        RepositoryContentDescriptorInternal desc = repo.getRepositoryDescriptorCopy();
+        List<String> includes = desc.describeIncludeRules();
+        List<String> excludes = desc.describeExcludeRules();
+        Set<String> onlyForConfigs = desc.getIncludedConfigurations() == null
+            ? ImmutableSet.of() : ImmutableSet.copyOf(desc.getIncludedConfigurations());
+        Set<String> notForConfigs = desc.getExcludedConfigurations() == null
+            ? ImmutableSet.of() : ImmutableSet.copyOf(desc.getExcludedConfigurations());
+        Map<String, Set<String>> attrs;
+        Map<Attribute<Object>, Set<Object>> raw = desc.getRequiredAttributes();
+        if (raw == null || raw.isEmpty()) {
+            attrs = ImmutableMap.of();
+        } else {
+            Map<String, Set<String>> stringified = new TreeMap<>();
+            for (Map.Entry<Attribute<Object>, Set<Object>> e : raw.entrySet()) {
+                Set<String> values = e.getValue().stream()
+                    .map(String::valueOf).collect(Collectors.toCollection(java.util.TreeSet::new));
+                stringified.put(e.getKey().getName(), values);
+            }
+            attrs = stringified;
+        }
+        return new ReportContentFilter(includes, excludes, onlyForConfigs, notForConfigs, attrs);
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportProjectModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportProjectModel.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 
 import com.google.common.collect.ImmutableList;
@@ -35,8 +42,19 @@ public final class RepositoryReportProjectModel {
         this.projectRepositories = ImmutableList.copyOf(projectRepositories);
     }
 
-    public Path getProjectPath() { return projectPath; }
-    public String getProjectName() { return projectName; }
-    public List<ReportRepository> getBuildscriptRepositories() { return buildscriptRepositories; }
-    public List<ReportRepository> getProjectRepositories() { return projectRepositories; }
+    public Path getProjectPath() {
+        return projectPath;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public List<ReportRepository> getBuildscriptRepositories() {
+        return buildscriptRepositories;
+    }
+
+    public List<ReportRepository> getProjectRepositories() {
+        return projectRepositories;
+    }
 }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportProjectModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportProjectModel.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+import java.util.Objects;
+
+@NullMarked
+public final class RepositoryReportProjectModel {
+    private final Path projectPath;
+    private final String projectName;
+    private final List<ReportRepository> buildscriptRepositories;
+    private final List<ReportRepository> projectRepositories;
+
+    public RepositoryReportProjectModel(
+        Path projectPath,
+        String projectName,
+        List<ReportRepository> buildscriptRepositories,
+        List<ReportRepository> projectRepositories
+    ) {
+        this.projectPath = Objects.requireNonNull(projectPath);
+        this.projectName = Objects.requireNonNull(projectName);
+        this.buildscriptRepositories = ImmutableList.copyOf(buildscriptRepositories);
+        this.projectRepositories = ImmutableList.copyOf(projectRepositories);
+    }
+
+    public Path getProjectPath() { return projectPath; }
+    public String getProjectName() { return projectName; }
+    public List<ReportRepository> getBuildscriptRepositories() { return buildscriptRepositories; }
+    public List<ReportRepository> getProjectRepositories() { return projectRepositories; }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportProjectModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportProjectModel.java
@@ -23,6 +23,10 @@ import org.jspecify.annotations.NullMarked;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Per-project slice of the repositories report: separate lists for buildscript repositories
+ * and project-level repositories, keyed by the project's {@link Path}.
+ */
 @NullMarked
 public final class RepositoryReportProjectModel {
     private final Path projectPath;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportSettingsModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportSettingsModel.java
@@ -21,6 +21,10 @@ import org.jspecify.annotations.NullMarked;
 
 import java.util.List;
 
+/**
+ * Settings-level slice of the repositories report: holds the three settings-scoped
+ * repository buckets (pluginManagement, settings.buildscript, dependencyResolutionManagement).
+ */
 @NullMarked
 public final class RepositoryReportSettingsModel {
     private final List<ReportRepository> pluginManagementRepositories;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportSettingsModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportSettingsModel.java
@@ -23,30 +23,31 @@ import java.util.List;
 
 /**
  * Settings-level slice of the repositories report: holds the three settings-scoped
- * repository buckets (pluginManagement, settings.buildscript, dependencyResolutionManagement).
+ * repository buckets in the same order that Gradle actually resolves them during a build
+ * (settings.buildscript, pluginManagement, dependencyResolutionManagement).
  */
 @NullMarked
 public final class RepositoryReportSettingsModel {
-    private final List<ReportRepository> pluginManagementRepositories;
     private final List<ReportRepository> settingsBuildscriptRepositories;
+    private final List<ReportRepository> pluginManagementRepositories;
     private final List<ReportRepository> dependencyResolutionManagementRepositories;
 
     public RepositoryReportSettingsModel(
-        List<ReportRepository> pluginManagementRepositories,
         List<ReportRepository> settingsBuildscriptRepositories,
+        List<ReportRepository> pluginManagementRepositories,
         List<ReportRepository> dependencyResolutionManagementRepositories
     ) {
-        this.pluginManagementRepositories = ImmutableList.copyOf(pluginManagementRepositories);
         this.settingsBuildscriptRepositories = ImmutableList.copyOf(settingsBuildscriptRepositories);
+        this.pluginManagementRepositories = ImmutableList.copyOf(pluginManagementRepositories);
         this.dependencyResolutionManagementRepositories = ImmutableList.copyOf(dependencyResolutionManagementRepositories);
-    }
-
-    public List<ReportRepository> getPluginManagementRepositories() {
-        return pluginManagementRepositories;
     }
 
     public List<ReportRepository> getSettingsBuildscriptRepositories() {
         return settingsBuildscriptRepositories;
+    }
+
+    public List<ReportRepository> getPluginManagementRepositories() {
+        return pluginManagementRepositories;
     }
 
     public List<ReportRepository> getDependencyResolutionManagementRepositories() {

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportSettingsModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportSettingsModel.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 
 import com.google.common.collect.ImmutableList;
@@ -30,7 +37,15 @@ public final class RepositoryReportSettingsModel {
         this.dependencyResolutionManagementRepositories = ImmutableList.copyOf(dependencyResolutionManagementRepositories);
     }
 
-    public List<ReportRepository> getPluginManagementRepositories() { return pluginManagementRepositories; }
-    public List<ReportRepository> getSettingsBuildscriptRepositories() { return settingsBuildscriptRepositories; }
-    public List<ReportRepository> getDependencyResolutionManagementRepositories() { return dependencyResolutionManagementRepositories; }
+    public List<ReportRepository> getPluginManagementRepositories() {
+        return pluginManagementRepositories;
+    }
+
+    public List<ReportRepository> getSettingsBuildscriptRepositories() {
+        return settingsBuildscriptRepositories;
+    }
+
+    public List<ReportRepository> getDependencyResolutionManagementRepositories() {
+        return dependencyResolutionManagementRepositories;
+    }
 }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportSettingsModel.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportSettingsModel.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import com.google.common.collect.ImmutableList;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+
+@NullMarked
+public final class RepositoryReportSettingsModel {
+    private final List<ReportRepository> pluginManagementRepositories;
+    private final List<ReportRepository> settingsBuildscriptRepositories;
+    private final List<ReportRepository> dependencyResolutionManagementRepositories;
+
+    public RepositoryReportSettingsModel(
+        List<ReportRepository> pluginManagementRepositories,
+        List<ReportRepository> settingsBuildscriptRepositories,
+        List<ReportRepository> dependencyResolutionManagementRepositories
+    ) {
+        this.pluginManagementRepositories = ImmutableList.copyOf(pluginManagementRepositories);
+        this.settingsBuildscriptRepositories = ImmutableList.copyOf(settingsBuildscriptRepositories);
+        this.dependencyResolutionManagementRepositories = ImmutableList.copyOf(dependencyResolutionManagementRepositories);
+    }
+
+    public List<ReportRepository> getPluginManagementRepositories() { return pluginManagementRepositories; }
+    public List<ReportRepository> getSettingsBuildscriptRepositories() { return settingsBuildscriptRepositories; }
+    public List<ReportRepository> getDependencyResolutionManagementRepositories() { return dependencyResolutionManagementRepositories; }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryRole.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryRole.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import org.gradle.api.Incubating;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Role a repository plays in a Gradle build, as surfaced by the {@code repositories} report.
+ *
+ * @since 9.5
+ */
+@Incubating
+@NullMarked
+public enum RepositoryRole {
+    /** Used by every project to load plugins — from {@code settings.pluginManagement.repositories}. */
+    PLUGINS,
+    /** Used by the settings script buildscript classpath — from {@code settings.buildscript.repositories}. */
+    SETTINGS_BUILDSCRIPT_DEPENDENCIES,
+    /** Used by legacy {@code apply plugin} classpath loading — from {@code project.buildscript.repositories}. */
+    PROJECT_LEGACY_PLUGINS,
+    /** Used by non-plugin buildscript classpath dependencies — from {@code project.buildscript.repositories}. */
+    PROJECT_BUILDSCRIPT_DEPENDENCIES,
+    /** Used by project dependency resolution — from {@code project.repositories} and {@code settings.dependencyResolutionManagement.repositories}. */
+    PROJECT_DEPENDENCIES
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryRole.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryRole.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 
 import org.gradle.api.Incubating;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryRole.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryRole.java
@@ -31,9 +31,7 @@ public enum RepositoryRole {
     PLUGINS,
     /** Used by the settings script buildscript classpath — from {@code settings.buildscript.repositories}. */
     SETTINGS_BUILDSCRIPT_DEPENDENCIES,
-    /** Used by legacy {@code apply plugin} classpath loading — from {@code project.buildscript.repositories}. */
-    PROJECT_LEGACY_PLUGINS,
-    /** Used by non-plugin buildscript classpath dependencies — from {@code project.buildscript.repositories}. */
+    /** Used by buildscript classpath dependencies (including legacy plugin loading) — from {@code project.buildscript.repositories}. */
     PROJECT_BUILDSCRIPT_DEPENDENCIES,
     /** Used by project dependency resolution — from {@code project.repositories} and {@code settings.dependencyResolutionManagement.repositories}. */
     PROJECT_DEPENDENCIES

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryType.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public enum RepositoryType {
+    MAVEN,
+    MAVEN_LOCAL,
+    IVY,
+    FLAT_DIR
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryType.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryType.java
@@ -18,10 +18,24 @@ package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 
 import org.jspecify.annotations.NullMarked;
 
+/**
+ * Categorization of a reported repository by its underlying Gradle implementation class.
+ *
+ * <p>The four standard types — {@link #MAVEN}, {@link #MAVEN_LOCAL}, {@link #IVY},
+ * {@link #FLAT_DIR} — cover every repository produced by Gradle's built-in repository
+ * factories. Third-party subclasses of {@code AbstractArtifactRepository} that do not
+ * implement any of those interfaces are classified as {@link #CUSTOM}.
+ */
 @NullMarked
 public enum RepositoryType {
+    /** Any {@code MavenArtifactRepository} that is not a local Maven repository. */
     MAVEN,
+    /** The {@code mavenLocal()} repository. */
     MAVEN_LOCAL,
+    /** Any {@code IvyArtifactRepository}. */
     IVY,
-    FLAT_DIR
+    /** Any {@code FlatDirectoryArtifactRepository}. */
+    FLAT_DIR,
+    /** A third-party {@code AbstractArtifactRepository} subclass that matches none of the above. */
+    CUSTOM
 }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryType.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryType.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 
 import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/package-info.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 @NullMarked
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/model/package-info.java
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+/**
+ * Model classes for the repositories report, representing repository declarations,
+ * content filters, and report structure.
+ */
 @NullMarked
 package org.gradle.api.tasks.diagnostics.internal.repositories.model;
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/package-info.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 @NullMarked
 package org.gradle.api.tasks.diagnostics.internal.repositories;
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/ReachabilityStatus.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/ReachabilityStatus.java
@@ -32,6 +32,8 @@ public enum ReachabilityStatus {
     UNREACHABLE,
     /** URL returned 401 or 403. */
     UNAUTHORIZED,
+    /** URL could not be parsed as a URI. */
+    MALFORMED_URL,
     /** Build was run with {@code --offline} — no probes were performed. */
     OFFLINE_SKIPPED
 }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/ReachabilityStatus.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/ReachabilityStatus.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.reachability;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Result of a lightweight reachability probe for a repository URL.
+ *
+ * <p>The probe is executed at task-execution time for unique remote repository URLs.
+ * Local repositories (e.g. {@code mavenLocal()}, {@code flatDir}) are never probed
+ * and consequently never carry a reachability status.
+ */
+@NullMarked
+public enum ReachabilityStatus {
+    /** URL returned 2xx or 3xx — no marker. */
+    REACHABLE,
+    /** URL could not be contacted (DNS, connect refused, timeout, 4xx other than auth, 5xx). */
+    UNREACHABLE,
+    /** URL returned 401 or 403. */
+    UNAUTHORIZED,
+    /** Build was run with {@code --offline} — no probes were performed. */
+    OFFLINE_SKIPPED
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityChecker.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityChecker.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.reachability;
+
+import com.google.common.collect.ImmutableMap;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Issues lightweight HEAD (or GET fallback) probes to unique remote repository URLs to classify
+ * their current reachability. Intended for diagnostic purposes only — not for build resolution.
+ *
+ * <p>Credentials are not sent; any URL gated behind HTTP authentication will be reported as
+ * {@link ReachabilityStatus#UNAUTHORIZED}.
+ */
+@NullMarked
+public final class RepositoryReachabilityChecker {
+
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+    private final Duration timeout;
+
+    public RepositoryReachabilityChecker() {
+        this(DEFAULT_TIMEOUT);
+    }
+
+    public RepositoryReachabilityChecker(Duration timeout) {
+        this.timeout = timeout;
+    }
+
+    /**
+     * Probes each unique remote URL among the given repositories and returns a map from
+     * repository {@code location} to {@link ReachabilityStatus}.
+     *
+     * <p>If {@code offline} is {@code true}, no probes are issued and an empty map is returned —
+     * callers should render the "offline" indicator on the report header instead.
+     *
+     * <p>Repositories whose {@link RepositoryType} is {@link RepositoryType#MAVEN_LOCAL} or
+     * {@link RepositoryType#FLAT_DIR} are skipped entirely; their locations never appear in the
+     * result map.
+     */
+    public Map<String, ReachabilityStatus> check(Collection<ReportRepository> repos, boolean offline) {
+        if (offline) {
+            return ImmutableMap.of();
+        }
+        Set<String> uniqueLocations = new LinkedHashSet<>();
+        for (ReportRepository r : repos) {
+            if (isProbeable(r)) {
+                uniqueLocations.add(r.getLocation());
+            }
+        }
+        if (uniqueLocations.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        ImmutableMap.Builder<String, ReachabilityStatus> result = ImmutableMap.builder();
+        // HttpClient is not AutoCloseable on Java 17 (this module's release target); rely on GC.
+        HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(timeout)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+        for (String location : uniqueLocations) {
+            result.put(location, probe(client, location));
+        }
+        return result.build();
+    }
+
+    private static boolean isProbeable(ReportRepository r) {
+        RepositoryType type = r.getType();
+        if (type == RepositoryType.MAVEN_LOCAL || type == RepositoryType.FLAT_DIR) {
+            return false;
+        }
+        String location = r.getLocation();
+        return location.startsWith("http://") || location.startsWith("https://");
+    }
+
+    private ReachabilityStatus probe(HttpClient client, String location) {
+        URI uri;
+        try {
+            uri = new URI(location);
+        } catch (URISyntaxException e) {
+            return ReachabilityStatus.UNREACHABLE;
+        }
+        Integer headStatus = issue(client, uri, "HEAD");
+        if (headStatus == null) {
+            // Network-level failure on HEAD; don't bother retrying with GET.
+            return ReachabilityStatus.UNREACHABLE;
+        }
+        if (headStatus == 405) {
+            // Server rejected HEAD — fall back to GET.
+            Integer getStatus = issue(client, uri, "GET");
+            if (getStatus == null) {
+                return ReachabilityStatus.UNREACHABLE;
+            }
+            return classify(getStatus);
+        }
+        return classify(headStatus);
+    }
+
+    private static ReachabilityStatus classify(int status) {
+        if (status == 401 || status == 403) {
+            return ReachabilityStatus.UNAUTHORIZED;
+        }
+        if (status >= 200 && status < 400) {
+            return ReachabilityStatus.REACHABLE;
+        }
+        return ReachabilityStatus.UNREACHABLE;
+    }
+
+    /**
+     * Issues one HTTP request. Returns the response status code on success, or {@code null}
+     * on a network-level failure (DNS, connect refused, timeout, malformed request, etc.).
+     */
+    private @Nullable Integer issue(HttpClient client, URI uri, String method) {
+        HttpRequest request;
+        try {
+            request = HttpRequest.newBuilder(uri)
+                .timeout(timeout)
+                .method(method, HttpRequest.BodyPublishers.noBody())
+                .build();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        try {
+            HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            return response.statusCode();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityChecker.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityChecker.java
@@ -41,7 +41,6 @@ import java.util.Set;
  */
 @NullMarked
 public final class RepositoryReachabilityChecker {
-
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
 
     private final Duration timeout;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityChecker.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityChecker.java
@@ -19,7 +19,8 @@ import com.google.common.collect.ImmutableMap;
 import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository;
 import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -28,9 +29,17 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Issues lightweight HEAD (or GET fallback) probes to unique remote repository URLs to classify
@@ -38,19 +47,27 @@ import java.util.Set;
  *
  * <p>Credentials are not sent; any URL gated behind HTTP authentication will be reported as
  * {@link ReachabilityStatus#UNAUTHORIZED}.
+ *
+ * <p>Probes run in parallel across a small fixed thread pool. Each probe respects a per-URL
+ * timeout (default 5 seconds) that bounds total wall time for a single URL regardless of
+ * fallback retries.
  */
 @NullMarked
 public final class RepositoryReachabilityChecker {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryReachabilityChecker.class);
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
-
+    private static final int PROBE_THREAD_POOL_SIZE = 8;
     private final Duration timeout;
-
-    public RepositoryReachabilityChecker() {
-        this(DEFAULT_TIMEOUT);
-    }
 
     public RepositoryReachabilityChecker(Duration timeout) {
         this.timeout = timeout;
+    }
+
+    /**
+     * Convenience constructor using the default 5-second per-URL timeout.
+     */
+    public static RepositoryReachabilityChecker withDefaultTimeout() {
+        return new RepositoryReachabilityChecker(DEFAULT_TIMEOUT);
     }
 
     /**
@@ -62,7 +79,14 @@ public final class RepositoryReachabilityChecker {
      *
      * <p>Repositories whose {@link RepositoryType} is {@link RepositoryType#MAVEN_LOCAL} or
      * {@link RepositoryType#FLAT_DIR} are skipped entirely; their locations never appear in the
-     * result map.
+     * result map. Non-http(s) schemes are likewise skipped.
+     *
+     * <p>Probes run in parallel on a dedicated thread pool; results remain keyed by the
+     * original {@code location} string regardless of completion order.
+     *
+     * @param repos all repositories being reported (may contain duplicates by location)
+     * @param offline whether the build is in offline mode — when true, no probes run
+     * @return map of location to status; empty when offline or no probeable URLs exist
      */
     public Map<String, ReachabilityStatus> check(Collection<ReportRepository> repos, boolean offline) {
         if (offline) {
@@ -77,16 +101,51 @@ public final class RepositoryReachabilityChecker {
         if (uniqueLocations.isEmpty()) {
             return ImmutableMap.of();
         }
-        ImmutableMap.Builder<String, ReachabilityStatus> result = ImmutableMap.builder();
         // HttpClient is not AutoCloseable on Java 17 (this module's release target); rely on GC.
         HttpClient client = HttpClient.newBuilder()
             .connectTimeout(timeout)
             .followRedirects(HttpClient.Redirect.NORMAL)
             .build();
-        for (String location : uniqueLocations) {
-            result.put(location, probe(client, location));
+        int poolSize = Math.min(PROBE_THREAD_POOL_SIZE, uniqueLocations.size());
+        ExecutorService executor = Executors.newFixedThreadPool(poolSize, r -> {
+            Thread t = new Thread(r, "repo-reachability-probe");
+            t.setDaemon(true);
+            return t;
+        });
+        try {
+            Map<String, Future<ReachabilityStatus>> futures = new LinkedHashMap<>();
+            for (String location : uniqueLocations) {
+                futures.put(location, executor.submit(() -> probe(client, location)));
+            }
+            ImmutableMap.Builder<String, ReachabilityStatus> result = ImmutableMap.builder();
+            // Wall-clock cap per future: timeout + small grace so an individual probe cannot
+            // block the entire report indefinitely on a pathological runtime.
+            long perFutureCapMs = timeout.toMillis() + 1_000L;
+            for (Map.Entry<String, Future<ReachabilityStatus>> e : futures.entrySet()) {
+                ReachabilityStatus status;
+                try {
+                    status = e.getValue().get(perFutureCapMs, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    LOGGER.info("Reachability probe of {} failed: {} - {}",
+                        e.getKey(), ie.getClass().getName(), ie.getMessage(), ie);
+                    status = ReachabilityStatus.UNREACHABLE;
+                } catch (ExecutionException ee) {
+                    LOGGER.info("Reachability probe of {} failed: {} - {}",
+                        e.getKey(), ee.getClass().getName(), ee.getMessage(), ee);
+                    status = ReachabilityStatus.UNREACHABLE;
+                } catch (TimeoutException te) {
+                    LOGGER.info("Reachability probe of {} failed: {} - {}",
+                        e.getKey(), te.getClass().getName(), te.getMessage(), te);
+                    e.getValue().cancel(true);
+                    status = ReachabilityStatus.UNREACHABLE;
+                }
+                result.put(e.getKey(), status);
+            }
+            return result.build();
+        } finally {
+            executor.shutdownNow();
         }
-        return result.build();
     }
 
     private static boolean isProbeable(ReportRepository r) {
@@ -98,27 +157,40 @@ public final class RepositoryReachabilityChecker {
         return location.startsWith("http://") || location.startsWith("https://");
     }
 
+    /**
+     * Probes a single URL. Issues HEAD first; on any 4xx/5xx response, retries with GET and
+     * classifies based on the GET response. Returns {@link ReachabilityStatus#MALFORMED_URL}
+     * if the location fails URI parsing, and {@link ReachabilityStatus#UNREACHABLE} when no
+     * response can be obtained at all.
+     *
+     * @param client shared HttpClient configured with this instance's timeout
+     * @param location the literal repository location string
+     * @return the classified {@link ReachabilityStatus}
+     */
     private ReachabilityStatus probe(HttpClient client, String location) {
         URI uri;
         try {
             uri = new URI(location);
         } catch (URISyntaxException e) {
+            LOGGER.info("Reachability probe of {} failed: {} - {}",
+                location, e.getClass().getName(), e.getMessage(), e);
+            return ReachabilityStatus.MALFORMED_URL;
+        }
+        Optional<Integer> headStatus = issue(client, uri, location, "HEAD");
+        if (!headStatus.isPresent()) {
+            // Network-level failure on HEAD; no point retrying with GET.
             return ReachabilityStatus.UNREACHABLE;
         }
-        Integer headStatus = issue(client, uri, "HEAD");
-        if (headStatus == null) {
-            // Network-level failure on HEAD; don't bother retrying with GET.
-            return ReachabilityStatus.UNREACHABLE;
-        }
-        if (headStatus == 405) {
-            // Server rejected HEAD — fall back to GET.
-            Integer getStatus = issue(client, uri, "GET");
-            if (getStatus == null) {
+        int head = headStatus.get();
+        if (head >= 400 && head < 600) {
+            // Server rejected HEAD — fall back to GET and classify on that response.
+            Optional<Integer> getStatus = issue(client, uri, location, "GET");
+            if (!getStatus.isPresent()) {
                 return ReachabilityStatus.UNREACHABLE;
             }
-            return classify(getStatus);
+            return classify(getStatus.get());
         }
-        return classify(headStatus);
+        return classify(head);
     }
 
     private static ReachabilityStatus classify(int status) {
@@ -132,24 +204,30 @@ public final class RepositoryReachabilityChecker {
     }
 
     /**
-     * Issues one HTTP request. Returns the response status code on success, or {@code null}
-     * on a network-level failure (DNS, connect refused, timeout, malformed request, etc.).
+     * Issues one HTTP request. Returns {@link Optional#empty()} on any failure (network,
+     * malformed request, interruption); the resulting status — if any — is returned wrapped.
+     *
+     * <p>All caught exceptions are logged at {@code info} level on this class's logger so
+     * diagnostic details surface without polluting default output. {@code InterruptedException}
+     * re-interrupts the current thread.
      */
-    private @Nullable Integer issue(HttpClient client, URI uri, String method) {
-        HttpRequest request;
+    private Optional<Integer> issue(HttpClient client, URI uri, String location, String method) {
         try {
-            request = HttpRequest.newBuilder(uri)
+            HttpRequest request = HttpRequest.newBuilder(uri)
                 .timeout(timeout)
                 .method(method, HttpRequest.BodyPublishers.noBody())
                 .build();
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
-        try {
             HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
-            return response.statusCode();
+            return Optional.of(response.statusCode());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.info("Reachability probe of {} failed: {} - {}",
+                location, e.getClass().getName(), e.getMessage(), e);
+            return Optional.empty();
         } catch (Exception e) {
-            return null;
+            LOGGER.info("Reachability probe of {} failed: {} - {}",
+                location, e.getClass().getName(), e.getMessage(), e);
+            return Optional.empty();
         }
     }
 }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/package-info.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 @NullMarked
 package org.gradle.api.tasks.diagnostics.internal.repositories.reachability;
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories.reachability;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/package-info.java
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * URL reachability checking for remote repository endpoints.
+ */
 @NullMarked
 package org.gradle.api.tasks.diagnostics.internal.repositories.reachability;
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
@@ -89,13 +89,14 @@ public final class ConsoleRepositoriesReportRenderer {
     }
 
     private boolean isModelEmpty(RepositoryReportFullModel model) {
-        if (!model.getSettings().getPluginManagementRepositories().isEmpty()) {
+        var settings = model.getSettings();
+        if (!settings.getPluginManagementRepositories().isEmpty()) {
             return false;
         }
-        if (!model.getSettings().getSettingsBuildscriptRepositories().isEmpty()) {
+        if (!settings.getSettingsBuildscriptRepositories().isEmpty()) {
             return false;
         }
-        if (!model.getSettings().getDependencyResolutionManagementRepositories().isEmpty()) {
+        if (!settings.getDependencyResolutionManagementRepositories().isEmpty()) {
             return false;
         }
         for (RepositoryReportProjectModel p : model.getProjectsByPath().values()) {
@@ -107,24 +108,25 @@ public final class ConsoleRepositoriesReportRenderer {
     }
 
     private void renderFull(RepositoryReportFullModel model, StyledTextOutput out) {
+        var settings = model.getSettings();
+        var projectsByPath = model.getProjectsByPath();
+        List<ReportRepository> pluginMgmt = settings.getPluginManagementRepositories();
+        List<ReportRepository> settingsBuildscript = settings.getSettingsBuildscriptRepositories();
+        List<ReportRepository> drm = settings.getDependencyResolutionManagementRepositories();
+
         // Section 1: All Repositories — flat, globally numbered in the following order:
         //   SETTINGS_BUILDSCRIPT_DEPENDENCIES, PLUGINS, settings DRM,
         //   then (alphabetical by project) buildscript repos + project.repositories.
         List<ReportRepository> allRepos = new ArrayList<>();
-        allRepos.addAll(model.getSettings().getSettingsBuildscriptRepositories());
-        allRepos.addAll(model.getSettings().getPluginManagementRepositories());
-        allRepos.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
-        for (RepositoryReportProjectModel p : model.getProjectsByPath().values()) {
+        allRepos.addAll(settingsBuildscript);
+        allRepos.addAll(pluginMgmt);
+        allRepos.addAll(drm);
+        for (RepositoryReportProjectModel p : projectsByPath.values()) {
             allRepos.addAll(p.getBuildscriptRepositories());
             allRepos.addAll(p.getProjectRepositories());
         }
 
-        IdentityHashMap<ReportRepository, Integer> numbers = new IdentityHashMap<>();
-        int n = 1;
-        for (ReportRepository r : allRepos) {
-            numbers.put(r, n++);
-        }
-
+        Map<ReportRepository, Integer> numbers = assignNumbers(allRepos);
         Set<ReportRepository> starred = computeStarred(allRepos);
         MarkerSet markers = new MarkerSet();
 
@@ -133,17 +135,17 @@ public final class ConsoleRepositoriesReportRenderer {
         // Section 2: Repositories by Location — settings block (all three buckets, in section-1 order) first,
         // then per-project blocks in alphabetical order.
         List<ReportRepository> settingsRefs = new ArrayList<>();
-        settingsRefs.addAll(model.getSettings().getSettingsBuildscriptRepositories());
-        settingsRefs.addAll(model.getSettings().getPluginManagementRepositories());
-        settingsRefs.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
+        settingsRefs.addAll(settingsBuildscript);
+        settingsRefs.addAll(pluginMgmt);
+        settingsRefs.addAll(drm);
 
         Map<Path, List<ReportRepository>> projectRefs = new LinkedHashMap<>();
-        for (Map.Entry<Path, RepositoryReportProjectModel> e : model.getProjectsByPath().entrySet()) {
+        for (Map.Entry<Path, RepositoryReportProjectModel> e : projectsByPath.entrySet()) {
             List<ReportRepository> refs = new ArrayList<>();
             // Settings-inherited buckets are listed in Gradle's actual repo-search order
             // (pluginManagement precedes DRM — settings.buildscript is not inherited per-project).
-            refs.addAll(model.getSettings().getPluginManagementRepositories());
-            refs.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
+            refs.addAll(pluginMgmt);
+            refs.addAll(drm);
             refs.addAll(e.getValue().getBuildscriptRepositories());
             refs.addAll(e.getValue().getProjectRepositories());
             projectRefs.put(e.getKey(), refs);
@@ -163,17 +165,14 @@ public final class ConsoleRepositoriesReportRenderer {
         RepositoryReportProjectModel target = model.getProjectsByPath().get(filterPath);
         assert target != null : "validateFilter() should have rejected unknown project '" + filter + "'";
 
+        var settings = model.getSettings();
         List<ReportRepository> filtered = new ArrayList<>();
-        filtered.addAll(model.getSettings().getPluginManagementRepositories());
-        filtered.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
+        filtered.addAll(settings.getPluginManagementRepositories());
+        filtered.addAll(settings.getDependencyResolutionManagementRepositories());
         filtered.addAll(target.getBuildscriptRepositories());
         filtered.addAll(target.getProjectRepositories());
 
-        IdentityHashMap<ReportRepository, Integer> numbers = new IdentityHashMap<>();
-        int n = 1;
-        for (ReportRepository r : filtered) {
-            numbers.put(r, n++);
-        }
+        Map<ReportRepository, Integer> numbers = assignNumbers(filtered);
         Set<ReportRepository> starred = computeStarred(filtered);
         MarkerSet markers = new MarkerSet();
 
@@ -239,14 +238,23 @@ public final class ConsoleRepositoriesReportRenderer {
         }
     }
 
+    private static Map<ReportRepository, Integer> assignNumbers(List<ReportRepository> repos) {
+        IdentityHashMap<ReportRepository, Integer> numbers = new IdentityHashMap<>();
+        int n = 1;
+        for (ReportRepository r : repos) {
+            numbers.put(r, n++);
+        }
+        return numbers;
+    }
+
     private Set<ReportRepository> computeStarred(List<ReportRepository> all) {
         Map<ReportRepository.IdentityKey, Integer> counts = new HashMap<>();
         for (ReportRepository r : all) {
-            counts.merge(r.identityKey(), 1, Integer::sum);
+            counts.merge(r.getIdentityKey(), 1, Integer::sum);
         }
         Set<ReportRepository> starred = Collections.newSetFromMap(new IdentityHashMap<>());
         for (ReportRepository r : all) {
-            if (counts.get(r.identityKey()) > 1) {
+            if (counts.get(r.getIdentityKey()) > 1) {
                 starred.add(r);
             }
         }
@@ -357,23 +365,24 @@ public final class ConsoleRepositoriesReportRenderer {
         out.withStyle(Header).println("Legend");
         out.println(DIVIDER);
         out.println();
+        StyledTextOutput info = out.withStyle(Info);
         if (markers.starUsed) {
-            out.withStyle(Info).println("(*) Identical repository declaration found in multiple locations.");
-            out.withStyle(Info).println("    Consider consolidating to settings.dependencyResolutionManagement.repositories");
-            out.withStyle(Info).println("    or settings.pluginManagement.repositories.");
-            out.withStyle(Info).println("    See " + LEGEND_URL);
+            info.println("(*) Identical repository declaration found in multiple locations.");
+            info.println("    Consider consolidating to settings.dependencyResolutionManagement.repositories");
+            info.println("    or settings.pluginManagement.repositories.");
+            info.println("    See " + LEGEND_URL);
         }
         if (markers.unreachableUsed) {
-            out.withStyle(Info).println("(ur) Unreachable — the URL could not be contacted.");
+            info.println("(ur) Unreachable \u2014 the URL could not be contacted.");
         }
         if (markers.unauthorizedUsed) {
-            out.withStyle(Info).println("(ua) Unauthorized — the URL returned 401/403; credentials were not sent.");
+            info.println("(ua) Unauthorized \u2014 the URL returned 401/403; credentials were not sent.");
         }
         if (markers.malformedUsed) {
-            out.withStyle(Info).println("(m)  Malformed URL — the URL could not be parsed.");
+            info.println("(m)  Malformed URL \u2014 the URL could not be parsed.");
         }
         if (markers.offlineUsed) {
-            out.withStyle(Info).println("(o)  Running in offline mode — no reachability checks were performed.");
+            info.println("(o)  Running in offline mode \u2014 no reachability checks were performed.");
         }
     }
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.renderer;
+
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportContentFilter;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportFullModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportProjectModel;
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole;
+import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.ReachabilityStatus;
+import org.gradle.api.tasks.diagnostics.internal.repositories.spec.RepositoriesReportSpec;
+import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.util.Path;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Failure;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Header;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Identifier;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Info;
+
+@NullMarked
+public final class ConsoleRepositoriesReportRenderer {
+
+    private static final String DIVIDER = "--------------------------------------------------------";
+    private static final String LEGEND_URL = "https://docs.gradle.org/current/userguide/centralizing_repositories.html";
+
+    private final RepositoriesReportSpec spec;
+
+    public ConsoleRepositoriesReportRenderer(RepositoriesReportSpec spec) {
+        this.spec = spec;
+    }
+
+    public void render(RepositoryReportFullModel model, StyledTextOutput out) {
+        if (spec.isFiltered()) {
+            validateFilter(model);
+        }
+        if (isModelEmpty(model)) {
+            if (spec.isFiltered()) {
+                out.println("There are no repositories present in project '" + spec.getProjectFilter() + "'.");
+            } else {
+                out.println("There are no repositories present.");
+            }
+            return;
+        }
+        if (spec.isFiltered()) {
+            renderFiltered(model, out);
+        } else {
+            renderFull(model, out);
+        }
+    }
+
+    private void validateFilter(RepositoryReportFullModel model) {
+        String filter = spec.getProjectFilter();
+        Path filterPath = Path.path(filter);
+        if (!model.getProjectsByPath().containsKey(filterPath)) {
+            throw new IllegalArgumentException(
+                "Project '" + filter + "' not found. Available projects: "
+                    + model.getProjectsByPath().keySet());
+        }
+    }
+
+    private boolean isModelEmpty(RepositoryReportFullModel model) {
+        if (!model.getSettings().getPluginManagementRepositories().isEmpty()) {
+            return false;
+        }
+        if (!model.getSettings().getSettingsBuildscriptRepositories().isEmpty()) {
+            return false;
+        }
+        if (!model.getSettings().getDependencyResolutionManagementRepositories().isEmpty()) {
+            return false;
+        }
+        for (RepositoryReportProjectModel p : model.getProjectsByPath().values()) {
+            if (!p.getBuildscriptRepositories().isEmpty() || !p.getProjectRepositories().isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void renderFull(RepositoryReportFullModel model, StyledTextOutput out) {
+        // Section 1: All Repositories — flat, globally numbered in the following order:
+        //   SETTINGS_BUILDSCRIPT_DEPENDENCIES, PLUGINS, settings DRM,
+        //   then (alphabetical by project) buildscript repos + project.repositories.
+        List<ReportRepository> allRepos = new ArrayList<>();
+        allRepos.addAll(model.getSettings().getSettingsBuildscriptRepositories());
+        allRepos.addAll(model.getSettings().getPluginManagementRepositories());
+        allRepos.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
+        for (RepositoryReportProjectModel p : model.getProjectsByPath().values()) {
+            allRepos.addAll(p.getBuildscriptRepositories());
+            allRepos.addAll(p.getProjectRepositories());
+        }
+
+        IdentityHashMap<ReportRepository, Integer> numbers = new IdentityHashMap<>();
+        int n = 1;
+        for (ReportRepository r : allRepos) {
+            numbers.put(r, n++);
+        }
+
+        Set<ReportRepository> starred = computeStarred(allRepos);
+        MarkerSet markers = new MarkerSet();
+
+        renderSection("All Repositories", allRepos, numbers, starred, out, true, markers);
+
+        // Section 2: Repositories by Location — settings block (all three buckets, in section-1 order) first,
+        // then per-project blocks in alphabetical order.
+        List<ReportRepository> settingsRefs = new ArrayList<>();
+        settingsRefs.addAll(model.getSettings().getSettingsBuildscriptRepositories());
+        settingsRefs.addAll(model.getSettings().getPluginManagementRepositories());
+        settingsRefs.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
+
+        Map<Path, List<ReportRepository>> projectRefs = new LinkedHashMap<>();
+        for (Map.Entry<Path, RepositoryReportProjectModel> e : model.getProjectsByPath().entrySet()) {
+            List<ReportRepository> refs = new ArrayList<>();
+            refs.addAll(model.getSettings().getPluginManagementRepositories());
+            refs.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
+            refs.addAll(e.getValue().getBuildscriptRepositories());
+            refs.addAll(e.getValue().getProjectRepositories());
+            projectRefs.put(e.getKey(), refs);
+        }
+
+        renderByLocationSection(settingsRefs, projectRefs, numbers, out);
+
+        if (!starred.isEmpty()) {
+            markers.starUsed = true;
+        }
+        renderLegendIfNeeded(markers, out);
+    }
+
+    private void renderFiltered(RepositoryReportFullModel model, StyledTextOutput out) {
+        String filter = spec.getProjectFilter();
+        Path filterPath = Path.path(filter);
+        RepositoryReportProjectModel target = model.getProjectsByPath().get(filterPath);
+        if (target == null) {
+            throw new IllegalArgumentException(
+                "Project '" + filter + "' not found. Available projects: "
+                    + model.getProjectsByPath().keySet());
+        }
+
+        List<ReportRepository> filtered = new ArrayList<>();
+        filtered.addAll(model.getSettings().getPluginManagementRepositories());
+        filtered.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
+        filtered.addAll(target.getBuildscriptRepositories());
+        filtered.addAll(target.getProjectRepositories());
+
+        IdentityHashMap<ReportRepository, Integer> numbers = new IdentityHashMap<>();
+        int n = 1;
+        for (ReportRepository r : filtered) {
+            numbers.put(r, n++);
+        }
+        Set<ReportRepository> starred = computeStarred(filtered);
+        MarkerSet markers = new MarkerSet();
+
+        renderSection("All Repositories", filtered, numbers, starred, out, true, markers);
+
+        // Section 2 in filtered mode: ONLY the target project's block, no settings block.
+        Map<Path, List<ReportRepository>> projectRefs = new LinkedHashMap<>();
+        projectRefs.put(filterPath, filtered);
+        renderByLocationSection(null, projectRefs, numbers, out);
+
+        if (!starred.isEmpty()) {
+            markers.starUsed = true;
+        }
+        renderLegendIfNeeded(markers, out);
+    }
+
+    private void renderByLocationSection(
+        @Nullable List<ReportRepository> settingsRefs,
+        Map<Path, List<ReportRepository>> projectRefs,
+        Map<ReportRepository, Integer> numbers,
+        StyledTextOutput out
+    ) {
+        boolean hasSettingsBlock = settingsRefs != null && !settingsRefs.isEmpty();
+        Map<Path, List<ReportRepository>> nonEmptyProjectRefs = new LinkedHashMap<>();
+        for (Map.Entry<Path, List<ReportRepository>> e : projectRefs.entrySet()) {
+            if (!e.getValue().isEmpty()) {
+                nonEmptyProjectRefs.put(e.getKey(), e.getValue());
+            }
+        }
+        if (!hasSettingsBlock && nonEmptyProjectRefs.isEmpty()) {
+            return;
+        }
+
+        out.println();
+        out.println(DIVIDER);
+        out.withStyle(Header).println("Repositories by Location");
+        out.println(DIVIDER);
+        out.println();
+
+        boolean first = true;
+        if (hasSettingsBlock) {
+            renderLocationBlock("settings uses", settingsRefs, numbers, out);
+            first = false;
+        }
+        for (Map.Entry<Path, List<ReportRepository>> e : nonEmptyProjectRefs.entrySet()) {
+            if (!first) {
+                out.println();
+            }
+            first = false;
+            renderLocationBlock("project '" + e.getKey() + "' uses", e.getValue(), numbers, out);
+        }
+    }
+
+    private void renderLocationBlock(
+        String header,
+        List<ReportRepository> refs,
+        Map<ReportRepository, Integer> numbers,
+        StyledTextOutput out
+    ) {
+        out.println(header);
+        for (ReportRepository r : refs) {
+            out.println("    - " + r.getName() + " (" + numbers.get(r) + ")");
+        }
+    }
+
+    private Set<ReportRepository> computeStarred(List<ReportRepository> all) {
+        Map<ReportRepository.IdentityKey, Integer> counts = new HashMap<>();
+        for (ReportRepository r : all) {
+            counts.merge(r.identityKey(), 1, Integer::sum);
+        }
+        Set<ReportRepository> starred = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (ReportRepository r : all) {
+            if (counts.get(r.identityKey()) > 1) {
+                starred.add(r);
+            }
+        }
+        return starred;
+    }
+
+    private void renderSection(
+        String heading,
+        List<ReportRepository> repos,
+        Map<ReportRepository, Integer> numbers,
+        Set<ReportRepository> starred,
+        StyledTextOutput out,
+        boolean allowEmpty,
+        MarkerSet markers
+    ) {
+        out.println();
+        out.println(DIVIDER);
+        String renderedHeading = heading;
+        if ("All Repositories".equals(heading) && spec.isOffline()) {
+            renderedHeading = heading + " (o)";
+            markers.offlineUsed = true;
+        }
+        out.withStyle(Header).println(renderedHeading);
+        out.println(DIVIDER);
+        out.println();
+        if (repos.isEmpty()) {
+            if (allowEmpty) {
+                out.withStyle(Info).println("(none)");
+            }
+            return;
+        }
+        boolean first = true;
+        for (ReportRepository r : repos) {
+            if (!first) {
+                out.println();
+            }
+            first = false;
+            renderRepoEntry(r, numbers.get(r), starred.contains(r), out, markers);
+        }
+    }
+
+    private void renderRepoEntry(ReportRepository r, int number, boolean star, StyledTextOutput out, MarkerSet markers) {
+        StringBuilder header = new StringBuilder(r.getName()).append(" (").append(number).append(")");
+        if (star) {
+            header.append(" *");
+        }
+        // Reachability markers are suppressed in offline mode; the (o) on the All Repositories
+        // heading already communicates that no probes were performed.
+        String locationMarker = "";
+        if (!spec.isOffline()) {
+            ReachabilityStatus status = spec.getReachabilityByLocation().get(r.getLocation());
+            if (status == ReachabilityStatus.UNREACHABLE) {
+                locationMarker = " (ur)";
+                markers.unreachableUsed = true;
+            } else if (status == ReachabilityStatus.UNAUTHORIZED) {
+                locationMarker = " (ua)";
+                markers.unauthorizedUsed = true;
+            }
+        }
+        out.withStyle(Identifier).text(header.toString());
+        out.println();
+        out.println("    Location:   " + r.getLocation() + locationMarker);
+        out.println("    Type:       " + r.getType());
+        out.println("    Roles:      " + r.getRoles().stream()
+            .sorted()
+            .map(RepositoryRole::name)
+            .collect(Collectors.joining(", ")));
+        if (!r.isSecure()) {
+            out.withStyle(Failure).println("    Secure:     false");
+        }
+        if (!r.getAuthSchemes().isEmpty()) {
+            out.println("    Auth:       " + String.join(", ", r.getAuthSchemes()));
+        }
+        if (r.hasCredentials()) {
+            out.println("    Credentials: PRESENT");
+        }
+        if (!r.getContentFilter().isEmpty()) {
+            out.println("    Content:    " + renderContent(r.getContentFilter()));
+        }
+        out.println("    Defined in: " + r.getDeclarationSite().render());
+    }
+
+    private String renderContent(ReportContentFilter f) {
+        List<String> parts = new ArrayList<>();
+        parts.addAll(f.getIncludeRules());
+        parts.addAll(f.getExcludeRules());
+        if (!f.getOnlyForConfigurations().isEmpty()) {
+            parts.add("onlyForConfigurations(" + f.getOnlyForConfigurations() + ")");
+        }
+        if (!f.getNotForConfigurations().isEmpty()) {
+            parts.add("notForConfigurations(" + f.getNotForConfigurations() + ")");
+        }
+        for (Map.Entry<String, Set<String>> a : f.getOnlyForAttributes().entrySet()) {
+            parts.add("onlyForAttribute(" + a.getKey() + ", " + a.getValue() + ")");
+        }
+        return String.join(", ", parts);
+    }
+
+    private void renderLegendIfNeeded(MarkerSet markers, StyledTextOutput out) {
+        if (!markers.any()) {
+            return;
+        }
+        out.println();
+        out.println(DIVIDER);
+        out.withStyle(Header).println("Legend");
+        out.println(DIVIDER);
+        out.println();
+        if (markers.starUsed) {
+            out.withStyle(Info).println("(*) Identical repository declaration found in multiple locations.");
+            out.withStyle(Info).println("    Consider consolidating to settings.dependencyResolutionManagement.repositories");
+            out.withStyle(Info).println("    or settings.pluginManagement.repositories.");
+            out.withStyle(Info).println("    See " + LEGEND_URL);
+        }
+        if (markers.unreachableUsed) {
+            out.withStyle(Info).println("(ur) Unreachable — the URL could not be contacted.");
+        }
+        if (markers.unauthorizedUsed) {
+            out.withStyle(Info).println("(ua) Unauthorized — the URL returned 401/403; credentials were not sent.");
+        }
+        if (markers.offlineUsed) {
+            out.withStyle(Info).println("(o)  Running in offline mode — no reachability checks were performed.");
+        }
+    }
+
+    /**
+     * Tracks which legend-worthy markers were actually emitted by the renderer so the Legend
+     * section only surfaces entries that correspond to visible markers.
+     */
+    private static final class MarkerSet {
+        boolean starUsed;
+        boolean unreachableUsed;
+        boolean unauthorizedUsed;
+        boolean offlineUsed;
+
+        boolean any() {
+            return starUsed || unreachableUsed || unauthorizedUsed || offlineUsed;
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
@@ -43,9 +43,13 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style.Header;
 import static org.gradle.internal.logging.text.StyledTextOutput.Style.Identifier;
 import static org.gradle.internal.logging.text.StyledTextOutput.Style.Info;
 
+/**
+ * Text renderer for the repositories report. Produces the "All Repositories" and
+ * "Repositories by Location" sections plus an optional Legend, honoring the filter
+ * and offline state carried in the supplied {@link RepositoriesReportSpec}.
+ */
 @NullMarked
 public final class ConsoleRepositoriesReportRenderer {
-
     private static final String DIVIDER = "--------------------------------------------------------";
     private static final String LEGEND_URL = "https://docs.gradle.org/current/userguide/centralizing_repositories.html";
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
@@ -161,11 +161,7 @@ public final class ConsoleRepositoriesReportRenderer {
         String filter = spec.getProjectFilter();
         Path filterPath = Path.path(filter);
         RepositoryReportProjectModel target = model.getProjectsByPath().get(filterPath);
-        if (target == null) {
-            throw new IllegalArgumentException(
-                "Project '" + filter + "' not found. Available projects: "
-                    + model.getProjectsByPath().keySet());
-        }
+        assert target != null : "validateFilter() should have rejected unknown project '" + filter + "'";
 
         List<ReportRepository> filtered = new ArrayList<>();
         filtered.addAll(model.getSettings().getPluginManagementRepositories());

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
@@ -140,6 +140,8 @@ public final class ConsoleRepositoriesReportRenderer {
         Map<Path, List<ReportRepository>> projectRefs = new LinkedHashMap<>();
         for (Map.Entry<Path, RepositoryReportProjectModel> e : model.getProjectsByPath().entrySet()) {
             List<ReportRepository> refs = new ArrayList<>();
+            // Settings-inherited buckets are listed in Gradle's actual repo-search order
+            // (pluginManagement precedes DRM — settings.buildscript is not inherited per-project).
             refs.addAll(model.getSettings().getPluginManagementRepositories());
             refs.addAll(model.getSettings().getDependencyResolutionManagementRepositories());
             refs.addAll(e.getValue().getBuildscriptRepositories());

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.renderer;
 
 import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportContentFilter;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRenderer.java
@@ -302,6 +302,9 @@ public final class ConsoleRepositoriesReportRenderer {
             } else if (status == ReachabilityStatus.UNAUTHORIZED) {
                 locationMarker = " (ua)";
                 markers.unauthorizedUsed = true;
+            } else if (status == ReachabilityStatus.MALFORMED_URL) {
+                locationMarker = " (m)";
+                markers.malformedUsed = true;
             }
         }
         out.withStyle(Identifier).text(header.toString());
@@ -364,6 +367,9 @@ public final class ConsoleRepositoriesReportRenderer {
         if (markers.unauthorizedUsed) {
             out.withStyle(Info).println("(ua) Unauthorized — the URL returned 401/403; credentials were not sent.");
         }
+        if (markers.malformedUsed) {
+            out.withStyle(Info).println("(m)  Malformed URL — the URL could not be parsed.");
+        }
         if (markers.offlineUsed) {
             out.withStyle(Info).println("(o)  Running in offline mode — no reachability checks were performed.");
         }
@@ -377,10 +383,11 @@ public final class ConsoleRepositoriesReportRenderer {
         boolean starUsed;
         boolean unreachableUsed;
         boolean unauthorizedUsed;
+        boolean malformedUsed;
         boolean offlineUsed;
 
         boolean any() {
-            return starUsed || unreachableUsed || unauthorizedUsed || offlineUsed;
+            return starUsed || unreachableUsed || unauthorizedUsed || malformedUsed || offlineUsed;
         }
     }
 }

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/package-info.java
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * Console text renderer for the repositories report.
+ */
 @NullMarked
 package org.gradle.api.tasks.diagnostics.internal.repositories.renderer;
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/package-info.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 @NullMarked
 package org.gradle.api.tasks.diagnostics.internal.repositories.renderer;
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories.renderer;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/RepositoriesReportSpec.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/RepositoriesReportSpec.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.diagnostics.internal.repositories.spec;
 
+import com.google.common.collect.ImmutableMap;
 import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.ReachabilityStatus;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -23,6 +24,11 @@ import org.jspecify.annotations.Nullable;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * Read-only parameter object passed to {@code ConsoleRepositoriesReportRenderer} describing
+ * how the report should be rendered: the optional project filter, whether the build is in
+ * offline mode, and the per-location reachability results (empty when offline).
+ */
 @NullMarked
 public final class RepositoriesReportSpec {
     private final @Nullable String projectFilter;
@@ -40,7 +46,9 @@ public final class RepositoriesReportSpec {
     ) {
         this.projectFilter = projectFilter;
         this.offline = offline;
-        this.reachabilityByLocation = reachabilityByLocation;
+        // Defensive copy — the spec is shared with the renderer and must not observe
+        // mutations from the caller after construction.
+        this.reachabilityByLocation = ImmutableMap.copyOf(reachabilityByLocation);
     }
 
     public @Nullable String getProjectFilter() {

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/RepositoriesReportSpec.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/RepositoriesReportSpec.java
@@ -21,7 +21,6 @@ import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.Reach
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -36,7 +35,7 @@ public final class RepositoriesReportSpec {
     private final Map<String, ReachabilityStatus> reachabilityByLocation;
 
     public RepositoriesReportSpec(@Nullable String projectFilter) {
-        this(projectFilter, false, Collections.emptyMap());
+        this(projectFilter, false, ImmutableMap.of());
     }
 
     public RepositoriesReportSpec(

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/RepositoriesReportSpec.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/RepositoriesReportSpec.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.spec;
+
+import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.ReachabilityStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+
+@NullMarked
+public final class RepositoriesReportSpec {
+    private final @Nullable String projectFilter;
+    private final boolean offline;
+    private final Map<String, ReachabilityStatus> reachabilityByLocation;
+
+    public RepositoriesReportSpec(@Nullable String projectFilter) {
+        this(projectFilter, false, Collections.emptyMap());
+    }
+
+    public RepositoriesReportSpec(
+        @Nullable String projectFilter,
+        boolean offline,
+        Map<String, ReachabilityStatus> reachabilityByLocation
+    ) {
+        this.projectFilter = projectFilter;
+        this.offline = offline;
+        this.reachabilityByLocation = reachabilityByLocation;
+    }
+
+    public @Nullable String getProjectFilter() {
+        return projectFilter;
+    }
+
+    public boolean isFiltered() {
+        return projectFilter != null;
+    }
+
+    /**
+     * Whether the build was invoked with {@code --offline}. When true, no reachability probes
+     * were performed and {@link #getReachabilityByLocation()} is empty; the renderer appends
+     * an {@code (o)} marker to the "All Repositories" heading instead of per-repo markers.
+     */
+    public boolean isOffline() {
+        return offline;
+    }
+
+    /**
+     * Per-location reachability status for remote HTTP(S) repositories. Keys are the literal
+     * {@code location} strings of {@code ReportRepository} entries. Repositories whose locations
+     * are not in this map carry no reachability marker (e.g. local repos, or when offline).
+     */
+    public Map<String, ReachabilityStatus> getReachabilityByLocation() {
+        return reachabilityByLocation;
+    }
+}

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/RepositoriesReportSpec.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/RepositoriesReportSpec.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.gradle.api.tasks.diagnostics.internal.repositories.spec;
 
 import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.ReachabilityStatus;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/package-info.java
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * Report specification and filter options for the repositories report.
+ */
 @NullMarked
 package org.gradle.api.tasks.diagnostics.internal.repositories.spec;
 

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+@NullMarked
+package org.gradle.api.tasks.diagnostics.internal.repositories.spec;
+
+import org.jspecify.annotations.NullMarked;

--- a/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/package-info.java
+++ b/platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/repositories/spec/package-info.java
@@ -6,7 +6,14 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 @NullMarked
 package org.gradle.api.tasks.diagnostics.internal.repositories.spec;
 

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactoryTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactoryTest.groovy
@@ -6,16 +6,19 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.gradle.api.tasks.diagnostics.internal.repositories.model
 
-import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository
-import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.internal.artifacts.repositories.AbstractArtifactRepository
-import org.gradle.api.internal.artifacts.repositories.DefaultMavenLocalArtifactRepository
 import org.gradle.api.internal.artifacts.repositories.RepositoryContentDescriptorInternal
 import org.gradle.api.provider.Property
 import org.gradle.authentication.Authentication

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactoryTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactoryTest.groovy
@@ -27,6 +27,7 @@ import spock.lang.Specification
 
 import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.SETTINGS
 
+/** Tests for {@link RepositoryReportModelFactory}. */
 class RepositoryReportModelFactoryTest extends Specification {
     def factory = new RepositoryReportModelFactory()
 
@@ -49,7 +50,7 @@ class RepositoryReportModelFactoryTest extends Specification {
         def site = new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories")
 
         when:
-        def result = factory.toReportRepository(repo, [RepositoryRole.PLUGINS] as Set, site)
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PLUGINS] as Set, site)
 
         then:
         result.name == "MavenRepo"
@@ -80,7 +81,7 @@ class RepositoryReportModelFactoryTest extends Specification {
         def site = new RepositoryDeclarationSite(SETTINGS, null, "repositories")
 
         when:
-        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
 
         then:
         result.type == RepositoryType.FLAT_DIR
@@ -107,7 +108,7 @@ class RepositoryReportModelFactoryTest extends Specification {
         }
 
         when:
-        def result = factory.toReportRepository(repo, [RepositoryRole.PLUGINS] as Set,
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PLUGINS] as Set,
             new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories"))
 
         then:
@@ -131,7 +132,7 @@ class RepositoryReportModelFactoryTest extends Specification {
         }
 
         when:
-        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
             new RepositoryDeclarationSite(SETTINGS, null, "dependencyResolutionManagement.repositories"))
 
         then:
@@ -168,7 +169,7 @@ class RepositoryReportModelFactoryTest extends Specification {
         }
 
         when:
-        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
             new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
 
         then:
@@ -196,7 +197,7 @@ class RepositoryReportModelFactoryTest extends Specification {
         }
 
         when:
-        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
             new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
 
         then:
@@ -224,7 +225,7 @@ class RepositoryReportModelFactoryTest extends Specification {
         }
 
         when:
-        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
             new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
 
         then:
@@ -245,7 +246,7 @@ class RepositoryReportModelFactoryTest extends Specification {
         }
 
         when:
-        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
             new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
 
         then:
@@ -271,7 +272,7 @@ class RepositoryReportModelFactoryTest extends Specification {
         }
 
         when:
-        def result = factory.toReportRepository(repo, [RepositoryRole.PLUGINS] as Set,
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PLUGINS] as Set,
             new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories"))
 
         then:
@@ -295,7 +296,7 @@ class RepositoryReportModelFactoryTest extends Specification {
         }
 
         when:
-        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+        def result = factory.buildReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
             new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
 
         then:

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactoryTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactoryTest.groovy
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.model
+
+import org.gradle.api.artifacts.repositories.ArtifactRepository
+import org.gradle.api.artifacts.repositories.AuthenticationContainer
+import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.internal.artifacts.repositories.AbstractArtifactRepository
+import org.gradle.api.internal.artifacts.repositories.DefaultMavenLocalArtifactRepository
+import org.gradle.api.internal.artifacts.repositories.RepositoryContentDescriptorInternal
+import org.gradle.api.provider.Property
+import org.gradle.authentication.Authentication
+import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal
+import spock.lang.Specification
+
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.SETTINGS
+
+class RepositoryReportModelFactoryTest extends Specification {
+    def factory = new RepositoryReportModelFactory()
+
+    def "converts MavenArtifactRepository"() {
+        given:
+        def repo = Stub(TestMavenRepo) {
+            getName() >> "MavenRepo"
+            getUrl() >> URI.create("https://repo.maven.apache.org/maven2/")
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        def site = new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories")
+
+        when:
+        def result = factory.toReportRepository(repo, [RepositoryRole.PLUGINS] as Set, site)
+
+        then:
+        result.name == "MavenRepo"
+        result.type == RepositoryType.MAVEN
+        result.location == "https://repo.maven.apache.org/maven2/"
+        result.secure
+        result.authSchemes == []
+        !result.hasCredentials()
+        result.contentFilter.isEmpty()
+        result.roles == [RepositoryRole.PLUGINS] as Set
+        result.declarationSite == site
+    }
+
+    def "converts FlatDirectoryArtifactRepository to dirs location"() {
+        given:
+        def descriptor = Stub(RepositoryContentDescriptorInternal) {
+            describeIncludeRules() >> []
+            describeExcludeRules() >> []
+            getIncludedConfigurations() >> null
+            getExcludedConfigurations() >> null
+            getRequiredAttributes() >> null
+        }
+        def repo = Stub(TestFlatDirRepo) {
+            getName() >> "flat"
+            getDirs() >> ([new File("/tmp/a"), new File("/tmp/b")] as Set)
+            getRepositoryDescriptorCopy() >> descriptor
+        }
+        def site = new RepositoryDeclarationSite(SETTINGS, null, "repositories")
+
+        when:
+        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+
+        then:
+        result.type == RepositoryType.FLAT_DIR
+        result.location.startsWith("dirs:[")
+        result.location.contains("/tmp/a")
+        result.location.contains("/tmp/b")
+        result.secure // FlatDir always reported as secure
+    }
+
+    def "marks repo as insecure when allowInsecureProtocol=true"() {
+        given:
+        def repo = Stub(TestMavenRepo) {
+            getName() >> "corp"
+            getUrl() >> URI.create("http://corp.example.com/maven/")
+            isAllowInsecureProtocol() >> true
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.toReportRepository(repo, [RepositoryRole.PLUGINS] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories"))
+
+        then:
+        !result.secure
+    }
+
+    def "captures content filter rules"() {
+        given:
+        def repo = Stub(TestMavenRepo) {
+            getName() >> "filtered"
+            getUrl() >> URI.create("https://example.com/")
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> ['includeGroup("com.example")']
+                describeExcludeRules() >> ['excludeModule("a", "b")']
+                getIncludedConfigurations() >> (["compile"] as Set)
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "dependencyResolutionManagement.repositories"))
+
+        then:
+        result.contentFilter.includeRules == ['includeGroup("com.example")']
+        result.contentFilter.excludeRules == ['excludeModule("a", "b")']
+        result.contentFilter.onlyForConfigurations == ["compile"] as Set
+    }
+
+    def "extracts authentication scheme class names sorted alphabetically"() {
+        given:
+        // Use concrete implementations named exactly 'BasicAuthentication'/'DigestAuthentication'
+        // so getClass().getSimpleName() returns those strings. Interface mocks/proxies would yield
+        // generated names like '$Proxy12'.
+        def basic = new BasicAuthentication()
+        def digest = new DigestAuthentication()
+        def auths = [basic, digest] as List<Authentication>
+        def authContainer = Stub(AuthenticationContainer) {
+            isEmpty() >> false
+            size() >> auths.size()
+            iterator() >> { auths.iterator() }
+        }
+        def repo = Stub(TestMavenRepo) {
+            getName() >> "secured"
+            getUrl() >> URI.create("https://secure.example.com/")
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> authContainer
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
+
+        then:
+        result.authSchemes == ['BasicAuthentication', 'DigestAuthentication']
+    }
+
+    def "detects credentials when configured credentials Property is present"() {
+        given:
+        def credentialsProperty = Stub(Property) {
+            isPresent() >> true
+        }
+        def repo = Stub(TestAuthMavenRepo) {
+            getName() >> "secured"
+            getUrl() >> URI.create("https://secure.example.com/")
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getConfiguredCredentials() >> credentialsProperty
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
+
+        then:
+        result.hasCredentials()
+    }
+
+    def "reports no credentials when configured credentials Property is empty"() {
+        given:
+        def credentialsProperty = Stub(Property) {
+            isPresent() >> false
+        }
+        def repo = Stub(TestAuthMavenRepo) {
+            getName() >> "open"
+            getUrl() >> URI.create("https://open.example.com/")
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getConfiguredCredentials() >> credentialsProperty
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
+
+        then:
+        !result.hasCredentials()
+    }
+
+    // These abstract classes merge AbstractArtifactRepository with the per-type API so Spock can stub both.
+    // (AbstractArtifactRepository is an abstract class, not an interface, so we use 'extends' + 'implements'.)
+    static abstract class TestMavenRepo extends AbstractArtifactRepository implements MavenArtifactRepository {
+        TestMavenRepo() { super(null, null) }
+    }
+    static abstract class TestFlatDirRepo extends AbstractArtifactRepository implements FlatDirectoryArtifactRepository {
+        TestFlatDirRepo() { super(null, null) }
+    }
+    // Adds AuthenticationSupportedInternal so the factory's instanceof check for credential
+    // detection via getConfiguredCredentials() applies to this stub.
+    static abstract class TestAuthMavenRepo extends AbstractArtifactRepository implements MavenArtifactRepository, AuthenticationSupportedInternal {
+        TestAuthMavenRepo() { super(null, null) }
+    }
+
+    // Concrete classes named identically to the SPI interfaces so the factory's
+    // `getClass().getSimpleName()` lookup yields 'BasicAuthentication' / 'DigestAuthentication'.
+    static class BasicAuthentication implements org.gradle.authentication.http.BasicAuthentication {
+        @Override String getName() { "basic" }
+    }
+    static class DigestAuthentication implements org.gradle.authentication.http.DigestAuthentication {
+        @Override String getName() { "digest" }
+    }
+}

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactoryTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/model/RepositoryReportModelFactoryTest.groovy
@@ -231,10 +231,85 @@ class RepositoryReportModelFactoryTest extends Specification {
         !result.hasCredentials()
     }
 
+    def "classifies unknown AbstractArtifactRepository subclass as CUSTOM and surfaces its class name as the location"() {
+        given:
+        def repo = Stub(TestCustomRepo) {
+            getName() >> "mystery"
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
+
+        then:
+        result.type == RepositoryType.CUSTOM
+        result.location.contains("TestCustomRepo")
+        result.secure // CUSTOM is reported as secure by default — no URL to inspect
+    }
+
+    def "uses <NO_URL> sentinel when MavenArtifactRepository.getUrl() returns null"() {
+        given:
+        def repo = Stub(TestMavenRepo) {
+            getName() >> "noUrl"
+            getUrl() >> null
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.toReportRepository(repo, [RepositoryRole.PLUGINS] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories"))
+
+        then:
+        result.location == "<NO_URL>"
+    }
+
+    def "uses <NO_URL> sentinel when IvyArtifactRepository.getUrl() returns null"() {
+        given:
+        def repo = Stub(TestIvyRepo) {
+            getName() >> "noUrl"
+            getUrl() >> null
+            isAllowInsecureProtocol() >> false
+            getAuthentication() >> Stub(AuthenticationContainer)
+            getRepositoryDescriptorCopy() >> Stub(RepositoryContentDescriptorInternal) {
+                describeIncludeRules() >> []
+                describeExcludeRules() >> []
+                getIncludedConfigurations() >> null
+                getExcludedConfigurations() >> null
+                getRequiredAttributes() >> null
+            }
+        }
+
+        when:
+        def result = factory.toReportRepository(repo, [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(SETTINGS, null, "repositories"))
+
+        then:
+        result.type == RepositoryType.IVY
+        result.location == "<NO_URL>"
+    }
+
     // These abstract classes merge AbstractArtifactRepository with the per-type API so Spock can stub both.
     // (AbstractArtifactRepository is an abstract class, not an interface, so we use 'extends' + 'implements'.)
     static abstract class TestMavenRepo extends AbstractArtifactRepository implements MavenArtifactRepository {
         TestMavenRepo() { super(null, null) }
+    }
+    static abstract class TestIvyRepo extends AbstractArtifactRepository implements org.gradle.api.artifacts.repositories.IvyArtifactRepository {
+        TestIvyRepo() { super(null, null) }
     }
     static abstract class TestFlatDirRepo extends AbstractArtifactRepository implements FlatDirectoryArtifactRepository {
         TestFlatDirRepo() { super(null, null) }
@@ -243,6 +318,11 @@ class RepositoryReportModelFactoryTest extends Specification {
     // detection via getConfiguredCredentials() applies to this stub.
     static abstract class TestAuthMavenRepo extends AbstractArtifactRepository implements MavenArtifactRepository, AuthenticationSupportedInternal {
         TestAuthMavenRepo() { super(null, null) }
+    }
+    // A minimal AbstractArtifactRepository subclass that does NOT implement any of the
+    // Maven/Ivy/FlatDir/MavenLocal marker interfaces — must fall through to CUSTOM classification.
+    static abstract class TestCustomRepo extends AbstractArtifactRepository {
+        TestCustomRepo() { super(null, null) }
     }
 
     // Concrete classes named identically to the SPI interfaces so the factory's

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityCheckerTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityCheckerTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.util.Path
 import spock.lang.AutoCleanup
 import spock.lang.Specification
 
-import java.net.InetSocketAddress
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityCheckerTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/reachability/RepositoryReachabilityCheckerTest.groovy
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.reachability
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportContentFilter
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType
+import org.gradle.util.Path
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import java.net.InetSocketAddress
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.PROJECT
+
+class RepositoryReachabilityCheckerTest extends Specification {
+    @AutoCleanup("stop")
+    LightweightHttpServer server = new LightweightHttpServer()
+
+    def checker = new RepositoryReachabilityChecker(Duration.ofSeconds(5))
+
+    def "REACHABLE for 200 response on HEAD"() {
+        given:
+        server.start({ exchange -> respond(exchange, 200) })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.REACHABLE
+    }
+
+    def "REACHABLE for 3xx redirect"() {
+        given:
+        // HttpClient follows redirects (NORMAL) by default but only for absolute targets.
+        // We just return a 302 with a location pointing at the same server so the follow yields 200.
+        server.start({ exchange ->
+            if (exchange.requestURI.path == "/redirected") {
+                respond(exchange, 200)
+            } else {
+                exchange.responseHeaders.add("Location", server.uri() + "redirected")
+                respond(exchange, 302)
+            }
+        })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.REACHABLE
+    }
+
+    def "UNAUTHORIZED for #status"(int status) {
+        given:
+        server.start({ exchange -> respond(exchange, status) })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.UNAUTHORIZED
+
+        where:
+        status << [401, 403]
+    }
+
+    def "UNREACHABLE for #status after GET fallback also fails with 4xx/5xx"(int status) {
+        given:
+        server.start({ exchange -> respond(exchange, status) })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.UNREACHABLE
+
+        where:
+        status << [404, 500, 501]
+    }
+
+    def "REACHABLE via 405-on-HEAD, 200-on-GET fallback"() {
+        given:
+        server.start({ exchange ->
+            if (exchange.requestMethod == "HEAD") {
+                respond(exchange, 405)
+            } else {
+                respond(exchange, 200)
+            }
+        })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.REACHABLE
+    }
+
+    def "REACHABLE via widened 4xx/5xx-on-HEAD, 200-on-GET fallback for status #headStatus"(int headStatus) {
+        given:
+        server.start({ exchange ->
+            if (exchange.requestMethod == "HEAD") {
+                respond(exchange, headStatus)
+            } else {
+                respond(exchange, 200)
+            }
+        })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.REACHABLE
+
+        where:
+        headStatus << [400, 501]
+    }
+
+    def "UNREACHABLE when HEAD returns 500 and GET also returns 500"() {
+        given:
+        server.start({ exchange -> respond(exchange, 500) })
+        def repo = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[server.uri()] == ReachabilityStatus.UNREACHABLE
+    }
+
+    def "MALFORMED_URL when location fails URI parsing"() {
+        given:
+        // Force probeable (http scheme) prefix then invalid [bracket to fail URI parsing at probe time.
+        def bad = "http://[not-a-url/"
+        def repo = makeRepo(bad)
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result[bad] == ReachabilityStatus.MALFORMED_URL
+    }
+
+    def "MAVEN_LOCAL repositories are skipped"() {
+        given:
+        def repo = new ReportRepository(
+            "local", RepositoryType.MAVEN_LOCAL, "file:///tmp/mvn",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories"))
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result.isEmpty()
+    }
+
+    def "FLAT_DIR repositories are skipped"() {
+        given:
+        def repo = new ReportRepository(
+            "flat", RepositoryType.FLAT_DIR, "dirs:[/tmp/libs]",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories"))
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result.isEmpty()
+    }
+
+    def "non-http scheme is skipped"() {
+        given:
+        def repo = new ReportRepository(
+            "file", RepositoryType.MAVEN, "file:///tmp/x",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories"))
+
+        when:
+        def result = checker.check([repo], false)
+
+        then:
+        result.isEmpty()
+    }
+
+    def "offline mode returns empty map regardless of inputs"() {
+        given:
+        def repo = makeRepo("http://anywhere.example.com/")
+
+        when:
+        def result = checker.check([repo], true)
+
+        then:
+        result.isEmpty()
+    }
+
+    def "deduplicates: two repos with same location produce only one probe"() {
+        given:
+        def counter = new AtomicInteger(0)
+        server.start({ exchange ->
+            counter.incrementAndGet()
+            respond(exchange, 200)
+        })
+        def r1 = makeRepo(server.uri())
+        def r2 = makeRepo(server.uri())
+
+        when:
+        def result = checker.check([r1, r2], false)
+
+        then:
+        result.size() == 1
+        result[server.uri()] == ReachabilityStatus.REACHABLE
+        counter.get() == 1
+    }
+
+    private static ReportRepository makeRepo(String location) {
+        return new ReportRepository(
+            "r", RepositoryType.MAVEN, location,
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set,
+            new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories"))
+    }
+
+    private static void respond(HttpExchange exchange, int status) {
+        exchange.sendResponseHeaders(status, -1)
+        exchange.close()
+    }
+
+    /**
+     * Minimal HTTP server fixture so these unit tests do not depend on Jetty or on the
+     * integration-test HttpServer fixture (which lives in testFixtures we don't consume here).
+     */
+    static class LightweightHttpServer {
+        HttpServer underlying
+        int port
+
+        void start(HttpHandler handler) {
+            underlying = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+            underlying.createContext("/", handler)
+            underlying.start()
+            port = underlying.address.port
+        }
+
+        String uri() {
+            return "http://127.0.0.1:${port}/"
+        }
+
+        void stop() {
+            if (underlying != null) {
+                underlying.stop(0)
+            }
+        }
+    }
+}

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
@@ -515,6 +515,23 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
         text.count("Credentials: PRESENT") == 1
     }
 
+    def "identityKey differs when hasCredentials differs"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def withCreds = new ReportRepository(
+            "Repo", RepositoryType.MAVEN, "https://example.com/",
+            true, [], true, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def withoutCreds = new ReportRepository(
+            "Repo", RepositoryType.MAVEN, "https://example.com/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+
+        expect:
+        withCreds.identityKey() != withoutCreds.identityKey()
+        withCreds.identityKey().hashCode() != withoutCreds.identityKey().hashCode()
+    }
+
     def "All Repositories numbers settings buckets before per-project entries"() {
         given:
         def bsSite = new RepositoryDeclarationSite(SETTINGS, null, "buildscript.repositories")

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
@@ -32,6 +32,7 @@ import spock.lang.Specification
 import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.PROJECT
 import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.SETTINGS
 
+/** Tests for {@link ConsoleRepositoriesReportRenderer}. */
 class ConsoleRepositoriesReportRendererTest extends Specification {
     def output = new TestStyledTextOutput()
 
@@ -39,7 +40,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
         given:
         def model = new RepositoryReportFullModel(
             new RepositoryReportSettingsModel([], [], []),
-            new TreeMap<>(RepositoryReportFullModel.pathComparator())
+            new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         )
         def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
 
@@ -57,7 +58,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
 
     def "renders filtered empty model with project-specific empty message"() {
         given:
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
         def model = new RepositoryReportFullModel(
@@ -85,7 +86,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             true, [], false, ReportContentFilter.EMPTY, [RepositoryRole.PLUGINS] as Set, site
         )
         def settings = new RepositoryReportSettingsModel([], [repo], [])
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
         def model = new RepositoryReportFullModel(settings, projects)
@@ -123,7 +124,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
         def repo2 = new ReportRepository(
             "MavenRepo", RepositoryType.MAVEN, "https://repo.maven.apache.org/maven2/",
             true, [], false, content, [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site2)
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo1]))
         projects.put(Path.path(":lib"),
@@ -150,7 +151,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             "RepoA", RepositoryType.MAVEN, "https://a.example/",
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
         projects.put(Path.path(":lib"),
@@ -182,7 +183,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             [RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES] as Set, site
         )
         def settings = new RepositoryReportSettingsModel([repo], [], [])
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         def model = new RepositoryReportFullModel(settings, projects)
         def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
 
@@ -221,7 +222,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, projSite
         )
         def settings = new RepositoryReportSettingsModel([], [pluginRepo], [drmRepo])
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))
         def model = new RepositoryReportFullModel(settings, projects)
@@ -248,7 +249,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, projSite
         )
         def settings = new RepositoryReportSettingsModel([], [], [])
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))
         projects.put(Path.path(":lib"),
@@ -282,7 +283,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             [RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES] as Set, settingsSite
         )
         def settings = new RepositoryReportSettingsModel([settingsBuildscriptRepo], [], [])
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
         projects.put(Path.path(":lib"),
@@ -316,7 +317,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, otherSite
         )
         def settings = new RepositoryReportSettingsModel([], [], [])
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":foo"),
             new RepositoryReportProjectModel(Path.path(":foo"), "foo", [], []))
         projects.put(Path.path(":other"),
@@ -345,7 +346,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             "DeadRepo", RepositoryType.MAVEN, "http://127.0.0.1:1/",
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
         def model = new RepositoryReportFullModel(new RepositoryReportSettingsModel([], [], []), projects)
@@ -374,7 +375,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             "AuthRepo", RepositoryType.MAVEN, "https://auth.example/",
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
         def model = new RepositoryReportFullModel(new RepositoryReportSettingsModel([], [], []), projects)
@@ -402,7 +403,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             "BadRepo", RepositoryType.MAVEN, "http://[not-a-url/",
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
         def model = new RepositoryReportFullModel(new RepositoryReportSettingsModel([], [], []), projects)
@@ -431,7 +432,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             "AnyRepo", RepositoryType.MAVEN, "https://any.example/",
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
         def model = new RepositoryReportFullModel(new RepositoryReportSettingsModel([], [], []), projects)
@@ -461,7 +462,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             "LiveRepo", RepositoryType.MAVEN, "https://live.example/",
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
         def model = new RepositoryReportFullModel(new RepositoryReportSettingsModel([], [], []), projects)
@@ -495,7 +496,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, siteWithoutCreds
         )
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repoWithCreds, repoWithoutCreds]))
         def settings = new RepositoryReportSettingsModel([], [], [])
@@ -515,7 +516,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
         text.count("Credentials: PRESENT") == 1
     }
 
-    def "identityKey differs when hasCredentials differs"() {
+    def "getIdentityKey differs when hasCredentials differs"() {
         given:
         def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
         def withCreds = new ReportRepository(
@@ -528,8 +529,8 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
 
         expect:
-        withCreds.identityKey() != withoutCreds.identityKey()
-        withCreds.identityKey().hashCode() != withoutCreds.identityKey().hashCode()
+        withCreds.getIdentityKey() != withoutCreds.getIdentityKey()
+        withCreds.getIdentityKey().hashCode() != withoutCreds.getIdentityKey().hashCode()
     }
 
     def "All Repositories numbers settings buckets before per-project entries"() {
@@ -559,7 +560,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, appSite
         )
         def settings = new RepositoryReportSettingsModel([bsRepo], [plRepo], [drmRepo])
-        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def projects = new TreeMap<>(RepositoryReportFullModel.getPathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))
         def model = new RepositoryReportFullModel(settings, projects)

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
@@ -395,6 +395,35 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
         !text.contains("(ur) Unreachable")
     }
 
+    def "renders (m) marker and legend entry when a repo has a MALFORMED_URL"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "BadRepo", RepositoryType.MAVEN, "http://[not-a-url/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        def model = new RepositoryReportFullModel(new RepositoryReportSettingsModel([], [], []), projects)
+        def spec = new RepositoriesReportSpec(null, false,
+            ["http://[not-a-url/": ReachabilityStatus.MALFORMED_URL])
+        def renderer = new ConsoleRepositoriesReportRenderer(spec)
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("BadRepo (1)")
+        text.contains("Location:   http://[not-a-url/ (m)")
+        !text.contains("BadRepo (1) (m)")
+        text.contains("Legend")
+        text.contains("(m)  Malformed URL")
+        !text.contains("(ur) Unreachable")
+        !text.contains("(ua) Unauthorized")
+    }
+
     def "renders (o) marker on All Repositories heading and legend when offline"() {
         given:
         def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
@@ -1,0 +1,529 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.gradle.api.tasks.diagnostics.internal.repositories.renderer
+
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportContentFilter
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.ReportRepository
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportFullModel
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportProjectModel
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryReportSettingsModel
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryRole
+import org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryType
+import org.gradle.api.tasks.diagnostics.internal.repositories.reachability.ReachabilityStatus
+import org.gradle.api.tasks.diagnostics.internal.repositories.spec.RepositoriesReportSpec
+import org.gradle.internal.logging.text.TestStyledTextOutput
+import org.gradle.util.Path
+import spock.lang.Specification
+
+import java.util.TreeMap
+
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.PROJECT
+import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.SETTINGS
+
+class ConsoleRepositoriesReportRendererTest extends Specification {
+    def output = new TestStyledTextOutput()
+
+    def "renders completely empty model with top-level empty message"() {
+        given:
+        def model = new RepositoryReportFullModel(
+            new RepositoryReportSettingsModel([], [], []),
+            new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        )
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("There are no repositories present.")
+        !text.contains("All Repositories")
+        !text.contains("Repositories by Location")
+        !text.contains("(none)")
+        !text.contains("Legend")
+    }
+
+    def "renders filtered empty model with project-specific empty message"() {
+        given:
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
+        def model = new RepositoryReportFullModel(
+            new RepositoryReportSettingsModel([], [], []),
+            projects
+        )
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(":app"))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("There are no repositories present in project ':app'.")
+        !text.contains("All Repositories")
+        !text.contains("Repositories by Location")
+        !text.contains("(none)")
+    }
+
+    def "renders single PLUGINS repo in All Repositories section with correct numbering"() {
+        given:
+        def site = new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories")
+        def repo = new ReportRepository(
+            "MavenRepo", RepositoryType.MAVEN, "https://repo.maven.apache.org/maven2/",
+            true, [], false, ReportContentFilter.EMPTY, [RepositoryRole.PLUGINS] as Set, site
+        )
+        def settings = new RepositoryReportSettingsModel([repo], [], [])
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
+        def model = new RepositoryReportFullModel(settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("All Repositories")
+        text.contains("MavenRepo (1)")
+        text.contains("Location:")
+        text.contains("https://repo.maven.apache.org/maven2/")
+        text.contains("Roles:")
+        text.contains("PLUGINS")
+        text.contains("Defined in:")
+        text.contains("settings > pluginManagement.repositories")
+        text.contains("Repositories by Location")
+        text.contains("settings uses")
+        text.contains("project ':app' uses")
+        text.contains("- MavenRepo (1)")
+        !text.contains("(none)")
+        !text.contains("Legend")
+    }
+
+    def "renders Legend when identical declarations present"() {
+        given:
+        def content = ReportContentFilter.EMPTY
+        def site1 = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def site2 = new RepositoryDeclarationSite(PROJECT, Path.path(":lib"), "repositories")
+        def repo1 = new ReportRepository(
+            "MavenRepo", RepositoryType.MAVEN, "https://repo.maven.apache.org/maven2/",
+            true, [], false, content, [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site1)
+        def repo2 = new ReportRepository(
+            "MavenRepo", RepositoryType.MAVEN, "https://repo.maven.apache.org/maven2/",
+            true, [], false, content, [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site2)
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo1]))
+        projects.put(Path.path(":lib"),
+            new RepositoryReportProjectModel(Path.path(":lib"), "lib", [], [repo2]))
+        def settings = new RepositoryReportSettingsModel([], [], [])
+        def model = new RepositoryReportFullModel(settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("MavenRepo (1) *")
+        text.contains("MavenRepo (2) *")
+        text.contains("Legend")
+        text.contains("Identical repository declaration")
+    }
+
+    def "--project filter suppresses settings block and limits Repositories by Location to the filtered project"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "RepoA", RepositoryType.MAVEN, "https://a.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        projects.put(Path.path(":lib"),
+            new RepositoryReportProjectModel(Path.path(":lib"), "lib", [], []))
+        def settings = new RepositoryReportSettingsModel([], [], [])
+        def model = new RepositoryReportFullModel(settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(":app"))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("All Repositories")
+        text.contains("RepoA (1)")
+        text.contains("Repositories by Location")
+        text.contains("project ':app' uses")
+        text.contains("- RepoA (1)")
+        !text.contains("settings uses")
+        !text.contains(":lib")
+    }
+
+    def "renders settings-declared buildscript repo in All Repositories and under settings uses"() {
+        given:
+        def site = new RepositoryDeclarationSite(SETTINGS, null, "buildscript.repositories")
+        def repo = new ReportRepository(
+            "BuildRepo", RepositoryType.MAVEN, "https://corp.example.com/buildscript/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES] as Set, site
+        )
+        def settings = new RepositoryReportSettingsModel([], [repo], [])
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        def model = new RepositoryReportFullModel(settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("All Repositories")
+        text.contains("BuildRepo (1)")
+        text.contains("SETTINGS_BUILDSCRIPT_DEPENDENCIES")
+        text.contains("settings > buildscript.repositories")
+        text.contains("Repositories by Location")
+        text.contains("settings uses")
+        text.contains("- BuildRepo (1)")
+    }
+
+    def "--project filter includes PLUGINS and DRM repos from settings but no settings uses block"() {
+        given:
+        def pluginSite = new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories")
+        def drmSite = new RepositoryDeclarationSite(SETTINGS, null, "dependencyResolutionManagement.repositories")
+        def projSite = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def pluginRepo = new ReportRepository(
+            "PluginPortal", RepositoryType.MAVEN, "https://plugins.gradle.org/m2/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PLUGINS] as Set, pluginSite
+        )
+        def drmRepo = new ReportRepository(
+            "DrmRepo", RepositoryType.MAVEN, "https://repo.maven.apache.org/maven2/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, drmSite
+        )
+        def appRepo = new ReportRepository(
+            "AppRepo", RepositoryType.MAVEN, "https://app.example.com/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, projSite
+        )
+        def settings = new RepositoryReportSettingsModel([pluginRepo], [], [drmRepo])
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))
+        def model = new RepositoryReportFullModel(settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(":app"))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("PluginPortal (1)")
+        text.contains("DrmRepo (2)")
+        text.contains("AppRepo (3)")
+        text.contains("project ':app' uses")
+        !text.contains("settings uses")
+    }
+
+    def "omits project blocks in Repositories by Location when their reference lists are empty"() {
+        given:
+        def projSite = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def appRepo = new ReportRepository(
+            "AppRepo", RepositoryType.MAVEN, "https://app.example.com/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, projSite
+        )
+        def settings = new RepositoryReportSettingsModel([], [], [])
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))
+        projects.put(Path.path(":lib"),
+            new RepositoryReportProjectModel(Path.path(":lib"), "lib", [], []))
+        def model = new RepositoryReportFullModel(settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("Repositories by Location")
+        text.contains("project ':app' uses")
+        text.contains("- AppRepo (1)")
+        // settings has no declared repos — block is suppressed
+        !text.contains("settings uses")
+        // :lib has no refs — block is suppressed
+        !text.contains("project ':lib' uses")
+        !text.contains("(none)")
+    }
+
+    def "omits empty project blocks but keeps settings uses when only settings.buildscript present"() {
+        given:
+        // A settings.buildscript repo — goes into All Repositories and under "settings uses" as a bucket.
+        // Projects have no refs (no PLUGINS, no DRM, no project repos).
+        def settingsSite = new RepositoryDeclarationSite(SETTINGS, null, "buildscript.repositories")
+        def settingsBuildscriptRepo = new ReportRepository(
+            "BuildRepo", RepositoryType.MAVEN, "https://corp.example.com/buildscript/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES] as Set, settingsSite
+        )
+        def settings = new RepositoryReportSettingsModel([], [settingsBuildscriptRepo], [])
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
+        projects.put(Path.path(":lib"),
+            new RepositoryReportProjectModel(Path.path(":lib"), "lib", [], []))
+        def model = new RepositoryReportFullModel(settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("All Repositories")
+        text.contains("BuildRepo (1)")
+        text.contains("Repositories by Location")
+        text.contains("settings uses")
+        text.contains("- BuildRepo (1)")
+        // Per-project blocks are suppressed because they inherit no PLUGINS/DRM and declare nothing
+        !text.contains("project ':app' uses")
+        !text.contains("project ':lib' uses")
+        !text.contains("(none)")
+    }
+
+    def "suppresses Repositories by Location heading entirely when --project target has empty reference list"() {
+        given:
+        // Some repo exists in another project so the top-level empty-model short-circuit does not trigger.
+        def otherSite = new RepositoryDeclarationSite(PROJECT, Path.path(":other"), "repositories")
+        def otherRepo = new ReportRepository(
+            "OtherRepo", RepositoryType.MAVEN, "https://other.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, otherSite
+        )
+        def settings = new RepositoryReportSettingsModel([], [], [])
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":foo"),
+            new RepositoryReportProjectModel(Path.path(":foo"), "foo", [], []))
+        projects.put(Path.path(":other"),
+            new RepositoryReportProjectModel(Path.path(":other"), "other", [], [otherRepo]))
+        def model = new RepositoryReportFullModel(settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(":foo"))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        // The filtered "All Repositories" section still renders (with (none) content since :foo has no repos).
+        text.contains("All Repositories")
+        // Repositories by Location section is suppressed entirely because :foo has no refs.
+        !text.contains("Repositories by Location")
+        !text.contains("settings uses")
+        !text.contains("project ':foo' uses")
+        !text.contains("project ':other' uses")
+    }
+
+    def "renders (ur) marker and legend entry when a repo is UNREACHABLE"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "DeadRepo", RepositoryType.MAVEN, "http://127.0.0.1:1/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        def model = new RepositoryReportFullModel(new RepositoryReportSettingsModel([], [], []), projects)
+        def spec = new RepositoriesReportSpec(null, false,
+            ["http://127.0.0.1:1/": ReachabilityStatus.UNREACHABLE])
+        def renderer = new ConsoleRepositoriesReportRenderer(spec)
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("DeadRepo (1)")
+        text.contains("Location:   http://127.0.0.1:1/ (ur)")
+        !text.contains("DeadRepo (1) (ur)")
+        text.contains("Legend")
+        text.contains("(ur) Unreachable")
+        !text.contains("(ua) Unauthorized")
+        !text.contains("(o)  Running in offline")
+    }
+
+    def "renders (ua) marker and legend entry when a repo is UNAUTHORIZED"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "AuthRepo", RepositoryType.MAVEN, "https://auth.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        def model = new RepositoryReportFullModel(new RepositoryReportSettingsModel([], [], []), projects)
+        def spec = new RepositoriesReportSpec(null, false,
+            ["https://auth.example/": ReachabilityStatus.UNAUTHORIZED])
+        def renderer = new ConsoleRepositoriesReportRenderer(spec)
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("AuthRepo (1)")
+        text.contains("Location:   https://auth.example/ (ua)")
+        !text.contains("AuthRepo (1) (ua)")
+        text.contains("Legend")
+        text.contains("(ua) Unauthorized")
+        !text.contains("(ur) Unreachable")
+    }
+
+    def "renders (o) marker on All Repositories heading and legend when offline"() {
+        given:
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "AnyRepo", RepositoryType.MAVEN, "https://any.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        def model = new RepositoryReportFullModel(new RepositoryReportSettingsModel([], [], []), projects)
+        def spec = new RepositoriesReportSpec(null, true, [:])
+        def renderer = new ConsoleRepositoriesReportRenderer(spec)
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("All Repositories (o)")
+        text.contains("Legend")
+        text.contains("(o)  Running in offline mode")
+        // No per-repo reachability markers in offline mode.
+        !text.contains("(ur)")
+        !text.contains("(ua)")
+        // Sanity: the repo itself still renders.
+        text.contains("AnyRepo (1)")
+    }
+
+    def "legend is suppressed when no marker was emitted even if reachability map is provided"() {
+        given:
+        // A REACHABLE status must not trigger any marker — and therefore no legend.
+        def site = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repo = new ReportRepository(
+            "LiveRepo", RepositoryType.MAVEN, "https://live.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, site)
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repo]))
+        def model = new RepositoryReportFullModel(new RepositoryReportSettingsModel([], [], []), projects)
+        def spec = new RepositoriesReportSpec(null, false,
+            ["https://live.example/": ReachabilityStatus.REACHABLE])
+        def renderer = new ConsoleRepositoriesReportRenderer(spec)
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("LiveRepo (1)")
+        !text.contains("(ur)")
+        !text.contains("(ua)")
+        !text.contains("(o)")
+        !text.contains("Legend")
+    }
+
+    def "renders Credentials: PRESENT line when hasCredentials is true and omits it otherwise"() {
+        given:
+        def siteWithCreds = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def siteWithoutCreds = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def repoWithCreds = new ReportRepository(
+            "SecuredRepo", RepositoryType.MAVEN, "https://corp.example.com/",
+            true, [], true, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, siteWithCreds
+        )
+        def repoWithoutCreds = new ReportRepository(
+            "OpenRepo", RepositoryType.MAVEN, "https://open.example.com/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, siteWithoutCreds
+        )
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [repoWithCreds, repoWithoutCreds]))
+        def settings = new RepositoryReportSettingsModel([], [], [])
+        def model = new RepositoryReportFullModel(settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        text.contains("SecuredRepo (1)")
+        text.contains("OpenRepo (2)")
+        // Credentials line renders for the repo that has them
+        text.contains("Credentials: PRESENT")
+        // Exactly once — not for the other repo
+        text.count("Credentials: PRESENT") == 1
+    }
+
+    def "All Repositories numbers settings buckets before per-project entries"() {
+        given:
+        def bsSite = new RepositoryDeclarationSite(SETTINGS, null, "buildscript.repositories")
+        def plSite = new RepositoryDeclarationSite(SETTINGS, null, "pluginManagement.repositories")
+        def drmSite = new RepositoryDeclarationSite(SETTINGS, null, "dependencyResolutionManagement.repositories")
+        def appSite = new RepositoryDeclarationSite(PROJECT, Path.path(":app"), "repositories")
+        def bsRepo = new ReportRepository(
+            "SBD", RepositoryType.MAVEN, "https://sbd.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES] as Set, bsSite
+        )
+        def plRepo = new ReportRepository(
+            "PL", RepositoryType.MAVEN, "https://pl.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PLUGINS] as Set, plSite
+        )
+        def drmRepo = new ReportRepository(
+            "DRM", RepositoryType.MAVEN, "https://drm.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, drmSite
+        )
+        def appRepo = new ReportRepository(
+            "APP", RepositoryType.MAVEN, "https://app.example/",
+            true, [], false, ReportContentFilter.EMPTY,
+            [RepositoryRole.PROJECT_DEPENDENCIES] as Set, appSite
+        )
+        def settings = new RepositoryReportSettingsModel([plRepo], [bsRepo], [drmRepo])
+        def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
+        projects.put(Path.path(":app"),
+            new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))
+        def model = new RepositoryReportFullModel(settings, projects)
+        def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
+
+        when:
+        renderer.render(model, output)
+
+        then:
+        def text = output.getRawValue()
+        // Ordering: SBD(1) -> PL(2) -> DRM(3) -> APP(4)
+        text.contains("SBD (1)")
+        text.contains("PL (2)")
+        text.contains("DRM (3)")
+        text.contains("APP (4)")
+    }
+}

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
@@ -6,6 +6,12 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.gradle.api.tasks.diagnostics.internal.repositories.renderer
 
@@ -22,8 +28,6 @@ import org.gradle.api.tasks.diagnostics.internal.repositories.spec.RepositoriesR
 import org.gradle.internal.logging.text.TestStyledTextOutput
 import org.gradle.util.Path
 import spock.lang.Specification
-
-import java.util.TreeMap
 
 import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.PROJECT
 import static org.gradle.api.tasks.diagnostics.internal.repositories.model.RepositoryDeclarationSite.Scope.SETTINGS

--- a/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
+++ b/platforms/software/software-diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/repositories/renderer/ConsoleRepositoriesReportRendererTest.groovy
@@ -84,7 +84,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             "MavenRepo", RepositoryType.MAVEN, "https://repo.maven.apache.org/maven2/",
             true, [], false, ReportContentFilter.EMPTY, [RepositoryRole.PLUGINS] as Set, site
         )
-        def settings = new RepositoryReportSettingsModel([repo], [], [])
+        def settings = new RepositoryReportSettingsModel([], [repo], [])
         def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
@@ -181,7 +181,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES] as Set, site
         )
-        def settings = new RepositoryReportSettingsModel([], [repo], [])
+        def settings = new RepositoryReportSettingsModel([repo], [], [])
         def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
         def model = new RepositoryReportFullModel(settings, projects)
         def renderer = new ConsoleRepositoriesReportRenderer(new RepositoriesReportSpec(null))
@@ -220,7 +220,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, projSite
         )
-        def settings = new RepositoryReportSettingsModel([pluginRepo], [], [drmRepo])
+        def settings = new RepositoryReportSettingsModel([], [pluginRepo], [drmRepo])
         def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))
@@ -281,7 +281,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.SETTINGS_BUILDSCRIPT_DEPENDENCIES] as Set, settingsSite
         )
-        def settings = new RepositoryReportSettingsModel([], [settingsBuildscriptRepo], [])
+        def settings = new RepositoryReportSettingsModel([settingsBuildscriptRepo], [], [])
         def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], []))
@@ -558,7 +558,7 @@ class ConsoleRepositoriesReportRendererTest extends Specification {
             true, [], false, ReportContentFilter.EMPTY,
             [RepositoryRole.PROJECT_DEPENDENCIES] as Set, appSite
         )
-        def settings = new RepositoryReportSettingsModel([plRepo], [bsRepo], [drmRepo])
+        def settings = new RepositoryReportSettingsModel([bsRepo], [plRepo], [drmRepo])
         def projects = new TreeMap<>(RepositoryReportFullModel.pathComparator())
         projects.put(Path.path(":app"),
             new RepositoryReportProjectModel(Path.path(":app"), "app", [], [appRepo]))

--- a/repositories-report.md
+++ b/repositories-report.md
@@ -1,0 +1,127 @@
+# Repositories Report
+
+`./gradlew :repositories` (or `./gradlew repositories` at the root project) prints a
+unified, diagnostics-only view of every repository declared in a build, across every
+settings-level and project-level declaration site, including repositories added by
+plugins. The report is incubating.
+
+## What the report shows
+
+### Section 1: All Repositories
+
+Flat, globally numbered list of every repository in the build, emitted in this order:
+
+1. `settings.buildscript.repositories`
+2. `settings.pluginManagement.repositories`
+3. `settings.dependencyResolutionManagement.repositories`
+4. Each project (alphabetical by path) — its `buildscript.repositories` followed by
+   its `repositories` block.
+
+Each entry renders:
+
+```
+<Name> (<number>) [*]
+    Location:   <url> [(ur)|(ua)|(m)]
+    Type:       MAVEN | MAVEN_LOCAL | IVY | FLAT_DIR | CUSTOM
+    Roles:      <sorted list of RepositoryRole values>
+    Secure:     false         # only when allowInsecureProtocol=true
+    Auth:       <scheme class names sorted alphabetically>  # only when declared
+    Credentials: PRESENT      # only when credentials{} declared (no values leak)
+    Content:    <rules joined with ", ">
+    Defined in: settings > <block>  | project ':path' > <block>
+```
+
+### Section 2: Repositories by Location
+
+Groups repositories by "who uses them":
+
+- `settings uses` lists every repository declared in any of the three settings buckets.
+- `project ':foo' uses` lists (a) every PLUGINS and DRM repo inherited from settings,
+  plus (b) project-local `buildscript.repositories` and `repositories` declarations.
+
+### Legend
+
+A final Legend section is emitted only when at least one marker was actually rendered
+in the report above.
+
+## Markers
+
+| Marker | Meaning |
+| --- | --- |
+| `(*)` | Identical repository declaration found in multiple locations. Appears on the entry, not on the `Location:` line. |
+| `(ur)` | Unreachable. The URL could not be contacted after the HEAD (+ GET fallback) probe. Rendered on the `Location:` line. |
+| `(ua)` | Unauthorized. The URL returned 401 or 403. Rendered on the `Location:` line. |
+| `(m)` | Malformed URL. The URL could not be parsed as a URI. Rendered on the `Location:` line. |
+| `(o)` | Offline. Appears on the "All Repositories" heading when the build was invoked with `--offline`; per-repo reachability markers are suppressed. |
+
+## Filtering
+
+`./gradlew :repositories --project :foo` limits Section 2 to a single project and
+suppresses the settings bucket block. Unknown project paths fail with a clear error
+message.
+
+## Reachability probes
+
+For every unique remote HTTP(S) URL (local and `FLAT_DIR` repositories are skipped),
+the task issues an HTTP `HEAD`. If the response is any 4xx/5xx, it retries with `GET`
+and classifies on the GET response. Each probe is bounded by a 5-second per-URL
+timeout. Probes run in parallel on a small fixed daemon thread pool (capped at 8).
+
+At task start the report emits (non-offline only):
+
+```
+Probing <N> repository URL(s)...
+...
+done.
+```
+
+`URISyntaxException` in the probe produces `MALFORMED_URL`, rendered as `(m)`.
+
+Credentials are never sent during the probe — any URL gated behind HTTP auth is
+classified as `UNAUTHORIZED` (`(ua)` marker).
+
+### Offline mode
+
+With `--offline`, no probes run, the "All Repositories" heading carries `(o)`, and
+the Legend explains offline mode.
+
+## Null URL handling
+
+If a `MavenArtifactRepository` or `IvyArtifactRepository` is misconfigured such that
+`getUrl()` returns null, the `Location:` line renders the sentinel `<NO_URL>` instead
+of the literal string `"null"`.
+
+## Repository types
+
+| Type | Underlying Gradle repository |
+| --- | --- |
+| `MAVEN` | `MavenArtifactRepository` (non-local) |
+| `MAVEN_LOCAL` | `mavenLocal()` |
+| `IVY` | `IvyArtifactRepository` |
+| `FLAT_DIR` | `FlatDirectoryArtifactRepository` |
+| `CUSTOM` | Any other `AbstractArtifactRepository` subclass. `Location:` surfaces the concrete class name. |
+
+## Configuration cache
+
+The task is CC-compatible. Model construction runs at configuration time via a
+`Cached<>` field; reachability probes run at task-execution time only.
+
+## Tests
+
+| Test class | Count |
+| --- | --- |
+| `DefaultRepositoryContentDescriptorDescribeRulesTest` | 12 |
+| `ConsoleRepositoriesReportRendererTest` | 18 |
+| `RepositoryReportModelFactoryTest` | 10 |
+| `RepositoryReachabilityCheckerTest` | 17 |
+| `RepositoriesReportTaskIntegrationTest` | 35 |
+
+## Verification commands
+
+```bash
+./gradlew :dependency-management:test --tests "*DefaultRepositoryContentDescriptorDescribeRulesTest*"
+./gradlew :software-diagnostics:test --tests "*ConsoleRepositoriesReportRendererTest*"
+./gradlew :software-diagnostics:test --tests "*RepositoryReportModelFactoryTest*"
+./gradlew :software-diagnostics:test --tests "*RepositoryReachabilityCheckerTest*"
+./gradlew :software-diagnostics:embeddedIntegTest --tests "*RepositoriesReportTaskIntegrationTest*"
+```

--- a/repositories-report.md
+++ b/repositories-report.md
@@ -17,6 +17,11 @@ Flat, globally numbered list of every repository in the build, emitted in this o
 4. Each project (alphabetical by path) — its `buildscript.repositories` followed by
    its `repositories` block.
 
+This sequence matches the order Gradle actually resolves repositories during a build
+(settings-script classpath → plugin resolution → per-project dependencies), and the
+task walks the settings containers and project containers in the same order it
+displays them — gather order and display order are unified.
+
 Each entry renders:
 
 ```

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/NewDefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/NewDefaultProjectTest.groovy
@@ -33,11 +33,11 @@ class NewDefaultProjectTest extends AbstractProjectBuilderSpec {
 
         then:
         rootTasks.size() == 2
-        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
-        rootTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":repositories", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
+        rootTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:repositories", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
 
         aTasks.size() == 1
-        aTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        aTasks[a]*.path as Set == [":a:artifactTransforms", ":a:bar", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:repositories", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
     }
 
     def "provides all tasks non-recursively"() {
@@ -51,10 +51,10 @@ class NewDefaultProjectTest extends AbstractProjectBuilderSpec {
 
         then:
         rootTasks.size() == 1
-        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
+        rootTasks[project]*.path as Set == [":bar", ":artifactTransforms", ":buildEnvironment", ":dependencies", ":dependencyInsight", ":foo", ":help", ":init", ":javaToolchains", ":outgoingVariants", ":projects", ":properties", ":repositories", ":resolvableConfigurations", ":tasks", ":wrapper", ":updateDaemonJvm", ":foo"] as Set
 
         aTasks.size() == 1
-        aTasks[a]*.path as Set == [":a:bar", ":a:artifactTransforms", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
+        aTasks[a]*.path as Set == [":a:bar", ":a:artifactTransforms", ":a:buildEnvironment", ":a:dependencies", ":a:dependencyInsight", ":a:foo", ":a:help", ":a:javaToolchains", ":a:outgoingVariants", ":a:projects", ":a:properties", ":a:repositories", ":a:resolvableConfigurations", ":a:tasks", ":a:foo"] as Set
     }
 
     def "provides task by name recursively"() {

--- a/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
+++ b/testing/architecture-test/src/changes/accepted-changes/accepted-public-api-changes.json
@@ -1,3 +1,10 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.tasks.diagnostics.RepositoriesReportTask",
+            "member": "Constructor org.gradle.api.tasks.diagnostics.RepositoriesReportTask()",
+            "acceptation": "Abstract class has no explicit constructor; @since is on the class itself",
+            "changes": []
+        }
+    ]
 }

--- a/testing/integ-test/src/integTest/groovy/org/gradle/api/tasks/diagnostics/FullTaskListingTaskReportTaskIntegrationTest.groovy
+++ b/testing/integ-test/src/integTest/groovy/org/gradle/api/tasks/diagnostics/FullTaskListingTaskReportTaskIntegrationTest.groovy
@@ -49,6 +49,7 @@ javaToolchains - Displays the detected java toolchains.
 outgoingVariants - Displays the outgoing variants of root project '$projectName'.
 projects - Displays the sub-projects of root project '$projectName'.
 properties - Displays the properties of root project '$projectName'.
+repositories - Displays the repositories available for dependency resolution.
 resolvableConfigurations - Displays the configurations that can be resolved in root project '$projectName'.
 tasks - Displays the tasks runnable from root project '$projectName'.""")
 
@@ -83,6 +84,7 @@ javaToolchains (org.gradle.jvm.toolchain.internal.task.ShowToolchainsTask) - Dis
 outgoingVariants (org.gradle.api.tasks.diagnostics.OutgoingVariantsReportTask) - Displays the outgoing variants of root project '$projectName'.
 projects (org.gradle.api.tasks.diagnostics.ProjectReportTask) - Displays the sub-projects of root project '$projectName'.
 properties (org.gradle.api.tasks.diagnostics.PropertyReportTask) - Displays the properties of root project '$projectName'.
+repositories (org.gradle.api.tasks.diagnostics.RepositoriesReportTask) - Displays the repositories available for dependency resolution.
 resolvableConfigurations (org.gradle.api.tasks.diagnostics.ResolvableConfigurationsReportTask) - Displays the configurations that can be resolved in root project '$projectName'.
 tasks (org.gradle.api.tasks.diagnostics.TaskReportTask) - Displays the tasks runnable from root project '$projectName'.""")
     }


### PR DESCRIPTION
Add a new `repositories` diagnostic task that provides a unified view of all repository declarations across settings and projects. This help task communicates where repositories are defined, what roles they play (e.g., plugins vs. project dependencies), and identifies potential configuration issues like insecure protocols or duplicate declarations.

This should help human and AI agents better understand potential sources for plugins and dependencies.

The report also includes lightweight reachability probes to identify unreachable or unauthorized remote repository URLs at execution time.

Roles, markers for the legend, and other minor formating and decisions about what fields to include should be treated as placeholders for further discussion.

> [!NOTE] 
> Run `RepositoriesReportTaskIntegrationTest` to see many examples.

```
--------------------------------------------------------
All Repositories
--------------------------------------------------------

MavenRepo (1) *
    Location:   https://repo.maven.apache.org/maven2/
    Type:       MAVEN
    Roles:      PROJECT_DEPENDENCIES
    Defined in: project ':' > repositories

MavenRepo (2) *
    Location:   https://repo.maven.apache.org/maven2/
    Type:       MAVEN
    Roles:      PROJECT_DEPENDENCIES
    Defined in: project ':app' > repositories

maven (3) *
    Location:   https://sub.example.com/ (ur)
    Type:       MAVEN
    Roles:      PROJECT_DEPENDENCIES
    Defined in: project ':app' > repositories

MavenRepo (4) *
    Location:   https://repo.maven.apache.org/maven2/
    Type:       MAVEN
    Roles:      PROJECT_DEPENDENCIES
    Defined in: project ':lib' > repositories

maven (5) *
    Location:   https://sub.example.com/ (ur)
    Type:       MAVEN
    Roles:      PROJECT_DEPENDENCIES
    Defined in: project ':lib' > repositories

--------------------------------------------------------
Repositories by Location
--------------------------------------------------------

project ':' uses
    - MavenRepo (1)

project ':app' uses
    - MavenRepo (2)
    - maven (3)

project ':lib' uses
    - MavenRepo (4)
    - maven (5)

--------------------------------------------------------
Legend
--------------------------------------------------------

(*) Identical repository declaration found in multiple locations.
    Consider consolidating to settings.dependencyResolutionManagement.repositories
    or settings.pluginManagement.repositories.
    See https://docs.gradle.org/current/userguide/centralizing_repositories.html
(ur) Unreachable — the URL could not be contacted.
```

# Details
`repositories` is a new Gradle console report task that gives a unified view of every repository a build uses across settings-level and project-level declaration sites, annotates each with the kinds of dependencies it is allowed to serve, and probes each remote URL for reachability.

## Summary

| Attribute | Value |
|---|---|
| Task name | `repositories` |
| Task class | `org.gradle.api.tasks.diagnostics.RepositoriesReportTask` |
| Group | `help` |
| Configuration-cache compatible | Yes |
| Included-build descent | No (scoped to the current build) |
| File outputs | None — console only |

Invocation:

```bash
./gradlew repositories
./gradlew repositories --project :app
./gradlew repositories --offline
```

## Why

Gradle builds declare repositories across up to five scopes:

- `settings.pluginManagement.repositories`
- `settings.buildscript.repositories`
- `settings.dependencyResolutionManagement.repositories`
- `project.buildscript.repositories`
- `project.repositories`

Until now there was no single place to inspect what repos a project will use, see what each one is allowed to serve, or verify that their URLs are actually reachable. The report makes the declared resolution surface inspectable without running a resolution.

## Output structure

```
--------------------------------------------------------
All Repositories [ (o) ]
--------------------------------------------------------

<Name> (<n>)[ *]
    Location:   <url>[ (ur|ua)]
    Type:       MAVEN | MAVEN_LOCAL | IVY | FLAT_DIR
    Roles:      <comma-separated roles>
    [Secure:     false]
    [Auth:       <scheme class names>]
    [Credentials: PRESENT]
    [Content:    <filter predicates>]
    Defined in: <declaration site>

... more repos ...

--------------------------------------------------------
Repositories by Location
--------------------------------------------------------

settings uses
    - <Name> (<n>)
    ...

project ':<path>' uses
    - <Name> (<n>)
    ...

... more project blocks, alphabetical by project path ...

--------------------------------------------------------
Legend
--------------------------------------------------------

<only the markers that actually appear>
```

### Section rules

- **`All Repositories`** — a flat, globally-numbered list of every repository in the build. Order:
  1. `settings.buildscript.repositories`
  2. `settings.pluginManagement.repositories`
  3. `settings.dependencyResolutionManagement.repositories`
  4. For each project (project-path alphabetical): `project.buildscript.repositories`, then `project.repositories`.

- **`Repositories by Location`** — shows where each declared repo is used:
  - `settings uses` block lists all settings-declared repos (only if non-empty).
  - One `project ':<path>' uses` block per project whose reference list is non-empty. Each list is composed of (in search order): inherited `PLUGINS`, inherited DRM, that project's `buildscript.repositories`, that project's `project.repositories`.
  - Blocks with empty reference lists are suppressed. If no block would render, the entire section is omitted.

- **`Legend`** — rendered only when at least one marker appears. Each marker entry is emitted only if that marker actually shows up in the output.

### `--project :foo` filter

- `All Repositories` narrows to filter-relevant entries: `PLUGINS` + DRM + `:foo`'s own buildscript + `:foo`'s project repositories. Numbering restarts at `(1)`.
- `Repositories by Location` shows only the `project ':foo' uses` block; the `settings uses` block is suppressed.
- Legend still renders if markers are present in the filtered output.
- Unknown project path fails with a clear error enumerating available paths.

### Empty-model short-circuit

- No repos declared anywhere: `There are no repositories present.`
- `--project :foo` with no repos for `:foo`: `There are no repositories present in project ':foo'.`

## Roles

| Role | Source |
|---|---|
| `PLUGINS` | `settings.pluginManagement.repositories` |
| `SETTINGS_BUILDSCRIPT_DEPENDENCIES` | `settings.buildscript.repositories` |
| `PROJECT_BUILDSCRIPT_DEPENDENCIES` | `project.buildscript.repositories` (classpath deps and legacy "apply"-based plugins)
| `PROJECT_DEPENDENCIES` | `project.repositories` + `settings.dependencyResolutionManagement.repositories` |

Because `PLUGINS` and DRM repos are accessed by every project, they appear in the reference list of each project under `Repositories by Location`.

## Markers

| Marker | Where | Meaning |
|---|---|---|
| `*` | Title line, after `(n)` | Identical declaration found in multiple locations (name, type, location, secure, auth, content filter all match). Suggests consolidating via `dependencyResolutionManagement` or `pluginManagement`. |
| `(ur)` | `Location:` line | Unreachable — the URL could not be contacted (connection refused, DNS failure, timeout, HTTP error). |
| `(ua)` | `Location:` line | Unauthorized — the URL returned 401/403. Credentials are **not** sent in v1, so this surfaces whenever auth is required, regardless of whether the user declared credentials. |
| `(o)` | `All Repositories` heading | Gradle ran in `--offline` mode. No reachability checks were performed. |

### Credential detection

A `Credentials: PRESENT` line is rendered for any repo whose `AuthenticationSupported` container has credentials configured (via `credentials(PasswordCredentials)`, `credentials { username = ...; password = ... }`, or any other `credentials(...)` mechanism). Detection is via `AuthenticationSupportedInternal.getConfiguredCredentials().isPresent()` at configuration time. The literal string `PRESENT` is the only value ever rendered — credential values (username, password, etc.) are never printed. The line is omitted when no credentials are configured.

Credential presence participates in the identical-declaration (`*`) structural-equality key: two otherwise-identical repos where one has credentials and the other does not are treated as different declarations.

### Identical-declaration (`*`) semantics

Structural-equality key over: `name`, `type`, `location`, `secure`, `authSchemes`, `contentFilter`. Excludes `roles` and `declarationSite`. No dedupe — every declaration is listed separately; the `*` marker flags groups of identical declarations across different declaration sites.

### Reachability semantics

- At task-execution time, each unique `location` URL is probed with HTTP HEAD; on 405 the probe falls back to GET. Timeout: 5 seconds.
- `2xx` / `3xx` → reachable, no marker.
- `401` / `403` → `(ua)`.
- All other outcomes (connection refused, timeout, 4xx other than auth, 5xx, DNS failure) → `(ur)`.
- `MAVEN_LOCAL` and `FLAT_DIR` repos are never probed (local filesystem).
- Non-`http://` / `https://` URLs are never probed.
- `--offline` suppresses all probes; only the `(o)` marker on `All Repositories` is added.

## Architecture

- **Task** extends `ConventionReportTask` directly (not `AbstractProjectBasedReportTask`) to own the full custom layout.
- **Data model** captured at configuration time via `Cached<RepositoryReportFullModel>` — CC-safe. All model types are immutable POJOs using Guava immutable collections.
- **Reachability** computed at task-execution time and passed into the renderer. Not part of the cached model (network state is non-deterministic and must not be persisted across CC reuse). When `--offline`, the probe step is skipped entirely.
- **Internal API extension:** `RepositoryContentDescriptorInternal` gained `describeIncludeRules()` and `describeExcludeRules()` so the report can surface content filter rules in a human-readable form.
- **Registration:** `SoftwareReportingTasksPlugin` registers the task on each project with `setImpliesSubProjects(true)`, mirroring the other software-diagnostics reports. Invoking `./gradlew repositories` runs once on the root project; the task enumerates all projects in the build internally.

### File layout

```
platforms/software/software-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/
  RepositoriesReportTask.java

  internal/repositories/
    model/
      RepositoryRole.java
      RepositoryType.java
      ReportRepository.java
      ReportContentFilter.java
      RepositoryDeclarationSite.java
      RepositoryReportProjectModel.java
      RepositoryReportSettingsModel.java
      RepositoryReportFullModel.java
      RepositoryReportModelFactory.java
    spec/
      RepositoriesReportSpec.java
    renderer/
      ConsoleRepositoriesReportRenderer.java
    reachability/
      ReachabilityStatus.java
      RepositoryReachabilityChecker.java

platforms/software/software-diagnostics/src/main/java/org/gradle/api/plugins/
  SoftwareReportingTasksPlugin.java                     [registration]

platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/plugins/
  HelpTasksPlugin.java                                  [constant]
platforms/core-configuration/base-diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/
  DiagnosticsTaskNames.java                             [constant]

platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/
  RepositoryContentDescriptorInternal.java              [extended]
  DefaultRepositoryContentDescriptor.java               [extended]
```

## Known limitations

- **Credentials not sent during reachability probes.** Any 401/403 surfaces as `(ua)` whether or not the user declared credentials on the repo. Sending credentials would require snapshotting `PasswordCredentials` into execution-time state in a CC-safe way; deferred.
- **Included builds not descended.** Each included build has its own settings + projects. Run the task against each included build separately.
- **`includeModule` vs `includeModuleByRegex` ambiguity.** Both store internally with the same matcher kind; the report renders both as `includeModuleByRegex(...)`. The regex form is behaviorally faithful since regex matchers accept literal strings.
- **Serial probes with 5s timeout.** A build with many dead remote repos could linger briefly when the task runs. Acceptable for a diagnostic task.
- **Component metadata supplier / version lister classes and Maven secondary `artifactUrls` are not displayed** — deliberately out of scope per design.

