### PR TITLE
Report IP problems via a dedicated listener

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossBuildConfigurationReportingGradle.kt
@@ -44,8 +44,8 @@ import org.gradle.initialization.SettingsState
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.PublicBuildPath
 import org.gradle.internal.composite.IncludedBuildInternal
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsListener
 import org.gradle.internal.configuration.problems.ProblemFactory
-import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.util.Path
@@ -56,7 +56,7 @@ internal
 class CrossBuildConfigurationReportingGradle(
     gradle: GradleInternal,
     private val referrer: GradleInternal,
-    private val problems: ProblemsListener,
+    private val ipProblems: IsolatedProjectsProblemsListener,
     private val problemFactory: ProblemFactory,
 ) : GradleInternal {
 
@@ -70,7 +70,7 @@ class CrossBuildConfigurationReportingGradle(
             .exception { message -> message.capitalized() }
             .build()
 
-        problems.onProblem(problem)
+        ipProblems.onIsolatedProjectsProblem(problem)
     }
 
     private fun shouldNotBeUsed(): Nothing {
@@ -86,13 +86,13 @@ class CrossBuildConfigurationReportingGradle(
 
     override fun getParent(): GradleInternal? =
         delegate.parent?.let { delegateParent ->
-            CrossBuildConfigurationReportingGradle(delegateParent, referrer, problems, problemFactory)
+            CrossBuildConfigurationReportingGradle(delegateParent, referrer, ipProblems, problemFactory)
         }
 
     override fun getRoot(): GradleInternal =
         when (val root = delegate.root) {
             delegate -> this
-            else -> CrossBuildConfigurationReportingGradle(root, referrer, problems, problemFactory)
+            else -> CrossBuildConfigurationReportingGradle(root, referrer, ipProblems, problemFactory)
         }
 
     override fun isRootBuild(): Boolean = delegate.isRootBuild

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -29,8 +29,8 @@ import org.gradle.execution.plan.ScheduledWork
 import org.gradle.execution.taskgraph.TaskExecutionGraphExecutionListener
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.internal.build.ExecutionResult
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsListener
 import org.gradle.internal.configuration.problems.ProblemFactory
-import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.util.Path
 import java.util.Objects
@@ -40,7 +40,7 @@ internal
 class CrossProjectConfigurationReportingTaskExecutionGraph(
     taskGraph: TaskExecutionGraphInternal,
     private val referrerProject: ProjectInternal,
-    private val problems: ProblemsListener,
+    private val ipProblems: IsolatedProjectsProblemsListener,
     private val crossProjectModelAccess: CrossProjectModelAccess,
     private val coupledProjectsListener: CoupledProjectsListener,
     private val problemFactory: ProblemFactory
@@ -167,7 +167,7 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
             // As the exception message is not used for grouping, we can safely add the exact task name to it:
             message.capitalized() + if (requestPath != null) "; tried to access '$requestPath'" else '"'
         }.build()
-        problems.onProblem(problem)
+        ipProblems.onIsolatedProjectsProblem(problem)
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingParentDynamicObject.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/CrossProjectModelAccessTrackingParentDynamicObject.kt
@@ -19,8 +19,8 @@ package org.gradle.internal.cc.impl
 import groovy.lang.MissingMethodException
 import groovy.lang.MissingPropertyException
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsListener
 import org.gradle.internal.configuration.problems.ProblemFactory
-import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.PropertyKind
 import org.gradle.internal.configuration.problems.PropertyTrace
 import org.gradle.internal.metaobject.DynamicInvokeResult
@@ -33,7 +33,7 @@ class CrossProjectModelAccessTrackingParentDynamicObject(
     private val ownerProject: ProjectInternal,
     private val delegate: HierarchicalDynamicObject,
     private val referrerProject: ProjectInternal,
-    private val problems: ProblemsListener,
+    private val ipProblems: IsolatedProjectsProblemsListener,
     private val coupledProjectsListener: CoupledProjectsListener,
     private val problemFactory: ProblemFactory,
     private val dynamicCallProblemReporting: DynamicCallProblemReporting
@@ -149,7 +149,7 @@ class CrossProjectModelAccessTrackingParentDynamicObject(
                 }
                 .exception()
                 .build()
-            problems.onProblem(problem)
+            ipProblems.onIsolatedProjectsProblem(problem)
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossBuildModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossBuildModelAccess.kt
@@ -19,21 +19,21 @@ package org.gradle.internal.cc.impl
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.CrossBuildModelAccess
 import org.gradle.internal.buildoption.InternalOptions
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsListener
 import org.gradle.internal.configuration.problems.ProblemFactory
-import org.gradle.internal.configuration.problems.ProblemsListener
 
 private val CROSS_BUILD_ACCESS_FLAG = InternalOptions.ofBoolean("org.gradle.internal.isolated-projects.report-cross-build-access", false)
 
 internal
 class ProblemReportingCrossBuildModelAccess(
-    private val problems: ProblemsListener,
+    private val ipProblems: IsolatedProjectsProblemsListener,
     private val problemFactory: ProblemFactory,
     private val internalOptions: InternalOptions
 ) : CrossBuildModelAccess {
 
     override fun access(referrer: GradleInternal, gradle: GradleInternal): GradleInternal =
         if (internalOptions.getBoolean(CROSS_BUILD_ACCESS_FLAG)) {
-            CrossBuildConfigurationReportingGradle(gradle, referrer, problems, problemFactory)
+            CrossBuildConfigurationReportingGradle(gradle, referrer, ipProblems, problemFactory)
         } else {
             gradle
         }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ProblemReportingCrossProjectModelAccess.kt
@@ -60,8 +60,8 @@ import org.gradle.internal.cc.impl.CrossProjectModelAccessPattern.ALLPROJECTS
 import org.gradle.internal.cc.impl.CrossProjectModelAccessPattern.CHILD
 import org.gradle.internal.cc.impl.CrossProjectModelAccessPattern.DIRECT
 import org.gradle.internal.cc.impl.CrossProjectModelAccessPattern.SUBPROJECT
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsListener
 import org.gradle.internal.configuration.problems.ProblemFactory
-import org.gradle.internal.configuration.problems.ProblemsListener
 import org.gradle.internal.configuration.problems.StructuredMessage
 import org.gradle.internal.extensions.stdlib.uncheckedCast
 import org.gradle.internal.logging.StandardOutputCapture
@@ -82,7 +82,7 @@ import java.util.concurrent.Callable
 
 internal
 class ProblemReportingCrossProjectModelAccess(
-    private val problems: ProblemsListener,
+    private val ipProblems: IsolatedProjectsProblemsListener,
     private val coupledProjectsListener: CoupledProjectsListener,
     private val problemFactory: ProblemFactory,
     private val dynamicCallProblemReporting: DynamicCallProblemReporting,
@@ -127,17 +127,17 @@ class ProblemReportingCrossProjectModelAccess(
     }
 
     override fun taskDependencyUsageTracker(referrerProject: ProjectInternal): TaskDependencyUsageTracker {
-        return ReportingTaskDependencyUsageTracker(referrerProject, coupledProjectsListener, problems, problemFactory)
+        return ReportingTaskDependencyUsageTracker(referrerProject, coupledProjectsListener, ipProblems, problemFactory)
     }
 
     override fun taskGraphForProject(referrerProject: ProjectInternal, taskGraph: TaskExecutionGraphInternal): TaskExecutionGraphInternal {
-        return CrossProjectConfigurationReportingTaskExecutionGraph(taskGraph, referrerProject, problems, this, coupledProjectsListener, problemFactory)
+        return CrossProjectConfigurationReportingTaskExecutionGraph(taskGraph, referrerProject, ipProblems, this, coupledProjectsListener, problemFactory)
     }
 
     override fun parentProjectDynamicInheritedScope(referrerProject: ProjectInternal): HierarchicalDynamicObject? {
         val parent = referrerProject.parent ?: return null
         return CrossProjectModelAccessTrackingParentDynamicObject(
-            parent, parent.inheritedScope, referrerProject, problems, coupledProjectsListener, problemFactory, dynamicCallProblemReporting
+            parent, parent.inheritedScope, referrerProject, ipProblems, coupledProjectsListener, problemFactory, dynamicCallProblemReporting
         )
     }
 
@@ -152,7 +152,7 @@ class ProblemReportingCrossProjectModelAccess(
             this,
             referrer,
             access,
-            problems,
+            ipProblems,
             coupledProjectsListener,
             problemFactory,
             buildModelParameters,
@@ -165,7 +165,7 @@ class ProblemReportingCrossProjectModelAccess(
         delegate: ProjectInternal,
         referrer: ProjectInternal,
         private val access: CrossProjectModelAccessInstance,
-        private val problems: ProblemsListener,
+        private val ipProblems: IsolatedProjectsProblemsListener,
         private val coupledProjectsListener: CoupledProjectsListener,
         private val problemFactory: ProblemFactory,
         private val buildModelParameters: BuildModelParameters,
@@ -573,7 +573,7 @@ class ProblemReportingCrossProjectModelAccess(
                 .exception()
                 .build()
 
-            problems.onProblem(problem)
+            ipProblems.onIsolatedProjectsProblem(problem)
         }
 
         private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ReportingTaskDependencyUsageTracker.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/ReportingTaskDependencyUsageTracker.kt
@@ -19,17 +19,19 @@ package org.gradle.internal.cc.impl
 import org.gradle.api.Task
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.TaskDependencyUsageTracker
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsListener
 import org.gradle.internal.configuration.problems.ProblemFactory
-import org.gradle.internal.configuration.problems.ProblemsListener
 
 
-/** Reports all usages of the tracked TaskDependency APIs as problems using the [problems] listener.
- * Also checks which tasks in the API return value come from the other projects and tracks the projects coupling using the [coupledProjectsListener]. */
+/**
+ * Reports all usages of the tracked TaskDependency APIs as problems using the [ipProblems] listener.
+ * Also checks which tasks in the API return value come from the other projects and tracks the projects coupling using the [coupledProjectsListener].
+ */
 internal
 class ReportingTaskDependencyUsageTracker(
     private val referrer: ProjectInternal,
     private val coupledProjectsListener: CoupledProjectsListener,
-    private val problems: ProblemsListener,
+    private val ipProblems: IsolatedProjectsProblemsListener,
     private val problemFactory: ProblemFactory
 ) : TaskDependencyUsageTracker {
     override fun onTaskDependencyUsage(taskDependencies: Set<Task>) {
@@ -55,6 +57,6 @@ class ReportingTaskDependencyUsageTracker(
         }
             .exception()
             .build()
-        problems.onProblem(problem)
+        ipProblems.onIsolatedProjectsProblem(problem)
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/problems/ConfigurationCacheProblems.kt
@@ -43,6 +43,7 @@ import org.gradle.internal.cc.impl.TooManyConfigurationCacheProblemsException
 import org.gradle.internal.cc.impl.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.configuration.problems.CommonReport
 import org.gradle.internal.configuration.problems.DocumentationSection
+import org.gradle.internal.configuration.problems.IsolatedProjectsProblemsListener
 import org.gradle.internal.configuration.problems.ProblemFactory
 import org.gradle.internal.configuration.problems.ProblemReportDetails
 import org.gradle.internal.configuration.problems.ProblemReportDetailsJsonSource
@@ -94,7 +95,7 @@ class ConfigurationCacheProblems(
 
     private
     val degradationController: DefaultConfigurationCacheDegradationController
-) : AbstractProblemsListener(), ProblemReporter, AutoCloseable {
+) : AbstractProblemsListener(), IsolatedProjectsProblemsListener, ProblemReporter, AutoCloseable {
 
     private
     val summarizer = ConfigurationCacheProblemsSummary()
@@ -247,6 +248,10 @@ class ConfigurationCacheProblems(
             .build()
         summarizer.onIncompatibleFeature(problem)
         report.onProblem(problem)
+    }
+
+    override fun onIsolatedProjectsProblem(problem: PropertyProblem) {
+        onProblem(problem, ProblemSeverity.Deferred)
     }
 
     override fun onProblem(problem: PropertyProblem) {

--- a/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/IsolatedProjectsProblemsListener.kt
+++ b/platforms/core-configuration/configuration-problems-base/src/main/kotlin/org/gradle/internal/configuration/problems/IsolatedProjectsProblemsListener.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.configuration.problems
+
+
+interface IsolatedProjectsProblemsListener {
+
+    fun onIsolatedProjectsProblem(problem: PropertyProblem)
+
+}

--- a/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
+++ b/platforms/core-configuration/graph-serialization/src/main/kotlin/org/gradle/internal/serialize/graph/Contexts.kt
@@ -389,6 +389,7 @@ abstract class AbstractIsolateContext<T>(
         get() = currentProblemsListener
 
     override fun onProblem(problem: PropertyProblem) {
+        // TODO:isolated where does this violation belong? Should it be interrupting?
         currentProblemsListener.onProblem(problem)
     }
 


### PR DESCRIPTION
This is preparation for IP-specific problem-handling controls that are (more) decoupled from CC problems