### PR TITLE
Update chore issue template to remove 'Deprecation' option

### DIFF
--- a/.github/ISSUE_TEMPLATE/50_maintainer_chore.yml
+++ b/.github/ISSUE_TEMPLATE/50_maintainer_chore.yml
@@ -9,7 +9,6 @@ body:
       label: Issue type
       options:
         - Polishing
-        - Deprecation
         - Refactoring
         - Other
     validations:


### PR DESCRIPTION
a:deprecation category is added, it should be used instead


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
