### PR TITLE
Merge release into master

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-rc-3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-rc-4-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/released-versions.json
+++ b/released-versions.json
@@ -1,7 +1,7 @@
 {
   "latestReleaseSnapshot": {
-    "version": "9.5.0-20260423021153+0000",
-    "buildTime": "20260423021153+0000"
+    "version": "9.5.0-20260424013949+0000",
+    "buildTime": "20260424013949+0000"
   },
   "latestRc": {
     "version": "9.5.0-rc-4",


### PR DESCRIPTION
Automated merge of `release` into `master` following the release promotion build.

Conflicts were resolved by analysing branch histories on `origin/master` and `origin/release`.

Resolves conflict in `gradle/wrapper/gradle-wrapper.properties`: kept `master`'s `9.6.0-milestone-1` wrapper (ongoing development) over `release`'s `9.5.0-rc-4`.