### PR TITLE
Avoid eager Studio version resolution

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/IdeProvisioningPlugin.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/IdeProvisioningPlugin.kt
@@ -89,7 +89,7 @@ class IdeProvisioningPlugin : Plugin<Project> {
             }
 
             dependencies {
-                add(androidStudioArchive.name, androidStudioDependencyCoordinates(androidStudioVersion).get())
+                add(androidStudioArchive.name, androidStudioDependencyCoordinates(androidStudioVersion))
                 add(intellijIdeaArchive.name, intellijIdeaInstallerCoordinates(intellijIdeaVersion))
             }
 


### PR DESCRIPTION
With an eager lookup, it's not possible to run basic tasks on gradle/gradle while being offline, even if all caches have been primed previously.

Running a build without internet resulted in:
```
[org.jetbrains.intellij.platform] org.jetbrains.intellij.platform.gradle.providers.AndroidStudioDownloadLinkValueSource$Inject_ execution failed.
java.net.UnknownHostException: jb.gg
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:572)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
	at java.base/java.net.Socket.connect(Socket.java:633)
	at java.base/sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:304)
	at java.base/sun.security.ssl.BaseSSLSocketImpl.connect(BaseSSLSocketImpl.java:174)
	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:183)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:533)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:638)
```