### PR TITLE
Upgrade BouncyCastle to 1.84

### DIFF
--- a/gradle/dependency-management/distribution.versions.toml
+++ b/gradle/dependency-management/distribution.versions.toml
@@ -2,7 +2,7 @@
 [versions]
 ant = "1.10.15!!"
 awsS3 = "1.12.780!!"
-bouncycastle = "1.81!!"
+bouncycastle = "1.84!!"
 commonsCodec = "1.18.0!!"
 commonsCompress = "1.26.1!!"
 commonsHttpclient = "4.5.14!!"


### PR DESCRIPTION
This makes sure Gradle uses a version where CVE-2026-5598 is no longer applicable.

Note that Gradle does not use FrodoKEM and was thus not impacted by that vulnerability.