### PR TITLE
Route project script fingerprints to correct project scope under parallel Isolated Projects

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/internal/cc/impl/isolated/IsolatedProjectsBuildOperationsIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.cc.impl.isolated
 
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.operations.configuration.ConfigurationCacheCheckFingerprintBuildOperationType
+import org.gradle.tooling.model.GradleProject
 
 class IsolatedProjectsBuildOperationsIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
     def operations = new BuildOperationsFixture(executer, temporaryFolder)
@@ -178,6 +179,86 @@ class IsolatedProjectsBuildOperationsIntegrationTest extends AbstractIsolatedPro
             originBuildInvocationId != null
         }
         outputContains("file '${buildFileA.relativePathFromBase}' has changed")
+    }
+
+    def "emits fingerprint check operation when creating preferred subproject build file"() {
+        given:
+        settingsFile """
+            include("a")
+            include("b")
+        """
+
+        def buildFileA = file("a/build.gradle")
+        buildFile("a/build.gradle.kts", """
+            // using Kotlin DSL
+        """)
+        buildFile("b/build.gradle", """
+            // project b
+        """)
+
+        withIsolatedProjects()
+        fetchModel(GradleProject)
+
+        when: "a newly preferred build file is created"
+        buildFile(buildFileA, """
+            // now using Groovy DSL
+        """)
+        withIsolatedProjects()
+        fetchModel(GradleProject)
+
+        then: "the build scope is not invalidated and project :a is invalidated"
+        with(operations.only(ConfigurationCacheCheckFingerprintBuildOperationType).result) {
+            status == "PARTIAL"
+            buildInvalidationReasons == []
+            projectInvalidationReasons.any {
+                it.projectPath == ":a" &&
+                    it.invalidationReasons == [[message: "the file system entry '${buildFileA.relativePathFromBase}' has been created"]]
+            }
+            originBuildInvocationId != null
+        }
+        outputContains("the file system entry '${buildFileA.relativePathFromBase}' has been created")
+    }
+
+    def "emits fingerprint check operation when invalidating applied subproject script"() {
+        given:
+        settingsFile """
+            include("a")
+            include("b")
+        """
+
+        def appliedScriptA = file("a/plugin.gradle")
+        buildFile("a/build.gradle", """
+            apply from: 'plugin.gradle'
+        """)
+        buildFile(appliedScriptA, """
+            println("project a plugin")
+        """)
+
+        buildFile("b/build.gradle", """
+            // project b
+        """)
+
+        withIsolatedProjects()
+        fetchModel(GradleProject)
+
+        when: "an applied script plugin is invalidated"
+        buildFile(appliedScriptA, """
+            println("project a plugin updated")
+        """)
+        withIsolatedProjects()
+        fetchModel(GradleProject)
+
+        then: "the build scope is not invalidated and project :a is invalidated"
+        with(operations.only(ConfigurationCacheCheckFingerprintBuildOperationType).result) {
+            status == "PARTIAL"
+            buildInvalidationReasons == []
+            projectInvalidationReasons.any {
+                it.projectPath == ":a" &&
+                    it.invalidationReasons == [[message: "file '${appliedScriptA.relativePathFromBase}' has changed"]]
+            }
+            originBuildInvocationId != null
+        }
+        outputContains("file '${appliedScriptA.relativePathFromBase}' has changed")
     }
 
     def "emits fingerprint check operation when invalidating multiple subprojects"() {
@@ -342,6 +423,45 @@ class IsolatedProjectsBuildOperationsIntegrationTest extends AbstractIsolatedPro
         outputDoesNotContain("project dependency ':b' has changed")
     }
 
+    def "single subproject build script edit only invalidates that project under parallel IP"() {
+        given:
+        settingsFile """
+            rootProject.name = 'root'
+            include("a")
+        """
+
+        def buildFileA = buildFile "a/build.gradle", """
+            // project a
+        """
+
+        executer.beforeExecute {
+            it.withArgument("-Dorg.gradle.internal.isolated-projects.parallel=true")
+            it.withArgument("-Dorg.gradle.workers.max=8")
+            it.withArgument(ENABLE_CLI)
+        }
+
+        and: "first model fetch populates the configuration cache"
+        fetchModel(GradleProject)
+
+        when: "the subproject's build script is edited"
+        buildFileA.text = """
+            // project a updated
+        """
+        fetchModel(GradleProject)
+
+        then: "only the edited project is invalidated, not the build scope"
+        with(operations.only(ConfigurationCacheCheckFingerprintBuildOperationType).result) {
+            status == "PARTIAL"
+            buildInvalidationReasons == []
+            projectInvalidationReasons.size() == 1
+            projectInvalidationReasons[0].buildPath == ":"
+            projectInvalidationReasons[0].projectPath == ":a"
+            projectInvalidationReasons[0].invalidationReasons == [[message: "file '${buildFileA.relativePathFromBase}' has changed".toString()]]
+            originBuildInvocationId != null
+        }
+        outputContains("file '${buildFileA.relativePathFromBase}' has changed")
+    }
+
     def "emits fingerprint check operation when invalidating included build"() {
         given:
         withSomeToolingModelBuilderPluginInBuildSrc()
@@ -375,13 +495,13 @@ class IsolatedProjectsBuildOperationsIntegrationTest extends AbstractIsolatedPro
                     buildPath: ":a",
                     projectPath: ":",
                     invalidationReasons: [
-                        [message: "file '${buildFileA.relativePathFromBase}' has changed"]
+                        [message: "the file system entry '${buildFileA.relativePathFromBase}' has been created"]
                     ]
                 ]
             ]
             originBuildInvocationId != null
         }
-        outputContains("file '${buildFileA.relativePathFromBase}' has changed")
+        outputContains("the file system entry '${buildFileA.relativePathFromBase}' has been created")
     }
 
     private def fetchAllModels() {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -130,6 +130,16 @@ class ConfigurationCacheFingerprintWriter(
     private
     val projectForThread = ThreadLocal<ProjectScopedSink>()
 
+    /**
+     * Maps each file-backed project script (build scripts and applied local scripts) to the
+     * [ProjectScopedSink]s that own it. Populated while a project sink is active so
+     * [onScriptClassLoaded] can recover the correct project scope when the [projectForThread]
+     * ThreadLocal is lost across worker-lease handoffs during parallel project evaluation
+     * under Isolated Projects.
+     */
+    private
+    val scriptFileToProjectSinks = ConcurrentHashMap<File, MutableSet<ProjectScopedSink>>()
+
     private
     val projectDependencies = newConcurrentHashSet<ProjectSpecificFingerprint>()
 
@@ -274,6 +284,12 @@ class ConfigurationCacheFingerprintWriter(
     fun scriptSourceObserved(scriptSource: ScriptSource) {
         if (isInputTrackingDisabled()) {
             return
+        }
+
+        scriptSource.resource.file?.let { scriptFile ->
+            projectForThread.get()?.let { projectSink ->
+                registerScriptFile(projectSink, scriptFile)
+            }
         }
 
         scriptSource.uri?.takeIf { it.isHttp }?.let { uri ->
@@ -594,13 +610,47 @@ class ConfigurationCacheFingerprintWriter(
         }
         projectForThread.set(projectSink)
         try {
-            return action()
+            return action().also { result ->
+                if (result is File) {
+                    registerScriptFile(projectSink, result)
+                }
+            }
         } finally {
             if (!keepAlive) {
-                sinksForProject.remove(project.buildTreePath)
+                unregisterProjectSink(project, projectSink)
             }
             projectForThread.set(previous)
         }
+    }
+
+    private
+    fun registerScriptFile(projectSink: ProjectScopedSink, scriptFile: File) {
+        projectSink.scriptFiles.add(scriptFile)
+        scriptFileToProjectSinks.computeIfAbsent(scriptFile) { newConcurrentHashSet() }.add(projectSink)
+    }
+
+    private
+    fun unregisterProjectSink(project: ProjectIdentity, projectSink: ProjectScopedSink) {
+        sinksForProject.remove(project.buildTreePath)
+        projectSink.scriptFiles.forEach { scriptFile ->
+            scriptFileToProjectSinks.computeIfPresent(scriptFile) { _, projectSinks ->
+                projectSinks.remove(projectSink)
+                projectSinks.takeIf { it.isNotEmpty() }
+            }
+        }
+        projectSink.scriptFiles.clear()
+    }
+
+    private
+    fun captureResolvedScriptForKnownProjects(scriptFile: File): Boolean {
+        val projectSinks = scriptFileToProjectSinks[scriptFile] ?: return false
+        projectSinks.forEach { projectSink ->
+            if (scriptFile.isFile) {
+                projectSink.captureFile(scriptFile)
+            }
+            projectSink.captureFileSystemEntry(scriptFile)
+        }
+        return true
     }
 
     fun projectObserved(consumingProjectPath: Path?, targetProjectPath: Path) {
@@ -956,6 +1006,8 @@ class ConfigurationCacheFingerprintWriter(
         private val writer: ScopedFingerprintWriter<ProjectSpecificFingerprint>
     ) : Sink(host) {
 
+        val scriptFiles: MutableSet<File> = newConcurrentHashSet()
+
         private
         val projectIdentityPath = project.buildTreePath
 
@@ -975,7 +1027,31 @@ class ConfigurationCacheFingerprintWriter(
     }
 
     fun onScriptFileResolved(scriptFile: File) {
-        fileObserved(scriptFile)
+        if (isInputTrackingDisabled()) {
+            return
+        }
+
+        projectForThread.get()?.let { projectSink ->
+            registerScriptFile(projectSink, scriptFile)
+            // Only capture file content for files that exist. For non-existent candidates
+            // (e.g. build.gradle when only build.gradle.kts is present), capturing content
+            // would cause "file has changed" on creation instead of the more accurate
+            // "file system entry has been created". Content for existing scripts will also
+            // be captured via onScriptClassLoaded when the script class is compiled.
+            if (scriptFile.isFile) {
+                projectSink.captureFile(scriptFile)
+            }
+            projectSink.captureFileSystemEntry(scriptFile)
+            return
+        }
+
+        if (captureResolvedScriptForKnownProjects(scriptFile)) {
+            return
+        }
+
+        // Without a project association, only track existence so project script content
+        // doesn't end up in the build-scoped fingerprint during script discovery.
+        sink().captureFileSystemEntry(scriptFile)
     }
 
     fun onGradlePropertiesLoaded(


### PR DESCRIPTION
Under **parallel** Isolated Projects (`-Dorg.gradle.internal.isolated-projects.parallel=true`), editing a single subproject's build script invalidates the entire configuration cache entry (status=INVALID) instead of just the edited project (status=PARTIAL). This happened because `onScriptClassLoaded` runs on worker-lease threads that don't inherit the `projectForThread` `ThreadLocal`, causing script content fingerprints to land in the build-scoped sink instead of the project-scoped sink.

Add a `scriptFileToProjectSink` map keyed by the project's build file, populated when `runCollectingFingerprintForProject` is entered with a known scriptFile. When `projectForThread` is null, `onScriptClassLoaded` looks up the correct `ProjectScopedSink` by file path and routes the capture there.

Also stop capturing project build script content during settings-time `onScriptFileResolved`; only the file-system-entry is recorded there. The content is captured later under the per-project scope by `onScriptClassLoaded`.

### Reproduction steps

1. Create a multi-project build with at least two subprojects, each with a build.gradle
1. Run a model fetch or task with Isolated Projects and parallel configuration enabled:
   `./gradlew help -Dorg.gradle.unsafe.isolated-projects=true -Dorg.gradle.internal.isolated-projects.parallel=true -Dorg.gradle.workers.max=8`
1. Edit only one subproject's build.gradle (e.g. add a comment)
1. Run the same command again

#### Expected result
`Configuration cache entry updated for 1 project, N projects up-to-date` (entry was partially valid and only affected projects were updated)

#### Actual result
`Configuration cache entry stored.` (entire entry was recreated)

### AI Use
I used a model to research the existing code to identify the spots I should look at and generate some of this code. I've iterated on it many times to minimize the reproducer tests and simplify the implementation.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
