### PR TITLE
Disable CodeRabbit summary in PR description

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -85,7 +85,7 @@ reviews:
     unit_tests:
       enabled: true
   high_level_summary: true
-  high_level_summary_in_walkthrough: false
+  high_level_summary_in_walkthrough: true
   high_level_summary_instructions: ""
   high_level_summary_placeholder: "@coderabbitai summary"
   in_progress_fortune: true


### PR DESCRIPTION
- https://docs.coderabbit.ai/pr-reviews/summaries

This PR doesn't disable the summaries entirely, but instead moves them into the CodeRabbit authored comments, where the _generated_ summary is co-located with the rest of the _generated_ overview/feedback.

---

Like the one below 👇

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration to enhance summary generation during review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->