### PR TITLE
Use `UNION ALL` to avoid extra SQL execution overhead

### DIFF
--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy
@@ -71,7 +71,7 @@ abstract class AbstractWritableResultsStore<T extends PerformanceTestResult> imp
      * - The old single-query form used one large OR predicate:
      *   {@code (... channel like ? ... OR teamcitybuildid in (...))}.
      * - On MySQL, that shape can trigger unstable plans (e.g. broad startTime scans).
-     * - Splitting into selective branches and joining with {@code UNION DISTINCT}
+     * - Splitting into selective branches and joining with {@code UNION ALL}
      *   gives the optimizer a more predictable path.
      *
      * Query shape produced:
@@ -82,7 +82,12 @@ abstract class AbstractWritableResultsStore<T extends PerformanceTestResult> imp
      *   on a single-column index when confronted with OR.
      * - Build ID branch (only when {@code teamcityBuildIds} is non-empty):
      *   {@code select <columns> from testExecution ... and teamcitybuildid in (?, ...)}
-     * - Branches are combined using {@code union distinct}.
+     * - Branches are combined using {@code union all} to avoid the temp-table
+     *   materialisation that {@code union distinct} requires before applying
+     *   {@code ORDER BY / LIMIT}. Duplicate rows (e.g. a build whose channel
+     *   also matches a pattern) are handled by callers: {@code executionsForName}
+     *   callers skip already-seen IDs in Java; {@code operationsForExecution}
+     *   callers deduplicate IDs via {@code GROUP BY} before joining testOperation.
      *
      * Parameter binding contract:
      * - This method only generates SQL text.
@@ -129,7 +134,7 @@ abstract class AbstractWritableResultsStore<T extends PerformanceTestResult> imp
                 where 1 = 0
                 """
         }
-        return String.join(" union distinct ", branches)
+        return String.join(" union all ", branches)
     }
 
     protected static void bindHistoryQueryParams(

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaseCrossBuildResultsStore.java
@@ -33,6 +33,7 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -192,9 +193,13 @@ public class BaseCrossBuildResultsStore<R extends CrossBuildPerformanceResults> 
                 try (ResultSet testExecutions = executionsForName.executeQuery()) {
                     executionsForNameRs = testExecutions;
                     List<CrossBuildPerformanceResults> results = new ArrayList<>();
+                    Set<Long> seenExecutionIds = new HashSet<>();
                     Set<BuildDisplayInfo> builds = Sets.newTreeSet(Comparator.comparing(BuildDisplayInfo::getDisplayName));
                     while (testExecutions.next()) {
                         long id = testExecutions.getLong(1);
+                        if (!seenExecutionIds.add(id)) {
+                            continue;
+                        }
                         CrossBuildPerformanceResults performanceResults = new CrossBuildPerformanceResults();
                         performanceResults.setTestClass(experiment.getScenario().getClassName());
                         performanceResults.setTestId(experiment.getScenario().getTestName());

--- a/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/testing/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -76,7 +76,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
     private static final String OPERATIONS_FOR_EXECUTION_SQL_TEMPLATE = """
         select version, testExecution, totalTime
         from testOperation
-        join (select t.id from (%s) as t order by t.startTime desc limit ?) as executionIds
+        join (select t.id from (%s) as t group by t.id order by max(t.startTime) desc limit ?) as executionIds
           on executionIds.id = testOperation.testExecution
         """;
 
@@ -281,6 +281,9 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                     executionsForNameRs = testExecutions;
                     while (testExecutions.next()) {
                         long id = testExecutions.getLong(1);
+                        if (results.containsKey(id)) {
+                            continue;
+                        }
                         CrossVersionPerformanceResults performanceResults = new CrossVersionPerformanceResults();
                         performanceResults.setTestClass(experiment.getScenario().getClassName());
                         performanceResults.setTestId(experiment.getScenario().getTestName());


### PR DESCRIPTION
The UNION-based history query (`operationsForExecution` / `executionsForName`) is built from three branches:

1. `channel LIKE 'commits-master'`
2. `channel LIKE 'commits-gh-readonly-queue/master/%'`
3. `teamcitybuildid IN (current batch IDs)`

However, branches 1–3 can produce duplicate testExecution rows. `UNION DISTINCT` was used to deduplicate, but MySQL cannot stream a `UNION DISTINCT` — it must fully materialise all matching rows from every branch into a temp table, deduplicate, and sort before LIMIT can be applied. For high-frequency test scenarios (e.g. Config-Cache + largeJavaMultiProject) this produced 49 queries exceeding 1 s in a single report run, the worst reaching 3.4 s.

This change switches to `UNION ALL` and moves deduplication out of the database:

- `operationsForExecution`: the inner subquery that selects execution IDs gains `GROUP BY t.id before ORDER BY MAX(t.startTime) DESC LIMIT ?`, so the JOIN against `testOperation` never sees duplicate IDs regardless of how many branches matched.
- `executionsForName`: the Java code does the deduplication.

## Result

After the change, there's no slow executions (>1s).

```
  ┌────────┬─────────┬───────┬─────────────┐
  │ Metric │ Before  │ After │ Improvement │
  ├────────┼─────────┼───────┼─────────────┤
  │ Count  │ 152     │ 190   │ —           │
  ├────────┼─────────┼───────┼─────────────┤
  │ P50    │ 193ms   │ 20ms  │ −90%        │
  ├────────┼─────────┼───────┼─────────────┤
  │ P90    │ 626ms   │ 95ms  │ −85%        │
  ├────────┼─────────┼───────┼─────────────┤
  │ P99    │ 1,427ms │ 163ms │ −89%        │
  ├────────┼─────────┼───────┼─────────────┤
  │ Max    │ 1,544ms │ 187ms │ −88%        │
  ├────────┼─────────┼───────┼─────────────┤
  │ >1s    │ 4       │ 0     │             │
  └────────┴─────────┴───────┴─────────────┘

  operationsForExecution

  ┌────────┬─────────┬───────┬─────────────┐
  │ Metric │ Before  │ After │ Improvement │
  ├────────┼─────────┼───────┼─────────────┤
  │ Count  │ 1,154   │ 194   │ —           │
  ├────────┼─────────┼───────┼─────────────┤
  │ P50    │ 1ms     │ 5ms   │ —           │
  ├────────┼─────────┼───────┼─────────────┤
  │ P90    │ 7ms     │ 9ms   │ —           │
  ├────────┼─────────┼───────┼─────────────┤
  │ P99    │ 1,453ms │ 47ms  │ −97%        │
  ├────────┼─────────┼───────┼─────────────┤
  │ Max    │ 3,397ms │ 202ms │ −94%        │
  ├────────┼─────────┼───────┼─────────────┤
  │ >1s    │ 57      │ 0     │             │
  └────────┴─────────┴───────┴─────────────┘
```