### PR TITLE
Documentation update: added reference to lifecycle api in build lifecycle tutorial page

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/fundamentals/authoring-builds/build_lifecycle_intermediate.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/fundamentals/authoring-builds/build_lifecycle_intermediate.adoc
@@ -139,3 +139,9 @@ image::task-dag-examples.png[]
 
 [.text-right]
 **Next Step:** <<writing_build_scripts_intermediate.adoc#writing_build_scripts,Learn how to write Build Scripts>> >>
+
+== Hooking into the Build Lifecycle
+
+As your build logic becomes more advanced, you might need to execute custom actions during specific build phases. Gradle exposes several APIs that let you listen to or react to key events in the lifecycle.
+
+For a detailed guide on available callbacks and listeners, refer to <<build_lifecycle.adoc#sec:lifecycle_api, Lifecycle API>>.

--- a/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_lifecycle.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/runtime-configuration/build_lifecycle.adoc
@@ -266,9 +266,10 @@ These hooks let you:
 - configure all projects before their own build scripts are evaluated,
 - debug or collect information during configuration.
 
+[[sec:lifecycle_api]]
 === Lifecycle API
 
-The link:{javadocPath}/org/gradle/api/invocation/GradleLifecycle.html[`GradleLifecycle`] API, accessible the link:{javadocPath}/org/gradle/api/invocation/Gradle.html[`gradle`] object, can be used to register actions to be executed at certain points in the build lifecycle:
+The link:{javadocPath}/org/gradle/api/invocation/GradleLifecycle.html[`GradleLifecycle`] API, accessible through the link:{javadocPath}/org/gradle/api/invocation/Gradle.html[`gradle`] object, can be used to register actions to be executed at certain points in the build lifecycle:
 
 [source,text]
 ----


### PR DESCRIPTION
<!--- The issue this PR addresses -->
### Details

This is a documentation change ONLY.

### Context

Fixes #36701

Changes:
1. Removed the duplicated content from [Build Lifecycle](https://docs.gradle.org/current/userguide/build_lifecycle.html#build_phases).
2. Created a new section in [Build Lifecycle Intermediate](https://docs.gradle.org/current/userguide/build_lifecycle_intermediate.html) that references the left documentation in Build Lifecycle that talks about the Lifecycle API. 

### Documentation Checklist
- [X] Make sure the User Manual, Javadocs, code snippets, and samples build with `./gradlew stageDocs -PquickDocs -t`
- [x] Make sure there are no dead links/URLs in the User Manual with `./gradlew :docs:checkDeadInternalLinks`
- [X] Make sure any *.adoc file that is deleted or renamed is added to the `/redirect` folder with the proper redirect
- [X] Make sure any changes in *.adoc files are reflected in `userguide_single.adoc`
- [X] New code snippets longer than two lines in a *.adoc file are snippet-ized as `include::sample[]` and located in `/snippets`
- [X] New code snippets are tested with `./gradlew :docs:docsTest --tests "*.snippet-path-to-snippet*"
- [X] Javadocs changes follow the [Javadoc Style Guide](https://github.com/gradle/gradle/blob/master/JavadocStyleGuide.md)
- [X] User Manual changes follow the [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [X] Create a render preview in the PR using `@bot-gradle test BD` and provide the link to reviewers in the PR description
