### PR TITLE
Make smoke-test:smokeTest depend on androidHomeWarmup

### DIFF
--- a/testing/smoke-test/build.gradle.kts
+++ b/testing/smoke-test/build.gradle.kts
@@ -149,6 +149,8 @@ tasks {
     register<SmokeTest>("smokeTest") {
         description = "Runs Smoke tests"
         configureForSmokeTest(excludes = listOf(gradleBuildTestPattern, androidProjectTestPattern))
+        
+        dependsOn("androidHomeWarmup")
     }
 
     register<SmokeTest>("configCacheSmokeTest") {


### PR DESCRIPTION
Because of the failures observed in https://ge.gradle.org/s/b67kswe2dn57k/tests/overview?outcome=FAILED