### PR TITLE
Revert "Run perf tests on Java 21 by default (#37590)"

### DIFF
--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -35,7 +35,7 @@ enum class Os(
     val perfTestWorkingDir: String = "%teamcity.build.checkoutDir%",
     val perfTestJavaVendor: JvmVendor = JvmVendor.OPENJDK,
     val buildJavaVersion: JvmVersion = BuildToolBuildJvm.version,
-    val perfTestJavaVersion: JvmVersion = JvmVersion.JAVA_21,
+    val perfTestJavaVersion: JvmVersion = JvmVersion.JAVA_17,
     val defaultArch: Arch = Arch.AMD64,
 ) {
     LINUX(

--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -70,10 +70,10 @@ abstract class AdHocPerformanceScenario(
             )
             text(
                 "testJavaVersion",
-                "21",
+                "17",
                 display = ParameterDisplay.PROMPT,
                 allowEmpty = false,
-                description = "The java version to run the performance tests, e.g. 8/11/21",
+                description = "The java version to run the performance tests, e.g. 8/11/17",
             )
             select(
                 "testJavaVendor",

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -85,7 +85,7 @@ class PerformanceTestBuildTypeTest {
         val expectedRunnerParams =
             listOf(
                 "-PperformanceBaselines=%performance.baselines%",
-                "-PtestJavaVersion=21",
+                "-PtestJavaVersion=17",
                 "-PtestJavaVendor=openjdk",
                 "-PautoDownloadAndroidStudio=true",
                 "-PrunAndroidStudioInHeadlessMode=true",
@@ -164,7 +164,7 @@ class PerformanceTestBuildTypeTest {
         val expectedRunnerParams =
             listOf(
                 "-PperformanceBaselines=%performance.baselines%",
-                "-PtestJavaVersion=21",
+                "-PtestJavaVersion=17",
                 "-PtestJavaVendor=openjdk",
                 "-PautoDownloadAndroidStudio=true",
                 "-PrunAndroidStudioInHeadlessMode=true",


### PR DESCRIPTION
This reverts commit 7bbd2f26ec6eef0cbf91f743b452016f7b091265, reversing changes made to 50be051bf915ded0b2f3a441f507fa4758a8b11e.

We found a performance test being very flaky: `JavaIncrementalExecutionPerformanceTest: up-to-date assemble (parallel #parallel)`.