### PR TITLE
Speed up configuration cache store with versionMapping fromResolutionResult()

### DIFF
--- a/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
+++ b/platforms/core-runtime/functional/src/main/java/org/gradle/internal/serialization/Cached.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.function.BooleanSupplier;
 
 /**
  * Represents a computation that must execute only once and
@@ -44,7 +45,20 @@ public abstract class Cached<T> {
      * @see <a href="https://github.com/gradle/gradle/issues/31239">bug report</a>
      */
     public static <T> Cached<T> of(Callable<T> computation) {
-        return new Deferred<>(computation);
+        return new Deferred<>(computation, null);
+    }
+
+    /**
+     * Creates a cacheable computation that is only evaluated at serialization time when
+     * {@code shouldEvaluate} returns {@code true}. When the predicate returns {@code false} the
+     * computation is skipped entirely and the cached value is treated as {@code null}.
+     *
+     * <p>Intended for {@link Cached} fields owned by a task that can be disabled — the predicate
+     * is typically {@code task::getEnabled}. A disabled task that will never run pays nothing for
+     * its cached input state at configuration cache store time.
+     */
+    public static <T> Cached<T> of(Callable<T> computation, BooleanSupplier shouldEvaluate) {
+        return new Deferred<>(computation, Objects.requireNonNull(shouldEvaluate));
     }
 
     public abstract T get();
@@ -53,10 +67,12 @@ public abstract class Cached<T> {
 
         // TODO(https://github.com/gradle/gradle/issues/31239) fields are volatile as a workaround for call sites still unwisely using Cached from multiple threads.
         private volatile @Nullable Callable<T> computation;
+        private volatile @Nullable BooleanSupplier shouldEvaluate;
         private volatile @Nullable Try<T> result;
 
-        public Deferred(@NonNull Callable<T> computation) {
+        public Deferred(@NonNull Callable<T> computation, @Nullable BooleanSupplier shouldEvaluate) {
             this.computation = computation;
+            this.shouldEvaluate = shouldEvaluate;
         }
 
         @Override
@@ -80,7 +96,14 @@ public abstract class Cached<T> {
             return EvaluationContext.current().evaluate(this, () -> Try.ofFailable(toCompute));
         }
 
+        @SuppressWarnings("NullAway")
         private Object writeReplace() {
+            BooleanSupplier check = shouldEvaluate;
+            if (check != null && !check.getAsBoolean()) {
+                // Predicate vetoed evaluation — don't invoke the computation. The serialized form
+                // carries a null result; callers must tolerate get() returning null in this case.
+                return new Fixed<T>(Try.successful((T) null));
+            }
             return new Fixed<>(result());
         }
     }

--- a/platforms/core-runtime/functional/src/test/groovy/org/gradle/internal/serialization/CachedTest.groovy
+++ b/platforms/core-runtime/functional/src/test/groovy/org/gradle/internal/serialization/CachedTest.groovy
@@ -20,10 +20,87 @@ import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.Flaky
 import spock.lang.Specification
 
+import java.util.concurrent.Callable
 import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.BooleanSupplier
 
 class CachedTest extends Specification {
+
+    def "shouldEvaluate=false at serialization time skips the computation and yields null"() {
+        given:
+        def invocations = new AtomicInteger(0)
+        def cached = Cached.of(
+            { invocations.incrementAndGet(); "value" } as Callable<String>,
+            { false } as BooleanSupplier
+        )
+
+        when:
+        def restored = roundTrip(cached)
+
+        then:
+        invocations.get() == 0
+        restored.get() == null
+    }
+
+    def "shouldEvaluate=true at serialization time forces the computation"() {
+        given:
+        def invocations = new AtomicInteger(0)
+        def cached = Cached.of(
+            { invocations.incrementAndGet(); "value" } as Callable<String>,
+            { true } as BooleanSupplier
+        )
+
+        when:
+        def restored = roundTrip(cached)
+
+        then:
+        invocations.get() == 1
+        restored.get() == "value"
+    }
+
+    def "shouldEvaluate is queried at writeReplace time, not at construction"() {
+        given:
+        def shouldEvaluate = new AtomicBoolean(false)
+        def invocations = new AtomicInteger(0)
+        def cached = Cached.of(
+            { invocations.incrementAndGet(); "value" } as Callable<String>,
+            { shouldEvaluate.get() } as BooleanSupplier
+        )
+
+        when: "shouldEvaluate is flipped to true after construction, before serialization"
+        shouldEvaluate.set(true)
+        def restored = roundTrip(cached)
+
+        then:
+        invocations.get() == 1
+        restored.get() == "value"
+    }
+
+    def "Cached.of without predicate behaves as before"() {
+        given:
+        def invocations = new AtomicInteger(0)
+        def cached = Cached.of({ invocations.incrementAndGet(); "value" } as Callable<String>)
+
+        when:
+        def restored = roundTrip(cached)
+
+        then:
+        invocations.get() == 1
+        restored.get() == "value"
+    }
+
+    /**
+     * Simulates configuration cache serialization by invoking the private {@code writeReplace}
+     * method that {@code Cached.Deferred} declares for that purpose. Returns the substituted
+     * {@code Fixed} that would be serialized in production.
+     */
+    private static <T> Cached<T> roundTrip(Cached<T> input) {
+        def writeReplace = input.getClass().getDeclaredMethod("writeReplace")
+        writeReplace.setAccessible(true)
+        return writeReplace.invoke(input) as Cached<T>
+    }
 
     /**
      * Once https://github.com/gradle/gradle/issues/31239 is addressed,

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
@@ -43,7 +43,13 @@ import java.io.File;
 public abstract class GenerateIvyDescriptor extends DefaultTask {
 
     private Transient.Var<IvyModuleDescriptorSpec> descriptor = Transient.varOf();
-    private final Cached<IvyDescriptorFileGenerator.DescriptorFileSpec> ivyDescriptorSpec = Cached.of(this::computeIvyDescriptorFileSpec);
+    // Skip the (potentially expensive) descriptor spec computation for disabled tasks.
+    // Cached.Deferred forces evaluation at configuration cache store time, which would otherwise
+    // trigger version-mapping / dependency-graph resolution even for tasks that will never run.
+    private final Cached<IvyDescriptorFileGenerator.DescriptorFileSpec> ivyDescriptorSpec = Cached.of(
+        this::computeIvyDescriptorFileSpec,
+        this::getEnabled
+    );
 
     private Object destination;
 

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
@@ -45,8 +45,12 @@ public abstract class GenerateMavenPom extends DefaultTask {
 
     private final Transient.Var<MavenPom> pom = varOf();
     private Object destination;
-    private final Cached<MavenPomFileGenerator.MavenPomSpec> mavenPomSpec = Cached.of(() ->
-        MavenPomFileGenerator.generateSpec((MavenPomInternal) getPom())
+    // Skip the (potentially expensive) spec computation for disabled tasks. Cached.Deferred
+    // forces evaluation at configuration cache store time, which would otherwise trigger
+    // version-mapping / dependency-graph resolution even for tasks that will never run.
+    private final Cached<MavenPomFileGenerator.MavenPomSpec> mavenPomSpec = Cached.of(
+        () -> MavenPomFileGenerator.generateSpec((MavenPomInternal) getPom()),
+        this::getEnabled
     );
 
     @Inject

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/mapping/VersionMappingComponentDependencyResolver.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/mapping/VersionMappingComponentDependencyResolver.java
@@ -31,16 +31,15 @@ import org.gradle.api.internal.artifacts.ProjectComponentIdentifierInternal;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint;
 import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
-import org.gradle.internal.Actions;
 import org.gradle.internal.component.local.model.ProjectComponentSelectorInternal;
 import org.gradle.util.Path;
 import org.jspecify.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-
-import static org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult.eachElement;
 
 /**
  * A {@link VariantDependencyResolver} that performs version mapping.
@@ -51,6 +50,11 @@ public class VersionMappingComponentDependencyResolver implements ComponentDepen
 
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
     private final ResolvedComponentResult root;
+
+    private boolean indexed;
+    private Map<ModuleKey, ModuleVersionIdentifier> selectedByCoordinates;
+    private Map<ModuleKey, ModuleVersionIdentifier> selectedByRequestedModule;
+    private Map<Path, ModuleVersionIdentifier> selectedByRequestedProjectIdentity;
 
     public VersionMappingComponentDependencyResolver(
         ProjectDependencyPublicationResolver projectDependencyResolver,
@@ -96,42 +100,97 @@ public class VersionMappingComponentDependencyResolver implements ComponentDepen
 
     @Nullable
     public ModuleVersionIdentifier maybeResolveVersion(String group, String module, @Nullable Path identityPath) {
-        final Set<ResolvedComponentResult> resolvedComponentResults = new LinkedHashSet<>();
-        eachElement(root, Actions.doNothing(), Actions.doNothing(), resolvedComponentResults);
+        ensureIndexed();
 
-        for (ResolvedComponentResult selected : resolvedComponentResults) {
-            ModuleVersionIdentifier moduleVersion = selected.getModuleVersion();
-            if (moduleVersion != null && group.equals(moduleVersion.getGroup()) && module.equals(moduleVersion.getName())) {
-                return moduleVersion;
-            }
+        ModuleKey key = new ModuleKey(group, module);
+        ModuleVersionIdentifier resolved = selectedByCoordinates.get(key);
+        if (resolved != null) {
+            return resolved;
         }
 
-        final Set<DependencyResult> allDependencies = new LinkedHashSet<>();
-        eachElement(root, Actions.doNothing(), allDependencies::add, new HashSet<>());
-
-        // If we reach this point it means we have a dependency which doesn't belong to the resolution result
+        // If we reach this point it means we have a dependency which doesn't belong to the resolution result.
         // Which can mean two things:
         // 1. the graph used to get the resolved version has nothing to do with the dependencies we're trying to get versions for (likely user error)
-        // 2. the graph contains first-level dependencies which have been substituted (likely) so we're going to iterate on dependencies instead
-        for (DependencyResult dependencyResult : allDependencies) {
-            if (dependencyResult instanceof ResolvedDependencyResult) {
-                ComponentSelector rcs = dependencyResult.getRequested();
-                ResolvedComponentResult selected = ((ResolvedDependencyResult) dependencyResult).getSelected();
-                if (rcs instanceof ModuleComponentSelector) {
-                    ModuleComponentSelector requested = (ModuleComponentSelector) rcs;
-                    if (requested.getGroup().equals(group) && requested.getModule().equals(module)) {
-                        return getModuleVersionId(selected);
-                    }
-                } else if (rcs instanceof ProjectComponentSelector) {
-                    ProjectComponentSelectorInternal pcs = (ProjectComponentSelectorInternal) rcs;
-                    if (pcs.getIdentityPath().equals(identityPath)) {
-                        return getModuleVersionId(selected);
-                    }
-                }
-            }
+        // 2. the graph contains first-level dependencies which have been substituted (likely) so we fall back to looking up the requested coordinates
+        resolved = selectedByRequestedModule.get(key);
+        if (resolved != null) {
+            return resolved;
+        }
+
+        if (identityPath != null) {
+            return selectedByRequestedProjectIdentity.get(identityPath);
         }
 
         return null;
+    }
+
+    /**
+     * Lazily indexes the resolution graph the first time it is queried.
+     *
+     * <p>Without this, every call to {@link #maybeResolveVersion} would walk the entire graph
+     * twice, leading to {@code O(graphSize × dependencies)} work when generating module/POM
+     * metadata for components with large dependency graphs.
+     */
+    private void ensureIndexed() {
+        if (indexed) {
+            return;
+        }
+        Map<ModuleKey, ModuleVersionIdentifier> byCoordinates = new HashMap<>();
+        Map<ModuleKey, ModuleVersionIdentifier> byRequestedModule = new HashMap<>();
+        Map<Path, ModuleVersionIdentifier> byRequestedProjectIdentity = new HashMap<>();
+        indexGraph(root, byCoordinates, byRequestedModule, byRequestedProjectIdentity, new HashSet<>());
+
+        this.selectedByCoordinates = byCoordinates;
+        this.selectedByRequestedModule = byRequestedModule;
+        this.selectedByRequestedProjectIdentity = byRequestedProjectIdentity;
+        this.indexed = true;
+    }
+
+    private void indexGraph(
+        ResolvedComponentResult node,
+        Map<ModuleKey, ModuleVersionIdentifier> byCoordinates,
+        Map<ModuleKey, ModuleVersionIdentifier> byRequestedModule,
+        Map<Path, ModuleVersionIdentifier> byRequestedProjectIdentity,
+        Set<ResolvedComponentResult> visited
+    ) {
+        if (!visited.add(node)) {
+            return;
+        }
+
+        ModuleVersionIdentifier moduleVersion = node.getModuleVersion();
+        if (moduleVersion != null) {
+            byCoordinates.putIfAbsent(new ModuleKey(moduleVersion.getGroup(), moduleVersion.getName()), moduleVersion);
+        }
+
+        for (DependencyResult dependency : node.getDependencies()) {
+            if (!(dependency instanceof ResolvedDependencyResult)) {
+                continue;
+            }
+            ResolvedDependencyResult resolved = (ResolvedDependencyResult) dependency;
+            ResolvedComponentResult selected = resolved.getSelected();
+            ComponentSelector requested = resolved.getRequested();
+
+            if (requested instanceof ModuleComponentSelector) {
+                ModuleComponentSelector mcs = (ModuleComponentSelector) requested;
+                ModuleKey key = new ModuleKey(mcs.getGroup(), mcs.getModule());
+                if (!byRequestedModule.containsKey(key)) {
+                    ModuleVersionIdentifier id = getModuleVersionId(selected);
+                    if (id != null) {
+                        byRequestedModule.put(key, id);
+                    }
+                }
+            } else if (requested instanceof ProjectComponentSelector) {
+                Path requestedIdentityPath = ((ProjectComponentSelectorInternal) requested).getIdentityPath();
+                if (!byRequestedProjectIdentity.containsKey(requestedIdentityPath)) {
+                    ModuleVersionIdentifier id = getModuleVersionId(selected);
+                    if (id != null) {
+                        byRequestedProjectIdentity.put(requestedIdentityPath, id);
+                    }
+                }
+            }
+
+            indexGraph(selected, byCoordinates, byRequestedModule, byRequestedProjectIdentity, visited);
+        }
     }
 
     @Nullable
@@ -142,5 +201,32 @@ public class VersionMappingComponentDependencyResolver implements ComponentDepen
             return projectDependencyResolver.resolveComponent(ModuleVersionIdentifier.class, identityPath);
         }
         return selected.getModuleVersion();
+    }
+
+    private static final class ModuleKey {
+        private final String group;
+        private final String module;
+
+        ModuleKey(String group, String module) {
+            this.group = group;
+            this.module = module;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ModuleKey)) {
+                return false;
+            }
+            ModuleKey other = (ModuleKey) o;
+            return group.equals(other.group) && module.equals(other.module);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(group, module);
+        }
     }
 }

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -88,7 +88,10 @@ public abstract class GenerateModuleMetadata extends DefaultTask {
     private final Transient<Property<Publication>> publication;
     private final Transient<ListProperty<Publication>> publications;
     private final FileCollection variantFiles;
-    private final Cached<InputState> inputState = Cached.of(this::computeInputState);
+    // Skip the (potentially expensive) module metadata spec computation for disabled tasks.
+    // Cached.Deferred forces evaluation at configuration cache store time, which would otherwise
+    // trigger version-mapping / dependency-graph resolution even for tasks that will never run.
+    private final Cached<InputState> inputState = Cached.of(this::computeInputState, this::getEnabled);
 
     public GenerateModuleMetadata() {
         ObjectFactory objectFactory = getObjectFactory();

--- a/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/mapping/VersionMappingComponentDependencyResolverTest.groovy
+++ b/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/mapping/VersionMappingComponentDependencyResolverTest.groovy
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.internal.mapping
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
+import spock.lang.Specification
+
+class VersionMappingComponentDependencyResolverTest extends Specification {
+
+    def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
+
+    def "graph is traversed only once across many lookups"() {
+        given:
+        // root -> a -> b
+        //      -> c
+        def aId = id("org", "a", "1.0")
+        def bId = id("org", "b", "1.0")
+        def cId = id("org", "c", "1.0")
+        def rootId = id("org", "root", "1.0")
+
+        def a = component(aId)
+        def b = component(bId)
+        def c = component(cId)
+        def root = component(rootId)
+
+        def aDep = moduleDependency("org", "a", a)
+        def bDep = moduleDependency("org", "b", b)
+        def cDep = moduleDependency("org", "c", c)
+
+        def resolver = new VersionMappingComponentDependencyResolver(projectDependencyResolver, root)
+
+        when:
+        100.times {
+            assert resolver.maybeResolveVersion("org", "a", null) == aId
+            assert resolver.maybeResolveVersion("org", "b", null) == bId
+            assert resolver.maybeResolveVersion("org", "c", null) == cId
+            assert resolver.maybeResolveVersion("org", "missing", null) == null
+        }
+
+        then:
+        1 * root.getDependencies() >> ([aDep, cDep] as Set)
+        1 * a.getDependencies() >> ([bDep] as Set)
+        1 * b.getDependencies() >> Collections.emptySet()
+        1 * c.getDependencies() >> Collections.emptySet()
+    }
+
+    def "falls back to requested coordinates when component was substituted"() {
+        given:
+        // requested org:requested-a was substituted with org:actual-a:2.0 via the resolution graph
+        def actualId = id("org", "actual-a", "2.0")
+        def rootId = id("org", "root", "1.0")
+
+        def actual = component(actualId)
+        def root = component(rootId)
+
+        actual.getDependencies() >> Collections.emptySet()
+        root.getDependencies() >> ([moduleDependency("org", "requested-a", actual)] as Set)
+
+        def resolver = new VersionMappingComponentDependencyResolver(projectDependencyResolver, root)
+
+        expect:
+        resolver.maybeResolveVersion("org", "requested-a", null) == actualId
+        resolver.maybeResolveVersion("org", "actual-a", null) == actualId
+        resolver.maybeResolveVersion("org", "missing", null) == null
+    }
+
+    private ResolvedComponentResult component(ModuleVersionIdentifier moduleVersion) {
+        Mock(ResolvedComponentResult) {
+            getModuleVersion() >> moduleVersion
+            getId() >> Mock(ModuleComponentIdentifier)
+        }
+    }
+
+    private ResolvedDependencyResult moduleDependency(String requestedGroup, String requestedModule, ResolvedComponentResult selected) {
+        def selector = Mock(ModuleComponentSelector) {
+            getGroup() >> requestedGroup
+            getModule() >> requestedModule
+        }
+        Mock(ResolvedDependencyResult) {
+            getRequested() >> selector
+            getSelected() >> selected
+        }
+    }
+
+    private static ModuleVersionIdentifier id(String group, String name, String version) {
+        DefaultModuleVersionIdentifier.newId(group, name, version)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #36332. On a 150-module reproducer with `versionMapping { allVariants { fromResolutionResult() } }`, configuration cache store time drops from ~44s to ~1.7s (warm).

Two fixes:

1. **Cache the resolution graph index in `VersionMappingComponentDependencyResolver`.** Each `maybeResolveVersion` was walking the full resolution graph twice via `eachElement`, giving O(n × m) behavior across n graph nodes and m dependencies/constraints. The resolver now builds the index lazily once per instance, making lookups O(1). The new unit test verifies `getDependencies()` is invoked exactly once across many lookups.

2. **Add `Cached.of(callable, shouldEvaluate)` and skip eager evaluation for disabled tasks.** `Cached.Deferred` forces evaluation at CC store time via `writeReplace`, even for tasks that won't run. For `GenerateMavenPom` / `GenerateModuleMetadata` / `GenerateIvyDescriptor` with `fromResolutionResult()`, this triggered full graph resolution and version mapping per variant — wasted work for disabled tasks. The new overload skips the computation when a predicate (here `task::getEnabled`) returns false.

The 3.3× speedup from (1) addresses the originally-reported root cause directly. The disabled-task skip in (2) handles the specific issue that disabling tasks still does work

## Test plan

- [x] `VersionMappingComponentDependencyResolverTest` — new unit tests for the caching behavior (verifies the graph is traversed only once, and the substitution fallback semantics are preserved)
- [x] `CachedTest` — new tests for `shouldEvaluate` predicate (false skips computation, true forces it, predicate is queried at writeReplace time)
- [x] Verified end-to-end against the issue's reproducer (https://github.com/FinlayRJW/gmm-cc-reproducer): 44s → 1.7s steady state with both fixes
- [ ] `:publish:check :maven:check :ivy:check :platform-jvm:check`