### PR TITLE
Fix sanityCheck failing without ANDROID_SDK_ROOT

### DIFF
--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
@@ -34,7 +34,7 @@ class IsolatedProjectsAndroidSyncPerformanceComparisonTest extends AbstractCross
 
     private static int maxWorkers = 8
 
-    def setup() {
+    private void studioSetup() {
         // NOTE: see the javadoc for required environment and possible configuration
         AndroidSyncPerformanceTestFixture.configureStudio(runner)
     }
@@ -42,6 +42,7 @@ class IsolatedProjectsAndroidSyncPerformanceComparisonTest extends AbstractCross
     // TODO:isolated introduce cold/warm daemon variation
     def "sync Studio after included build logic refactoring"() {
         given:
+        studioSetup()
         def runner = getRunner() // otherwise, IDEA thinks it's PerformanceTestRunner despite the override
 
         runner.addBuildMutator { settings ->

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/ip/IsolatedProjectsAndroidSyncPerformanceRegressionTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/ip/IsolatedProjectsAndroidSyncPerformanceRegressionTest.groovy
@@ -32,7 +32,7 @@ class IsolatedProjectsAndroidSyncPerformanceRegressionTest extends AbstractCross
 
     private static int maxWorkers = 8
 
-    def setup() {
+    private void studioSetup() {
         // NOTE: see the javadoc for required environment and possible configuration
         AndroidSyncPerformanceTestFixture.configureStudio(runner)
     }
@@ -41,6 +41,7 @@ class IsolatedProjectsAndroidSyncPerformanceRegressionTest extends AbstractCross
         @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["android500Kts"])
     ])
     def "sync Studio after included build logic refactoring with #daemon daemon"() {
+        studioSetup()
         def runner = getRunner() // otherwise, IDEA thinks it's PerformanceTestRunner despite the override
         runner.useDaemon = daemon == warm
         // Use multiple warm-ups for cold scenario to warm-up Android Studio itself


### PR DESCRIPTION
## Summary

- The `setup()` methods in `IsolatedProjectsAndroidSyncPerformanceRegressionTest` and `IsolatedProjectsAndroidSyncPerformanceComparisonTest` (added in #37387) call `AndroidSyncPerformanceTestFixture.configureStudio(runner)`, which asserts `ANDROID_SDK_ROOT` is set.
- Spock runs `setup()` for every feature method, including during `:performance:writeTmpPerformanceScenarioDefinitions`, which is part of `sanityCheck` and fake-runs all performance tests (setup runs, bodies are skipped). This made `sanityCheck` fail on machines without `ANDROID_SDK_ROOT`.
- Rename `setup()` to `private void studioSetup()` and invoke it from the feature method bodies. The class-level note about required environment and options stays visible at the top of the class, but the assertion is no longer on the unconditional setup path.

## Test plan

- [x] `./gradlew sanityCheck` passes locally without `ANDROID_SDK_ROOT` set.
- [ ] CI green for the affected performance test modules.