### PR TITLE
Fix exception thrown from BaseDirFileResolver when Tooling API receives a relative project directory

### DIFF
--- a/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
+++ b/platforms/core-runtime/client-services/src/main/java/org/gradle/launcher/daemon/toolchain/DaemonClientToolchainServices.java
@@ -137,7 +137,8 @@ public class DaemonClientToolchainServices implements ServiceRegistrationProvide
         installationSuppliers.add(new WindowsInstallationSupplier(windowsRegistry, os));
 
         // Caveat: when adding new manually created services ensure to close them if required, since the service registry does not manage them
-        File rootDirectory = buildLayoutFactory.getLayoutFor(buildLayoutConfiguration).getRootDirectory();
+        // Ensure rootDirectory is absolute, as it may be relative when the Tooling API is invoked with a relative project directory
+        File rootDirectory = buildLayoutFactory.getLayoutFor(buildLayoutConfiguration).getRootDirectory().getAbsoluteFile();
         FileResolver fileResolver = new BaseDirFileResolver(rootDirectory);
         CurrentBuildPlatform currentBuildPlatform = new CurrentBuildPlatform(systemInfo, os);
         DefaultFilePropertyFactory filePropertyFactory = new DefaultFilePropertyFactory(propertyHost, fileResolver, fileCollectionFactory);

--- a/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/platforms/ide/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.integtests.tooling
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.logging.LogLevel
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
@@ -25,7 +26,9 @@ import org.gradle.integtests.tooling.fixture.ToolingApi
 import org.gradle.internal.time.CountdownTimer
 import org.gradle.internal.time.Time
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.internal.consumer.DefaultGradleConnector
 import org.gradle.tooling.model.GradleProject
 import org.gradle.util.GradleVersion
 import spock.lang.Issue
@@ -361,5 +364,33 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec implements Other
 
         where:
         withColor << [true, false]
+    }
+
+    def "can connect with a relative project directory when daemon toolchain criteria are configured"() {
+        given:
+        file("gradle/gradle-daemon-jvm.properties").writeProperties(
+            "toolchainVersion": JavaVersion.current().majorVersion,
+        )
+
+        // Compute a relative path from the OS working directory to the test project
+        def osCwd = new File("").getAbsoluteFile()
+        def relativeProjectDir = osCwd.toPath().relativize(projectDir.toPath()).toFile()
+
+        when:
+        DefaultGradleConnector connector = GradleConnector.newConnector() as DefaultGradleConnector
+        connector.forProjectDirectory(relativeProjectDir)
+        connector.useInstallation(distribution.gradleHomeDir)
+        connector.daemonBaseDir(toolingApi.daemonBaseDir)
+        connector.embedded(false)
+        connector.daemonMaxIdleTime(120, java.util.concurrent.TimeUnit.SECONDS)
+        def connection = connector.connect()
+        try {
+            connection.newBuild().forTasks("help").run()
+        } finally {
+            connection.close()
+        }
+
+        then:
+        noExceptionThrown()
     }
 }


### PR DESCRIPTION
PR https://github.com/gradle/gradle/pull/32894 introduced a regression where `DaemonClientToolchainServices` passes `getRootDirectory()` directly to `BaseDirFileResolver`, which requires an absolute path. When the Tooling API is invoked with a relative project directory (e.g. `File(".")`), this throws:

```
IllegalArgumentException: base dir '.' is not an absolute file.
```

### Context
This affects any Tooling API consumer that connects with a relative or default project directory, such as block/artifact-swap which defaults `--dir` to `Path(".")` [here](https://github.com/block/artifact-swap/blob/v0.1.12/cli/src/main/kotlin/xyz/block/artifactswap/cli/options/CommonOptions.kt#L14-L18).

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team.
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective.
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic.
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes.
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`.
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
