### PR TITLE
Deprecate RepositoryHandler.flatDir(Map) and mavenCentral(Map)

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -74,8 +74,8 @@ For `flatDir`:
 ----
 repositories {
     flatDir {
-        name = 'libs'
-        dirs "$projectDir/libs1", "$projectDir/libs2"
+        name = "libs"
+        dirs "libs1", "libs2"
     }
 }
 ----
@@ -88,7 +88,7 @@ repositories {
 repositories {
     flatDir {
         name = "libs"
-        dirs("$projectDir/libs1", "$projectDir/libs2")
+        dirs("libs1", "libs2")
     }
 }
 ----
@@ -105,7 +105,7 @@ For `mavenCentral`:
 ----
 repositories {
     mavenCentral {
-        name = 'nonDefaultName'
+        name = "nonDefaultName"
     }
 }
 ----

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -58,6 +58,72 @@ The same deprecation applies to passing `artifactUrls` as a key in the map argum
 These methods let a single Maven repository declaration look for POMs at the base URL while looking for artifacts (such as JARs) at one or more additional URLs.
 This is a Gradle-specific extension with no equivalent in Maven, and there is no direct replacement.
 
+[[deprecated_repository_handler_map_overloads]]
+==== Deprecation of `RepositoryHandler.flatDir(Map)` and `RepositoryHandler.mavenCentral(Map)`
+
+The map-argument overloads `RepositoryHandler.flatDir(Map)` and `RepositoryHandler.mavenCentral(Map)` are deprecated and will be removed in Gradle 10.
+Use the action-based overloads (`flatDir(Action)`, `mavenCentral(Action)`) instead — they are typed, work in both the Groovy and Kotlin DSLs, and are the canonical way to configure a repository.
+
+For `flatDir`:
+
+====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+repositories {
+    flatDir {
+        name = 'libs'
+        dirs "$projectDir/libs1", "$projectDir/libs2"
+    }
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+repositories {
+    flatDir {
+        name = "libs"
+        dirs("$projectDir/libs1", "$projectDir/libs2")
+    }
+}
+----
+=====
+====
+
+For `mavenCentral`:
+
+====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+repositories {
+    mavenCentral {
+        name = 'nonDefaultName'
+    }
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+repositories {
+    mavenCentral {
+        name = "nonDefaultName"
+    }
+}
+----
+=====
+====
+
 [[dependency_project_notation]]
 ==== Deprecation of using Project objects as dependency notation
 

--- a/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaModuleIntegrationTest.groovy
+++ b/platforms/ide/ide-plugins/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaModuleIntegrationTest.groovy
@@ -412,7 +412,7 @@ apply plugin: 'java'
 apply plugin: 'idea'
 
 repositories {
-  flatDir dirs: 'repo'
+  flatDir { dirs 'repo' }
 }
 
 dependencies {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m5/EclipseModelWithFlatRepoCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m5/EclipseModelWithFlatRepoCrossVersionSpec.groovy
@@ -32,7 +32,7 @@ class EclipseModelWithFlatRepoCrossVersionSpec extends ToolingApiSpecification i
 apply plugin: "java"
 
 repositories {
-	flatDir dirs: file("${repoDir.toURI()}")
+	flatDir { dirs file("${repoDir.toURI()}") }
 }
 
 dependencies {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryHandlerMapOverloadsDeprecationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryHandlerMapOverloadsDeprecationIntegrationTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class RepositoryHandlerMapOverloadsDeprecationIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final String FLAT_DIR_MAP_DEPRECATION = "The RepositoryHandler.flatDir(Map) method has been deprecated. " +
+        "This is scheduled to be removed in Gradle 10. Use flatDir(Action) instead. " +
+        "Consult the upgrading guide for further information: " +
+        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_repository_handler_map_overloads"
+
+    private static final String MAVEN_CENTRAL_MAP_DEPRECATION = "The RepositoryHandler.mavenCentral(Map) method has been deprecated. " +
+        "This is scheduled to be removed in Gradle 10. Use mavenCentral(Action) instead. " +
+        "Consult the upgrading guide for further information: " +
+        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_repository_handler_map_overloads"
+
+    def "flatDir(Map) emits a deprecation warning"() {
+        given:
+        file("repo/lib-1.0.jar").createFile()
+        buildFile << """
+            repositories {
+                flatDir(name: 'libs', dirs: 'repo')
+            }
+            configurations { compile }
+            dependencies {
+                compile 'group:lib:1.0'
+            }
+            task resolve {
+                def files = configurations.compile
+                doLast {
+                    assert files.collect { it.name } == ['lib-1.0.jar']
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning(FLAT_DIR_MAP_DEPRECATION)
+        succeeds("resolve")
+    }
+
+    def "mavenCentral(Map) emits a deprecation warning"() {
+        given:
+        buildFile << """
+            repositories {
+                mavenCentral(name: 'central')
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning(MAVEN_CENTRAL_MAP_DEPRECATION)
+        succeeds("help")
+    }
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.artifacts.DefaultArtifactRepositoryContainer;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.internal.ConfigureUtil;
 
@@ -77,7 +78,13 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
     }
 
     @Override
+    @Deprecated
     public FlatDirectoryArtifactRepository flatDir(Map<String, ?> args) {
+        DeprecationLogger.deprecateMethod(RepositoryHandler.class, "flatDir(Map)")
+            .withAdvice("Use flatDir(Action) instead.")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecated_repository_handler_map_overloads")
+            .nagUser();
         Map<String, Object> modifiedArgs = new HashMap<>(args);
         if (modifiedArgs.containsKey("dirs")) {
             modifiedArgs.put("dirs", flattenCollections(modifiedArgs.get("dirs")));
@@ -106,7 +113,13 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
     }
 
     @Override
+    @Deprecated
     public MavenArtifactRepository mavenCentral(Map<String, ?> args) {
+        DeprecationLogger.deprecateMethod(RepositoryHandler.class, "mavenCentral(Map)")
+            .withAdvice("Use mavenCentral(Action) instead.")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecated_repository_handler_map_overloads")
+            .nagUser();
         Map<String, Object> modifiedArgs = new HashMap<>(args);
         return addRepository(repositoryFactory.createMavenCentralRepository(), DEFAULT_MAVEN_CENTRAL_REPO_NAME, new ConfigureByMapAction<>(modifiedArgs));
     }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandlerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandlerTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.artifacts.BaseRepositoryFactory
 import org.gradle.api.internal.artifacts.DefaultArtifactRepositoryContainerTest
 import org.gradle.internal.reflect.Instantiator
+import org.gradle.test.fixtures.ExpectDeprecation
 import org.gradle.util.TestUtil
 
 class DefaultRepositoryHandlerTest extends DefaultArtifactRepositoryContainerTest {
@@ -50,6 +51,7 @@ class DefaultRepositoryHandlerTest extends DefaultArtifactRepositoryContainerTes
         handler.flatDir { name = 'libs' }.is(repository)
     }
 
+    @ExpectDeprecation("The RepositoryHandler.flatDir(Map) method has been deprecated.")
     def testFlatDirWithMap() {
         given:
         def repository = Mock(TestFlatDirectoryArtifactRepository) { getName() >> "name" }
@@ -69,6 +71,7 @@ class DefaultRepositoryHandlerTest extends DefaultArtifactRepositoryContainerTes
         handler.mavenCentral().is(repository)
     }
 
+    @ExpectDeprecation("The RepositoryHandler.mavenCentral(Map) method has been deprecated.")
     public void testMavenCentralWithMap() {
         when:
         MavenArtifactRepository repository = Mock(TestMavenArtifactRepository) { getName() >> "name" }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -61,19 +61,13 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      *     <td>Specifies a list of rootDirs where to look for dependencies. These are evaluated as per {@link org.gradle.api.Project#files(Object...)}</td></tr>
      * </table>
      *
-     * <p>Examples:</p>
-     * <pre class='autoTested'>
-     * repositories {
-     *     flatDir name: 'libs', dirs: "$projectDir/libs"
-     *     flatDir dirs: ["$projectDir/libs1", "$projectDir/libs2"]
-     * }
-     * </pre>
-     *
      * @param args The arguments used to configure the repository.
      * @return the added resolver
      * @throws org.gradle.api.InvalidUserDataException In the case neither rootDir nor rootDirs is specified of if both
      * are specified.
+     * @deprecated This method is scheduled to be removed in Gradle 10. Use {@link #flatDir(Action)} instead.
      */
+    @Deprecated
     @HiddenInDefinition
     FlatDirectoryArtifactRepository flatDir(Map<String, ?> args);
 
@@ -135,19 +129,11 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * </td></tr>
      * </table>
      *
-     * <p>Note: passing {@code artifactUrls} as a key in this map is deprecated and scheduled to be removed in Gradle 10,
-     * since it delegates to {@link MavenArtifactRepository#setArtifactUrls(Iterable)}.
-     *
-     * <p>Examples:</p>
-     * <pre class='autoTested'>
-     * repositories {
-     *     mavenCentral name: "nonDefaultName"
-     * }
-     * </pre>
-     *
      * @param args Configuration map for the Maven Central repository.
      * @return the added repository
+     * @deprecated This method is scheduled to be removed in Gradle 10. Use {@link #mavenCentral(Action)} instead.
      */
+    @Deprecated
     @HiddenInDefinition
     MavenArtifactRepository mavenCentral(Map<String, ?> args);
 
@@ -164,7 +150,7 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * </pre>
      *
      * @return the added resolver
-     * @see #mavenCentral(java.util.Map)
+     * @see #mavenCentral(Action)
      */
     @Adding
     MavenArtifactRepository mavenCentral();


### PR DESCRIPTION

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
