### PR TITLE
Deprecate artifactUrls on MavenArtifactRepository

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/supported_repository_types.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/dependency-management/declaring-repositories/supported_repository_types.adoc
@@ -33,19 +33,6 @@ include::sample[dir="snippets/reference/dependency-management/declaring-reposito
 include::sample[dir="snippets/reference/dependency-management/declaring-repositories/defineRepository/groovy",files="build.gradle[tags=maven-like-repo]"]
 ====
 
-[[sec:custom-maven-repo]]
-=== Composite Maven repository
-
-Sometimes, POMs are published in one location, and JARs in another.
-You can define such a repository as follows:
-
-====
-include::sample[dir="snippets/reference/dependency-management/declaring-repositories/defineRepository/kotlin",files="build.gradle.kts[tags=maven-like-repo-with-jar-repo]"]
-include::sample[dir="snippets/reference/dependency-management/declaring-repositories/defineRepository/groovy",files="build.gradle[tags=maven-like-repo-with-jar-repo]"]
-====
-
-Gradle will first look for POMs and artifacts at the base URL, and if the artifact is not found, it will check the additional `artifactUrls`.
-
 [[strict_limitation_to_declared_repositories]]
 === Strict limitation for Maven repositories
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -41,6 +41,64 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Deprecations
 
+[[deprecated_maven_artifact_urls]]
+==== Deprecation of `artifactUrls` on Maven repositories
+
+The `artifactUrls` family of methods on link:{javadocPath}/org/gradle/api/artifacts/repositories/MavenArtifactRepository.html[`MavenArtifactRepository`] is deprecated and will be removed in Gradle 10.
+
+This includes:
+
+- `MavenArtifactRepository.getArtifactUrls()`
+- `MavenArtifactRepository.artifactUrls(Object...)`
+- `MavenArtifactRepository.setArtifactUrls(Set)`
+- `MavenArtifactRepository.setArtifactUrls(Iterable)`
+
+The same deprecation applies to passing `artifactUrls` as a key in the map argument to `RepositoryHandler.mavenCentral(Map)`, since that path delegates to the methods above.
+
+These methods let a single Maven repository declaration look for POMs at the base URL while looking for artifacts (such as JARs) at one or more additional URLs.
+This is a Gradle-specific extension with no equivalent in Maven, and there is no direct replacement.
+
+If you need Gradle to look for artifacts in a separate location, declare a second `maven` repository and, if that location only hosts artifacts, configure its `metadataSources` to allow artifact-only resolution:
+
+====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+repositories {
+    maven {
+        url = "http://repo.mycompany.com/maven2"
+    }
+    maven {
+        url = "http://repo.mycompany.com/jars"
+        metadataSources {
+            artifact()
+        }
+    }
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+repositories {
+    maven {
+        url = uri("http://repo.mycompany.com/maven2")
+    }
+    maven {
+        url = uri("http://repo.mycompany.com/jars")
+        metadataSources {
+            artifact()
+        }
+    }
+}
+----
+=====
+====
+
 [[dependency_project_notation]]
 ==== Deprecation of using Project objects as dependency notation
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -58,47 +58,6 @@ The same deprecation applies to passing `artifactUrls` as a key in the map argum
 These methods let a single Maven repository declaration look for POMs at the base URL while looking for artifacts (such as JARs) at one or more additional URLs.
 This is a Gradle-specific extension with no equivalent in Maven, and there is no direct replacement.
 
-If you need Gradle to look for artifacts in a separate location, declare a second `maven` repository and, if that location only hosts artifacts, configure its `metadataSources` to allow artifact-only resolution:
-
-====
-[.multi-language-sample]
-=====
-.build.gradle
-[source,groovy]
-----
-repositories {
-    maven {
-        url = "http://repo.mycompany.com/maven2"
-    }
-    maven {
-        url = "http://repo.mycompany.com/jars"
-        metadataSources {
-            artifact()
-        }
-    }
-}
-----
-=====
-[.multi-language-sample]
-=====
-.build.gradle.kts
-[source,kotlin]
-----
-repositories {
-    maven {
-        url = uri("http://repo.mycompany.com/maven2")
-    }
-    maven {
-        url = uri("http://repo.mycompany.com/jars")
-        metadataSources {
-            artifact()
-        }
-    }
-}
-----
-=====
-====
-
 [[dependency_project_notation]]
 ==== Deprecation of using Project objects as dependency notation
 

--- a/platforms/documentation/docs/src/snippets/integration-tests/artifacts/defineRepository/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/integration-tests/artifacts/defineRepository/groovy/build.gradle
@@ -110,18 +110,6 @@ repositories {
 }
 // end::maven-like-repo[]
 
-// tag::maven-like-repo-with-jar-repo[]
-repositories {
-    maven {
-        // Look for POMs and artifacts, such as JARs, here
-        url = "http://repo2.mycompany.com/maven2"
-        // Look for artifacts here if not found at the above location
-        artifactUrls "http://repo.mycompany.com/jars"
-        artifactUrls "http://repo.mycompany.com/jars2"
-    }
-}
-// end::maven-like-repo-with-jar-repo[]
-
 // tag::authenticated-maven-repo[]
 repositories {
     maven {

--- a/platforms/documentation/docs/src/snippets/integration-tests/artifacts/defineRepository/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/integration-tests/artifacts/defineRepository/kotlin/build.gradle.kts
@@ -110,18 +110,6 @@ repositories {
 }
 // end::maven-like-repo[]
 
-// tag::maven-like-repo-with-jar-repo[]
-repositories {
-    maven {
-        // Look for POMs and artifacts, such as JARs, here
-        url = uri("http://repo2.mycompany.com/maven2")
-        // Look for artifacts here if not found at the above location
-        artifactUrls("http://repo.mycompany.com/jars")
-        artifactUrls("http://repo.mycompany.com/jars2")
-    }
-}
-// end::maven-like-repo-with-jar-repo[]
-
 // tag::authenticated-maven-repo[]
 repositories {
     maven {

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/basics/defineRepository/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/basics/defineRepository/groovy/build.gradle
@@ -110,18 +110,6 @@ repositories {
 }
 // end::maven-like-repo[]
 
-// tag::maven-like-repo-with-jar-repo[]
-repositories {
-    maven {
-        // Look for POMs and artifacts, such as JARs, here
-        url = "http://repo2.mycompany.com/maven2"
-        // Look for artifacts here if not found at the above location
-        artifactUrls "http://repo.mycompany.com/jars"
-        artifactUrls "http://repo.mycompany.com/jars2"
-    }
-}
-// end::maven-like-repo-with-jar-repo[]
-
 // tag::authenticated-maven-repo[]
 repositories {
     maven {

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/basics/defineRepository/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/basics/defineRepository/kotlin/build.gradle.kts
@@ -110,18 +110,6 @@ repositories {
 }
 // end::maven-like-repo[]
 
-// tag::maven-like-repo-with-jar-repo[]
-repositories {
-    maven {
-        // Look for POMs and artifacts, such as JARs, here
-        url = uri("http://repo2.mycompany.com/maven2")
-        // Look for artifacts here if not found at the above location
-        artifactUrls("http://repo.mycompany.com/jars")
-        artifactUrls("http://repo.mycompany.com/jars2")
-    }
-}
-// end::maven-like-repo-with-jar-repo[]
-
 // tag::authenticated-maven-repo[]
 repositories {
     maven {

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-repositories/defineRepository/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-repositories/defineRepository/groovy/build.gradle
@@ -110,18 +110,6 @@ repositories {
 }
 // end::maven-like-repo[]
 
-// tag::maven-like-repo-with-jar-repo[]
-repositories {
-    maven {
-        // Look for POMs and artifacts, such as JARs, here
-        url = "http://repo2.mycompany.com/maven2"
-        // Look for artifacts here if not found at the above location
-        artifactUrls "http://repo.mycompany.com/jars"
-        artifactUrls "http://repo.mycompany.com/jars2"
-    }
-}
-// end::maven-like-repo-with-jar-repo[]
-
 // tag::authenticated-maven-repo[]
 repositories {
     maven {

--- a/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-repositories/defineRepository/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/dependency-management/declaring-repositories/defineRepository/kotlin/build.gradle.kts
@@ -110,18 +110,6 @@ repositories {
 }
 // end::maven-like-repo[]
 
-// tag::maven-like-repo-with-jar-repo[]
-repositories {
-    maven {
-        // Look for POMs and artifacts, such as JARs, here
-        url = uri("http://repo2.mycompany.com/maven2")
-        // Look for artifacts here if not found at the above location
-        artifactUrls("http://repo.mycompany.com/jars")
-        artifactUrls("http://repo.mycompany.com/jars2")
-    }
-}
-// end::maven-like-repo-with-jar-repo[]
-
 // tag::authenticated-maven-repo[]
 repositories {
     maven {

--- a/platforms/documentation/docs/src/snippets/reference/platforms/jvm/defineRepository/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/reference/platforms/jvm/defineRepository/groovy/build.gradle
@@ -110,18 +110,6 @@ repositories {
 }
 // end::maven-like-repo[]
 
-// tag::maven-like-repo-with-jar-repo[]
-repositories {
-    maven {
-        // Look for POMs and artifacts, such as JARs, here
-        url = "http://repo2.mycompany.com/maven2"
-        // Look for artifacts here if not found at the above location
-        artifactUrls "http://repo.mycompany.com/jars"
-        artifactUrls "http://repo.mycompany.com/jars2"
-    }
-}
-// end::maven-like-repo-with-jar-repo[]
-
 // tag::authenticated-maven-repo[]
 repositories {
     maven {

--- a/platforms/documentation/docs/src/snippets/reference/platforms/jvm/defineRepository/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/reference/platforms/jvm/defineRepository/kotlin/build.gradle.kts
@@ -110,18 +110,6 @@ repositories {
 }
 // end::maven-like-repo[]
 
-// tag::maven-like-repo-with-jar-repo[]
-repositories {
-    maven {
-        // Look for POMs and artifacts, such as JARs, here
-        url = uri("http://repo2.mycompany.com/maven2")
-        // Look for artifacts here if not found at the above location
-        artifactUrls("http://repo.mycompany.com/jars")
-        artifactUrls("http://repo.mycompany.com/jars2")
-    }
-}
-// end::maven-like-repo-with-jar-repo[]
-
 // tag::authenticated-maven-repo[]
 repositories {
     maven {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LenientArtifactViewIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LenientArtifactViewIntegrationTest.groovy
@@ -240,11 +240,13 @@ class LenientArtifactViewIntegrationTest extends AbstractHttpDependencyResolutio
         expect:
         module.pom.expectGet()
         module.artifact.expectGetMissing()
+        executer.expectDocumentedDeprecationWarning("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_maven_artifact_urls")
         fails("resolve")
         failure.assertHasErrorOutput("does-not-exist.invalid") // Cannot check whole message, as it differs between OS
 
         and:
         module.artifact.expectGetMissing()
+        executer.expectDocumentedDeprecationWarning("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_maven_artifact_urls")
         succeeds("resolveLenient")
         outputContains("[]")
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
@@ -234,6 +234,7 @@ class ResolveConfigurationRepositoriesBuildOperationIntegrationTest extends Abst
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_maven_artifact_urls")
         succeeds 'resolve'
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenFileRepoResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenFileRepoResolveIntegrationTest.groovy
@@ -132,6 +132,7 @@ task retrieve(type: Sync) {
 """
 
         when:
+        executer.expectDocumentedDeprecationWarning("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_maven_artifact_urls")
         runRetrieveTask()
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenHttpRepoResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenHttpRepoResolveIntegrationTest.groovy
@@ -310,6 +310,7 @@ task retrieve(type: Sync) {
         projectBArtifacts.artifact.expectGet()
 
         then:
+        executer.expectDocumentedDeprecationWarning("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_maven_artifact_urls")
         succeeds 'retrieve'
         file('libs').assertHasDescendants('projectA-1.0.jar', 'projectB-1.0.jar')
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.maven.MavenModule
 import org.gradle.test.fixtures.maven.MavenRepository
@@ -174,7 +175,10 @@ task retrieve(type: Sync) {
 
         when: "We resolve with snapshots cached: no server requests"
         server.resetExpectations()
-        executer.expectDocumentedDeprecationWarning("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_maven_artifact_urls")
+        if (!GradleContextualExecuter.configCache) {
+            // With CC, the configuration is reused and the build script is not re-evaluated, so the deprecation does not re-fire
+            executer.expectDocumentedDeprecationWarning("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_maven_artifact_urls")
+        }
         def result = run('retrieve')
 
         then: "Everything is up to date"

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -164,6 +164,7 @@ task retrieve(type: Sync) {
         repo2ProjectB.artifact.expectGet()
 
         and: "We resolve dependencies"
+        executer.expectDocumentedDeprecationWarning("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_maven_artifact_urls")
         runRetrieveTask()
 
         then: "Snapshots are downloaded"
@@ -173,6 +174,7 @@ task retrieve(type: Sync) {
 
         when: "We resolve with snapshots cached: no server requests"
         server.resetExpectations()
+        executer.expectDocumentedDeprecationWarning("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated. This is scheduled to be removed in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_maven_artifact_urls")
         def result = run('retrieve')
 
         then: "Everything is up to date"

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -60,6 +60,7 @@ import org.gradle.internal.component.external.model.ModuleComponentResolveMetada
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
@@ -171,7 +172,13 @@ public abstract class DefaultMavenArtifactRepository extends AbstractAuthenticat
     }
 
     @Override
+    @Deprecated
     public Set<URI> getArtifactUrls() {
+        nagAboutArtifactUrlsDeprecation("getArtifactUrls()");
+        return getArtifactUrlsInternal();
+    }
+
+    private Set<URI> getArtifactUrlsInternal() {
         Set<URI> result = new LinkedHashSet<>();
         for (Object additionalUrl : additionalUrls) {
             result.add(fileResolver.resolveUri(additionalUrl));
@@ -180,21 +187,38 @@ public abstract class DefaultMavenArtifactRepository extends AbstractAuthenticat
     }
 
     @Override
+    @Deprecated
     public void artifactUrls(Object... urls) {
+        nagAboutArtifactUrlsDeprecation("artifactUrls(Object...)");
         invalidateDescriptor();
         additionalUrls.addAll(ImmutableList.copyOf(urls));
     }
 
     @Override
+    @Deprecated
     public void setArtifactUrls(Set<URI> urls) {
+        nagAboutArtifactUrlsDeprecation("setArtifactUrls(Set)");
         invalidateDescriptor();
-        setArtifactUrls((Iterable<?>) urls);
+        setArtifactUrlsInternal(urls);
     }
 
     @Override
+    @Deprecated
     public void setArtifactUrls(Iterable<?> urls) {
+        nagAboutArtifactUrlsDeprecation("setArtifactUrls(Iterable)");
         invalidateDescriptor();
+        setArtifactUrlsInternal(urls);
+    }
+
+    private void setArtifactUrlsInternal(Iterable<?> urls) {
         additionalUrls = Lists.newArrayList(urls);
+    }
+
+    private static void nagAboutArtifactUrlsDeprecation(String methodWithParams) {
+        DeprecationLogger.deprecateMethod(MavenArtifactRepository.class, methodWithParams)
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecated_maven_artifact_urls")
+            .nagUser();
     }
 
     @Override
@@ -204,7 +228,7 @@ public abstract class DefaultMavenArtifactRepository extends AbstractAuthenticat
             .setAuthenticated(usesCredentials())
             .setAuthenticationSchemes(getAuthenticationSchemes())
             .setMetadataSources(metadataSources.asList())
-            .setArtifactUrls(Sets.newHashSet(getArtifactUrls()))
+            .setArtifactUrls(Sets.newHashSet(getArtifactUrlsInternal()))
             .create();
     }
 
@@ -216,7 +240,7 @@ public abstract class DefaultMavenArtifactRepository extends AbstractAuthenticat
         if (root != null) {
             builder.add(root);
         }
-        builder.addAll(getArtifactUrls());
+        builder.addAll(getArtifactUrlsInternal());
         return builder.build();
     }
 

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -126,6 +126,54 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         repo.artifactPatterns.any { it.startsWith uri2.toString() }
     }
 
+    @ExpectDeprecation("The MavenArtifactRepository.setArtifactUrls(Set) method has been deprecated.")
+    def "setArtifactUrls(Set) replaces additional artifact URLs"() {
+        given:
+        def uri = new URI("https://localhost:9090/repo")
+        def uri1 = new URI("https://localhost:9090/repo1")
+        _ * resolver.resolveUri('repo-dir') >> uri
+        _ * resolver.resolveUri(uri1) >> uri1
+        transportFactory.createTransport('https', 'repo', _, _) >> transport()
+
+        and:
+        repository.name = 'repo'
+        repository.url = 'repo-dir'
+        repository.setArtifactUrls([uri1] as Set)
+
+        when:
+        def repo = repository.createResolver()
+
+        then:
+        repo instanceof MavenResolver
+        repo.artifactPatterns.size() == 2
+        repo.artifactPatterns.any { it.startsWith uri.toString() }
+        repo.artifactPatterns.any { it.startsWith uri1.toString() }
+    }
+
+    @ExpectDeprecation("The MavenArtifactRepository.setArtifactUrls(Iterable) method has been deprecated.")
+    def "setArtifactUrls(Iterable) replaces additional artifact URLs"() {
+        given:
+        def uri = new URI("https://localhost:9090/repo")
+        def uri1 = new URI("https://localhost:9090/repo1")
+        _ * resolver.resolveUri('repo-dir') >> uri
+        _ * resolver.resolveUri('repo1') >> uri1
+        transportFactory.createTransport('https', 'repo', _, _) >> transport()
+
+        and:
+        repository.name = 'repo'
+        repository.url = 'repo-dir'
+        repository.setArtifactUrls(['repo1'])
+
+        when:
+        def repo = repository.createResolver()
+
+        then:
+        repo instanceof MavenResolver
+        repo.artifactPatterns.size() == 2
+        repo.artifactPatterns.any { it.startsWith uri.toString() }
+        repo.artifactPatterns.any { it.startsWith uri1.toString() }
+    }
+
     def "creates s3 repository"() {
         given:
         def uri = new URI("s3://localhost:9090/repo")

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -38,6 +38,7 @@ import org.gradle.internal.resource.ExternalResourceRepository
 import org.gradle.internal.resource.cached.DefaultExternalResourceFileStore
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
+import org.gradle.test.fixtures.ExpectDeprecation
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -97,6 +98,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         repo.root == uri
     }
 
+    @ExpectDeprecation("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated.")
     def "creates repository with additional artifact URLs"() {
         given:
         def uri = new URI("https://localhost:9090/repo")
@@ -291,6 +293,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         different.descriptor.id == repo.descriptor.id
     }
 
+    @ExpectDeprecation("The MavenArtifactRepository.artifactUrls(Object...) method has been deprecated.")
     def "repositories have the same id when artifact urls and other configuration is the same"() {
         def repo = newRepo()
         def same = newRepo()

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -122,7 +122,7 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * Adds a repository which looks in the Maven central repository for dependencies. The URL used to access this repository is
      * {@value org.gradle.api.artifacts.ArtifactRepositoryContainer#MAVEN_CENTRAL_URL}.
      *
-     * <p>The following parameter are accepted as keys for the map:
+     * <p>The following parameter is accepted as a key for the map:
      *
      * <table>
      * <caption>Shows property keys and associated values</caption>
@@ -133,21 +133,19 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * {@value org.gradle.api.artifacts.ArtifactRepositoryContainer#DEFAULT_MAVEN_CENTRAL_REPO_NAME} is used as the name. A name
      * must be unique amongst a repository group.
      * </td></tr>
-     * <tr><td><code>artifactUrls</code></td>
-     *     <td>A single jar repository or a collection of jar repositories containing additional artifacts not found in the Maven central repository.
-     * But be aware that the POM must exist in Maven central.
-     * The provided values are evaluated as per {@link org.gradle.api.Project#uri(Object)}.</td></tr>
      * </table>
+     *
+     * <p>Note: passing {@code artifactUrls} as a key in this map is deprecated and scheduled to be removed in Gradle 10,
+     * since it delegates to {@link MavenArtifactRepository#setArtifactUrls(Iterable)}.
      *
      * <p>Examples:</p>
      * <pre class='autoTested'>
      * repositories {
-     *     mavenCentral artifactUrls: ["http://www.mycompany.com/artifacts1", "http://www.mycompany.com/artifacts2"]
-     *     mavenCentral name: "nonDefaultName", artifactUrls: ["http://www.mycompany.com/artifacts1"]
+     *     mavenCentral name: "nonDefaultName"
      * }
      * </pre>
      *
-     * @param args A list of urls of repositories to look for artifacts only.
+     * @param args Configuration map for the Maven Central repository.
      * @return the added repository
      */
     @HiddenInDefinition

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
@@ -64,7 +64,7 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
      * Returns the additional URLs to use to find artifact files. Note that these URLs are not used to find POM files.
      *
      * @return The additional URLs. Returns an empty list if there are no such URLs.
-     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10. Declare a separate Maven repository for the additional artifact location instead.
+     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10.
      */
     @Deprecated
     @HiddenInDefinition
@@ -77,7 +77,7 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
      * relative to the project directory.
      *
      * @param urls The URLs to add.
-     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10. Declare a separate Maven repository for the additional artifact location instead.
+     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10.
      */
     @Deprecated
     @HiddenInDefinition
@@ -88,7 +88,7 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
      *
      * @param urls The URLs.
      * @since 4.0
-     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10. Declare a separate Maven repository for the additional artifact location instead.
+     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10.
      */
     @Deprecated
     @HiddenInDefinition
@@ -101,7 +101,7 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
      * relative to the project directory.
      *
      * @param urls The URLs.
-     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10. Declare a separate Maven repository for the additional artifact location instead.
+     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10.
      */
     @Deprecated
     @HiddenInDefinition

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
@@ -31,8 +31,7 @@ import java.util.Set;
 public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifactRepository, AuthenticationSupported, MetadataSupplierAware {
 
     /**
-     * The base URL of this repository. This URL is used to find both POMs and artifact files. You can add additional URLs to use to look for artifact files, such as jars, using {@link
-     * #setArtifactUrls(Iterable)}.
+     * The base URL of this repository. This URL is used to find both POMs and artifact files.
      *
      * @return The URL.
      */
@@ -41,8 +40,7 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
     URI getUrl();
 
     /**
-     * Sets the base URL of this repository. This URL is used to find both POMs and artifact files. You can add additional URLs to use to look for artifact files, such as jars, using {@link
-     * #setArtifactUrls(Iterable)}.
+     * Sets the base URL of this repository. This URL is used to find both POMs and artifact files.
      *
      * @param url The base URL.
      * @since 4.0
@@ -51,8 +49,7 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
     void setUrl(URI url);
 
     /**
-     * Sets the base URL of this repository. This URL is used to find both POMs and artifact files. You can add additional URLs to use to look for artifact files, such as jars, using {@link
-     * #setArtifactUrls(Iterable)}.
+     * Sets the base URL of this repository. This URL is used to find both POMs and artifact files.
      *
      * <p>The provided value is evaluated as per {@link org.gradle.api.Project#uri(Object)}. This means, for example, you can pass in a {@code File} object, or a relative path to be evaluated relative
      * to the project directory.
@@ -67,8 +64,9 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
      * Returns the additional URLs to use to find artifact files. Note that these URLs are not used to find POM files.
      *
      * @return The additional URLs. Returns an empty list if there are no such URLs.
+     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10. Declare a separate Maven repository for the additional artifact location instead.
      */
-    @ToBeReplacedByLazyProperty
+    @Deprecated
     @HiddenInDefinition
     Set<URI> getArtifactUrls();
 
@@ -79,7 +77,9 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
      * relative to the project directory.
      *
      * @param urls The URLs to add.
+     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10. Declare a separate Maven repository for the additional artifact location instead.
      */
+    @Deprecated
     @HiddenInDefinition
     void artifactUrls(Object... urls);
 
@@ -88,7 +88,9 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
      *
      * @param urls The URLs.
      * @since 4.0
+     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10. Declare a separate Maven repository for the additional artifact location instead.
      */
+    @Deprecated
     @HiddenInDefinition
     void setArtifactUrls(Set<URI> urls);
 
@@ -99,7 +101,9 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
      * relative to the project directory.
      *
      * @param urls The URLs.
+     * @deprecated Maven repositories with separate locations for POMs and artifacts are a Gradle-only feature with no equivalent in Maven. This method is scheduled to be removed in Gradle 10. Declare a separate Maven repository for the additional artifact location instead.
      */
+    @Deprecated
     @HiddenInDefinition
     void setArtifactUrls(Iterable<?> urls);
 


### PR DESCRIPTION
The artifactUrls family of methods on MavenArtifactRepository is a Gradle-only feature with no equivalent in Maven repository declarations. Nag users via DeprecationLogger and document removal in Gradle 10 in the upgrade guide. 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
