### PR TITLE
Polish model parameters for Gradle modes

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParameters.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/BuildModelParameters.kt
@@ -36,6 +36,7 @@ internal sealed class AbstractBuildModelParameters : BuildModelParameters {
         "parallelProjectConfiguration" to isParallelProjectConfiguration,
         "parallelProjectExecution" to isParallelProjectExecution,
         "resilientModelBuilding" to isResilientModelBuilding,
+        "vintage" to isVintage,
     )
 }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/DefaultBuildModelParametersFactory.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/buildtree/control/DefaultBuildModelParametersFactory.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.buildtree.control
 
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
 import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.buildtree.BuildActionModelRequirements
@@ -25,11 +26,16 @@ import org.gradle.util.internal.IncubationLogger
 
 internal class DefaultBuildModelParametersFactory : BuildModelParametersFactory {
 
+    companion object {
+        private val verboseParameters = InternalOptions.ofBoolean("org.gradle.internal.operations.verbose.parameters", false)
+    }
+
     private val logger = Logging.getLogger(DefaultBuildModelParametersFactory::class.java)
 
     override fun parametersForRootBuildTree(requirements: BuildActionModelRequirements, internalOptions: InternalOptions): BuildModelParameters {
         val modelParameters = BuildModelParametersProvider.parameters(requirements, internalOptions)
-        logger.info("Operational build model parameters: {}", modelParameters.toDisplayMap())
+        val parametersLogLevel = if (internalOptions.getBoolean(verboseParameters)) LogLevel.QUIET else LogLevel.INFO
+        logger.log(parametersLogLevel, "Operational build model parameters: {}", modelParameters.toDisplayMap())
 
         modelParameters.configurationCacheDisabledReason?.let { reason ->
             logger.lifecycle("{} as configuration cache cannot be reused {}", requirements.actionDisplayName.capitalizedDisplayName, reason)

--- a/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
@@ -29,6 +29,7 @@ class BuildModelParametersProviderTest extends Specification {
 
     def vintageDefaults() {
         [
+            vintage: true,
             parallelProjectExecution: false,
             configureOnDemand: false,
 
@@ -51,6 +52,7 @@ class BuildModelParametersProviderTest extends Specification {
 
     def configurationCacheDefaults() {
         vintageDefaults() + [
+            vintage: false,
             configurationCache: true,
             configurationCacheParallelLoad: true,
             parallelProjectExecution: false, // With CC, tasks are known to be isolated, so they run in parallel even without "parallel execution"
@@ -423,8 +425,7 @@ class BuildModelParametersProviderTest extends Specification {
 
     def "display map contains all parameter getters"() {
         def expectedGetterCount =
-            BuildModelParameters.methods.count { it.name.matches(/^(is|get)[A-Z].*/) && it.name != 'getClass' } -
-                1 // isVintage helper
+            BuildModelParameters.methods.count { it.name.matches(/^(is|get)[A-Z].*/) && it.name != 'getClass' }
 
         expect:
         def params = parameters(runsTasks: true, createsModel: false)

--- a/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/test/groovy/org/gradle/internal/buildtree/BuildModelParametersProviderTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 
 class BuildModelParametersProviderTest extends Specification {
 
-    def defaults() {
+    def vintageDefaults() {
         [
             parallelProjectExecution: false,
             configureOnDemand: false,
@@ -49,12 +49,30 @@ class BuildModelParametersProviderTest extends Specification {
         ]
     }
 
+    def configurationCacheDefaults() {
+        vintageDefaults() + [
+            configurationCache: true,
+            configurationCacheParallelLoad: true,
+            parallelProjectExecution: false, // With CC, tasks are known to be isolated, so they run in parallel even without "parallel execution"
+        ]
+    }
+
+    def isolatedProjectsDefaults() {
+        configurationCacheDefaults() + [
+            isolatedProjects: true,
+            parallelProjectExecution: true,
+            configurationCacheParallelStore: true,
+            parallelProjectConfiguration: true,
+            invalidateCoupledProjects: true,
+        ]
+    }
+
     def "default parameters for #description"() {
         given:
         def params = parameters(runsTasks: tasks, createsModel: models)
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), vintageDefaults() + [
             modelBuilding: models
         ])
 
@@ -74,7 +92,7 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), vintageDefaults() + [
             configureOnDemand: !models,
             modelBuilding: models,
         ])
@@ -93,7 +111,7 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), vintageDefaults() + [
             parallelProjectExecution: true,
             modelBuilding: models,
             parallelModelBuilding: models,
@@ -114,7 +132,7 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), vintageDefaults() + [
             parallelProjectExecution: true,
             modelBuilding: models,
             parallelModelBuilding: false,
@@ -135,7 +153,7 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), vintageDefaults() + [
             parallelProjectExecution: true,
             modelBuilding: models,
             parallelModelBuilding: false,
@@ -156,7 +174,7 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), vintageDefaults() + [
             modelBuilding: models,
             parallelModelBuilding: models,
             parallelProjectExecution: models, // enabled automatically, because it's required for nested tooling actions parallelism
@@ -176,12 +194,7 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
-            configurationCache: true,
-            configurationCacheParallelLoad: true,
-            configurationCacheParallelStore: false,
-            parallelProjectExecution: false, // With CC, tasks are known to be isolated, so they run in parallel even without "parallel execution"
-        ])
+        checkParameters(params.toDisplayMap(), configurationCacheDefaults())
     }
 
     def "configuration cache is automatically disabled when building models"() {
@@ -191,7 +204,7 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), vintageDefaults() + [
             modelBuilding: true,
             configurationCache: false,
         ])
@@ -210,7 +223,7 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), vintageDefaults() + [
             configurationCache: false,
             configurationCacheDisabledReason: "due to --$option"
         ])
@@ -229,16 +242,9 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), isolatedProjectsDefaults() + [
             modelBuilding: models,
-            parallelProjectExecution: true,
-            configurationCache: true,
-            configurationCacheParallelStore: true,
-            configurationCacheParallelLoad: true,
-            isolatedProjects: true,
-            parallelProjectConfiguration: true,
             parallelModelBuilding: models,
-            invalidateCoupledProjects: true,
             modelAsProjectDependency: models
         ])
 
@@ -259,16 +265,9 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), isolatedProjectsDefaults() + [
             modelBuilding: models,
-            parallelProjectExecution: true,
-            configurationCache: true,
-            configurationCacheParallelStore: true,
-            configurationCacheParallelLoad: true,
-            isolatedProjects: true,
-            parallelProjectConfiguration: true,
             parallelModelBuilding: models,
-            invalidateCoupledProjects: true,
             modelAsProjectDependency: models
         ])
 
@@ -287,16 +286,9 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), isolatedProjectsDefaults() + [
             modelBuilding: models,
-            parallelProjectExecution: true,
-            configurationCache: true,
-            configurationCacheParallelStore: true,
-            configurationCacheParallelLoad: true,
-            isolatedProjects: true,
-            parallelProjectConfiguration: true,
             parallelModelBuilding: models,
-            invalidateCoupledProjects: true,
             modelAsProjectDependency: models
         ])
 
@@ -315,17 +307,10 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), isolatedProjectsDefaults() + [
             modelBuilding: models,
             configureOnDemand: configureOnDemandExpected,
-            parallelProjectExecution: true,
-            configurationCache: true,
-            configurationCacheParallelStore: true,
-            configurationCacheParallelLoad: true,
-            isolatedProjects: true,
-            parallelProjectConfiguration: true,
             parallelModelBuilding: models,
-            invalidateCoupledProjects: true,
             modelAsProjectDependency: models
         ])
 
@@ -355,16 +340,12 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), isolatedProjectsDefaults() + [
             modelBuilding: models,
             parallelProjectExecution: ipParallelExpected,
-            configurationCache: true,
             configurationCacheParallelStore: ipParallelExpected,
-            configurationCacheParallelLoad: true,
-            isolatedProjects: true,
             parallelProjectConfiguration: ipParallelExpected,
             parallelModelBuilding: ipParallelExpected && models,
-            invalidateCoupledProjects: true,
             modelAsProjectDependency: models
         ])
 
@@ -394,17 +375,10 @@ class BuildModelParametersProviderTest extends Specification {
         }
 
         expect:
-        checkParameters(params.toDisplayMap(), defaults() + [
+        checkParameters(params.toDisplayMap(), isolatedProjectsDefaults() + [
             modelBuilding: models,
-            parallelProjectExecution: true,
-            configurationCache: true,
-            configurationCacheParallelStore: true,
-            configurationCacheParallelLoad: true,
-            isolatedProjects: true,
-            parallelProjectConfiguration: true,
             parallelModelBuilding: models,
             cachingModelBuilding: ipCachingExpected,
-            invalidateCoupledProjects: true,
             modelAsProjectDependency: models
         ])
 

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
@@ -25,8 +25,11 @@ import java.util.Map;
 @ServiceScope(Scope.BuildTree.class)
 public interface BuildModelParameters {
 
+    /**
+     * Vintage mode is when neither CC nor IP are enabled.
+     */
     default boolean isVintage() {
-        return !isConfigurationCache();
+        return !isConfigurationCache() && !isIsolatedProjects();
     }
 
     /**
@@ -46,6 +49,11 @@ public interface BuildModelParameters {
 
     boolean isConfigureOnDemand();
 
+    /**
+     * Whether Configuration Cache is enabled.
+     * <p>
+     * Also true if Isolated Projects is enabled.
+     */
     boolean isConfigurationCache();
 
     /**
@@ -60,6 +68,9 @@ public interface BuildModelParameters {
 
     boolean isConfigurationCacheParallelLoad();
 
+    /**
+     * Whether Isolated Projects is enabled.
+     */
     boolean isIsolatedProjects();
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/configuration/BuildFeaturesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/configuration/BuildFeaturesIntegrationTest.groovy
@@ -17,8 +17,22 @@
 package org.gradle.api.configuration
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
 class BuildFeaturesIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can print operational parameters via an internal option"() {
+        when:
+        run "help", "-q", "-Dorg.gradle.internal.operations.verbose.parameters=true"
+
+        then:
+        def cc = GradleContextualExecuter.isConfigCache()
+        def ip = GradleContextualExecuter.isIsolatedProjects()
+        outputContains("Operational build model parameters: {")
+        outputContains("configurationCache=$cc")
+        outputContains("isolatedProjects=$ip")
+        outputContains("vintage=${!cc && !ip}")
+    }
 
     def "can inject service into settings plugin"() {
         settingsFile """


### PR DESCRIPTION
- Clarify implications for model parameters in docstrings
- Group parameter defaults by a Gradle mode to make related tests clearer and more maintainable