### PR TITLE
Fix filesystem watching breaking with symlinks

### DIFF
--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -69,9 +70,11 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
         removedSnapshots.stream()
             .filter(watchableHierarchies::shouldWatch)
             .forEach(snapshot -> {
-                String previousWatchedRoot = watchedDirectoryForSnapshot.remove(snapshot.getAbsolutePath());
-                decrement(previousWatchedRoot, changedWatchedDirectories);
-                snapshot.accept(new SubdirectoriesToWatchVisitor(path -> decrement(path, changedWatchedDirectories)));
+                // Reuse the canonical key stored on add, so removal needs no filesystem access.
+                String base = snapshot.getAbsolutePath();
+                String watchedRootKey = watchedDirectoryForSnapshot.remove(base);
+                decrement(watchedRootKey, changedWatchedDirectories);
+                snapshot.accept(new SubdirectoriesToWatchVisitor(path -> decrement(resolveDescendant(base, watchedRootKey, path), changedWatchedDirectories)));
             });
         addedSnapshots.stream()
             .filter(watchableHierarchies::shouldWatch)
@@ -81,9 +84,12 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
                 if (!watchableHierarchies.isInWatchableHierarchy(pathToWatchForRoot)) {
                     return;
                 }
-                watchedDirectoryForSnapshot.put(snapshot.getAbsolutePath(), pathToWatchForRoot);
-                increment(pathToWatchForRoot, changedWatchedDirectories);
-                snapshot.accept(new SubdirectoriesToWatchVisitor(path -> increment(path, changedWatchedDirectories)));
+                // Canonicalize the watched root once; its subdirectories reuse it via resolveDescendant.
+                String base = snapshot.getAbsolutePath();
+                String watchedRootKey = canonicalize(pathToWatchForRoot);
+                watchedDirectoryForSnapshot.put(base, watchedRootKey);
+                increment(watchedRootKey, changedWatchedDirectories);
+                snapshot.accept(new SubdirectoriesToWatchVisitor(path -> increment(resolveDescendant(base, watchedRootKey, path), changedWatchedDirectories)));
             });
         if (changedWatchedDirectories.isEmpty()) {
             return false;
@@ -97,11 +103,13 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
         // Most of the changes already happened in `handleVirtualFileSystemContentsChanged`.
         // Here we only need to update watches for the roots of the hierarchies.
         Map<String, Integer> changedWatchDirectories = new HashMap<>();
-        watchedWatchableHierarchies.forEach(absolutePath -> decrement(absolutePath, changedWatchDirectories));
+        // watchedWatchableHierarchies holds canonical keys, so they can be decremented directly.
+        watchedWatchableHierarchies.forEach(key -> decrement(key, changedWatchDirectories));
         watchedWatchableHierarchies.clear();
         newWatchedFiles.visitRoots(absolutePath -> {
-            watchedWatchableHierarchies.add(absolutePath);
-            increment(absolutePath, changedWatchDirectories);
+            String key = canonicalize(absolutePath);
+            watchedWatchableHierarchies.add(key);
+            increment(key, changedWatchDirectories);
         });
         if (!changedWatchDirectories.isEmpty()) {
             updateWatchedDirectories(changedWatchDirectories);
@@ -166,12 +174,29 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
         }
     }
 
-    private static void decrement(String path, Map<String, Integer> changedWatchedDirectories) {
-        changedWatchedDirectories.compute(path, (key, value) -> zeroToNull(nullToZero(value) - 1));
+    private static String canonicalize(String absolutePath) {
+        try {
+            return new File(absolutePath).getCanonicalPath();
+        } catch (IOException e) {
+            return absolutePath;
+        }
     }
 
-    private static void increment(String path, Map<String, Integer> changedWatchedDirectories) {
-        changedWatchedDirectories.compute(path, (key, value) -> zeroToNull(nullToZero(value) + 1));
+    // Resolves a descendant of base without another getCanonicalPath() call. Symlinked subtrees are
+    // skipped while visiting, so canonicalize(base + suffix) == canonicalBase + suffix.
+    private static String resolveDescendant(String base, String canonicalBase, String descendantPath) {
+        if (canonicalBase.equals(base)) {
+            return descendantPath;
+        }
+        return canonicalBase + descendantPath.substring(base.length());
+    }
+
+    private static void decrement(String key, Map<String, Integer> changedWatchedDirectories) {
+        changedWatchedDirectories.compute(key, (k, value) -> zeroToNull(nullToZero(value) - 1));
+    }
+
+    private static void increment(String key, Map<String, Integer> changedWatchedDirectories) {
+        changedWatchedDirectories.compute(key, (k, value) -> zeroToNull(nullToZero(value) + 1));
     }
 
     @Nullable

--- a/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
+++ b/platforms/core-execution/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
@@ -89,6 +89,43 @@ class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTe
         0 * _
     }
 
+    def "deduplicates watches for symlinked directories resolving to the same path"() {
+        // Reproduces https://github.com/gradle/gradle/issues/27940
+        // When an included build has a symlink (e.g. build-logic/conventions/gradle -> ../../gradle),
+        // both the real path and the symlink path may be requested for watching.
+        // The watcher should canonicalize paths so the same physical directory is only watched once.
+        def rootDir = file("root").createDir()
+        def realDir = rootDir.file("real-dir").createDir()
+        realDir.file("file.txt").createFile()
+
+        // Create a symlink that points to the same directory
+        def symlinkDir = rootDir.file("link-dir")
+        symlinkDir.createLink(realDir)
+
+        when:
+        registerWatchableHierarchies([rootDir])
+        then:
+        0 * _
+
+        when:
+        // Add a snapshot via the real path
+        addSnapshot(snapshotRegularFile(realDir.file("file.txt")))
+        then:
+        1 * watcher.startWatching({ equalIgnoringOrder(it, [probeRegistry.getProbeDirectory(rootDir)]) })
+        1 * watcher.startWatching({ equalIgnoringOrder(it, [realDir]) })
+        1 * watcher.startWatching({ equalIgnoringOrder(it, [rootDir]) })
+        0 * _
+
+        when:
+        // Add a snapshot via the symlink path - this should NOT trigger another startWatching
+        // for the same physical directory, since it canonicalizes to realDir
+        def fileViaSymlink = new File(symlinkDir, "file.txt")
+        addSnapshot(snapshotRegularFile(fileViaSymlink))
+        then:
+        // No additional startWatching calls because the canonical path is already watched
+        0 * _
+    }
+
     def "removes content on unsupported file systems at the end of the build"() {
         def watchableHierarchy = file("watchable").createDir()
         def watchableContent = watchableHierarchy.file("some/dir/file.txt").createFile()


### PR DESCRIPTION
Canonicalize directory paths in `NonHierarchicalFileWatcherUpdater` before tracking them in the watchedDirectories multiset and passing them to the native file watcher. This prevents the 'Already watching path' error when two different logical paths (one direct, one via symlink) resolve to the same physical directory.

This commonly occurs with included builds that use symlinks to share the gradle wrapper directory (e.g. `build-logic/conventions/gradle` -> `../../gradle`).

Fixes #27940

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
