### PR TITLE
Add internal flag to fail builds on implicit parent-project lookup

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
@@ -19,6 +19,7 @@ import groovy.lang.Closure;
 import groovy.lang.MissingMethodException;
 import groovy.lang.MissingPropertyException;
 import org.codehaus.groovy.runtime.GeneratedClosure;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
@@ -68,6 +69,7 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
     private CompositeDynamicObject delegateObjects;
     @Nullable
     private HierarchicalDynamicObject parent;
+    private boolean failOnParentAccess;
 
     public ExtensibleDynamicObject(Object delegate, Class<?> publicType, InstanceGenerator instanceGenerator) {
         this(delegate, new BeanDynamicObject(delegate, publicType), new DefaultExtensionContainer(instanceGenerator));
@@ -132,6 +134,18 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
         this.parent = parent;
     }
 
+    /**
+     * Enables strict mode for parent-project property/method lookup. When set, any property or
+     * method that resolves through the parent chain causes the build to fail with an
+     * {@link InvalidUserCodeException} at the lookup site. Used to opt into the eventual
+     * Gradle 10 behavior early or to enforce zero parent-walking in CI builds.
+     *
+     * @see org.gradle.api.internal.project.DefaultProject#FAIL_ON_PARENT_PROPERTY_LOOKUP
+     */
+    public void setFailOnParentAccess(boolean failOnParentAccess) {
+        this.failOnParentAccess = failOnParentAccess;
+    }
+
     public ExtensionContainer getExtensions() {
         return extensionContainer;
     }
@@ -180,6 +194,7 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
         HierarchicalDynamicObject parent = this.parent;
         while (parent != null) {
             if (parent.hasProperty(name)) {
+                failOnParentAccessIfNeeded("property", name, parent);
                 return true;
             }
             parent = parent.getParent();
@@ -197,6 +212,7 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
         while (parent != null) {
             result = parent.tryGetProperty(name);
             if (result.isFound()) {
+                failOnParentAccessIfNeeded("property", name, parent);
                 return result;
             }
             parent = parent.getParent();
@@ -244,6 +260,7 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
         HierarchicalDynamicObject parent = this.parent;
         while (parent != null) {
             if (parent.hasMethod(name, arguments)) {
+                failOnParentAccessIfNeeded("method", name, parent);
                 return true;
             }
             parent = parent.getParent();
@@ -260,11 +277,25 @@ public class ExtensibleDynamicObject extends AbstractDynamicObject implements Hi
         while (parent != null) {
             result = parent.tryInvokeMethod(name, arguments);
             if (result.isFound()) {
+                failOnParentAccessIfNeeded("method", name, parent);
                 return result;
             }
             parent = parent.getParent();
         }
         return DynamicInvokeResult.notFound();
+    }
+
+    private void failOnParentAccessIfNeeded(String memberKind, String memberName, DynamicObject resolvedParent) {
+        if (!failOnParentAccess) {
+            return;
+        }
+        throw new InvalidUserCodeException(
+            "Implicit parent-project " + memberKind + " lookup is not allowed: "
+                + memberKind + " '" + memberName + "' was resolved from " + resolvedParent.getDisplayName()
+                + " for " + getDisplayName() + ". "
+                + "Define '" + memberName + "' explicitly in " + getDisplayName()
+                + ", or unset the org.gradle.internal.fail-on-parent-property-lookup system property."
+        );
     }
 
     @Override

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ParentPropertyLookupFailOnAccessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ParentPropertyLookupFailOnAccessIntegrationTest.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import spock.lang.IgnoreIf
+
+/**
+ * Tests for the {@code org.gradle.internal.fail-on-parent-property-lookup} internal flag,
+ * which makes any implicit parent-project property/method lookup fail the build at the
+ * lookup site with {@code InvalidUserCodeException}.
+ */
+class ParentPropertyLookupFailOnAccessIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final String FAIL_ON_PARENT_LOOKUP = "-Dorg.gradle.internal.fail-on-parent-property-lookup=true"
+
+    def setup() {
+        createDirs("child")
+        settingsFile("""
+            rootProject.name = "root"
+            include "child"
+        """)
+        buildFile("""
+            ext.foo = "bar"
+            def fooMethod() { "from parent" }
+        """)
+    }
+
+    @IgnoreIf({ GradleContextualExecuter.isolatedProjects })
+    def "fails on #scenario from child"() {
+        buildFile("child/build.gradle", "println $expression")
+
+        when:
+        fails "help", FAIL_ON_PARENT_LOOKUP
+
+        then:
+        failure.assertHasCause("Implicit parent-project property lookup is not allowed: property 'foo' was resolved from root project 'root' for project ':child'.")
+
+        where:
+        scenario             | expression
+        "implicit reference" | "foo"
+        "findProperty"       | "findProperty('foo')"
+        "property"           | "property('foo')"
+        "getProperty"        | "getProperty('foo')"
+        "hasProperty"        | "hasProperty('foo')"
+    }
+
+    @IgnoreIf({ GradleContextualExecuter.isolatedProjects })
+    def "fails on method invocation from child"() {
+        buildFile("child/build.gradle", "println fooMethod()")
+
+        when:
+        fails "help", FAIL_ON_PARENT_LOOKUP
+
+        then:
+        failure.assertHasCause("Implicit parent-project method lookup is not allowed: method 'fooMethod' was resolved from root project 'root' for project ':child'.")
+    }
+
+    @IgnoreIf({ GradleContextualExecuter.isolatedProjects })
+    def "succeeds when flag is not set"() {
+        buildFile("child/build.gradle", """
+            println foo
+            println findProperty('foo')
+            println property('foo')
+            println getProperty('foo')
+            println hasProperty('foo')
+            println fooMethod()
+        """)
+
+        expect:
+        succeeds "help"
+    }
+
+    def "succeeds when child defines the property locally even with flag set"() {
+        buildFile("child/build.gradle", """
+            ext.foo = "local"
+            println foo
+            println findProperty('foo')
+        """)
+
+        when:
+        succeeds "help", FAIL_ON_PARENT_LOOKUP
+
+        then:
+        outputContains("local")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -87,6 +87,8 @@ import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
+import org.gradle.internal.buildoption.InternalOption;
+import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.extensibility.ExtensibleDynamicObject;
@@ -158,6 +160,18 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     private static final ModelType<ProjectIdentifier> PROJECT_IDENTIFIER_MODEL_TYPE = ModelType.of(ProjectIdentifier.class);
     private static final ModelType<ExtensionContainer> EXTENSION_CONTAINER_MODEL_TYPE = ModelType.of(ExtensionContainer.class);
     private static final Logger BUILD_LOGGER = Logging.getLogger(Project.class);
+
+    /**
+     * Internal flag that, when set, makes any property or method that resolves through the
+     * parent-project chain throw {@link org.gradle.api.InvalidUserCodeException} at the lookup
+     * site. Used as a CI-side enforcement / pre-flight-check mechanism for the eventual
+     * Gradle 10 behavior in which parent-project lookup is removed entirely.
+     *
+     * <p>Wired into {@link ExtensibleDynamicObject#setFailOnParentAccess(boolean)} on every
+     * Project that has a parent.
+     */
+    public static final InternalOption<Boolean> FAIL_ON_PARENT_PROPERTY_LOOKUP =
+        InternalOptions.ofBoolean("org.gradle.internal.fail-on-parent-property-lookup", false);
 
     private final ProjectState owner;
     private final ClassLoaderScope classLoaderScope;
@@ -247,6 +261,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
         @Nullable HierarchicalDynamicObject parentInherited = services.get(CrossProjectModelAccess.class).parentProjectDynamicInheritedScope(this);
         if (parentInherited != null) {
             extensibleDynamicObject.setParent(parentInherited);
+            extensibleDynamicObject.setFailOnParentAccess(services.get(InternalOptions.class).getBoolean(FAIL_ON_PARENT_PROPERTY_LOOKUP));
         }
         extensibleDynamicObject.addObject(taskContainer.getTasksAsDynamicObject(), ExtensibleDynamicObject.Location.AfterConvention);
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -41,6 +41,8 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.util.internal.PatternSets
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator
 import org.gradle.internal.Describables
+import org.gradle.internal.buildoption.DefaultInternalOptions
+import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.management.DependencyResolutionManagementInternal
 import org.gradle.internal.project.ImmutableProjectDescriptor
@@ -267,6 +269,7 @@ class DefaultProjectSpec extends Specification {
         serviceRegistry.add(GradleLifecycleActionExecutor, Stub(GradleLifecycleActionExecutor))
         serviceRegistry.add(ProjectFeatureDeclarations, Stub(ProjectFeatureDeclarations))
         serviceRegistry.add(ProjectFeatureApplicator, Stub(ProjectFeatureApplicator))
+        serviceRegistry.add(InternalOptions, new DefaultInternalOptions([:]))
 
         def antBuilder = Mock(AntBuilder)
         serviceRegistry.add(AntBuilderFactory, Mock(AntBuilderFactory) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -82,6 +82,8 @@ import org.gradle.initialization.ClassLoaderScopeRegistryListener
 import org.gradle.internal.Actions
 import org.gradle.internal.Describables
 import org.gradle.internal.build.BuildState
+import org.gradle.internal.buildoption.DefaultInternalOptions
+import org.gradle.internal.buildoption.InternalOptions
 import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.logging.LoggingManagerInternal
@@ -273,6 +275,7 @@ class DefaultProjectTest extends Specification {
         serviceRegistryMock.get((Type) ObjectFactory) >> Stub(ObjectFactory)
         serviceRegistryMock.get((Type) DependencyLockingHandler) >> Stub(DependencyLockingHandler)
         serviceRegistryMock.get((Type) DynamicCallContextTracker) >> Stub(DynamicCallContextTracker)
+        serviceRegistryMock.get(InternalOptions) >> new DefaultInternalOptions([:])
 
         projectState = Mock(ProjectState)
         projectState.name >> 'root'


### PR DESCRIPTION
## Motivation

This is intended to gather early feedback from partners on deprecating parent lookup. having it fail makes sure in test sets that ignore deprecation warnings we still get a signal.

## Summary

Adds the internal option `org.gradle.internal.fail-on-parent-property-lookup`. When enabled, any property or method that resolves through the parent-project chain at the lookup site throws `InvalidUserCodeException` and fails the build immediately, instead of emitting a deprecation warning.

Intended as a CI-side enforcement / pre-flight-check tool aligned with the eventual Gradle 10 behavior in which implicit parent-walking is removed entirely.

- Wired into `ExtensibleDynamicObject` by `DefaultProject` only when the project's parent is set, so non-Project dynamic objects (extension hierarchies, etc.) are unaffected.
- Covers all four parent-walking paths: `tryGetProperty`, `hasProperty`, `hasMethod`, and the inner `doTryInvokeMethod` called by `tryInvokeMethod`.
- Default is off; existing behavior is unchanged. The option is internal and intentionally undocumented in the upgrade guide.

Failure message format:
> Implicit parent-project property lookup is not allowed: property 'foo' was resolved from root project 'root' for project ':child'. Define 'foo' explicitly in project ':child', or unset the org.gradle.internal.fail-on-parent-property-lookup system property.

## Test plan

- [x] `./gradlew :core:forkingIntegTest --tests '*ParentPropertyLookupFailOnAccessIntegrationTest*'` (8/8 pass)
- [x] `./gradlew :model-core:test --tests '*ExtensibleDynamicObject*'` (no regressions)
- [ ] CI green