### PR TITLE
Deprecate Develocity plugin versions before 4.0

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -42,14 +42,13 @@ The previous step will help you identify potential problems by issuing deprecati
 === Deprecations
 
 [[deprecated_develocity_plugin_pre_4_0]]
-==== Earliest supported Develocity plugin version starting in Gradle 10 is 4.0
+==== Develocity plugin versions before 4.0 are no longer supported in Gradle 10
 
-Starting in Gradle 10, the earliest supported Develocity plugin version is 4.0.
-The plugin versions before 4.0 rely on Gradle's implicit parent-project property lookup, which is being removed in Gradle 10, and will be ignored when applied.
+Gradle 10 requires Develocity plugin 4.0 or later.
+Earlier versions rely on Gradle's implicit parent-project property lookup, which will be removed in Gradle 10 and silently ignored if applied.
 
-Upgrade to version 4.0 or later of the Develocity plugin.
-You can find the link:https://plugins.gradle.org/plugin/com.gradle.develocity[latest available version on the Gradle Plugin Portal].
-More information on the compatibility can be found link:https://gradle.com/help/gradle-plugin-compatibility/[here].
+Upgrade to the link:https://plugins.gradle.org/plugin/com.gradle.develocity[latest Develocity plugin] from the Gradle Plugin Portal.
+See the link:https://gradle.com/help/gradle-plugin-compatibility/[Develocity plugin compatibility matrix] for details.
 
 [[deprecated_maven_artifact_urls]]
 ==== Deprecation of `artifactUrls` on Maven repositories

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -41,6 +41,16 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Deprecations
 
+[[deprecated_develocity_plugin_pre_4_0]]
+==== Earliest supported Develocity plugin version starting in Gradle 10 is 4.0
+
+Starting in Gradle 10, the earliest supported Develocity plugin version is 4.0.
+The plugin versions before 4.0 rely on Gradle's implicit parent-project property lookup, which is being removed in Gradle 10, and will be ignored when applied.
+
+Upgrade to version 4.0 or later of the Develocity plugin.
+You can find the link:https://plugins.gradle.org/plugin/com.gradle.develocity[latest available version on the Gradle Plugin Portal].
+More information on the compatibility can be found link:https://gradle.com/help/gradle-plugin-compatibility/[here].
+
 [[deprecated_maven_artifact_urls]]
 ==== Deprecation of `artifactUrls` on Maven repositories
 

--- a/platforms/enterprise/enterprise/build.gradle.kts
+++ b/platforms/enterprise/enterprise/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(projects.dependencyManagement)
     implementation(projects.files)
     implementation(projects.hashing)
+    implementation(projects.logging)
     implementation(projects.serialization)
     implementation(projects.testingBase)
 

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/BaseBuildScanPluginCheckInFixture.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/BaseBuildScanPluginCheckInFixture.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.enterprise
 
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.execution.RunRootBuildWorkBuildOperationType
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
@@ -32,6 +33,8 @@ import org.gradle.test.fixtures.plugin.PluginBuilder
 
 import javax.annotation.Nullable
 import java.util.regex.Pattern
+
+import static org.gradle.internal.enterprise.impl.legacy.DevelocityPluginCompatibility.FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP
 
 @SuppressWarnings("GrMethodMayBeStatic")
 abstract class BaseBuildScanPluginCheckInFixture {
@@ -208,6 +211,21 @@ abstract class BaseBuildScanPluginCheckInFixture {
 
     void assertUnsupportedMessage(String output, String unsupported) {
         assert output.contains("${propertyPrefix}.checkIn.unsupported.reasonMessage = $unsupported")
+    }
+
+    /**
+     * Registers an expectation for the deprecation warning emitted at plugin check-in for
+     * Develocity plugin versions affected by the implicit parent-project property lookup.
+     */
+    void expectParentPropertyLookupDeprecation(GradleExecuter executer, String pluginVersion) {
+        executer.expectDocumentedDeprecationWarning(
+            "Usage of the Develocity plugin ${pluginVersion} has been deprecated. " +
+                "This will fail with an error in Gradle 10. " +
+                "The plugin application will be ignored. " +
+                "Upgrade to version ${FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP} or later of the Develocity plugin. " +
+                "Consult the upgrading guide for further information: " +
+                "${new DocumentationRegistry().getDocumentationFor("upgrading_version_9", "deprecated_develocity_plugin_pre_4_0")}"
+        )
     }
 
     void assertEndOfBuildWithFailure(String output, @Nullable String failure) {

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/BaseBuildScanPluginCheckInFixture.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/BaseBuildScanPluginCheckInFixture.groovy
@@ -20,7 +20,10 @@ import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.execution.RunRootBuildWorkBuildOperationType
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleExecuter
+import org.gradle.internal.enterprise.impl.legacy.DevelocityPluginCompatibility
+import org.gradle.util.internal.VersionNumber
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
 import org.gradle.internal.operations.notify.BuildOperationFinishedNotification
 import org.gradle.internal.operations.notify.BuildOperationNotificationListener
@@ -218,6 +221,12 @@ abstract class BaseBuildScanPluginCheckInFixture {
      * Develocity plugin versions affected by the implicit parent-project property lookup.
      */
     void expectParentPropertyLookupDeprecation(GradleExecuter executer, String pluginVersion) {
+        // Under IP, plugin versions older than 3.15 hit the unsupported-with-IP path
+        // and short-circuit before the pre-4.0 deprecation, so the warning is not emitted.
+        if (GradleContextualExecuter.isIsolatedProjects()
+            && DevelocityPluginCompatibility.isUnsupportedWithIsolatedProjects(VersionNumber.parse(pluginVersion))) {
+            return
+        }
         executer.expectDocumentedDeprecationWarning(
             "Usage of the Develocity plugin ${pluginVersion} has been deprecated. " +
                 "This will fail with an error in Gradle 10. " +

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/DevelocityPluginCheckInIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/DevelocityPluginCheckInIntegrationTest.groovy
@@ -100,6 +100,9 @@ class DevelocityPluginCheckInIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << """
             println "present: " + services.get($GradleEnterprisePluginManager.name).present
         """
+        if (supported) {
+            plugin.expectParentPropertyLookupDeprecation(executer, pluginVersion)
+        }
 
         when:
         succeeds("t", "-Dorg.gradle.unsafe.isolated-projects=true")
@@ -118,5 +121,25 @@ class DevelocityPluginCheckInIntegrationTest extends AbstractIntegrationSpec {
         pluginVersion                    | supported
         MINIMUM_SUPPORTED_PLUGIN_VERSION | false
         '3.15'                           | true
+    }
+
+    def "emits deprecation when Develocity plugin version #pluginVersion relies on parent-property lookup"() {
+        given:
+        plugin.runtimeVersion = pluginVersion
+        plugin.artifactVersion = pluginVersion
+        applyPlugin()
+        if (deprecated) {
+            plugin.expectParentPropertyLookupDeprecation(executer, pluginVersion)
+        }
+
+        expect:
+        succeeds "t"
+
+        where:
+        pluginVersion | deprecated
+        '3.17'        | true
+        '3.19.2'      | true
+        '4.0'         | false
+        '4.4.1'       | false
     }
 }

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyClasspathIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyClasspathIntegrationTest.groovy
@@ -165,6 +165,9 @@ abstract class BuildScanAutoApplyClasspathIntegrationTest extends AbstractIntegr
     }
 
     def "transitively applied Develocity plugin disables auto-application"() {
+        given:
+        transitivePluginFixture.expectParentPropertyLookupDeprecation(executer, MINIMUM_SUPPORTED_PLUGIN_VERSION_NUMBER.toString())
+
         when:
         succeeds "cacheableTask", "--scan"
 
@@ -174,6 +177,9 @@ abstract class BuildScanAutoApplyClasspathIntegrationTest extends AbstractIntegr
     }
 
     def "task is up-to-date when using --scan"() {
+        given:
+        transitivePluginFixture.expectParentPropertyLookupDeprecation(executer, MINIMUM_SUPPORTED_PLUGIN_VERSION_NUMBER.toString())
+
         when:
         succeeds "cacheableTask"
 
@@ -183,6 +189,7 @@ abstract class BuildScanAutoApplyClasspathIntegrationTest extends AbstractIntegr
         executedAndNotSkipped(":cacheableTask")
 
         when:
+        transitivePluginFixture.expectParentPropertyLookupDeprecation(executer, MINIMUM_SUPPORTED_PLUGIN_VERSION_NUMBER.toString())
         succeeds "cacheableTask", "--scan"
 
         then:

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanAutoApplyIntegrationTest.groovy
@@ -114,6 +114,9 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec implemen
         fixture.runtimeVersion = version
         fixture.artifactVersion = version
         settingsFile() << fixture.plugins()
+        if (deprecated) {
+            fixture.expectParentPropertyLookupDeprecation(executer, version)
+        }
 
         and:
         runBuildWithScanRequest()
@@ -122,10 +125,10 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec implemen
         pluginAppliedOnce()
 
         where:
-        sequence | version
-        "older"  | MINIMUM_SUPPORTED_PLUGIN_VERSION
-        "same"   | PLUGIN_AUTO_APPLY_VERSION
-        "newer"  | PLUGIN_NEWER_VERSION
+        sequence | version                          | deprecated
+        "older"  | MINIMUM_SUPPORTED_PLUGIN_VERSION | true
+        "same"   | PLUGIN_AUTO_APPLY_VERSION        | false
+        "newer"  | PLUGIN_NEWER_VERSION             | false
     }
 
     @SkipDsl(dsl = GradleDsl.DECLARATIVE, because = "Declarative DSL does not support buildscript block")
@@ -144,6 +147,9 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec implemen
             }
             ${applyPluginId(fixture.id)}
         """
+        if (deprecated) {
+            fixture.expectParentPropertyLookupDeprecation(executer, version)
+        }
 
         and:
         runBuildWithScanRequest()
@@ -152,10 +158,10 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec implemen
         pluginAppliedOnce()
 
         where:
-        sequence | version
-        "older"  | MINIMUM_SUPPORTED_PLUGIN_VERSION
-        "same"   | PLUGIN_AUTO_APPLY_VERSION
-        "newer"  | PLUGIN_NEWER_VERSION
+        sequence | version                          | deprecated
+        "older"  | MINIMUM_SUPPORTED_PLUGIN_VERSION | true
+        "same"   | PLUGIN_AUTO_APPLY_VERSION        | false
+        "newer"  | PLUGIN_NEWER_VERSION             | false
     }
 
     def applyPluginId(String pluginId) {
@@ -185,6 +191,9 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec implemen
                 it.apply plugin: $fixture.className
             }
         """
+        if (deprecated) {
+            fixture.expectParentPropertyLookupDeprecation(executer, version)
+        }
 
         and:
         runBuildWithScanRequest('-I', 'init.gradle')
@@ -193,10 +202,10 @@ class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec implemen
         pluginAppliedOnce()
 
         where:
-        sequence | version
-        "older"  | MINIMUM_SUPPORTED_PLUGIN_VERSION
-        "same"   | PLUGIN_AUTO_APPLY_VERSION
-        "newer"  | PLUGIN_NEWER_VERSION
+        sequence | version                          | deprecated
+        "older"  | MINIMUM_SUPPORTED_PLUGIN_VERSION | true
+        "same"   | PLUGIN_AUTO_APPLY_VERSION        | false
+        "newer"  | PLUGIN_NEWER_VERSION             | false
     }
 
     def "does not auto-apply plugin when explicitly requested and not applied"() {

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginCheckInService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginCheckInService.java
@@ -18,6 +18,7 @@ package org.gradle.internal.enterprise.impl;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.gradle.internal.buildtree.BuildModelParameters;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.enterprise.GradleEnterprisePluginCheckInResult;
 import org.gradle.internal.enterprise.GradleEnterprisePluginCheckInService;
 import org.gradle.internal.enterprise.GradleEnterprisePluginMetadata;
@@ -29,8 +30,10 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.function.Supplier;
 
+import static org.gradle.internal.enterprise.impl.legacy.DevelocityPluginCompatibility.FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP;
 import static org.gradle.internal.enterprise.impl.legacy.DevelocityPluginCompatibility.getUnsupportedPluginMessage;
 import static org.gradle.internal.enterprise.impl.legacy.DevelocityPluginCompatibility.getUnsupportedWithIsolatedProjectsMessage;
+import static org.gradle.internal.enterprise.impl.legacy.DevelocityPluginCompatibility.isAffectedByParentPropertyLookup;
 import static org.gradle.internal.enterprise.impl.legacy.DevelocityPluginCompatibility.isUnsupportedPluginVersion;
 import static org.gradle.internal.enterprise.impl.legacy.DevelocityPluginCompatibility.isUnsupportedWithIsolatedProjects;
 
@@ -76,6 +79,15 @@ public class DefaultGradleEnterprisePluginCheckInService implements GradleEnterp
 
         if (isIsolatedProjectsEnabled && isUnsupportedWithIsolatedProjects(pluginBaseVersion)) {
             return checkInUnsupportedResult(pluginBaseVersion, getUnsupportedWithIsolatedProjectsMessage(pluginVersion));
+        }
+
+        if (isAffectedByParentPropertyLookup(pluginBaseVersion)) {
+            DeprecationLogger.deprecateIndirectUsage("Usage of the Develocity plugin " + pluginVersion)
+                .withContext("The plugin application will be ignored.")
+                .withAdvice("Upgrade to version " + FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP + " or later of the Develocity plugin.")
+                .willBecomeAnErrorInGradle10()
+                .withUpgradeGuideSection(9, "deprecated_develocity_plugin_pre_4_0")
+                .nagUser();
         }
 
         DefaultGradleEnterprisePluginAdapter adapter = pluginAdapterFactory.create(serviceFactory);

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/DevelocityPluginCompatibility.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/DevelocityPluginCompatibility.java
@@ -39,6 +39,17 @@ public class DevelocityPluginCompatibility {
     private static final String ISOLATED_PROJECTS_SUPPORTED_PLUGIN_VERSION = "3.15";
     private static final VersionNumber ISOLATED_PROJECTS_SUPPORTED_PLUGIN_VERSION_NUMBER = VersionNumber.parse(ISOLATED_PROJECTS_SUPPORTED_PLUGIN_VERSION);
 
+    /**
+     * Develocity plugin 4.0 is the first version that registers its project extension on every project,
+     * so configuring {@code develocity { ... }} from a subproject no longer relies on Gradle's
+     * implicit parent-project property lookup. That implicit lookup is being removed in Gradle 10,
+     * so versions below 4.0 are deprecated to give users time to upgrade ahead of the change.
+     */
+    @VisibleForTesting
+    public static final String FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP = "4.0";
+    @VisibleForTesting
+    public static final VersionNumber FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP_NUMBER = VersionNumber.parse(FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP);
+
     public static boolean isUnsupportedPluginVersion(VersionNumber pluginBaseVersion) {
         return MINIMUM_SUPPORTED_PLUGIN_VERSION_NUMBER.compareTo(pluginBaseVersion) > 0;
     }
@@ -61,5 +72,9 @@ public class DevelocityPluginCompatibility {
             pluginVersion,
             ISOLATED_PROJECTS_SUPPORTED_PLUGIN_VERSION
         );
+    }
+
+    public static boolean isAffectedByParentPropertyLookup(VersionNumber pluginBaseVersion) {
+        return FIRST_PLUGIN_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP_NUMBER.compareTo(pluginBaseVersion) > 0;
     }
 }

--- a/testing/smoke-test/build.gradle.kts
+++ b/testing/smoke-test/build.gradle.kts
@@ -149,8 +149,6 @@ tasks {
     register<SmokeTest>("smokeTest") {
         description = "Runs Smoke tests"
         configureForSmokeTest(excludes = listOf(gradleBuildTestPattern, androidProjectTestPattern))
-        
-        dependsOn("androidHomeWarmup")
     }
 
     register<SmokeTest>("configCacheSmokeTest") {

--- a/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/DevelocityPluginSmokeTest.groovy
+++ b/testing/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/DevelocityPluginSmokeTest.groovy
@@ -177,6 +177,9 @@ class DevelocityPluginSmokeTest extends AbstractSmokeTest {
     private static final VersionNumber FIRST_VERSION_UNDER_DEVELOCITY_BRAND = VersionNumber.parse("3.17")
     private static final VersionNumber FIRST_VERSION_WITH_IMPORT_JUNIT_XML_REPORTS = VersionNumber.parse("3.17")
     private static final VersionNumber FIRST_VERSION_WITHOUT_CROSS_PROJECT_IMPORT_JUNIT_XML_REPORTS = VersionNumber.parse("4.4")
+    private static final VersionNumber FIRST_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP = VersionNumber.parse("4.0")
+
+    private String currentPluginVersion
 
     def "coverage at least up to auto-applied version"() {
         expect:
@@ -402,6 +405,7 @@ public class MyFlakyTest {
 
     @Requires(TestExecutionPreconditions.NotConfigCached)
     def "can inject plugin #pluginVersion in #ci using '#ciScriptVersion' script version"() {
+        currentPluginVersion = pluginVersion
         def versionNumber = VersionNumber.parse(pluginVersion)
         def initScript = "init-script.gradle"
         file(initScript) << getCiInjectionScriptContent(ci)
@@ -552,10 +556,23 @@ public class MyFlakyTest {
 
     SmokeTestGradleRunner scanRunner(String... args) {
         // Run with --build-cache to test also build cache events
-        runner("build", "-Dscan.dump", "--build-cache", *args)
+        def runner = runner("build", "-Dscan.dump", "--build-cache", *args)
+        if (currentPluginVersion != null && VersionNumber.parse(currentPluginVersion) < FIRST_VERSION_WITHOUT_PARENT_PROPERTY_LOOKUP) {
+            // Plugin check-in only deprecates once per daemon, so multiple builds in the same test
+            // would only see the warning on the first run.
+            runner.maybeExpectLegacyDeprecationWarning(
+                "Usage of the Develocity plugin ${currentPluginVersion} has been deprecated. " +
+                    "This will fail with an error in Gradle 10. " +
+                    "The plugin application will be ignored. " +
+                    "Upgrade to version 4.0 or later of the Develocity plugin. " +
+                    "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_9.html#deprecated_develocity_plugin_pre_4_0"
+            )
+        }
+        runner
     }
 
     void usePluginVersion(String version) {
+        currentPluginVersion = version
         def develocityPlugin = VersionNumber.parse(version) >= VersionNumber.parse("3.17")
         def gradleEnterprisePlugin = VersionNumber.parse(version) >= VersionNumber.parse("3.0")
         if (develocityPlugin) {


### PR DESCRIPTION
## Summary

- Emit a build-level deprecation warning at Develocity plugin check-in for any plugin version below 4.0, advising users to upgrade ahead of the parent-property-lookup removal in Gradle 10.
- Add a self-contained `[[deprecated_develocity_plugin_pre_4_0]]` section in the v9 upgrade guide explaining the deprecation and the upcoming change it pre-announces.
- Add a shared `expectParentPropertyLookupDeprecation(executer, version)` helper to `BaseBuildScanPluginCheckInFixture` so the affected enterprise tests can register the expected warning in one line; wire it into the existing tests that explicitly use plugin versions below 4.0 (auto-apply matrix, IP-supported branch, classpath transitive plugin).

This change lands ahead of the larger parent-property-lookup deprecation work (gradle/gradle#37205) so users on Develocity 3.x get advance notice that an upgrade will be required for Gradle 10 compatibility.

## Why

Develocity plugin 4.0 is the first version that registers its project extension on every project — earlier versions rely on Gradle's implicit parent-project property lookup to resolve `develocity { ... }` from subprojects. Gradle 10 removes that implicit lookup, after which subprojects on Develocity 3.x will no longer be able to configure scan tags or values. Rather than have those users discover this when they upgrade Gradle, we surface it now via a deprecation tied to the plugin-check-in machinery.

## Test plan

- [x] New `emits deprecation when Develocity plugin version #pluginVersion relies on parent-property lookup` test covers 3.17, 3.19.2 (deprecated) and 4.0, 4.4.1 (silent).
- [x] Existing tests broken by the new deprecation updated:
    - `BuildScanAutoApplyIntegrationTest` — `deprecated` column added to the three "uses #sequence version of plugin when ..." data tables.
    - `BuildScanAutoApplyClasspathIntegrationTest` (Develocity + GradleEnterprise variants) — both tests using `MINIMUM_SUPPORTED_PLUGIN_VERSION_NUMBER` for the transitive plugin.
    - `DevelocityPluginCheckInIntegrationTest` — IP `[3.15, supported: true]` row.
- [x] All 94 affected tests pass locally on `:enterprise:embeddedIntegTest`.
- [x] `:docs:checkDeadInternalLinks` passes (new upgrade-guide anchor is valid).