### PR TITLE
Fix XcodeCppApplicationProjectIntegrationTest after project display name change

### DIFF
--- a/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCppApplicationProjectIntegrationTest.groovy
+++ b/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCppApplicationProjectIntegrationTest.groovy
@@ -156,7 +156,7 @@ class XcodeCppApplicationProjectIntegrationTest extends AbstractXcodeCppProjectI
 
         then:
         resultApp.assertHasCause("Could not resolve all dependencies for configuration ':app:nativeRuntimeDebug'.")
-        resultApp.assertHasCause("Could not resolve project :greeter.")
+        resultApp.assertHasCause("Could not resolve project ':greeter'.")
 
 
         when:


### PR DESCRIPTION
PR #37110 changed how project names are formatted in error messages — from `project :greeter` to `project ':greeter'` (with single quotes). It updated similar assertions in CppApplicationIntegrationTest but missed this one in the Xcode integration test, causing it to fail on every master build.

Verified in https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Platform_14_bucket2/112064290?hideTestsFromDependencies=true