### PR TITLE
Make HTML test report columns sortable

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskRelocationIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskRelocationIntegrationTest.groovy
@@ -60,6 +60,7 @@ class TestTaskRelocationIntegrationTest extends AbstractProjectRelocationIntegra
         def contents = normaliseLineSeparators(projectDir.file("build/reports/tests/test/index.html").text)
         contents = contents.replaceAll(/(<a href=".*">Gradle .*?<\/a>) at [^<]+/, '$1 at [DATE]' )
         contents = contents.replaceAll(/\b\d+(\.\d+)?s\b/, "[TIME]")
+        contents = contents.replaceAll(/data-sort-value="\d+"/, 'data-sort-value="[NUM]"')
         return contents
     }
 }

--- a/platforms/software/testing-base/src/integTest/groovy/org/gradle/testing/TestEventReporterHtmlReportIntegrationTest.groovy
+++ b/platforms/software/testing-base/src/integTest/groovy/org/gradle/testing/TestEventReporterHtmlReportIntegrationTest.groovy
@@ -412,6 +412,35 @@ class TestEventReporterHtmlReportIntegrationTest extends AbstractIntegrationSpec
         tests.testPath(":").onlyRoot().assertOnlyChildrenExecuted(*testNames)
     }
 
+    def "HTML report renders sortable markup for test-results tables"() {
+        given:
+        buildFile << passingTask("passing")
+
+        when:
+        succeeds("passing")
+
+        then:
+        def results = aggregateResults()
+        // Table is marked sortable and its data rows live inside a <tbody>
+        results.assertHtml("table.test-results.sortable > tbody > tr") {
+            assert !it.isEmpty()
+        }
+        // Numeric columns default to descending on first click
+        results.assertHtml("table.test-results th[data-sort-default=desc]") {
+            def headers = it*.text()
+            assert headers.containsAll(["Tests", "Failures", "Skipped", "Duration"])
+            assert !headers.contains("Success rate")
+            assert !headers.contains("Child")
+        }
+        // Duration cells carry a numeric data-sort-value (parseable as a long)
+        results.assertHtml("table.test-results > tbody > tr > td[data-sort-value]") {
+            assert !it.isEmpty()
+            it.each { cell ->
+                Long.parseLong(cell.attr("data-sort-value"))
+            }
+        }
+    }
+
     def passingTask(String name, boolean print = false) {
         assert !name.toCharArray().any { it.isWhitespace() }
 

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/PerRootTabRenderer.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/generic/PerRootTabRenderer.java
@@ -35,8 +35,6 @@ import org.gradle.reporting.TabsRenderer;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -297,7 +295,7 @@ public abstract class PerRootTabRenderer extends ReportRenderer<TestTreeModel, S
 
             @Override
             public void render(TestTreeModel model, SimpleHtmlWriter htmlWriter) throws IOException {
-                htmlWriter.startElement("table").attribute("class", "test-results");
+                htmlWriter.startElement("table").attribute("class", "test-results sortable");
                 htmlWriter.startElement("thead");
                 htmlWriter.startElement("tr");
 
@@ -318,10 +316,10 @@ public abstract class PerRootTabRenderer extends ReportRenderer<TestTreeModel, S
                 }
                 htmlWriter.characters("Name").endElement();
 
-                htmlWriter.startElement("th").characters("Tests").endElement();
-                htmlWriter.startElement("th").characters("Failures").endElement();
-                htmlWriter.startElement("th").characters("Skipped").endElement();
-                htmlWriter.startElement("th").characters("Duration").endElement();
+                htmlWriter.startElement("th").attribute("data-sort-default", "desc").characters("Tests").endElement();
+                htmlWriter.startElement("th").attribute("data-sort-default", "desc").characters("Failures").endElement();
+                htmlWriter.startElement("th").attribute("data-sort-default", "desc").characters("Skipped").endElement();
+                htmlWriter.startElement("th").attribute("data-sort-default", "desc").characters("Duration").endElement();
                 htmlWriter.startElement("th").characters("Success rate").endElement();
 
                 htmlWriter.endElement();
@@ -330,6 +328,7 @@ public abstract class PerRootTabRenderer extends ReportRenderer<TestTreeModel, S
                 List<ChildEntry> sortedByName = new ArrayList<>(children);
                 sortedByName.sort(CHILD_PATH_COMPARATOR);
 
+                htmlWriter.startElement("tbody");
                 for (ChildEntry pair : sortedByName) {
                     PerRootInfo perRootInfo = pair.perRootInfo;
                     String statusClass = getStatusClass(getResultType(perRootInfo));
@@ -361,13 +360,35 @@ public abstract class PerRootTabRenderer extends ReportRenderer<TestTreeModel, S
                     htmlWriter.startElement("td").characters(Integer.toString(perRootInfo.getTotalLeafCount())).endElement();
                     htmlWriter.startElement("td").characters(Integer.toString(perRootInfo.getFailedLeafCount())).endElement();
                     htmlWriter.startElement("td").characters(Integer.toString(perRootInfo.getSkippedLeafCount())).endElement();
-                    htmlWriter.startElement("td").characters(getFormattedDuration(perRootInfo)).endElement();
-                    htmlWriter.startElement("td").attribute("class", statusClass).characters(getFormattedSuccessRate(perRootInfo)).endElement();
+                    htmlWriter.startElement("td")
+                        .attribute("data-sort-value", Long.toString(getTotalDurationMillis(perRootInfo)))
+                        .characters(getFormattedDuration(perRootInfo)).endElement();
+                    htmlWriter.startElement("td")
+                        .attribute("class", statusClass)
+                        .attribute("data-sort-value", Integer.toString(getSuccessRatePercent(perRootInfo)))
+                        .characters(getFormattedSuccessRate(perRootInfo)).endElement();
 
                     htmlWriter.endElement();
                 }
+                htmlWriter.endElement(); // tbody
                 htmlWriter.endElement();
             }
+        }
+
+        private static long getTotalDurationMillis(PerRootInfo info) {
+            long total = 0;
+            for (SerializableTestResult r : info.getResults()) {
+                total += r.getDuration();
+            }
+            return total;
+        }
+
+        private static int getSuccessRatePercent(PerRootInfo info) {
+            int total = info.getTotalLeafCount();
+            if (total == 0) {
+                return -1;
+            }
+            return (total - info.getFailedLeafCount()) * 100 / total;
         }
 
         private static TestResult.ResultType getResultType(PerRootInfo info) {
@@ -404,14 +425,8 @@ public abstract class PerRootTabRenderer extends ReportRenderer<TestTreeModel, S
         }
 
         private static String getFormattedSuccessRate(PerRootInfo info) {
-            if (info.getTotalLeafCount() == 0) {
-                return "-";
-            }
-
-            BigDecimal runTests = BigDecimal.valueOf(info.getTotalLeafCount());
-            BigDecimal successful = BigDecimal.valueOf(info.getTotalLeafCount() - info.getFailedLeafCount());
-
-            return successful.divide(runTests, 2, RoundingMode.DOWN).multiply(BigDecimal.valueOf(100)).intValue() + "%";
+            int percent = getSuccessRatePercent(info);
+            return percent < 0 ? "-" : percent + "%";
         }
     }
 

--- a/subprojects/core/src/main/resources/org/gradle/reporting/base-style.css
+++ b/subprojects/core/src/main/resources/org/gradle/reporting/base-style.css
@@ -175,3 +175,23 @@ span.wrapped pre {
 label.hidden {
     display: none;
 }
+
+th.sortable-header {
+    cursor: pointer;
+    user-select: none;
+}
+
+th.sortable-header::after {
+    content: " \2195";
+    color: #b0b0b0;
+}
+
+th.sortable-header[data-sort-dir="asc"]::after {
+    content: " \25B2";
+    color: inherit;
+}
+
+th.sortable-header[data-sort-dir="desc"]::after {
+    content: " \25BC";
+    color: inherit;
+}

--- a/subprojects/core/src/main/resources/org/gradle/reporting/report.js
+++ b/subprojects/core/src/main/resources/org/gradle/reporting/report.js
@@ -219,10 +219,67 @@
         return elements;
     }
 
+    function initTableSorting() {
+        document.querySelectorAll("table.sortable").forEach((table) => {
+            const thead = table.tHead;
+            if (!thead || thead.rows.length === 0) return;
+            const headerRow = thead.rows[0];
+            const headers = Array.from(headerRow.cells);
+            const tbody = table.tBodies[0] || table;
+            const originalRows = Array.from(tbody.querySelectorAll(":scope > tr"));
+
+            headers.forEach((th, colIndex) => {
+                if (th.classList.contains("no-sort")) return;
+                th.classList.add("sortable-header");
+                th.addEventListener("click", () => {
+                    const current = th.getAttribute("data-sort-dir");
+                    const firstDir = th.getAttribute("data-sort-default") === "desc" ? "desc" : "asc";
+                    const secondDir = firstDir === "desc" ? "asc" : "desc";
+                    // Cycle: none -> firstDir -> secondDir -> none
+                    let next;
+                    if (current === firstDir) next = secondDir;
+                    else if (current === secondDir) next = "none";
+                    else next = firstDir;
+
+                    headers.forEach((h) => h.removeAttribute("data-sort-dir"));
+
+                    if (next === "none") {
+                        originalRows.forEach((r) => tbody.appendChild(r));
+                        return;
+                    }
+                    th.setAttribute("data-sort-dir", next);
+
+                    const rows = Array.from(tbody.querySelectorAll(":scope > tr"));
+                    const dir = next === "asc" ? 1 : -1;
+                    rows.sort((a, b) => {
+                        const av = getSortValue(a.cells[colIndex]);
+                        const bv = getSortValue(b.cells[colIndex]);
+                        if (av === bv) return 0;
+                        // Numeric compare if both parse as numbers
+                        const an = parseFloat(av), bn = parseFloat(bv);
+                        if (!isNaN(an) && !isNaN(bn) && isFinite(an) && isFinite(bn)
+                            && av.trim() !== "" && bv.trim() !== "") {
+                            return (an - bn) * dir;
+                        }
+                        return av.localeCompare(bv) * dir;
+                    });
+                    rows.forEach((r) => tbody.appendChild(r));
+                });
+            });
+        });
+    }
+
+    function getSortValue(cell) {
+        if (!cell) return "";
+        const v = cell.getAttribute("data-sort-value");
+        return v !== null ? v : cell.textContent;
+    }
+
     // Entry point.
 
     window.onload = function() {
         initTabs();
         initControls();
+        initTableSorting();
     };
 } (window, window.document));


### PR DESCRIPTION
Clicking a column header in the test results table now sorts rows by that column. A second click reverses the direction; a third restores the original order.

Numeric columns (Tests, Failures, Skipped, Duration) default to descending on first click so the most interesting values (slowest, most-failed) surface first. Success rate defaults to ascending so flaky/broken classes surface first. Text columns default to ascending.

Duration and Success rate cells carry a data-sort-value attribute with the raw numeric value so that formatted strings like '1m30.00s' and '85%' sort correctly.

Fixes #29054