### PR TITLE
Improve error message for corrupted signatures

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1991,4 +1991,42 @@ This can indicate that a dependency has been compromised. Please carefully verif
         def artifact = module.getArtifact([type: artifactType, classifier: classifier])
         return new File(new File(modulePath, getChecksum(module, "sha1", artifactType)), artifact.file.name)
     }
+
+    private static byte[] corruptAscBytes() {
+        // ASCII-armored envelope wrapping garbage; triggers ArmoredInputException in bcpg
+        def out = new ByteArrayOutputStream()
+        out.write("-----BEGIN PGP SIGNATURE-----\n\n".bytes)
+        out.write([0xff, 0xfe, 0xfd, 0xfc, 0x0a] as byte[])
+        out.write("-----END PGP SIGNATURE-----\n".bytes)
+        return out.toByteArray()
+    }
+
+    def "fails verification with clear message when signature file is corrupt"() {
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+            verifySignatures()
+        }
+
+        given:
+        terseConsoleOutput(false)
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature { artifact ->
+                new File("${artifact}.asc").bytes = corruptAscBytes()
+            }
+        }
+        buildFile """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        when:
+        fails ":compileJava"
+
+        then:
+        failure.assertHasCause("Dependency verification failed for configuration ':compileClasspath'")
+        failure.assertHasErrorOutput("foo-1.0.jar (org:foo:1.0) in repository 'maven': signature file is corrupt (ArmoredInputException")
+    }
+
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/DependencyVerificationReportWriter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/DependencyVerificationReportWriter.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.Repo
 import org.gradle.api.internal.artifacts.verification.verifier.ChecksumVerificationFailure;
 import org.gradle.api.internal.artifacts.verification.verifier.DeletedArtifact;
 import org.gradle.api.internal.artifacts.verification.verifier.InvalidSignature;
+import org.gradle.api.internal.artifacts.verification.verifier.InvalidSignatureFile;
 import org.gradle.api.internal.artifacts.verification.verifier.MissingChecksums;
 import org.gradle.api.internal.artifacts.verification.verifier.MissingSignature;
 import org.gradle.api.internal.artifacts.verification.verifier.OnlyIgnoredKeys;
@@ -190,6 +191,9 @@ public class DependencyVerificationReportWriter {
                 state.hasUntrustedKeys();
             }
         } else if (failure instanceof InvalidSignature) {
+            state.failedSignatures();
+            state.maybeCompromised();
+        } else if (failure instanceof InvalidSignatureFile) {
             state.failedSignatures();
             state.maybeCompromised();
         } else if (failure instanceof DeletedArtifact || failure instanceof ChecksumVerificationFailure || failure instanceof OnlyIgnoredKeys || failure instanceof MissingSignature) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/HtmlDependencyVerificationReportRenderer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/HtmlDependencyVerificationReportRenderer.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.RepositoryAwareVerificationFailure;
 import org.gradle.api.internal.artifacts.verification.verifier.ChecksumVerificationFailure;
 import org.gradle.api.internal.artifacts.verification.verifier.DeletedArtifact;
+import org.gradle.api.internal.artifacts.verification.verifier.InvalidSignatureFile;
 import org.gradle.api.internal.artifacts.verification.verifier.MissingChecksums;
 import org.gradle.api.internal.artifacts.verification.verifier.MissingSignature;
 import org.gradle.api.internal.artifacts.verification.verifier.OnlyIgnoredKeys;
@@ -257,6 +258,10 @@ class HtmlDependencyVerificationReportRenderer implements DependencyVerification
             "        <p>The signature file for this artifact wasn't found.</p>",
             "        <p>Usually it indicates that the signature doesn't exist in the repository the artifact was downloaded from.</p>",
             "        <p>In general this is not a problem but you should then declare at least one checksum for verification to pass.</p>");
+        registerModal("signature-file-corrupt", "Corrupt signature file",
+            "        <p>The signature file (.asc) for this artifact <b>could not be parsed</b>.</p>",
+            "        <p>This usually means the file is malformed (invalid ASCII armor or corrupt PGP packets), the upstream repository serves a broken signature, the file was truncated during download or the repository is misconfigured.</p>",
+            "        <p>Because the signature cannot be read, Gradle cannot decide whether the artifact is trustworthy. <b>Carefully review this problem</b>: fetch the signature from a trusted source, or contact the upstream maintainers to fix the published signature.</p>");
     }
 
     private void copyReportResource(File outputDirectory, String dirName, String fileName) {
@@ -372,6 +377,10 @@ class HtmlDependencyVerificationReportRenderer implements DependencyVerification
     private void reportSignatureProblems(VerificationFailure vf) {
         if (vf instanceof MissingSignature) {
             reportItem("Signature file is missing", "signature-file-missing", "info");
+        } else if (vf instanceof InvalidSignatureFile) {
+            InvalidSignatureFile isf = (InvalidSignatureFile) vf;
+            String reason = actual("Signature file is corrupt: " + isf.getCauseDescription());
+            reportItem(reason, "signature-file-corrupt", "warning");
         } else if (vf instanceof SignatureVerificationFailure) {
             SignatureVerificationFailure svf = (SignatureVerificationFailure) vf;
             Map<String, SignatureVerificationFailure.SignatureError> errors = svf.getErrors();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriterSignatureVerificationResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriterSignatureVerificationResult.java
@@ -57,4 +57,9 @@ class WriterSignatureVerificationResult implements SignatureVerificationResultBu
     public void noSignatures() {
         entry.noSignatures();
     }
+
+    @Override
+    public void failedToReadSignatureFile(String causeDescription) {
+        entry.noSignatures();
+    }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildSignatureVerificationService.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildSignatureVerificationService.java
@@ -213,6 +213,7 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
         private List<PGPPublicKey> failedKeys = null;
         private List<String> ignoredKeys = null;
         private boolean hasNoSignatures = false;
+        private String corruptionError = null;
 
         private CacheEntryBuilder(long timestamp, HashCode originHash, HashCode signatureHash) {
             this.timestamp = timestamp;
@@ -264,8 +265,13 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
             hasNoSignatures = true;
         }
 
+        @Override
+        public void failedToReadSignatureFile(String causeDescription) {
+            corruptionError = causeDescription;
+        }
+
         CacheEntry build() {
-            return new CacheEntry(timestamp, originHash, signatureHash, missingKeys, trustedKeys, validKeys, failedKeys, ignoredKeys, hasNoSignatures);
+            return new CacheEntry(timestamp, originHash, signatureHash, missingKeys, trustedKeys, validKeys, failedKeys, ignoredKeys, hasNoSignatures, corruptionError);
         }
     }
 
@@ -279,8 +285,9 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
         private final List<PGPPublicKey> failedKeys;
         private final List<String> ignoredKeys;
         private final boolean hasNoSignatures;
+        private final String corruptionError;
 
-        public CacheEntry(long timestamp, HashCode originHash, HashCode signatureHash, List<String> missingKeys, List<PGPPublicKey> trustedKeys, List<PGPPublicKey> validKeys, List<PGPPublicKey> failedKeys, List<String> ignoredKeys, boolean hasNoSignatures) {
+        public CacheEntry(long timestamp, HashCode originHash, HashCode signatureHash, List<String> missingKeys, List<PGPPublicKey> trustedKeys, List<PGPPublicKey> validKeys, List<PGPPublicKey> failedKeys, List<String> ignoredKeys, boolean hasNoSignatures, String corruptionError) {
             this.timestamp = timestamp;
             this.originHash = originHash;
             this.signatureHash = signatureHash;
@@ -290,6 +297,7 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
             this.failedKeys = failedKeys;
             this.ignoredKeys = ignoredKeys;
             this.hasNoSignatures = hasNoSignatures;
+            this.corruptionError = corruptionError;
         }
 
         void applyTo(SignatureVerificationResultBuilder builder) {
@@ -321,6 +329,9 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
             if (hasNoSignatures) {
                 builder.noSignatures();
             }
+            if (corruptionError != null) {
+                builder.failedToReadSignatureFile(corruptionError);
+            }
         }
 
         public boolean updated(HashCode originHash, HashCode signatureHash) {
@@ -348,7 +359,8 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
             List<PGPPublicKey> failedKeys = readKeys(decoder);
             List<String> ignoredKeys = readStringKeys(decoder);
             boolean hasNoSignatures = decoder.readBoolean();
-            return new CacheEntry(timestamp, originHash, signatureHash, missingKeys, trustedKeys, validKeys, failedKeys, ignoredKeys, hasNoSignatures);
+            String corruptionError = decoder.readNullableString();
+            return new CacheEntry(timestamp, originHash, signatureHash, missingKeys, trustedKeys, validKeys, failedKeys, ignoredKeys, hasNoSignatures, corruptionError);
         }
 
         private List<String> readStringKeys(Decoder decoder) throws Exception {
@@ -386,6 +398,7 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
             writeKeys(encoder, value.failedKeys);
             writeStringKeys(encoder, value.ignoredKeys);
             encoder.writeBoolean(value.hasNoSignatures);
+            encoder.writeNullableString(value.corruptionError);
         }
 
         private void writeStringKeys(Encoder encoder, List<String> keys) throws Exception {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/DefaultSignatureVerificationServiceFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/DefaultSignatureVerificationServiceFactory.java
@@ -36,6 +36,7 @@ import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.security.internal.EmptyPublicKeyService;
 import org.gradle.security.internal.Fingerprint;
+import org.gradle.security.internal.InvalidSignatureFileException;
 import org.gradle.security.internal.PublicKeyDownloadService;
 import org.gradle.security.internal.PublicKeyResultBuilder;
 import org.gradle.security.internal.PublicKeyService;
@@ -132,7 +133,14 @@ public class DefaultSignatureVerificationServiceFactory implements SignatureVeri
 
         @Override
         public void verify(File origin, File signature, Set<String> trustedKeys, Set<String> ignoredKeys, SignatureVerificationResultBuilder result) {
-            PGPSignatureList pgpSignatures = SecuritySupport.readSignatures(signature);
+            PGPSignatureList pgpSignatures;
+            try {
+                pgpSignatures = SecuritySupport.readSignatures(signature);
+            } catch (InvalidSignatureFileException e) {
+                Throwable cause = e.getCause() != null ? e.getCause() : e;
+                result.failedToReadSignatureFile(cause.getClass().getSimpleName() + ": " + cause.getMessage());
+                return;
+            }
             if (pgpSignatures == null) {
                 result.noSignatures();
                 return;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/SignatureVerificationResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/SignatureVerificationResultBuilder.java
@@ -24,4 +24,6 @@ public interface SignatureVerificationResultBuilder {
     void ignored(String keyId);
 
     void noSignatures();
+
+    void failedToReadSignatureFile(String causeDescription);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifier.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifier.java
@@ -270,6 +270,7 @@ public class DependencyVerifier {
         private List<PGPPublicKey> failedKeys = null;
         private List<String> ignoredKeys = null;
         private boolean hasValidSignatures = true;
+        private String corruptionError = null;
 
         private DefaultSignatureVerificationResultBuilder(File file, File signatureFile) {
             this.file = file;
@@ -320,6 +321,11 @@ public class DependencyVerifier {
             hasValidSignatures = false;
         }
 
+        @Override
+        public void failedToReadSignatureFile(String causeDescription) {
+            corruptionError = causeDescription;
+        }
+
         private boolean hasOnlyIgnoredKeys() {
             return ignoredKeys != null
                 && trustedKeys == null
@@ -329,6 +335,9 @@ public class DependencyVerifier {
         }
 
         public VerificationFailure asError(PublicKeyService publicKeyService) {
+            if (corruptionError != null) {
+                return new InvalidSignatureFile(file, signatureFile, corruptionError);
+            }
             if (!hasValidSignatures) {
                 return new InvalidSignature(file, signatureFile);
             }
@@ -360,7 +369,7 @@ public class DependencyVerifier {
         }
 
         public boolean hasError() {
-            return failedKeys != null || validNotTrusted != null || missingKeys != null || !hasValidSignatures || hasOnlyIgnoredKeys();
+            return failedKeys != null || validNotTrusted != null || missingKeys != null || !hasValidSignatures || corruptionError != null || hasOnlyIgnoredKeys();
         }
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/InvalidSignatureFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/InvalidSignatureFile.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.verifier;
+
+import org.gradle.internal.logging.text.TreeFormatter;
+import org.jspecify.annotations.NullMarked;
+
+import java.io.File;
+
+/**
+ * Verification failure raised when the signature file (.asc) cannot be parsed
+ * (e.g. it has invalid ASCII armor or otherwise corrupt PGP packets).
+ */
+@NullMarked
+public class InvalidSignatureFile extends AbstractVerificationFailure {
+    private final File signatureFile;
+    private final String causeDescription;
+
+    public InvalidSignatureFile(File affectedFile, File signatureFile, String causeDescription) {
+        super(affectedFile);
+        this.signatureFile = signatureFile;
+        this.causeDescription = causeDescription;
+    }
+
+    @Override
+    public File getSignatureFile() {
+        return signatureFile;
+    }
+
+    public String getCauseDescription() {
+        return causeDescription;
+    }
+
+    @Override
+    public boolean isFatal() {
+        return true;
+    }
+
+    @Override
+    public void explainTo(TreeFormatter formatter) {
+        formatter.append("signature file is corrupt (").append(causeDescription).append(")");
+    }
+}

--- a/platforms/software/security/src/main/java/org/gradle/security/internal/InvalidSignatureFileException.java
+++ b/platforms/software/security/src/main/java/org/gradle/security/internal/InvalidSignatureFileException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.security.internal;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.io.File;
+
+/**
+ * Thrown when a PGP signature file (.asc) cannot be parsed, e.g. when it contains
+ * invalid armor or otherwise malformed PGP packets.
+ */
+@NullMarked
+public class InvalidSignatureFileException extends RuntimeException {
+    private final File signatureFile;
+
+    public InvalidSignatureFileException(File signatureFile, Throwable cause) {
+        super("Could not read signatures from " + signatureFile + ": " + cause.getClass().getSimpleName() + ": " + cause.getMessage(), cause);
+        this.signatureFile = signatureFile;
+    }
+
+    public File getSignatureFile() {
+        return signatureFile;
+    }
+}

--- a/platforms/software/security/src/main/java/org/gradle/security/internal/SecuritySupport.java
+++ b/platforms/software/security/src/main/java/org/gradle/security/internal/SecuritySupport.java
@@ -85,7 +85,7 @@ public class SecuritySupport {
         ) {
             return readSignatureList(decoderStream, file.toString());
         } catch (IOException | PGPException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
+            throw new InvalidSignatureFileException(file, e);
         }
     }
 


### PR DESCRIPTION
Context:
Due to [Ivy repo patterns misconfiguration](https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2140) in the IJ platform plugin, Gradle fetched tar.gz as an asc signature, causing cryptic error.

See
https://github.com/gradle/gradle/pull/37558/changes#r3138291977

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
