### PR TITLE
Update Documentation to use Spock 2.4

### DIFF
--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionCustomTestSourceSet/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionCustomTestSourceSet/groovy/build.gradle
@@ -21,7 +21,7 @@ gradlePlugin {
 }
 
 dependencies {
-    functionalTestImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
+    functionalTestImplementation('org.spockframework:spock-core:2.4-groovy-4.0') {
         exclude group: 'org.apache.groovy'
     }
     functionalTestRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionCustomTestSourceSet/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionCustomTestSourceSet/groovy/build.gradle
@@ -22,7 +22,7 @@ gradlePlugin {
 
 dependencies {
     functionalTestImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
-        exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.apache.groovy'
     }
     functionalTestRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionCustomTestSourceSet/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionCustomTestSourceSet/kotlin/build.gradle.kts
@@ -21,7 +21,7 @@ gradlePlugin {
 }
 
 dependencies {
-    "functionalTestImplementation"("org.spockframework:spock-core:2.3-groovy-4.0") {
+    "functionalTestImplementation"("org.spockframework:spock-core:2.4-groovy-4.0") {
         exclude(group = "org.apache.groovy")
     }
     "functionalTestRuntimeOnly"("org.junit.platform:junit-platform-launcher")

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionCustomTestSourceSet/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionCustomTestSourceSet/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ gradlePlugin {
 
 dependencies {
     "functionalTestImplementation"("org.spockframework:spock-core:2.3-groovy-4.0") {
-        exclude(group = "org.codehaus.groovy")
+        exclude(group = "org.apache.groovy")
     }
     "functionalTestRuntimeOnly"("org.junit.platform:junit-platform-launcher")
 }

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionQuickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionQuickstart/groovy/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
+    testImplementation('org.spockframework:spock-core:2.4-groovy-4.0') {
         exclude group: 'org.apache.groovy'
     }
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionQuickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionQuickstart/groovy/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
-        exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.apache.groovy'
     }
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionQuickstart/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionQuickstart/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation("org.spockframework:spock-core:2.3-groovy-4.0") {
+    testImplementation("org.spockframework:spock-core:2.4-groovy-4.0") {
         exclude(group = "org.apache.groovy")
     }
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionQuickstart/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/automaticClasspathInjectionQuickstart/kotlin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     testImplementation("org.spockframework:spock-core:2.3-groovy-4.0") {
-        exclude(group = "org.codehaus.groovy")
+        exclude(group = "org.apache.groovy")
     }
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/gradleVersion/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/gradleVersion/groovy/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 }
 
 dependencies {
-    testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
+    testImplementation('org.spockframework:spock-core:2.4-groovy-4.0') {
         exclude group: 'org.apache.groovy'
     }
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/gradleVersion/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/gradleVersion/groovy/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
 dependencies {
     testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
-        exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.apache.groovy'
     }
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/spockQuickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/spockQuickstart/groovy/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
 // tag::declare-spock-dependency[]
 dependencies {
-    testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
+    testImplementation('org.spockframework:spock-core:2.4-groovy-4.0') {
         exclude group: 'org.apache.groovy'
     }
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/platforms/documentation/docs/src/snippets/integration-tests/testKit/spockQuickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/testKit/spockQuickstart/groovy/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 // tag::declare-spock-dependency[]
 dependencies {
     testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
-        exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.apache.groovy'
     }
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/platforms/documentation/docs/src/snippets/optimizing-builds/configuration-cache/testKit/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/optimizing-builds/configuration-cache/testKit/groovy/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation platform("org.spockframework:spock-bom:2.3-groovy-4.0")
+    testImplementation platform("org.spockframework:spock-bom:2.4-groovy-4.0")
     testImplementation 'org.spockframework:spock-core'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionCustomTestSourceSet/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionCustomTestSourceSet/groovy/build.gradle
@@ -21,7 +21,7 @@ gradlePlugin {
 }
 
 dependencies {
-    functionalTestImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
+    functionalTestImplementation('org.spockframework:spock-core:2.4-groovy-4.0') {
         exclude group: 'org.apache.groovy'
     }
     functionalTestRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionCustomTestSourceSet/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionCustomTestSourceSet/groovy/build.gradle
@@ -22,7 +22,7 @@ gradlePlugin {
 
 dependencies {
     functionalTestImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
-        exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.apache.groovy'
     }
     functionalTestRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionCustomTestSourceSet/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionCustomTestSourceSet/kotlin/build.gradle.kts
@@ -21,7 +21,7 @@ gradlePlugin {
 }
 
 dependencies {
-    "functionalTestImplementation"("org.spockframework:spock-core:2.3-groovy-4.0") {
+    "functionalTestImplementation"("org.spockframework:spock-core:2.4-groovy-4.0") {
         exclude(group = "org.apache.groovy")
     }
     "functionalTestRuntimeOnly"("org.junit.platform:junit-platform-launcher")

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionCustomTestSourceSet/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionCustomTestSourceSet/kotlin/build.gradle.kts
@@ -22,7 +22,7 @@ gradlePlugin {
 
 dependencies {
     "functionalTestImplementation"("org.spockframework:spock-core:2.3-groovy-4.0") {
-        exclude(group = "org.codehaus.groovy")
+        exclude(group = "org.apache.groovy")
     }
     "functionalTestRuntimeOnly"("org.junit.platform:junit-platform-launcher")
 }

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionQuickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionQuickstart/groovy/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
+    testImplementation('org.spockframework:spock-core:2.4-groovy-4.0') {
         exclude group: 'org.apache.groovy'
     }
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionQuickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionQuickstart/groovy/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
-        exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.apache.groovy'
     }
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionQuickstart/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionQuickstart/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation("org.spockframework:spock-core:2.3-groovy-4.0") {
+    testImplementation("org.spockframework:spock-core:2.4-groovy-4.0") {
         exclude(group = "org.apache.groovy")
     }
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionQuickstart/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/automaticClasspathInjectionQuickstart/kotlin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     testImplementation("org.spockframework:spock-core:2.3-groovy-4.0") {
-        exclude(group = "org.codehaus.groovy")
+        exclude(group = "org.apache.groovy")
     }
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/gradleVersion/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/gradleVersion/groovy/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 }
 
 dependencies {
-    testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
+    testImplementation('org.spockframework:spock-core:2.4-groovy-4.0') {
         exclude group: 'org.apache.groovy'
     }
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/gradleVersion/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/gradleVersion/groovy/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
 dependencies {
     testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
-        exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.apache.groovy'
     }
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/spockQuickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/spockQuickstart/groovy/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
 // tag::declare-spock-dependency[]
 dependencies {
-    testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
+    testImplementation('org.spockframework:spock-core:2.4-groovy-4.0') {
         exclude group: 'org.apache.groovy'
     }
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/spockQuickstart/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/spockQuickstart/groovy/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 // tag::declare-spock-dependency[]
 dependencies {
     testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
-        exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.apache.groovy'
     }
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/testKitFunctionalTestSpockBuildCache/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/testKitFunctionalTestSpockBuildCache/groovy/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
+    testImplementation('org.spockframework:spock-core:2.4-groovy-4.0') {
         exclude group: 'org.apache.groovy'
     }
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/platforms/documentation/docs/src/snippets/reference/other-topics/testKitFunctionalTestSpockBuildCache/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/other-topics/testKitFunctionalTestSpockBuildCache/groovy/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
-        exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.apache.groovy'
     }
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/platforms/documentation/docs/src/snippets/reference/plugin-development/testingPlugins/groovy/url-verifier-plugin/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/plugin-development/testingPlugins/groovy/url-verifier-plugin/build.gradle
@@ -48,15 +48,15 @@ repositories {
 }
 
 dependencies {
-    testImplementation platform("org.spockframework:spock-bom:2.3-groovy-4.0")
+    testImplementation platform("org.spockframework:spock-bom:2.4-groovy-4.0")
     testImplementation 'org.spockframework:spock-core'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    integrationTestImplementation platform("org.spockframework:spock-bom:2.3-groovy-4.0")
+    integrationTestImplementation platform("org.spockframework:spock-bom:2.4-groovy-4.0")
     integrationTestImplementation 'org.spockframework:spock-core'
     integrationTestRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    functionalTestImplementation platform("org.spockframework:spock-bom:2.3-groovy-4.0")
+    functionalTestImplementation platform("org.spockframework:spock-bom:2.4-groovy-4.0")
     functionalTestImplementation 'org.spockframework:spock-core'
     functionalTestRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/platforms/documentation/docs/src/snippets/reference/plugin-development/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/plugin-development/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
@@ -48,15 +48,15 @@ repositories {
 }
 
 dependencies {
-    testImplementation(platform("org.spockframework:spock-bom:2.3-groovy-4.0"))
+    testImplementation(platform("org.spockframework:spock-bom:2.4-groovy-4.0"))
     testImplementation("org.spockframework:spock-core")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-    "integrationTestImplementation"(platform("org.spockframework:spock-bom:2.3-groovy-4.0"))
+    "integrationTestImplementation"(platform("org.spockframework:spock-bom:2.4-groovy-4.0"))
     "integrationTestImplementation"("org.spockframework:spock-core")
     "integrationTestRuntimeOnly"("org.junit.platform:junit-platform-launcher")
 
-    "functionalTestImplementation"(platform("org.spockframework:spock-bom:2.3-groovy-4.0"))
+    "functionalTestImplementation"(platform("org.spockframework:spock-bom:2.4-groovy-4.0"))
     "functionalTestImplementation"("org.spockframework:spock-core")
     "functionalTestRuntimeOnly"("org.junit.platform:junit-platform-launcher")
 }

--- a/platforms/documentation/docs/src/snippets/tutorials/developing-plugins/plugin-tutorial/groovy/plugin/build.gradle
+++ b/platforms/documentation/docs/src/snippets/tutorials/developing-plugins/plugin-tutorial/groovy/plugin/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     testImplementation libs.spock.core
      */
     // tag::publish[]
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    testImplementation 'org.spockframework:spock-core:2.4-groovy-4.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     // tag::slack-api[]
     // Use the Java Slack Client APIs

--- a/platforms/documentation/docs/src/snippets/unused/plugins/plugin-tutorial/groovy/plugin/build.gradle
+++ b/platforms/documentation/docs/src/snippets/unused/plugins/plugin-tutorial/groovy/plugin/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     testImplementation libs.spock.core
      */
     // tag::publish[]
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    testImplementation 'org.spockframework:spock-core:2.4-groovy-4.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     // tag::slack-api[]
     // Use the Java Slack Client APIs


### PR DESCRIPTION

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation code examples to use Spock testing framework version 2.4-groovy-4.0 (previously 2.3-groovy-4.0).
  * Updated dependency exclusion configuration in example build files from `org.codehaus.groovy` to `org.apache.groovy`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->