### PR TITLE
Change DefaultGradle.toString

### DIFF
--- a/platforms/core-configuration/domain-object-collections/src/testFixtures/groovy/org/gradle/api/AbstractDomainObjectContainerIntegrationTest.groovy
+++ b/platforms/core-configuration/domain-object-collections/src/testFixtures/groovy/org/gradle/api/AbstractDomainObjectContainerIntegrationTest.groovy
@@ -30,7 +30,7 @@ abstract class AbstractDomainObjectContainerIntegrationTest extends AbstractInte
         if (method.startsWith("Project")) {
             return "root project 'root'"
         } else if (method.startsWith("Gradle")) {
-            return "build 'root'"
+            return "build ':'"
         } else {
             return containerStringRepresentation
         }

--- a/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/platforms/core-runtime/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -89,7 +89,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         succeeds 't', 't2', '-I', 'init.gradle'
 
         then:
-        def initDeprecation = operations.only("Apply initialization script 'init.gradle' to build").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }.each {}
+        def initDeprecation = operations.only("Apply initialization script 'init.gradle' to build ':'").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }.each {}
         Map<String, Object> initDeprecationDetails = initDeprecation.details['deprecation'] as Map<String, Object>
         initDeprecationDetails.summary == 'Init script has been deprecated.'
         initDeprecationDetails.removalDetails.startsWith('This is scheduled to be removed in Gradle ')

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/AbstractProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/AbstractProgressCrossVersionSpec.groovy
@@ -23,7 +23,7 @@ class AbstractProgressCrossVersionSpec extends ToolingApiSpecification {
 
     String applyInitScript(File script) {
         if (targetVersion.baseVersion >= GradleVersion.version("6.6")) {
-            return "Apply initialization script '${pathOfScript(script)}' to build"
+            return "Apply initialization script '${pathOfScript(script)}' to ${buildToString()}"
         } else {
             return "Apply script ${script.name} to build"
         }
@@ -31,10 +31,14 @@ class AbstractProgressCrossVersionSpec extends ToolingApiSpecification {
 
     String applyInitScriptPlugin(File script) {
         if (targetVersion.baseVersion >= GradleVersion.version("6.6")) {
-            return "Apply script '${pathOfScript(script)}' to build"
+            return "Apply script '${pathOfScript(script)}' to ${buildToString()}"
         } else {
             return "Apply script ${script.name} to build"
         }
+    }
+
+    String buildToString() {
+        return targetVersion.baseVersion >= GradleVersion.version("9.6") ? "build ':'" : "build"
     }
 
     String applySettingsFile() {

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/PluginApplicationBuildProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/PluginApplicationBuildProgressCrossVersionSpec.groovy
@@ -171,7 +171,7 @@ class PluginApplicationBuildProgressCrossVersionSpec extends AbstractProgressCro
         events.assertIsABuild()
 
         def applyInitScript = events.operation(applyInitScript(initScript))
-        def examplePlugin = events.operation("Apply plugin ExamplePlugin to build")
+        def examplePlugin = events.operation("Apply plugin ExamplePlugin to ${buildToString()}")
 
         examplePlugin.parent == applyInitScript
     }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientGradleBuildBuilderCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r940/ResilientGradleBuildBuilderCrossVersionSpec.groovy
@@ -210,47 +210,54 @@ class ResilientGradleBuildBuilderCrossVersionSpec extends KotlinDslPluginRelated
          def e = thrown(BuildException)
         e.cause.message.contains("Script compilation error")
         def model = modelCollector.model
-        assertFailures(model, *expectedFailures)
+        assertFailures(model, *expectedFailures.call(targetVersion))
         assertModel(model, modelAvailable, expectedIncludedBuilds, expectedEditableBuilds)
 
         where:
         brokenFile                              | modelAvailable | expectedFailures | expectedIncludedBuilds | expectedEditableBuilds
         "settings.gradle.kts"                   | false
-                | [
-                    "The settings are not yet available for build."
-                ]
+                | { GradleVersion v -> [
+                    settingsNotAvailableMessage(v)
+                ] }
                 | []
                 | []
 
         "buildSrc/settings.gradle.kts"          | true
-                | [
+                | { GradleVersion v -> [
                     ".*Settings file.*buildSrc\\" + File.separatorChar + "settings\\.gradle\\.kts.*Script compilation error.*"
-                ]
+                ] }
                 | []
                 | ["buildSrc"]
 
         "buildSrc/build.gradle.kts"             | true
-                | [
+                | { GradleVersion v -> [
                     ".*Build file.*buildSrc\\" + File.separatorChar + "build\\.gradle\\.kts.*Script compilation error.*",
                     "A problem occurred configuring project ':buildSrc'.",
-                ]
+                ] }
                 | []
                 | ["buildSrc", "buildSrc-included"]
 
         "buildSrc-included/settings.gradle.kts" | true
-                | [
+                | { GradleVersion v -> [
                     ".*Settings file.*buildSrc-included\\" + File.separatorChar + "settings\\.gradle\\.kts.*Script compilation error.*"
-                ]
+                ] }
                 | ["UNKNOWN"]
                 | ["buildSrc", "UNKNOWN"]
 
         "buildSrc-included/build.gradle.kts"    | true
-                | [
+                | { GradleVersion v -> [
                     ".*Build file.*buildSrc-included\\" + File.separatorChar + "build\\.gradle\\.kts.*Script compilation error.*",
                     "A problem occurred configuring project ':buildSrc-included'.",
-                ]
+                ] }
                 | []
                 | ["buildSrc", "buildSrc-included"]
+    }
+
+    static String settingsNotAvailableMessage(GradleVersion targetVersion) {
+        if (targetVersion >= GradleVersion.version("9.6")) {
+            return "The settings are not yet available for build ':'\\."
+        }
+        return "The settings are not yet available for build\\."
     }
 
     void assertModel(GradleBuildModel model, boolean available, List includedBuilds, List editableBuilds) {

--- a/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildLookupIntegrationTest.groovy
+++ b/platforms/software/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildLookupIntegrationTest.groovy
@@ -72,7 +72,7 @@ class SourceDependencyBuildLookupIntegrationTest extends AbstractIntegrationSpec
         fails("broken")
 
         then:
-        failure.assertHasCause("Included build 'buildB' not found in build 'root'.")
+        failure.assertHasCause("Included build 'buildB' not found in build ':'.")
         result.assertTaskScheduled(":buildB:jar")
     }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildLookupIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildLookupIntegrationTest.groovy
@@ -42,7 +42,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildValidati
         fails(buildA, "broken")
 
         then:
-        failure.assertHasCause("Included build 'unknown' not found in build 'buildA'.")
+        failure.assertHasCause("Included build 'unknown' not found in build ':'.")
     }
 
     def "dir name is used as build name"() {
@@ -75,7 +75,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildValidati
         fails(buildA, "broken")
 
         then:
-        failure.assertHasCause("Included build 'b' not found in build 'buildA'.")
+        failure.assertHasCause("Included build 'b' not found in build ':'.")
     }
 
     def "build name can be specified at include time"() {
@@ -108,7 +108,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildValidati
         fails(buildA, "broken")
 
         then:
-        failure.assertHasCause("Included build 'buildB' not found in build 'buildA'.")
+        failure.assertHasCause("Included build 'buildB' not found in build ':'.")
     }
 
     def "included builds added from command-line are visible to root build"() {
@@ -165,12 +165,12 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildValidati
         fails(buildA, "buildB:broken1")
 
         then:
-        failure.assertHasCause("Included build 'buildA' not found in build 'buildB'.")
+        failure.assertHasCause("Included build 'buildA' not found in build ':buildB'.")
 
         when:
         fails(buildA, "buildB:broken2")
 
         then:
-        failure.assertHasCause("Included build 'buildC' not found in build 'buildB'.")
+        failure.assertHasCause("Included build 'buildC' not found in build ':buildB'.")
     }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildNestedBuildLookupIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildNestedBuildLookupIntegrationTest.groovy
@@ -41,7 +41,7 @@ class CompositeBuildNestedBuildLookupIntegrationTest extends AbstractCompositeBu
         fails(buildA, "buildB:broken")
 
         then:
-        failure.assertHasCause("Included build 'unknown' not found in build 'buildB'.")
+        failure.assertHasCause("Included build 'unknown' not found in build ':buildB'.")
     }
 
     def "other builds are not visible from included build"() {
@@ -76,12 +76,12 @@ class CompositeBuildNestedBuildLookupIntegrationTest extends AbstractCompositeBu
         fails(buildA, "buildC:broken1")
 
         then:
-        failure.assertHasCause("Included build 'buildA' not found in build 'buildC'.")
+        failure.assertHasCause("Included build 'buildA' not found in build ':buildC'.")
 
         when:
         fails(buildA, "buildC:broken2")
 
         then:
-        failure.assertHasCause("Included build 'buildB' not found in build 'buildC'.")
+        failure.assertHasCause("Included build 'buildB' not found in build ':buildC'.")
     }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskDependencyIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskDependencyIntegrationTest.groovy
@@ -211,7 +211,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project 'buildA'.")
-        failure.assertHasCause("Included build 'does-not-exist' not found in build 'buildA'.")
+        failure.assertHasCause("Included build 'does-not-exist' not found in build ':'.")
     }
 
     def "reports failure when task does not exist for included build"() {
@@ -285,7 +285,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project 'buildB'.")
-        failure.assertHasCause("Included build 'does-not-exist' not found in build 'buildB'.")
+        failure.assertHasCause("Included build 'does-not-exist' not found in build ':'.")
     }
 
     def "included build cannot reference tasks in #scenario"() {
@@ -311,7 +311,7 @@ class CompositeBuildTaskDependencyIntegrationTest extends AbstractCompositeBuild
 
         and:
         failure.assertHasDescription("A problem occurred evaluating project ':buildC'.")
-        failure.assertHasCause("Included build '${buildName}' not found in build 'buildC'.")
+        failure.assertHasCause("Included build '${buildName}' not found in build ':buildC'.")
 
         where:
         scenario  | buildName

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptErrorIntegrationTest.groovy
@@ -38,7 +38,7 @@ public class InitScriptErrorIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasDescription("A problem occurred evaluating initialization script.")
-                .assertHasCause("Could not find method createTakk() for arguments [do-stuff] on build of type ${DefaultGradle.name}.")
+                .assertHasCause("Could not find method createTakk() for arguments [do-stuff] on build ':' of type ${DefaultGradle.name}.")
                 .assertHasFileName("Initialization script '$initScript'")
                 .assertHasLineNumber(2)
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractDeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractDeferredTaskDefinitionIntegrationTest.groovy
@@ -83,7 +83,7 @@ abstract class AbstractDeferredTaskDefinitionIntegrationTest extends AbstractInt
         if (description.startsWith("Project")) {
             target = "root project 'root'"
         } else if (description.startsWith("Gradle")) {
-            target = "build 'root'"
+            target = "build ':'"
         } else {
             throw new IllegalArgumentException("Can't determine the exception text for '${description}'")
         }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -100,7 +100,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
 
         then:
 
-        def applyInitScriptProgress = operations.only("Apply initialization script 'init${File.separator}init.gradle' to build").progress
+        def applyInitScriptProgress = operations.only("Apply initialization script 'init${File.separator}init.gradle' to build ':'").progress
         applyInitScriptProgress.size() == 1
         applyInitScriptProgress[0].details.logLevel == 'WARN'
         applyInitScriptProgress[0].details.category == 'org.gradle.api.Script'

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -138,11 +138,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
 
     @Override
     public String toString() {
-        if (!buildState.isProjectsLoaded()) {
-            return "build";
-        }
-        // Does the rootProject name really make sense here? Wouldn't it be better to use the build identity path?
-        return "build '" + buildState.getRootProject().getName() + "'";
+        return getOwner().getDisplayName().getDisplayName();
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/RuleSourceApplicationTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/RuleSourceApplicationTest.groovy
@@ -69,7 +69,7 @@ class RuleSourceApplicationTest extends Specification {
         then:
         PluginApplicationException e = thrown()
         e.cause instanceof UnsupportedOperationException
-        e.cause.message == "Cannot apply model rules of plugin '${CustomRuleSource.name}' as the target 'build 'test'' is not model rule aware"
+        e.cause.message == "Cannot apply model rules of plugin '${CustomRuleSource.name}' as the target 'build ':'' is not model rule aware"
     }
 
     def "useful message is presented when applying rule source only type as a plugin"() {

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.MutationGuard
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.StartParameterInternal
+import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.project.CrossProjectConfigurator
 import org.gradle.api.internal.project.CrossBuildModelAccess
@@ -41,6 +42,7 @@ import org.gradle.configuration.internal.TestListenerBuildOperationDecorator
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.initialization.ClassLoaderScopeRegistry
 import org.gradle.initialization.SettingsState
+import org.gradle.internal.Describables
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.DefaultPublicBuildPath
 import org.gradle.internal.build.PublicBuildPath
@@ -330,6 +332,10 @@ class DefaultGradleSpec extends Specification {
     }
 
     def "get settings throws exception when settings is not available"() {
+        given:
+        // Allow toString() to work
+        _ * build.getDisplayName() >> Describables.of(new DefaultBuildIdentifier(Path.ROOT))
+
         when:
         gradle.settings
 
@@ -446,19 +452,13 @@ class DefaultGradleSpec extends Specification {
 
     def "has toString()"() {
         given:
-        def projectsLoaded = false
-        def rootProjectState = projectState('rootProject')
-        _ * build.isProjectsLoaded() >> { projectsLoaded }
-        _ * build.getRootProject() >> rootProjectState
+        _ * build.getDisplayName() >> Describables.of(new DefaultBuildIdentifier(identityPath))
 
         expect:
-        gradle.toString() == 'build'
+        gradle.toString() == "build '$identityPath'"
 
-        when:
-        projectsLoaded = true
-
-        then:
-        gradle.toString() == "build 'rootProject'"
+        where:
+        identityPath << [Path.ROOT, Path.path(":buildB")]
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
An extra change from #37659 -- this aligns with how we mention builds elsewhere, and removes the awkward unnamed `"build"` when there is no root project yet.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
