### PR TITLE
Suppress OSC taskbar reset on plain/piped stdout

### DIFF
--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/TaskbarProgressResetFunctionalTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/internal/logging/console/TaskbarProgressResetFunctionalTest.groovy
@@ -98,4 +98,40 @@ class TaskbarProgressResetFunctionalTest extends AbstractIntegrationSpec {
         then:
         result.output.contains(OSC_RESET)
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/37611")
+    @SuppressWarnings("IntegrationTestFixtures")
+    @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor,
+        reason = "OSC taskbar progress sequences are only emitted by the forked client JVM")
+    def "does not emit OSC 9;4 sequences when --console=plain"() {
+        given:
+        executer.withConsole(ConsoleOutput.Plain)
+        buildFile << """
+            task ok { }
+        """
+
+        when:
+        result = succeeds("ok")
+
+        then:
+        !result.output.contains(OSC_PROGRESS_PREFIX)
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/37611")
+    @SuppressWarnings("IntegrationTestFixtures")
+    @Requires(value = IntegTestPreconditions.NotEmbeddedExecutor,
+        reason = "OSC taskbar progress sequences are only emitted by the forked client JVM")
+    def "does not emit OSC 9;4 sequences when console is Auto and stdout is not a terminal"() {
+        given:
+        executer.withConsole(ConsoleOutput.Auto)
+        buildFile << """
+            task ok { }
+        """
+
+        when:
+        result = succeeds("ok")
+
+        then:
+        !result.output.contains(OSC_PROGRESS_PREFIX)
+    }
 }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
@@ -59,7 +59,16 @@ public class ConsoleConfigureAction {
             configureColoredConsole(renderer, consoleMetadata, stdout, stderr);
         }
 
-        registerTaskbarReset(consoleMetadata, stdout);
+        if (shouldEmitTaskbarProgress(consoleOutput, consoleMetadata)) {
+            registerTaskbarReset(consoleMetadata, stdout);
+        }
+    }
+
+    private static boolean shouldEmitTaskbarProgress(ConsoleOutput consoleOutput, ConsoleMetaData consoleMetadata) {
+        if (consoleOutput == ConsoleOutput.Plain) {
+            return false;
+        }
+        return consoleOutput != ConsoleOutput.Auto || consoleMetadata.isStdOutATerminal();
     }
 
     private static void registerTaskbarReset(ConsoleMetaData consoleMetadata, OutputStream stdout) {


### PR DESCRIPTION
The shutdown hook that emits ESC]9;4;0 BEL to clear iTerm/ConEmu/ Ghostty/Kitty taskbar progress was registered whenever the host terminal was detected via env vars, ignoring the active console mode and whether stdout was actually a terminal. That leaked the trailing control sequence into piped output and into --console=plain runs.

Gate the hook on the configuration that actually renders progress: skip it for ConsoleOutput.Plain, and for ConsoleOutput.Auto when stdout is not a TTY. Rich, Verbose, Colored, and Auto-with-TTY are unchanged, preserving the previous behavior.

* Fixes https://github.com/gradle/gradle/issues/37611

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
