### PR TITLE
Document why Android Studio sync setup is not in setup()

### DIFF
--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/crossbuild/ip/IsolatedProjectsAndroidSyncPerformanceComparisonTest.groovy
@@ -34,6 +34,11 @@ class IsolatedProjectsAndroidSyncPerformanceComparisonTest extends AbstractCross
 
     private static int maxWorkers = 8
 
+    // Invoked from feature methods rather than Spock's setup() because
+    // :performance:writeTmpPerformanceScenarioDefinitions (run by sanityCheck)
+    // executes setup() for every feature even though the bodies are skipped.
+    // configureStudio() requires ANDROID_SDK_ROOT, which would then break
+    // sanityCheck on machines without that variable set.
     private void studioSetup() {
         // NOTE: see the javadoc for required environment and possible configuration
         AndroidSyncPerformanceTestFixture.configureStudio(runner)

--- a/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/ip/IsolatedProjectsAndroidSyncPerformanceRegressionTest.groovy
+++ b/testing/performance/src/performanceTest/groovy/org/gradle/performance/regression/ip/IsolatedProjectsAndroidSyncPerformanceRegressionTest.groovy
@@ -32,6 +32,11 @@ class IsolatedProjectsAndroidSyncPerformanceRegressionTest extends AbstractCross
 
     private static int maxWorkers = 8
 
+    // Invoked from feature methods rather than Spock's setup() because
+    // :performance:writeTmpPerformanceScenarioDefinitions (run by sanityCheck)
+    // executes setup() for every feature even though the bodies are skipped.
+    // configureStudio() requires ANDROID_SDK_ROOT, which would then break
+    // sanityCheck on machines without that variable set.
     private void studioSetup() {
         // NOTE: see the javadoc for required environment and possible configuration
         AndroidSyncPerformanceTestFixture.configureStudio(runner)


### PR DESCRIPTION
## Summary

- Follow-up to #37714, explaining the reason for moving the initialization to the test methods.
- `:performance:writeTmpPerformanceScenarioDefinitions` (run by `sanityCheck`) executes `setup()` for every feature method even when the bodies are skipped. `AndroidSyncPerformanceTestFixture.configureStudio()` asserts `ANDROID_SDK_ROOT`, so a plain `setup()` would break `sanityCheck` on machines without that variable.
- Adds the same comment to both `IsolatedProjectsAndroidSyncPerformanceRegressionTest` and `IsolatedProjectsAndroidSyncPerformanceComparisonTest`.

## Test plan

- [x] Comment-only change; no behavior impact.
- [ ] CI green.