### PR TITLE
Decouple ProjectState impl from containing registry

### DIFF
--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -25,7 +25,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
-import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.internal.project.ProjectStateLookup;
 import org.gradle.api.internal.tasks.TaskDependencyUtil;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.TaskDependency;
@@ -115,8 +115,8 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
         this.uniqueProjectNameProvider = uniqueProjectNameProvider;
     }
 
-    public EclipseModelBuilder(GradleProjectBuilderInternal gradleProjectBuilder, ProjectStateRegistry projectStateRegistry) {
-        this(gradleProjectBuilder, new EclipseModelAwareUniqueProjectNameProvider(projectStateRegistry));
+    public EclipseModelBuilder(GradleProjectBuilderInternal gradleProjectBuilder, ProjectStateLookup projectStateLookup) {
+        this(gradleProjectBuilder, new EclipseModelAwareUniqueProjectNameProvider(projectStateLookup));
     }
 
     @Override

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
@@ -18,7 +18,7 @@ package org.gradle.plugins.ide.internal.tooling;
 
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublicationRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.internal.project.ProjectStateLookup;
 import org.gradle.api.internal.project.ProjectTaskLister;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.buildtree.BuildModelParameters;
@@ -44,8 +44,8 @@ public class ToolingModelServices extends AbstractGradleModuleServices {
     private static class BuildScopeToolingServices implements ServiceRegistrationProvider {
 
         @Provides
-        protected UniqueProjectNameProvider createBuildProjectRegistry(ProjectStateRegistry projectRegistry) {
-            return new DefaultUniqueProjectNameProvider(projectRegistry);
+        protected UniqueProjectNameProvider createBuildProjectRegistry(ProjectStateLookup projectStateLookup) {
+            return new DefaultUniqueProjectNameProvider(projectStateLookup);
         }
 
         @Provides
@@ -54,7 +54,7 @@ public class ToolingModelServices extends AbstractGradleModuleServices {
             final ProjectPublicationRegistry projectPublicationRegistry,
             final FileCollectionFactory fileCollectionFactory,
             final BuildStateRegistry buildStateRegistry,
-            final ProjectStateRegistry projectStateRegistry,
+            final ProjectStateLookup projectStateLookup,
             BuildModelParameters buildModelParameters,
             IntermediateToolingModelProvider intermediateToolingModelProvider,
             BuildIncludeListener failedIncludedBuildsRegistry,
@@ -69,7 +69,7 @@ public class ToolingModelServices extends AbstractGradleModuleServices {
                     IdeaModelBuilderInternal ideaModelBuilder = createIdeaModelBuilder(isolatedProjects, gradleProjectBuilder);
                     registry.register(new RunBuildDependenciesTaskBuilder());
                     registry.register(new RunEclipseTasksBuilder());
-                    registry.register(new EclipseModelBuilder(gradleProjectBuilder, projectStateRegistry));
+                    registry.register(new EclipseModelBuilder(gradleProjectBuilder, projectStateLookup));
                     registry.register(ideaModelBuilder);
                     registry.register(gradleProjectBuilder);
                     registry.register(new GradleBuildBuilder(buildStateRegistry, failedIncludedBuildsRegistry, failureFactory));

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/AbstractUniqueProjectNameProvider.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/AbstractUniqueProjectNameProvider.java
@@ -18,16 +18,16 @@ package org.gradle.plugins.ide.internal.configurer;
 
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectState;
-import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.internal.project.ProjectStateLookup;
 import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
 public abstract class AbstractUniqueProjectNameProvider implements UniqueProjectNameProvider {
 
-    protected final ProjectStateRegistry projectRegistry;
+    protected final ProjectStateLookup projectStateLookup;
 
-    protected AbstractUniqueProjectNameProvider(ProjectStateRegistry projectRegistry) {
-        this.projectRegistry = projectRegistry;
+    protected AbstractUniqueProjectNameProvider(ProjectStateLookup projectStateLookup) {
+        this.projectStateLookup = projectStateLookup;
     }
 
     /**
@@ -44,7 +44,7 @@ public abstract class AbstractUniqueProjectNameProvider implements UniqueProject
         if (parentInBuildTreePath == null) {
             return null;
         }
-        ProjectState parentInBuildTree = projectRegistry.findProjectState(parentInBuildTreePath);
+        ProjectState parentInBuildTree = projectStateLookup.findProject(parentInBuildTreePath);
         if (parentInBuildTree == null) {
             return null;
         }

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/DefaultUniqueProjectNameProvider.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/DefaultUniqueProjectNameProvider.java
@@ -17,7 +17,7 @@ package org.gradle.plugins.ide.internal.configurer;
 
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectState;
-import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.internal.project.ProjectStateLookup;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
@@ -30,8 +30,8 @@ public class DefaultUniqueProjectNameProvider extends AbstractUniqueProjectNameP
     @Nullable
     private Map<ProjectIdentity, String> deduplicated;
 
-    public DefaultUniqueProjectNameProvider(ProjectStateRegistry projectRegistry) {
-        super(projectRegistry);
+    public DefaultUniqueProjectNameProvider(ProjectStateLookup projectStateLookup) {
+        super(projectStateLookup);
     }
 
     @Override
@@ -43,7 +43,7 @@ public class DefaultUniqueProjectNameProvider extends AbstractUniqueProjectNameP
     private synchronized Map<ProjectIdentity, String> getDeduplicatedNames() {
         if (deduplicated == null) {
             HierarchicalElementDeduplicator<ProjectIdentity> deduplicator = new HierarchicalElementDeduplicator<>(new ProjectPathDeduplicationAdapter());
-            List<ProjectIdentity> allProjects = projectRegistry.getAllProjects().stream()
+            List<ProjectIdentity> allProjects = projectStateLookup.getAllProjects().stream()
                 .map(ProjectState::getIdentity)
                 .collect(toList());
             this.deduplicated = deduplicator.deduplicate(allProjects);

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/EclipseModelAwareUniqueProjectNameProvider.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/EclipseModelAwareUniqueProjectNameProvider.java
@@ -17,7 +17,7 @@ package org.gradle.plugins.ide.internal.configurer;
 
 import org.gradle.api.internal.project.ProjectIdentity;
 import org.gradle.api.internal.project.ProjectState;
-import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.internal.project.ProjectStateLookup;
 import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 import org.jspecify.annotations.Nullable;
 
@@ -37,8 +37,8 @@ public class EclipseModelAwareUniqueProjectNameProvider extends AbstractUniquePr
     private List<ProjectStateWrapper> reservedNames = Collections.emptyList();
     private Map<ProjectIdentity, ProjectStateWrapper> projectToInformationMap = Collections.emptyMap();
 
-    public EclipseModelAwareUniqueProjectNameProvider(ProjectStateRegistry projectRegistry) {
-        super(projectRegistry);
+    public EclipseModelAwareUniqueProjectNameProvider(ProjectStateLookup projectStateLookup) {
+        super(projectStateLookup);
     }
 
     public synchronized void setReservedProjectNames(List<String> reservedNames) {
@@ -65,7 +65,7 @@ public class EclipseModelAwareUniqueProjectNameProvider extends AbstractUniquePr
         if (deduplicated == null) {
 
             projectToInformationMap = new HashMap<>();
-            for (ProjectState state : projectRegistry.getAllProjects()) {
+            for (ProjectState state : projectStateLookup.getAllProjects()) {
                 String projectNameForEclipse = getName(state);
                 projectToInformationMap.put(state.getIdentity(), new ProjectStateWrapper(projectNameForEclipse, state));
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParser;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.project.ProjectState;
-import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.internal.project.ProjectStateLookup;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.scopes.Scope;
@@ -38,7 +38,7 @@ public class DefaultProjectDependencyFactory {
     private final NotationParser<Object, Capability> capabilityNotationParser;
     private final ObjectFactory objectFactory;
     private final AttributesFactory attributesFactory;
-    private final ProjectStateRegistry projectStateRegistry;
+    private final ProjectStateLookup projectStateLookup;
     private final ProjectFinder projectFinder;
 
     public DefaultProjectDependencyFactory(
@@ -46,14 +46,14 @@ public class DefaultProjectDependencyFactory {
         CapabilityNotationParser capabilityNotationParser,
         ObjectFactory objectFactory,
         AttributesFactory attributesFactory,
-        ProjectStateRegistry projectStateRegistry,
+        ProjectStateLookup projectStateLookup,
         ProjectFinder projectFinder
     ) {
         this.instantiator = instantiator;
         this.capabilityNotationParser = capabilityNotationParser;
         this.objectFactory = objectFactory;
         this.attributesFactory = attributesFactory;
-        this.projectStateRegistry = projectStateRegistry;
+        this.projectStateLookup = projectStateLookup;
         this.projectFinder = projectFinder;
     }
 
@@ -68,7 +68,7 @@ public class DefaultProjectDependencyFactory {
     }
 
     public ProjectDependency create(Path projectIdentityPath) {
-        ProjectState projectState = projectStateRegistry.findProjectState(projectIdentityPath);
+        ProjectState projectState = projectStateLookup.findProject(projectIdentityPath);
         if (projectState == null) {
             throw new UnknownProjectException(String.format("Project with path '%s' could not be found.", projectIdentityPath.asString()));
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParser;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyConstraintFactoryInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal;
+import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ExternalModuleComponentResolverFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolverProviderFactories;
@@ -61,8 +62,6 @@ import org.gradle.api.internal.artifacts.transform.TransformExecutionListener;
 import org.gradle.api.internal.artifacts.transform.TransformStepNodeDependencyResolver;
 import org.gradle.api.internal.artifacts.verification.signatures.DefaultSignatureVerificationServiceFactory;
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationServiceFactory;
-import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
 import org.gradle.api.internal.attributes.AttributesFactory;
 import org.gradle.api.internal.catalog.DefaultDependenciesAccessors;
 import org.gradle.api.internal.catalog.DependenciesAccessorsWorkspaceProvider;
@@ -72,6 +71,7 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.notations.DependencyConstraintNotationParser;
 import org.gradle.api.internal.notations.DependencyNotationParser;
 import org.gradle.api.internal.notations.ProjectDependencyFactory;
+import org.gradle.api.internal.project.ProjectStateLookup;
 import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.api.internal.resources.ApiTextResourceAdapter;
 import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarFactory;
@@ -172,14 +172,14 @@ class DependencyManagementBuildScopeServices implements ServiceRegistrationProvi
         CapabilityNotationParser capabilityNotationParser,
         ObjectFactory objectFactory,
         AttributesFactory attributesFactory,
-        ProjectStateRegistry projectStateRegistry
+        ProjectStateLookup projectStateLookup
     ) {
         return new DefaultProjectDependencyFactory(
             instantiator,
             capabilityNotationParser,
             objectFactory,
             attributesFactory,
-            projectStateRegistry,
+            projectStateLookup,
             new UnknownProjectFinder("Project dependencies cannot be declared here.")
         );
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectState
-import org.gradle.api.internal.project.ProjectStateRegistry
+import org.gradle.api.internal.project.ProjectStateLookup
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.Path
 import org.gradle.util.TestUtil
@@ -39,15 +39,15 @@ class ProjectDependencyFactoryTest extends Specification {
     }
 
     def capabilityNotationParser = new CapabilityNotationParserFactory(false).create()
-    def projectStateRegistry = Mock(ProjectStateRegistry) {
-        findProjectState(Path.path(":foo:bar")) >> projectState
+    def projectStateLookup = Mock(ProjectStateLookup) {
+        findProject(Path.path(":foo:bar")) >> projectState
     }
     def depFactory = new DefaultProjectDependencyFactory(
         TestUtil.instantiatorFactory().decorateLenient(),
         capabilityNotationParser,
         TestUtil.objectFactory(),
         AttributeTestUtil.attributesFactory(),
-        projectStateRegistry,
+        projectStateLookup,
         projectFinder
     )
     def factory = new ProjectDependencyFactory(depFactory)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectState.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project;
+
+import com.google.common.collect.Iterables;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
+import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.internal.build.BuildState;
+import org.gradle.internal.model.CalculatedModelValue;
+import org.gradle.internal.model.ModelContainer;
+import org.gradle.internal.model.StateTransitionControllerFactory;
+import org.gradle.internal.project.ImmutableProjectDescriptor;
+import org.gradle.internal.resources.ProjectLeaseRegistry;
+import org.gradle.internal.resources.ResourceLock;
+import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.work.WorkerLeaseService;
+import org.jspecify.annotations.Nullable;
+
+import java.io.Closeable;
+import java.io.File;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+class DefaultProjectState implements ProjectState, Closeable {
+
+    private final BuildState owner;
+    private final ImmutableProjectDescriptor descriptor;
+    private final ProjectIdentity identity;
+    private final IProjectFactory projectFactory;
+    private final ProjectLifecycleController controller;
+    private final WorkerLeaseService workerLeaseService;
+    private final ProjectStateLookup projectStateLookup;
+
+    private final ResourceLock allProjectsLock;
+    private final ResourceLock projectLock;
+    private final ResourceLock taskLock;
+
+    private final Set<Thread> canDoAnythingToThisProject = new CopyOnWriteArraySet<>();
+
+    DefaultProjectState(
+        BuildState owner,
+        ImmutableProjectDescriptor descriptor,
+        IProjectFactory projectFactory,
+        StateTransitionControllerFactory stateTransitionControllerFactory,
+        ServiceRegistry buildServices,
+        WorkerLeaseService workerLeaseService,
+        ProjectStateLookup projectStateLookup
+    ) {
+        this.owner = owner;
+        this.descriptor = descriptor;
+        this.identity = descriptor.getIdentity();
+        this.projectFactory = projectFactory;
+        this.controller = new ProjectLifecycleController(getDisplayName(), stateTransitionControllerFactory, buildServices);
+        this.workerLeaseService = workerLeaseService;
+        this.projectStateLookup = projectStateLookup;
+        this.allProjectsLock = workerLeaseService.getAllProjectsLock(owner.getIdentityPath());
+        this.projectLock = workerLeaseService.getProjectLock(owner.getIdentityPath(), identity.getBuildTreePath());
+        this.taskLock = workerLeaseService.getTaskExecutionLock(owner.getIdentityPath(), identity.getBuildTreePath());
+    }
+
+    @Override
+    public BuildState getOwner() {
+        return owner;
+    }
+
+    // region About this project
+
+    @Override
+    public ProjectIdentity getIdentity() {
+        return identity;
+    }
+
+    @Override
+    public File getProjectDir() {
+        return descriptor.getProjectDir();
+    }
+
+    @Override
+    public ProjectComponentIdentifier getComponentIdentifier() {
+        return new DefaultProjectComponentIdentifier(identity);
+    }
+
+    @Override
+    public ImmutableProjectDescriptor getDescriptor() {
+        return descriptor;
+    }
+
+    @Override
+    public String toString() {
+        return getDisplayName().getDisplayName();
+    }
+
+    // endregion
+
+    // region Project hierarchy
+
+    @Override
+    @Nullable
+    public ProjectState getParent() {
+        ProjectIdentity parentIdentity = descriptor.getParent();
+        if (parentIdentity == null) {
+            return null;
+        }
+
+        return getState(parentIdentity);
+    }
+
+    @Override
+    public Set<ProjectState> getChildProjects() {
+        Set<ProjectState> children = new TreeSet<>(Comparator.comparing(ProjectState::getIdentityPath));
+        for (ProjectIdentity child : descriptor.getChildren()) {
+            children.add(getState(child));
+        }
+        return children;
+    }
+
+    @Override
+    public Iterable<ProjectState> getUnorderedChildProjects() {
+        return Iterables.transform(descriptor.getChildren(), this::getState);
+    }
+
+    private ProjectState getState(ProjectIdentity identity) {
+        ProjectState state = projectStateLookup.findProject(identity.getBuildTreePath());
+        if (state == null) {
+            throw new IllegalStateException("Project '" + identity.getBuildTreePath() + "' is not found in the registry");
+        }
+        return state;
+    }
+
+    @Override
+    public boolean hasChildren() {
+        return !descriptor.getChildren().isEmpty();
+    }
+
+    // endregion
+
+    // region Lifecycle management
+
+    @Override
+    public boolean isCreated() {
+        return controller.isCreated();
+    }
+
+    @Override
+    public void createMutableModel(ClassLoaderScope selfClassLoaderScope, ClassLoaderScope baseClassLoaderScope) {
+        controller.createMutableModel(descriptor, owner, this, selfClassLoaderScope, baseClassLoaderScope, projectFactory);
+    }
+
+    @Override
+    public ProjectInternal getMutableModel() {
+        return controller.getMutableModel();
+    }
+
+    @Override
+    public ProjectInternal getMutableModelEvenAfterFailure() {
+        return controller.getMutableModelEvenAfterFailure();
+    }
+
+    @Override
+    public void ensureConfigured() {
+        // Need to configure intermediate parent projects for configure-on-demand
+        ProjectState parent = getParent();
+        if (parent != null) {
+            parent.ensureConfigured();
+        }
+        controller.ensureSelfConfigured();
+    }
+
+    @Override
+    public void ensureSelfConfigured() {
+        ProjectState parent = getParent();
+        if (parent != null) {
+            ((DefaultProjectState) parent).controller.assertConfigured();
+        }
+        controller.ensureSelfConfigured();
+    }
+
+    @Override
+    public void ensureTasksDiscovered() {
+        controller.ensureTasksDiscovered();
+    }
+
+    // endregion
+
+    @Override
+    public ResourceLock getAccessLock() {
+        return projectLock;
+    }
+
+    @Override
+    public ResourceLock getTaskExecutionLock() {
+        return taskLock;
+    }
+
+    @Override
+    public void applyToMutableState(Consumer<? super ProjectInternal> action) {
+        fromMutableState(p -> {
+            action.accept(p);
+            return null;
+        });
+    }
+
+    @Override
+    public <S extends @Nullable Object> S fromMutableState(Function<? super ProjectInternal, ? extends S> function) {
+        return runWithModelLock(() -> function.apply(getMutableModel()));
+    }
+
+    @Override
+    public <S extends @Nullable Object> S runWithModelLock(Supplier<S> action) {
+        Thread currentThread = Thread.currentThread();
+        if (workerLeaseService.isAllowedUncontrolledAccessToAnyProject() || canDoAnythingToThisProject.contains(currentThread)) {
+            // Current thread is allowed to access anything at any time, so run the action
+            return action.get();
+        }
+
+        Collection<? extends ResourceLock> currentLocks = workerLeaseService.getCurrentProjectLocks();
+        if (currentLocks.contains(projectLock) || currentLocks.contains(allProjectsLock)) {
+            // if we already hold the project lock for this project
+            if (currentLocks.size() == 1) {
+                // the lock for this project is the only lock we hold, can run the action
+                return action.get();
+            } else {
+                throw new IllegalStateException("Current thread holds more than one project lock. It should hold only one project lock at any given time.");
+            }
+        } else {
+            return workerLeaseService.withReplacedLocks(currentLocks, projectLock, action::get);
+        }
+    }
+
+    @Override
+    public <S> S forceAccessToMutableState(Function<? super ProjectInternal, ? extends S> factory) {
+        Thread currentThread = Thread.currentThread();
+        boolean added = canDoAnythingToThisProject.add(currentThread);
+        try {
+            return factory.apply(getMutableModel());
+        } finally {
+            if (added) {
+                canDoAnythingToThisProject.remove(currentThread);
+            }
+        }
+    }
+
+    @Override
+    public boolean hasMutableState() {
+        Thread currentThread = Thread.currentThread();
+        if (canDoAnythingToThisProject.contains(currentThread) || workerLeaseService.isAllowedUncontrolledAccessToAnyProject()) {
+            return true;
+        }
+        Collection<? extends ResourceLock> locks = workerLeaseService.getCurrentProjectLocks();
+        return locks.contains(projectLock) || locks.contains(allProjectsLock);
+    }
+
+    @Override
+    public <T> CalculatedModelValue<T> newCalculatedValue(@Nullable T initialValue) {
+        return new CalculatedModelValueImpl<>(this, workerLeaseService, initialValue);
+    }
+
+    @Override
+    public void close() {
+        controller.close();
+    }
+
+    private static class CalculatedModelValueImpl<T> implements CalculatedModelValue<T> {
+        private final ProjectLeaseRegistry projectLeaseRegistry;
+        private final ModelContainer<?> owner;
+        private final ReentrantLock lock = new ReentrantLock();
+        private volatile @Nullable T value;
+
+        public CalculatedModelValueImpl(DefaultProjectState owner, WorkerLeaseService projectLeaseRegistry, @Nullable T initialValue) {
+            this.projectLeaseRegistry = projectLeaseRegistry;
+            this.value = initialValue;
+            this.owner = owner;
+        }
+
+        @Override
+        public T get() throws IllegalStateException {
+            T currentValue = getOrNull();
+            if (currentValue == null) {
+                throw new IllegalStateException("No calculated value is available for " + owner);
+            }
+            return currentValue;
+        }
+
+        @Override
+        public @Nullable T getOrNull() {
+            // Grab the current value, ignore updates that may be happening
+            return value;
+        }
+
+        @Override
+        public void set(T newValue) {
+            assertCanMutate();
+            value = newValue;
+        }
+
+        @Override
+        public T update(Function<T, T> updateFunction) {
+            acquireUpdateLock();
+            try {
+                T newValue = updateFunction.apply(value);
+                value = newValue;
+                return newValue;
+            } finally {
+                releaseUpdateLock();
+            }
+        }
+
+        private void acquireUpdateLock() {
+            // It's important that we do not block waiting for the lock while holding the project mutation lock.
+            // Doing so can lead to deadlocks.
+
+            assertCanMutate();
+
+            if (lock.tryLock()) {
+                // Update lock was not contended, can keep holding the project locks
+                return;
+            }
+
+            // Another thread holds the update lock, release the project locks and wait for the other thread to finish the update
+            projectLeaseRegistry.blocking(lock::lock);
+        }
+
+        private void assertCanMutate() {
+            if (!owner.hasMutableState()) {
+                throw new IllegalStateException("Current thread does not hold the state lock for " + owner);
+            }
+        }
+
+        private void releaseUpdateLock() {
+            lock.unlock();
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -161,7 +161,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         ServiceRegistry buildServices = buildState.getMutableModel().getServices();
         IProjectFactory projectFactory = buildServices.get(IProjectFactory.class);
         StateTransitionControllerFactory stateTransitionControllerFactory = buildServices.get(StateTransitionControllerFactory.class);
-        ProjectStateImpl projectState = new ProjectStateImpl(buildState, descriptor, projectFactory, stateTransitionControllerFactory, buildServices);
+        ProjectStateImpl projectState = new ProjectStateImpl(buildState, descriptor, projectFactory, stateTransitionControllerFactory, buildServices, workerLeaseService, this);
         projectsByPath.put(descriptor.getIdentity().getBuildTreePath(), projectState);
         projectsById.put(projectState.getComponentIdentifier(), projectState);
         projectRegistry.add(descriptor.getIdentity().getProjectPath(), projectState);
@@ -316,7 +316,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         }
     }
 
-    private class ProjectStateImpl implements ProjectState, Closeable {
+    private static class ProjectStateImpl implements ProjectState, Closeable {
 
         private final ImmutableProjectDescriptor descriptor;
         private final IProjectFactory projectFactory;
@@ -327,18 +327,24 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         private final ResourceLock taskLock;
         private final Set<Thread> canDoAnythingToThisProject = new CopyOnWriteArraySet<>();
         private final ProjectLifecycleController controller;
+        private final WorkerLeaseService workerLeaseService;
+        private final ProjectStateLookup projectStateLookup;
 
         ProjectStateImpl(
             BuildState owner,
             ImmutableProjectDescriptor descriptor,
             IProjectFactory projectFactory,
             StateTransitionControllerFactory stateTransitionControllerFactory,
-            ServiceRegistry buildServices
+            ServiceRegistry buildServices,
+            WorkerLeaseService workerLeaseService,
+            ProjectStateLookup projectStateLookup
         ) {
             this.owner = owner;
             this.descriptor = descriptor;
             this.projectFactory = projectFactory;
             this.identity = descriptor.getIdentity();
+            this.workerLeaseService = workerLeaseService;
+            this.projectStateLookup = projectStateLookup;
             this.allProjectsLock = workerLeaseService.getAllProjectsLock(owner.getIdentityPath());
             this.projectLock = workerLeaseService.getProjectLock(owner.getIdentityPath(), identity.getBuildTreePath());
             this.taskLock = workerLeaseService.getTaskExecutionLock(owner.getIdentityPath(), identity.getBuildTreePath());
@@ -368,7 +374,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
                 return null;
             }
 
-            ProjectState parentState = findProject(parentIdentity.getBuildTreePath());
+            ProjectState parentState = projectStateLookup.findProject(parentIdentity.getBuildTreePath());
             if (parentState == null) {
                 throw new IllegalStateException("Parent project " + parentIdentity.getBuildTreePath() + " is not registered for " + identity);
             }
@@ -400,7 +406,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         }
 
         private ProjectState getStateForChild(ProjectIdentity childIdentity) {
-            return findProject(childIdentity.getBuildTreePath());
+            return projectStateLookup.findProject(childIdentity.getBuildTreePath());
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -15,28 +15,21 @@
  */
 package org.gradle.api.internal.project;
 
-import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
-import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.initialization.ProjectDescriptorInternal;
 import org.gradle.initialization.ProjectDescriptorRegistry;
-import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factory;
 import org.gradle.internal.build.AllProjectsAccess;
 import org.gradle.internal.build.BuildProjectRegistry;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.lazy.Lazy;
-import org.gradle.internal.model.CalculatedModelValue;
-import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.model.StateTransitionControllerFactory;
 import org.gradle.internal.project.DefaultImmutableProjectDescriptor;
 import org.gradle.internal.project.ImmutableProjectDescriptor;
-import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.work.WorkerLeaseService;
@@ -54,17 +47,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closeable {
     private final WorkerLeaseService workerLeaseService;
     private final Object lock = new Object();
-    private final Map<Path, ProjectStateImpl> projectsByPath = new LinkedHashMap<>();
-    private final Map<ProjectComponentIdentifier, ProjectStateImpl> projectsById = new HashMap<>();
+    private final Map<Path, ProjectState> projectsByPath = new LinkedHashMap<>();
+    private final Map<ProjectComponentIdentifier, ProjectState> projectsById = new HashMap<>();
     private final Map<BuildIdentifier, DefaultBuildProjectRegistry> projectsByBuild = new HashMap<>();
 
     public DefaultProjectStateRegistry(WorkerLeaseService workerLeaseService) {
@@ -147,7 +137,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     public void discardProjectsFor(BuildState build) {
         DefaultBuildProjectRegistry registry = projectsByBuild.get(build.getBuildIdentifier());
         if (registry != null) {
-            for (ProjectStateImpl project : registry.projectsByPath.values()) {
+            for (ProjectState project : registry.projectsByPath.values()) {
                 projectsById.remove(project.getComponentIdentifier());
                 projectsByPath.remove(project.getIdentityPath());
             }
@@ -161,7 +151,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
         ServiceRegistry buildServices = buildState.getMutableModel().getServices();
         IProjectFactory projectFactory = buildServices.get(IProjectFactory.class);
         StateTransitionControllerFactory stateTransitionControllerFactory = buildServices.get(StateTransitionControllerFactory.class);
-        ProjectStateImpl projectState = new ProjectStateImpl(buildState, descriptor, projectFactory, stateTransitionControllerFactory, buildServices, workerLeaseService, this);
+        DefaultProjectState projectState = new DefaultProjectState(buildState, descriptor, projectFactory, stateTransitionControllerFactory, buildServices, workerLeaseService, this);
         projectsByPath.put(descriptor.getIdentity().getBuildTreePath(), projectState);
         projectsById.put(projectState.getComponentIdentifier(), projectState);
         projectRegistry.add(descriptor.getIdentity().getProjectPath(), projectState);
@@ -169,7 +159,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     }
 
     @Override
-    public Collection<ProjectStateImpl> getAllProjects() {
+    public Collection<ProjectState> getAllProjects() {
         synchronized (lock) {
             return projectsByPath.values();
         }
@@ -184,7 +174,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     @Override
     public ProjectState stateFor(ProjectComponentIdentifier identifier) {
         synchronized (lock) {
-            ProjectStateImpl projectState = projectsById.get(identifier);
+            ProjectState projectState = projectsById.get(identifier);
             if (projectState == null) {
                 throw new IllegalArgumentException(identifier.getDisplayName() + " not found.");
             }
@@ -195,7 +185,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     @Override
     public ProjectState stateFor(Path identityPath) {
         synchronized (lock) {
-            ProjectStateImpl projectState = projectsByPath.get(identityPath);
+            ProjectState projectState = projectsByPath.get(identityPath);
             if (projectState == null) {
                 throw new IllegalArgumentException(identityPath.asString() + " not found.");
             }
@@ -242,14 +232,14 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     private static class DefaultBuildProjectRegistry implements BuildProjectRegistry {
         private final BuildState owner;
         private final WorkerLeaseService workerLeaseService;
-        private final Map<Path, ProjectStateImpl> projectsByPath = new LinkedHashMap<>();
+        private final Map<Path, ProjectState> projectsByPath = new LinkedHashMap<>();
 
         public DefaultBuildProjectRegistry(BuildState owner, WorkerLeaseService workerLeaseService) {
             this.owner = owner;
             this.workerLeaseService = workerLeaseService;
         }
 
-        public void add(Path projectPath, ProjectStateImpl projectState) {
+        public void add(Path projectPath, DefaultProjectState projectState) {
             projectsByPath.put(projectPath, projectState);
         }
 
@@ -260,7 +250,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
 
         @Override
         public ProjectState getProject(Path projectPath) {
-            ProjectStateImpl projectState = projectsByPath.get(projectPath);
+            ProjectState projectState = projectsByPath.get(projectPath);
             if (projectState == null) {
                 throw new IllegalArgumentException("Project with path '" + projectPath + "' not found in " + owner.getDisplayName() + ".");
             }
@@ -313,330 +303,6 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
             }
             // SAFETY: The caller is only allowed to call this method while holding the all projects lock
             return project.getMutableModel();
-        }
-    }
-
-    private static class ProjectStateImpl implements ProjectState, Closeable {
-
-        private final ImmutableProjectDescriptor descriptor;
-        private final IProjectFactory projectFactory;
-        private final BuildState owner;
-        private final ProjectIdentity identity;
-        private final ResourceLock allProjectsLock;
-        private final ResourceLock projectLock;
-        private final ResourceLock taskLock;
-        private final Set<Thread> canDoAnythingToThisProject = new CopyOnWriteArraySet<>();
-        private final ProjectLifecycleController controller;
-        private final WorkerLeaseService workerLeaseService;
-        private final ProjectStateLookup projectStateLookup;
-
-        ProjectStateImpl(
-            BuildState owner,
-            ImmutableProjectDescriptor descriptor,
-            IProjectFactory projectFactory,
-            StateTransitionControllerFactory stateTransitionControllerFactory,
-            ServiceRegistry buildServices,
-            WorkerLeaseService workerLeaseService,
-            ProjectStateLookup projectStateLookup
-        ) {
-            this.owner = owner;
-            this.descriptor = descriptor;
-            this.projectFactory = projectFactory;
-            this.identity = descriptor.getIdentity();
-            this.workerLeaseService = workerLeaseService;
-            this.projectStateLookup = projectStateLookup;
-            this.allProjectsLock = workerLeaseService.getAllProjectsLock(owner.getIdentityPath());
-            this.projectLock = workerLeaseService.getProjectLock(owner.getIdentityPath(), identity.getBuildTreePath());
-            this.taskLock = workerLeaseService.getTaskExecutionLock(owner.getIdentityPath(), identity.getBuildTreePath());
-            this.controller = new ProjectLifecycleController(getDisplayName(), stateTransitionControllerFactory, buildServices);
-        }
-
-        @Override
-        public DisplayName getDisplayName() {
-            return identity;
-        }
-
-        @Override
-        public String toString() {
-            return getDisplayName().getDisplayName();
-        }
-
-        @Override
-        public BuildState getOwner() {
-            return owner;
-        }
-
-        @Override
-        @Nullable
-        public ProjectState getParent() {
-            ProjectIdentity parentIdentity = descriptor.getParent();
-            if (parentIdentity == null) {
-                return null;
-            }
-
-            ProjectState parentState = projectStateLookup.findProject(parentIdentity.getBuildTreePath());
-            if (parentState == null) {
-                throw new IllegalStateException("Parent project " + parentIdentity.getBuildTreePath() + " is not registered for " + identity);
-            }
-            return parentState;
-        }
-
-        @Override
-        public Set<ProjectState> getChildProjects() {
-            Set<ProjectState> children = new TreeSet<>(Comparator.comparing(ProjectState::getIdentityPath));
-            for (ProjectIdentity child : descriptor.getChildren()) {
-                children.add(getStateForChild(child));
-            }
-            return children;
-        }
-
-        @Override
-        public Iterable<ProjectState> getUnorderedChildProjects() {
-            return Iterables.transform(descriptor.getChildren(), this::getStateForChild);
-        }
-
-        @Override
-        public boolean hasChildren() {
-            return !descriptor.getChildren().isEmpty();
-        }
-
-        @Override
-        public ImmutableProjectDescriptor getDescriptor() {
-            return descriptor;
-        }
-
-        private ProjectState getStateForChild(ProjectIdentity childIdentity) {
-            return projectStateLookup.findProject(childIdentity.getBuildTreePath());
-        }
-
-        @Override
-        public String getName() {
-            return identity.getProjectName();
-        }
-
-        @Override
-        public Path getIdentityPath() {
-            return identity.getBuildTreePath();
-        }
-
-        @Override
-        public ProjectIdentity getIdentity() {
-            return identity;
-        }
-
-        @Override
-        public Path getProjectPath() {
-            return identity.getProjectPath();
-        }
-
-        @Override
-        public File getProjectDir() {
-            return descriptor.getProjectDir();
-        }
-
-        @Override
-        public int getDepth() {
-            return getProjectPath().segmentCount();
-        }
-
-        @Override
-        public boolean isCreated() {
-            return controller.isCreated();
-        }
-
-        @Override
-        public void createMutableModel(ClassLoaderScope selfClassLoaderScope, ClassLoaderScope baseClassLoaderScope) {
-            controller.createMutableModel(descriptor, owner, this, selfClassLoaderScope, baseClassLoaderScope, projectFactory);
-        }
-
-        @Override
-        public ProjectInternal getMutableModel() {
-            return controller.getMutableModel();
-        }
-
-        @Override
-        public ProjectInternal getMutableModelEvenAfterFailure() {
-            return controller.getMutableModelEvenAfterFailure();
-        }
-
-        @Override
-        public void ensureConfigured() {
-            // Need to configure intermediate parent projects for configure-on-demand
-            ProjectState parent = getParent();
-            if (parent != null) {
-                parent.ensureConfigured();
-            }
-            controller.ensureSelfConfigured();
-        }
-
-        @Override
-        public void ensureSelfConfigured() {
-            ProjectState parent = getParent();
-            if (parent != null) {
-                ((ProjectStateImpl) parent).controller.assertConfigured();
-            }
-            controller.ensureSelfConfigured();
-        }
-
-        @Override
-        public void ensureTasksDiscovered() {
-            controller.ensureTasksDiscovered();
-        }
-
-        @Override
-        public ProjectComponentIdentifier getComponentIdentifier() {
-            return new DefaultProjectComponentIdentifier(identity);
-        }
-
-        @Override
-        public ResourceLock getAccessLock() {
-            return projectLock;
-        }
-
-        @Override
-        public ResourceLock getTaskExecutionLock() {
-            return taskLock;
-        }
-
-        @Override
-        public void applyToMutableState(Consumer<? super ProjectInternal> action) {
-            fromMutableState(p -> {
-                action.accept(p);
-                return null;
-            });
-        }
-
-        @Override
-        public <S extends @Nullable Object> S fromMutableState(Function<? super ProjectInternal, ? extends S> function) {
-            return runWithModelLock(() -> function.apply(getMutableModel()));
-        }
-
-        @Override
-        public <S extends @Nullable Object> S runWithModelLock(Supplier<S> action) {
-            Thread currentThread = Thread.currentThread();
-            if (workerLeaseService.isAllowedUncontrolledAccessToAnyProject() || canDoAnythingToThisProject.contains(currentThread)) {
-                // Current thread is allowed to access anything at any time, so run the action
-                return action.get();
-            }
-
-            Collection<? extends ResourceLock> currentLocks = workerLeaseService.getCurrentProjectLocks();
-            if (currentLocks.contains(projectLock) || currentLocks.contains(allProjectsLock)) {
-                // if we already hold the project lock for this project
-                if (currentLocks.size() == 1) {
-                    // the lock for this project is the only lock we hold, can run the action
-                    return action.get();
-                } else {
-                    throw new IllegalStateException("Current thread holds more than one project lock. It should hold only one project lock at any given time.");
-                }
-            } else {
-                return workerLeaseService.withReplacedLocks(currentLocks, projectLock, action::get);
-            }
-        }
-
-        @Override
-        public <S> S forceAccessToMutableState(Function<? super ProjectInternal, ? extends S> factory) {
-            Thread currentThread = Thread.currentThread();
-            boolean added = canDoAnythingToThisProject.add(currentThread);
-            try {
-                return factory.apply(getMutableModel());
-            } finally {
-                if (added) {
-                    canDoAnythingToThisProject.remove(currentThread);
-                }
-            }
-        }
-
-        @Override
-        public boolean hasMutableState() {
-            Thread currentThread = Thread.currentThread();
-            if (canDoAnythingToThisProject.contains(currentThread) || workerLeaseService.isAllowedUncontrolledAccessToAnyProject()) {
-                return true;
-            }
-            Collection<? extends ResourceLock> locks = workerLeaseService.getCurrentProjectLocks();
-            return locks.contains(projectLock) || locks.contains(allProjectsLock);
-        }
-
-        @Override
-        public <T> CalculatedModelValue<T> newCalculatedValue(@Nullable T initialValue) {
-            return new CalculatedModelValueImpl<>(this, workerLeaseService, initialValue);
-        }
-
-        @Override
-        public void close() {
-            controller.close();
-        }
-    }
-
-    private static class CalculatedModelValueImpl<T> implements CalculatedModelValue<T> {
-        private final ProjectLeaseRegistry projectLeaseRegistry;
-        private final ModelContainer<?> owner;
-        private final ReentrantLock lock = new ReentrantLock();
-        @Nullable
-        private volatile T value;
-
-        public CalculatedModelValueImpl(ProjectStateImpl owner, WorkerLeaseService projectLeaseRegistry, @Nullable T initialValue) {
-            this.projectLeaseRegistry = projectLeaseRegistry;
-            this.value = initialValue;
-            this.owner = owner;
-        }
-
-        @Override
-        public T get() throws IllegalStateException {
-            T currentValue = getOrNull();
-            if (currentValue == null) {
-                throw new IllegalStateException("No calculated value is available for " + owner);
-            }
-            return currentValue;
-        }
-
-        @Override
-        @Nullable
-        public T getOrNull() {
-            // Grab the current value, ignore updates that may be happening
-            return value;
-        }
-
-        @Override
-        public void set(T newValue) {
-            assertCanMutate();
-            value = newValue;
-        }
-
-        @Override
-        public T update(Function<T, T> updateFunction) {
-            acquireUpdateLock();
-            try {
-                T newValue = updateFunction.apply(value);
-                value = newValue;
-                return newValue;
-            } finally {
-                releaseUpdateLock();
-            }
-        }
-
-        private void acquireUpdateLock() {
-            // It's important that we do not block waiting for the lock while holding the project mutation lock.
-            // Doing so can lead to deadlocks.
-
-            assertCanMutate();
-
-            if (lock.tryLock()) {
-                // Update lock was not contended, can keep holding the project locks
-                return;
-            }
-
-            // Another thread holds the update lock, release the project locks and wait for the other thread to finish the update
-            projectLeaseRegistry.blocking(lock::lock);
-        }
-
-        private void assertCanMutate() {
-            if (!owner.hasMutableState()) {
-                throw new IllegalStateException("Current thread does not hold the state lock for " + owner);
-            }
-        }
-
-        private void releaseUpdateLock() {
-            lock.unlock();
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -204,7 +204,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
     }
 
     @Override
-    public @Nullable ProjectState findProjectState(Path identityPath) {
+    public @Nullable ProjectState findProject(Path identityPath) {
         synchronized (lock) {
             return projectsByPath.get(identityPath);
         }
@@ -368,7 +368,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
                 return null;
             }
 
-            ProjectStateImpl parentState = projectsByPath.get(parentIdentity.getBuildTreePath());
+            ProjectState parentState = findProject(parentIdentity.getBuildTreePath());
             if (parentState == null) {
                 throw new IllegalStateException("Parent project " + parentIdentity.getBuildTreePath() + " is not registered for " + identity);
             }
@@ -399,8 +399,8 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry, Closea
             return descriptor;
         }
 
-        private ProjectStateImpl getStateForChild(ProjectIdentity childIdentity) {
-            return projectsByPath.get(childIdentity.getBuildTreePath());
+        private ProjectState getStateForChild(ProjectIdentity childIdentity) {
+            return findProject(childIdentity.getBuildTreePath());
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectRegistry.java
@@ -44,7 +44,7 @@ public interface ProjectRegistry extends HoldsProjectState {
     @Nullable ProjectIdentifier getProject(String path);
 
     /**
-     * Prefer {@link ProjectStateRegistry#findProjectState(Path)}.
+     * Prefer {@link ProjectStateRegistry#findProject(Path)}.
      */
     @Nullable ProjectInternal getProjectInternal(String path);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -38,12 +38,75 @@ import java.util.function.Function;
  */
 @ThreadSafe
 public interface ProjectState extends ModelContainer<ProjectInternal> {
-    DisplayName getDisplayName();
 
     /**
      * Returns the containing build of this project.
      */
     BuildState getOwner();
+
+    // region About this project
+
+    /**
+     * Gets the identity of this project, containing the identity within the build tree and the owning build.
+     */
+    ProjectIdentity getIdentity();
+
+    /**
+     * Returns an identifying path for this project in the build tree.
+     */
+    default Path getIdentityPath() {
+        return getIdentity().getBuildTreePath();
+    }
+
+    /**
+     * Returns a path for this project within its containing build. These are not unique within a build tree. Use instead {@link #getIdentityPath()} to uniquely this project.
+     */
+    default Path getProjectPath() {
+        return getIdentity().getProjectPath();
+    }
+
+    /**
+     * Returns the name of this project (which may not necessarily be unique).
+     */
+    default String getName() {
+        return getIdentity().getProjectName();
+    }
+
+    /**
+     * Returns the nesting level of a project in a multi-project hierarchy.
+     * <p>
+     * Returns 0 for the root project, 1 for its direct children, etc.
+     * <p>
+     * The depth is computed independently for each build in the build tree.
+     */
+    default int getDepth() {
+        return getProjectPath().segmentCount();
+    }
+
+    default DisplayName getDisplayName() {
+        return getIdentity();
+    }
+
+    /**
+     * Returns the project directory.
+     */
+    File getProjectDir();
+
+    /**
+     * Returns the identifier of the default component produced by this project.
+     */
+    ProjectComponentIdentifier getComponentIdentifier();
+
+    /**
+     * Returns the descriptor for this project.
+     * <p>
+     * Prefer the direct methods on this class, such as {@link #getIdentity()}, {@link #getParent()}, {@link #getChildProjects()}, etc.
+     */
+    ImmutableProjectDescriptor getDescriptor();
+
+    // endregion
+
+    // region Project hierarchy
 
     /**
      * Returns the parent of this project, as per {@link Project#getParent()}.
@@ -70,49 +133,9 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
      */
     boolean hasChildren();
 
-    /**
-     * Returns the name of this project (which may not necessarily be unique).
-     */
-    String getName();
+    // endregion
 
-    /**
-     * Returns an identifying path for this project in the build tree.
-     */
-    Path getIdentityPath();
-
-    /**
-     * Gets the identity of this project, containing the identity within the build tree and the owning build.
-     */
-    ProjectIdentity getIdentity();
-
-    /**
-     * Returns a path for this project within its containing build. These are not unique within a build tree. Use instead {@link #getIdentityPath()} to uniquely this project.
-     */
-    Path getProjectPath();
-
-    /**
-     * Returns the project directory.
-     */
-    File getProjectDir();
-
-    /**
-     * Returns the descriptor for this project.
-     */
-    ImmutableProjectDescriptor getDescriptor();
-
-    /**
-     * Returns the nesting level of a project in a multi-project hierarchy.
-     * <p>
-     * Returns 0 for the root project, 1 for its direct children, etc.
-     * <p>
-     * The depth is computed independently for each build in the build tree.
-     */
-    int getDepth();
-
-    /**
-     * Returns the identifier of the default component produced by this project.
-     */
-    ProjectComponentIdentifier getComponentIdentifier();
+    // region Lifecycle management
 
     /**
      * Is the mutable model for this project available?
@@ -142,6 +165,8 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
      * Configure the mutable model for this project and discovers any registered tasks, if not already done.
      */
     void ensureTasksDiscovered();
+
+    // endregion
 
     /**
      * Returns the mutable model for this project. This should not be used directly. This property is here to help with migration away from direct usage.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateLookup.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateLookup.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project;
+
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.util.Path;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+
+@ServiceScope(Scope.BuildTree.class)
+public interface ProjectStateLookup {
+
+    /**
+     * Returns all projects in the build tree.
+     */
+    Collection<? extends ProjectState> getAllProjects();
+
+    /**
+     * Locates the state object that owns the project.
+     *
+     * @param identityPath The identity path aka build-tree path of the project.
+     * @return The project state, or null if the project is not present.
+     * @see ProjectStateRegistry
+     */
+    @Nullable
+    ProjectState findProject(Path identityPath);
+
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -29,19 +29,13 @@ import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
 import javax.annotation.concurrent.ThreadSafe;
-import java.util.Collection;
 
 /**
  * A registry of all projects present in a build tree.
  */
 @ThreadSafe
 @ServiceScope(Scope.BuildTree.class)
-public interface ProjectStateRegistry {
-    /**
-     * Returns all projects in the build tree.
-     */
-    Collection<? extends ProjectState> getAllProjects();
-
+public interface ProjectStateRegistry extends ProjectStateLookup {
     /**
      * Locates the state object that owns the given public project model. Can use {@link ProjectInternal#getOwner()} instead.
      */
@@ -56,11 +50,6 @@ public interface ProjectStateRegistry {
      * Locates the state object that owns the project with the identity path.
      */
     ProjectState stateFor(Path identityPath) throws IllegalArgumentException;
-
-    /**
-     * Locates the state object that owns the project with the given identity path, or null if this project is not present.
-     */
-    @Nullable ProjectState findProjectState(Path identityPath);
 
     /**
      * Locates the state objects for all projects of the given build.

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.model.DefaultObjectFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.options.InternalOptionsFactory;
 import org.gradle.api.internal.project.DefaultProjectStateRegistry;
+import org.gradle.api.internal.project.ProjectStateLookup;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.project.taskfactory.TaskIdentityFactory;
 import org.gradle.api.internal.properties.DefaultGradlePropertiesController;
@@ -127,7 +128,7 @@ public class BuildTreeScopeServices implements ServiceRegistrationProvider {
         registration.add(BuildLifecycleControllerFactory.class, DefaultBuildLifecycleControllerFactory.class);
         registration.add(BuildOptionBuildOperationProgressEventsEmitter.class);
         registration.add(BuildInclusionCoordinator.class);
-        registration.add(ProjectStateRegistry.class, DefaultProjectStateRegistry.class);
+        registration.add(ProjectStateRegistry.class, ProjectStateLookup.class, DefaultProjectStateRegistry.class);
         registration.add(ConfigurationTimeBarrier.class, DefaultConfigurationTimeBarrier.class);
         registration.add(ProblemReporter.class, DeprecationsReporter.class);
         registration.add(ProjectConfigurer.class, TaskPathProjectEvaluator.class);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder
 import org.gradle.api.internal.project.ProjectIdentity
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
-import org.gradle.api.internal.project.ProjectStateRegistry
+import org.gradle.api.internal.project.ProjectStateLookup
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.Path
 import org.gradle.util.TestUtil
@@ -79,8 +79,8 @@ class DefaultProjectDependencyConstraintTest extends Specification {
         }
         projectState.getMutableModel() >> project
 
-        def projectStateRegistry = Mock(ProjectStateRegistry) {
-            findProjectState(Path.ROOT) >> projectState
+        def projectStateLookup = Mock(ProjectStateLookup) {
+            findProject(Path.ROOT) >> projectState
         }
 
         def dependencyFactory = new DefaultProjectDependencyFactory(
@@ -88,7 +88,7 @@ class DefaultProjectDependencyConstraintTest extends Specification {
             new CapabilityNotationParserFactory(false).create(),
             TestUtil.objectFactory(),
             AttributeTestUtil.attributesFactory(),
-            projectStateRegistry,
+            projectStateLookup,
             new UnknownProjectFinder("")
         )
 


### PR DESCRIPTION
The logic of managing Project-scoped `ProjectState` and corresponding mutable model (`Project`) today is scattered around many classes, making it hard to understand and maintain. We should treat the user-facing mutable model `Project` with care and generally avoid using it internally, preferring `ProjectState` or, where possible, more lightweight alternatives such as `ProjectIdentity`.

In order to be able to consolidate the Project-state management logic, we are decoupling the `ProjectState` class from its surrounding registry. The registry's purpose can be limited to the creation of the `ProjectState` objects and management of project- and build-scoped locks. This change will accommodate making the implementation of `ProjectState` deeper in the future, while keeping clear separation of concerns.

### Changes

- Introduce a more targeted `ProjectStateLookup` interface that is useful in many contexts, normally, after the projects were configured
- Relying on the new interface, decouple the impl of `ProjectState` from depending on the project state registry impl
- Finally, move the impl of `ProjectState` into `DefaultProjectState`