### PR TITLE
Run CapturingMultipleUserInputCrossVersionSpec.groovy with target>=8.9

### DIFF
--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r62/CapturingMultipleUserInputCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r62/CapturingMultipleUserInputCrossVersionSpec.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.ProjectConnection
 import spock.lang.Timeout
 
-@TargetGradleVersion(">=8.7")
+@TargetGradleVersion(">=8.9")
 @Timeout(120)
 class CapturingMultipleUserInputCrossVersionSpec extends ToolingApiSpecification {
     private static final String DUMMY_TASK_NAME = 'doSomething'


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/5199

## Summary

`CapturingMultipleUserInputCrossVersionSpec` fails when run against a Gradle 8.8 daemon. The test expects the user-provided answers to be echoed back, but instead sees the default values:

```
Your answer to 'Foo?' was: yes   # expected: "something one"
Your answer to 'Bar?' was: no    # expected: "something two"
```

## Root Cause

The failure was introduced by commit `d9cbcfab390` (PR #37533, merged April 21, 2026), which changed `runBuildWithStandardInput()` from an async `PipedInputStream + poll()` approach to a synchronous `ByteArrayInputStream` approach. This revealed a pre-existing serialization incompatibility with Gradle 8.8.

**The serialization mismatch:**

- Commit `497f354367` (April 27, 2024) changed `TextQuestionPromptEvent` from a 2-field format (timestamp + pre-formatted prompt string) to a 3-field format (timestamp + question + defaultValue). This change is **not** in Gradle 8.8 (released June 2024) but **is** in Gradle 8.9 (August 2024).

- When the current TAPI client connects to a Gradle 8.8 daemon:
  - Daemon serializes `TextQuestionPromptEvent` as: `[timestamp][prompt string]` (2 fields)
  - Current client deserializes expecting 3 fields — the 3rd `readString()` reads bytes from the **next** message in the stream

- The daemon–client connection uses a continuous Kryo-backed stream with **no per-message length framing** (see `SocketConnection`, `KryoBackedMessageSerializer`). Reading extra bytes from one message corrupts all subsequent messages.

- The corrupted stream causes an exception in the `monitorBuild()` loop → the `finally` block sends `CloseInput` to the daemon → daemon calls `putInput(END_OF_INPUT)` → `prompt()` returns `null` → default answers are used.

## Fix

Change `@TargetGradleVersion(">=8.7")` to `@TargetGradleVersion(">=8.9")` in `CapturingMultipleUserInputCrossVersionSpec`. The test's `askQuestion()` + `UserResponse` protocol requires the 3-field `TextQuestionPromptEvent` format, which only exists from Gradle 8.9 onwards.

Verified in https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsCrossVersion_11_bucket10/112064046