### PR TITLE
Resolve relative GitVersionControlSpec URL strings via FileResolver

### DIFF
--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVcsIntegrationTest.groovy
@@ -176,6 +176,31 @@ The following types/formats are supported:
   - String describing the module in 'group:name' format, for example 'org.gradle:gradle-core'.""")
     }
 
+    def 'string-form git URL is resolved against the settings directory'() {
+        // GitVersionControlSpec.setUrl(String) routes through FileResolver.resolveUri so that
+        // relative path strings are resolved the same way Project.uri(String) resolves them.
+        given:
+        def commit = repo.commit('initial commit')
+
+        settingsFile << """
+            sourceControl {
+                vcsMappings {
+                    withModule("org.test:dep") {
+                        from(GitVersionControlSpec) {
+                            // Relative path resolved against the settings directory.
+                            url = "dep"
+                        }
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds('assemble')
+        def gitCheckout = checkoutDir(repo.name, commit.id.name, "git-repo:${repo.url.toASCIIString()}")
+        gitCheckout.file('.git').assertExists()
+    }
+
     @Issue('gradle/gradle-native#206')
     def 'can define and use source repositories with initscript resolution present'() {
         given:

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/git/internal/DefaultGitVersionControlSpec.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/git/internal/DefaultGitVersionControlSpec.java
@@ -16,15 +16,21 @@
 
 package org.gradle.vcs.git.internal;
 
-import org.gradle.internal.UncheckedException;
+import org.gradle.api.internal.file.FileResolver;
 import org.gradle.vcs.git.GitVersionControlSpec;
 import org.gradle.vcs.internal.spec.AbstractVersionControlSpec;
 
+import javax.inject.Inject;
 import java.net.URI;
-import java.net.URISyntaxException;
 
 public class DefaultGitVersionControlSpec extends AbstractVersionControlSpec implements GitVersionControlSpec {
+    private final FileResolver fileResolver;
     private URI url;
+
+    @Inject
+    public DefaultGitVersionControlSpec(FileResolver fileResolver) {
+        this.fileResolver = fileResolver;
+    }
 
     @Override
     public URI getUrl() {
@@ -38,12 +44,7 @@ public class DefaultGitVersionControlSpec extends AbstractVersionControlSpec imp
 
     @Override
     public void setUrl(String url) {
-        // TODO - should use a resolver so that this method is consistent with Project.uri(string)
-        try {
-            setUrl(new URI(url));
-        } catch (URISyntaxException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        }
+        setUrl(fileResolver.resolveUri(url));
     }
 
     @Override

--- a/platforms/software/version-control/src/test/groovy/org/gradle/vcs/git/internal/DefaultGitVersionControlSpecSpec.groovy
+++ b/platforms/software/version-control/src/test/groovy/org/gradle/vcs/git/internal/DefaultGitVersionControlSpecSpec.groovy
@@ -17,11 +17,15 @@
 package org.gradle.vcs.git.internal
 
 
+import org.gradle.api.internal.file.FileResolver
 import org.gradle.vcs.git.GitVersionControlSpec
 import spock.lang.Specification
 
 class DefaultGitVersionControlSpecSpec extends Specification {
-    GitVersionControlSpec spec = new DefaultGitVersionControlSpec()
+    FileResolver fileResolver = Mock(FileResolver) {
+        resolveUri(_) >> { args -> args[0] instanceof URI ? args[0] : new URI(args[0].toString()) }
+    }
+    GitVersionControlSpec spec = new DefaultGitVersionControlSpec(fileResolver)
 
     def 'handles file urls'() {
         given:
@@ -51,5 +55,22 @@ class DefaultGitVersionControlSpecSpec extends Specification {
         spec.repoName == 'gradle-checksum'
         spec.uniqueId == 'git-repo:https://github.com/gradle/gradle-checksum.git'
         spec.displayName == 'Git repository at https://github.com/gradle/gradle-checksum.git'
+    }
+
+    def 'resolves relative URL strings via the file resolver'() {
+        given:
+        def resolved = new URI("file:/abs/project/dep")
+        def localResolver = Mock(FileResolver) {
+            resolveUri('dep') >> resolved
+        }
+        def localSpec = new DefaultGitVersionControlSpec(localResolver)
+
+        when:
+        localSpec.url = 'dep'
+
+        then:
+        localSpec.url == resolved
+        localSpec.repoName == 'dep'
+        localSpec.uniqueId == 'git-repo:file:/abs/project/dep'
     }
 }

--- a/platforms/software/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
+++ b/platforms/software/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.vcs.git.internal
 
 import org.eclipse.jgit.revwalk.RevCommit
 import org.gradle.api.GradleException
+import org.gradle.api.internal.file.FileResolver
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.OsTestPreconditions
@@ -62,7 +63,10 @@ class GitVersionControlSystemSpec extends Specification {
         anotherSource << 'Goodbye world!'
         c2 = repo.commit('Second Commit')
         repoHead = GitVersionRef.from(repo.head)
-        repoSpec = new DefaultGitVersionControlSpec()
+        FileResolver fileResolver = Mock(FileResolver) {
+            resolveUri(_) >> { args -> args[0] instanceof URI ? args[0] : new URI(args[0].toString()) }
+        }
+        repoSpec = new DefaultGitVersionControlSpec(fileResolver)
         repoSpec.url = repo.url
 
         submoduleRepo.workTree.file("foo.txt") << "hello from submodule"


### PR DESCRIPTION
`setUrl(String)` now routes through `FileResolver.resolveUri()` so relative paths resolve against the settings directory, more or less consistent with `Project.uri(String)`.

Issue: #31372

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
