### PR TITLE
DCL: do not reject enum entries as args in DOM

### DIFF
--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/DocumentError.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/DocumentError.kt
@@ -40,7 +40,6 @@ sealed interface UnsupportedSyntaxCause {
     data object ElementArgumentFormat : UnsupportedSyntaxCause
     data object ElementMultipleLambdas : UnsupportedSyntaxCause
     data object ValueFactoryCallWithComplexReceiver : UnsupportedSyntaxCause
-    data object ValueFactoryCallWithNamedReference : UnsupportedSyntaxCause
     data object ValueFactoryArgumentFormat : UnsupportedSyntaxCause
     data object UnsupportedThisValue : UnsupportedSyntaxCause
     data object UnsupportedNullValue : UnsupportedSyntaxCause

--- a/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/fromLanguageTree/LanguageTreeToDom.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/main/kotlin/org/gradle/internal/declarativedsl/dom/fromLanguageTree/LanguageTreeToDom.kt
@@ -191,10 +191,6 @@ class LanguageTreeToDomContext {
                 errors += UnsupportedSyntax(UnsupportedSyntaxCause.ValueFactoryArgumentFormat)
             }
 
-            if (expr.args.any { it is FunctionArgument.SingleValueArgument && it.expr is NamedReference }) {
-                errors += UnsupportedSyntax(UnsupportedSyntaxCause.ValueFactoryCallWithNamedReference)
-            }
-
             val values = expr.args.filterIsInstance<FunctionArgument.Positional>().map { exprToValue(it.expr) }
             errors += values.filterIsInstance<ExprConversion.Failed>().flatMap { it.errors }
             if (errors.isEmpty()) {

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomTest.kt
@@ -119,6 +119,46 @@ class DomTest {
         )
     }
 
+    @Test
+    fun `reports AssignmentWithExplicitReceiver for augmenting assignment with dotted lhs`() {
+        val tree = parseAsTopLevelBlock("a.x += 1")
+        assertEquals(
+            "error(UnsupportedSyntax(AssignmentWithExplicitReceiver)[0..7]\n",
+            prettyPrint(tree)
+        )
+    }
+
+    @Test
+    fun `reports ElementArgumentFormat for function call with named argument`() {
+        val tree = parseAsTopLevelBlock("myFun(x = 1)")
+        assertEquals(
+            "error(UnsupportedSyntax(ElementArgumentFormat)[0..11]\n",
+            prettyPrint(tree)
+        )
+    }
+
+    @Test
+    fun `reports ValueFactoryCallWithComplexReceiver for value factory with non-name receiver`() {
+        val tree = parseAsTopLevelBlock("a = f().g(1)")
+        assertEquals(
+            "error(UnsupportedSyntax(ValueFactoryCallWithComplexReceiver)[0..11]\n",
+            prettyPrint(tree)
+        )
+    }
+
+    @Test
+    fun `reports NamedReferenceWithExplicitReceiver for qualified name in value position`() {
+        val tree = parseAsTopLevelBlock("a = x.y")
+        assertEquals(
+            "error(UnsupportedSyntax(NamedReferenceWithExplicitReceiver)[0..6]\n",
+            prettyPrint(tree)
+        )
+    }
+
+    private
+    fun prettyPrint(tree: org.gradle.internal.declarativedsl.language.Block): String =
+        DomPrettyPrinter(withSourceData = true).domAsString(convertBlockToDocument(tree))
+
     internal
     class DomPrettyPrinter(private val withSourceData: Boolean) {
         fun domAsString(document: DeclarativeDocument) = buildString {

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/DomTest.kt
@@ -35,6 +35,7 @@ class DomTest {
                 nested {
                     x = "y"
                 }
+                d = listOf(FOO, BAR)
                 factory(1)
             }
             """.trimIndent()
@@ -42,13 +43,14 @@ class DomTest {
 
         assertEquals(
             """
-            element(myFun)[0..106]
+            element(myFun)[0..131]
                 property(a, literal(1)[16..16])[12..16]
                 property(b, valueFactory(f, literal(x)[28..30], valueFactory(z.f, literal(y)[37..39])[35..40])[26..41])[22..41]
                 property(c, literal(true)[51..54])[47..54]
                 element(nested)[60..89]
                     property(x, literal(y)[81..83])[77..83]
-                element(factory, literal(1)[103..103])[95..104]
+                property(d, valueFactory(listOf, namedReference(FOO)[106..108], namedReference(BAR)[111..113])[99..114])[95..114]
+                element(factory, literal(1)[128..128])[120..129]
 
             """.trimIndent(),
             DomPrettyPrinter(withSourceData = true).domAsString(convertBlockToDocument(tree))

--- a/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/resolution/DomResolutionTest.kt
+++ b/platforms/core-configuration/declarative-dsl-core/src/test/kotlin/org/gradle/internal/declarativedsl/dom/resolution/DomResolutionTest.kt
@@ -122,7 +122,9 @@ class DomResolutionTest {
             LiteralValueResolved -> 1
             PropertyNotAssigned(UnresolvedBase)
             LiteralValueResolved -> 123
-            ErrorResolution(IsError)
+            PropertyNotAssigned(UnresolvedBase)
+            ValueFactoryNotResolved(UnresolvedBase)
+            NamedReferenceNotResolved(UnresolvedBase)
             ElementNotResolved(UnresolvedSignature)
             LiteralValueResolved -> test2
             PropertyNotAssigned(ValueTypeMismatch)

--- a/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDslProjectBuildFileIntegrationSpec.groovy
+++ b/platforms/core-configuration/declarative-dsl-provider/src/integTest/groovy/org/gradle/internal/declarativedsl/project/DeclarativeDslProjectBuildFileIntegrationSpec.groovy
@@ -62,18 +62,21 @@ class DeclarativeDslProjectBuildFileIntegrationSpec extends AbstractIntegrationS
                 primaryAccess {
                     read = false
                     write = false
+                    exec = listOf(USER)
                 }
 
                 secondaryAccess {
                     name = "two"
                     read = true
                     write = false
+                    exec = listOf(GROUP, USER)
                 }
 
                 secondaryAccess {
                     name = "three"
                     read = true
                     write = true
+                    exec = listOf(USER, GROUP, ALL)
                 }
             }
         """
@@ -87,9 +90,9 @@ referencePoint = (1, 2)
 arguments = [one, two]
 flags = []
 mapProperty = {}
-primaryAccess = { primary, false, false}
-secondaryAccess { two, true, false}
-secondaryAccess { three, true, true}"""
+primaryAccess = { primary, false, false, [USER] }
+secondaryAccess { two, true, false, [GROUP, USER] }
+secondaryAccess { three, true, true, [USER, GROUP, ALL] }"""
         )
 
         where:
@@ -233,16 +236,16 @@ secondaryAccess { three, true, true}"""
                                 System.out.println("flags = " + definition.getFlags());
                                 System.out.println("mapProperty = " + definition.getMapProperty().get());
                                 System.out.println("primaryAccess = { " +
-                                        acc.getName().get() + ", " + acc.getRead().get() + ", " + acc.getWrite().get() + "}"
-                                );
-                                secondaryAccess.get().forEach(it -> {
-                                    System.out.println("secondaryAccess { " +
-                                            it.getName().get() + ", " + it.getRead().get() + ", " + it.getWrite().get() +
-                                            "}"
+                                        acc.getName().get() + ", " + acc.getRead().get() + ", " + acc.getWrite().get() + ", " + acc.getExec().get() + " }"
                                     );
+                                    secondaryAccess.get().forEach(it -> {
+                                        System.out.println("secondaryAccess { " +
+                                                it.getName().get() + ", " + it.getRead().get() + ", " + it.getWrite().get() + ", " + it.getExec().get() + " }"
+                                        );
+                                    });
                                 });
                             });
-                        });
+
                     }
                 }
 
@@ -359,6 +362,12 @@ secondaryAccess { three, true, true}"""
                 public abstract Property<Boolean> getRead();
 
                 public abstract Property<Boolean> getWrite();
+
+                public abstract ListProperty<ExecutionAccess> getExec();
+
+                public enum ExecutionAccess {
+                    USER, GROUP, ALL
+                }
             }
 
             public static class Point {
@@ -443,6 +452,12 @@ secondaryAccess { three, true, true}"""
                 abstract val read: Property<Boolean>
 
                 abstract val write: Property<Boolean>
+
+                abstract val exec: ListProperty<ExecutionAccess>
+
+                enum class ExecutionAccess {
+                    USER, GROUP, ALL
+                }
             }
 
             class Point(val x: Int, val y: Int)


### PR DESCRIPTION
While the resolver has been allowing enum entries used in argument position since https://github.com/gradle/gradle/pull/34121, they would still appear as error elements in the DOM. Since erroneous DOM nodes are reported in the resolution pipeline now, the support for
enum entries in call args has been effectively broken, like in:

```kotlin
foos = listOf(BAR, BAZ) // reported as unsupported syntax in the DOM
```

Fix this by not producing DOM error nodes for named-reference call args.

Fixes:
* https://github.com/gradle/gradle/issues/34114