### PR TITLE
Deprecate Pmd.targetJdk, PmdExtension.targetJdk and TargetJdk

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/pmd_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/pmd_plugin.adoc
@@ -34,8 +34,8 @@ Note that PMD will run with the same Java version used to run Gradle.
 [[sec:pmd_supported_versions]]
 === Supported PMD versions
 
-Gradle supports PMD versions from 5.1.0 through 7.16.0.
-The default PMD version used by the plugin is 7.24.0.
+Gradle supports PMD versions from 5.1.0 through 7.24.0.
+
 Older PMD releases may work but are not tested against.
 Use link:{groovyDslPath}/org.gradle.api.plugins.quality.PmdExtension.html#org.gradle.api.plugins.quality.PmdExtension:toolVersion[`pmd.toolVersion`] to select a specific PMD version.
 

--- a/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/pmd_plugin.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/core-plugins/pmd_plugin.adoc
@@ -31,6 +31,14 @@ The plugin adds a number of tasks to the project that perform the quality checks
 
 Note that PMD will run with the same Java version used to run Gradle.
 
+[[sec:pmd_supported_versions]]
+=== Supported PMD versions
+
+Gradle supports PMD versions from 5.1.0 through 7.16.0.
+The default PMD version used by the plugin is 7.24.0.
+Older PMD releases may work but are not tested against.
+Use link:{groovyDslPath}/org.gradle.api.plugins.quality.PmdExtension.html#org.gradle.api.plugins.quality.PmdExtension:toolVersion[`pmd.toolVersion`] to select a specific PMD version.
+
 [[sec:pmd_tasks]]
 == Tasks
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -64,7 +64,7 @@ This includes:
 - `PmdPlugin.getDefaultTargetJdk(JavaVersion)`
 
 These were used by PMD versions older than 5.0 to select the target Java language level via Ant's `targetjdk` attribute.
-PMD 5.0 and later infer the language version from the configured rule sets, so this property has been a no-op for all supported PMD versions.
+PMD 5.0 and later infer the language version from the configured rule sets, so this property has been a no-op for all supported PMD versions.  Gradle does not support PMD versions earlier than PMD 5.1.0.
 
 There is no replacement.
 Remove any `targetJdk` configuration from your build.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_9.adoc
@@ -51,6 +51,24 @@ Earlier versions rely on Gradle's implicit parent-project property lookup, which
 Upgrade to the link:https://plugins.gradle.org/plugin/com.gradle.develocity[latest Develocity plugin] from the Gradle Plugin Portal.
 See the link:https://gradle.com/help/gradle-plugin-compatibility/[Develocity plugin compatibility matrix] for details.
 
+[[deprecated_pmd_target_jdk]]
+==== Deprecation of `targetJdk` on the PMD plugin
+
+The `targetJdk` property on link:{javadocPath}/org/gradle/api/plugins/quality/Pmd.html[`Pmd`] and link:{javadocPath}/org/gradle/api/plugins/quality/PmdExtension.html[`PmdExtension`], along with the link:{javadocPath}/org/gradle/api/plugins/quality/TargetJdk.html[`TargetJdk`] enum, are deprecated and will be removed in Gradle 10.
+
+This includes:
+
+- `Pmd.getTargetJdk()` / `Pmd.setTargetJdk(TargetJdk)`
+- `PmdExtension.getTargetJdk()` / `PmdExtension.setTargetJdk(TargetJdk)` / `PmdExtension.setTargetJdk(Object)`
+- The `TargetJdk` enum and its `toVersion(Object)` static method
+- `PmdPlugin.getDefaultTargetJdk(JavaVersion)`
+
+These were used by PMD versions older than 5.0 to select the target Java language level via Ant's `targetjdk` attribute.
+PMD 5.0 and later infer the language version from the configured rule sets, so this property has been a no-op for all supported PMD versions.
+
+There is no replacement.
+Remove any `targetJdk` configuration from your build.
+
 [[deprecated_maven_artifact_urls]]
 ==== Deprecation of `artifactUrls` on Maven repositories
 

--- a/platforms/jvm/code-quality-workers/src/main/java/org/gradle/api/plugins/quality/TargetJdk.java
+++ b/platforms/jvm/code-quality-workers/src/main/java/org/gradle/api/plugins/quality/TargetJdk.java
@@ -16,13 +16,18 @@
 
 package org.gradle.api.plugins.quality;
 
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 
 /**
- * Represents the PMD targetjdk property available for PMD &lt; 5.0
+ * Represents the PMD targetjdk property available for PMD &lt; 5.0.
+ *
+ * @deprecated This type is only used by the deprecated {@code targetJdk} property on the PMD plugin.
+ *     It will be removed in Gradle 10. PMD 5.0 and later infer the Java language version from the rule sets.
  */
+@Deprecated
 public enum TargetJdk {
     VERSION_1_3,
     VERSION_1_4,
@@ -40,6 +45,10 @@ public enum TargetJdk {
      */
     @Nullable
     public static TargetJdk toVersion(@Nullable Object value) throws IllegalArgumentException {
+        DeprecationLogger.deprecateType(TargetJdk.class)
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecated_pmd_target_jdk")
+            .nagUser();
         if (value == null) {
             return null;
         }

--- a/platforms/jvm/code-quality-workers/src/main/java/org/gradle/api/plugins/quality/internal/PmdActionParameters.java
+++ b/platforms/jvm/code-quality-workers/src/main/java/org/gradle/api/plugins/quality/internal/PmdActionParameters.java
@@ -19,18 +19,18 @@ package org.gradle.api.plugins.quality.internal;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.internal.ant.AntWorkParameters;
-import org.gradle.api.plugins.quality.TargetJdk;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 /**
  * Parameters used to configure a {@link PmdAction}.
  */
+@SuppressWarnings("deprecation") // TargetJdk is deprecated; this internal type is removed alongside it.
 public interface PmdActionParameters extends AntWorkParameters {
 
     ConfigurableFileCollection getPmdClasspath();
 
-    Property<TargetJdk> getTargetJdk();
+    Property<org.gradle.api.plugins.quality.TargetJdk> getTargetJdk();
 
     ListProperty<String> getRuleSets();
 

--- a/platforms/jvm/code-quality-workers/src/test/groovy/org/gradle/api/plugins/quality/TargetJdkSpec.groovy
+++ b/platforms/jvm/code-quality-workers/src/test/groovy/org/gradle/api/plugins/quality/TargetJdkSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.plugins.quality
 
+import org.gradle.internal.deprecation.DeprecationLogger
 import spock.lang.Specification
 
 class TargetJdkSpec extends Specification {
@@ -32,70 +33,75 @@ class TargetJdkSpec extends Specification {
 
     def convertsStringToVersion() {
         expect:
-        TargetJdk.toVersion("1.3") == TargetJdk.VERSION_1_3
-        TargetJdk.toVersion("1.4") == TargetJdk.VERSION_1_4
-        TargetJdk.toVersion("1.5") == TargetJdk.VERSION_1_5
-        TargetJdk.toVersion("1.6") == TargetJdk.VERSION_1_6
-        TargetJdk.toVersion("1.7") == TargetJdk.VERSION_1_7
-        TargetJdk.toVersion("jsp") == TargetJdk.VERSION_JSP
-        TargetJdk.toVersion("JSP") == TargetJdk.VERSION_JSP
+        toVersion("1.3") == TargetJdk.VERSION_1_3
+        toVersion("1.4") == TargetJdk.VERSION_1_4
+        toVersion("1.5") == TargetJdk.VERSION_1_5
+        toVersion("1.6") == TargetJdk.VERSION_1_6
+        toVersion("1.7") == TargetJdk.VERSION_1_7
+        toVersion("jsp") == TargetJdk.VERSION_JSP
+        toVersion("JSP") == TargetJdk.VERSION_JSP
     }
 
     def failsToConvertStringToVersionForUnknownVersion() {
         expect:
-        conversionFails("1.1");
-        conversionFails("1.2");
-        conversionFails("1");
-        conversionFails("2");
+        conversionFails("1.1")
+        conversionFails("1.2")
+        conversionFails("1")
+        conversionFails("2")
 
-        conversionFails("17");
+        conversionFails("17")
 
-        conversionFails("a");
-        conversionFails("");
-        conversionFails("  ");
+        conversionFails("a")
+        conversionFails("")
+        conversionFails("  ")
 
-        conversionFails("1.54");
-        conversionFails("1.9");
-        conversionFails("1.10");
-        conversionFails("2.0");
-        conversionFails("1_4");
+        conversionFails("1.54")
+        conversionFails("1.9")
+        conversionFails("1.10")
+        conversionFails("2.0")
+        conversionFails("1_4")
     }
 
     def convertsVersionToVersion() {
         expect:
-        TargetJdk.toVersion(TargetJdk.VERSION_1_4) == TargetJdk.VERSION_1_4
+        toVersion(TargetJdk.VERSION_1_4) == TargetJdk.VERSION_1_4
     }
 
     def convertsNumberToVersion() {
         expect:
-        TargetJdk.toVersion(1.3) == TargetJdk.VERSION_1_3
-        TargetJdk.toVersion(1.4) == TargetJdk.VERSION_1_4
-        TargetJdk.toVersion(1.5) == TargetJdk.VERSION_1_5
-        TargetJdk.toVersion(1.6) == TargetJdk.VERSION_1_6
-        TargetJdk.toVersion(1.7) == TargetJdk.VERSION_1_7
+        toVersion(1.3) == TargetJdk.VERSION_1_3
+        toVersion(1.4) == TargetJdk.VERSION_1_4
+        toVersion(1.5) == TargetJdk.VERSION_1_5
+        toVersion(1.6) == TargetJdk.VERSION_1_6
+        toVersion(1.7) == TargetJdk.VERSION_1_7
     }
 
     def failsToConvertNumberToVersionForUnknownVersion() {
         expect:
-        conversionFails(1.1);
-        conversionFails(1.2);
-        conversionFails(1);
-        conversionFails(2);
-        conversionFails(17);
-        conversionFails(1.21);
-        conversionFails(2.0);
-        conversionFails(4.2);
+        conversionFails(1.1)
+        conversionFails(1.2)
+        conversionFails(1)
+        conversionFails(2)
+        conversionFails(17)
+        conversionFails(1.21)
+        conversionFails(2.0)
+        conversionFails(4.2)
     }
 
     def convertsNullToNull() {
         expect:
-        TargetJdk.toVersion(null) == null
+        toVersion(null) == null
+    }
+
+    // toVersion fires a deprecation nag; whileDisabled keeps these tests focused on the conversion logic.
+    private static TargetJdk toVersion(Object value) {
+        DeprecationLogger.whileDisabled({ TargetJdk.toVersion(value) } as org.gradle.internal.Factory)
     }
 
     private void conversionFails(Object value) {
         try {
-            TargetJdk.toVersion(value);
-            org.junit.Assert.fail();
+            toVersion(value)
+            org.junit.Assert.fail()
         } catch (IllegalArgumentException e) {
             assert e.getMessage() == "Could not determine targetjdk from '" + value + "'."
         }

--- a/platforms/jvm/code-quality/build.gradle.kts
+++ b/platforms/jvm/code-quality/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     api(libs.inject)
     api(libs.jspecify)
 
+    implementation(projects.logging)
     implementation(projects.native)
     implementation(projects.pluginsGroovy)
     implementation(projects.serviceLookup)

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
@@ -115,6 +115,7 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
                 ruleSetFiles = files()
                 ruleSets = ["category/java/errorprone.xml"]
                 rulesMinimumPriority = 5
+                // Required because the plugin is not applied; deprecation warning is expected.
                 targetJdk = TargetJdk.VERSION_1_4
                 threads = 1
                 incrementalAnalysis = false
@@ -122,6 +123,12 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning("The Pmd.setTargetJdk(TargetJdk) method has been deprecated. " +
+            "This is scheduled to be removed in Gradle 10. " +
+            "This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. " +
+            "Remove the targetJdk configuration from your build. " +
+            "Consult the upgrading guide for further information: " +
+            "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_pmd_target_jdk")
         succeeds("myPmd")
 
         then:

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
@@ -125,7 +125,7 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
         when:
         executer.expectDocumentedDeprecationWarning("The Pmd.setTargetJdk(TargetJdk) method has been deprecated. " +
             "This is scheduled to be removed in Gradle 10. " +
-            "This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. " +
+            "This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets. " +
             "Remove the targetJdk configuration from your build. " +
             "Consult the upgrading guide for further information: " +
             "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_pmd_target_jdk")

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -40,8 +40,6 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
 
             pmd {
                 toolVersion = '$version'
-                // Set target JDK for PMD <5.x tests, so the test code is accepted
-                targetJdk = TargetJdk.VERSION_1_7
                 ${supportIncrementalAnalysis() ? "" : "incrementalAnalysis = false"}
             }
 

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdTargetJdkDeprecationIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdTargetJdkDeprecationIntegrationTest.groovy
@@ -25,13 +25,13 @@ class PmdTargetJdkDeprecationIntegrationTest extends AbstractIntegrationSpec {
 
     private static final String PMD_EXTENSION_DEPRECATION = "The PmdExtension.setTargetJdk(TargetJdk) method has been deprecated. " +
         "This is scheduled to be removed in Gradle 10. " +
-        "This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. " +
+        "This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets. " +
         "Remove the targetJdk configuration from your build. " +
         "Consult the upgrading guide for further information: " + UPGRADE_GUIDE_URL
 
     private static final String PMD_TASK_DEPRECATION = "The Pmd.setTargetJdk(TargetJdk) method has been deprecated. " +
         "This is scheduled to be removed in Gradle 10. " +
-        "This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. " +
+        "This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets. " +
         "Remove the targetJdk configuration from your build. " +
         "Consult the upgrading guide for further information: " + UPGRADE_GUIDE_URL
 
@@ -41,7 +41,7 @@ class PmdTargetJdkDeprecationIntegrationTest extends AbstractIntegrationSpec {
 
     private static final String PMD_EXTENSION_OBJECT_DEPRECATION = "The PmdExtension.setTargetJdk(Object) method has been deprecated. " +
         "This is scheduled to be removed in Gradle 10. " +
-        "This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. " +
+        "This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets. " +
         "Remove the targetJdk configuration from your build. " +
         "Consult the upgrading guide for further information: " + UPGRADE_GUIDE_URL
 

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdTargetJdkDeprecationIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdTargetJdkDeprecationIntegrationTest.groovy
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.quality.pmd
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class PmdTargetJdkDeprecationIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final String UPGRADE_GUIDE_URL =
+        "https://docs.gradle.org/current/userguide/upgrading_version_9.html#deprecated_pmd_target_jdk"
+
+    private static final String PMD_EXTENSION_DEPRECATION = "The PmdExtension.setTargetJdk(TargetJdk) method has been deprecated. " +
+        "This is scheduled to be removed in Gradle 10. " +
+        "This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. " +
+        "Remove the targetJdk configuration from your build. " +
+        "Consult the upgrading guide for further information: " + UPGRADE_GUIDE_URL
+
+    private static final String PMD_TASK_DEPRECATION = "The Pmd.setTargetJdk(TargetJdk) method has been deprecated. " +
+        "This is scheduled to be removed in Gradle 10. " +
+        "This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. " +
+        "Remove the targetJdk configuration from your build. " +
+        "Consult the upgrading guide for further information: " + UPGRADE_GUIDE_URL
+
+    private static final String TARGET_JDK_TYPE_DEPRECATION = "The org.gradle.api.plugins.quality.TargetJdk type has been deprecated. " +
+        "This is scheduled to be removed in Gradle 10. " +
+        "Consult the upgrading guide for further information: " + UPGRADE_GUIDE_URL
+
+    private static final String PMD_EXTENSION_OBJECT_DEPRECATION = "The PmdExtension.setTargetJdk(Object) method has been deprecated. " +
+        "This is scheduled to be removed in Gradle 10. " +
+        "This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. " +
+        "Remove the targetJdk configuration from your build. " +
+        "Consult the upgrading guide for further information: " + UPGRADE_GUIDE_URL
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id("java")
+                id("pmd")
+            }
+
+            ${mavenCentralRepository()}
+        """
+    }
+
+    def "setting PmdExtension.targetJdk emits a deprecation warning"() {
+        given:
+        buildFile << """
+            pmd {
+                targetJdk = TargetJdk.VERSION_1_7
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning(PMD_EXTENSION_DEPRECATION)
+        succeeds("help")
+    }
+
+    def "setting Pmd.targetJdk on a task emits a deprecation warning"() {
+        given:
+        buildFile << """
+            tasks.named('pmdMain') {
+                targetJdk = TargetJdk.VERSION_1_7
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning(PMD_TASK_DEPRECATION)
+        succeeds("pmdMain", "--dry-run")
+    }
+
+    def "setting PmdExtension.targetJdk via Object overload emits a deprecation warning"() {
+        given:
+        buildFile << """
+            pmd {
+                targetJdk = '1.7'
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning(PMD_EXTENSION_OBJECT_DEPRECATION)
+        succeeds("help")
+    }
+
+    def "calling TargetJdk.toVersion directly emits a deprecation warning"() {
+        given:
+        buildFile << """
+            TargetJdk.toVersion('1.7')
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning(TARGET_JDK_TYPE_DEPRECATION)
+        succeeds("help")
+    }
+}

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
@@ -221,7 +221,7 @@ public abstract class Pmd extends AbstractCodeQualityTask implements Reporting<P
     /**
      * The target JDK to use with PMD.
      *
-     * @deprecated This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets.
+     * @deprecated This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets.
      *     Scheduled to be removed in Gradle 10.
      */
     @Deprecated
@@ -234,7 +234,7 @@ public abstract class Pmd extends AbstractCodeQualityTask implements Reporting<P
     /**
      * The target JDK to use with PMD.
      *
-     * @deprecated This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets.
+     * @deprecated This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets.
      *     Scheduled to be removed in Gradle 10.
      */
     @Deprecated
@@ -245,7 +245,7 @@ public abstract class Pmd extends AbstractCodeQualityTask implements Reporting<P
 
     private static void nagAboutTargetJdkDeprecation(String methodWithParams) {
         DeprecationLogger.deprecateMethod(Pmd.class, methodWithParams)
-            .withAdvice("This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. Remove the targetJdk configuration from your build.")
+            .withAdvice("This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets. Remove the targetJdk configuration from your build.")
             .willBeRemovedInGradle10()
             .withUpgradeGuideSection(9, "deprecated_pmd_target_jdk")
             .nagUser();

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
@@ -226,7 +226,6 @@ public abstract class Pmd extends AbstractCodeQualityTask implements Reporting<P
      */
     @Deprecated
     @Input
-    @ToBeReplacedByLazyProperty
     public TargetJdk getTargetJdk() {
         nagAboutTargetJdkDeprecation("getTargetJdk()");
         return targetJdk;

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/Pmd.java
@@ -40,6 +40,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.Describables;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.gradle.internal.nativeintegration.console.ConsoleDetector;
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData;
@@ -59,6 +60,7 @@ import java.util.stream.Collectors;
  * @see PmdExtension
  */
 @CacheableTask
+@SuppressWarnings("deprecation") // The targetJdk property and TargetJdk type are themselves deprecated.
 public abstract class Pmd extends AbstractCodeQualityTask implements Reporting<PmdReports> {
 
     private FileCollection pmdClasspath;
@@ -88,7 +90,7 @@ public abstract class Pmd extends AbstractCodeQualityTask implements Reporting<P
     private void setupParameters(PmdActionParameters parameters) {
         parameters.getAntLibraryClasspath().setFrom(getPmdClasspath());
         parameters.getPmdClasspath().setFrom(getPmdClasspath());
-        parameters.getTargetJdk().set(getTargetJdk());
+        parameters.getTargetJdk().set(DeprecationLogger.whileDisabled(this::getTargetJdk));
         parameters.getRuleSets().set(getRuleSets());
         parameters.getRuleSetConfigFiles().from(getRuleSetFiles());
         if (getRuleSetConfig() != null) {
@@ -218,18 +220,36 @@ public abstract class Pmd extends AbstractCodeQualityTask implements Reporting<P
 
     /**
      * The target JDK to use with PMD.
+     *
+     * @deprecated This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets.
+     *     Scheduled to be removed in Gradle 10.
      */
+    @Deprecated
     @Input
     @ToBeReplacedByLazyProperty
     public TargetJdk getTargetJdk() {
+        nagAboutTargetJdkDeprecation("getTargetJdk()");
         return targetJdk;
     }
 
     /**
      * The target JDK to use with PMD.
+     *
+     * @deprecated This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets.
+     *     Scheduled to be removed in Gradle 10.
      */
+    @Deprecated
     public void setTargetJdk(TargetJdk targetJdk) {
+        nagAboutTargetJdkDeprecation("setTargetJdk(TargetJdk)");
         this.targetJdk = targetJdk;
+    }
+
+    private static void nagAboutTargetJdkDeprecation(String methodWithParams) {
+        DeprecationLogger.deprecateMethod(Pmd.class, methodWithParams)
+            .withAdvice("This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. Remove the targetJdk configuration from your build.")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecated_pmd_target_jdk")
+            .nagUser();
     }
 
     /**

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdExtension.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.resources.TextResource;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.instrumentation.api.annotations.ToBeReplacedByLazyProperty;
 import org.jspecify.annotations.Nullable;
 
@@ -32,6 +33,7 @@ import java.util.List;
  *
  * @see PmdPlugin
  */
+@SuppressWarnings("deprecation") // The targetJdk property and TargetJdk type are themselves deprecated.
 public abstract class PmdExtension extends CodeQualityExtension {
 
     private final Project project;
@@ -88,9 +90,14 @@ public abstract class PmdExtension extends CodeQualityExtension {
 
     /**
      * The target jdk to use with pmd, 1.3, 1.4, 1.5, 1.6, 1.7 or jsp
+     *
+     * @deprecated This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets.
+     *     Scheduled to be removed in Gradle 10.
      */
+    @Deprecated
     @ToBeReplacedByLazyProperty
     public TargetJdk getTargetJdk() {
+        nagAboutTargetJdkDeprecation("getTargetJdk()");
         return targetJdk;
     }
 
@@ -99,9 +106,21 @@ public abstract class PmdExtension extends CodeQualityExtension {
      *
      * @param targetJdk The target jdk
      * @since 4.0
+     * @deprecated This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets.
+     *     Scheduled to be removed in Gradle 10.
      */
+    @Deprecated
     public void setTargetJdk(TargetJdk targetJdk) {
+        nagAboutTargetJdkDeprecation("setTargetJdk(TargetJdk)");
         this.targetJdk = targetJdk;
+    }
+
+    private static void nagAboutTargetJdkDeprecation(String methodWithParams) {
+        DeprecationLogger.deprecateMethod(PmdExtension.class, methodWithParams)
+            .withAdvice("This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. Remove the targetJdk configuration from your build.")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecated_pmd_target_jdk")
+            .nagUser();
     }
 
     /**
@@ -117,9 +136,13 @@ public abstract class PmdExtension extends CodeQualityExtension {
      * Sets the target jdk used with pmd.
      *
      * @param value The value for the target jdk as defined by {@link TargetJdk#toVersion(Object)}
+     * @deprecated This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets.
+     *     Scheduled to be removed in Gradle 10.
      */
+    @Deprecated
     public void setTargetJdk(Object value) {
-        targetJdk = TargetJdk.toVersion(value);
+        nagAboutTargetJdkDeprecation("setTargetJdk(Object)");
+        targetJdk = DeprecationLogger.whileDisabled(() -> TargetJdk.toVersion(value));
     }
 
     /**

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdExtension.java
@@ -91,7 +91,7 @@ public abstract class PmdExtension extends CodeQualityExtension {
     /**
      * The target jdk to use with pmd, 1.3, 1.4, 1.5, 1.6, 1.7 or jsp
      *
-     * @deprecated This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets.
+     * @deprecated This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets.
      *     Scheduled to be removed in Gradle 10.
      */
     @Deprecated
@@ -105,7 +105,7 @@ public abstract class PmdExtension extends CodeQualityExtension {
      *
      * @param targetJdk The target jdk
      * @since 4.0
-     * @deprecated This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets.
+     * @deprecated This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets.
      *     Scheduled to be removed in Gradle 10.
      */
     @Deprecated
@@ -116,7 +116,7 @@ public abstract class PmdExtension extends CodeQualityExtension {
 
     private static void nagAboutTargetJdkDeprecation(String methodWithParams) {
         DeprecationLogger.deprecateMethod(PmdExtension.class, methodWithParams)
-            .withAdvice("This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets. Remove the targetJdk configuration from your build.")
+            .withAdvice("This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets. Remove the targetJdk configuration from your build.")
             .willBeRemovedInGradle10()
             .withUpgradeGuideSection(9, "deprecated_pmd_target_jdk")
             .nagUser();
@@ -135,7 +135,7 @@ public abstract class PmdExtension extends CodeQualityExtension {
      * Sets the target jdk used with pmd.
      *
      * @param value The value for the target jdk as defined by {@link TargetJdk#toVersion(Object)}
-     * @deprecated This property is a no-op for PMD 5.0 and later, which infer the language version from the rule sets.
+     * @deprecated This property has no effect for PMD 5.0 and later, which infer the language version from the rule sets.
      *     Scheduled to be removed in Gradle 10.
      */
     @Deprecated

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdExtension.java
@@ -95,7 +95,6 @@ public abstract class PmdExtension extends CodeQualityExtension {
      *     Scheduled to be removed in Gradle 10.
      */
     @Deprecated
-    @ToBeReplacedByLazyProperty
     public TargetJdk getTargetJdk() {
         nagAboutTargetJdkDeprecation("getTargetJdk()");
         return targetJdk;

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -99,12 +99,12 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
     /**
      * Returns the default {@link TargetJdk} for the given Java source compatibility version.
      *
-     * @deprecated The {@code targetJdk} property is a no-op for PMD 5.0 and later. Scheduled to be removed in Gradle 10.
+     * @deprecated The {@code targetJdk} property has no effect for PMD 5.0 and later. Scheduled to be removed in Gradle 10.
      */
     @Deprecated
     public TargetJdk getDefaultTargetJdk(JavaVersion javaVersion) {
         DeprecationLogger.deprecateMethod(PmdPlugin.class, "getDefaultTargetJdk(JavaVersion)")
-            .withAdvice("This method is only used to compute the deprecated PMD targetJdk property, which is a no-op for PMD 5.0 and later.")
+            .withAdvice("This method is only used to compute the deprecated PMD targetJdk property, which has no effect for PMD 5.0 and later.")
             .willBeRemovedInGradle10()
             .withUpgradeGuideSection(9, "deprecated_pmd_target_jdk")
             .nagUser();

--- a/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/platforms/jvm/code-quality/src/main/java/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -28,6 +28,7 @@ import org.gradle.api.plugins.quality.internal.AbstractCodeQualityPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
@@ -58,6 +59,7 @@ import static org.gradle.api.internal.lambdas.SerializableLambdas.action;
  * @see Pmd
  * @see <a href="https://docs.gradle.org/current/userguide/pmd_plugin.html">PMD plugin reference</a>
  */
+@SuppressWarnings("deprecation") // The targetJdk property and TargetJdk type are themselves deprecated.
 public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
 
     // When updating DEFAULT_PMD_VERSION, also update links in Pmd and PmdExtension!
@@ -90,18 +92,31 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         extension.setRuleSetFiles(project.getLayout().files());
         extension.getRuleSetsProperty().convention(project.getProviders().provider(() -> ruleSetsConvention(extension)));
         conventionMappingOf(extension).map("targetJdk", () ->
-            getDefaultTargetJdk(getJavaPluginExtension().getSourceCompatibility()));
+            DeprecationLogger.whileDisabled(() -> getDefaultTargetJdk(getJavaPluginExtension().getSourceCompatibility())));
         return extension;
     }
 
+    /**
+     * Returns the default {@link TargetJdk} for the given Java source compatibility version.
+     *
+     * @deprecated The {@code targetJdk} property is a no-op for PMD 5.0 and later. Scheduled to be removed in Gradle 10.
+     */
+    @Deprecated
     public TargetJdk getDefaultTargetJdk(JavaVersion javaVersion) {
-        try {
-            return TargetJdk.toVersion(javaVersion.toString());
-        } catch (IllegalArgumentException ignored) {
-            // TargetJDK does not include 1.1, 1.2 and 1.8;
-            // Use same fallback as PMD
-            return TargetJdk.VERSION_1_4;
-        }
+        DeprecationLogger.deprecateMethod(PmdPlugin.class, "getDefaultTargetJdk(JavaVersion)")
+            .withAdvice("This method is only used to compute the deprecated PMD targetJdk property, which is a no-op for PMD 5.0 and later.")
+            .willBeRemovedInGradle10()
+            .withUpgradeGuideSection(9, "deprecated_pmd_target_jdk")
+            .nagUser();
+        return DeprecationLogger.whileDisabled(() -> {
+            try {
+                return TargetJdk.toVersion(javaVersion.toString());
+            } catch (IllegalArgumentException ignored) {
+                // TargetJDK does not include 1.1, 1.2 and 1.8;
+                // Use same fallback as PMD
+                return TargetJdk.VERSION_1_4;
+            }
+        });
     }
 
     @Override
@@ -151,7 +166,7 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         taskMapping.map("ruleSetConfig", () -> extension.getRuleSetConfig());
         taskMapping.map("ruleSetFiles", () -> extension.getRuleSetFiles());
         taskMapping.map("consoleOutput", () -> extension.isConsoleOutput());
-        taskMapping.map("targetJdk", () -> extension.getTargetJdk());
+        taskMapping.map("targetJdk", () -> DeprecationLogger.whileDisabled(extension::getTargetJdk));
 
         task.getRulesMinimumPriority().convention(extension.getRulesMinimumPriority());
         task.getMaxFailures().convention(extension.getMaxFailures());

--- a/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -104,29 +104,6 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         configuresPmdTask("pmdOther", project.sourceSets.other)
     }
 
-    def "configures pmd targetjdk based on sourcecompatibilityLevel"() {
-        project.pluginManager.apply(JavaBasePlugin)
-        when:
-        project.java.setSourceCompatibility(sourceCompatibility)
-        project.java.sourceSets {
-            main
-        }
-        then:
-        project.tasks.getByName("pmdMain").targetJdk == targetJdk
-
-        where:
-        sourceCompatibility | targetJdk
-        1.3                 | TargetJdk.VERSION_1_3
-        1.4                 | TargetJdk.VERSION_1_4
-        1.5                 | TargetJdk.VERSION_1_5
-        1.6                 | TargetJdk.VERSION_1_6
-        1.7                 | TargetJdk.VERSION_1_7
-        // 1.4 is the default in the pmd plugin so we use it as a default too
-        1.8                 | TargetJdk.VERSION_1_4
-        1.1                 | TargetJdk.VERSION_1_4
-        1.2                 | TargetJdk.VERSION_1_4
-    }
-
     private void configuresPmdTask(String taskName, SourceSet sourceSet) {
         def task = project.tasks.findByName(taskName)
         assert task instanceof Pmd


### PR DESCRIPTION
The targetJdk property and TargetJdk enum were used with PMD versions older than 5.0 to set the Ant targetjdk attribute. PMD 5.0 and later infer the language version from the configured rule sets, so the property has been a no-op for all supported PMD versions and there is no replacement.

Deprecates:
- Pmd.getTargetJdk() / setTargetJdk(TargetJdk)
- PmdExtension.getTargetJdk() / setTargetJdk(TargetJdk) / setTargetJdk(Object)
- TargetJdk enum (warning fires from TargetJdk.toVersion(Object))
- PmdPlugin.getDefaultTargetJdk(JavaVersion)

Internal call sites read the value via DeprecationLogger.whileDisabled to avoid firing the nag during normal task execution.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
